### PR TITLE
Workspace start

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -21,6 +21,9 @@ prepare: |
       publish_test_sdk_content "$SDKCONTENT" "$SDK_STORE_BUCKET_DIR"
       /bin/sh -c "nohup go run github.com/fsouza/fake-gcs-server@latest -data /data -scheme http -port 8080 -public-host localhost:8080 > ~/fake_sdk_store.log 2>&1 &"
 
+debug: |
+      lxc list -f compact --all-projects
+
 restore: |
       rm -rf /data
       rm -rf /storage

--- a/client/projects.go
+++ b/client/projects.go
@@ -86,3 +86,10 @@ func (client *Client) Refresh(projectId string, names []string, mode string) (ch
 		},
 	})
 }
+
+func (client *Client) Start(projectId string, names []string) (changeId string, err error) {
+	return client.doWorkspaceAction(projectId, &WorkspaceActionSetup{
+		Action: "start",
+		Names:  names,
+	})
+}

--- a/client/projects_test.go
+++ b/client/projects_test.go
@@ -62,3 +62,18 @@ func (cs *clientSuite) TestClientRefresh(c *check.C) {
 
 	c.Assert(string(body), check.Matches, `{"names":\["ws"\],"action":"refresh","options":{"refresh-mode":"transactional"}}\n`)
 }
+
+func (cs *clientSuite) TestClientStart(c *check.C) {
+	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
+
+	id, err := cs.cli.Start("42ws42ws", []string{"ws"})
+
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Assert(id, check.Equals, "24")
+	c.Assert(err, check.IsNil)
+
+	body, err := io.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(string(body), check.Matches, `{"names":\["ws"\],"action":"start"}\n`)
+}

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -64,6 +64,7 @@ func main() {
 	rootCmd.AddCommand((&CmdChanges{}).Command())
 	rootCmd.AddCommand((&CmdTasks{}).Command())
 	rootCmd.AddCommand((&CmdRefresh{}).Command())
+	rootCmd.AddCommand((&CmdStart{}).Command())
 
 	rootCmd.SilenceErrors = true
 

--- a/cmd/workspace/start.go
+++ b/cmd/workspace/start.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/canonical/workspace/client"
+	"github.com/spf13/cobra"
+)
+
+type CmdStart struct {
+	waitMixin
+}
+
+func (c *CmdStart) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "start <workspace>...",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Start one or many workspaces",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
+	var err error
+
+	cli, err := client.New(&ClientConfig)
+	if err != nil {
+		return fmt.Errorf("cannot create client: %v", err)
+	}
+
+	c.setClient(cli)
+
+	project, err := c.client.Project(Project)
+	if err != nil {
+		return err
+	}
+
+	changeId, err := c.client.Start(project.Id, av)
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.wait(changeId, false); err != nil {
+		if err == errNoWait {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/cmd/workspace/start.go
+++ b/cmd/workspace/start.go
@@ -31,6 +31,7 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
+	c.skipAbort = true
 
 	project, err := c.client.Project(Project)
 	if err != nil {

--- a/cmd/workspace/start_test.go
+++ b/cmd/workspace/start_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+)
+
+type WorkspaceStart struct {
+	BaseWorkspaceSuite
+	prjDir string
+	prjId  string
+}
+
+var _ = check.Suite(&WorkspaceStart{})
+
+func (m *WorkspaceStart) SetUpTest(c *check.C) {
+	m.prjDir = c.MkDir()
+	m.prjId = "42424242"
+	m.BaseWorkspaceSuite.SetUpTest(c)
+}
+
+func (m *WorkspaceStart) TestStartSuccess(c *check.C) {
+	cmd := &CmdStart{}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workspaces", m.prjId))
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
+			fmt.Fprintln(w, mockReadyChangeJSON)
+		default:
+			c.Errorf("expected 3 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"ws"})
+	c.Assert(err, check.IsNil)
+}

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -235,8 +235,8 @@ func v1PostProjectWorkspace(c *Command, r *http.Request, _ *userState) Response 
 			}
 
 			for _, name := range reqData.Names {
-				statecontext.StartRefresh(st, name, projectId, change.ID(),
-					refreshMode == statecontext.RefreshWaitOnError)
+				statecontext.StartOperation(st, name, projectId,
+					statecontext.Operation{ChangeId: change.ID(), Operation: statecontext.OperationRefresh, WaitOnError: refreshMode == statecontext.RefreshWaitOnError})
 			}
 		}
 

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -13,6 +13,8 @@ import (
 	"github.com/canonical/workspace/internal/workspacebackend"
 	"github.com/canonical/x-go/strutil"
 	"golang.org/x/exp/maps"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type SdkInfo struct {
@@ -183,17 +185,17 @@ func v1PostProjectWorkspace(c *Command, r *http.Request, _ *userState) Response 
 		return statusBadRequest("cannot %s: user is not known", reqData.Action)
 	}
 
+	var summary string
+	switch len(reqData.Names) {
+	case 1:
+		summary = fmt.Sprintf("%s workspace %q", cases.Title(language.BritishEnglish).String(reqData.Action), reqData.Names[0])
+	default:
+		summary = fmt.Sprintf("%s workspaces %s", cases.Title(language.BritishEnglish).String(reqData.Action), strutil.Quoted(reqData.Names))
+	}
+
 	var change *state.Change
 	switch reqData.Action {
 	case "launch":
-		var summary string
-		switch len(reqData.Names) {
-		case 1:
-			summary = fmt.Sprintf("Launch workspace %q", reqData.Names[0])
-		default:
-			summary = fmt.Sprintf("Launch workspaces %s", strutil.Quoted(reqData.Names))
-		}
-
 		change = st.NewChange("launch", summary)
 
 		taskset, err := wsmgr.LaunchMany(r.Context(), reqData.Names, projectId)
@@ -207,19 +209,21 @@ func v1PostProjectWorkspace(c *Command, r *http.Request, _ *userState) Response 
 	case "refresh":
 		refreshMode := statecontext.ParseRefreshMode(reqData.Options.Mode)
 
-		var summary string
-		switch len(reqData.Names) {
-		case 1:
-			summary = fmt.Sprintf("Refresh workspace %q", reqData.Names[0])
-		default:
-			summary = fmt.Sprintf("Refresh workspaces %s", strutil.Quoted(reqData.Names))
-		}
-
 		if len(reqData.Names) > 1 && refreshMode != statecontext.RefreshTransactional {
 			return statusBadRequest("wait-on-error is not supported for multiple workspaces")
 		}
 
 		if refreshMode == statecontext.RefreshTransactional || refreshMode == statecontext.RefreshWaitOnError {
+			// check if all the workspace are available for the operation
+			avail, ops, err := wsmgr.CheckStatus(r.Context(), reqData.Names, projectId, workspacebackend.WorkspaceReady)
+			if err != nil {
+				return statusBadRequest("cannot %s: %v", reqData.Action, err)
+			}
+
+			if !avail {
+				return statusConflict("cannot %s: operation is already in progress for %s", reqData.Action, strutil.Quoted(ops))
+			}
+
 			taskset, err := wsmgr.RefreshMany(r.Context(), reqData.Names, projectId)
 			if err != nil {
 				return statusBadRequest(err.Error())
@@ -243,7 +247,31 @@ func v1PostProjectWorkspace(c *Command, r *http.Request, _ *userState) Response 
 				return statusBadRequest(err.Error())
 			}
 		}
+	case "start":
+		// check if all the workspaces are stopped
+		avail, ops, err := wsmgr.CheckStatus(r.Context(), reqData.Names, projectId, workspacebackend.WorkspaceStopped)
+		if err != nil {
+			return statusBadRequest("cannot %s: %v", reqData.Action, err)
+		}
 
+		if !avail {
+			return statusConflict("cannot %s: %s must be stopped", reqData.Action, strutil.Quoted(ops))
+		}
+
+		taskset, err := wsmgr.StartMany(r.Context(), reqData.Names, projectId)
+		if err != nil {
+			return statusBadRequest(err.Error())
+		}
+
+		change = st.NewChange("start", summary)
+		for _, i := range taskset {
+			change.AddAll(i)
+		}
+
+		for _, name := range reqData.Names {
+			statecontext.StartOperation(st, name, projectId,
+				statecontext.Operation{ChangeId: change.ID(), Operation: statecontext.OperationStart})
+		}
 	default:
 		return statusBadRequest("unknown action")
 	}
@@ -254,7 +282,6 @@ func v1PostProjectWorkspace(c *Command, r *http.Request, _ *userState) Response 
 	ensureStateSoon(st, 0)
 
 	return AsyncResponse(nil, change.ID())
-
 }
 
 func v1GetProjectWorkspace(c *Command, r *http.Request, _ *userState) Response {

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -264,9 +264,7 @@ func v1PostProjectWorkspace(c *Command, r *http.Request, _ *userState) Response 
 		}
 
 		change = st.NewChange("start", summary)
-		for _, i := range taskset {
-			change.AddAll(i)
-		}
+		change.AddAll(taskset)
 
 		for _, name := range reqData.Names {
 			statecontext.StartOperation(st, name, projectId,

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -188,9 +188,9 @@ func v1PostProjectWorkspace(c *Command, r *http.Request, _ *userState) Response 
 	var summary string
 	switch len(reqData.Names) {
 	case 1:
-		summary = fmt.Sprintf("%s workspace %q", cases.Title(language.BritishEnglish).String(reqData.Action), reqData.Names[0])
+		summary = fmt.Sprintf("%s %q workspace", cases.Title(language.BritishEnglish).String(reqData.Action), reqData.Names[0])
 	default:
-		summary = fmt.Sprintf("%s workspaces %s", cases.Title(language.BritishEnglish).String(reqData.Action), strutil.Quoted(reqData.Names))
+		summary = fmt.Sprintf("%s %s workspaces", cases.Title(language.BritishEnglish).String(reqData.Action), strutil.Quoted(reqData.Names))
 	}
 
 	var change *state.Change

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -193,7 +193,7 @@ base: ubuntu@20.04`), 0644)
 	buffers := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["ws"],"action":"launch"}`),
 		bytes.NewBufferString(`{"names":[],"action":"launch"}`),
-		bytes.NewBufferString(`{"names":["ws", "ws1"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["ws1", "ws"],"action":"launch"}`),
 	}
 
 	requests := []*http.Request{}
@@ -252,6 +252,8 @@ func (s *apiSuite) TestProjectsPostProjectRefreshWorkspaceContinue(c *check.C) {
 	projectsCmd := apiCmd("/v1/projects/{id}/workspaces")
 	s.vars = map[string]string{"id": s.project.ProjectId}
 	os.WriteFile(filepath.Join(s.workspaceDir, ".workspace.ws.yaml"), []byte(`name: ws
+base: ubuntu@20.04`), 0644)
+	os.WriteFile(filepath.Join(s.workspaceDir, ".workspace.ws1.yaml"), []byte(`name: ws1
 base: ubuntu@20.04`), 0644)
 
 	buffers := []*bytes.Buffer{
@@ -312,8 +314,8 @@ base: ubuntu@20.04`), 0644)
 		},
 		{
 			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: "cannot refresh: refresh is already in progress for \"ws\"",
+			Status:  http.StatusConflict,
+			Message: "cannot refresh: operation is already in progress for \"ws\"",
 		},
 		{
 			Type:   ResponseTypeAsync,
@@ -365,7 +367,11 @@ base: ubuntu@20.04`), 0644)
 	}, &ensureStateSoon)
 	defer restoreEnsure()
 
-	s.b.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
+	err := s.b.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
+	c.Assert(err, check.IsNil)
+
+	err = s.b.LaunchWorkspace(s.ctx, "ws1", "ubuntu@20.04")
+	c.Assert(err, check.IsNil)
 
 	for num, i := range requests {
 		// Execute
@@ -382,4 +388,82 @@ base: ubuntu@20.04`), 0644)
 
 	// all successful responses must initiate the ensure call
 	c.Assert(soon, check.Equals, 5)
+}
+
+func (s *apiSuite) TestProjectsPostProjectWorkspaceStart(c *check.C) {
+	// Setup
+	s.daemon(c)
+	projectsCmd := apiCmd("/v1/projects/{id}/workspaces")
+	s.vars = map[string]string{"id": s.project.ProjectId}
+	os.WriteFile(filepath.Join(s.workspaceDir, ".workspace.ws.yaml"), []byte(`name: ws
+base: ubuntu@20.04`), 0644)
+
+	err := s.b.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
+	c.Assert(err, check.IsNil)
+	err = s.b.SetWorkspaceState(s.ctx, "ws", "stop")
+	c.Assert(err, check.IsNil)
+
+	buffers := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["ws"],"action":"start"}`),
+		// a second attempt to start the workspace that is already in Pending (i.e. being started)
+		bytes.NewBufferString(`{"names":["ws"],"action":"start"}`),
+		// ensure another operation is not going to work when the workspace in Pending
+		bytes.NewBufferString(`{"names":["ws"],"action":"refresh"}`),
+	}
+
+	requests := []*http.Request{}
+	expected := []*struct {
+		Type    ResponseType
+		Status  int
+		Message string
+	}{
+		{
+			Type:   ResponseTypeAsync,
+			Status: http.StatusAccepted,
+		},
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusConflict,
+			Message: "cannot start: \"ws\" must be stopped",
+		},
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusConflict,
+			Message: "cannot refresh: operation is already in progress for \"ws\"",
+		},
+	}
+
+	for _, i := range buffers {
+		req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workspaces", i)
+		c.Assert(err, check.IsNil)
+		requests = append(requests, req)
+	}
+
+	soon := 0
+	restoreEnsure := testutil.FakeFunc(func(st *state.State, d time.Duration) {
+		soon++
+	}, &ensureStateSoon)
+	defer restoreEnsure()
+
+	for num, i := range requests {
+		// Execute
+		rsp := v1PostProjectWorkspace(projectsCmd, i, nil).(*resp)
+		{
+			// Verify
+			c.Check(rsp.Type, check.Equals, expected[num].Type)
+			c.Assert(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v", num))
+			if rsp.Type == ResponseTypeError {
+				c.Assert(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
+			}
+		}
+	}
+
+	s.d.overlord.State().Lock()
+	ws, err := s.d.overlord.WorkspaceManager().Workspace(s.ctx, "ws", s.project.ProjectId)
+	c.Assert(err, check.IsNil)
+	c.Assert(ws.State(), check.Equals, workspacebackend.WorkspacePending)
+	s.d.overlord.State().Unlock()
+
+	// all successful responses must initiate the ensure call
+	c.Assert(soon, check.Equals, 1)
 }

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -361,7 +361,7 @@ base: ubuntu@20.04`), 0644)
 	soon := 0
 	restoreEnsure := testutil.FakeFunc(func(st *state.State, d time.Duration) {
 		if mockRefreshChanges[soon] == state.DoneStatus {
-			statecontext.StopRefresh(st, "ws", s.project.ProjectId)
+			statecontext.StopOperation(st, "ws", s.project.ProjectId, statecontext.OperationRefresh)
 		}
 		soon++
 	}, &ensureStateSoon)

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -400,7 +400,7 @@ base: ubuntu@20.04`), 0644)
 
 	err := s.b.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
 	c.Assert(err, check.IsNil)
-	err = s.b.SetWorkspaceState(s.ctx, "ws", "stop")
+	err = s.b.StopWorkspace(s.ctx, "ws", false)
 	c.Assert(err, check.IsNil)
 
 	buffers := []*bytes.Buffer{

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -199,6 +199,7 @@ var (
 	statusForbidden        = makeErrorResponder(403)
 	statusNotFound         = makeErrorResponder(404)
 	statusMethodNotAllowed = makeErrorResponder(405)
+	statusConflict         = makeErrorResponder(409)
 	statusInternalError    = makeErrorResponder(500)
 	statusGatewayTimeout   = makeErrorResponder(504)
 )

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -87,18 +87,19 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 
 func (h *HookManager) executeHook(ctx context.Context, task *state.Task, workspace, projectId string, hook *HookSetup) error {
 	hookPath := sdk.SdkHookPath(hook.Sdk.Name, hook.Type())
-	{
-		wsFs, err := h.backend.GetWorkspaceFs(ctx, workspace)
-		if err != nil {
-			return err
-		}
 
-		info, err := wsFs.Stat(hookPath)
-		wsFs.Close()
-		if errors.Is(err, afero.ErrFileNotFound) || !info.Mode().IsRegular() {
-			return nil
-		}
+	// 
+	wsFs, err := h.backend.GetWorkspaceFs(ctx, workspace)
+	if err != nil {
+		return err
 	}
+
+	info, err := wsFs.Stat(hookPath)
+	wsFs.Close()
+	if errors.Is(err, afero.ErrFileNotFound) || !info.Mode().IsRegular() {
+		return nil
+	}
+
 
 	/* create a memory out/err to log the hook output into the task's log */
 	memFs := afero.NewMemMapFs()
@@ -125,18 +126,14 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, workspa
 	args.Stdin = out
 	args.Stdout = out
 
-	done, err := h.backend.Exec(ctx, workspace, &args)
-	<-done
+	err = h.backend.Exec(ctx, workspace, &args)
 
 	hookLog, _ := afero.ReadFile(memFs, out.Name())
 
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
-	if err == nil {
-		task.Logf(string(hookLog))
-		return nil
-	}
+	task.Logf(string(hookLog))
 
-	return fmt.Errorf("%v: %v", err, string(hookLog))
+	return err
 }

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -37,7 +37,7 @@ func NewHookManager(runner *state.TaskRunner, server workspacebackend.WorkspaceB
 		backend: server,
 	}
 
-	runner.AddHandler("run-hook", OnDoError(manager.doRunHook), nil)
+	runner.AddHandler("run-hook", OnDo(manager.doRunHook), nil)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -136,10 +136,8 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 		Stdin:   nil,
 		Stdout:  out,
 		Stderr:  out}
-	done, err := m.backend.Exec(ctx, workspace, &args)
 
-	/* The server will close this channel when exec is finished and no i/o remains outstanding */
-	<-done
+	err = m.backend.Exec(ctx, workspace, &args)
 
 	if err != nil {
 		hookLog, _ := afero.ReadFile(memFs, out.Name())

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -146,11 +146,9 @@ func (s *H) TestDoInstallSdkExecFail(c *check.C) {
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
-	s.backend.DoExec = func(ctx context.Context, name string, args *workspacebackend.ExecArgs) (chan bool, error) {
+	s.backend.DoExec = func(ctx context.Context, name string, args *workspacebackend.ExecArgs) error {
 		args.Stderr.Write([]byte(os.ErrDeadlineExceeded.Error()))
-		done := make(chan bool)
-		close(done)
-		return done, os.ErrDeadlineExceeded
+		return os.ErrDeadlineExceeded
 	}
 
 	s.state.Unlock()
@@ -186,10 +184,10 @@ func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
 	chg.AddTask(terr)
 
 	/* emulate install behaviour that unpacks an SDK to a certain directory */
-	s.backend.DoExec = func(ctx context.Context, name string, args *workspacebackend.ExecArgs) (chan bool, error) {
+	s.backend.DoExec = func(ctx context.Context, name string, args *workspacebackend.ExecArgs) error {
 		fs, _ := s.backend.GetWorkspaceFs(ctx, name)
 		fs.MkdirAll(filepath.Join(sdk.WorkspaceSdksDir, "new"), 0755)
-		return workspacebackend.DoExecDefault(ctx, name, args)
+		return nil
 	}
 
 	s.state.Unlock()

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -18,9 +18,9 @@ type SdkSequenceRecord struct {
 func NewSdkManager(runner *state.TaskRunner, server backend.WorkspaceBackend) *SdkManager {
 	manager := &SdkManager{backend: server}
 
-	runner.AddHandler("retrieve-sdk", OnDoError(manager.doRetrieveSdk), nil)
-	runner.AddHandler("install-sdk", OnDoError(manager.doInstallSDK), manager.undoInstallSdk)
-	runner.AddHandler("link-sdk", OnDoError(manager.doLinkSdk), manager.undoLinkSdk)
+	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
+	runner.AddHandler("install-sdk", OnDo(manager.doInstallSDK), manager.undoInstallSdk)
+	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.undoLinkSdk)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -19,8 +19,8 @@ func NewSdkManager(runner *state.TaskRunner, server backend.WorkspaceBackend) *S
 	manager := &SdkManager{backend: server}
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
-	runner.AddHandler("install-sdk", OnDo(manager.doInstallSDK), manager.undoInstallSdk)
-	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.undoLinkSdk)
+	runner.AddHandler("install-sdk", OnDo(manager.doInstallSDK), OnUndo(manager.undoInstallSdk))
+	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), OnUndo(manager.undoLinkSdk))
 
 	return manager
 }

--- a/internal/overlord/state/task.go
+++ b/internal/overlord/state/task.go
@@ -444,11 +444,6 @@ func (t *Task) Log() []string {
 	return t.log
 }
 
-func (t *Task) ClearLog() {
-	t.state.writing()
-	t.log = []string{}
-}
-
 // Logf logs information about the progress of the task.
 func (t *Task) Logf(format string, args ...interface{}) {
 	t.state.writing()

--- a/internal/overlord/statecontext/common_state_context.go
+++ b/internal/overlord/statecontext/common_state_context.go
@@ -33,8 +33,10 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 		case err == nil:
 			if task.Has("stop-operation") {
 				op := OperationInProgress(st, ws, p.ProjectId)
-				if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
-					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
+				if op != nil {
+					if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+						return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
+					}
 				}
 			}
 			return nil
@@ -71,6 +73,34 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 		}
 
 		return nil
+	}
+}
+
+func OnUndo(handler state.HandlerFunc) state.HandlerFunc {
+	return func(task *state.Task, tomb *tomb.Tomb) error {
+		_, p, ws, err := UserProjectWorkspace(task)
+		if err != nil {
+			return err
+		}
+
+		err = handler(task, tomb)
+		st := task.State()
+		st.Lock()
+		defer st.Unlock()
+
+		// if the task was marked as the starter of the operation then
+		// remove the operation from being in progress as this is the last
+		// task that has just completed its undoing logic, i.e. the
+		// workspace is ready for the new commands again
+		if task.Has("start-operation") {
+			op := OperationInProgress(st, ws, p.ProjectId)
+			if op != nil {
+				if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
+				}
+			}
+		}
+		return err
 	}
 }
 

--- a/internal/overlord/statecontext/common_state_context.go
+++ b/internal/overlord/statecontext/common_state_context.go
@@ -17,7 +17,7 @@ import (
 // due to abortion, e.g. a running hook is called off because their change was
 // aborted.
 // 3. The error needs to be reported as is which will cause the abortion.
-func OnDoError(handler state.HandlerFunc) state.HandlerFunc {
+func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 	return func(task *state.Task, tomb *tomb.Tomb) error {
 		_, p, ws, err := UserProjectWorkspace(task)
 		if err != nil {
@@ -31,15 +31,24 @@ func OnDoError(handler state.HandlerFunc) state.HandlerFunc {
 
 		switch {
 		case err == nil:
-			var opname string
-			if err = task.Get("operation-to-stop", &opname); err == nil {
-				if e := StopOperation(st, ws, p.ProjectId, opname); e != nil {
-					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", opname, ws, e, err)
+			if task.Has("stop-operation") {
+				op := OperationInProgress(st, ws, p.ProjectId)
+				if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
 				}
 			}
 			return nil
 		case errors.Is(err, context.Canceled):
 			task.Logf("The task execution was cancelled")
+			// the context cancellation here means the change was aborted and
+			// the undo logic chain started. we don't report the context
+			// cancellation as error here as it is an expected interruption
+			op := OperationInProgress(st, ws, p.ProjectId)
+			if op != nil {
+				if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
+				}
+			}
 			return nil
 		case err != nil:
 			op := OperationInProgress(st, ws, p.ProjectId)

--- a/internal/overlord/statecontext/common_state_context.go
+++ b/internal/overlord/statecontext/common_state_context.go
@@ -25,37 +25,42 @@ func OnDoError(handler state.HandlerFunc) state.HandlerFunc {
 		}
 
 		err = handler(task, tomb)
-		if err != nil {
-			switch {
-			case errors.Is(err, context.Canceled):
-				st := task.State()
-				st.Lock()
-				defer st.Unlock()
+		st := task.State()
+		st.Lock()
+		defer st.Unlock()
 
-				task.Logf("The task execution was cancelled")
-				return nil
-
-			case err != nil:
-				st := task.State()
-				st.Lock()
-				defer st.Unlock()
-
-				op, inProgress := RefreshInProgress(st, ws, p.ProjectId)
-				if inProgress && op.WaitOnError {
+		switch {
+		case err == nil:
+			var opname string
+			if err = task.Get("operation-to-stop", &opname); err == nil {
+				if e := StopOperation(st, ws, p.ProjectId, opname); e != nil {
+					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", opname, ws, e, err)
+				}
+			}
+			return nil
+		case errors.Is(err, context.Canceled):
+			task.Logf("The task execution was cancelled")
+			return nil
+		case err != nil:
+			op := OperationInProgress(st, ws, p.ProjectId)
+			if op != nil {
+				if op.Operation == OperationRefresh && op.WaitOnError {
 					task.Logf("Setting the task to wait until the refresh is either aborted or continued...")
 					task.Errorf("%v", err)
 					return &state.Wait{
 						WaitedStatus: state.DoingStatus,
 						Reason:       fmt.Sprintf("wait on error: %v", err),
 					}
-				} else if inProgress {
-					if e := StopRefresh(st, ws, p.ProjectId); e != nil {
-						return fmt.Errorf("internal error: cannot stop refresh for %q: %v, refresh error: %v", ws, e, err)
-					}
 				}
-				return err
+
+				if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
+				}
 			}
+
+			return err
 		}
+
 		return nil
 	}
 }

--- a/internal/overlord/statecontext/common_state_context_test.go
+++ b/internal/overlord/statecontext/common_state_context_test.go
@@ -40,16 +40,28 @@ func (s *CommonStateFuncs) SetUpTest(c *check.C) {
 }
 
 func (s *CommonStateFuncs) TestContextCancelled(c *check.C) {
-	handler := statecontext.OnDoError(func(task *state.Task, tomb *tomb.Tomb) error {
+	task := s.setupTask()
+
+	s.state.Lock()
+	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
+	c.Assert(err, check.IsNil)
+	task.Change().Abort()
+	s.state.Unlock()
+
+	handler := statecontext.OnDo(func(task *state.Task, tomb *tomb.Tomb) error {
 		return fmt.Errorf("execution error %w", context.Canceled)
 	})
-	task := s.setupTask()
-	err := handler(task, nil)
+	err = handler(task, nil)
 	c.Assert(err, check.IsNil)
+
+	s.state.Lock()
+	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	c.Assert(op, check.IsNil)
+	s.state.Unlock()
 }
 
 func (s *CommonStateFuncs) TestExecutionError(c *check.C) {
-	handler := statecontext.OnDoError(func(task *state.Task, tomb *tomb.Tomb) error {
+	handler := statecontext.OnDo(func(task *state.Task, tomb *tomb.Tomb) error {
 		return errors.New("task failed")
 	})
 	task := s.setupTask()
@@ -64,7 +76,7 @@ func (s *CommonStateFuncs) TestExecutionError(c *check.C) {
 }
 
 func (s *CommonStateFuncs) TestRefreshInProgressError(c *check.C) {
-	handler := statecontext.OnDoError(func(task *state.Task, tomb *tomb.Tomb) error {
+	handler := statecontext.OnDo(func(task *state.Task, tomb *tomb.Tomb) error {
 		return errors.New("task failed")
 	})
 	s.state.Lock()

--- a/internal/overlord/statecontext/common_state_context_test.go
+++ b/internal/overlord/statecontext/common_state_context_test.go
@@ -68,7 +68,7 @@ func (s *CommonStateFuncs) TestRefreshInProgressError(c *check.C) {
 		return errors.New("task failed")
 	})
 	s.state.Lock()
-	err := statecontext.StartRefresh(s.state, "ws", s.project.ProjectId, "1", true)
+	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 
@@ -80,8 +80,8 @@ func (s *CommonStateFuncs) TestRefreshInProgressError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	op, in := statecontext.RefreshInProgress(s.state, "ws", s.project.ProjectId)
-	c.Assert(in, check.Equals, true)
+	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	c.Assert(op, check.NotNil)
 	c.Assert(op.ChangeId, check.Equals, "1")
 	c.Assert(op.Operation, check.Equals, "refresh")
 }

--- a/internal/overlord/statecontext/common_state_context_test.go
+++ b/internal/overlord/statecontext/common_state_context_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/canonical/workspace/internal/overlord/state"
 	"github.com/canonical/workspace/internal/overlord/statecontext"
-	"github.com/canonical/workspace/internal/testutil"
 	"github.com/canonical/workspace/internal/workspacebackend"
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
@@ -39,6 +38,29 @@ func (s *CommonStateFuncs) SetUpTest(c *check.C) {
 	s.project = &workspacebackend.Project{Path: c.MkDir(), ProjectId: "42ws42ws"}
 }
 
+func (s *CommonStateFuncs) TestStopTaskOperation(c *check.C) {
+	task := s.setupTask()
+
+	s.state.Lock()
+	// mark task to stop the associated operation
+	task.Set("stop-operation", true)
+	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
+	c.Assert(err, check.IsNil)
+	task.Change().Abort()
+	s.state.Unlock()
+
+	handler := statecontext.OnDo(func(task *state.Task, tomb *tomb.Tomb) error {
+		return nil
+	})
+	err = handler(task, nil)
+	c.Assert(err, check.IsNil)
+
+	s.state.Lock()
+	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	c.Assert(op, check.IsNil)
+	s.state.Unlock()
+}
+
 func (s *CommonStateFuncs) TestContextCancelled(c *check.C) {
 	task := s.setupTask()
 
@@ -60,19 +82,47 @@ func (s *CommonStateFuncs) TestContextCancelled(c *check.C) {
 	s.state.Unlock()
 }
 
-func (s *CommonStateFuncs) TestExecutionError(c *check.C) {
+func (s *CommonStateFuncs) TestExecutionErrorOnDo(c *check.C) {
+	task := s.setupTask()
+
+	s.state.Lock()
+	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: false})
+	c.Assert(err, check.IsNil)
+	s.state.Unlock()
+
 	handler := statecontext.OnDo(func(task *state.Task, tomb *tomb.Tomb) error {
 		return errors.New("task failed")
 	})
-	task := s.setupTask()
-	err := handler(task, nil)
+
+	err = handler(task, nil)
 	c.Assert(err, check.ErrorMatches, "task failed")
-	var ops statecontext.Operations
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	err = s.state.Get(statecontext.OpsInProgressKey, &ops)
-	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
+	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	c.Assert(op, check.IsNil)
+}
+
+func (s *CommonStateFuncs) TestStartTaskOnUndo(c *check.C) {
+	task := s.setupTask()
+
+	s.state.Lock()
+	task.Set("start-operation", true)
+	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: false})
+	c.Assert(err, check.IsNil)
+	s.state.Unlock()
+
+	handler := statecontext.OnUndo(func(task *state.Task, tomb *tomb.Tomb) error {
+		return nil
+	})
+
+	err = handler(task, nil)
+	c.Assert(err, check.IsNil)
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	c.Assert(op, check.IsNil)
 }
 
 func (s *CommonStateFuncs) TestRefreshInProgressError(c *check.C) {

--- a/internal/overlord/statecontext/operation.go
+++ b/internal/overlord/statecontext/operation.go
@@ -71,33 +71,13 @@ func OperationInProgress(st *state.State, name, projectId string) *Operation {
 	return nil
 }
 
-// Returns an associated refresh operation for the workspace. An empty
-// string will be returned if no refresh in progress. The state must be locked
-func RefreshInProgress(st *state.State, name, projectId string) (*Operation, bool) {
-	op := OperationInProgress(st, name, projectId)
-	if op == nil || op.Operation != OperationRefresh {
-		return nil, false
+func StartOperation(st *state.State, name, projectId string, op Operation) error {
+	if op := OperationInProgress(st, name, projectId); op != nil {
+		return fmt.Errorf("cannot start %s: has another operation in progress", op.Operation)
 	}
-	return op, true
-}
-
-func StartOperation(st *state.State, name, projectId string, op Operation) {
 	var refresh Operations = make(Operations)
 	st.Get(OpsInProgressKey, &refresh)
 	refresh[workspacebackend.InstanceName(name, projectId)] = op
-	st.Set(OpsInProgressKey, refresh)
-}
-
-// Sets a given workspace to the refresh mode, the state must be locked. The
-// method associates the workspace with a change id that can be used to continue
-// or abort the refresh operation later on.
-func StartRefresh(st *state.State, name, projectId, change string, wait bool) error {
-	var refresh Operations = make(Operations)
-	var setup = Operation{ChangeId: change, Operation: OperationRefresh, WaitOnError: wait}
-
-	st.Get(OpsInProgressKey, &refresh)
-
-	refresh[workspacebackend.InstanceName(name, projectId)] = setup
 	st.Set(OpsInProgressKey, refresh)
 	return nil
 }
@@ -111,8 +91,8 @@ func ResumeRefresh(st *state.State,
 		return nil, fmt.Errorf("cannot resume: only abort or continue can be used to resume the refresh operation")
 	}
 
-	op, inProgress := RefreshInProgress(st, name, projectId)
-	if !inProgress {
+	op := OperationInProgress(st, name, projectId)
+	if op == nil {
 		return nil, fmt.Errorf("cannot %s, no refresh in progress", mode)
 	}
 
@@ -141,17 +121,20 @@ func ResumeRefresh(st *state.State,
 	return change, nil
 }
 
-// Unset the refresh mode for a given workspace, the state must be locked. The
-// method removes an association between a workspace and a change indicating
-// that the refresh is over and continue or abort will not be possible from this
-// point.
-func StopRefresh(st *state.State, name, projectId string) error {
+// Stop the operation in progress for a given workspace, the state must be
+// locked.
+func StopOperation(st *state.State, name, projectId, opname string) error {
 	var ops Operations
 	err := st.Get(OpsInProgressKey, &ops)
 	if err != nil {
 		return err
 	}
-	delete(ops, workspacebackend.InstanceName(name, projectId))
+	opkey := workspacebackend.InstanceName(name, projectId)
+	op, ok := ops[opkey]
+	if !ok || opname != op.Operation {
+		return fmt.Errorf("cannot stop: no %s in progress", opname)
+	}
+	delete(ops, opkey)
 	st.Set(OpsInProgressKey, ops)
 	return nil
 }

--- a/internal/overlord/statecontext/operation.go
+++ b/internal/overlord/statecontext/operation.go
@@ -36,6 +36,12 @@ func ParseRefreshMode(s string) RefreshMode {
 
 type Operations map[string]Operation
 
+const (
+	OperationLaunch  = "launch"
+	OperationRefresh = "refresh"
+	OperationStart   = "start"
+)
+
 type Operation struct {
 	ChangeId    string `json:"changeId"`
 	Operation   string `json:"operation"`
@@ -52,19 +58,34 @@ type Operation struct {
 // operation. It involves more complexity on maintaining the workspace state
 // record and, likely, makes it more error-prone.
 
-// Returns an associated refresh operation for the workspace. An empty
-// string will be returned if no refresh in progress. The state must be locked
-func RefreshInProgress(st *state.State, name, projectId string) (*Operation, bool) {
+func OperationInProgress(st *state.State, name, projectId string) *Operation {
 	var ops Operations
 	err := st.Get(OpsInProgressKey, &ops)
 	if err != nil {
+		return nil
+	}
+
+	if op, ok := ops[workspacebackend.InstanceName(name, projectId)]; ok {
+		return &op
+	}
+	return nil
+}
+
+// Returns an associated refresh operation for the workspace. An empty
+// string will be returned if no refresh in progress. The state must be locked
+func RefreshInProgress(st *state.State, name, projectId string) (*Operation, bool) {
+	op := OperationInProgress(st, name, projectId)
+	if op == nil || op.Operation != OperationRefresh {
 		return nil, false
 	}
-	op := ops[workspacebackend.InstanceName(name, projectId)]
-	if op.Operation != "refresh" {
-		return nil, false
-	}
-	return &op, true
+	return op, true
+}
+
+func StartOperation(st *state.State, name, projectId string, op Operation) {
+	var refresh Operations = make(Operations)
+	st.Get(OpsInProgressKey, &refresh)
+	refresh[workspacebackend.InstanceName(name, projectId)] = op
+	st.Set(OpsInProgressKey, refresh)
 }
 
 // Sets a given workspace to the refresh mode, the state must be locked. The
@@ -72,7 +93,7 @@ func RefreshInProgress(st *state.State, name, projectId string) (*Operation, boo
 // or abort the refresh operation later on.
 func StartRefresh(st *state.State, name, projectId, change string, wait bool) error {
 	var refresh Operations = make(Operations)
-	var setup = Operation{ChangeId: change, Operation: "refresh", WaitOnError: wait}
+	var setup = Operation{ChangeId: change, Operation: OperationRefresh, WaitOnError: wait}
 
 	st.Get(OpsInProgressKey, &refresh)
 

--- a/internal/overlord/statecontext/operation_test.go
+++ b/internal/overlord/statecontext/operation_test.go
@@ -35,7 +35,7 @@ func (s *OperationSuite) TestResumeRefreshContinue(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	statecontext.StartRefresh(s.state, "ws", s.project.ProjectId, "1", true)
+	statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
 	change := s.state.NewChange("refresh", "...")
 	task := s.state.NewTask("no-op", "...")
 	task.SetToWait(state.DoingStatus)
@@ -50,7 +50,7 @@ func (s *OperationSuite) TestResumeRefreshAbort(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	statecontext.StartRefresh(s.state, "ws", s.project.ProjectId, "1", true)
+	statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
 	change := s.state.NewChange("refresh", "...")
 	task := s.state.NewTask("no-op", "...")
 	change.AddTask(task)

--- a/internal/overlord/workspacestate/export_test.go
+++ b/internal/overlord/workspacestate/export_test.go
@@ -5,7 +5,7 @@ var (
 	RefreshManyImpl   = refreshMany
 	RestoreStateHooks = restoreStateHooks
 	SaveStateHooks    = saveStateHooks
-
-	Launch         = launch
-	WorkspaceState = (*WorkspaceManager).workspaceState
+	StartManyImpl     = startMany
+	Launch            = launch
+	WorkspaceState    = (*WorkspaceManager).workspaceState
 )

--- a/internal/overlord/workspacestate/handlers.go
+++ b/internal/overlord/workspacestate/handlers.go
@@ -71,10 +71,7 @@ func (m *WorkspaceManager) doMountProject(task *state.Task, tomb *tomb.Tomb) err
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	if err = m.backend.AddWorkspaceDevice(ctx, workspace, prjMount); err != nil {
-		return err
-	}
-	return nil
+	return m.backend.AddWorkspaceDevice(ctx, workspace, prjMount)
 }
 
 func (m *WorkspaceManager) undoMountProject(task *state.Task, tomb *tomb.Tomb) error {
@@ -90,11 +87,7 @@ func (m *WorkspaceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project)
 	defer cancel()
 
-	if err = m.backend.StartWorkspace(ctx, workspace); err != nil {
-		return err
-	}
-
-	return nil
+	return m.backend.StartWorkspace(ctx, workspace)
 }
 
 func (m *WorkspaceManager) doDeleteWorkspace(task *state.Task, tomb *tomb.Tomb) error {
@@ -110,11 +103,7 @@ func (m *WorkspaceManager) doDeleteWorkspace(task *state.Task, tomb *tomb.Tomb) 
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	err = m.backend.DeleteWorkspace(ctx, workspace)
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.backend.DeleteWorkspace(ctx, workspace)
 }
 
 func (m *WorkspaceManager) doRemoveWorkspaceStash(task *state.Task, tomb *tomb.Tomb) error {
@@ -130,11 +119,7 @@ func (m *WorkspaceManager) doRemoveWorkspaceStash(task *state.Task, tomb *tomb.T
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	err = m.backend.RemoveWorkspaceStash(ctx, workspace)
-	if err != nil {
-		return err
-	}
-	return StopOperation(st, workspace, prj.ProjectId, OperationRefresh)
+	return m.backend.RemoveWorkspaceStash(ctx, workspace)
 }
 
 func (m *WorkspaceManager) doStashWorkspace(task *state.Task, tomb *tomb.Tomb) error {
@@ -166,12 +151,7 @@ func (m *WorkspaceManager) undoStashWorkspace(task *state.Task, tomb *tomb.Tomb)
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	err = m.backend.UnstashWorkspace(ctx, workspace)
-	if err != nil {
-		return err
-	}
-
-	return StopOperation(st, workspace, prj.ProjectId, OperationRefresh)
+	return m.backend.UnstashWorkspace(ctx, workspace)
 }
 
 func (m *WorkspaceManager) doStop(task *state.Task, tomb *tomb.Tomb) error {
@@ -187,11 +167,7 @@ func (m *WorkspaceManager) doStop(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	err = m.backend.StopWorkspace(ctx, workspace, false)
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.backend.StopWorkspace(ctx, workspace, false)
 }
 
 func (m *WorkspaceManager) doCreateStateStorage(task *state.Task, tomb *tomb.Tomb) error {
@@ -207,11 +183,7 @@ func (m *WorkspaceManager) doCreateStateStorage(task *state.Task, tomb *tomb.Tom
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	err = m.backend.CreateStateStorage(ctx, workspace)
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.backend.CreateStateStorage(ctx, workspace)
 }
 
 func (m *WorkspaceManager) doRemoveStateStorage(task *state.Task, tomb *tomb.Tomb) error {
@@ -227,9 +199,5 @@ func (m *WorkspaceManager) doRemoveStateStorage(task *state.Task, tomb *tomb.Tom
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	err = m.backend.DeleteStateStorage(ctx, workspace)
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.backend.DeleteStateStorage(ctx, workspace)
 }

--- a/internal/overlord/workspacestate/handlers.go
+++ b/internal/overlord/workspacestate/handlers.go
@@ -24,7 +24,7 @@ func (m *WorkspaceManager) undoCreateWorkspace(task *state.Task, tomb *tomb.Tomb
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	return m.backend.DeleteWorkspace(ctx, workspace, true)
+	return m.backend.DeleteWorkspace(ctx, workspace)
 }
 
 func (m *WorkspaceManager) doCreateWorkspace(task *state.Task, tomb *tomb.Tomb) error {
@@ -109,7 +109,7 @@ func (m *WorkspaceManager) doDeleteWorkspace(task *state.Task, tomb *tomb.Tomb) 
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	err = m.backend.DeleteWorkspace(ctx, workspace, true)
+	err = m.backend.DeleteWorkspace(ctx, workspace)
 	if err != nil {
 		return err
 	}

--- a/internal/overlord/workspacestate/handlers.go
+++ b/internal/overlord/workspacestate/handlers.go
@@ -87,36 +87,11 @@ func (m *WorkspaceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	st := task.State()
-	st.Lock()
-
 	ctx, cancel := BackendContext(tomb, user, project)
 	defer cancel()
 
-	/* Start the workspace. TODO: make sure that we have it ready before attempting to proceed */
-	err = m.backend.SetWorkspaceState(ctx, workspace, "start")
-	st.Unlock()
-	if err != nil {
+	if err = m.backend.StartWorkspace(ctx, workspace); err != nil {
 		return err
-	}
-
-	/* Wait until system is up an running before returning */
-	args := workspacebackend.ExecArgs{
-		User: "root",
-		Command: []string{
-			"bash", "-eu", "-c", "while " +
-				"[ \"$(systemctl is-system-running 2>/dev/null)\" != \"running\" ] && " +
-				"[ \"$(systemctl is-system-running 2>/dev/null)\" != \"degraded\" ]; do :; done",
-		},
-		WorkDir: "/",
-		Stdin:   nil,
-		Stdout:  nil,
-		Stderr:  nil}
-
-	if done, err := m.backend.Exec(ctx, workspace, &args); err != nil {
-		return err
-	} else {
-		<-done
 	}
 	return nil
 }
@@ -211,7 +186,7 @@ func (m *WorkspaceManager) doStop(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, prj)
 	defer cancel()
 
-	err = m.backend.SetWorkspaceState(ctx, workspace, "stop")
+	err = m.backend.StopWorkspace(ctx, workspace, false)
 	if err != nil {
 		return err
 	}

--- a/internal/overlord/workspacestate/handlers.go
+++ b/internal/overlord/workspacestate/handlers.go
@@ -93,6 +93,7 @@ func (m *WorkspaceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 	if err = m.backend.StartWorkspace(ctx, workspace); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -133,7 +134,7 @@ func (m *WorkspaceManager) doRemoveWorkspaceStash(task *state.Task, tomb *tomb.T
 	if err != nil {
 		return err
 	}
-	return StopRefresh(st, workspace, prj.ProjectId)
+	return StopOperation(st, workspace, prj.ProjectId, OperationRefresh)
 }
 
 func (m *WorkspaceManager) doStashWorkspace(task *state.Task, tomb *tomb.Tomb) error {
@@ -170,7 +171,7 @@ func (m *WorkspaceManager) undoStashWorkspace(task *state.Task, tomb *tomb.Tomb)
 		return err
 	}
 
-	return StopRefresh(st, workspace, prj.ProjectId)
+	return StopOperation(st, workspace, prj.ProjectId, OperationRefresh)
 }
 
 func (m *WorkspaceManager) doStop(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workspacestate/manager.go
+++ b/internal/overlord/workspacestate/manager.go
@@ -20,14 +20,14 @@ func NewWorkspaceManager(st *state.State, runner *state.TaskRunner, server works
 	}
 
 	/* Workspace management */
-	runner.AddHandler("create-workspace", OnDo(manager.doCreateWorkspace), manager.undoCreateWorkspace)
-	runner.AddHandler("start-workspace", OnDo(manager.doStart), manager.doStop)
-	runner.AddHandler("stop-workspace", OnDo(manager.doStop), manager.doStart)
+	runner.AddHandler("create-workspace", OnDo(manager.doCreateWorkspace), OnUndo(manager.undoCreateWorkspace))
+	runner.AddHandler("start-workspace", OnDo(manager.doStart), OnUndo(manager.doStop))
+	runner.AddHandler("stop-workspace", OnDo(manager.doStop), OnUndo(manager.doStart))
 	runner.AddHandler("delete-workspace", OnDo(manager.doDeleteWorkspace), nil)
-	runner.AddHandler("mount-project", OnDo(manager.doMountProject), manager.undoMountProject)
+	runner.AddHandler("mount-project", OnDo(manager.doMountProject), OnUndo(manager.undoMountProject))
 	runner.AddHandler("remove-workspace-stash", OnDo(manager.doRemoveWorkspaceStash), nil)
-	runner.AddHandler("stash-workspace", OnDo(manager.doStashWorkspace), manager.undoStashWorkspace)
-	runner.AddHandler("create-state-storage", OnDo(manager.doCreateStateStorage), manager.doRemoveStateStorage)
+	runner.AddHandler("stash-workspace", OnDo(manager.doStashWorkspace), OnUndo(manager.undoStashWorkspace))
+	runner.AddHandler("create-state-storage", OnDo(manager.doCreateStateStorage), OnUndo(manager.doRemoveStateStorage))
 	runner.AddHandler("remove-state-storage", OnDo(manager.doRemoveStateStorage), nil)
 
 	return manager

--- a/internal/overlord/workspacestate/manager.go
+++ b/internal/overlord/workspacestate/manager.go
@@ -37,6 +37,28 @@ func (w *WorkspaceManager) Ensure() error {
 	return nil
 }
 
+// Checks all of the provided list of workspaces are in the required status
+func (w *WorkspaceManager) CheckStatus(ctx context.Context, names []string, pId string,
+	status workspacebackend.WorkspaceState) (bool, []string, error) {
+	invalid := []string{}
+	for _, name := range names {
+		wrkspc, err := w.Workspace(ctx, name, pId)
+		if err != nil {
+			return false, nil, err
+		}
+
+		st := w.workspaceState(wrkspc)
+		if st != status {
+			invalid = append(invalid, wrkspc.Name)
+		}
+	}
+
+	if len(invalid) > 0 {
+		return false, invalid, nil
+	}
+	return true, nil, nil
+}
+
 // Loads a workspace, the state must be locked as it is used to find out the
 // workspace state
 func (w *WorkspaceManager) Workspace(ctx context.Context, name, pId string) (*workspacebackend.Workspace, error) {
@@ -74,8 +96,8 @@ func (w *WorkspaceManager) Workspaces(ctx context.Context, pId string) ([]*works
 // operations in progress for the workspace. The state must be locked before the
 // call.
 func (w *WorkspaceManager) workspaceState(ws *workspacebackend.Workspace) workspacebackend.WorkspaceState {
-	op, opInProgress := RefreshInProgress(w.state, ws.Name, ws.ProjectId())
-	if opInProgress {
+	op := OperationInProgress(w.state, ws.Name, ws.ProjectId())
+	if op != nil {
 		if ws.IsRunning() {
 			change := w.state.Change(op.ChangeId)
 			if change == nil {

--- a/internal/overlord/workspacestate/manager.go
+++ b/internal/overlord/workspacestate/manager.go
@@ -20,15 +20,15 @@ func NewWorkspaceManager(st *state.State, runner *state.TaskRunner, server works
 	}
 
 	/* Workspace management */
-	runner.AddHandler("create-workspace", OnDoError(manager.doCreateWorkspace), manager.undoCreateWorkspace)
-	runner.AddHandler("start-workspace", OnDoError(manager.doStart), manager.doStop)
-	runner.AddHandler("stop-workspace", OnDoError(manager.doStop), manager.doStart)
-	runner.AddHandler("delete-workspace", OnDoError(manager.doDeleteWorkspace), nil)
-	runner.AddHandler("mount-project", OnDoError(manager.doMountProject), manager.undoMountProject)
-	runner.AddHandler("remove-workspace-stash", OnDoError(manager.doRemoveWorkspaceStash), nil)
-	runner.AddHandler("stash-workspace", OnDoError(manager.doStashWorkspace), manager.undoStashWorkspace)
-	runner.AddHandler("create-state-storage", OnDoError(manager.doCreateStateStorage), manager.doRemoveStateStorage)
-	runner.AddHandler("remove-state-storage", OnDoError(manager.doRemoveStateStorage), nil)
+	runner.AddHandler("create-workspace", OnDo(manager.doCreateWorkspace), manager.undoCreateWorkspace)
+	runner.AddHandler("start-workspace", OnDo(manager.doStart), manager.doStop)
+	runner.AddHandler("stop-workspace", OnDo(manager.doStop), manager.doStart)
+	runner.AddHandler("delete-workspace", OnDo(manager.doDeleteWorkspace), nil)
+	runner.AddHandler("mount-project", OnDo(manager.doMountProject), manager.undoMountProject)
+	runner.AddHandler("remove-workspace-stash", OnDo(manager.doRemoveWorkspaceStash), nil)
+	runner.AddHandler("stash-workspace", OnDo(manager.doStashWorkspace), manager.undoStashWorkspace)
+	runner.AddHandler("create-state-storage", OnDo(manager.doCreateStateStorage), manager.doRemoveStateStorage)
+	runner.AddHandler("remove-state-storage", OnDo(manager.doRemoveStateStorage), nil)
 
 	return manager
 }

--- a/internal/overlord/workspacestate/manager_test.go
+++ b/internal/overlord/workspacestate/manager_test.go
@@ -100,7 +100,7 @@ func (s *ManagerSuite) TestWorkspaceStateChanges(c *check.C) {
 		if setup.refreshInProgress {
 			chg := s.state.NewChange("test", "...")
 			chg.SetStatus(setup.status)
-			err := statecontext.StartRefresh(s.state, "ws", "42424242", chg.ID(), true)
+			err := statecontext.StartOperation(s.state, "ws", "42424242", statecontext.Operation{Operation: statecontext.OperationRefresh, ChangeId: chg.ID(), WaitOnError: true})
 			c.Assert(err, check.IsNil)
 		}
 
@@ -108,6 +108,10 @@ func (s *ManagerSuite) TestWorkspaceStateChanges(c *check.C) {
 		st := workspacestate.WorkspaceState(s.manager, wrkspc)
 		c.Assert(st, check.Equals, setup.expectedState, check.Commentf("case num: %v", i))
 		c.Assert(wrkspc.Errors(), testutil.DeepUnsortedMatches, setup.expectedErrors, check.Commentf("case num: %v", i))
+		if setup.refreshInProgress {
+			err := statecontext.StopOperation(s.state, "ws", "42424242", statecontext.OperationRefresh)
+			c.Assert(err, check.IsNil)
+		}
 	}
 }
 

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -7,17 +7,15 @@ import (
 	"github.com/canonical/workspace/internal/overlord/hookstate"
 	"github.com/canonical/workspace/internal/overlord/sdkstate"
 	"github.com/canonical/workspace/internal/overlord/state"
-	"github.com/canonical/workspace/internal/overlord/statecontext"
 	"github.com/canonical/workspace/internal/sdk"
 	"github.com/canonical/workspace/internal/workspacebackend"
 	"golang.org/x/exp/slices"
 )
 
 const (
-	RefreshOldWorkspacePrefix         = "refresh-incumbent-"
-	RefereshDeleteCopyLane            = 1
-	LastBeforeRefreshIrreversibleEdge = state.TaskSetEdge("last-before-irreversible")
-	CleanupRefreshEdge                = state.TaskSetEdge("refresh-cleanup")
+	LaneCleanupRefresh                = 1
+	EdgeLastBeforeRefreshIrreversible = state.TaskSetEdge("last-before-irreversible")
+	EdgeCleanupRefresh                = state.TaskSetEdge("refresh-cleanup")
 )
 
 func (w *WorkspaceManager) loadProject(ctx context.Context, id string) (*workspacebackend.Project, error) {
@@ -150,7 +148,7 @@ func refreshMany(st *state.State, w []*workspacebackend.WorkspaceFile, content [
 	}
 
 	for _, ts := range taskset {
-		cleanup, err := ts.Edge(CleanupRefreshEdge)
+		cleanup, err := ts.Edge(EdgeCleanupRefresh)
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +163,7 @@ func refreshMany(st *state.State, w []*workspacebackend.WorkspaceFile, content [
 		// other changes before execution.
 		for _, otherts := range taskset {
 			if ts != otherts {
-				last, err := otherts.Edge(LastBeforeRefreshIrreversibleEdge)
+				last, err := otherts.Edge(EdgeLastBeforeRefreshIrreversible)
 				if err != nil {
 					return nil, err
 				}
@@ -181,9 +179,9 @@ func refreshMany(st *state.State, w []*workspacebackend.WorkspaceFile, content [
 				// all the cleanup tasks are extracted into a separate lane. If
 				// any problem happens, the workspaces which had finished their
 				// refresh will not suffer.
-				cleanup.JoinLane(RefereshDeleteCopyLane)
+				cleanup.JoinLane(LaneCleanupRefresh)
 				for _, t := range cleanup.HaltTasks() {
-					t.JoinLane(RefereshDeleteCopyLane)
+					t.JoinLane(LaneCleanupRefresh)
 				}
 			}
 		}
@@ -228,7 +226,7 @@ func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*s
 		// the point of no return is the last launch task (i.e.
 		// before the moment when we delete the copy of the workspace
 		// after the refresh operation)
-		launch.MarkEdge(lastLaunchTask, LastBeforeRefreshIrreversibleEdge)
+		launch.MarkEdge(lastLaunchTask, EdgeLastBeforeRefreshIrreversible)
 	}
 	launch.WaitFor(makeCopy)
 	if len(saveStateHooks.Tasks()) > 0 {
@@ -247,7 +245,7 @@ func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*s
 	refresh.AddTask(removeStateStorage)
 	refresh.AddTask(deleteCopy)
 
-	refresh.MarkEdge(removeStateStorage, CleanupRefreshEdge)
+	refresh.MarkEdge(removeStateStorage, EdgeCleanupRefresh)
 
 	for _, i := range refresh.Tasks() {
 		i.Set("workspace", file.Name)
@@ -273,7 +271,7 @@ func restoreStateHooks(st *state.State, content []*sdk.SdkInfo, newContent works
 		last := stateHooks.Tasks()[len(stateHooks.Tasks())-1]
 		// last restore state hook for the refresh call is the last task before the
 		// previous refresh copy removal, ie. before making something irreversible
-		stateHooks.MarkEdge(last, LastBeforeRefreshIrreversibleEdge)
+		stateHooks.MarkEdge(last, EdgeLastBeforeRefreshIrreversible)
 	}
 	return stateHooks
 }
@@ -311,7 +309,7 @@ func startMany(st *state.State, names []string, project *workspacebackend.Projec
 
 	for _, name := range names {
 		start := st.NewTask("start-workspace", fmt.Sprintf("Start %q workspace", name))
-		start.Set("operation-to-stop", statecontext.OperationStart)
+		start.Set("stop-operation", true)
 		taskset.AddTask(start)
 
 		start.Set("workspace", name)

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -7,10 +7,8 @@ import (
 	"github.com/canonical/workspace/internal/overlord/hookstate"
 	"github.com/canonical/workspace/internal/overlord/sdkstate"
 	"github.com/canonical/workspace/internal/overlord/state"
-	"github.com/canonical/workspace/internal/overlord/statecontext"
 	"github.com/canonical/workspace/internal/sdk"
 	"github.com/canonical/workspace/internal/workspacebackend"
-	"github.com/canonical/x-go/strutil"
 	"golang.org/x/exp/slices"
 )
 
@@ -120,17 +118,6 @@ func (w *WorkspaceManager) RefreshMany(ctx context.Context,
 		return nil, err
 	}
 
-	var inProgress = []string{}
-	for _, r := range names {
-		if _, prg := statecontext.RefreshInProgress(w.state, r, project.ProjectId); prg {
-			inProgress = append(inProgress, r)
-		}
-	}
-	if len(inProgress) > 0 {
-		return nil, fmt.Errorf("cannot refresh: refresh is already in progress for %s", strutil.Quoted(inProgress))
-	}
-
-	// we are only interested in the existing (launched) workspaces
 	_, workspaces, err := w.Workspaces(ctx, projectId)
 	if err != nil {
 		return nil, err
@@ -310,9 +297,24 @@ func createStateHooks(st *state.State, content []*sdk.SdkInfo, newContent worksp
 	return stateHooks
 }
 
-func (w *WorkspaceManager) StartMany(ctx context.Context,
-	names []string, projectId string) ([]*state.TaskSet, error) {
-	taskset := make([]*state.TaskSet, 0, len(names))
+func (w *WorkspaceManager) StartMany(ctx context.Context, names []string, projectId string) (*state.TaskSet, error) {
+	project, err := w.loadProject(ctx, projectId)
+	if err != nil {
+		return nil, err
+	}
+	return startMany(w.state, names, project)
+}
+
+func startMany(st *state.State, names []string, project *workspacebackend.Project) (*state.TaskSet, error) {
+	taskset := state.NewTaskSet([]*state.Task{}...)
+
+	for _, name := range names {
+		start := st.NewTask("start-workspace", fmt.Sprintf("Start %q workspace", name))
+		taskset.AddTask(start)
+
+		start.Set("workspace", name)
+		start.Set("project", *project)
+	}
 
 	return taskset, nil
 }

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -309,3 +309,10 @@ func createStateHooks(st *state.State, content []*sdk.SdkInfo, newContent worksp
 	}
 	return stateHooks
 }
+
+func (w *WorkspaceManager) StartMany(ctx context.Context,
+	names []string, projectId string) ([]*state.TaskSet, error) {
+	taskset := make([]*state.TaskSet, 0, len(names))
+
+	return taskset, nil
+}

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -193,7 +193,7 @@ func refreshMany(st *state.State, w []*workspacebackend.WorkspaceFile, content [
 func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*sdk.SdkInfo, p *workspacebackend.Project) (*state.TaskSet, error) {
 	// 1. Save previous state
 	// 2. Stop previous workspace
-	// 3. Make unavailable
+	// 3. Put to stash
 	// 4. Launch the new workspace
 	// 5. Run restore state
 	// 6. Delete the old workspace
@@ -201,7 +201,7 @@ func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*s
 	createStateStorage := st.NewTask("create-state-storage", "Create SDK state storage")
 	saveStateHooks := saveStateHooks(st, content, file.Sdks)
 
-	makeCopy := st.NewTask("stash-workspace", fmt.Sprintf("Stash previous %q workspace", file.Name))
+	putToStash := st.NewTask("stash-workspace", fmt.Sprintf("Stash previous %q workspace", file.Name))
 
 	launch, err := launch(st, file, p)
 	if err != nil {
@@ -211,10 +211,10 @@ func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*s
 	restoreStateHooks := restoreStateHooks(st, content, file.Sdks)
 
 	removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
-	deleteCopy := st.NewTask("remove-workspace-stash", fmt.Sprintf("Remove %q workspace from stash", file.Name))
+	removeFromStash := st.NewTask("remove-workspace-stash", fmt.Sprintf("Remove %q workspace from stash", file.Name))
 
 	// save-state -> stop-workspace -> launch -> restore state
-	deleteCopy.WaitFor(removeStateStorage)
+	removeFromStash.WaitFor(removeStateStorage)
 	if len(restoreStateHooks.Tasks()) > 0 {
 		removeStateStorage.WaitAll(restoreStateHooks)
 		restoreStateHooks.WaitAll(launch)
@@ -228,12 +228,12 @@ func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*s
 		// after the refresh operation)
 		launch.MarkEdge(lastLaunchTask, EdgeLastBeforeRefreshIrreversible)
 	}
-	launch.WaitFor(makeCopy)
+	launch.WaitFor(putToStash)
 	if len(saveStateHooks.Tasks()) > 0 {
-		makeCopy.WaitAll(saveStateHooks)
+		putToStash.WaitAll(saveStateHooks)
 		saveStateHooks.WaitFor(createStateStorage)
 	} else {
-		makeCopy.WaitFor(createStateStorage)
+		putToStash.WaitFor(createStateStorage)
 	}
 
 	refresh := state.NewTaskSet([]*state.Task{}...)
@@ -241,9 +241,17 @@ func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*s
 	refresh.AddAll(saveStateHooks)
 	refresh.AddAllWithEdges(launch)
 	refresh.AddAllWithEdges(restoreStateHooks)
-	refresh.AddTask(makeCopy)
+	refresh.AddTask(putToStash)
 	refresh.AddTask(removeStateStorage)
-	refresh.AddTask(deleteCopy)
+	refresh.AddTask(removeFromStash)
+
+	// mark the first task to start the operation so if cancelled or failed the
+	// operation will be removed from the list of the active ones
+	createStateStorage.Set("start-operation", true)
+
+	// mark the last task to stop the operation
+	// and make the workspace available for other commands
+	removeFromStash.Set("stop-operation", true)
 
 	refresh.MarkEdge(removeStateStorage, EdgeCleanupRefresh)
 
@@ -309,6 +317,8 @@ func startMany(st *state.State, names []string, project *workspacebackend.Projec
 
 	for _, name := range names {
 		start := st.NewTask("start-workspace", fmt.Sprintf("Start %q workspace", name))
+		// start is a single task, so it is the beginning and the end of the operation
+		start.Set("start-operation", true)
 		start.Set("stop-operation", true)
 		taskset.AddTask(start)
 

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -7,6 +7,7 @@ import (
 	"github.com/canonical/workspace/internal/overlord/hookstate"
 	"github.com/canonical/workspace/internal/overlord/sdkstate"
 	"github.com/canonical/workspace/internal/overlord/state"
+	"github.com/canonical/workspace/internal/overlord/statecontext"
 	"github.com/canonical/workspace/internal/sdk"
 	"github.com/canonical/workspace/internal/workspacebackend"
 	"golang.org/x/exp/slices"
@@ -310,6 +311,7 @@ func startMany(st *state.State, names []string, project *workspacebackend.Projec
 
 	for _, name := range names {
 		start := st.NewTask("start-workspace", fmt.Sprintf("Start %q workspace", name))
+		start.Set("operation-to-stop", statecontext.OperationStart)
 		taskset.AddTask(start)
 
 		start.Set("workspace", name)

--- a/internal/overlord/workspacestate/request_test.go
+++ b/internal/overlord/workspacestate/request_test.go
@@ -346,7 +346,7 @@ func (s *S) TestRefreshManyTasktest(c *check.C) {
 
 }
 
-func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingCopy(c *check.C) {
+func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -481,4 +481,15 @@ func (s *S) TestRefreshManyNoRestoreStateHooks(c *check.C) {
 
 	ts := workspacestate.RestoreStateHooks(s.state, []*sdk.SdkInfo{}, file.Sdks)
 	c.Assert(ts.Tasks(), check.HasLen, 0)
+}
+
+func (s *S) TestStartMany(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ts, err := workspacestate.StartManyImpl(s.state, []string{"ws-1", "ws-2"}, s.project)
+	c.Assert(err, check.IsNil)
+	c.Assert(ts.Tasks(), check.HasLen, 2)
+	c.Assert(ts.Tasks()[0].Kind(), check.Equals, "start-workspace")
+	c.Assert(ts.Tasks()[1].Kind(), check.Equals, "start-workspace")
 }

--- a/internal/overlord/workspacestate/request_test.go
+++ b/internal/overlord/workspacestate/request_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/canonical/workspace/internal/overlord/state"
+	"github.com/canonical/workspace/internal/overlord/statecontext"
 	"github.com/canonical/workspace/internal/overlord/workspacestate"
 	"github.com/canonical/workspace/internal/sdk"
 	"github.com/canonical/workspace/internal/testutil"
@@ -492,4 +493,10 @@ func (s *S) TestStartMany(c *check.C) {
 	c.Assert(ts.Tasks(), check.HasLen, 2)
 	c.Assert(ts.Tasks()[0].Kind(), check.Equals, "start-workspace")
 	c.Assert(ts.Tasks()[1].Kind(), check.Equals, "start-workspace")
+
+	var opname string
+	ts.Tasks()[0].Get("operation-to-stop", &opname)
+	c.Assert(opname, check.Equals, statecontext.OperationStart)
+	ts.Tasks()[1].Get("operation-to-stop", &opname)
+	c.Assert(opname, check.Equals, statecontext.OperationStart)
 }

--- a/internal/overlord/workspacestate/request_test.go
+++ b/internal/overlord/workspacestate/request_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/canonical/workspace/internal/overlord/state"
-	"github.com/canonical/workspace/internal/overlord/statecontext"
 	"github.com/canonical/workspace/internal/overlord/workspacestate"
 	"github.com/canonical/workspace/internal/sdk"
 	"github.com/canonical/workspace/internal/testutil"
@@ -226,18 +225,18 @@ func (s *S) TestRefreshManyEmptyWorkspaceMany(c *check.C) {
 	verifyExpectedTasks(c, ts[0].Tasks(), expected_ws)
 	verifyExpectedTasks(c, ts[1].Tasks(), expected_ws_1)
 
-	c.Assert(ts[0].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge).Kind(), check.Equals, "start-workspace")
-	waitFor := ts[0].MaybeEdge(workspacestate.CleanupRefreshEdge).WaitTasks()
+	c.Assert(ts[0].MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible).Kind(), check.Equals, "start-workspace")
+	waitFor := ts[0].MaybeEdge(workspacestate.EdgeCleanupRefresh).WaitTasks()
 	c.Assert(waitFor, testutil.DeepUnsortedMatches, []*state.Task{
-		ts[0].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge),
-		ts[1].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge),
+		ts[0].MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible),
+		ts[1].MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible),
 	})
 
-	c.Assert(ts[1].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge).Kind(), check.Equals, "run-hook")
-	waitFor = ts[1].MaybeEdge(workspacestate.CleanupRefreshEdge).WaitTasks()
+	c.Assert(ts[1].MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible).Kind(), check.Equals, "run-hook")
+	waitFor = ts[1].MaybeEdge(workspacestate.EdgeCleanupRefresh).WaitTasks()
 	c.Assert(waitFor, testutil.DeepUnsortedMatches, []*state.Task{
-		ts[0].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge),
-		ts[1].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge),
+		ts[0].MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible),
+		ts[1].MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible),
 	})
 
 	for i, t := range ts {
@@ -382,18 +381,18 @@ func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 	ts, err := workspacestate.RefreshManyImpl(s.state, files, content, s.project)
 	c.Assert(err, check.IsNil)
 
-	lastChanceWs := ts[0].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge)
+	lastChanceWs := ts[0].MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible)
 	c.Assert(lastChanceWs, check.NotNil)
 	c.Assert(lastChanceWs.Kind(), check.Equals, "run-hook")
 
-	lastChanceWs1 := ts[1].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge)
+	lastChanceWs1 := ts[1].MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible)
 	c.Assert(lastChanceWs1, check.NotNil)
 	c.Assert(lastChanceWs1.Kind(), check.Equals, "run-hook")
 
 	// Ensure that the delete-copy for ws will wait on the own
 	// remove-state-storage and ws1's (i.e. all the other workspaces') restore
 	// state hooks
-	removeWsStStorage := ts[0].MaybeEdge(workspacestate.CleanupRefreshEdge)
+	removeWsStStorage := ts[0].MaybeEdge(workspacestate.EdgeCleanupRefresh)
 	deleteCopy := removeWsStStorage.HaltTasks()[0]
 	c.Assert(removeWsStStorage.WaitTasks(), testutil.DeepUnsortedMatches, []*state.Task{lastChanceWs, lastChanceWs1})
 
@@ -408,7 +407,7 @@ func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 	// Ensure that the delete-copy for ws1 will wait on the own
 	// remove-state-storage and ws's (i.e. all the other workspaces') restore
 	// state hooks
-	removeWsStStorage = ts[1].MaybeEdge(workspacestate.CleanupRefreshEdge)
+	removeWsStStorage = ts[1].MaybeEdge(workspacestate.EdgeCleanupRefresh)
 	deleteCopy = removeWsStStorage.HaltTasks()[0]
 	c.Assert(removeWsStStorage.WaitTasks(), testutil.DeepUnsortedMatches, []*state.Task{lastChanceWs1, lastChanceWs})
 
@@ -443,7 +442,7 @@ func (s *S) TestRefreshManyRestoreStateHooksExecutedSequentially(c *check.C) {
 		}
 		prev = t
 	}
-	c.Assert(ts.MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge), check.Equals, prev)
+	c.Assert(ts.MaybeEdge(workspacestate.EdgeLastBeforeRefreshIrreversible), check.Equals, prev)
 }
 
 func (s *S) TestRefreshManySaveStateHooksExecutedSequentially(c *check.C) {
@@ -494,9 +493,9 @@ func (s *S) TestStartMany(c *check.C) {
 	c.Assert(ts.Tasks()[0].Kind(), check.Equals, "start-workspace")
 	c.Assert(ts.Tasks()[1].Kind(), check.Equals, "start-workspace")
 
-	var opname string
-	ts.Tasks()[0].Get("operation-to-stop", &opname)
-	c.Assert(opname, check.Equals, statecontext.OperationStart)
-	ts.Tasks()[1].Get("operation-to-stop", &opname)
-	c.Assert(opname, check.Equals, statecontext.OperationStart)
+	var opname bool
+	ts.Tasks()[0].Get("stop-operation", &opname)
+	c.Assert(opname, check.Equals, true)
+	ts.Tasks()[1].Get("stop-operation", &opname)
+	c.Assert(opname, check.Equals, true)
 }

--- a/internal/overlord/workspacestate/request_test.go
+++ b/internal/overlord/workspacestate/request_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/canonical/workspace/internal/overlord/state"
 	"github.com/canonical/workspace/internal/overlord/workspacestate"
-	workspace "github.com/canonical/workspace/internal/overlord/workspacestate"
 	"github.com/canonical/workspace/internal/sdk"
 	"github.com/canonical/workspace/internal/testutil"
 	"github.com/canonical/workspace/internal/workspacebackend"
@@ -57,7 +56,7 @@ func (s *S) TestLaunchWorkspaceNoSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	file := &workspacebackend.WorkspaceFile{Name: "test", Base: "ubuntu@22.04"}
-	ts, err := workspace.Launch(s.state, file, s.project)
+	ts, err := workspacestate.Launch(s.state, file, s.project)
 
 	expected := []string{"create-workspace",
 		"mount-project",
@@ -85,7 +84,7 @@ func (s *S) TestLaunchWorkspaceWithSdks(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workspacebackend.SdkList{sdk, sdk_2}}
 
-	ts, err := workspace.Launch(s.state, file, s.project)
+	ts, err := workspacestate.Launch(s.state, file, s.project)
 
 	expected := []string{
 		"create-workspace",
@@ -147,7 +146,7 @@ func (s *S) TestRefreshEmptyWorkspace(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workspacebackend.SdkList{}}
 
-	ts, err := workspace.Refresh(s.state, file, []*sdk.SdkInfo{}, s.project)
+	ts, err := workspacestate.Refresh(s.state, file, []*sdk.SdkInfo{}, s.project)
 	c.Assert(err, check.IsNil)
 
 	expected := []string{
@@ -187,14 +186,14 @@ func (s *S) TestRefreshManyEmptyWorkspaceMany(c *check.C) {
 
 	content := [][]*sdk.SdkInfo{
 		nil,
-		[]*sdk.SdkInfo{{
+		{{
 			Name:    "sdk",
 			Channel: "latest/stable",
 		},
 		},
 	}
 
-	ts, err := workspace.RefreshManyImpl(s.state, files, content, s.project)
+	ts, err := workspacestate.RefreshManyImpl(s.state, files, content, s.project)
 	c.Assert(err, check.IsNil)
 
 	expected_ws := []string{
@@ -226,18 +225,18 @@ func (s *S) TestRefreshManyEmptyWorkspaceMany(c *check.C) {
 	verifyExpectedTasks(c, ts[0].Tasks(), expected_ws)
 	verifyExpectedTasks(c, ts[1].Tasks(), expected_ws_1)
 
-	c.Assert(ts[0].MaybeEdge(workspace.LastBeforeRefreshIrreversibleEdge).Kind(), check.Equals, "start-workspace")
-	waitFor := ts[0].MaybeEdge(workspace.CleanupRefreshEdge).WaitTasks()
+	c.Assert(ts[0].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge).Kind(), check.Equals, "start-workspace")
+	waitFor := ts[0].MaybeEdge(workspacestate.CleanupRefreshEdge).WaitTasks()
 	c.Assert(waitFor, testutil.DeepUnsortedMatches, []*state.Task{
-		ts[0].MaybeEdge(workspace.LastBeforeRefreshIrreversibleEdge),
-		ts[1].MaybeEdge(workspace.LastBeforeRefreshIrreversibleEdge),
+		ts[0].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge),
+		ts[1].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge),
 	})
 
-	c.Assert(ts[1].MaybeEdge(workspace.LastBeforeRefreshIrreversibleEdge).Kind(), check.Equals, "run-hook")
-	waitFor = ts[1].MaybeEdge(workspace.CleanupRefreshEdge).WaitTasks()
+	c.Assert(ts[1].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge).Kind(), check.Equals, "run-hook")
+	waitFor = ts[1].MaybeEdge(workspacestate.CleanupRefreshEdge).WaitTasks()
 	c.Assert(waitFor, testutil.DeepUnsortedMatches, []*state.Task{
-		ts[0].MaybeEdge(workspace.LastBeforeRefreshIrreversibleEdge),
-		ts[1].MaybeEdge(workspace.LastBeforeRefreshIrreversibleEdge),
+		ts[0].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge),
+		ts[1].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge),
 	})
 
 	for i, t := range ts {
@@ -256,7 +255,7 @@ func (s *S) TestRefreshWithAnSDK(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workspacebackend.SdkList{testSdk}}
 
-	ts, err := workspace.Refresh(s.state, file, []*sdk.SdkInfo{
+	ts, err := workspacestate.Refresh(s.state, file, []*sdk.SdkInfo{
 		{
 			Name:    "sdk",
 			Channel: "latest/stable",
@@ -308,19 +307,19 @@ func (s *S) TestRefreshManyTasktest(c *check.C) {
 	}
 
 	content := [][]*sdk.SdkInfo{
-		[]*sdk.SdkInfo{{
+		{{
 			Name:    "sdk",
 			Channel: "latest/stable",
 		},
 		},
-		[]*sdk.SdkInfo{{
+		{{
 			Name:    "sdk",
 			Channel: "latest/stable",
 		},
 		},
 	}
 
-	ts, err := workspace.RefreshManyImpl(s.state, files, content, s.project)
+	ts, err := workspacestate.RefreshManyImpl(s.state, files, content, s.project)
 	c.Assert(err, check.IsNil)
 
 	expected := []string{
@@ -367,19 +366,19 @@ func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingCopy(c *check.C) {
 	}
 
 	content := [][]*sdk.SdkInfo{
-		[]*sdk.SdkInfo{{
+		{{
 			Name:    "sdk",
 			Channel: "latest/stable",
 		},
 		},
-		[]*sdk.SdkInfo{{
+		{{
 			Name:    "sdk",
 			Channel: "latest/stable",
 		},
 		},
 	}
 
-	ts, err := workspace.RefreshManyImpl(s.state, files, content, s.project)
+	ts, err := workspacestate.RefreshManyImpl(s.state, files, content, s.project)
 	c.Assert(err, check.IsNil)
 
 	lastChanceWs := ts[0].MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge)
@@ -432,7 +431,7 @@ func (s *S) TestRefreshManyRestoreStateHooksExecutedSequentially(c *check.C) {
 	one := &sdk.SdkInfo{Name: "one", Channel: "latest/stable"}
 	two := &sdk.SdkInfo{Name: "two", Channel: "latest/stable"}
 
-	ts := workspace.RestoreStateHooks(s.state,
+	ts := workspacestate.RestoreStateHooks(s.state,
 		[]*sdk.SdkInfo{one, two}, workspacebackend.SdkList{oneinst, twoinst})
 	c.Assert(ts.Tasks(), check.HasLen, 2)
 
@@ -443,7 +442,7 @@ func (s *S) TestRefreshManyRestoreStateHooksExecutedSequentially(c *check.C) {
 		}
 		prev = t
 	}
-	c.Assert(ts.MaybeEdge(workspace.LastBeforeRefreshIrreversibleEdge), check.Equals, prev)
+	c.Assert(ts.MaybeEdge(workspacestate.LastBeforeRefreshIrreversibleEdge), check.Equals, prev)
 }
 
 func (s *S) TestRefreshManySaveStateHooksExecutedSequentially(c *check.C) {
@@ -458,7 +457,7 @@ func (s *S) TestRefreshManySaveStateHooksExecutedSequentially(c *check.C) {
 	one := &sdk.SdkInfo{Name: "one", Channel: "latest/stable"}
 	two := &sdk.SdkInfo{Name: "two", Channel: "latest/stable"}
 
-	ts := workspace.SaveStateHooks(s.state, []*sdk.SdkInfo{one, two}, installed)
+	ts := workspacestate.SaveStateHooks(s.state, []*sdk.SdkInfo{one, two}, installed)
 	c.Assert(ts.Tasks(), check.HasLen, 2)
 
 	prev := (*state.Task)(nil)
@@ -480,6 +479,6 @@ func (s *S) TestRefreshManyNoRestoreStateHooks(c *check.C) {
 		Sdks: workspacebackend.SdkList{},
 	}
 
-	ts := workspace.RestoreStateHooks(s.state, []*sdk.SdkInfo{}, file.Sdks)
+	ts := workspacestate.RestoreStateHooks(s.state, []*sdk.SdkInfo{}, file.Sdks)
 	c.Assert(ts.Tasks(), check.HasLen, 0)
 }

--- a/internal/workspacebackend/backend.go
+++ b/internal/workspacebackend/backend.go
@@ -65,11 +65,13 @@ type WorkspaceBackend interface {
 	// is not in the Stopped state.
 	DeleteWorkspace(ctx context.Context, name string, forceful bool) error
 
-	// Used to execute an action for the workspace. Currently,
-	// "start" and "stop" actions are supported. TODO: choose a more
-	// correct naming for this method as "launch" is also an action but
-	// it is represented as a separate method.
-	SetWorkspaceState(ctx context.Context, name, action string) error
+	// Starts a workspace and waits until it is ready
+	// to accept commands
+	StartWorkspace(ctx context.Context, name string) error
+
+	// Stops workspace gracefully (i.e. waits for the graceful instance and all
+	// its running services termination) unless force is used.
+	StopWorkspace(ctx context.Context, name string, force bool) error
 
 	// Make a stash of the workspace. The workspace will be stopped and will not
 	// be available to other workspace operations, e.g. list, stop, start and so
@@ -121,5 +123,5 @@ type WorkspaceBackend interface {
 	// not related to the command (i.e. the workspace does not exist) and the
 	// errors that were caused by the command itself (e.g. != 0 return code). If
 	// the latter, an instance of ErrExec with the status code must be returned.
-	Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error)
+	Exec(ctx context.Context, name string, args *ExecArgs) error
 }

--- a/internal/workspacebackend/backend.go
+++ b/internal/workspacebackend/backend.go
@@ -57,11 +57,11 @@ type WorkspaceBackend interface {
 	// Returns a list of projects known to the backend.
 	Projects(ctx context.Context) (map[string]*Project, error)
 
-	// Launch a barebone workspace instance using the base provided. Currently,
-	// the supported bases are ubuntu@20.04 and ubuntu@22.04.
+	// Launch a barebone workspace instance using the base provided. The
+	// supported bases are ubuntu@20.04 and ubuntu@22.04.
 	LaunchWorkspace(ctx context.Context, name, base string) error
 
-	// Delete workspace. Stop the workspace if not in Stopped
+	// Delete workspace. Stop the workspace forcefully if not in Stopped before deleting
 	DeleteWorkspace(ctx context.Context, name string) error
 
 	// Starts a workspace and waits until it is ready

--- a/internal/workspacebackend/backend.go
+++ b/internal/workspacebackend/backend.go
@@ -61,9 +61,8 @@ type WorkspaceBackend interface {
 	// the supported bases are ubuntu@20.04 and ubuntu@22.04.
 	LaunchWorkspace(ctx context.Context, name, base string) error
 
-	// Delete workspace. Will fail if forceful flag is false and the workspace
-	// is not in the Stopped state.
-	DeleteWorkspace(ctx context.Context, name string, forceful bool) error
+	// Delete workspace. Stop the workspace if not in Stopped
+	DeleteWorkspace(ctx context.Context, name string) error
 
 	// Starts a workspace and waits until it is ready
 	// to accept commands

--- a/internal/workspacebackend/lxd_backend.go
+++ b/internal/workspacebackend/lxd_backend.go
@@ -41,7 +41,7 @@ type LxdBackend struct {
 const (
 	LxdSock = "/var/snap/lxd/common/lxd/unix.socket"
 	// name prefix for the workspaces that were made unavailable
-	UnavailablePrefix = "unavailable-"
+	StashNamePrefix = "stash-"
 )
 
 var (
@@ -924,7 +924,7 @@ func (s *LxdBackend) RemoveWorkspaceStash(ctx context.Context, name string) erro
 	}
 
 	system := conn.UseProject(LxdSystemProjectName(user))
-	op, err := system.DeleteInstance(InstanceName(UnavailablePrefix+name, projectId))
+	op, err := system.DeleteInstance(InstanceName(StashNamePrefix+name, projectId))
 	if err != nil {
 		return err
 	}
@@ -980,7 +980,7 @@ func (s *LxdBackend) moveInstanceProject(conn lxd.InstanceServer, ctx context.Co
 		// the new name must not be the same, otherwise the LXD's DNS will fail
 		// the new instance creation
 		op, err = conn.MigrateInstance(instance, api.InstancePost{
-			Name:      UnavailablePrefix + instance,
+			Name:      StashNamePrefix + instance,
 			Project:   LxdSystemProjectName(user),
 			Migration: true,
 		})
@@ -989,7 +989,7 @@ func (s *LxdBackend) moveInstanceProject(conn lxd.InstanceServer, ctx context.Co
 		// switch the project for the connection first to make the reverse
 		// migration successful (i.e. from system -> user project)
 		conn = conn.UseProject(LxdSystemProjectName(user))
-		op, err = conn.MigrateInstance(UnavailablePrefix+instance, api.InstancePost{
+		op, err = conn.MigrateInstance(StashNamePrefix+instance, api.InstancePost{
 			Name:      instance,
 			Project:   LxdProjectName(user),
 			Migration: true,

--- a/internal/workspacebackend/lxd_backend.go
+++ b/internal/workspacebackend/lxd_backend.go
@@ -29,6 +29,7 @@ type ExecArgs struct {
 	Command     []string
 	WorkDir     string
 	Environment map[string]string
+	Interactive bool
 	Stdin       io.ReadCloser
 	Stdout      io.WriteCloser
 	Stderr      io.WriteCloser
@@ -364,7 +365,7 @@ func (s *LxdBackend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx 
 
 		/* Take the first instance from the group, we need any running
 		and ready to execute commands to validate the project directory */
-		stdout, err := memFs.Create(i.Name)
+		out, err := memFs.Create(i.Name)
 		if err != nil {
 			return "", err
 		}
@@ -376,16 +377,16 @@ func (s *LxdBackend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx 
 				"findmnt --mountpoint /project -o source -n | awk -F\"[][]\" '{printf $2}'"},
 			WorkDir: "/",
 			Stdin:   nil,
-			Stdout:  stdout,
-			Stderr:  nil}
+			Stdout:  out,
+			Stderr:  out}
 
 		execCtx := context.WithValue(ctx, ContextProjectId, p.ProjectId)
-		done, err := s.Exec(execCtx, WorkspaceName(i.Name), &args)
+		err = s.execCommand(conn, execCtx, WorkspaceName(i.Name), &args)
 		if err != nil {
-			logger.Debugf("cannot check %q bind-mounts: %v", i.Name, err)
+			outbuf, _ := afero.ReadFile(memFs, out.Name())
+			logger.Debugf("cannot check %q bind-mounts: %v, findmnt output: %s", i.Name, err, outbuf)
 			continue
 		}
-		<-done
 
 		/* Process the findmnt results */
 		if currentPath, err := afero.ReadFile(memFs, i.Name); err == nil {
@@ -512,12 +513,41 @@ func (s *LxdBackend) updateInstanceState(conn lxd.InstanceServer, ctx context.Co
 	return op.WaitContext(ctx)
 }
 
-func (s *LxdBackend) SetWorkspaceState(ctx context.Context, name, action string) error {
+func (s *LxdBackend) StartWorkspace(ctx context.Context, name string) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
 	}
-	return s.updateInstanceState(conn, ctx, name, action)
+	if err = s.updateInstanceState(conn, ctx, name, "start"); err != nil {
+		return err
+	}
+
+	// Wait until system is up an running before returning
+	// see: https://blog.simos.info/how-to-know-when-a-lxd-container-has-finished-starting-up/
+	args := ExecArgs{
+		User: "root",
+		Command: []string{
+			"bash", "-eu", "-c", "while " +
+				"[ \"$(systemctl is-system-running 2>/dev/null)\" != \"running\" ] && " +
+				"[ \"$(systemctl is-system-running 2>/dev/null)\" != \"degraded\" ]; do :; done",
+		},
+		WorkDir: "/",
+		Stdin:   nil,
+		Stdout:  nil,
+		Stderr:  nil}
+
+	if err := s.Exec(ctx, name, &args); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *LxdBackend) StopWorkspace(ctx context.Context, name string, force bool) error {
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return err
+	}
+	return s.updateInstanceState(conn, ctx, name, "stop")
 }
 
 func (s *LxdBackend) AddWorkspaceConfig(ctx context.Context, name string, item *WorkspaceConfigValue) error {
@@ -536,9 +566,12 @@ func (s *LxdBackend) AddWorkspaceConfig(ctx context.Context, name string, item *
 		return err
 	}
 	inst.Config[item.Name] = item.Value
-	op, _ := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+	op, err := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+	if err != nil {
+		return err
+	}
 
-	return op.Wait()
+	return op.WaitContext(ctx)
 }
 
 func (s *LxdBackend) RemoveWorkspaceConfig(ctx context.Context, name string, key string) error {
@@ -606,48 +639,62 @@ func (s *LxdBackend) RemoveWorkspaceDevice(ctx context.Context, name string, dev
 	return op.Wait()
 }
 
-func (s *LxdBackend) Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error) {
-	conn, err := s.LxdClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *LxdBackend) execCommand(conn lxd.InstanceServer, ctx context.Context, name string, args *ExecArgs) error {
 	projectId, ok := ctx.Value(ContextProjectId).(string)
 	if !ok {
-		return nil, fmt.Errorf("context key project-id not found")
+		return fmt.Errorf("context key project-id not found")
 	}
 
 	req := api.InstanceExecPost{
-		Command: args.Command, WaitForWS: true,
-		User: 0, Group: 0, Cwd: args.WorkDir,
-		Interactive: false, Environment: args.Environment,
+		Command:     args.Command,
+		WaitForWS:   true,
+		User:        0,
+		Group:       0,
+		Cwd:         args.WorkDir,
+		Interactive: args.Interactive,
+		Environment: args.Environment,
 	}
 
 	done := make(chan bool)
 
 	arg := lxd.InstanceExecArgs{
-		Stdin: args.Stdin, Stdout: args.Stdout, Stderr: args.Stderr,
-		Control: nil, DataDone: done,
+		Stdin:    args.Stdin,
+		Stdout:   args.Stdout,
+		Stderr:   args.Stderr,
+		Control:  nil,
+		DataDone: done,
 	}
 
 	op, err := conn.ExecInstance(InstanceName(name, projectId), req, &arg)
 
 	if err != nil {
-		return done, err
+		return err
 	}
 
 	if err := op.WaitContext(ctx); err != nil {
-		return done, err
+		return err
 	}
+
+	// waiting for any remaining data IO to be flushed LXD closes this channel
+	// unconditionally right after the operation has exited
+	<-arg.DataDone
 
 	if status, ok := op.Get().Metadata["return"].(float64); ok {
 		if status != 0 {
 			logger.Debugf("cannot exec: %v", int(status))
-			return done, &ErrExec{Status: int(status)}
+			return &ErrExec{Status: int(status)}
 		}
 	}
+	return nil
+}
 
-	return done, nil
+func (s *LxdBackend) Exec(ctx context.Context, name string, args *ExecArgs) error {
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	return s.execCommand(conn, ctx, name, args)
 }
 
 func (s *LxdBackend) GetWorkspace(ctx context.Context, name string) (*Workspace, error) {

--- a/internal/workspacebackend/lxd_backend.go
+++ b/internal/workspacebackend/lxd_backend.go
@@ -482,7 +482,7 @@ func (s *LxdBackend) LaunchWorkspace(ctx context.Context, name, base string) err
 	return nil
 }
 
-func (s *LxdBackend) updateInstanceState(conn lxd.InstanceServer, ctx context.Context, name, action string) error {
+func (s *LxdBackend) updateInstanceState(conn lxd.InstanceServer, ctx context.Context, name, action string, force bool) error {
 	projectId, ok := ctx.Value(ContextProjectId).(string)
 	if !ok {
 		return fmt.Errorf("context key project-id not found")
@@ -501,8 +501,8 @@ func (s *LxdBackend) updateInstanceState(conn lxd.InstanceServer, ctx context.Co
 
 	req := api.InstanceStatePut{
 		Action:  action,
-		Timeout: 10,
-		Force:   false,
+		Timeout: 30,
+		Force:   force,
 	}
 
 	op, err := conn.UpdateInstanceState(inst.Name, req, etag)
@@ -518,7 +518,7 @@ func (s *LxdBackend) StartWorkspace(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	if err = s.updateInstanceState(conn, ctx, name, "start"); err != nil {
+	if err = s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
 		return err
 	}
 
@@ -536,10 +536,7 @@ func (s *LxdBackend) StartWorkspace(ctx context.Context, name string) error {
 		Stdout:  nil,
 		Stderr:  nil}
 
-	if err := s.Exec(ctx, name, &args); err != nil {
-		return err
-	}
-	return nil
+	return s.execCommand(conn, ctx, name, &args)
 }
 
 func (s *LxdBackend) StopWorkspace(ctx context.Context, name string, force bool) error {
@@ -547,7 +544,7 @@ func (s *LxdBackend) StopWorkspace(ctx context.Context, name string, force bool)
 	if err != nil {
 		return err
 	}
-	return s.updateInstanceState(conn, ctx, name, "stop")
+	return s.updateInstanceState(conn, ctx, name, "stop", force)
 }
 
 func (s *LxdBackend) AddWorkspaceConfig(ctx context.Context, name string, item *WorkspaceConfigValue) error {
@@ -861,7 +858,7 @@ func mergeInstancesAndFiles(f []*WorkspaceFile, instances []*Workspace) ([]*Work
 	return files, instances
 }
 
-func (s *LxdBackend) DeleteWorkspace(ctx context.Context, name string, forceful bool) error {
+func (s *LxdBackend) DeleteWorkspace(ctx context.Context, name string) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -878,24 +875,8 @@ func (s *LxdBackend) DeleteWorkspace(ctx context.Context, name string, forceful 
 	}
 
 	if inst.StatusCode != 0 && inst.StatusCode != api.Stopped {
-		if forceful {
-			req := api.InstanceStatePut{
-				Action:  "stop",
-				Timeout: -1,
-				Force:   true,
-			}
-
-			op, err := conn.UpdateInstanceState(inst.Name, req, "")
-			if err != nil {
-				return err
-			}
-
-			err = op.WaitContext(ctx)
-			if err != nil {
-				return fmt.Errorf("stopping the instance failed: %s", err)
-			}
-		} else {
-			return fmt.Errorf("cannot delete a non-stopped workspace: %q", name)
+		if err = s.updateInstanceState(conn, ctx, name, "stop", true); err != nil {
+			return err
 		}
 	}
 
@@ -959,7 +940,7 @@ func (s *LxdBackend) UnstashWorkspace(ctx context.Context, name string) error {
 		return err
 	}
 
-	if err := s.updateInstanceState(conn, ctx, name, "start"); err != nil {
+	if err := s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
 		return err
 	}
 	return nil
@@ -970,7 +951,7 @@ func (s *LxdBackend) StashWorkspace(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	if err := s.updateInstanceState(conn, ctx, name, "stop"); err != nil {
+	if err := s.updateInstanceState(conn, ctx, name, "stop", false); err != nil {
 		return err
 	}
 

--- a/internal/workspacebackend/lxd_backend_mock.go
+++ b/internal/workspacebackend/lxd_backend_mock.go
@@ -121,7 +121,17 @@ func (f *FakeWorkspaceBackend) DeleteWorkspace(ctx context.Context, name string,
 }
 
 func (f *FakeWorkspaceBackend) SetWorkspaceState(ctx context.Context, name, action string) error {
-	panic("not implemented") // TODO: Implement
+	w, err := f.GetWorkspace(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if action == "start" {
+		w.running = true
+	} else if action == "stop" {
+		w.running = false
+	}
+	return nil
 }
 
 func (f *FakeWorkspaceBackend) AddWorkspaceDevice(ctx context.Context, name string, props WorkspaceDevice) error {
@@ -167,7 +177,13 @@ func (f *FakeWorkspaceBackend) GetWorkspace(ctx context.Context, name string) (*
 	}
 
 	project := f.projects[user][projectId]
-	workspace := f.Workspaces[projectId][name].Workspace
+	if project == nil {
+		return nil, api.StatusErrorf(404, "project not found")
+	}
+	workspace := f.Workspaces[projectId][name]
+	if workspace == nil {
+		return nil, api.StatusErrorf(404, "workspace not found")
+	}
 	workspace.file, err = project.WorkspaceFile(workspace.Name)
 	if err != nil {
 		return nil, err
@@ -177,7 +193,7 @@ func (f *FakeWorkspaceBackend) GetWorkspace(ctx context.Context, name string) (*
 	if err != nil {
 		return nil, err
 	}
-	return workspace, nil
+	return workspace.Workspace, nil
 }
 
 func (f *FakeWorkspaceBackend) GetProjectWorkspaces(ctx context.Context) ([]*WorkspaceFile, []*Workspace, error) {

--- a/internal/workspacebackend/lxd_backend_mock.go
+++ b/internal/workspacebackend/lxd_backend_mock.go
@@ -13,7 +13,7 @@ import (
 
 /* Fake backend implementation for tests */
 
-type ExecFunc func(ctx context.Context, name string, args *ExecArgs) (chan bool, error)
+type ExecFunc func(ctx context.Context, name string, args *ExecArgs) error
 
 type FakeWorkspace struct {
 	*Workspace
@@ -120,17 +120,24 @@ func (f *FakeWorkspaceBackend) DeleteWorkspace(ctx context.Context, name string,
 	panic("not implemented") // TODO: Implement
 }
 
-func (f *FakeWorkspaceBackend) SetWorkspaceState(ctx context.Context, name, action string) error {
-	w, err := f.GetWorkspace(ctx, name)
+func (s *FakeWorkspaceBackend) StartWorkspace(ctx context.Context, name string) error {
+	w, err := s.GetWorkspace(ctx, name)
 	if err != nil {
 		return err
 	}
-
-	if action == "start" {
-		w.running = true
-	} else if action == "stop" {
-		w.running = false
+	if w.running {
+		return api.StatusErrorf(http.StatusConflict, "workspace already running")
 	}
+	w.running = true
+	return nil
+}
+
+func (s *FakeWorkspaceBackend) StopWorkspace(ctx context.Context, name string, force bool) error {
+	w, err := s.GetWorkspace(ctx, name)
+	if err != nil {
+		return err
+	}
+	w.running = false
 	return nil
 }
 
@@ -234,16 +241,13 @@ func (s *FakeWorkspaceBackend) GetWorkspaceFs(ctx context.Context, name string) 
 	return s.Workspaces[projectId][name].WorkspaceFilesystem, nil
 }
 
-func (f *FakeWorkspaceBackend) Exec(ctx context.Context, name string, args *ExecArgs) (chan bool, error) {
+func (f *FakeWorkspaceBackend) Exec(ctx context.Context, name string, args *ExecArgs) error {
 	f.ExecCalls = append(f.ExecCalls, &ExecCall{name, args})
 	return f.DoExec(ctx, name, args)
 }
 
-func DoExecDefault(ctx context.Context, name string, args *ExecArgs) (chan bool, error) {
-	done := make(chan bool)
-	close(done)
-
-	return done, nil
+func DoExecDefault(ctx context.Context, name string, args *ExecArgs) error {
+	return nil
 }
 
 func (s *FakeWorkspaceBackend) RemoveWorkspaceStash(ctx context.Context, name string) error {

--- a/internal/workspacebackend/lxd_backend_mock.go
+++ b/internal/workspacebackend/lxd_backend_mock.go
@@ -116,7 +116,7 @@ func (f *FakeWorkspaceBackend) LaunchWorkspace(ctx context.Context, name, base s
 	return nil
 }
 
-func (f *FakeWorkspaceBackend) DeleteWorkspace(ctx context.Context, name string, forceful bool) error {
+func (f *FakeWorkspaceBackend) DeleteWorkspace(ctx context.Context, name string) error {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/internal/workspacebackend/tests/integration/workspace_test.go
+++ b/internal/workspacebackend/tests/integration/workspace_test.go
@@ -141,3 +141,23 @@ func (f *WsOps) TestLxdBackendRemoveWorkspaceStash(c *check.C) {
 	_, _, err = cli.GetInstance(workspacebackend.InstanceName("test-1", f.project.ProjectId))
 	c.Assert(err, check.ErrorMatches, "Instance not found")
 }
+
+func (f *WsOps) TestLxdBackendStartWorkspace(c *check.C) {
+	// Setup
+	err := f.be.LaunchWorkspace(f.ctx, "test-1", "ubuntu@22.04")
+	c.Assert(err, check.IsNil)
+	err = f.be.StopWorkspace(f.ctx, "test-1", false)
+	c.Assert(err, check.IsNil)
+
+	// Execute
+	err = f.be.StartWorkspace(f.ctx, "test-1")
+
+	//Validate
+	c.Assert(err, check.IsNil)
+	_, err = f.be.GetWorkspace(f.ctx, "test-1")
+	c.Assert(err, check.IsNil)
+	// Execute
+	err = f.be.DeleteWorkspace(f.ctx, "test-1", true)
+	//Validate
+	c.Assert(err, check.IsNil)
+}

--- a/internal/workspacebackend/tests/integration/workspace_test.go
+++ b/internal/workspacebackend/tests/integration/workspace_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/workspace/internal/testutil"
 	"github.com/canonical/workspace/internal/workspacebackend"
 	lxd "github.com/lxc/lxd/client"
+	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
 )
 
@@ -65,19 +66,13 @@ func (f *WsOps) TearDownSuite(c *check.C) {
 }
 
 func (f *WsOps) TestLxdBackendTrivialLaunch(c *check.C) {
-	// Setup
-
 	// Execute
 	err := f.be.LaunchWorkspace(f.ctx, "test-1", "ubuntu@22.04")
+	defer f.be.DeleteWorkspace(f.ctx, "test-1")
 
 	//Validate
 	c.Assert(err, check.IsNil)
 	_, err = f.be.GetWorkspace(f.ctx, "test-1")
-	c.Assert(err, check.IsNil)
-
-	// Execute
-	err = f.be.DeleteWorkspace(f.ctx, "test-1", true)
-	//Validate
 	c.Assert(err, check.IsNil)
 }
 
@@ -124,6 +119,7 @@ func (f *WsOps) TestLxdBackendStateStorageVolumeAddRemove(c *check.C) {
 func (f *WsOps) TestLxdBackendRemoveWorkspaceStash(c *check.C) {
 	// Setup
 	err := f.be.LaunchWorkspace(f.ctx, "test-1", "ubuntu@22.04")
+	defer f.be.DeleteWorkspace(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
 
 	// Execute
@@ -146,8 +142,7 @@ func (f *WsOps) TestLxdBackendStartWorkspace(c *check.C) {
 	// Setup
 	err := f.be.LaunchWorkspace(f.ctx, "test-1", "ubuntu@22.04")
 	c.Assert(err, check.IsNil)
-	err = f.be.StopWorkspace(f.ctx, "test-1", false)
-	c.Assert(err, check.IsNil)
+	defer f.be.DeleteWorkspace(f.ctx, "test-1")
 
 	// Execute
 	err = f.be.StartWorkspace(f.ctx, "test-1")
@@ -156,8 +151,36 @@ func (f *WsOps) TestLxdBackendStartWorkspace(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, err = f.be.GetWorkspace(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
+
+	// now, ensure that the systemd is in the final state
+	memFs := afero.NewMemMapFs()
+	out, _ := memFs.Create("stdout")
+	args := workspacebackend.ExecArgs{
+		User: "root",
+		Command: []string{
+			"bash", "-eu", "-c",
+			"systemctl is-system-running 2>/dev/null",
+		},
+		WorkDir: "/",
+		Stdin:   nil,
+		Stdout:  out,
+		Stderr:  out}
+
+	err = f.be.Exec(f.ctx, "test-1", &args)
+	c.Assert(err, check.IsNil)
+	buf, err := afero.ReadFile(memFs, out.Name())
+	c.Assert(err, check.IsNil)
+	c.Assert(string(buf), check.Equals, "running\n")
+}
+
+func (f *WsOps) TestLxdBackendDeleteWorkspace(c *check.C) {
 	// Execute
-	err = f.be.DeleteWorkspace(f.ctx, "test-1", true)
+	err := f.be.LaunchWorkspace(f.ctx, "test-1", "ubuntu@22.04")
+	c.Assert(err, check.IsNil)
+	err = f.be.StartWorkspace(f.ctx, "test-1")
+	c.Assert(err, check.IsNil)
+
 	//Validate
+	err = f.be.DeleteWorkspace(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
 }

--- a/tests/main/changes/task.yaml
+++ b/tests/main/changes/task.yaml
@@ -20,4 +20,4 @@ execute: |
   launch $project ws
 
   echo "The launch change must present in the list"
-  changes $project | MATCH "^1[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch workspace.*$"
+  changes $project | MATCH "^1[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workspace$"

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -11,6 +11,7 @@ restore: |
   uninstall_workspaced
 
 debug: |
+  lxc list -f compact --all-projects
   workspace changes
   workspace tasks 1
 
@@ -32,7 +33,7 @@ execute: |
   echo "\"Fix\" the SDK error by replacing the setup-base hook"
   project_id=$(cat "$project"/.workspace.lock)
   instance=ws-"$project_id"
-  lxc exec "$instance" -- sed -i "s/exit 1/exit 0/g" /var/lib/workspace/sdk/test-sdk-setup-fail/current/hooks/setup-base
+  lxc exec "$instance" --project workspace.ubuntu -- sed -i "s/exit 1/exit 0/g" /var/lib/workspace/sdk/test-sdk-setup-fail/current/hooks/setup-base
 
   echo "Check the workspace refresh --continue reverts to the previous state"
   workspace_exec refresh --project $project --continue ws | MATCH "\"ws\" refreshed"

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -23,12 +23,12 @@ execute: |
   launch $project ws
 
   echo "Check launch change is Done"
-  changes $project | MATCH "^1[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch workspace.*$"
+  changes $project | MATCH "^1[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workspace$"
 
   workspace_exec refresh --project $project ws
 
   echo "Check refresh change is Done"
-  changes $project | MATCH "^2[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh workspace \"ws\"$"
+  changes $project | MATCH "^2[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws\" workspace$"
 
   echo "Check the workspace is in Ready state"
   list "$project" | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
@@ -38,12 +38,12 @@ execute: |
 
   launch $project ws
   echo "Check launch change is Done"
-  changes $project | MATCH "^3[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch workspace.*$"
+  changes $project | MATCH "^3[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workspace$"
 
   workspace_exec refresh --project $project ws
 
   echo "Check refresh change is Done"
-  changes $project | MATCH "^4[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh workspace \"ws\"$"
+  changes $project | MATCH "^4[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws\" workspace$"
 
   echo "Check the workspace is in Ready state"
   list "$project" | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -1,0 +1,37 @@
+summary: Check workspace start
+environment:
+  WORKSPACES: $SPREAD_PATH/tests/lib
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  install_workspaced
+
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup "$WORKSPACES"
+  uninstall_workspaced
+
+debug: |
+  lxc list -f compact --all-projects
+  workspace changes
+  workspace tasks 1
+
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Launch a workspace"
+  project="$WORKSPACES"/workspaces-sdk/test-sdk-basic
+  launch $project ws
+
+  # Stop the workspace instance
+  project_id=$(cat "$project"/.workspace.lock)
+  instance=ws-"$project_id"
+  lxc stop "$instance" --project workspace.ubuntu
+
+  echo "Check the workspace is in Stopped state"
+  list "$project" | MATCH "^.+[[:space:]]+ws[[:space:]]+Stopped[[:space:]]+-$"
+
+  echo "Start the workspace"
+  workspace_exec start --project $project ws
+
+  echo "Check the workspace is in Ready state"
+  list "$project" | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"


### PR DESCRIPTION
The start command to start and wait until the instance is Ready. 
```
workspace start <workspace>...
```

The command starts the workspace instance and awaits until the systemd reports `multi-user.target` as active. For the duration of the start, the workspace is in Pending state and unavailable for other commands.