### PR TITLE
Add context to long running workspace backend operations

### DIFF
--- a/cmd/workspace/changes.go
+++ b/cmd/workspace/changes.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/canonical/workspace/internal/overlord"
 	"github.com/canonical/workspace/internal/overlord/projectstate"
 	"github.com/canonical/workspace/internal/overlord/state"
+	"github.com/canonical/workspace/internal/timeutil"
 	"github.com/spf13/cobra"
 )
 
@@ -55,16 +55,25 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 
 	if len(changes) > 0 {
 		w := tabWriter()
-		fmt.Fprintf(w, "ID\tStatus\tProject\tSummary\n")
+		fmt.Fprintf(w, "ID\tStatus\tSpawn\tReady\tProject\tSummary\n")
 
 		for _, chg := range changes {
 			var project = projectstate.ProjectKey{Path: "-", ProjectId: "-"}
 			chg.Get("project-key", &project)
-			fmt.Fprintln(w, strings.Join([]string{
+
+			spawnTime := timeutil.Human(chg.SpawnTime())
+			readyTime := timeutil.Human(chg.ReadyTime())
+			if chg.ReadyTime().IsZero() {
+				readyTime = "-"
+			}
+
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 				chg.ID(),
 				chg.Status().String(),
+				spawnTime,
+				readyTime,
 				contractHomeDirectory(project.Path),
-				chg.Summary()}, "\t"))
+				chg.Summary())
 		}
 		w.Flush()
 	}

--- a/cmd/workspace/launch.go
+++ b/cmd/workspace/launch.go
@@ -94,7 +94,7 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 		} else if change.Status() == state.UndoneStatus {
 			fmt.Println("Aborted.")
 		} else if launched {
-			fmt.Printf("Workspace %s started.\n", ws)
+			fmt.Printf("Workspace \"%s\" started.\n", ws)
 		}
 	}
 	st.Unlock()

--- a/cmd/workspace/tasks.go
+++ b/cmd/workspace/tasks.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/canonical/workspace/internal/overlord"
+	"github.com/canonical/workspace/internal/timeutil"
 	"github.com/spf13/cobra"
 )
 
@@ -39,12 +40,20 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 
 		if len(tasks) > 0 {
 			w := tabWriter()
-			fmt.Fprintf(w, "ID\tStatus\tSummary\n")
+			fmt.Fprintf(w, "ID\tStatus\tSpawn\tReady\tSummary\n")
 
 			for _, tsk := range tasks {
+				spawnTime := timeutil.Human(tsk.SpawnTime())
+				readyTime := timeutil.Human(tsk.ReadyTime())
+				if tsk.ReadyTime().IsZero() {
+					readyTime = "-"
+				}
+
 				fmt.Fprintln(w, strings.Join([]string{
 					tsk.ID(),
 					tsk.Status().String(),
+					spawnTime,
+					readyTime,
 					tsk.Summary()}, "\t"))
 			}
 			w.Flush()

--- a/internal/osutil/flock.go
+++ b/internal/osutil/flock.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// FileLock describes a file system lock
+type FileLock struct {
+	file *os.File
+}
+
+var ErrAlreadyLocked = errors.New("cannot acquire lock, already locked")
+
+// OpenExistingLockForReading opens an existing lock file given by "path".
+// The lock is opened in read-only mode.
+func OpenExistingLockForReading(path string) (*FileLock, error) {
+	flag := syscall.O_RDONLY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+	file, err := os.OpenFile(path, flag, 0)
+	if err != nil {
+		return nil, err
+	}
+	l := &FileLock{file: file}
+	return l, nil
+}
+
+// NewFileLockWithMode creates and opens the lock file given by "path" with the given mode.
+func NewFileLockWithMode(path string, mode os.FileMode) (*FileLock, error) {
+	flag := syscall.O_RDWR | syscall.O_CREAT | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+	file, err := os.OpenFile(path, flag, mode)
+	if err != nil {
+		return nil, err
+	}
+	l := &FileLock{file: file}
+	return l, nil
+}
+
+// NewFileLock creates and opens the lock file given by "path" with mode 0600.
+func NewFileLock(path string) (*FileLock, error) {
+	return NewFileLockWithMode(path, 0600)
+}
+
+// Path returns the path of the lock file.
+func (l *FileLock) Path() string {
+	return l.file.Name()
+}
+
+// File returns the underlying file.
+func (l *FileLock) File() *os.File {
+	return l.file
+}
+
+// Close closes the lock, unlocking it automatically if needed.
+func (l *FileLock) Close() error {
+	return l.file.Close()
+}
+
+// Lock acquires an exclusive lock and blocks until the lock is free.
+//
+// Only one process can acquire an exclusive lock at a given time, preventing
+// shared or exclusive locks from being acquired.
+func (l *FileLock) Lock() error {
+	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX)
+}
+
+// Lock acquires an shared lock and blocks until the lock is free.
+//
+// Multiple processes can acquire a shared lock at the same time, unless an
+// exclusive lock is held.
+func (l *FileLock) ReadLock() error {
+	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_SH)
+}
+
+// TryLock acquires an exclusive lock and errors if the lock cannot be acquired.
+func (l *FileLock) TryLock() error {
+	err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == syscall.EWOULDBLOCK {
+		return ErrAlreadyLocked
+	}
+	return err
+}
+
+// Unlock releases an acquired lock.
+func (l *FileLock) Unlock() error {
+	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -27,6 +27,9 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
+	ctx, cancel := BackendContext(tomb, project)
+	defer cancel()
+
 	var hook util.WorkspaceHookType
 	err = task.Get("hook-setup", &hook)
 	if err != nil {
@@ -55,7 +58,7 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		Stdout:  outerr,
 		Stderr:  outerr}
 
-	done, err := h.backend.Exec(workspace, project.ProjectId, &args)
+	done, err := h.backend.Exec(ctx, workspace, &args)
 	hookLog, _ := afero.ReadFile(memFs, outerr.Name())
 	task.Logf(string(hookLog))
 	if err != nil {

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -24,15 +24,14 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	st := task.State()
-	st.Lock()
-	defer st.Unlock()
-
 	ctx, cancel := BackendContext(tomb, project)
 	defer cancel()
 
+	st := task.State()
+	st.Lock()
 	var hook util.WorkspaceHookType
 	err = task.Get("hook-setup", &hook)
+	st.Unlock()
 	if err != nil {
 		return err
 	}
@@ -64,7 +63,9 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	done, err := h.backend.Exec(ctx, workspace, &args)
 	hookLog, _ := afero.ReadFile(memFs, outerr.Name())
 	if err != nil {
+		st.Lock()
 		task.Logf(string(hookLog))
+		st.Unlock()
 		return err
 	}
 

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -71,6 +71,9 @@ type Overlord struct {
 	project   *projectstate.ProjectManager
 	hook      *hookstate.HookManager
 	runner    *state.TaskRunner
+
+	// exclusive file lock for the state to avoid multiple running workspaces (temporary)
+	stateFileLock *osutil.FileLock
 }
 
 // New creates a new Overlord with all its state managers.
@@ -82,12 +85,34 @@ func New(restartHandler restart.Handler, serviceOutput io.Writer) (*Overlord, er
 		inited:   true,
 	}
 
+	var err error
+
 	if !filepath.IsAbs(util.StateDir) {
 		return nil, fmt.Errorf("directory %q must be absolute", util.StateDir)
 	}
 	if !osutil.IsDir(util.StateDir) {
 		return nil, fmt.Errorf("directory %q does not exist", util.StateDir)
 	}
+
+	/* We use file locking here as multiple clients can try access the state file now,
+	this will be removed once moved to a client-server arch */
+	o.stateFileLock, err = osutil.NewFileLock(filepath.Join(util.StateDir, ".lock"))
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		err = o.stateFileLock.TryLock()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Cannot start, could another workspace be running?")
+			fmt.Fprintln(os.Stderr, "Retry in 5 seconds...")
+
+			time.Sleep(5 * time.Second)
+		} else {
+			break
+		}
+	}
+
 	statePath := filepath.Join(util.StateDir, "state.json")
 
 	backend := &overlordStateBackend{

--- a/internal/overlord/projectstate/project.go
+++ b/internal/overlord/projectstate/project.go
@@ -1,6 +1,7 @@
 package projectstate
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"math/rand"
@@ -8,6 +9,7 @@ import (
 	"regexp"
 
 	util "github.com/canonical/workspace/internal"
+	"github.com/canonical/workspace/internal/workspacebackend"
 	backend "github.com/canonical/workspace/internal/workspacebackend"
 	"golang.org/x/exp/slices"
 
@@ -380,7 +382,9 @@ func updateConfigFromBindMounts(be backend.WorkspaceBackend, fs afero.Fs) (updat
 			Stdin:   nil,
 			Stdout:  stdout,
 			Stderr:  nil}
-		done, err := be.Exec(instance.Name, key.ProjectId, &args)
+
+		ctx := context.WithValue(context.Background(), workspacebackend.ContextProjectId, key.ProjectId)
+		done, err := be.Exec(ctx, instance.Name, &args)
 		if err != nil {
 			continue
 		}

--- a/internal/overlord/projectstate/project_test.go
+++ b/internal/overlord/projectstate/project_test.go
@@ -1,6 +1,7 @@
 package projectstate
 
 import (
+	"context"
 	"errors"
 	"math/rand"
 	"testing"
@@ -16,6 +17,7 @@ import (
 type P struct {
 	Fs      afero.Fs
 	Backend workspacebackend.WorkspaceBackend
+	ctx     context.Context
 }
 
 var _ = Suite(&P{})
@@ -27,6 +29,7 @@ func (p *P) SetUpTest(c *C) {
 	p.Backend = workspacebackend.NewFakeWorkspaceBackend()
 	p.Fs.MkdirAll(util.DataDir, 0755)
 	p.Fs.MkdirAll(util.SdksDir, 0755)
+	p.ctx = context.WithValue(context.TODO(), workspacebackend.ContextProjectId, "projectId")
 	rand.Seed(1)
 }
 
@@ -73,14 +76,14 @@ func (s *P) TestLoadProject(c *C) {
 	c.Check(err, NotNil)
 
 	/* Project exists, no workspace instances */
-	afero.WriteFile(s.Fs, "/.workspace.lock", []byte("PROJECTID"), 0644)
+	afero.WriteFile(s.Fs, "/.workspace.lock", []byte("projectId"), 0644)
 	project, err := LoadProject(s.Backend, s.Fs, "/")
 	c.Check(project.ProjectDirectory(), Equals, "/")
-	c.Check(project.ProjectId(), Equals, "PROJECTID")
+	c.Check(project.ProjectId(), Equals, "projectId")
 	c.Check(err, IsNil)
 
 	/* Project exists, some workspace instances running */
-	s.Backend.LaunchWorkspaceInstance("ws", "ubuntu@20.04", "projectId")
+	s.Backend.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
 	project, err = LoadProject(s.Backend, s.Fs, "/")
 	c.Check(project.ProjectDirectory(), Equals, "/")
 	c.Check(err, IsNil)
@@ -117,7 +120,7 @@ func (s *P) TestEnumWorkspacesFilesOnly(c *C) {
 }
 
 func (s *P) TestEnumWorkspacesInstancesOnly(c *C) {
-	s.Backend.LaunchWorkspaceInstance("instance1", "ubuntu@20.04", "projectId")
+	s.Backend.LaunchWorkspace(s.ctx, "instance1", "ubuntu@20.04")
 	project := Project{fs: s.Fs, backend: s.Backend, path: "/", projectId: "projectId"}
 
 	result, err := project.RetrieveWorkspaces()
@@ -130,8 +133,8 @@ func (s *P) TestEnumWorkspacesInstancesOnly(c *C) {
 }
 
 func (s *P) TestEnumWorkspacesSomeOrphanedInstances(c *C) {
-	s.Backend.LaunchWorkspaceInstance("instance1", "ubuntu@20.04", "projectId")
-	s.Backend.LaunchWorkspaceInstance("project1", "ubuntu@20.04", "projectId")
+	s.Backend.LaunchWorkspace(s.ctx, "instance1", "ubuntu@20.04")
+	s.Backend.LaunchWorkspace(s.ctx, "project1", "ubuntu@20.04")
 
 	project := Project{fs: s.Fs, backend: s.Backend, path: "/", projectId: "projectId"}
 	afero.WriteFile(s.Fs, ".workspace.project1.yaml", []byte(""), 0644)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -72,6 +72,9 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
+	ctx, cancel := BackendContext(tomb, project)
+	defer cancel()
+
 	fmt.Printf("Setting up SDK \"%s\" from %s revision %d...\n", blob.Name, blob.Channel, blob.Revision)
 
 	sdkMount := sdkBlobDevice(blob)
@@ -118,7 +121,7 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 		Stdin:   nil,
 		Stdout:  outerr,
 		Stderr:  outerr}
-	done, err := m.backend.Exec(workspace, project.ProjectId, &args)
+	done, err := m.backend.Exec(ctx, workspace, &args)
 
 	if err != nil {
 		hookLog, _ := afero.ReadFile(memFs, outerr.Name())

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -69,8 +69,6 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	st := task.State()
-	st.Lock()
-	defer st.Unlock()
 
 	ctx, cancel := BackendContext(tomb, project)
 	defer cancel()
@@ -124,7 +122,9 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 
 	if err != nil {
 		hookLog, _ := afero.ReadFile(memFs, outerr.Name())
+		st.Lock()
 		task.Logf(string(hookLog))
+		st.Unlock()
 	}
 
 	/* The server will close this channel when exec is finished and no i/o remains outstanding */

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -152,7 +152,7 @@ func (s *H) TestDoInstallSdkExecFail(c *C) {
 	c.Check(strings.HasSuffix(t1.Log()[0], os.ErrDeadlineExceeded.Error()), Equals, true)
 }
 
-func (s *H) TestunDoInstallSdk(c *C) {
+func (s *H) TestUndoInstallSdkSuccess(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -233,7 +233,7 @@ func (s *H) TestDoLinkSdkSuccess(c *C) {
 		"{\"new\":[{\"channel\":\"latest/stable\",\"revision\":2}]}")
 }
 
-func (s *H) TestunDoLinkSdkSuccess(c *C) {
+func (s *H) TestUndoLinkSdkAndRemoveSdk(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -270,5 +270,51 @@ func (s *H) TestunDoLinkSdkSuccess(c *C) {
 	props, _ := s.backend.GetWorkspace("ws", "projectId")
 	_, ok := props.Config["user.workspace.sdk"]
 	c.Check(ok, Equals, false)
+	c.Check(link.Status(), Equals, state.UndoneStatus)
+}
+
+func (s *H) TestUndoLinkToPreviousSdk(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	projectKey := projectstate.ProjectKey{
+		Path:      "/project/Path",
+		ProjectId: "projectId",
+	}
+
+	newSdk := store.SdkBlob{"new", "latest/stable", 2}
+	t := s.state.NewTask("fake-task", "retrieve")
+	t.Set("sdk-setup", newSdk)
+	link := s.state.NewTask("link-sdk", "test")
+	link.Set("sdk-retrieve-task", t.ID())
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(link)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.Set("workspace", "ws")
+	chg.Set("project-key", &projectKey)
+	chg.AddTask(link)
+	chg.AddTask(t)
+	chg.AddTask(terr)
+
+	previousSdkRev := "{\"new\":[{\"channel\":\"latest/stable\",\"revision\":277}]}"
+	s.backend.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
+	s.backend.AddWorkspaceConfig("ws", "projectId", &workspacebackend.WorkspaceConfigValue{
+		Name:  "user.workspace.sdk",
+		Value: previousSdkRev,
+	})
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	props, _ := s.backend.GetWorkspace("ws", "projectId")
+	_, ok := props.Config["user.workspace.sdk"]
+	c.Check(ok, Equals, true)
+	c.Check(props.Config["user.workspace.sdk"], Equals, previousSdkRev)
 	c.Check(link.Status(), Equals, state.UndoneStatus)
 }

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -1,6 +1,7 @@
 package sdkstate_test
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ type H struct {
 	runner  *state.TaskRunner
 	se      *overlord.StateEngine
 	wsmgr   *sdkstate.SdkManager
+	ctx     context.Context
 }
 
 var _ = Suite(&H{})
@@ -41,6 +43,8 @@ var ErrTrigger = errors.New("error out")
 
 func (s *H) SetUpTest(c *C) {
 	s.fs = afero.NewMemMapFs()
+	s.ctx = context.WithValue(context.TODO(), workspacebackend.ContextProjectId, "projectId")
+
 	s.backend = workspacebackend.NewFakeWorkspaceBackend()
 
 	s.state = state.New(nil)
@@ -82,7 +86,7 @@ func (s *H) TestDoInstallSdkSuccess(c *C) {
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
-	s.backend.LaunchWorkspaceInstance("ws", "ubuntu@20.04", "projectId")
+	s.backend.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
 	s.backend.DoExec = func(name, project_id string, args *workspacebackend.ExecArgs) (chan bool, error) {
 		c.Assert(args.Command, DeepEquals, []string{
 			"tar",
@@ -128,7 +132,7 @@ func (s *H) TestDoInstallSdkExecFail(c *C) {
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
-	s.backend.LaunchWorkspaceInstance("ws", "ubuntu@20.04", "projectId")
+	s.backend.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
 	s.backend.DoExec = func(name, project_id string, args *workspacebackend.ExecArgs) (chan bool, error) {
 		args.Stderr.Write([]byte(os.ErrDeadlineExceeded.Error()))
 		done := make(chan bool)
@@ -172,7 +176,7 @@ func (s *H) TestunDoInstallSdk(c *C) {
 	chg.AddTask(t)
 	chg.AddTask(terr)
 
-	s.backend.LaunchWorkspaceInstance("ws", "ubuntu@20.04", "projectId")
+	s.backend.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
 	/* emulate install behaviour that unpacks an SDK to a certain directory */
 	s.backend.DoExec = func(name, project_id string, args *workspacebackend.ExecArgs) (chan bool, error) {
 		s.backend.Fs.MkdirAll(filepath.Join(util.WorkspaceSdksDir, "new"), 0755)
@@ -214,7 +218,7 @@ func (s *H) TestDoLinkSdkSuccess(c *C) {
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
-	s.backend.LaunchWorkspaceInstance("ws", "ubuntu@20.04", "projectId")
+	s.backend.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
 
 	s.state.Unlock()
 	s.se.Ensure()
@@ -253,7 +257,7 @@ func (s *H) TestunDoLinkSdkSuccess(c *C) {
 	chg.AddTask(t)
 	chg.AddTask(terr)
 
-	s.backend.LaunchWorkspaceInstance("ws", "ubuntu@20.04", "projectId")
+	s.backend.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {

--- a/internal/overlord/sharedstate/helpers.go
+++ b/internal/overlord/sharedstate/helpers.go
@@ -1,11 +1,14 @@
 package sharedstate
 
 import (
+	"context"
 	"fmt"
 
 	store "github.com/canonical/workspace/internal/fakestore"
 	"github.com/canonical/workspace/internal/overlord/projectstate"
 	"github.com/canonical/workspace/internal/overlord/state"
+	"github.com/canonical/workspace/internal/workspacebackend"
+	"gopkg.in/tomb.v2"
 )
 
 func SdkSetup(task *state.Task) (*store.SdkBlob, error) {
@@ -55,4 +58,11 @@ func ProjectAndWorkspace(task *state.Task) (*projectstate.ProjectKey, string, er
 	}
 
 	return &project, name, nil
+}
+
+func BackendContext(tomb *tomb.Tomb, project *projectstate.ProjectKey) (context.Context, context.CancelFunc) {
+	ctx := tomb.Context(context.TODO())
+	ctxProject := context.WithValue(ctx, workspacebackend.ContextProjectId, project.ProjectId)
+	ctxCancel, cancel := context.WithCancel(ctxProject)
+	return ctxCancel, cancel
 }

--- a/internal/overlord/sharedstate/helpers.go
+++ b/internal/overlord/sharedstate/helpers.go
@@ -61,7 +61,7 @@ func ProjectAndWorkspace(task *state.Task) (*projectstate.ProjectKey, string, er
 }
 
 func BackendContext(tomb *tomb.Tomb, project *projectstate.ProjectKey) (context.Context, context.CancelFunc) {
-	ctx := tomb.Context(context.TODO())
+	ctx := tomb.Context(context.Background())
 	ctxProject := context.WithValue(ctx, workspacebackend.ContextProjectId, project.ProjectId)
 	ctxCancel, cancel := context.WithCancel(ctxProject)
 	return ctxCancel, cancel

--- a/internal/overlord/state/taskrunner.go
+++ b/internal/overlord/state/taskrunner.go
@@ -367,8 +367,8 @@ ConsiderTasks:
 		}
 
 		tb := r.tombs[t.ID()]
-
 		if t.Status() == AbortStatus {
+			logger.Debugf("%v %v", t.Summary(), t.Status())
 			if tb != nil {
 				tb.Kill(nil)
 				continue

--- a/internal/overlord/workspacestate/handlers.go
+++ b/internal/overlord/workspacestate/handlers.go
@@ -86,10 +86,13 @@ func (m *WorkspaceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 
 	st := task.State()
 	st.Lock()
-	defer st.Unlock()
+
+	ctx, cancel := BackendContext(tomb, project)
+	defer cancel()
 
 	/* Start the workspace. TODO: make sure that we have it ready before attempting to proceed */
 	err = m.backend.SetWorkspaceState(workspace, project.ProjectId, "start")
+	st.Unlock()
 	if err != nil {
 		return err
 	}
@@ -107,7 +110,7 @@ func (m *WorkspaceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 		Stdout:  nil,
 		Stderr:  nil}
 
-	if done, err := m.backend.Exec(workspace, project.ProjectId, &args); err != nil {
+	if done, err := m.backend.Exec(ctx, workspace, &args); err != nil {
 		return err
 	} else {
 		<-done

--- a/internal/overlord/workspacestate/handlers.go
+++ b/internal/overlord/workspacestate/handlers.go
@@ -22,7 +22,7 @@ func (m *WorkspaceManager) undoCreateWorkspace(task *state.Task, tomb *tomb.Tomb
 	st.Lock()
 	defer st.Unlock()
 
-	return m.backend.DeleteWorkspaceInstance(workspace, project.ProjectId)
+	return m.backend.DeleteWorkspace(workspace, project.ProjectId)
 }
 
 func (m *WorkspaceManager) doCreateWorkspace(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workspacestate/handlers.go
+++ b/internal/overlord/workspacestate/handlers.go
@@ -35,6 +35,9 @@ func (m *WorkspaceManager) doCreateWorkspace(task *state.Task, tomb *tomb.Tomb) 
 	st.Lock()
 	defer st.Unlock()
 
+	ctx, cancel := BackendContext(tomb, project)
+	defer cancel()
+
 	var base string
 	err = task.Get("base", &base)
 
@@ -43,9 +46,10 @@ func (m *WorkspaceManager) doCreateWorkspace(task *state.Task, tomb *tomb.Tomb) 
 	}
 
 	fmt.Printf("Setting up workspace \"%s\"...\n", workspace)
+
 	/* Launch a workspace with the required base */
-	return m.backend.LaunchWorkspaceInstance(workspace,
-		base, project.ProjectId)
+	return m.backend.LaunchWorkspace(ctx, workspace,
+		base)
 }
 
 func (m *WorkspaceManager) doMountProject(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -14,13 +14,30 @@ func Launch(st *state.State, file *workspacebackend.WorkspaceFile) (*state.TaskS
 	install := state.NewTaskSet([]*state.Task{}...)
 	setupHook := state.NewTaskSet([]*state.Task{}...)
 
+	prevInstall := (*state.TaskSet)(nil)
+	prevSetup := (*state.Task)(nil)
 	for _, sdk := range file.Sdks {
 		r := sdkstate.Retrieve(st, &sdk)
 		retrieve.AddTask(r)
 
-		install.AddAll(sdkstate.Install(st, &sdk, r.ID()))
+		/* install task sets must not run concurrently as exec ops are not allowed
+		by LXD to be run concurrently */
+		installTaskSet := sdkstate.Install(st, &sdk, r.ID())
+		if prevInstall != nil {
+			installTaskSet.WaitAll(prevInstall)
+		} else {
+			prevInstall = installTaskSet
+		}
+		install.AddAll(installTaskSet)
 
-		setupHook.AddTask(hookstate.SetupHook(st, &sdk, r.ID()))
+		/* Make sure that the hook tasks are not concurrent */
+		setupHookTask := hookstate.SetupHook(st, &sdk, r.ID())
+		if prevSetup != nil {
+			setupHookTask.WaitFor(prevSetup)
+		} else {
+			prevSetup = setupHookTask
+		}
+		setupHook.AddTask(setupHookTask)
 	}
 
 	create := st.NewTask("create-workspace", fmt.Sprintf("Create workspace %q", file.Name))

--- a/internal/timeutil/export_test.go
+++ b/internal/timeutil/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timeutil
+
+var (
+	HumanTimeSince = humanTimeSince
+)

--- a/internal/timeutil/human.go
+++ b/internal/timeutil/human.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timeutil
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/canonical/x-go/i18n"
+)
+
+var (
+	timeNow = time.Now
+)
+
+// start-of-day
+func sod(t time.Time) time.Time {
+	y, m, d := t.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, t.Location())
+}
+
+// Human turns the time into a relative expression of time meant for human
+// consumption.
+// Human(t)  --> "today at 07:47"
+func Human(then time.Time) string {
+	return humanTimeSince(then.Local(), time.Now().Local(), 60)
+}
+
+func delta(then, now time.Time) int {
+	if then.After(now) {
+		return -delta(now, then)
+	}
+
+	then = sod(then)
+	now = sod(now)
+
+	n := int(then.Sub(now).Hours() / 24)
+	now = now.AddDate(0, 0, n)
+	for then.Before(now) {
+		then = then.AddDate(0, 0, 1)
+		n--
+	}
+	return n
+}
+
+func humanTimeSince(then, now time.Time, cutoffDays int) string {
+	d := delta(then, now)
+	switch {
+	case d < -cutoffDays || d > cutoffDays:
+		return then.Format("2006-01-02")
+	case d < -1:
+		// TRANSLATORS: %d will be at least 2; the singular is only included to help gettext
+		return fmt.Sprintf(then.Format(i18n.NG("%d day ago, at 15:04 MST", "%d days ago, at 15:04 MST", -d)), -d)
+	case d == -1:
+		return then.Format(i18n.G("yesterday at 15:04 MST"))
+	case d == 0:
+		return then.Format(i18n.G("today at 15:04 MST"))
+	case d == 1:
+		return then.Format(i18n.G("tomorrow at 15:04 MST"))
+	case d > 1:
+		// TRANSLATORS: %d will be at least 2; the singular is only included to help gettext
+		return fmt.Sprintf(then.Format(i18n.NG("in %d day, at 15:04 MST", "in %d days, at 15:04 MST", d)), d)
+	default:
+		// the following message is brought to you by Joel Armando, the self-described awesome and sexy mathematician.
+		panic("you have broken the law of trichotomy! ℤ is no longer totally ordered! chaos ensues!")
+	}
+}
+
+// MockTimeNow mocks the time.Now() calls used in the timeutil package.
+func MockTimeNow(f func() time.Time) (restorer func()) {
+	origTimeNow := timeNow
+	timeNow = f
+	return func() { timeNow = origTimeNow }
+}

--- a/internal/timeutil/human_test.go
+++ b/internal/timeutil/human_test.go
@@ -1,0 +1,93 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timeutil_test
+
+import (
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/timeutil"
+)
+
+type humanSuite struct {
+	beforeDSTbegins, afterDSTbegins, beforeDSTends, afterDSTends time.Time
+}
+
+var _ = check.Suite(&humanSuite{})
+
+func (s *humanSuite) SetUpSuite(c *check.C) {
+	loc, err := time.LoadLocation("Europe/London")
+	c.Assert(err, check.IsNil)
+
+	s.beforeDSTbegins = time.Date(2017, 3, 26, 0, 59, 0, 0, loc)
+	// note this is actually 2:01am DST
+	s.afterDSTbegins = time.Date(2017, 3, 26, 1, 1, 0, 0, loc)
+
+	// apparently no way to straight out initialise a time inside the DST overlap
+	s.beforeDSTends = time.Date(2017, 10, 29, 0, 59, 0, 0, loc).Add(60 * time.Minute)
+	s.afterDSTends = time.Date(2017, 10, 29, 1, 1, 0, 0, loc)
+
+	// validity check
+	c.Check(s.beforeDSTbegins.Format("MST"), check.Equals, s.afterDSTends.Format("MST"))
+	c.Check(s.beforeDSTbegins.Format("MST"), check.Equals, "GMT")
+	c.Check(s.afterDSTbegins.Format("MST"), check.Equals, s.beforeDSTends.Format("MST"))
+	c.Check(s.afterDSTbegins.Format("MST"), check.Equals, "BST")
+
+	// “The month, day, hour, min, sec, and nsec values may be outside their
+	//  usual ranges and will be normalized during the conversion.”
+	// so you can always add or subtract 1 from a day and it'll just work \o/
+	c.Check(time.Date(2017, -1, -1, -1, -1, -1, 0, loc), check.DeepEquals, time.Date(2016, 10, 29, 22, 58, 59, 0, loc))
+	c.Check(time.Date(2017, 13, 32, 25, 61, 63, 0, loc), check.DeepEquals, time.Date(2018, 2, 2, 2, 2, 3, 0, loc))
+}
+
+func (s *humanSuite) TestHumanTimeDST(c *check.C) {
+	c.Check(timeutil.HumanTimeSince(s.beforeDSTbegins, s.afterDSTbegins, 300), check.Equals, "today at 00:59 GMT")
+	c.Check(timeutil.HumanTimeSince(s.beforeDSTends, s.afterDSTends, 300), check.Equals, "today at 01:59 BST")
+	c.Check(timeutil.HumanTimeSince(s.beforeDSTbegins, s.afterDSTends, 300), check.Equals, "217 days ago, at 00:59 GMT")
+}
+
+func (s *humanSuite) TestHumanTimeDSTMore(c *check.C) {
+	loc, err := time.LoadLocation("Europe/London")
+	c.Assert(err, check.IsNil)
+	d0 := time.Date(2018, 3, 23, 13, 14, 15, 0, loc)
+	df := time.Date(2018, 3, 25, 13, 14, 15, 0, loc)
+	c.Check(timeutil.HumanTimeSince(d0, df, 300), check.Equals, "2 days ago, at 13:14 GMT")
+	c.Check(timeutil.HumanTimeSince(df, d0, 300), check.Equals, "in 2 days, at 13:14 BST")
+}
+
+func (*humanSuite) TestHuman(c *check.C) {
+	now := time.Now()
+
+	for i, expected := range []string{
+		"2 days ago, at ", "yesterday at ", "today at ", "tomorrow at ", "in 2 days, at ",
+	} {
+		t := now.AddDate(0, 0, i-2)
+		timePart := t.Format("15:04 MST")
+		c.Check(timeutil.Human(t), check.Equals, expected+timePart)
+	}
+
+	// two outside of the 60-day cutoff:
+	d1 := now.AddDate(0, -3, 0)
+	d2 := now.AddDate(0, 3, 0)
+	c.Check(timeutil.Human(d1), check.Equals, d1.Format("2006-01-02"))
+	c.Check(timeutil.Human(d2), check.Equals, d2.Format("2006-01-02"))
+
+}

--- a/internal/workspacebackend/backend.go
+++ b/internal/workspacebackend/backend.go
@@ -13,7 +13,6 @@ import (
 	lxd "github.com/lxc/lxd/client"
 
 	"github.com/lxc/lxd/shared/api"
-	"github.com/spf13/afero"
 )
 
 type ErrExec struct {
@@ -65,7 +64,6 @@ type ExecArgs struct {
 }
 
 type LxdBackend struct {
-	lxd.InstanceServer
 }
 
 const LxdSock = "/var/snap/lxd/common/lxd/unix.socket"
@@ -111,38 +109,15 @@ type WorkspaceBackend interface {
 	Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error)
 }
 
-func (s *LxdBackend) connect(fs afero.Fs) (lxd.InstanceServer, error) {
-	project, err := GetLXDProjectName()
-	if err != nil {
-		return nil, err
-	}
-	if ok, err := afero.Exists(fs, LxdSock); err != nil {
-		return nil, err
-	} else if ok {
-		if srv, err := lxd.ConnectLXDUnix(LxdSock, nil); err != nil {
-			return nil, err
-		} else {
-			return srv.UseProject(project), nil
-		}
-	} else {
-		if srv, err := lxd.ConnectLXDUnix("", nil); err != nil {
-			return nil, err
-		} else {
-			return srv.UseProject(project), nil
-		}
-	}
-}
-
 func New() (WorkspaceBackend, error) {
 	server := LxdBackend{}
-	fs := afero.NewOsFs()
-	if lxdInst, err := server.connect(fs); err != nil {
+
+	if lxdInst, err := server.getLxdClient(context.Background()); err != nil {
 		return nil, err
 	} else {
 		if err = InitProject(lxdInst); err != nil {
 			return nil, err
 		}
-		server.InstanceServer = lxdInst
 	}
 
 	return &server, nil
@@ -153,29 +128,34 @@ func (s *LxdBackend) LaunchWorkspace(ctx context.Context, name, base string) err
 	var imageSrv lxd.ImageServer
 	var image *api.Image
 
+	conn, err := s.getLxdClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	projectId, ok := ctx.Value(ContextProjectId).(string)
 	if !ok {
 		return fmt.Errorf("context key project-id not found")
 	}
 
 	/* Skip if the instance exists already */
-	if _, _, err := s.getLxdInstance(name, projectId); err == nil {
+	if _, _, err := conn.GetInstance(util.ToInstanceName(name, projectId)); err == nil {
 		return fmt.Errorf("workspace \"%s\" already exists", name)
 	}
 
 	/* Check if we have the base image stored locally */
-	if alias, _, err := s.GetImageAlias(base); err == nil {
-		if image, _, err = s.GetImage(alias.Target); err != nil {
+	if alias, _, err := conn.GetImageAlias(base); err == nil {
+		if image, _, err = conn.GetImage(alias.Target); err != nil {
 			return err
 		}
-		imageSrv = s
+		imageSrv = conn
 	} else {
 		imageSrv, image, err = s.fetchRemoteImage(base)
 		if err != nil {
 			return err
 		}
 
-		defer s.CreateImageAlias(api.ImageAliasesPost{ImageAliasesEntry: api.ImageAliasesEntry{
+		defer conn.CreateImageAlias(api.ImageAliasesPost{ImageAliasesEntry: api.ImageAliasesEntry{
 			Name: base,
 			ImageAliasesEntryPut: api.ImageAliasesEntryPut{
 				Target: image.Fingerprint,
@@ -201,12 +181,310 @@ func (s *LxdBackend) LaunchWorkspace(ctx context.Context, name, base string) err
 			Project:     projectName,
 		},
 	}
-	op, err := s.CreateInstanceFromImage(imageSrv, *image, req)
+	op, err := conn.CreateInstanceFromImage(imageSrv, *image, req)
 	if err != nil {
 		return err
 	}
 
 	return op.Wait()
+}
+
+func (s *LxdBackend) SetWorkspaceState(name, projectId, action string) error {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return err
+	}
+
+	inst, _, err := conn.GetInstance(util.ToInstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+
+	/* Do nothing if the instance is already in the desired state */
+	if (inst.StatusCode == api.Running && action == "start") ||
+		(inst.StatusCode == api.Stopped && action == "stop") {
+		return nil
+	}
+
+	req := api.InstanceStatePut{
+		Action:  action,
+		Timeout: 5,
+		Force:   false,
+	}
+
+	op, err := conn.UpdateInstanceState(inst.Name, req, "")
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (s *LxdBackend) AddWorkspaceConfig(name, projectId string, item *WorkspaceConfigValue) error {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return err
+	}
+
+	inst, etag, err := conn.GetInstance(util.ToInstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+	inst.Config[item.Name] = item.Value
+	op, _ := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+
+	return op.Wait()
+}
+
+func (s *LxdBackend) RemoveWorkspaceConfig(name, projectId string, key string) error {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return err
+	}
+
+	inst, etag, err := conn.GetInstance(util.ToInstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+
+	delete(inst.Config, key)
+	op, _ := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+
+	return op.Wait()
+}
+
+func (s *LxdBackend) AddWorkspaceDevice(name, projectId string, device WorkspaceDevice) error {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return err
+	}
+
+	inst, etag, err := conn.GetInstance(util.ToInstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+	inst.Devices[device.Name] = device.Properties
+	op, _ := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+
+	return op.Wait()
+}
+
+func (s *LxdBackend) RemoveWorkspaceDevice(name, projectId, device string) error {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return err
+	}
+
+	inst, etag, err := conn.GetInstance(util.ToInstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+
+	delete(inst.Devices, device)
+	op, _ := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+
+	return op.Wait()
+}
+
+func (s *LxdBackend) Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error) {
+	conn, err := s.getLxdClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	projectId, ok := ctx.Value(ContextProjectId).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key project-id not found")
+	}
+
+	req := api.InstanceExecPost{
+		Command: args.Command, WaitForWS: true,
+		User: 0, Group: 0, Cwd: args.WorkDir,
+		Interactive: false,
+	}
+
+	done := make(chan bool)
+
+	arg := lxd.InstanceExecArgs{
+		Stdin: args.Stdin, Stdout: args.Stdout, Stderr: args.Stderr,
+		Control: nil, DataDone: done,
+	}
+
+	op, err := conn.ExecInstance(util.ToInstanceName(name, projectId), req, &arg)
+
+	if err != nil {
+		return done, err
+	}
+
+	if err := op.WaitContext(ctx); err != nil {
+		return done, err
+	}
+
+	if status, ok := op.Get().Metadata["return"].(float64); ok {
+		if status != 0 {
+			logger.Debugf("command execution failed with %v", int(status))
+			return done, &ErrExec{Status: int(status)}
+		}
+	}
+
+	return done, nil
+}
+
+func (s *LxdBackend) AddWorkspacesConfig(filter WorkspaceConfigFilter, item *WorkspaceConfigValue) error {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return err
+	}
+
+	inst, err := conn.GetInstances(api.InstanceTypeContainer)
+	if err != nil {
+		return err
+	}
+
+	for _, i := range inst {
+		if filter(i.Config) {
+			i.Config[item.Name] = item.Value
+			conn.UpdateInstance(i.Name, i.InstancePut, "")
+		}
+	}
+
+	return nil
+}
+
+func (s *LxdBackend) GetWorkspace(name, projectId string) (*WorkspaceProps, error) {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	inst, _, err := conn.GetInstance(util.ToInstanceName(name, projectId))
+	if err != nil {
+		return nil, err
+	}
+	return &WorkspaceProps{
+		Name:    name,
+		state:   fromLxdToWorkspaceState(inst.StatusCode),
+		Devices: inst.Devices,
+		Config:  inst.Config,
+	}, nil
+}
+
+func (s *LxdBackend) GetWorkspacesByConfig(filter WorkspaceConfigFilter) ([]*WorkspaceProps, error) {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	instances, err := conn.GetInstances(api.InstanceTypeContainer)
+	if err != nil {
+		return nil, err
+	}
+	var ws []*WorkspaceProps = make([]*WorkspaceProps, 0, len(instances))
+	for _, i := range instances {
+		if filter(i.Config) {
+			ws = append(ws, &WorkspaceProps{
+				Name:    util.ToWorkspaceName(i.Name),
+				state:   fromLxdToWorkspaceState(i.StatusCode),
+				Devices: i.Devices,
+				Config:  i.Config,
+			})
+		}
+	}
+
+	return ws, nil
+}
+
+func (s *LxdBackend) GetWorkspacesByDevices(filter WorkspaceDeviceFilter) (map[string]*WorkspaceProps, error) {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	instances, err := conn.GetInstances(api.InstanceTypeContainer)
+	if err != nil {
+		return nil, err
+	}
+	var ws map[string]*WorkspaceProps = make(map[string]*WorkspaceProps, len(instances))
+	for _, i := range instances {
+		if filter(i.Devices) {
+			name := util.ToWorkspaceName(i.Name)
+			ws[name] = &WorkspaceProps{
+				Name:    name,
+				state:   fromLxdToWorkspaceState(i.StatusCode),
+				Devices: i.Devices,
+				Config:  i.Config,
+			}
+
+		}
+	}
+
+	return ws, nil
+}
+
+func (s *LxdBackend) DeleteWorkspaceInstance(name, projectId string) error {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return err
+	}
+
+	inst, _, err := conn.GetInstance(util.ToInstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+
+	if inst.StatusCode != 0 && inst.StatusCode != api.Stopped {
+		return fmt.Errorf("cannot delete a non-stopped workspace: %q", name)
+	}
+
+	op, err := conn.DeleteInstance(util.ToInstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
+}
+
+func (s *LxdBackend) GetWorkspaceFs(name, project_id string) (WorkspaceFs, error) {
+	conn, err := s.getLxdClient(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	sftp, err := conn.GetInstanceFileSFTP(util.ToInstanceName(name, project_id))
+	if err != nil {
+		return nil, err
+	}
+
+	return NewWorkspaceFs(sftp), nil
+}
+
+func (s *LxdBackend) getLxdClient(ctx context.Context) (lxd.InstanceServer, error) {
+	project, err := GetLXDProjectName()
+	if err != nil {
+		return nil, err
+	}
+	if srv, err := lxd.ConnectLXDUnixWithContext(ctx, LxdSock, nil); err != nil {
+		return nil, err
+	} else {
+		return srv.UseProject(project), nil
+	}
+}
+
+func fromLxdToWorkspaceState(lxdStatus api.StatusCode) util.WorkspaceState {
+	var state util.WorkspaceState
+	switch lxdStatus {
+	case api.Running, api.Ready:
+		state = util.Ready
+	case api.Stopped:
+		state = util.Stopped
+	default:
+		state = util.Pending
+	}
+	return state
 }
 
 func defaultDevices() map[string]map[string]string {
@@ -248,238 +526,6 @@ func (s *LxdBackend) fetchRemoteImage(base string) (lxd.ImageServer, *api.Image,
 	}
 
 	return imageServer, image, nil
-}
-
-func (s *LxdBackend) SetWorkspaceState(name, project_id, action string) error {
-	inst, _, err := s.getLxdInstance(name, project_id)
-	if err != nil {
-		return err
-	}
-
-	/* Do nothing if the instance is already in the desired state */
-	if (inst.StatusCode == api.Running && action == "start") ||
-		(inst.StatusCode == api.Stopped && action == "stop") {
-		return nil
-	}
-
-	req := api.InstanceStatePut{
-		Action:  action,
-		Timeout: 5,
-		Force:   false,
-	}
-
-	op, err := s.UpdateInstanceState(inst.Name, req, "")
-	if err != nil {
-		return err
-	}
-
-	err = op.Wait()
-	if err != nil {
-		return err
-	}
-	return err
-}
-
-func (s *LxdBackend) AddWorkspaceConfig(name, project_id string, item *WorkspaceConfigValue) error {
-	inst, etag, err := s.getLxdInstance(name, project_id)
-	if err != nil {
-		return err
-	}
-	inst.Config[item.Name] = item.Value
-	op, _ := s.UpdateInstance(inst.Name, inst.InstancePut, etag)
-
-	return op.Wait()
-}
-
-func (s *LxdBackend) RemoveWorkspaceConfig(name, project_id string, key string) error {
-	inst, etag, err := s.getLxdInstance(name, project_id)
-	if err != nil {
-		return err
-	}
-
-	delete(inst.Config, key)
-	op, _ := s.UpdateInstance(inst.Name, inst.InstancePut, etag)
-
-	return op.Wait()
-}
-
-func (s *LxdBackend) getLxdInstance(name, project_id string) (instance *api.Instance, ETag string, err error) {
-	return s.GetInstance(util.ToInstanceName(name, project_id))
-}
-
-func (s *LxdBackend) AddWorkspaceDevice(name, project_id string, device WorkspaceDevice) error {
-	inst, etag, err := s.getLxdInstance(name, project_id)
-	if err != nil {
-		return err
-	}
-	inst.Devices[device.Name] = device.Properties
-	op, _ := s.UpdateInstance(inst.Name, inst.InstancePut, etag)
-
-	return op.Wait()
-}
-
-func (s *LxdBackend) RemoveWorkspaceDevice(name, project_id, device string) error {
-	inst, etag, err := s.getLxdInstance(name, project_id)
-	if err != nil {
-		return err
-	}
-
-	delete(inst.Devices, device)
-	op, _ := s.UpdateInstance(inst.Name, inst.InstancePut, etag)
-
-	return op.Wait()
-}
-
-func (s *LxdBackend) Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error) {
-	projectId, ok := ctx.Value(ContextProjectId).(string)
-	if !ok {
-		return nil, fmt.Errorf("context key project-id not found")
-	}
-
-	req := api.InstanceExecPost{
-		Command: args.Command, WaitForWS: true,
-		User: 0, Group: 0, Cwd: args.WorkDir,
-		Interactive: false,
-	}
-
-	done := make(chan bool)
-
-	arg := lxd.InstanceExecArgs{
-		Stdin: args.Stdin, Stdout: args.Stdout, Stderr: args.Stderr,
-		Control: nil, DataDone: done,
-	}
-
-	op, err := s.ExecInstance(util.ToInstanceName(name, projectId), req, &arg)
-
-	if err != nil {
-		return done, err
-	}
-
-	logger.Debugf("Start waiting")
-	if err := op.WaitContext(ctx); err != nil {
-		return done, err
-	}
-	logger.Debugf("End waiting")
-
-	if status, ok := op.Get().Metadata["return"].(float64); ok {
-		if status != 0 {
-			logger.Debugf("command execution failed with %v", int(status))
-			return done, &ErrExec{Status: int(status)}
-		}
-	}
-
-	return done, nil
-}
-
-func (s *LxdBackend) AddWorkspacesConfig(filter WorkspaceConfigFilter, item *WorkspaceConfigValue) error {
-	inst, err := s.GetInstances(api.InstanceTypeContainer)
-	if err != nil {
-		return err
-	}
-
-	for _, i := range inst {
-		if filter(i.Config) {
-			i.Config[item.Name] = item.Value
-			s.UpdateInstance(i.Name, i.InstancePut, "")
-		}
-	}
-
-	return nil
-}
-
-func (s *LxdBackend) GetWorkspace(name, project_id string) (*WorkspaceProps, error) {
-	inst, _, err := s.getLxdInstance(name, project_id)
-	if err != nil {
-		return nil, err
-	}
-	return &WorkspaceProps{
-		Name:    name,
-		state:   fromLxdToWorkspaceState(inst.StatusCode),
-		Devices: inst.Devices,
-		Config:  inst.Config,
-	}, nil
-}
-
-func (s *LxdBackend) GetWorkspacesByConfig(filter WorkspaceConfigFilter) ([]*WorkspaceProps, error) {
-	instances, err := s.GetInstances(api.InstanceTypeContainer)
-	if err != nil {
-		return nil, err
-	}
-	var ws []*WorkspaceProps = make([]*WorkspaceProps, 0, len(instances))
-	for _, i := range instances {
-		if filter(i.Config) {
-			ws = append(ws, &WorkspaceProps{
-				Name:    util.ToWorkspaceName(i.Name),
-				state:   fromLxdToWorkspaceState(i.StatusCode),
-				Devices: i.Devices,
-				Config:  i.Config,
-			})
-		}
-	}
-
-	return ws, nil
-}
-
-func (s *LxdBackend) GetWorkspacesByDevices(filter WorkspaceDeviceFilter) (map[string]*WorkspaceProps, error) {
-	instances, err := s.GetInstances(api.InstanceTypeContainer)
-	if err != nil {
-		return nil, err
-	}
-	var ws map[string]*WorkspaceProps = make(map[string]*WorkspaceProps, len(instances))
-	for _, i := range instances {
-		if filter(i.Devices) {
-			name := util.ToWorkspaceName(i.Name)
-			ws[name] = &WorkspaceProps{
-				Name:    name,
-				state:   fromLxdToWorkspaceState(i.StatusCode),
-				Devices: i.Devices,
-				Config:  i.Config,
-			}
-
-		}
-	}
-
-	return ws, nil
-}
-
-func (s *LxdBackend) DeleteWorkspaceInstance(name, project_id string) error {
-	inst, _, err := s.getLxdInstance(name, project_id)
-	if err != nil {
-		return err
-	}
-
-	if inst.StatusCode != 0 && inst.StatusCode != api.Stopped {
-		return fmt.Errorf("cannot delete a non-stopped workspace: %q", name)
-	}
-
-	op, err := s.DeleteInstance(util.ToInstanceName(name, project_id))
-	if err != nil {
-		return err
-	}
-
-	return op.Wait()
-}
-
-func (s *LxdBackend) GetWorkspaceFs(name, project_id string) (WorkspaceFs, error) {
-	sftp, err := s.GetInstanceFileSFTP(util.ToInstanceName(name, project_id))
-	if err != nil {
-		return nil, err
-	}
-
-	return NewWorkspaceFs(sftp), nil
-}
-
-func fromLxdToWorkspaceState(lxdStatus api.StatusCode) util.WorkspaceState {
-	var state util.WorkspaceState
-	switch lxdStatus {
-	case api.Running, api.Ready:
-		state = util.Ready
-	case api.Stopped:
-		state = util.Stopped
-	default:
-		state = util.Pending
-	}
-	return state
 }
 
 /* Fake backend implementation for tests */

--- a/internal/workspacebackend/backend.go
+++ b/internal/workspacebackend/backend.go
@@ -91,7 +91,7 @@ func EveryWorkspace() WorkspaceConfigFilter {
 
 type WorkspaceBackend interface {
 	LaunchWorkspace(ctx context.Context, name, base string) error
-	DeleteWorkspaceInstance(name, project_id string) error
+	DeleteWorkspace(name, project_id string) error
 	SetWorkspaceState(name, action, project_id string) error
 
 	AddWorkspaceDevice(name, project_id string, props WorkspaceDevice) error
@@ -425,7 +425,7 @@ func (s *LxdBackend) GetWorkspacesByDevices(filter WorkspaceDeviceFilter) (map[s
 	return ws, nil
 }
 
-func (s *LxdBackend) DeleteWorkspaceInstance(name, projectId string) error {
+func (s *LxdBackend) DeleteWorkspace(name, projectId string) error {
 	conn, err := s.getLxdClient(context.Background())
 	if err != nil {
 		return err
@@ -567,7 +567,7 @@ func (f *FakeWorkspaceBackend) LaunchWorkspace(ctx context.Context, name, base s
 	return nil
 }
 
-func (f *FakeWorkspaceBackend) DeleteWorkspaceInstance(name string, project_id string) error {
+func (f *FakeWorkspaceBackend) DeleteWorkspace(name string, project_id string) error {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/internal/workspacebackend/backend.go
+++ b/internal/workspacebackend/backend.go
@@ -1,6 +1,7 @@
 package workspacebackend
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -71,6 +72,10 @@ const LxdSock = "/var/snap/lxd/common/lxd/unix.socket"
 
 var ConnectSimpleStreams = lxd.ConnectSimpleStreams
 
+type ContextKeyProjectId string
+
+const ContextProjectId = ContextKeyProjectId("project-id")
+
 type WorkspaceConfigFilter func(config map[string]string) bool
 type WorkspaceDeviceFilter func(devices map[string]map[string]string) bool
 
@@ -87,7 +92,7 @@ func EveryWorkspace() WorkspaceConfigFilter {
 }
 
 type WorkspaceBackend interface {
-	LaunchWorkspaceInstance(name, base, project_id string) error
+	LaunchWorkspace(ctx context.Context, name, base string) error
 	DeleteWorkspaceInstance(name, project_id string) error
 	SetWorkspaceState(name, action, project_id string) error
 
@@ -143,13 +148,18 @@ func New() (WorkspaceBackend, error) {
 	return &server, nil
 }
 
-func (s *LxdBackend) LaunchWorkspaceInstance(name, base, project_id string) error {
+func (s *LxdBackend) LaunchWorkspace(ctx context.Context, name, base string) error {
 	var err error
 	var imageSrv lxd.ImageServer
 	var image *api.Image
 
+	projectId, ok := ctx.Value(ContextProjectId).(string)
+	if !ok {
+		return fmt.Errorf("context key project-id not found")
+	}
+
 	/* Skip if the instance exists already */
-	if _, _, err := s.getLxdInstance(name, project_id); err == nil {
+	if _, _, err := s.getLxdInstance(name, projectId); err == nil {
 		return fmt.Errorf("workspace \"%s\" already exists", name)
 	}
 
@@ -181,9 +191,9 @@ func (s *LxdBackend) LaunchWorkspaceInstance(name, base, project_id string) erro
 	req := api.InstancesPost{
 		InstancePut: api.InstancePut{
 			Devices: defaultDevices(),
-			Config:  defaultConfig(project_id),
+			Config:  defaultConfig(projectId),
 		},
-		Name: util.ToInstanceName(name, project_id),
+		Name: util.ToInstanceName(name, projectId),
 		Type: api.InstanceType("container"),
 		Source: api.InstanceSource{
 			Type:        "image",
@@ -490,14 +500,15 @@ func (f *FakeWorkspaceBackend) workspace(name, project string) *WorkspaceProps {
 	return f.workspaces[project][name]
 }
 
-func (f *FakeWorkspaceBackend) LaunchWorkspaceInstance(name string, base string, project_id string) error {
-	if f.workspaces[project_id] == nil {
-		f.workspaces[project_id] = make(map[string]*WorkspaceProps)
+func (f *FakeWorkspaceBackend) LaunchWorkspace(ctx context.Context, name, base string) error {
+	projectId := ctx.Value(ContextProjectId).(string)
+	if f.workspaces[projectId] == nil {
+		f.workspaces[projectId] = make(map[string]*WorkspaceProps)
 	}
-	f.workspaces[project_id][name] = &WorkspaceProps{
+	f.workspaces[projectId][name] = &WorkspaceProps{
 		Name:    name,
 		Devices: defaultDevices(),
-		Config:  defaultConfig(project_id),
+		Config:  defaultConfig(projectId),
 		state:   util.Ready,
 	}
 	return nil

--- a/internal/workspacebackend/backend.go
+++ b/internal/workspacebackend/backend.go
@@ -108,7 +108,7 @@ type WorkspaceBackend interface {
 	GetWorkspacesByConfig(filter WorkspaceConfigFilter) ([]*WorkspaceProps, error)
 	GetWorkspacesByDevices(filter WorkspaceDeviceFilter) (map[string]*WorkspaceProps, error)
 
-	Exec(name, project_id string, args *ExecArgs) (chan bool, error)
+	Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error)
 }
 
 func (s *LxdBackend) connect(fs afero.Fs) (lxd.InstanceServer, error) {
@@ -330,7 +330,12 @@ func (s *LxdBackend) RemoveWorkspaceDevice(name, project_id, device string) erro
 	return op.Wait()
 }
 
-func (s *LxdBackend) Exec(name, project_id string, args *ExecArgs) (chan bool, error) {
+func (s *LxdBackend) Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error) {
+	projectId, ok := ctx.Value(ContextProjectId).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key project-id not found")
+	}
+
 	req := api.InstanceExecPost{
 		Command: args.Command, WaitForWS: true,
 		User: 0, Group: 0, Cwd: args.WorkDir,
@@ -344,15 +349,17 @@ func (s *LxdBackend) Exec(name, project_id string, args *ExecArgs) (chan bool, e
 		Control: nil, DataDone: done,
 	}
 
-	op, err := s.ExecInstance(util.ToInstanceName(name, project_id), req, &arg)
+	op, err := s.ExecInstance(util.ToInstanceName(name, projectId), req, &arg)
 
 	if err != nil {
 		return done, err
 	}
 
-	if err := op.Wait(); err != nil {
+	logger.Debugf("Start waiting")
+	if err := op.WaitContext(ctx); err != nil {
 		return done, err
 	}
+	logger.Debugf("End waiting")
 
 	if status, ok := op.Get().Metadata["return"].(float64); ok {
 		if status != 0 {
@@ -570,8 +577,9 @@ func (s *FakeWorkspaceBackend) GetWorkspaceFs(name, project_id string) (Workspac
 	return s.Fs, nil
 }
 
-func (f *FakeWorkspaceBackend) Exec(name string, project_id string, args *ExecArgs) (chan bool, error) {
-	return f.DoExec(name, project_id, args)
+func (f *FakeWorkspaceBackend) Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error) {
+	projectId := ctx.Value(ContextProjectId).(string)
+	return f.DoExec(name, projectId, args)
 }
 
 func DoExecDefault(name string, project_id string, args *ExecArgs) (chan bool, error) {

--- a/internal/workspacebackend/workspace_file_test.go
+++ b/internal/workspacebackend/workspace_file_test.go
@@ -1,6 +1,8 @@
 package workspacebackend_test
 
 import (
+	"testing"
+
 	util "github.com/canonical/workspace/internal"
 	"github.com/canonical/workspace/internal/workspacebackend"
 	"github.com/spf13/afero"
@@ -16,6 +18,8 @@ var _ = Suite(&F{})
 func (f *F) SetUpTest(c *C) {
 	f.fs = afero.NewMemMapFs()
 }
+
+func Test(t *testing.T) { TestingT(t) }
 
 func (f *F) TestWorkspaceFileParseNormal(c *C) {
 	buf := []byte(`name: xbert-gpu

--- a/tests/main/changes/task.yaml
+++ b/tests/main/changes/task.yaml
@@ -21,6 +21,6 @@ execute: |
   echo "Must reflect the latest change after the launch"
   project="$WORKSPACES"/test-empty-ubuntu20
   launch $project ws
-  changes $project | MATCH "^1[[:space:]]+Done[[:space:]]+$project[[:space:]]+Launch workspace \"ws\"$"
+  changes $project | MATCH "^1[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+$project[[:space:]]+Launch workspace \"ws\"$"
 
 


### PR DESCRIPTION
Some actions, such as launching, may require long running LXD operations (e.g. setup-hook) which the end user must have control over. This change introduces a Go context to the workspace back-end implementation which is passed to LXD operations as well and can be used to cancel the ongoing change immediately and undoing any progress that was made.