### PR TITLE
Add missing-file error state to the list output

### DIFF
--- a/cmd/workspace/list.go
+++ b/cmd/workspace/list.go
@@ -9,6 +9,7 @@ import (
 
 	"text/tabwriter"
 
+	util "github.com/canonical/workspace/internal"
 	srv "github.com/canonical/workspace/internal/server"
 	workspace "github.com/canonical/workspace/internal/workspace"
 	"github.com/spf13/afero"
@@ -53,7 +54,6 @@ func (c *CmdList) Run(cmd *cobra.Command, av []string) error {
 
 	if !c.global {
 		project, err = workspace.LoadProject(server, fs, Project)
-
 		if err == nil {
 			/* List all workspaces for the current project */
 			wsList, err := project.RetrieveWorkspaces()
@@ -80,30 +80,10 @@ func (c *CmdList) Run(cmd *cobra.Command, av []string) error {
 }
 
 func listGlobal(server srv.WorkspaceServer, fs afero.Fs) error {
-	wsList, err := workspace.RetrieveWorkspacesGlobal(server, fs)
-	if err != nil || len(wsList) == 0 {
+	list, err := workspace.RetrieveWorkspacesGlobal(server, fs)
+	if err != nil || len(list) == 0 {
 		return err
 	}
-	listAllWorkspaces(wsList)
-	return nil
-}
-
-func listWorkspaces(wsList []*srv.WorkspaceProps, project *workspace.Project) {
-	w := tabWriter()
-	fmt.Fprintf(w, "Project\tWorkspace\tState\n")
-
-	for _, val := range wsList {
-		line := []string{
-			contractHomeDirectory(project.ProjectDirectory()),
-			val.Name,
-			val.State.String(),
-		}
-		fmt.Fprintln(w, strings.Join(line, "\t"))
-	}
-	w.Flush()
-}
-
-func listAllWorkspaces(list map[*workspace.Project][]*srv.WorkspaceProps) {
 	w := tabWriter()
 
 	fmt.Fprintf(w, "Project\tWorkspace\tState\tNote\n")
@@ -114,20 +94,52 @@ func listAllWorkspaces(list map[*workspace.Project][]*srv.WorkspaceProps) {
 
 	for _, project := range keys {
 		for _, j := range list[project] {
-			comment := "-"
-			if !project.Exists() {
-				comment = "missing-project"
+			if j.State() == util.Inactive {
+				continue
 			}
-			line := []string{
-				contractHomeDirectory(project.ProjectDirectory()),
-				j.Name,
-				j.State.String(),
-				comment,
-			}
+			line := listWorkspace(j, project)
 			fmt.Fprintln(w, strings.Join(line, "\t"))
 		}
 	}
 	w.Flush()
+	return nil
+}
+
+func listWorkspaces(wsList []*srv.WorkspaceProps, project *workspace.Project) {
+	/* if all workspaces are inactive, we do not list them */
+	isAllInactive := func(i *srv.WorkspaceProps) bool { return i.State() != util.Inactive }
+	if slices.IndexFunc(wsList, isAllInactive) == -1 {
+		return
+	}
+
+	w := tabWriter()
+	fmt.Fprintf(w, "Project\tWorkspace\tState\tNote\n")
+
+	slices.SortFunc(wsList,
+		func(i, j *srv.WorkspaceProps) bool { return i.Name > j.Name })
+
+	for _, val := range wsList {
+		if val.State() == util.Inactive {
+			continue
+		}
+		line := listWorkspace(val, project)
+		fmt.Fprintln(w, strings.Join(line, "\t"))
+	}
+	w.Flush()
+}
+
+func listWorkspace(j *srv.WorkspaceProps, project *workspace.Project) []string {
+	comment := "-"
+	if j.State() == util.Error {
+		comment = j.Reason().String()
+	}
+	line := []string{
+		contractHomeDirectory(project.ProjectDirectory()),
+		j.Name,
+		j.State().String(),
+		comment,
+	}
+	return line
 }
 
 /*

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,9 +38,11 @@ type WorkspaceConfigValue struct {
 
 type WorkspaceProps struct {
 	Name    string
-	State   util.WorkspaceState
 	Devices map[string]map[string]string
 	Config  map[string]string
+
+	state  util.WorkspaceState
+	reason util.WorkspaceStateReason
 }
 
 type ExecArgs struct {
@@ -378,7 +380,7 @@ func (s *LxdServer) GetWorkspacesByConfig(filter WorkspaceConfigFilter) ([]*Work
 		if filter(i.Config) {
 			ws = append(ws, &WorkspaceProps{
 				Name:    util.ToWorkspaceName(i.Name),
-				State:   getWorkspaceState(i.StatusCode),
+				state:   fromLxdToWorkspaceState(i.StatusCode),
 				Devices: i.Devices,
 				Config:  i.Config,
 			})
@@ -399,7 +401,7 @@ func (s *LxdServer) GetWorkspacesByDevices(filter WorkspaceDeviceFilter) (map[st
 			name := util.ToWorkspaceName(i.Name)
 			ws[name] = &WorkspaceProps{
 				Name:    name,
-				State:   getWorkspaceState(i.StatusCode),
+				state:   fromLxdToWorkspaceState(i.StatusCode),
 				Devices: i.Devices,
 				Config:  i.Config,
 			}
@@ -434,7 +436,7 @@ func SignalHandler(control *websocket.Conn) {
 	}
 }
 
-func getWorkspaceState(lxdStatus api.StatusCode) util.WorkspaceState {
+func fromLxdToWorkspaceState(lxdStatus api.StatusCode) util.WorkspaceState {
 	var state util.WorkspaceState
 	switch lxdStatus {
 	case api.Running, api.Ready:
@@ -445,4 +447,16 @@ func getWorkspaceState(lxdStatus api.StatusCode) util.WorkspaceState {
 		state = util.Pending
 	}
 	return state
+}
+
+func (w *WorkspaceProps) State() util.WorkspaceState {
+	return w.state
+}
+
+func (w *WorkspaceProps) Reason() util.WorkspaceStateReason {
+	return w.reason
+}
+
+func (w *WorkspaceProps) SetState(s util.WorkspaceState, r util.WorkspaceStateReason) {
+	w.state, w.reason = s, r
 }

--- a/internal/util.go
+++ b/internal/util.go
@@ -30,6 +30,7 @@ var (
 )
 
 type WorkspaceState int
+type WorkspaceStateReason int
 
 const (
 	Inactive WorkspaceState = iota
@@ -41,6 +42,17 @@ const (
 
 func (s WorkspaceState) String() string {
 	return [...]string{"Inactive", "Ready", "Stopped", "Pending", "Error"}[s]
+}
+
+const (
+	None WorkspaceStateReason = iota
+	Unknown
+	MissingProject
+	MissingFile
+)
+
+func (s WorkspaceStateReason) String() string {
+	return [...]string{"", "", "missing-project", "missing-file"}[s]
 }
 
 func ToFileName(name string) string {

--- a/internal/workspace/project.go
+++ b/internal/workspace/project.go
@@ -235,26 +235,23 @@ func (w *Project) RetrieveWorkspaces() ([]*srv.WorkspaceProps, error) {
 func mergeInstancesAndFiles(files []*srv.WorkspaceProps, instances []*srv.WorkspaceProps) []*srv.WorkspaceProps {
 	/* Merge both lists from to build a list of workspaces with their states */
 	result := make([]*srv.WorkspaceProps, 0, len(files)+len(instances))
-	for _, ws := range files {
+	for _, ws := range instances {
 		finder := func(p *srv.WorkspaceProps) bool { return p.Name == ws.Name }
-		idx := slices.IndexFunc(instances, finder)
+		idx := slices.IndexFunc(files, finder)
 		if idx == -1 {
-			/* We only have a file no instance which
-			we won't include in the final output
-			*/
-			ws.State = util.Inactive
-			continue
+			/* We only have an instance, no file
+			 */
+			ws.SetState(util.Error, util.MissingFile)
 		} else {
-			/* Both a file and instance exists */
-			ws.State = instances[idx].State
-			instances = slices.Delete(instances, idx, idx+1)
+			/* Both a file and instance exist */
+			files = slices.Delete(files, idx, idx+1)
 		}
 		result = append(result, ws)
 	}
 
-	/* Now, instances contains only orphaned workspaces, i.e. no file */
-	for _, ws := range instances {
-		ws.State = util.Error
+	/* Now, files contains only inactive workspaces */
+	for _, ws := range files {
+		ws.SetState(util.Inactive, util.None)
 		result = append(result, ws)
 	}
 	return result
@@ -275,7 +272,7 @@ func (w *Project) EnumWorkspaceFiles() ([]*srv.WorkspaceProps, error) {
 
 		/* The first element in names will contain the workspace name if matched */
 		if names := validWorkspaceFilename.FindStringSubmatch(info.Name()); names != nil {
-			workspaces = append(workspaces, &srv.WorkspaceProps{Name: names[1], State: util.Inactive})
+			workspaces = append(workspaces, &srv.WorkspaceProps{Name: names[1]})
 		}
 	}
 	return workspaces, nil
@@ -320,7 +317,7 @@ func RetrieveWorkspacesGlobal(server srv.WorkspaceServer, fs afero.Fs) (map[*Pro
 			workspaces, err := project.retrieveWorkspaceInstances()
 			if len(workspaces) > 0 && err == nil {
 				for _, i := range workspaces {
-					i.State = util.Error
+					i.SetState(util.Error, util.MissingProject)
 				}
 				fullList[project] = workspaces
 			}
@@ -351,7 +348,7 @@ func updateConfigFromBindMounts(server srv.WorkspaceServer, fs afero.Fs) (update
 	/* Group by instances by project-id and project directory  */
 	var grouped = make(map[ProjectKey][]*srv.WorkspaceProps, len(workspaces))
 	for _, i := range workspaces {
-		if i.State == util.Ready {
+		if i.State() == util.Ready {
 			projectPath := i.Devices[ProjectDevice]["source"]
 			key := ProjectKey{projectPath, i.Config[ProjectId]}
 			grouped[key] = append(grouped[key], i)

--- a/internal/workspace/project_test.go
+++ b/internal/workspace/project_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/slices"
 )
 
 type ProjectTestSuite struct {
@@ -93,12 +94,12 @@ func (s *ProjectTestSuite) TestLoadProject() {
 	/* Project exists, some workspace instances running */
 	instances := []*server.WorkspaceProps{
 		{
-			Name:  "instance1",
-			State: util.Ready,
+			Name: "instance1",
 			Devices: map[string]map[string]string{"workspace.project": {
 				"type": "disk", "source": "/", "path": "/project"}},
 		},
 	}
+	instances[0].SetState(util.Ready, util.None)
 	h.Unset()
 	s.Srv.On("GetWorkspacesByConfig", mock.Anything).Once().Return(instances, nil)
 	project, err = LoadProject(s.Srv, s.Fs, "/")
@@ -136,16 +137,19 @@ func (s *ProjectTestSuite) TestEnumWorkspacesFilesOnly() {
 	result, err := project.RetrieveWorkspaces()
 	/* Make sure files without instances are not returned */
 	assert.NoError(s.T(), err)
-	assert.Len(s.T(), result, 0)
+	assert.Len(s.T(), result, 1)
+	assert.Equal(s.T(), result[0].State(), util.Inactive)
+	assert.Equal(s.T(), util.None, result[0].Reason())
 }
 
 func (s *ProjectTestSuite) TestEnumWorkspacesInstancesOnly() {
 	instances := []*server.WorkspaceProps{
 		{
-			Name:  "instance1",
-			State: util.Ready,
+			Name: "instance1",
 		},
 	}
+	instances[0].SetState(util.Ready, util.None)
+
 	s.Srv.On("GetWorkspacesByConfig", mock.Anything).Once().Return(instances, nil)
 	project := Project{fs: s.Fs, server: s.Srv, path: "/"}
 
@@ -153,31 +157,36 @@ func (s *ProjectTestSuite) TestEnumWorkspacesInstancesOnly() {
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), result, 1)
 	/* the workspace does not have a corresponding file, hence, an error state */
-	assert.Equal(s.T(), util.Error, result[0].State)
+	assert.Equal(s.T(), util.Error, result[0].State())
+	assert.Equal(s.T(), util.MissingFile, result[0].Reason())
 	assert.Equal(s.T(), "instance1", result[0].Name)
 }
 
 func (s *ProjectTestSuite) TestEnumWorkspacesSomeOrphanedInstances() {
 	instances := []*server.WorkspaceProps{
 		{
-			Name:  "instance1",
-			State: util.Ready,
+			Name: "instance1",
 		},
 		{
-			Name:  "project1",
-			State: util.Ready,
+			Name: "project1",
 		},
 	}
+	instances[0].SetState(util.Ready, util.None)
+	instances[1].SetState(util.Ready, util.None)
+
 	s.Srv.On("GetWorkspacesByConfig", mock.Anything).Once().Return(instances, nil)
 	project := Project{fs: s.Fs, server: s.Srv, path: "/"}
 	afero.WriteFile(s.Fs, ".workspace.project1.yaml", []byte(""), 0644)
 
 	result, err := project.RetrieveWorkspaces()
+	// Make sure the order is always predictable
+	slices.SortFunc(result, func(i, j *server.WorkspaceProps) bool { return i.Name > j.Name })
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), util.Error, result[1].State)
+	assert.Equal(s.T(), util.Error, result[1].State())
+	assert.Equal(s.T(), util.MissingFile, result[1].Reason())
 	assert.Equal(s.T(), "instance1", result[1].Name)
 
-	assert.Equal(s.T(), util.Ready, result[0].State)
+	assert.Equal(s.T(), util.Ready, result[0].State())
 	assert.Equal(s.T(), "project1", result[0].Name)
 	assert.Len(s.T(), result, 2)
 }

--- a/tests/core/integrity-checks/task.yaml
+++ b/tests/core/integrity-checks/task.yaml
@@ -1,0 +1,30 @@
+summary: Error states tracking and recovery for the .workspace.lock
+
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup_workspaces_in_tree "$WORKSPACES"
+
+debug: |
+  lxc project switch workspace.ubuntu
+  lxc list -f compact
+  ls "$WORKSPACES"/*
+
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  for path in "$WORKSPACES"/*; do
+    launch "$path" ws | MATCH started
+    test -f "$path"/.workspace.lock
+    assert_workspace_config "$path" "$(cat "$path"/.workspace.lock)"
+
+    # remove .workspace.lock accidentally to validate recovery
+    rm -f "$path"/.workspace.lock
+    list "$path"
+    test -f "$path"/.workspace.lock
+
+    # delete the workspace file and check its state
+    mv "$path"/.workspace.ws.yaml "$path"/.workspace.ws.yaml.bak
+    list "$path" | MATCH "^$path[[:space:]]+ws[[:space:]]+Error[[:space:]]+missing-file$"
+    mv "$path"/.workspace.ws.yaml.bak "$path"/.workspace.ws.yaml
+    list "$path" | MATCH "^$path[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+  done

--- a/tests/core/launch/task.yaml
+++ b/tests/core/launch/task.yaml
@@ -17,12 +17,4 @@ execute: |
     launch "$path" ws | MATCH started
     test -f "$path"/.workspace.lock
     assert_workspace_config "$path" $(cat "$path"/.workspace.lock)
-
-    # remove .workspace.lock accidentally to validate recovery
-    rm -f "$path"/.workspace.lock
-  done
-
-  for path in "$WORKSPACES"/*; do
-    list "$path"
-    test -f "$path"/.workspace.lock
   done

--- a/tests/core/list/task.yaml
+++ b/tests/core/list/task.yaml
@@ -34,12 +34,12 @@ execute: |
   list_cwd | MATCH "^$"
 
   for path in "$WORKSPACES"/*; do
-   list "$path" | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready$"
+   list "$path" | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
    test -f "$path"/.workspace.lock
 
    echo "list from a nested directory must work similarly as if run from a project directory"
    pushd ./; mkdir "$path"/nested; cd "$path"/nested
-   list_cwd | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready$" 
+   list_cwd | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$" 
    rm -rf "$path"/nested; popd 
   done
 
@@ -56,7 +56,7 @@ execute: |
     echo "The directory was moved, its instances must update configuration with a new path"
     sudo -u ubuntu mv "$path" "$path"-new
     project_id=$(cat "$path"-new/.workspace.lock)
-    list "$path"-new | MATCH "^${path}-new[[:space:]]+ws[[:space:]]+Ready$"
+    list "$path"-new | MATCH "^${path}-new[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
     assert_workspace_config "$path"-new "$project_id"
     sudo -u ubuntu mv "$path"-new "$path"
 
@@ -71,7 +71,7 @@ execute: |
 
     # launch from a new directory successfully 
     launch "$path"-copy ws | MATCH started
-    list "$path"-copy | MATCH "^${path}-copy[[:space:]]+ws[[:space:]]+Ready$"
+    list "$path"-copy | MATCH "^${path}-copy[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
     assert_workspace_config "$path"-copy "$project_id_copy"
   done
     #TODO: 

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -9,7 +9,7 @@ function assert_workspace_config() {
 }
 
 function cleanup_workspaces_in_tree() {
-  lxc delete `lxc list -c n -f csv --project workspace.ubuntu` --force --project workspace.ubuntu
+  lxc delete $(lxc list -c n -f csv --project workspace.ubuntu) --force --project workspace.ubuntu
   for i in $1/*; do
     rm -f "$i"/.workspace.lock
   done


### PR DESCRIPTION
_workspace list_ handles cases when there is a running workspace but no corresponding .workspace.project.yaml file by reporting those as Error