### PR TITLE
Deduplicate CLI positional args

### DIFF
--- a/cmd/workspace/launch.go
+++ b/cmd/workspace/launch.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/canonical/workspace/client"
+	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 type CmdLaunch struct {
@@ -35,7 +35,7 @@ Notes:
 - SDKs are installed in alphabetical order
 `,
 
-		RunE:  c.Run,
+		RunE: c.Run,
 	}
 
 	return cmd
@@ -43,6 +43,8 @@ Notes:
 
 func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	var err error
+
+	av = strutil.Deduplicate(av)
 
 	cli, err := client.New(&ClientConfig)
 	if err != nil {
@@ -68,14 +70,8 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	workspaces, err := c.client.ListWorkspaces(&client.ListOptions{ProjectId: project.Id})
-	if err != nil {
-		return nil
-	}
 	for _, i := range av {
-		if slices.ContainsFunc(workspaces, func(w *client.Workspace) bool { return w.Name == i && w.State == "Ready" }) {
-			fmt.Fprintf(Stdout, "%q launched\n", i)
-		}
+		fmt.Fprintf(Stdout, "%q launched\n", i)
 	}
 
 	return nil

--- a/cmd/workspace/launch_test.go
+++ b/cmd/workspace/launch_test.go
@@ -1,1 +1,52 @@
 package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+)
+
+type WorkspaceLaunch struct {
+	BaseWorkspaceSuite
+	prjDir string
+	prjId  string
+}
+
+var _ = check.Suite(&WorkspaceLaunch{})
+
+func (m *WorkspaceLaunch) SetUpTest(c *check.C) {
+	m.prjDir = c.MkDir()
+	m.prjId = "42424242"
+	m.BaseWorkspaceSuite.SetUpTest(c)
+}
+
+func (m *WorkspaceLaunch) TestLaunchSuccess(c *check.C) {
+	cmd := &CmdLaunch{}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workspaces", m.prjId))
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
+			fmt.Fprintln(w, mockReadyChangeJSON)
+		default:
+			c.Errorf("expected 3 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1", "ws"})
+	c.Assert(err, check.IsNil)
+	c.Assert(m.stdout.String(), check.Matches, `"ws" launched\n"ws-1" launched\n`)
+}

--- a/cmd/workspace/refresh.go
+++ b/cmd/workspace/refresh.go
@@ -45,16 +45,16 @@ Notes:
 - Updated and newly added SDKs are installed in alphabetical order
 `,
 
-		RunE:  c.Run,
+		RunE: c.Run,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",
 		false,
 		"Pause the operation on error; to resume, use '--continue' or '--abort'.")
-		cmd.PersistentFlags().BoolVar(&c.Continue, "continue",
+	cmd.PersistentFlags().BoolVar(&c.Continue, "continue",
 		false,
 		"Continue the previously paused operation.")
-		cmd.PersistentFlags().BoolVar(&c.Abort, "abort",
+	cmd.PersistentFlags().BoolVar(&c.Abort, "abort",
 		false,
 		"Abort the previously paused operation, reverting any changes.")
 
@@ -63,6 +63,8 @@ Notes:
 
 func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 	var err error
+
+	av = strutil.Deduplicate(av)
 
 	if c.Abort && c.Continue {
 		return fmt.Errorf("cannot refresh: '--abort' incompatible with '--continue'")
@@ -113,8 +115,8 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 			return nil
 		}
 		if err == errWaitOnError {
-			return fmt.Errorf("cannot refresh; fix the errors reported by \"workspace info\",\n" +
-				"then run \"workspace refresh --continue %s\".\n" +
+			return fmt.Errorf("cannot refresh; fix the errors reported by \"workspace info\",\n"+
+				"then run \"workspace refresh --continue %s\".\n"+
 				"To abort and revert, run \"workspace refresh --abort %s\"", av[0], av[0])
 		}
 

--- a/cmd/workspace/refresh_test.go
+++ b/cmd/workspace/refresh_test.go
@@ -91,9 +91,9 @@ func (m *WorkspaceRefresh) TestRefreshTransactionalSuccess(c *check.C) {
 		}
 	})
 
-	err := cmd.Run(cmd.Command(), []string{"ws"})
+	err := cmd.Run(cmd.Command(), []string{"ws", "ws"})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, "\"ws\" refreshed\n")
+	c.Assert(m.stdout.String(), check.Matches, `"ws" refreshed\n`)
 }
 
 func (m *WorkspaceRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
@@ -123,7 +123,7 @@ func (m *WorkspaceRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) 
 
 	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1"})
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "(?s).*\"ws\", \"ws-1\" refresh aborted")
+	c.Assert(err, check.ErrorMatches, `(?s).*"ws", "ws-1" refresh aborted`)
 }
 
 func (m *WorkspaceRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
@@ -157,7 +157,7 @@ func (m *WorkspaceRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "cannot refresh; fix the errors reported by \"workspace info\",\nthen run \"workspace refresh --continue ws\".\nTo abort and revert, run \"workspace refresh --abort ws\"")
+	c.Assert(err, check.ErrorMatches, `cannot refresh; fix the errors reported by "workspace info",\nthen run "workspace refresh --continue ws".\nTo abort and revert, run "workspace refresh --abort ws"`)
 }
 
 func (m *WorkspaceRefresh) TestRefreshWaitOnErrorAbortedSuccessfully(c *check.C) {
@@ -191,7 +191,7 @@ func (m *WorkspaceRefresh) TestRefreshWaitOnErrorAbortedSuccessfully(c *check.C)
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, "\"ws\" refresh aborted\n")
+	c.Assert(m.stdout.String(), check.Matches, `"ws" refresh aborted\n`)
 }
 
 func (m *WorkspaceRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C) {
@@ -225,7 +225,7 @@ func (m *WorkspaceRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, "\"ws\" refreshed\n")
+	c.Assert(m.stdout.String(), check.Matches, `"ws" refreshed\n`)
 }
 
 func (m *WorkspaceRefresh) TestRefreshIncompatibleOptions(c *check.C) {

--- a/cmd/workspace/remove.go
+++ b/cmd/workspace/remove.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/workspace/client"
+	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +25,8 @@ func (c *CmdRemove) Command() *cobra.Command {
 
 func (c *CmdRemove) Run(cmd *cobra.Command, av []string) error {
 	var err error
+
+	av = strutil.Deduplicate(av)
 
 	cli, err := client.New(&ClientConfig)
 	if err != nil {
@@ -51,7 +54,7 @@ func (c *CmdRemove) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	for _, name := range av {
-		fmt.Fprintf(Stdout, "%s removed\n", name)
+		fmt.Fprintf(Stdout, "%q removed\n", name)
 	}
 
 	return nil

--- a/cmd/workspace/remove_test.go
+++ b/cmd/workspace/remove_test.go
@@ -46,7 +46,7 @@ func (m *WorkspaceRemove) TestStartSuccess(c *check.C) {
 		}
 	})
 
-	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1"})
+	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1", "ws"})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, "ws removed\nws-1 removed\n")
+	c.Assert(m.stdout.String(), check.Matches, `"ws" removed\n"ws-1" removed\n`)
 }

--- a/cmd/workspace/start.go
+++ b/cmd/workspace/start.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/workspace/client"
+	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +17,7 @@ func (c *CmdStart) Command() *cobra.Command {
 		Use:   "start <WORKSPACE>...",
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Start one or many workspaces.",
-		Long:  `
+		Long: `
 This command activates the workspaces listed as arguments. For each one, it:
 
 - Makes sure the workspace was actually launched
@@ -30,7 +31,7 @@ Notes:
 - When interrupted, the command attempts to gracefully revert its actions
 - To stop a started workspace, use 'workspace stop'
 `,
-		RunE:  c.Run,
+		RunE: c.Run,
 	}
 
 	return cmd
@@ -38,6 +39,8 @@ Notes:
 
 func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 	var err error
+
+	av = strutil.Deduplicate(av)
 
 	cli, err := client.New(&ClientConfig)
 	if err != nil {
@@ -65,7 +68,7 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	for _, name := range av {
-		fmt.Fprintf(Stdout, "%s started\n", name)
+		fmt.Fprintf(Stdout, "%q started\n", name)
 	}
 
 	return nil

--- a/cmd/workspace/start_test.go
+++ b/cmd/workspace/start_test.go
@@ -46,7 +46,7 @@ func (m *WorkspaceStart) TestStartSuccess(c *check.C) {
 		}
 	})
 
-	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1"})
+	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1", "ws"})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, "ws started\nws-1 started\n")
+	c.Assert(m.stdout.String(), check.Matches, `"ws" started\n"ws-1" started\n`)
 }

--- a/cmd/workspace/stop.go
+++ b/cmd/workspace/stop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/workspace/client"
+	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +17,7 @@ func (c *CmdStop) Command() *cobra.Command {
 		Use:   "stop <WORKSPACE>...",
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Stop one or many workspaces.",
-		Long:  `
+		Long: `
 This command deactivates the workspaces listed as arguments. For each one, it:
 
 - Makes sure the workspace was actually started or is already stopped
@@ -30,7 +31,7 @@ Notes:
 - When interrupted, the command attempts to gracefully revert its actions
 - To start a stopped workspace, use 'workspace start'
 `,
-		RunE:  c.Run,
+		RunE: c.Run,
 	}
 
 	return cmd
@@ -38,6 +39,8 @@ Notes:
 
 func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	var err error
+
+	av = strutil.Deduplicate(av)
 
 	cli, err := client.New(&ClientConfig)
 	if err != nil {
@@ -65,7 +68,7 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	for _, name := range av {
-		fmt.Fprintf(Stdout, "%s stopped\n", name)
+		fmt.Fprintf(Stdout, "%q stopped\n", name)
 	}
 	return nil
 }

--- a/cmd/workspace/stop_test.go
+++ b/cmd/workspace/stop_test.go
@@ -46,7 +46,7 @@ func (m *WorkspaceStop) TestStopSuccess(c *check.C) {
 		}
 	})
 
-	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1"})
+	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1", "ws"})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, "ws stopped\nws-1 stopped\n")
+	c.Assert(m.stdout.String(), check.Matches, `"ws" stopped\n"ws-1" stopped\n`)
 }

--- a/cmd/workspace/tasks.go
+++ b/cmd/workspace/tasks.go
@@ -18,7 +18,7 @@ type CmdTasks struct {
 func (c *CmdTasks) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "tasks change-id",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.RangeArgs(1, 1),
 		Short: "Show a summary of tasks for the change",
 		RunE:  c.Run,
 	}

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -297,7 +297,7 @@ func (e *execution) do(ctx context.Context, task *state.Task, backend workspaceb
 		}
 	}
 
-	return nil
+	return err
 }
 
 func setExitCode(task *state.Task, exitCode int) {


### PR DESCRIPTION
The de-duplication happens on the API side as well; here it is done to make the output to reflect the actual progress correctly. For example, there should be no duplication regarding a workspace being launched twice if it was used twice in the command arguments.

Also, the change set introduces stricter control on the number of allowed positional args and consistent messaging about the results of a command execution: all names quoted.