### PR TITLE
Add changes and tasks commands

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -73,4 +73,5 @@ suites:
       cd /remote; GOBIN=/usr/bin go install -buildvcs=false /remote/cmd/workspace/
       lxd init --auto
 
+
 path: /remote

--- a/cmd/workspace/changes.go
+++ b/cmd/workspace/changes.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/canonical/workspace/internal/overlord"
+	"github.com/canonical/workspace/internal/overlord/projectstate"
+	"github.com/canonical/workspace/internal/overlord/state"
+	"github.com/spf13/cobra"
+)
+
+type CmdChanges struct {
+}
+
+func (c *CmdChanges) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "changes",
+		Args:  cobra.NoArgs,
+		Short: "Show a summary of recent changes to the system's workspaces",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
+	overlord, err := overlord.New(nil, os.Stdout)
+	if err != nil {
+		return err
+	}
+
+	st := overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	all_changes := st.Changes()
+	var changes = make([]*state.Change, 0, len(all_changes))
+
+	/* Only report changes for a certain project */
+	if cmd.Parent().Flag("project").Changed {
+		for _, chg := range all_changes {
+			var project = projectstate.ProjectKey{Path: "-", ProjectId: "-"}
+			err := chg.Get("project-key", &project)
+			if err == nil {
+				if project.Path == Project {
+					changes = append(changes, chg)
+				}
+			}
+		}
+	} else {
+		changes = all_changes
+	}
+
+	if len(changes) > 0 {
+		w := tabWriter()
+		fmt.Fprintf(w, "ID\tStatus\tProject\tSummary\n")
+
+		for _, chg := range changes {
+			var project = projectstate.ProjectKey{Path: "-", ProjectId: "-"}
+			chg.Get("project-key", &project)
+			fmt.Fprintln(w, strings.Join([]string{
+				chg.ID(),
+				chg.Status().String(),
+				contractHomeDirectory(project.Path),
+				chg.Summary()}, "\t"))
+		}
+		w.Flush()
+	}
+
+	return nil
+}

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -52,7 +51,6 @@ func getProjectDirectory(fs afero.Fs, cwd string) (string, error) {
 func main() {
 	cwd, err := os.Getwd()
 	if err != nil {
-		fmt.Println(err)
 		panic(err)
 	}
 
@@ -64,8 +62,7 @@ func main() {
 	fs := afero.NewOsFs()
 	cwd, err = getProjectDirectory(fs, cwd)
 	if err != nil {
-		fmt.Println(err)
-		panic("cannot get project directory")
+		panic(err)
 	}
 
 	logger.SetLogger(logger.New(os.Stderr, "[workspace] "))
@@ -74,5 +71,8 @@ func main() {
 
 	rootCmd.AddCommand((&CmdLaunch{}).Command())
 	rootCmd.AddCommand((&CmdList{}).Command())
+	rootCmd.AddCommand((&CmdChanges{}).Command())
+	rootCmd.AddCommand((&CmdTasks{}).Command())
+
 	rootCmd.Execute()
 }

--- a/cmd/workspace/tasks.go
+++ b/cmd/workspace/tasks.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/canonical/workspace/internal/overlord"
+	"github.com/spf13/cobra"
+)
+
+type CmdTasks struct {
+}
+
+func (c *CmdTasks) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "tasks change-id",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Show a summary of tasks for the change",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
+	overlord, err := overlord.New(nil, os.Stdout)
+	if err != nil {
+		return err
+	}
+
+	st := overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	change := st.Change(av[0])
+	if change != nil {
+		tasks := change.Tasks()
+
+		if len(tasks) > 0 {
+			w := tabWriter()
+			fmt.Fprintf(w, "ID\tStatus\tSummary\n")
+
+			for _, tsk := range tasks {
+				fmt.Fprintln(w, strings.Join([]string{
+					tsk.ID(),
+					tsk.Status().String(),
+					tsk.Summary()}, "\t"))
+			}
+			w.Flush()
+		}
+	} else {
+		return fmt.Errorf("change with id %q not found", av[0])
+	}
+
+	return nil
+}

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -27,11 +27,13 @@ function assert_workspace_sdk() {
 
 # General functions
 
-function cleanup_workspaces_in_tree() {
+function cleanup() {
   lxc delete $(lxc list -c n -f csv --project workspace.ubuntu) --force --project workspace.ubuntu
   for i in $1/*; do
     rm -f "$i"/.workspace.lock
   done
+  rm -rf /home/ubuntu/.local/share/workspace/sdks
+  rm -rf -- /home/ubuntu/.local/share/workspace /home/ubuntu/.local/state/workspace/state.json
 }
 
 function assert_arrays_equal() {
@@ -58,9 +60,18 @@ function list_cwd() {
 }
 
 function list_all() {
-    sudo -u ubuntu -- workspace list --global
+  sudo -u ubuntu -- workspace list --global
 }
 
 function delete() {
     lxc delete $1 --force --project workspace.ubuntu
 }
+
+function changes() {
+  sudo -u ubuntu -- workspace changes --project $1
+}
+
+function changes_global() {
+  sudo -u ubuntu -- workspace changes
+}
+

--- a/tests/main/changes/task.yaml
+++ b/tests/main/changes/task.yaml
@@ -1,0 +1,26 @@
+summary: Ensure the changes command output correctness
+prepare: |
+  # make sure there is no existing changes 
+  rm -f /home/ubuntu/.local/state/workspace/state.json
+
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup "$WORKSPACES"
+
+debug: |
+  lxc project switch workspace.ubuntu
+  lxc list -f compact
+  ls "$WORKSPACES"/*
+
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Changes list is empty on a new system"
+  changes_global | MATCH "^$"
+
+  echo "Must reflect the latest change after the launch"
+  project="$WORKSPACES"/test-empty-ubuntu20
+  launch $project ws
+  changes $project | MATCH "^1[[:space:]]+Done[[:space:]]+$project[[:space:]]+Launch workspace \"ws\"$"
+
+

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -2,7 +2,7 @@ summary: Error states tracking and recovery for the .workspace.lock
 
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup_workspaces_in_tree "$WORKSPACES"
+  cleanup "$WORKSPACES"
 
 debug: |
   lxc project switch workspace.ubuntu

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that 'workspace launch' creates a core LXD config correctly
 
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup_workspaces_in_tree "$WORKSPACES"
+  cleanup "$WORKSPACES"
   rm -rf /home/ubuntu/.local/share/workspace/sdk
 
 prepare: |

--- a/tests/main/launch/task.yaml
+++ b/tests/main/launch/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that 'workspace launch' creates a core LXD config correctly
 
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup_workspaces_in_tree "$WORKSPACES"
+  cleanup "$WORKSPACES"
   rm -rf /home/ubuntu/.local/share/workspace/sdks
 
 debug: |

--- a/tests/main/list-all/task.yaml
+++ b/tests/main/list-all/task.yaml
@@ -16,7 +16,7 @@ debug: |
 
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup_workspaces_in_tree "$WORKSPACES"
+  cleanup "$WORKSPACES"
   for path in "$WORKSPACES"/{*-copy,*-new}; do
     rm -rf "$path"
   done

--- a/tests/main/list/task.yaml
+++ b/tests/main/list/task.yaml
@@ -21,7 +21,7 @@ debug: |
 
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup_workspaces_in_tree "$WORKSPACES"
+  cleanup "$WORKSPACES"
   for path in "$WORKSPACES"/{*-copy,*-new}; do
     rm -rf "$path"
   done


### PR DESCRIPTION
The following commands were introduced:
```
workspace changes
workspace tasks change-id
```
These allow a user to explore the recent changes to the system's workspaces as well as each change's task set (see snapd).