### PR TITLE
doc: update .readthedocs.yaml to look in docs/

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: dirhtml
-  configuration: conf.py
+  configuration: docs/conf.py
   fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
@@ -24,4 +24,4 @@ formats:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - requirements: .sphinx/requirements.txt
+   - requirements: /docs/.sphinx/requirements.txt


### PR DESCRIPTION
RTD was looking in root of project not in docs/ subdir.
RTD may not build fully yet - some conf.py tweaks to be done - but should be closer.