### PR TITLE
Chore: stop removed projects tracking

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -77,6 +77,8 @@ backends:
 suites:
   tests/main/:
     summary: Core workspace scenarios
+  tests/integration/:
+    summary: LXD integration tests
 
 path: /remote
 exclude:

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
 	golang.org/x/term v0.3.0 // indirect
-	golang.org/x/text v0.5.0 // indirect
+	golang.org/x/text v0.5.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect

--- a/internal/workspacebackend/lxd_backend.go
+++ b/internal/workspacebackend/lxd_backend.go
@@ -72,7 +72,7 @@ func allocateProjectId() (string, error) {
 	return hex.EncodeToString(bytes), nil
 }
 
-func (s *LxdBackend) getProject(client lxd.InstanceServer, ctx context.Context, path string) (*Project, error) {
+func (s *LxdBackend) loadProject(client lxd.InstanceServer, ctx context.Context, path string) (*Project, error) {
 
 	user, ok := ctx.Value(ContextUser).(string)
 	if !ok {
@@ -118,12 +118,36 @@ func (s *LxdBackend) getProject(client lxd.InstanceServer, ctx context.Context, 
 	return nil, ErrProjectNotFound
 }
 
-func (s *LxdBackend) trackProject(ctx context.Context, prj *Project) error {
-	client, err := s.LxdClient(ctx)
+func (s *LxdBackend) untrackProject(client lxd.InstanceServer, ctx context.Context, prj *Project) error {
+	user, ok := ctx.Value(ContextUser).(string)
+	if !ok {
+		return fmt.Errorf("context key %s not found", ContextUser)
+	}
+
+	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
 	if err != nil {
 		return err
 	}
 
+	var projects map[string]*Project = make(map[string]*Project, 0)
+	if buf, ok := lxdPrj.Config["user.workspace.projects"]; ok {
+		if err = json.Unmarshal([]byte(buf), &projects); err != nil {
+			return err
+		}
+	}
+
+	delete(projects, prj.ProjectId)
+
+	buf, err := json.Marshal(projects)
+	if err != nil {
+		return err
+	}
+	lxdPrj.ProjectPut.Config["user.workspace.projects"] = string(buf)
+
+	return client.UpdateProject(LxdProjectName(user), lxdPrj.ProjectPut, etag)
+}
+
+func (s *LxdBackend) trackProject(client lxd.InstanceServer, ctx context.Context, prj *Project) error {
 	user, ok := ctx.Value(ContextUser).(string)
 	if !ok {
 		return fmt.Errorf("context key %s not found", ContextUser)
@@ -149,10 +173,7 @@ func (s *LxdBackend) trackProject(ctx context.Context, prj *Project) error {
 	}
 	lxdPrj.ProjectPut.Config["user.workspace.projects"] = string(buf)
 
-	if err = client.UpdateProject(LxdProjectName(user), lxdPrj.ProjectPut, etag); err != nil {
-		return err
-	}
-	return nil
+	return client.UpdateProject(LxdProjectName(user), lxdPrj.ProjectPut, etag)
 }
 
 // projectPath returns a project path for the cwd provided
@@ -203,7 +224,7 @@ func (s *LxdBackend) CreateOrLoadProject(ctx context.Context, path string) (*Pro
 	}
 
 	// see if we have this project already existing
-	if existingProject, err := s.getProject(client, ctx, projectDir); err == nil {
+	if existingProject, err := s.loadProject(client, ctx, projectDir); err == nil {
 		// the tracked path and the requested path must be the same
 		// otherwise it means that the project directory was moved or copied
 		// If that is the case, we must update the project's configuration
@@ -223,7 +244,7 @@ func (s *LxdBackend) CreateOrLoadProject(ctx context.Context, path string) (*Pro
 				// 1. Update the new path to the actual and track it
 				// 2. Update all the workspaces to the new project mount
 				existingProject.Path = projectDir
-				err := s.trackProject(ctx, existingProject)
+				err := s.trackProject(client, ctx, existingProject)
 				if err != nil {
 					return nil, false, err
 				}
@@ -243,7 +264,7 @@ func (s *LxdBackend) CreateOrLoadProject(ctx context.Context, path string) (*Pro
 				if err = newPrj.UpdateLockFile(); err != nil {
 					return nil, false, err
 				}
-				s.trackProject(ctx, &newPrj)
+				s.trackProject(client, ctx, &newPrj)
 				return &newPrj, true, nil
 			}
 		}
@@ -282,7 +303,7 @@ func (s *LxdBackend) CreateOrLoadProject(ctx context.Context, path string) (*Pro
 
 	// Now, add the project ID to the tracking map
 	// stored in a custom user.* key of the LXD project for this user
-	if err = s.trackProject(ctx, &project); err != nil {
+	if err = s.trackProject(client, ctx, &project); err != nil {
 		return nil, false, err
 	}
 
@@ -330,18 +351,32 @@ func (s *LxdBackend) Projects(ctx context.Context) (map[string]*Project, error) 
 		}
 	}
 
-	for _, i := range projects {
-		if ok, _, err := osutil.ExistsIsDir(i.Path); !ok && err == nil {
-			// we realised that there is no project directory for the
-			// projectId anymore. It can mean moving or deletion happened in the past
-			// Try to recover the new project path
-			newPath, err := s.findProjectPathFromBindMounts(client, ctx, i)
-			if err == nil && newPath != "" {
+	for _, prj := range projects {
+		if ok, _, err := osutil.ExistsIsDir(prj.Path); !ok && err == nil {
+			// If got here then there is no project directory for the projectId
+			// anymore. It can mean moving or deletion happened in the past. Try
+			// to recover the new project path
+			newPath, _ := s.findProjectPathFromBindMounts(client, ctx, prj)
+			if newPath != "" {
 				// start tracking this project under a new path
-				i.Path = newPath
-				if err = s.trackProject(ctx, i); err == nil {
-					s.updateWorkspacesProjectPath(client, ctx, i)
+				prj.Path = newPath
+				if err = s.trackProject(client, ctx, prj); err == nil {
+					// update the workspaces configuration with the new path
+					s.updateWorkspacesProjectPath(client, ctx, prj)
 				}
+				continue
+			}
+			// Could not recover the directory, reconcile the project from the
+			// list of projects that we track (only if there are no remaining
+			// workspaces for this project)
+			inst, err := s.filterLxdInstancesByConfig(client, func(config map[string]string) bool {
+				return config["user.workspace.project-id"] == prj.ProjectId
+			})
+			if err == nil && len(inst) == 0 {
+				if err = s.untrackProject(client, ctx, prj); err != nil {
+					return nil, err
+				}
+				delete(projects, prj.ProjectId)
 			}
 		}
 	}

--- a/internal/workspacebackend/tests/integration/project_test.go
+++ b/internal/workspacebackend/tests/integration/project_test.go
@@ -18,15 +18,15 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-type LT struct {
+type wsProject struct {
 	ctx      context.Context
 	client   lxd.InstanceServer
 	username string
 }
 
-var _ = check.Suite(&LT{})
+var _ = check.Suite(&wsProject{})
 
-func (f *LT) SetUpTest(c *check.C) {
+func (f *wsProject) SetUpTest(c *check.C) {
 	f.username = "testuser"
 	f.ctx = context.WithValue(context.Background(), workspacebackend.ContextUser, f.username)
 	be := workspacebackend.LxdBackend{}
@@ -50,19 +50,21 @@ func cleanUpLxdProject(c *check.C, client lxd.InstanceServer, project string) {
 	instances, err := cli.GetInstances(api.InstanceType("container"))
 	c.Check(err, check.IsNil)
 	for _, i := range instances {
-		req := api.InstanceStatePut{
-			Action:  "stop",
-			Timeout: 1,
-			Force:   true,
+		if i.Status == "Running" {
+			req := api.InstanceStatePut{
+				Action:  "stop",
+				Timeout: 1,
+				Force:   true,
+			}
+
+			op, err := cli.UpdateInstanceState(i.Name, req, "")
+			c.Check(err, check.IsNil)
+			if err == nil {
+				c.Check(op.Wait(), check.IsNil)
+			}
 		}
 
-		op, err := cli.UpdateInstanceState(i.Name, req, "")
-		c.Check(err, check.IsNil)
-		if err == nil {
-			c.Check(op.Wait(), check.IsNil)
-		}
-
-		op, err = cli.DeleteInstance(i.Name)
+		op, err := cli.DeleteInstance(i.Name)
 		c.Check(err, check.IsNil)
 		if err == nil {
 			c.Check(op.Wait(), check.IsNil)
@@ -73,13 +75,14 @@ func cleanUpLxdProject(c *check.C, client lxd.InstanceServer, project string) {
 	c.Check(err, check.IsNil)
 }
 
-func (f *LT) TearDownTest(c *check.C) {
+func (f *wsProject) TearDownTest(c *check.C) {
 	cleanUpLxdProject(c, f.client, workspacebackend.LxdProjectName(f.username))
+	cleanUpLxdProject(c, f.client, workspacebackend.LxdSystemProjectName(f.username))
 }
 
-func TestWorkspaceBackendProjectIntegration(t *testing.T) { check.TestingT(t) }
+func TestWorkspaceBackendIntegration(t *testing.T) { check.TestingT(t) }
 
-func (f *LT) TestLxdBackendCreateProjectNoWorkspaceFiles(c *check.C) {
+func (f *wsProject) TestLxdBackendCreateProjectNoWorkspaceFiles(c *check.C) {
 	// Setup
 	be := workspacebackend.LxdBackend{}
 
@@ -96,7 +99,7 @@ func (f *LT) TestLxdBackendCreateProjectNoWorkspaceFiles(c *check.C) {
 	c.Assert(projects, check.HasLen, 0)
 }
 
-func (f *LT) TestLxdBackendCreateProject(c *check.C) {
+func (f *wsProject) TestLxdBackendCreateProject(c *check.C) {
 	// Setup
 	be := workspacebackend.LxdBackend{}
 	numCalls := 0
@@ -133,7 +136,7 @@ base: ubuntu@22.04
 	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"},"d4352dea":{"path":"%s","id":"d4352dea"}}`, projectDir, projectDir2))
 }
 
-func (f *LT) TestLxdBackendLoadProject(c *check.C) {
+func (f *wsProject) TestLxdBackendLoadProject(c *check.C) {
 	// Setup
 	be := workspacebackend.LxdBackend{}
 	restore := testutil.FakeFunc(func() (string, error) { return "b8639dea", nil }, &workspacebackend.NewProjectId)
@@ -163,7 +166,7 @@ base: ubuntu@22.04
 	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"}}`, projectDir))
 }
 
-func (f *LT) TestLxdBackendLoadProjectDirectoryMoved(c *check.C) {
+func (f *wsProject) TestLxdBackendLoadProjectDirectoryMoved(c *check.C) {
 	// Setup
 	// We pre-create a project to emulate the scenario when
 	// the directory was moved, but the project's settings were not
@@ -195,7 +198,7 @@ base: ubuntu@22.04
 	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"}}`, newDir))
 }
 
-func (f *LT) TestLxdBackendLoadProjectDirectoryCopied(c *check.C) {
+func (f *wsProject) TestLxdBackendLoadProjectDirectoryCopied(c *check.C) {
 	// Setup
 	// We pre-create a project to emulate the scenario when
 	// the directory was copied, but the project's settings were not
@@ -230,7 +233,7 @@ base: ubuntu@22.04
 	c.Assert(lxdProject.Config["user.workspace.projects"], check.Matches, fmt.Sprintf(`.*"abcdefgi":{"path":"%s","id":"abcdefgi"}.*`, newDir))
 }
 
-func (f *LT) TestLxdBackendListAvailableProjects(c *check.C) {
+func (f *wsProject) TestLxdBackendListAvailableProjects(c *check.C) {
 	// Setup
 	be := workspacebackend.LxdBackend{}
 	numCalls := 0
@@ -262,4 +265,29 @@ base: ubuntu@22.04
 	})
 	c.Assert(workspacebackend.LockPath(projectDir), testutil.FilePresent)
 	c.Assert(workspacebackend.LockPath(projectDir2), testutil.FilePresent)
+}
+
+func (f *wsProject) TestLxdBackendLoadProjectDirectoryRemoved(c *check.C) {
+	// Setup
+	// We pre-create a project to emulate the scenario when
+	// the directory was removed
+	be := workspacebackend.LxdBackend{}
+	projectDir := c.MkDir()
+	workspace := `name: test
+base: ubuntu@22.04
+`
+	err := os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspace), 0644)
+	c.Assert(err, check.IsNil)
+	_, _, err = be.CreateOrLoadProject(f.ctx, projectDir)
+	c.Assert(err, check.IsNil)
+
+	// Execute
+	err = os.RemoveAll(projectDir)
+	c.Assert(err, check.IsNil)
+	projects, err := be.Projects(f.ctx)
+
+	// Validate (if the directory does not exist, the project
+	// needs to be removed from tracking)
+	c.Assert(err, check.IsNil)
+	c.Assert(projects, check.HasLen, 0)
 }

--- a/tests/integration/project-tracking/task.yaml
+++ b/tests/integration/project-tracking/task.yaml
@@ -1,0 +1,4 @@
+summary: Run LXD integration tests for project tracking
+
+execute: |
+  go test $SPREAD_PATH/internal/workspacebackend/tests/integration -tags=integration -check.f wsProject

--- a/tests/integration/workspace-ops/task.yaml
+++ b/tests/integration/workspace-ops/task.yaml
@@ -1,0 +1,4 @@
+summary: Run LXD integration tests for workspace operations (launch, delete, attach storage, etc.)
+
+execute: |
+  go test $SPREAD_PATH/internal/workspacebackend/tests/integration -tags=integration -check.f WsOps


### PR DESCRIPTION
Workspace tracks projects using .lock files and their bind-mount paths. There are a couple of possible scenarios that Workspace should handle differently:
- If the project has no running instances and its directory was removed by the user, Workspace should remove this project from the tracking list (introduced by this changeset).
- If the project has running instances and its directory was removed, Workspace continues to track it and report its workspaces  with a `missing-project` note.