### PR TITLE
Do not block the state for the LXD instance's creation duration

### DIFF
--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -101,7 +101,7 @@ func New(dir string, b workspacebackend.WorkspaceBackend, restartHandler restart
 	for {
 		err = o.stateFileLock.TryLock()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Cannot start, could another workspace be running?")
+			fmt.Fprintln(os.Stderr, "Cannot start, could another workspaced be running?")
 			fmt.Fprintln(os.Stderr, "Retry in 5 seconds...")
 
 			time.Sleep(5 * time.Second)

--- a/internal/overlord/workspacestate/handlers.go
+++ b/internal/overlord/workspacestate/handlers.go
@@ -34,14 +34,14 @@ func (m *WorkspaceManager) doCreateWorkspace(task *state.Task, tomb *tomb.Tomb) 
 	}
 
 	st := task.State()
-	st.Lock()
-	defer st.Unlock()
 
 	ctx, cancel := BackendContext(tomb, user, project)
 	defer cancel()
 
 	var base string
+	st.Lock()
 	err = task.Get("base", &base)
+	st.Unlock()
 
 	if err != nil {
 		return fmt.Errorf("cannot get workspace base for task %q: %v", task.ID(), err)

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -21,7 +21,8 @@ func Launch(st *state.State, file *workspacebackend.WorkspaceFile, project *work
 		retrieve.AddTask(r)
 
 		/* install task sets must not run concurrently as exec ops are not allowed
-		by LXD to be run concurrently */
+		by LXD to be run concurrently and in general case we cannot guarantee safety of
+		concurrent installations */
 		installTaskSet := sdkstate.Install(st, sdk.Name, r.ID())
 		if prevInstall != nil {
 			installTaskSet.WaitAll(prevInstall)


### PR DESCRIPTION
The workspace's tasks should avoid locking the state for longer than necessary to update or read it. In this case, we used to lock the state in the "create-workspace" task until it is completed fully. This blocks any outside commands that do require state access and may not be conflicting with the resources that we operate on (e.g. launching another workspace). 