### PR TITLE
Feature/interface system foundation

### DIFF
--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -37,7 +37,7 @@ var Project string
 
 // ClientConfig is the configuration of the Client used by all commands.
 var ClientConfig = client.Config{
-	// we need the powerful snapd socket
+	// we need the powerful socket
 	Socket: dirs.WorkspaceSocket,
 }
 

--- a/cmd/workspaced/run.go
+++ b/cmd/workspaced/run.go
@@ -96,7 +96,7 @@ func runWatchdog(d *daemon.Daemon) (*time.Ticker, error) {
 		// Not running under systemd.
 		return nil, nil
 	}
-	usec, err := strconv.ParseFloat(os.Getenv("WATCHDOG_USEC"), 10)
+	usec, err := strconv.ParseFloat(os.Getenv("WATCHDOG_USEC"), 32)
 	if usec == 0 || err != nil {
 		return nil, fmt.Errorf("cannot parse WATCHDOG_USEC: %q", os.Getenv("WATCHDOG_USEC"))
 	}
@@ -164,7 +164,9 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	}
 
 	d.Version = version.Version
-	d.Start()
+	if err = d.Start(); err != nil {
+		return err
+	}
 
 	watchdog, err := runWatchdog(d)
 	if err != nil {

--- a/internal/asserts/asserts.go
+++ b/internal/asserts/asserts.go
@@ -1,0 +1,1026 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"bufio"
+	"bytes"
+	"crypto"
+	"fmt"
+	"io"
+	"sort"
+
+	"strings"
+	"unicode/utf8"
+
+	"github.com/canonical/workspace/internal/osutil"
+)
+
+type typeFlags int
+
+const (
+	noAuthority typeFlags = 1 << iota
+	sequenceForming
+)
+
+// MetaHeaders is a list of headers in assertions which are about the assertion
+// itself.
+var MetaHeaders = [...]string{
+	"type",
+	"format",
+	"authority-id",
+	"revision",
+	"body-length",
+	"sign-key-sha3-384",
+}
+
+// AssertionType describes a known assertion type with its name and metadata.
+type AssertionType struct {
+	// Name of the type.
+	Name string
+	// PrimaryKey holds the names of the headers that constitute the
+	// unique primary key for this assertion type.
+	PrimaryKey []string
+	// OptionalPrimaryKeyDefaults holds the default values for
+	// optional primary key headers.
+	// Optional primary key headers can be added to types defined
+	// in previous versions of workspaced, as long as they are added at
+	// the end of the old primary key together with a default value set in
+	// this map. So they must form a contiguous suffix of PrimaryKey with
+	// each member having a default value set in this map.
+	// Optional primary key headers are not supported for sequence
+	// forming types.
+	OptionalPrimaryKeyDefaults map[string]string
+
+	assembler func(assert assertionBase) (Assertion, error)
+	flags     typeFlags
+}
+
+func (at *AssertionType) validate() {
+	if len(at.OptionalPrimaryKeyDefaults) != 0 && at.flags&sequenceForming != 0 {
+		panic(fmt.Sprintf("assertion type %q cannot be both sequence forming and have optional primary keys", at.Name))
+	}
+	noptional := 0
+	for _, k := range at.PrimaryKey {
+		defl := at.OptionalPrimaryKeyDefaults[k]
+		if noptional > 0 {
+			if defl == "" {
+				panic(fmt.Sprintf("assertion type %q primary key header %q has no default, optional primary keys must be a proper suffix of the primary key", at.Name, k))
+			}
+		}
+		if defl != "" {
+			noptional++
+		}
+	}
+	if len(at.OptionalPrimaryKeyDefaults) != noptional {
+		panic(fmt.Sprintf("assertion type %q has defaults values for unknown primary key headers", at.Name))
+	}
+}
+
+// SequencingForming returns true if the assertion type has a positive
+// integer >= 1 as the last component (preferably called "sequence")
+// of its primary key over which the assertions of the type form
+// sequences, usually without gaps, one sequence per sequence key (the
+// primary key prefix omitting the sequence number).
+// See SequenceMember.
+func (at *AssertionType) SequenceForming() bool {
+	return at.flags&sequenceForming != 0
+}
+
+// AcceptablePrimaryKey returns whether the given key could be an acceptable primary key for this type, allowing for the omission of optional primary key headers.
+func (at *AssertionType) AcceptablePrimaryKey(key []string) bool {
+	n := len(at.PrimaryKey)
+	nopt := len(at.OptionalPrimaryKeyDefaults)
+	ninp := len(key)
+	if ninp > n || ninp < (n-nopt) {
+		return false
+	}
+	return true
+}
+
+// MaxSupportedFormat returns the maximum supported format iteration for the type.
+func (at *AssertionType) MaxSupportedFormat() int {
+	return maxSupportedFormat[at.Name]
+}
+
+// Understood assertion types.
+var (
+	BaseDeclarationType = &AssertionType{"base-declaration", []string{"series"}, nil, assembleBaseDeclaration, 0}
+)
+
+var typeRegistry = map[string]*AssertionType{
+	BaseDeclarationType.Name: BaseDeclarationType,
+}
+
+// Type returns the AssertionType with name or nil
+func Type(name string) *AssertionType {
+	return typeRegistry[name]
+}
+
+// TypeNames returns a sorted list of known assertion type names.
+func TypeNames() []string {
+	names := make([]string, 0, len(typeRegistry))
+	for k := range typeRegistry {
+		names = append(names, k)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+var maxSupportedFormat = map[string]int{}
+
+func init() {
+	for _, at := range typeRegistry {
+		at.validate()
+	}
+}
+
+func MockOptionalPrimaryKey(assertType *AssertionType, key, defaultValue string) (restore func()) {
+	osutil.MustBeTestBinary("mocking new assertion optional primary keys can be done only from tests")
+	oldPrimaryKey := assertType.PrimaryKey
+	oldOptionalPrimaryKeyDefaults := assertType.OptionalPrimaryKeyDefaults
+	newOptionalPrimaryKeyDefaults := make(map[string]string, len(oldOptionalPrimaryKeyDefaults)+1)
+	for k, defl := range oldOptionalPrimaryKeyDefaults {
+		newOptionalPrimaryKeyDefaults[k] = defl
+	}
+	assertType.PrimaryKey = append(assertType.PrimaryKey, key)
+	assertType.OptionalPrimaryKeyDefaults = newOptionalPrimaryKeyDefaults
+	newOptionalPrimaryKeyDefaults[key] = defaultValue
+	return func() {
+		assertType.PrimaryKey = oldPrimaryKey
+		assertType.OptionalPrimaryKeyDefaults = oldOptionalPrimaryKeyDefaults
+	}
+}
+
+// HeadersFromPrimaryKey constructs a headers mapping from the
+// primaryKey values and the assertion type, it errors if primaryKey
+// does not cover all the non-optional primary key headers or provides
+// too many values.
+func HeadersFromPrimaryKey(assertType *AssertionType, primaryKey []string) (headers map[string]string, err error) {
+	if !assertType.AcceptablePrimaryKey(primaryKey) {
+		return nil, fmt.Errorf("primary key has wrong length for %q assertion", assertType.Name)
+	}
+	ninp := len(primaryKey)
+	headers = make(map[string]string, len(assertType.PrimaryKey))
+	for i, name := range assertType.PrimaryKey {
+		var keyVal string
+		if i < ninp {
+			keyVal = primaryKey[i]
+			if keyVal == "" {
+				return nil, fmt.Errorf("primary key %q header cannot be empty", name)
+			}
+		} else {
+			keyVal = assertType.OptionalPrimaryKeyDefaults[name]
+		}
+		headers[name] = keyVal
+	}
+	return headers, nil
+}
+
+// HeadersFromSequenceKey constructs a headers mapping from the
+// sequenceKey values and the sequence forming assertion type,
+// it errors if sequenceKey has the wrong length; the length must be
+// one less than the primary key of the given assertion type.
+func HeadersFromSequenceKey(assertType *AssertionType, sequenceKey []string) (headers map[string]string, err error) {
+	if !assertType.SequenceForming() {
+		return nil, fmt.Errorf("internal error: HeadersFromSequenceKey should only be used for sequence forming assertion types, got: %s", assertType.Name)
+	}
+	if len(sequenceKey) != len(assertType.PrimaryKey)-1 {
+		return nil, fmt.Errorf("sequence key has wrong length for %q assertion", assertType.Name)
+	}
+	headers = make(map[string]string, len(sequenceKey))
+	for i, val := range sequenceKey {
+		key := assertType.PrimaryKey[i]
+		if val == "" {
+			return nil, fmt.Errorf("sequence key %q header cannot be empty", key)
+		}
+		headers[key] = val
+	}
+	return headers, nil
+}
+
+// PrimaryKeyFromHeaders extracts the tuple of values from headers
+// corresponding to a primary key under the assertion type, it errors
+// if there are missing primary key headers unless they are optional
+// in which case it fills in their default values.
+func PrimaryKeyFromHeaders(assertType *AssertionType, headers map[string]string) (primaryKey []string, err error) {
+	return keysFromHeaders(assertType.PrimaryKey, headers, assertType.OptionalPrimaryKeyDefaults)
+}
+
+func keysFromHeaders(keys []string, headers map[string]string, defaults map[string]string) (keyValues []string, err error) {
+	keyValues = make([]string, len(keys))
+	for i, k := range keys {
+		keyVal := headers[k]
+		if keyVal == "" {
+			keyVal = defaults[k]
+			if keyVal == "" {
+				return nil, fmt.Errorf("must provide primary key: %v", k)
+			}
+		}
+		keyValues[i] = keyVal
+	}
+	return keyValues, nil
+}
+
+// ReducePrimaryKey produces a primary key prefix by omitting any
+// suffix of optional primary key headers default values.
+// Too short or long primary keys are returned as is.
+func ReducePrimaryKey(assertType *AssertionType, primaryKey []string) []string {
+	n := len(assertType.PrimaryKey)
+	nopt := len(assertType.OptionalPrimaryKeyDefaults)
+	ninp := len(primaryKey)
+	if ninp > n || ninp < (n-nopt) {
+		return primaryKey
+	}
+	reduced := make([]string, n-nopt, n)
+	copy(reduced, primaryKey[:n-nopt])
+	rest := ninp - (n - nopt)
+	for i := ninp - 1; i >= n-nopt; i-- {
+		defl := assertType.OptionalPrimaryKeyDefaults[assertType.PrimaryKey[i]]
+		if primaryKey[i] != defl {
+			break
+		}
+		// it matches the default value, leave it out
+		rest--
+	}
+	reduced = append(reduced, primaryKey[n-nopt:n-nopt+rest]...)
+	return reduced
+}
+
+// Ref expresses a reference to an assertion.
+type Ref struct {
+	Type       *AssertionType
+	PrimaryKey []string
+}
+
+func (ref *Ref) String() string {
+	pkStr := "-"
+	n := len(ref.Type.PrimaryKey)
+	nopt := len(ref.Type.OptionalPrimaryKeyDefaults)
+	ninp := len(ref.PrimaryKey)
+	if ninp > n || ninp < (n-nopt) {
+		pkStr = "???"
+	} else if n > 0 {
+		pkStr = ref.PrimaryKey[n-nopt-1]
+		if n > 1 {
+			sfx := []string{pkStr + ";"}
+			for i, k := range ref.Type.PrimaryKey[:n-nopt-1] {
+				sfx = append(sfx, fmt.Sprintf("%s:%s", k, ref.PrimaryKey[i]))
+			}
+			// optional primary keys
+			for i := n - nopt; i < ninp; i++ {
+				v := ref.PrimaryKey[i]
+				k := ref.Type.PrimaryKey[i]
+				defl := ref.Type.OptionalPrimaryKeyDefaults[k]
+				if v != defl {
+					sfx = append(sfx, fmt.Sprintf("%s:%s", k, v))
+				}
+			}
+			pkStr = strings.Join(sfx, " ")
+		}
+	}
+	return fmt.Sprintf("%s (%s)", ref.Type.Name, pkStr)
+}
+
+// Unique returns a unique string representing the reference that can be used as a key in maps.
+func (ref *Ref) Unique() string {
+	return fmt.Sprintf("%s/%s", ref.Type.Name, strings.Join(ReducePrimaryKey(ref.Type, ref.PrimaryKey), "/"))
+}
+
+// Resolve resolves the reference using the given find function.
+func (ref *Ref) Resolve(find func(assertType *AssertionType, headers map[string]string) (Assertion, error)) (Assertion, error) {
+	headers, err := HeadersFromPrimaryKey(ref.Type, ref.PrimaryKey)
+	if err != nil {
+		return nil, fmt.Errorf("%q assertion reference primary key has the wrong length (expected %v): %v", ref.Type.Name, ref.Type.PrimaryKey, ref.PrimaryKey)
+	}
+	return find(ref.Type, headers)
+}
+
+const RevisionNotKnown = -1
+
+// AtRevision represents an assertion at a given revision, possibly
+// not known (RevisionNotKnown).
+type AtRevision struct {
+	Ref
+	Revision int
+}
+
+func (at *AtRevision) String() string {
+	s := at.Ref.String()
+	if at.Revision == RevisionNotKnown {
+		return s
+	}
+	return fmt.Sprintf("%s at revision %d", s, at.Revision)
+}
+
+// AtSequence references a sequence forming assertion at a given sequence point,
+// possibly <=0 (meaning not specified) and revision, possibly not known
+// (RevisionNotKnown).
+// Setting Pinned = true means pinning at the given sequence point (which must be
+// set, i.e. > 0). Pinned sequence forming assertion will be updated to the
+// latest revision at the specified sequence point.
+type AtSequence struct {
+	Type        *AssertionType
+	SequenceKey []string
+	Sequence    int
+	Pinned      bool
+	Revision    int
+}
+
+// Unique returns a unique string representing the sequence by its sequence key
+// that can be used as a key in maps.
+func (at *AtSequence) Unique() string {
+	return fmt.Sprintf("%s/%s", at.Type.Name, strings.Join(at.SequenceKey, "/"))
+}
+
+func (at *AtSequence) String() string {
+	var pkStr string
+	if len(at.SequenceKey) != len(at.Type.PrimaryKey)-1 {
+		pkStr = "???"
+	} else {
+		n := 0
+		// omit series if present in the primary key
+		if at.Type.PrimaryKey[0] == "series" {
+			n++
+		}
+		pkStr = strings.Join(at.SequenceKey[n:], "/")
+		if at.Sequence > 0 {
+			sep := "/"
+			if at.Pinned {
+				sep = "="
+			}
+			pkStr = fmt.Sprintf("%s%s%d", pkStr, sep, at.Sequence)
+		}
+	}
+	sk := fmt.Sprintf("%s %s", at.Type.Name, pkStr)
+	if at.Revision == RevisionNotKnown {
+		return sk
+	}
+	return fmt.Sprintf("%s at revision %d", sk, at.Revision)
+}
+
+// Assertion represents an assertion through its general elements.
+type Assertion interface {
+	// Type returns the type of this assertion
+	Type() *AssertionType
+	// Format returns the format iteration of this assertion
+	Format() int
+	// SupportedFormat returns whether the assertion uses a supported
+	// format iteration. If false the assertion might have been only
+	// partially parsed.
+	SupportedFormat() bool
+	// Revision returns the revision of this assertion
+	Revision() int
+	// AuthorityID returns the authority responsible for this
+	// assertion
+	AuthorityID() string
+
+	// Header retrieves the header with name
+	Header(name string) interface{}
+
+	// Headers returns the complete headers
+	Headers() map[string]interface{}
+
+	// HeaderString retrieves the string value of header with name or ""
+	HeaderString(name string) string
+
+	// Body returns the body of this assertion
+	Body() []byte
+
+	// Signature returns the signed content and its unprocessed signature
+	Signature() (content, signature []byte)
+
+	// SignKeyID returns the key id for the key that signed this assertion.
+	SignKeyID() string
+
+	// Prerequisites returns references to the prerequisite assertions for the validity of this one.
+	Prerequisites() []*Ref
+
+	// Ref returns a reference representing this assertion.
+	Ref() *Ref
+
+	// At returns an AtRevision referencing this assertion at its revision.
+	At() *AtRevision
+}
+
+// SequenceMember is implemented by assertions of sequence forming types.
+type SequenceMember interface {
+	Assertion
+
+	// Sequence returns the sequence number of this assertion.
+	Sequence() int
+}
+
+// MediaType is the media type for encoded assertions on the wire.
+const MediaType = "application/x.ubuntu.assertion"
+
+// assertionBase is the concrete base to hold representation data for actual assertions.
+type assertionBase struct {
+	headers map[string]interface{}
+	body    []byte
+	// parsed format iteration
+	format int
+	// parsed revision
+	revision int
+	// preserved content
+	content []byte
+	// unprocessed signature
+	signature []byte
+}
+
+// HeaderString retrieves the string value of header with name or ""
+func (ab *assertionBase) HeaderString(name string) string {
+	s, _ := ab.headers[name].(string)
+	return s
+}
+
+// Type returns the assertion type.
+func (ab *assertionBase) Type() *AssertionType {
+	return Type(ab.HeaderString("type"))
+}
+
+// Format returns the assertion format iteration.
+func (ab *assertionBase) Format() int {
+	return ab.format
+}
+
+// SupportedFormat returns whether the assertion uses a supported
+// format iteration. If false the assertion might have been only
+// partially parsed.
+func (ab *assertionBase) SupportedFormat() bool {
+	return ab.format <= maxSupportedFormat[ab.HeaderString("type")]
+}
+
+// Revision returns the assertion revision.
+func (ab *assertionBase) Revision() int {
+	return ab.revision
+}
+
+// AuthorityID returns the authority-id a.k.a the authority responsible for the assertion.
+func (ab *assertionBase) AuthorityID() string {
+	return ab.HeaderString("authority-id")
+}
+
+// Header returns the value of an header by name.
+func (ab *assertionBase) Header(name string) interface{} {
+	v := ab.headers[name]
+	if v == nil {
+		return nil
+	}
+	return copyHeader(v)
+}
+
+// Headers returns the complete headers.
+func (ab *assertionBase) Headers() map[string]interface{} {
+	return copyHeaders(ab.headers)
+}
+
+// Body returns the body of the assertion.
+func (ab *assertionBase) Body() []byte {
+	return ab.body
+}
+
+// Signature returns the signed content and its unprocessed signature.
+func (ab *assertionBase) Signature() (content, signature []byte) {
+	return ab.content, ab.signature
+}
+
+// SignKeyID returns the key id for the key that signed this assertion.
+func (ab *assertionBase) SignKeyID() string {
+	return ab.HeaderString("sign-key-sha3-384")
+}
+
+// Prerequisites returns references to the prerequisite assertions for the validity of this one.
+func (ab *assertionBase) Prerequisites() []*Ref {
+	return nil
+}
+
+// Ref returns a reference representing this assertion.
+func (ab *assertionBase) Ref() *Ref {
+	assertType := ab.Type()
+	primKey := make([]string, len(assertType.PrimaryKey))
+	for i, name := range assertType.PrimaryKey {
+		primKey[i] = ab.HeaderString(name)
+	}
+	return &Ref{
+		Type:       assertType,
+		PrimaryKey: primKey,
+	}
+}
+
+// At returns an AtRevision referencing this assertion at its revision.
+func (ab *assertionBase) At() *AtRevision {
+	return &AtRevision{Ref: *ab.Ref(), Revision: ab.Revision()}
+}
+
+// expected interface is implemented
+var _ Assertion = (*assertionBase)(nil)
+
+// Decode parses a serialized assertion.
+//
+// The expected serialisation format looks like:
+//
+//	HEADER ("\n\n" BODY?)? "\n\n" SIGNATURE
+//
+// where:
+//
+//	HEADER is a set of header entries separated by "\n"
+//	BODY can be arbitrary text,
+//	SIGNATURE is the signature
+//
+// Both BODY and HEADER must be UTF8.
+//
+// A header entry for a single line value (no '\n' in it) looks like:
+//
+//	NAME ": " SIMPLEVALUE
+//
+// The format supports multiline text values (with '\n's in them) and
+// lists or maps, possibly nested, with string scalars in them.
+//
+// For those a header entry looks like:
+//
+//	NAME ":\n" MULTI(baseindent)
+//
+// where MULTI can be
+//
+// * (baseindent + 4)-space indented value (multiline text)
+//
+// * entries of a list each of the form:
+//
+//	" "*baseindent "  -"  ( " " SIMPLEVALUE | "\n" MULTI )
+//
+// * entries of map each of the form:
+//
+//	" "*baseindent "  " NAME ":"  ( " " SIMPLEVALUE | "\n" MULTI )
+//
+// baseindent starts at 0 and then grows with nesting matching the
+// previous level introduction (e.g. the " "*baseindent " -" bit)
+// length minus 1.
+//
+// In general the following headers are mandatory:
+//
+//	type
+//	authority-id (except for on the wire/self-signed assertions like serial-request)
+//
+// Further for a given assertion type all the primary key headers
+// must be non empty and must not contain '/'.
+//
+// The following headers expect string representing integer values and
+// if omitted otherwise are assumed to be 0:
+//
+//	revision (a positive int)
+//	body-length (expected to be equal to the length of BODY)
+//	format (a positive int for the format iteration of the type used)
+//
+// Times are expected to be in the RFC3339 format: "2006-01-02T15:04:05Z07:00".
+func Decode(serializedAssertion []byte) (Assertion, error) {
+	// copy to get an independent backstorage that can't be mutated later
+	assertionSnapshot := make([]byte, len(serializedAssertion))
+	copy(assertionSnapshot, serializedAssertion)
+	contentSignatureSplit := bytes.LastIndex(assertionSnapshot, nlnl)
+	if contentSignatureSplit == -1 {
+		return nil, fmt.Errorf("assertion content/signature separator not found")
+	}
+	content := assertionSnapshot[:contentSignatureSplit]
+	signature := assertionSnapshot[contentSignatureSplit+2:]
+
+	headersBodySplit := bytes.Index(content, nlnl)
+	var body, head []byte
+	if headersBodySplit == -1 {
+		head = content
+	} else {
+		body = content[headersBodySplit+2:]
+		if len(body) == 0 {
+			body = nil
+		}
+		head = content[:headersBodySplit]
+	}
+
+	headers, err := parseHeaders(head)
+	if err != nil {
+		return nil, fmt.Errorf("parsing assertion headers: %v", err)
+	}
+
+	return assemble(headers, body, content, signature)
+}
+
+// Maximum assertion component sizes.
+const (
+	MaxBodySize      = 2 * 1024 * 1024
+	MaxHeadersSize   = 128 * 1024
+	MaxSignatureSize = 128 * 1024
+)
+
+// Decoder parses a stream of assertions bundled by separating them with double newlines.
+type Decoder struct {
+	rd             io.Reader
+	initialBufSize int
+	b              *bufio.Reader
+	err            error
+	maxHeadersSize int
+	maxSigSize     int
+
+	defaultMaxBodySize int
+	typeMaxBodySize    map[*AssertionType]int
+}
+
+// initBuffer finishes a Decoder initialization by setting up the bufio.Reader,
+// it returns the *Decoder for convenience of notation.
+func (d *Decoder) initBuffer() *Decoder {
+	d.b = bufio.NewReaderSize(d.rd, d.initialBufSize)
+	return d
+}
+
+const defaultDecoderBufSize = 4096
+
+// NewDecoder returns a Decoder to parse the stream of assertions from the reader.
+func NewDecoder(r io.Reader) *Decoder {
+	return (&Decoder{
+		rd:                 r,
+		initialBufSize:     defaultDecoderBufSize,
+		maxHeadersSize:     MaxHeadersSize,
+		maxSigSize:         MaxSignatureSize,
+		defaultMaxBodySize: MaxBodySize,
+	}).initBuffer()
+}
+
+// NewDecoderWithTypeMaxBodySize returns a Decoder to parse the stream of assertions from the reader enforcing optional per type max body sizes or the default one as fallback.
+func NewDecoderWithTypeMaxBodySize(r io.Reader, typeMaxBodySize map[*AssertionType]int) *Decoder {
+	return (&Decoder{
+		rd:                 r,
+		initialBufSize:     defaultDecoderBufSize,
+		maxHeadersSize:     MaxHeadersSize,
+		maxSigSize:         MaxSignatureSize,
+		defaultMaxBodySize: MaxBodySize,
+		typeMaxBodySize:    typeMaxBodySize,
+	}).initBuffer()
+}
+
+func (d *Decoder) peek(size int) ([]byte, error) {
+	buf, err := d.b.Peek(size)
+	if err == bufio.ErrBufferFull {
+		rebuf, reerr := d.b.Peek(d.b.Buffered())
+		if reerr != nil {
+			panic(reerr)
+		}
+		mr := io.MultiReader(bytes.NewBuffer(rebuf), d.rd)
+		d.b = bufio.NewReaderSize(mr, (size/d.initialBufSize+1)*d.initialBufSize)
+		buf, err = d.b.Peek(size)
+	}
+	if err != nil && d.err == nil {
+		d.err = err
+	}
+	return buf, d.err
+}
+
+// NB: readExact and readUntil use peek underneath and their returned
+// buffers are valid only until the next reading call
+
+func (d *Decoder) readExact(size int) ([]byte, error) {
+	buf, err := d.peek(size)
+	d.b.Discard(len(buf))
+	if len(buf) == size {
+		return buf, nil
+	}
+	if err == io.EOF {
+		return buf, io.ErrUnexpectedEOF
+	}
+	return buf, err
+}
+
+func (d *Decoder) readUntil(delim []byte, maxSize int) ([]byte, error) {
+	last := 0
+	size := d.initialBufSize
+	for {
+		buf, err := d.peek(size)
+		if i := bytes.Index(buf[last:], delim); i >= 0 {
+			d.b.Discard(last + i + len(delim))
+			return buf[:last+i+len(delim)], nil
+		}
+		// report errors only once we have consumed what is buffered
+		if err != nil && len(buf) == d.b.Buffered() {
+			d.b.Discard(len(buf))
+			return buf, err
+		}
+		last = size - len(delim) + 1
+		size *= 2
+		if size > maxSize {
+			return nil, fmt.Errorf("maximum size exceeded while looking for delimiter %q", delim)
+		}
+	}
+}
+
+// Decode parses the next assertion from the stream.
+// It returns the error io.EOF at the end of a well-formed stream.
+func (d *Decoder) Decode() (Assertion, error) {
+	// read the headers and the nlnl separator after them
+	headAndSep, err := d.readUntil(nlnl, d.maxHeadersSize)
+	if err != nil {
+		if err == io.EOF {
+			if len(headAndSep) != 0 {
+				return nil, io.ErrUnexpectedEOF
+			}
+			return nil, io.EOF
+		}
+		return nil, fmt.Errorf("error reading assertion headers: %v", err)
+	}
+
+	headLen := len(headAndSep) - len(nlnl)
+	headers, err := parseHeaders(headAndSep[:headLen])
+	if err != nil {
+		return nil, fmt.Errorf("parsing assertion headers: %v", err)
+	}
+
+	typeStr, _ := headers["type"].(string)
+	typ := Type(typeStr)
+
+	length, err := checkIntWithDefault(headers, "body-length", 0)
+	if err != nil {
+		return nil, fmt.Errorf("assertion: %v", err)
+	}
+	if typMaxBodySize := d.typeMaxBodySize[typ]; typMaxBodySize != 0 && length > typMaxBodySize {
+		return nil, fmt.Errorf("assertion body length %d exceeds maximum body size %d for %q assertions", length, typMaxBodySize, typ.Name)
+	} else if length > d.defaultMaxBodySize {
+		return nil, fmt.Errorf("assertion body length %d exceeds maximum body size", length)
+	}
+
+	// save the headers before we try to read more, and setup to capture
+	// the whole content in a buffer
+	contentBuf := bytes.NewBuffer(make([]byte, 0, len(headAndSep)+length))
+	contentBuf.Write(headAndSep)
+
+	if length > 0 {
+		// read the body if length != 0
+		body, err := d.readExact(length)
+		if err != nil {
+			return nil, err
+		}
+		contentBuf.Write(body)
+	}
+
+	// try to read the end of body a.k.a content/signature separator
+	endOfBody, err := d.readUntil(nlnl, d.maxSigSize)
+	if err != nil && err != io.EOF {
+		return nil, fmt.Errorf("error reading assertion trailer: %v", err)
+	}
+
+	var sig []byte
+	if bytes.Equal(endOfBody, nlnl) {
+		// we got the nlnl content/signature separator, read the signature now and the assertion/assertion nlnl separation
+		sig, err = d.readUntil(nlnl, d.maxSigSize)
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("error reading assertion signature: %v", err)
+		}
+	} else {
+		// we got the signature directly which is a ok format only if body length == 0
+		if length > 0 {
+			return nil, fmt.Errorf("missing content/signature separator")
+		}
+		sig = endOfBody
+		contentBuf.Truncate(headLen)
+	}
+
+	// normalize sig ending newlines
+	if bytes.HasSuffix(sig, nlnl) {
+		sig = sig[:len(sig)-1]
+	}
+
+	finalContent := contentBuf.Bytes()
+	var finalBody []byte
+	if length > 0 {
+		finalBody = finalContent[headLen+len(nlnl):]
+	}
+
+	finalSig := make([]byte, len(sig))
+	copy(finalSig, sig)
+
+	return assemble(headers, finalBody, finalContent, finalSig)
+}
+
+func checkIteration(headers map[string]interface{}, name string) (int, error) {
+	iternum, err := checkIntWithDefault(headers, name, 0)
+	if err != nil {
+		return -1, err
+	}
+	if iternum < 0 {
+		return -1, fmt.Errorf("%s should be positive: %v", name, iternum)
+	}
+	return iternum, nil
+}
+
+func checkFormat(headers map[string]interface{}) (int, error) {
+	return checkIteration(headers, "format")
+}
+
+func checkRevision(headers map[string]interface{}) (int, error) {
+	return checkIteration(headers, "revision")
+}
+
+// Assemble assembles an assertion from its components.
+func Assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
+	err := checkHeaders(headers)
+	if err != nil {
+		return nil, err
+	}
+	return assemble(headers, body, content, signature)
+}
+
+func checkAuthority(_ *AssertionType, headers map[string]interface{}) error {
+	if _, err := checkNotEmptyString(headers, "authority-id"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkNoAuthority(assertType *AssertionType, headers map[string]interface{}) error {
+	if _, ok := headers["authority-id"]; ok {
+		return fmt.Errorf("%q assertion cannot have authority-id set", assertType.Name)
+	}
+	return nil
+}
+
+// assemble is the internal variant of Assemble, assumes headers are already checked for supported types
+func assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
+	length, err := checkIntWithDefault(headers, "body-length", 0)
+	if err != nil {
+		return nil, fmt.Errorf("assertion: %v", err)
+	}
+	if length != len(body) {
+		return nil, fmt.Errorf("assertion body length and declared body-length don't match: %v != %v", len(body), length)
+	}
+
+	if !utf8.Valid(body) {
+		return nil, fmt.Errorf("assertion body is not utf8")
+	}
+
+	if _, err := checkDigest(headers, "sign-key-sha3-384", crypto.SHA3_384); err != nil {
+		return nil, fmt.Errorf("assertion: %v", err)
+	}
+
+	typ, err := checkNotEmptyString(headers, "type")
+	if err != nil {
+		return nil, fmt.Errorf("assertion: %v", err)
+	}
+	assertType := Type(typ)
+	if assertType == nil {
+		return nil, fmt.Errorf("unknown assertion type: %q", typ)
+	}
+
+	if assertType.flags&noAuthority == 0 {
+		if err := checkAuthority(assertType, headers); err != nil {
+			return nil, fmt.Errorf("assertion: %v", err)
+		}
+	} else {
+		if err := checkNoAuthority(assertType, headers); err != nil {
+			return nil, err
+		}
+	}
+
+	formatnum, err := checkFormat(headers)
+	if err != nil {
+		return nil, fmt.Errorf("assertion: %v", err)
+	}
+
+	for _, primKey := range assertType.PrimaryKey {
+		if _, ok := headers[primKey]; !ok {
+			if defl := assertType.OptionalPrimaryKeyDefaults[primKey]; defl != "" {
+				headers[primKey] = defl
+			}
+		}
+		if _, err := checkPrimaryKey(headers, primKey); err != nil {
+			return nil, fmt.Errorf("assertion %s: %v", assertType.Name, err)
+		}
+	}
+
+	revision, err := checkRevision(headers)
+	if err != nil {
+		return nil, fmt.Errorf("assertion: %v", err)
+	}
+
+	if len(signature) == 0 {
+		return nil, fmt.Errorf("empty assertion signature")
+	}
+
+	assert, err := assertType.assembler(assertionBase{
+		headers:   headers,
+		body:      body,
+		format:    formatnum,
+		revision:  revision,
+		content:   content,
+		signature: signature,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("assertion %s: %v", assertType.Name, err)
+	}
+	return assert, nil
+}
+
+// Encode serializes an assertion.
+func Encode(assert Assertion) []byte {
+	content, signature := assert.Signature()
+	needed := len(content) + 2 + len(signature)
+	buf := bytes.NewBuffer(make([]byte, 0, needed))
+	buf.Write(content)
+	buf.Write(nlnl)
+	buf.Write(signature)
+	return buf.Bytes()
+}
+
+// Encoder emits a stream of assertions bundled by separating them with double newlines.
+type Encoder struct {
+	wr      io.Writer
+	nextSep []byte
+}
+
+// NewEncoder returns a Encoder to emit a stream of assertions to a writer.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{wr: w}
+}
+
+func (enc *Encoder) writeSep(last byte) error {
+	if last != '\n' {
+		_, err := enc.wr.Write(nl)
+		if err != nil {
+			return err
+		}
+	}
+	enc.nextSep = nl
+	return nil
+}
+
+// WriteEncoded writes the encoded assertion into the stream with the required separator.
+func (enc *Encoder) WriteEncoded(encoded []byte) error {
+	sz := len(encoded)
+	if sz == 0 {
+		return fmt.Errorf("internal error: encoded assertion cannot be empty")
+	}
+
+	_, err := enc.wr.Write(enc.nextSep)
+	if err != nil {
+		return err
+	}
+
+	_, err = enc.wr.Write(encoded)
+	if err != nil {
+		return err
+	}
+
+	return enc.writeSep(encoded[sz-1])
+}
+
+// WriteContentSignature writes the content and signature of an assertion into the stream with all the required separators.
+func (enc *Encoder) WriteContentSignature(content, signature []byte) error {
+	if len(content) == 0 {
+		return fmt.Errorf("internal error: content cannot be empty")
+	}
+
+	sz := len(signature)
+	if sz == 0 {
+		return fmt.Errorf("internal error: signature cannot be empty")
+	}
+
+	_, err := enc.wr.Write(enc.nextSep)
+	if err != nil {
+		return err
+	}
+
+	_, err = enc.wr.Write(content)
+	if err != nil {
+		return err
+	}
+	_, err = enc.wr.Write(nlnl)
+	if err != nil {
+		return err
+	}
+	_, err = enc.wr.Write(signature)
+	if err != nil {
+		return err
+	}
+
+	return enc.writeSep(signature[sz-1])
+}
+
+// Encode emits the assertion into the stream with the required separator.
+// Errors here are always about writing given that Encode() itself cannot error.
+func (enc *Encoder) Encode(assert Assertion) error {
+	return enc.WriteContentSignature(assert.Signature())
+}

--- a/internal/asserts/asserts_test.go
+++ b/internal/asserts/asserts_test.go
@@ -1,0 +1,861 @@
+package asserts_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/asserts"
+)
+
+type assertsSuite struct{}
+
+var _ = check.Suite(&assertsSuite{})
+
+func TestAsserts(t *testing.T) { check.TestingT(t) }
+
+func (as *assertsSuite) TestType(c *check.C) {
+	c.Check(asserts.Type("test-only"), check.Equals, asserts.TestOnlyType)
+}
+
+func (as *assertsSuite) TestUnknown(c *check.C) {
+	c.Check(asserts.Type(""), check.IsNil)
+	c.Check(asserts.Type("unknown"), check.IsNil)
+}
+
+func (as *assertsSuite) TestTypeNames(c *check.C) {
+	c.Check(asserts.TypeNames(), check.DeepEquals, []string{
+		"base-declaration",
+		"test-only",
+		"test-only-2",
+		"test-only-no-authority",
+	})
+}
+
+func (as *assertsSuite) TestPrimaryKeyHelpers(c *check.C) {
+	headers, err := asserts.HeadersFromPrimaryKey(asserts.TestOnlyType, []string{"one"})
+	c.Assert(err, check.IsNil)
+	c.Check(headers, check.DeepEquals, map[string]string{
+		"primary-key": "one",
+	})
+
+	headers, err = asserts.HeadersFromPrimaryKey(asserts.TestOnly2Type, []string{"bar", "baz"})
+	c.Assert(err, check.IsNil)
+	c.Check(headers, check.DeepEquals, map[string]string{
+		"pk1": "bar",
+		"pk2": "baz",
+	})
+
+	_, err = asserts.HeadersFromPrimaryKey(asserts.TestOnly2Type, []string{"bar"})
+	c.Check(err, check.ErrorMatches, `primary key has wrong length for "test-only-2" assertion`)
+
+	_, err = asserts.HeadersFromPrimaryKey(asserts.TestOnly2Type, []string{"", "baz"})
+	c.Check(err, check.ErrorMatches, `primary key "pk1" header cannot be empty`)
+
+	pk, err := asserts.PrimaryKeyFromHeaders(asserts.TestOnly2Type, headers)
+	c.Assert(err, check.IsNil)
+	c.Check(pk, check.DeepEquals, []string{"bar", "baz"})
+
+	headers["other"] = "foo"
+	pk1, err := asserts.PrimaryKeyFromHeaders(asserts.TestOnly2Type, headers)
+	c.Assert(err, check.IsNil)
+	c.Check(pk1, check.DeepEquals, pk)
+
+	delete(headers, "pk2")
+	_, err = asserts.PrimaryKeyFromHeaders(asserts.TestOnly2Type, headers)
+	c.Check(err, check.ErrorMatches, `must provide primary key: pk2`)
+}
+
+func (as *assertsSuite) TestPrimaryKeyHelpersOptionalPrimaryKeys(c *check.C) {
+	// optional primary key headers
+	r := asserts.MockOptionalPrimaryKey(asserts.TestOnlyType, "opt1", "o1-defl")
+	defer r()
+
+	pk, err := asserts.PrimaryKeyFromHeaders(asserts.TestOnlyType, map[string]string{"primary-key": "k1"})
+	c.Assert(err, check.IsNil)
+	c.Check(pk, check.DeepEquals, []string{"k1", "o1-defl"})
+
+	pk, err = asserts.PrimaryKeyFromHeaders(asserts.TestOnlyType, map[string]string{"primary-key": "k1", "opt1": "B"})
+	c.Assert(err, check.IsNil)
+	c.Check(pk, check.DeepEquals, []string{"k1", "B"})
+
+	hdrs, err := asserts.HeadersFromPrimaryKey(asserts.TestOnlyType, []string{"k1", "B"})
+	c.Assert(err, check.IsNil)
+	c.Check(hdrs, check.DeepEquals, map[string]string{
+		"primary-key": "k1",
+		"opt1":        "B",
+	})
+
+	hdrs, err = asserts.HeadersFromPrimaryKey(asserts.TestOnlyType, []string{"k1"})
+	c.Assert(err, check.IsNil)
+	c.Check(hdrs, check.DeepEquals, map[string]string{
+		"primary-key": "k1",
+		"opt1":        "o1-defl",
+	})
+
+	_, err = asserts.HeadersFromPrimaryKey(asserts.TestOnlyType, nil)
+	c.Check(err, check.ErrorMatches, `primary key has wrong length for "test-only" assertion`)
+
+	_, err = asserts.HeadersFromPrimaryKey(asserts.TestOnlyType, []string{"pk", "opt1", "what"})
+	c.Check(err, check.ErrorMatches, `primary key has wrong length for "test-only" assertion`)
+}
+
+func (as *assertsSuite) TestRef(c *check.C) {
+	ref := &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc", "xyz"},
+	}
+	c.Check(ref.Unique(), check.Equals, "test-only-2/abc/xyz")
+}
+
+func (as *assertsSuite) TestRefString(c *check.C) {
+	ref := &asserts.Ref{
+		Type:       asserts.BaseDeclarationType,
+		PrimaryKey: []string{"canonical"},
+	}
+
+	c.Check(ref.String(), check.Equals, "base-declaration (canonical)")
+
+	ref2 := &asserts.Ref{
+		Type: asserts.TestOnlyNoAuthorityType,
+	}
+
+	c.Check(ref2.String(), check.Equals, "test-only-no-authority (-)")
+}
+
+func (as *assertsSuite) TestRefResolveError(c *check.C) {
+	ref := &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc"},
+	}
+	_, err := ref.Resolve(nil)
+	c.Check(err, check.ErrorMatches, `"test-only-2" assertion reference primary key has the wrong length \(expected \[pk1 pk2\]\): \[abc\]`)
+}
+
+func (as *assertsSuite) TestReducePrimaryKey(c *check.C) {
+	// optional primary key headers
+	defer asserts.MockOptionalPrimaryKey(asserts.TestOnly2Type, "opt1", "o1-defl")()
+	defer asserts.MockOptionalPrimaryKey(asserts.TestOnly2Type, "opt2", "o2-defl")()
+
+	tests := []struct {
+		pk      []string
+		reduced []string
+	}{
+		{nil, nil},
+		{[]string{"k1"}, []string{"k1"}},
+		{[]string{"k1", "k2"}, []string{"k1", "k2"}},
+		{[]string{"k1", "k2", "A"}, []string{"k1", "k2", "A"}},
+		{[]string{"k1", "k2", "o1-defl"}, []string{"k1", "k2"}},
+		{[]string{"k1", "k2", "A", "o2-defl"}, []string{"k1", "k2", "A"}},
+		{[]string{"k1", "k2", "A", "B"}, []string{"k1", "k2", "A", "B"}},
+		{[]string{"k1", "k2", "o1-defl", "B"}, []string{"k1", "k2", "o1-defl", "B"}},
+		{[]string{"k1", "k2", "o1-defl", "o2-defl"}, []string{"k1", "k2"}},
+		{[]string{"k1", "k2", "o1-defl", "o2-defl", "what"}, []string{"k1", "k2", "o1-defl", "o2-defl", "what"}},
+	}
+
+	for _, t := range tests {
+		c.Check(asserts.ReducePrimaryKey(asserts.TestOnly2Type, t.pk), check.DeepEquals, t.reduced)
+	}
+}
+
+func (as *assertsSuite) TestRefOptionalPrimaryKeys(c *check.C) {
+	// optional primary key headers
+	defer asserts.MockOptionalPrimaryKey(asserts.TestOnly2Type, "opt1", "o1-defl")()
+	defer asserts.MockOptionalPrimaryKey(asserts.TestOnly2Type, "opt2", "o2-defl")()
+
+	ref := &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc", "xyz"},
+	}
+	c.Check(ref.Unique(), check.Equals, "test-only-2/abc/xyz")
+	c.Check(ref.String(), check.Equals, `test-only-2 (xyz; pk1:abc)`)
+
+	ref = &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc", "xyz", "o1-defl"},
+	}
+	c.Check(ref.Unique(), check.Equals, "test-only-2/abc/xyz")
+	c.Check(ref.String(), check.Equals, `test-only-2 (xyz; pk1:abc)`)
+
+	ref = &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc", "xyz", "o1-defl", "o2-defl"},
+	}
+	c.Check(ref.Unique(), check.Equals, "test-only-2/abc/xyz")
+	c.Check(ref.String(), check.Equals, `test-only-2 (xyz; pk1:abc)`)
+
+	ref = &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc", "xyz", "A"},
+	}
+	c.Check(ref.Unique(), check.Equals, "test-only-2/abc/xyz/A")
+	c.Check(ref.String(), check.Equals, `test-only-2 (xyz; pk1:abc opt1:A)`)
+
+	ref = &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc", "xyz", "A", "o2-defl"},
+	}
+	c.Check(ref.Unique(), check.Equals, "test-only-2/abc/xyz/A")
+	c.Check(ref.String(), check.Equals, `test-only-2 (xyz; pk1:abc opt1:A)`)
+
+	ref = &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc", "xyz", "o1-defl", "B"},
+	}
+	c.Check(ref.Unique(), check.Equals, "test-only-2/abc/xyz/o1-defl/B")
+	c.Check(ref.String(), check.Equals, `test-only-2 (xyz; pk1:abc opt2:B)`)
+
+	ref = &asserts.Ref{
+		Type:       asserts.TestOnly2Type,
+		PrimaryKey: []string{"abc", "xyz", "A", "B"},
+	}
+	c.Check(ref.Unique(), check.Equals, "test-only-2/abc/xyz/A/B")
+	c.Check(ref.String(), check.Equals, `test-only-2 (xyz; pk1:abc opt1:A opt2:B)`)
+}
+
+func (as *assertsSuite) TestAcceptablePrimaryKey(c *check.C) {
+	// optional primary key headers
+	defer asserts.MockOptionalPrimaryKey(asserts.TestOnly2Type, "opt1", "o1-defl")()
+	defer asserts.MockOptionalPrimaryKey(asserts.TestOnly2Type, "opt2", "o2-defl")()
+
+	tests := []struct {
+		pk []string
+		ok bool
+	}{
+		{nil, false},
+		{[]string{"k1"}, false},
+		{[]string{"k1", "k2"}, true},
+		{[]string{"k1", "k2", "A"}, true},
+		{[]string{"k1", "k2", "o1-defl"}, true},
+		{[]string{"k1", "k2", "A", "B"}, true},
+		{[]string{"k1", "k2", "o1-defl", "o2-defl", "what"}, false},
+	}
+
+	for _, t := range tests {
+		c.Check(asserts.TestOnly2Type.AcceptablePrimaryKey(t.pk), check.Equals, t.ok)
+	}
+}
+
+func (as *assertsSuite) TestAtRevisionString(c *check.C) {
+	ref := asserts.Ref{
+		Type:       asserts.BaseDeclarationType,
+		PrimaryKey: []string{"canonical"},
+	}
+
+	at := &asserts.AtRevision{
+		Ref: ref,
+	}
+	c.Check(at.String(), check.Equals, "base-declaration (canonical) at revision 0")
+
+	at = &asserts.AtRevision{
+		Ref:      ref,
+		Revision: asserts.RevisionNotKnown,
+	}
+	c.Check(at.String(), check.Equals, "base-declaration (canonical)")
+}
+
+const exKeyID = "Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij"
+
+const exampleEmptyBodyAllDefaults = "type: test-only\n" +
+	"authority-id: auth-id1\n" +
+	"primary-key: abc\n" +
+	"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+	"\n\n" +
+	"AXNpZw=="
+
+func (as *assertsSuite) TestDecodeEmptyBodyAllDefaults(c *check.C) {
+	a, err := asserts.Decode([]byte(exampleEmptyBodyAllDefaults))
+	c.Assert(err, check.IsNil)
+	c.Check(a.Type(), check.Equals, asserts.TestOnlyType)
+	_, ok := a.(*asserts.TestOnly)
+	c.Check(ok, check.Equals, true)
+	c.Check(a.Revision(), check.Equals, 0)
+	c.Check(a.Format(), check.Equals, 0)
+	c.Check(a.Body(), check.IsNil)
+	c.Check(a.Header("header1"), check.IsNil)
+	c.Check(a.HeaderString("header1"), check.Equals, "")
+	c.Check(a.AuthorityID(), check.Equals, "auth-id1")
+	c.Check(a.SignKeyID(), check.Equals, exKeyID)
+}
+
+const exampleEmptyBodyOptionalPrimaryKeySet = "type: test-only\n" +
+	"authority-id: auth-id1\n" +
+	"primary-key: abc\n" +
+	"opt1: A\n" +
+	"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+	"\n\n" +
+	"AXNpZw=="
+
+func (as *assertsSuite) TestDecodeOptionalPrimaryKeys(c *check.C) {
+	r := asserts.MockOptionalPrimaryKey(asserts.TestOnlyType, "opt1", "o1-defl")
+	defer r()
+
+	a, err := asserts.Decode([]byte(exampleEmptyBodyAllDefaults))
+	c.Assert(err, check.IsNil)
+	c.Check(a.Type(), check.Equals, asserts.TestOnlyType)
+	_, ok := a.(*asserts.TestOnly)
+	c.Check(ok, check.Equals, true)
+	c.Check(a.Revision(), check.Equals, 0)
+	c.Check(a.Format(), check.Equals, 0)
+	c.Check(a.Body(), check.IsNil)
+	c.Check(a.HeaderString("opt1"), check.Equals, "o1-defl")
+	c.Check(a.Header("header1"), check.IsNil)
+	c.Check(a.HeaderString("header1"), check.Equals, "")
+	c.Check(a.AuthorityID(), check.Equals, "auth-id1")
+	c.Check(a.SignKeyID(), check.Equals, exKeyID)
+
+	a, err = asserts.Decode([]byte(exampleEmptyBodyOptionalPrimaryKeySet))
+	c.Assert(err, check.IsNil)
+	c.Check(a.Type(), check.Equals, asserts.TestOnlyType)
+	_, ok = a.(*asserts.TestOnly)
+	c.Check(ok, check.Equals, true)
+	c.Check(a.Revision(), check.Equals, 0)
+	c.Check(a.Format(), check.Equals, 0)
+	c.Check(a.Body(), check.IsNil)
+	c.Check(a.HeaderString("opt1"), check.Equals, "A")
+	c.Check(a.Header("header1"), check.IsNil)
+	c.Check(a.HeaderString("header1"), check.Equals, "")
+	c.Check(a.AuthorityID(), check.Equals, "auth-id1")
+	c.Check(a.SignKeyID(), check.Equals, exKeyID)
+}
+
+const exampleEmptyBody2NlNl = "type: test-only\n" +
+	"authority-id: auth-id1\n" +
+	"primary-key: xyz\n" +
+	"revision: 0\n" +
+	"body-length: 0\n" +
+	"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+	"\n\n" +
+	"\n\n" +
+	"AXNpZw==\n"
+
+func (as *assertsSuite) TestDecodeEmptyBodyNormalize2NlNl(c *check.C) {
+	a, err := asserts.Decode([]byte(exampleEmptyBody2NlNl))
+	c.Assert(err, check.IsNil)
+	c.Check(a.Type(), check.Equals, asserts.TestOnlyType)
+	c.Check(a.Revision(), check.Equals, 0)
+	c.Check(a.Format(), check.Equals, 0)
+	c.Check(a.Body(), check.IsNil)
+}
+
+const exampleBodyAndExtraHeaders = "type: test-only\n" +
+	"format: 1\n" +
+	"authority-id: auth-id2\n" +
+	"primary-key: abc\n" +
+	"revision: 5\n" +
+	"header1: value1\n" +
+	"header2: value2\n" +
+	"body-length: 8\n" +
+	"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+	"THE-BODY" +
+	"\n\n" +
+	"AXNpZw==\n"
+
+func (as *assertsSuite) TestDecodeWithABodyAndExtraHeaders(c *check.C) {
+	a, err := asserts.Decode([]byte(exampleBodyAndExtraHeaders))
+	c.Assert(err, check.IsNil)
+	c.Check(a.Type(), check.Equals, asserts.TestOnlyType)
+	c.Check(a.AuthorityID(), check.Equals, "auth-id2")
+	c.Check(a.SignKeyID(), check.Equals, exKeyID)
+	c.Check(a.Header("primary-key"), check.Equals, "abc")
+	c.Check(a.Revision(), check.Equals, 5)
+	c.Check(a.Format(), check.Equals, 1)
+	c.Check(a.SupportedFormat(), check.Equals, true)
+	c.Check(a.Header("header1"), check.Equals, "value1")
+	c.Check(a.Header("header2"), check.Equals, "value2")
+	c.Check(a.Body(), check.DeepEquals, []byte("THE-BODY"))
+
+}
+
+const exampleUnsupportedFormat = "type: test-only\n" +
+	"format: 77\n" +
+	"authority-id: auth-id2\n" +
+	"primary-key: abc\n" +
+	"revision: 5\n" +
+	"header1: value1\n" +
+	"header2: value2\n" +
+	"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+	"AXNpZw==\n"
+
+func (as *assertsSuite) TestDecodeUnsupportedFormat(c *check.C) {
+	a, err := asserts.Decode([]byte(exampleUnsupportedFormat))
+	c.Assert(err, check.IsNil)
+	c.Check(a.Type(), check.Equals, asserts.TestOnlyType)
+	c.Check(a.AuthorityID(), check.Equals, "auth-id2")
+	c.Check(a.SignKeyID(), check.Equals, exKeyID)
+	c.Check(a.Header("primary-key"), check.Equals, "abc")
+	c.Check(a.Revision(), check.Equals, 5)
+	c.Check(a.Format(), check.Equals, 77)
+	c.Check(a.SupportedFormat(), check.Equals, false)
+}
+
+func (as *assertsSuite) TestDecodeGetSignatureBits(c *check.C) {
+	content := "type: test-only\n" +
+		"authority-id: auth-id1\n" +
+		"primary-key: xyz\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"body-length: 8\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+		"THE-BODY"
+	encoded := content +
+		"\n\n" +
+		"AXNpZw=="
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, check.IsNil)
+	c.Check(a.Type(), check.Equals, asserts.TestOnlyType)
+	c.Check(a.AuthorityID(), check.Equals, "auth-id1")
+	c.Check(a.SignKeyID(), check.Equals, exKeyID)
+	cont, signature := a.Signature()
+	c.Check(signature, check.DeepEquals, []byte("AXNpZw=="))
+	c.Check(cont, check.DeepEquals, []byte(content))
+}
+
+func (as *assertsSuite) TestDecodeNoSignatureSplit(c *check.C) {
+	for _, encoded := range []string{"", "foo"} {
+		_, err := asserts.Decode([]byte(encoded))
+		c.Check(err, check.ErrorMatches, "assertion content/signature separator not found")
+	}
+}
+
+func (as *assertsSuite) TestDecodeHeaderParsingErrors(c *check.C) {
+	headerParsingErrorsTests := []struct{ encoded, expectedErr string }{
+		{string([]byte{255, '\n', '\n'}), "header is not utf8"},
+		{"foo: a\nbar\n\n", `header entry missing ':' separator: "bar"`},
+		{"TYPE: foo\n\n", `invalid header name: "TYPE"`},
+		{"foo: a\nbar:>\n\n", `header entry should have a space or newline \(for multiline\) before value: "bar:>"`},
+		{"foo: a\nbar:\n\n", `expected 4 chars nesting prefix after multiline introduction "bar:": EOF`},
+		{"foo: a\nbar:\nbaz: x\n\n", `expected 4 chars nesting prefix after multiline introduction "bar:": "baz: x"`},
+		{"foo: a:\nbar: b\nfoo: x\n\n", `repeated header: "foo"`},
+	}
+
+	for _, test := range headerParsingErrorsTests {
+		_, err := asserts.Decode([]byte(test.encoded))
+		c.Check(err, check.ErrorMatches, "parsing assertion headers: "+test.expectedErr)
+	}
+}
+
+func (as *assertsSuite) TestDecodeInvalid(c *check.C) {
+	keyIDHdr := "sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n"
+	encoded := "type: test-only\n" +
+		"format: 0\n" +
+		"authority-id: auth-id\n" +
+		"primary-key: abc\n" +
+		"revision: 0\n" +
+		"body-length: 5\n" +
+		keyIDHdr +
+		"\n" +
+		"abcde" +
+		"\n\n" +
+		"AXNpZw=="
+
+	invalidAssertTests := []struct{ original, invalid, expectedErr string }{
+		{"body-length: 5", "body-length: z", `assertion: "body-length" header is not an integer: z`},
+		{"body-length: 5", "body-length: 3", "assertion body length and declared body-length don't match: 5 != 3"},
+		{"authority-id: auth-id\n", "", `assertion: "authority-id" header is mandatory`},
+		{"authority-id: auth-id\n", "authority-id: \n", `assertion: "authority-id" header should not be empty`},
+		{keyIDHdr, "", `assertion: "sign-key-sha3-384" header is mandatory`},
+		{keyIDHdr, "sign-key-sha3-384: \n", `assertion: "sign-key-sha3-384" header should not be empty`},
+		{keyIDHdr, "sign-key-sha3-384: $\n", `assertion: "sign-key-sha3-384" header cannot be decoded: .*`},
+		{keyIDHdr, "sign-key-sha3-384: eHl6\n", `assertion: "sign-key-sha3-384" header does not have the expected bit length: 24`},
+		{"AXNpZw==", "", "empty assertion signature"},
+		{"type: test-only\n", "", `assertion: "type" header is mandatory`},
+		{"type: test-only\n", "type: unknown\n", `unknown assertion type: "unknown"`},
+		{"revision: 0\n", "revision: Z\n", `assertion: "revision" header is not an integer: Z`},
+		{"revision: 0\n", "revision:\n  - 1\n", `assertion: "revision" header is not an integer: \[1\]`},
+		{"revision: 0\n", "revision: 00\n", `assertion: "revision" header has invalid prefix zeros: 00`},
+		{"revision: 0\n", "revision: -10\n", "assertion: revision should be positive: -10"},
+		{"revision: 0\n", "revision: 99999999999999999999\n", `assertion: "revision" header is out of range: 99999999999999999999`},
+		{"format: 0\n", "format: Z\n", `assertion: "format" header is not an integer: Z`},
+		{"format: 0\n", "format: -10\n", "assertion: format should be positive: -10"},
+		{"primary-key: abc\n", "", `assertion test-only: "primary-key" header is mandatory`},
+		{"primary-key: abc\n", "primary-key:\n  - abc\n", `assertion test-only: "primary-key" header must be a string`},
+		{"primary-key: abc\n", "primary-key: a/c\n", `assertion test-only: "primary-key" primary key header cannot contain '/'`},
+		{"abcde", "ab\xffde", "assertion body is not utf8"},
+	}
+
+	for _, test := range invalidAssertTests {
+		invalid := strings.Replace(encoded, test.original, test.invalid, 1)
+		_, err := asserts.Decode([]byte(invalid))
+		c.Check(err, check.ErrorMatches, test.expectedErr)
+	}
+}
+
+func (as *assertsSuite) TestDecodeNoAuthorityInvalid(c *check.C) {
+	invalid := "type: test-only-no-authority\n" +
+		"authority-id: auth-id1\n" +
+		"hdr: FOO\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+		"\n\n" +
+		"openpgp c2ln"
+
+	_, err := asserts.Decode([]byte(invalid))
+	c.Check(err, check.ErrorMatches, `"test-only-no-authority" assertion cannot have authority-id set`)
+}
+
+func checkContent(c *check.C, a asserts.Assertion, encoded string) {
+	expected, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, check.IsNil)
+	expectedCont, _ := expected.Signature()
+
+	cont, _ := a.Signature()
+	c.Check(cont, check.DeepEquals, expectedCont)
+}
+
+func (as *assertsSuite) TestEncoderDecoderHappy(c *check.C) {
+	stream := new(bytes.Buffer)
+	enc := asserts.NewEncoder(stream)
+	enc.WriteEncoded([]byte(exampleEmptyBody2NlNl))
+	enc.WriteEncoded([]byte(exampleBodyAndExtraHeaders))
+	enc.WriteEncoded([]byte(exampleEmptyBodyAllDefaults))
+
+	decoder := asserts.NewDecoder(stream)
+	a, err := decoder.Decode()
+	c.Assert(err, check.IsNil)
+	c.Check(a.Type(), check.Equals, asserts.TestOnlyType)
+	_, ok := a.(*asserts.TestOnly)
+	c.Check(ok, check.Equals, true)
+	checkContent(c, a, exampleEmptyBody2NlNl)
+
+	a, err = decoder.Decode()
+	c.Assert(err, check.IsNil)
+	checkContent(c, a, exampleBodyAndExtraHeaders)
+
+	a, err = decoder.Decode()
+	c.Assert(err, check.IsNil)
+	checkContent(c, a, exampleEmptyBodyAllDefaults)
+
+	a, err = decoder.Decode()
+	c.Assert(err, check.Equals, io.EOF)
+	c.Check(a, check.IsNil)
+}
+
+func (as *assertsSuite) TestDecodeEmptyStream(c *check.C) {
+	stream := new(bytes.Buffer)
+	decoder := asserts.NewDecoder(stream)
+	_, err := decoder.Decode()
+	c.Check(err, check.Equals, io.EOF)
+}
+
+func (as *assertsSuite) TestDecoderHappyWithSeparatorsVariations(c *check.C) {
+	streams := []string{
+		exampleBodyAndExtraHeaders,
+		exampleEmptyBody2NlNl,
+		exampleEmptyBodyAllDefaults,
+	}
+
+	for _, streamData := range streams {
+		stream := bytes.NewBufferString(streamData)
+		decoder := asserts.NewDecoderStressed(stream, 16, 1024, 1024, 1024)
+		a, err := decoder.Decode()
+		c.Assert(err, check.IsNil, check.Commentf("stream: %q", streamData))
+
+		checkContent(c, a, streamData)
+
+		a, err = decoder.Decode()
+		c.Check(a, check.IsNil)
+		c.Check(err, check.Equals, io.EOF, check.Commentf("stream: %q", streamData))
+	}
+}
+
+func (as *assertsSuite) TestDecoderHappyWithTrailerDoubleNewlines(c *check.C) {
+	streams := []string{
+		exampleBodyAndExtraHeaders,
+		exampleEmptyBody2NlNl,
+		exampleEmptyBodyAllDefaults,
+	}
+
+	for _, streamData := range streams {
+		stream := bytes.NewBufferString(streamData)
+		if strings.HasSuffix(streamData, "\n") {
+			stream.WriteString("\n")
+		} else {
+			stream.WriteString("\n\n")
+		}
+
+		decoder := asserts.NewDecoderStressed(stream, 16, 1024, 1024, 1024)
+		a, err := decoder.Decode()
+		c.Assert(err, check.IsNil, check.Commentf("stream: %q", streamData))
+
+		checkContent(c, a, streamData)
+
+		a, err = decoder.Decode()
+		c.Check(a, check.IsNil)
+		c.Check(err, check.Equals, io.EOF, check.Commentf("stream: %q", streamData))
+	}
+}
+
+func (as *assertsSuite) TestDecoderUnexpectedEOF(c *check.C) {
+	streamData := exampleBodyAndExtraHeaders + "\n" + exampleEmptyBodyAllDefaults
+	fstHeadEnd := strings.Index(exampleBodyAndExtraHeaders, "\n\n")
+	sndHeadEnd := len(exampleBodyAndExtraHeaders) + 1 + strings.Index(exampleEmptyBodyAllDefaults, "\n\n")
+
+	for _, brk := range []int{1, fstHeadEnd / 2, fstHeadEnd, fstHeadEnd + 1, fstHeadEnd + 2, fstHeadEnd + 6} {
+		stream := bytes.NewBufferString(streamData[:brk])
+		decoder := asserts.NewDecoderStressed(stream, 16, 1024, 1024, 1024)
+		_, err := decoder.Decode()
+		c.Check(err, check.Equals, io.ErrUnexpectedEOF, check.Commentf("brk: %d", brk))
+	}
+
+	for _, brk := range []int{sndHeadEnd, sndHeadEnd + 1} {
+		stream := bytes.NewBufferString(streamData[:brk])
+		decoder := asserts.NewDecoder(stream)
+		_, err := decoder.Decode()
+		c.Assert(err, check.IsNil)
+
+		_, err = decoder.Decode()
+		c.Check(err, check.Equals, io.ErrUnexpectedEOF, check.Commentf("brk: %d", brk))
+	}
+}
+
+func (as *assertsSuite) TestDecoderBrokenBodySeparation(c *check.C) {
+	streamData := strings.Replace(exampleBodyAndExtraHeaders, "THE-BODY\n\n", "THE-BODY", 1)
+	decoder := asserts.NewDecoder(bytes.NewBufferString(streamData))
+	_, err := decoder.Decode()
+	c.Assert(err, check.ErrorMatches, "missing content/signature separator")
+
+	streamData = strings.Replace(exampleBodyAndExtraHeaders, "THE-BODY\n\n", "THE-BODY\n", 1)
+	decoder = asserts.NewDecoder(bytes.NewBufferString(streamData))
+	_, err = decoder.Decode()
+	c.Assert(err, check.ErrorMatches, "missing content/signature separator")
+}
+
+func (as *assertsSuite) TestDecoderHeadTooBig(c *check.C) {
+	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 4, 4, 1024, 1024)
+	_, err := decoder.Decode()
+	c.Assert(err, check.ErrorMatches, `error reading assertion headers: maximum size exceeded while looking for delimiter "\\n\\n"`)
+}
+
+func (as *assertsSuite) TestDecoderBodyTooBig(c *check.C) {
+	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 1024, 1024, 5, 1024)
+	_, err := decoder.Decode()
+	c.Assert(err, check.ErrorMatches, "assertion body length 8 exceeds maximum body size")
+}
+
+func (as *assertsSuite) TestDecoderSignatureTooBig(c *check.C) {
+	decoder := asserts.NewDecoderStressed(bytes.NewBufferString(exampleBodyAndExtraHeaders), 4, 1024, 1024, 7)
+	_, err := decoder.Decode()
+	c.Assert(err, check.ErrorMatches, `error reading assertion signature: maximum size exceeded while looking for delimiter "\\n\\n"`)
+}
+
+func (as *assertsSuite) TestDecoderDefaultMaxBodySize(c *check.C) {
+	enc := strings.Replace(exampleBodyAndExtraHeaders, "body-length: 8", "body-length: 2097153", 1)
+	decoder := asserts.NewDecoder(bytes.NewBufferString(enc))
+	_, err := decoder.Decode()
+	c.Assert(err, check.ErrorMatches, "assertion body length 2097153 exceeds maximum body size")
+}
+
+func (as *assertsSuite) TestDecoderWithTypeMaxBodySize(c *check.C) {
+	ex1 := strings.Replace(exampleBodyAndExtraHeaders, "body-length: 8", "body-length: 2097152", 1)
+	ex1 = strings.Replace(ex1, "THE-BODY", strings.Repeat("B", 2*1024*1024), 1)
+	ex1toobig := strings.Replace(exampleBodyAndExtraHeaders, "body-length: 8", "body-length: 2097153", 1)
+	ex1toobig = strings.Replace(ex1toobig, "THE-BODY", strings.Repeat("B", 2*1024*1024+1), 1)
+	const ex2 = `type: test-only-2
+authority-id: auth-id1
+pk1: foo
+pk2: bar
+body-length: 3
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+XYZ
+
+AXNpZw==`
+
+	decoder := asserts.NewDecoderWithTypeMaxBodySize(bytes.NewBufferString(ex1+"\n"+ex2), map[*asserts.AssertionType]int{
+		asserts.TestOnly2Type: 3,
+	})
+	a1, err := decoder.Decode()
+	c.Assert(err, check.IsNil)
+	c.Check(a1.Body(), check.HasLen, 2*1024*1024)
+	a2, err := decoder.Decode()
+	c.Assert(err, check.IsNil)
+	c.Check(a2.Body(), check.DeepEquals, []byte("XYZ"))
+
+	decoder = asserts.NewDecoderWithTypeMaxBodySize(bytes.NewBufferString(ex1+"\n"+ex2), map[*asserts.AssertionType]int{
+		asserts.TestOnly2Type: 2,
+	})
+	a1, err = decoder.Decode()
+	c.Assert(err, check.IsNil)
+	c.Check(a1.Body(), check.HasLen, 2*1024*1024)
+	_, err = decoder.Decode()
+	c.Assert(err, check.ErrorMatches, `assertion body length 3 exceeds maximum body size 2 for "test-only-2" assertions`)
+
+	decoder = asserts.NewDecoderWithTypeMaxBodySize(bytes.NewBufferString(ex2+"\n\n"+ex1toobig), map[*asserts.AssertionType]int{
+		asserts.TestOnly2Type: 3,
+	})
+	a2, err = decoder.Decode()
+	c.Assert(err, check.IsNil)
+	c.Check(a2.Body(), check.DeepEquals, []byte("XYZ"))
+	_, err = decoder.Decode()
+	c.Assert(err, check.ErrorMatches, "assertion body length 2097153 exceeds maximum body size")
+}
+
+func (as *assertsSuite) TestEncode(c *check.C) {
+	encoded := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key: xyz\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"AXNpZw==")
+	a, err := asserts.Decode(encoded)
+	c.Assert(err, check.IsNil)
+	encodeRes := asserts.Encode(a)
+	c.Check(encodeRes, check.DeepEquals, encoded)
+}
+
+func (as *assertsSuite) TestEncoderOK(c *check.C) {
+	encoded := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key: xyzyz\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"AXNpZw==")
+	a0, err := asserts.Decode(encoded)
+	c.Assert(err, check.IsNil)
+	cont0, _ := a0.Signature()
+
+	stream := new(bytes.Buffer)
+	enc := asserts.NewEncoder(stream)
+	enc.Encode(a0)
+
+	c.Check(bytes.HasSuffix(stream.Bytes(), []byte{'\n'}), check.Equals, true)
+
+	dec := asserts.NewDecoder(stream)
+	a1, err := dec.Decode()
+	c.Assert(err, check.IsNil)
+
+	cont1, _ := a1.Signature()
+	c.Check(cont1, check.DeepEquals, cont0)
+}
+
+func (as *assertsSuite) TestEncoderSingleDecodeOK(c *check.C) {
+	encoded := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key: abc\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"AXNpZw==")
+	a0, err := asserts.Decode(encoded)
+	c.Assert(err, check.IsNil)
+	cont0, _ := a0.Signature()
+
+	stream := new(bytes.Buffer)
+	enc := asserts.NewEncoder(stream)
+	enc.Encode(a0)
+
+	a1, err := asserts.Decode(stream.Bytes())
+	c.Assert(err, check.IsNil)
+
+	cont1, _ := a1.Signature()
+	c.Check(cont1, check.DeepEquals, cont0)
+}
+
+func (as *assertsSuite) TestHeaders(c *check.C) {
+	encoded := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key: abc\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"AXNpZw==")
+	a, err := asserts.Decode(encoded)
+	c.Assert(err, check.IsNil)
+
+	hs := a.Headers()
+	c.Check(hs, check.DeepEquals, map[string]interface{}{
+		"type":              "test-only",
+		"authority-id":      "auth-id2",
+		"primary-key":       "abc",
+		"revision":          "5",
+		"header1":           "value1",
+		"header2":           "value2",
+		"body-length":       "8",
+		"sign-key-sha3-384": exKeyID,
+	})
+}
+
+func (as *assertsSuite) TestHeadersReturnsCopy(c *check.C) {
+	encoded := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key: xyz\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"AXNpZw==")
+	a, err := asserts.Decode(encoded)
+	c.Assert(err, check.IsNil)
+
+	hs := a.Headers()
+	// casual later result mutation doesn't trip us
+	delete(hs, "primary-key")
+	c.Check(a.Header("primary-key"), check.Equals, "xyz")
+}
+
+func (as *assertsSuite) TestAssembleRoundtrip(c *check.C) {
+	encoded := []byte("type: test-only\n" +
+		"format: 1\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key: abc\n" +
+		"revision: 5\n" +
+		"header1: value1\n" +
+		"header2: value2\n" +
+		"body-length: 8\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij\n\n" +
+		"THE-BODY" +
+		"\n\n" +
+		"AXNpZw==")
+	a, err := asserts.Decode(encoded)
+	c.Assert(err, check.IsNil)
+
+	cont, sig := a.Signature()
+	reassembled, err := asserts.Assemble(a.Headers(), a.Body(), cont, sig)
+	c.Assert(err, check.IsNil)
+
+	c.Check(reassembled.Headers(), check.DeepEquals, a.Headers())
+	c.Check(reassembled.Body(), check.DeepEquals, a.Body())
+
+	reassembledEncoded := asserts.Encode(reassembled)
+	c.Check(reassembledEncoded, check.DeepEquals, encoded)
+}
+
+func (as *assertsSuite) TestAssembleHeadersCheck(c *check.C) {
+	cont := []byte("type: test-only\n" +
+		"authority-id: auth-id2\n" +
+		"primary-key: abc\n" +
+		"revision: 5")
+	headers := map[string]interface{}{
+		"type":         "test-only",
+		"authority-id": "auth-id2",
+		"primary-key":  "abc",
+		"revision":     5, // must be a string actually!
+	}
+
+	_, err := asserts.Assemble(headers, nil, cont, nil)
+	c.Check(err, check.ErrorMatches, `header "revision": header values must be strings or nested lists or maps with strings as the only scalars: 5`)
+}

--- a/internal/asserts/constraint.go
+++ b/internal/asserts/constraint.go
@@ -1,0 +1,356 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/x-go/strutil"
+)
+
+const (
+	// feature label for $SLOT()/$PLUG()/$MISSING
+	dollarAttrConstraintsFeature = "dollar-attr-constraints"
+	// feature label for alt attribute matcher usage
+	altAttrMatcherFeature = "alt-attr-matcher"
+)
+
+type attrMatchingContext struct {
+	// attrWord is the usage context word for "attribute", mainly
+	// useful in errors
+	attrWord string
+	helper   AttrMatchContext
+}
+
+type attrMatcher interface {
+	match(apath string, v interface{}, ctx *attrMatchingContext) error
+
+	feature(flabel string) bool
+}
+
+func chain(path, k string) string {
+	if path == "" {
+		return k
+	}
+	return fmt.Sprintf("%s.%s", path, k)
+}
+
+type compileAttrMatcherOptions struct {
+	allowedOperations []string
+}
+
+type compileContext struct {
+	dotted string
+	hadMap bool
+	wasAlt bool
+
+	opts *compileAttrMatcherOptions
+}
+
+func (cc compileContext) String() string {
+	return cc.dotted
+}
+
+func (cc compileContext) keyEntry(k string) compileContext {
+	return compileContext{
+		dotted: chain(cc.dotted, k),
+		hadMap: true,
+		wasAlt: false,
+		opts:   cc.opts,
+	}
+}
+
+func (cc compileContext) alt(alt int) compileContext {
+	return compileContext{
+		dotted: fmt.Sprintf("%s/alt#%d/", cc.dotted, alt+1),
+		hadMap: cc.hadMap,
+		wasAlt: true,
+		opts:   cc.opts,
+	}
+}
+
+// compileAttrMatcher compiles an attrMatcher derived from constraints,
+func compileAttrMatcher(cc compileContext, constraints interface{}) (attrMatcher, error) {
+	switch x := constraints.(type) {
+	case map[string]interface{}:
+		return compileMapAttrMatcher(cc, x)
+	case []interface{}:
+		if cc.wasAlt {
+			return nil, fmt.Errorf("cannot nest alternative constraints directly at %q", cc)
+		}
+		return compileAltAttrMatcher(cc, x)
+	case string:
+		if !cc.hadMap {
+			return nil, fmt.Errorf("first level of non alternative constraints must be a set of key-value contraints")
+		}
+		if strings.HasPrefix(x, "$") {
+			if x == "$MISSING" {
+				return missingAttrMatcher{}, nil
+			}
+			return compileEvalAttrMatcher(cc, x)
+		}
+		return compileRegexpAttrMatcher(cc, x)
+	default:
+		c := cc.String()
+		if c == "" {
+			c = "top constraint"
+		} else {
+			c = fmt.Sprintf("constraint %q", c)
+		}
+		return nil, fmt.Errorf("%s must be a key-value map, regexp or a list of alternative constraints: %v", c, x)
+	}
+}
+
+type mapAttrMatcher map[string]attrMatcher
+
+func compileMapAttrMatcher(cc compileContext, m map[string]interface{}) (attrMatcher, error) {
+	matcher := make(mapAttrMatcher)
+	for k, constraint := range m {
+		matcher1, err := compileAttrMatcher(cc.keyEntry(k), constraint)
+		if err != nil {
+			return nil, err
+		}
+		matcher[k] = matcher1
+	}
+	return matcher, nil
+}
+
+func matchEntry(apath, k string, matcher1 attrMatcher, v interface{}, ctx *attrMatchingContext) error {
+	apath = chain(apath, k)
+	// every entry matcher expects the attribute to be set except for $MISSING
+	if _, ok := matcher1.(missingAttrMatcher); !ok && v == nil {
+		return fmt.Errorf("%s %q has constraints but is unset", ctx.attrWord, apath)
+	}
+	if err := matcher1.match(apath, v, ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func matchList(apath string, matcher attrMatcher, l []interface{}, ctx *attrMatchingContext) error {
+	for i, elem := range l {
+		if err := matcher.match(chain(apath, strconv.Itoa(i)), elem, ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (matcher mapAttrMatcher) feature(flabel string) bool {
+	for _, matcher1 := range matcher {
+		if matcher1.feature(flabel) {
+			return true
+		}
+	}
+	return false
+}
+
+func (matcher mapAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+	switch x := v.(type) {
+	case Attrer:
+		// we get Atter from root-level Check (apath is "")
+		for k, matcher1 := range matcher {
+			v, _ := x.Lookup(k)
+			if err := matchEntry("", k, matcher1, v, ctx); err != nil {
+				return err
+			}
+		}
+	case map[string]interface{}: // maps in attributes look like this
+		for k, matcher1 := range matcher {
+			if err := matchEntry(apath, k, matcher1, x[k], ctx); err != nil {
+				return err
+			}
+		}
+	case []interface{}:
+		return matchList(apath, matcher, x, ctx)
+	default:
+		return fmt.Errorf("%s %q must be a map", ctx.attrWord, apath)
+	}
+	return nil
+}
+
+type missingAttrMatcher struct{}
+
+func (matcher missingAttrMatcher) feature(flabel string) bool {
+	return flabel == dollarAttrConstraintsFeature
+}
+
+func (matcher missingAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+	if v != nil {
+		return fmt.Errorf("%s %q is constrained to be missing but is set", ctx.attrWord, apath)
+	}
+	return nil
+}
+
+type evalAttrMatcher struct {
+	// first iteration supports just $(SLOT|PLUG)(arg)
+	op  string
+	arg string
+}
+
+var (
+	validEvalAttrMatcher    = regexp.MustCompile(`^\$([A-Z]+)\(([^,]+)(?:,([^,]+))?\)$`)
+	validEvalAttrMatcherOps = map[string]bool{
+		"PLUG": true,
+		"SLOT": true,
+	}
+)
+
+func compileEvalAttrMatcher(cc compileContext, s string) (attrMatcher, error) {
+	if len(cc.opts.allowedOperations) == 0 {
+		return nil, fmt.Errorf("cannot compile %q constraint %q: no $OP() constraints supported", cc, s)
+	}
+	ops := validEvalAttrMatcher.FindStringSubmatch(s)
+	if len(ops) == 0 || !validEvalAttrMatcherOps[ops[1]] || !strutil.ListContains(cc.opts.allowedOperations, ops[1]) {
+		oplst := make([]string, 0, len(cc.opts.allowedOperations))
+		for _, op := range cc.opts.allowedOperations {
+			oplst = append(oplst, fmt.Sprintf("$%s()", op))
+		}
+		return nil, fmt.Errorf("cannot compile %q constraint %q: not a valid %s constraint", cc, s, strings.Join(oplst, "/"))
+	}
+	if ops[3] != "" {
+		return nil, fmt.Errorf("cannot compile %q constraint %q: $%s() constraint expects 1 argument", cc, s, ops[1])
+	}
+	return evalAttrMatcher{
+		op:  ops[1],
+		arg: ops[2],
+	}, nil
+}
+
+func (matcher evalAttrMatcher) feature(flabel string) bool {
+	return flabel == dollarAttrConstraintsFeature
+}
+
+func (matcher evalAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+	if ctx.helper == nil {
+		return fmt.Errorf("%s %q cannot be matched without context", ctx.attrWord, apath)
+	}
+	var comp func(string) (interface{}, error)
+	switch matcher.op {
+	case "SLOT":
+		comp = ctx.helper.SlotAttr
+	case "PLUG":
+		comp = ctx.helper.PlugAttr
+	}
+	v1, err := comp(matcher.arg)
+	if err != nil {
+		return fmt.Errorf("%s %q constraint $%s(%s) cannot be evaluated: %v", ctx.attrWord, apath, matcher.op, matcher.arg, err)
+	}
+	if !reflect.DeepEqual(v, v1) {
+		return fmt.Errorf("%s %q does not match $%s(%s): %v != %v", ctx.attrWord, apath, matcher.op, matcher.arg, v, v1)
+	}
+	return nil
+}
+
+type regexpAttrMatcher struct {
+	*regexp.Regexp
+}
+
+func compileRegexpAttrMatcher(cc compileContext, s string) (attrMatcher, error) {
+	rx, err := regexp.Compile("^(" + s + ")$")
+	if err != nil {
+		return nil, fmt.Errorf("cannot compile %q constraint %q: %v", cc, s, err)
+	}
+	return regexpAttrMatcher{rx}, nil
+}
+
+func (matcher regexpAttrMatcher) feature(flabel string) bool {
+	return false
+}
+
+func (matcher regexpAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+	var s string
+	switch x := v.(type) {
+	case string:
+		s = x
+	case bool:
+		s = strconv.FormatBool(x)
+	case int64:
+		s = strconv.FormatInt(x, 10)
+	case []interface{}:
+		return matchList(apath, matcher, x, ctx)
+	default:
+		return fmt.Errorf("%s %q must be a scalar or list", ctx.attrWord, apath)
+	}
+	if !matcher.Regexp.MatchString(s) {
+		return fmt.Errorf("%s %q value %q does not match %v", ctx.attrWord, apath, s, matcher.Regexp)
+	}
+	return nil
+
+}
+
+type altAttrMatcher struct {
+	alts []attrMatcher
+}
+
+func compileAltAttrMatcher(cc compileContext, l []interface{}) (attrMatcher, error) {
+	alts := make([]attrMatcher, len(l))
+	for i, constraint := range l {
+		matcher1, err := compileAttrMatcher(cc.alt(i), constraint)
+		if err != nil {
+			return nil, err
+		}
+		alts[i] = matcher1
+	}
+	return altAttrMatcher{alts}, nil
+
+}
+
+func (matcher altAttrMatcher) feature(flabel string) bool {
+	if flabel == altAttrMatcherFeature {
+		return true
+	}
+	for _, alt := range matcher.alts {
+		if alt.feature(flabel) {
+			return true
+		}
+	}
+	return false
+}
+
+func (matcher altAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+	// if the value is a list apply the alternative matcher to each element
+	// like we do for other matchers
+	switch x := v.(type) {
+	case []interface{}:
+		return matchList(apath, matcher, x, ctx)
+	default:
+	}
+
+	var firstErr error
+	for _, alt := range matcher.alts {
+		err := alt.match(apath, v, ctx)
+		if err == nil {
+			return nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	apathDescr := ""
+	if apath != "" {
+		apathDescr = fmt.Sprintf(" for %s %q", ctx.attrWord, apath)
+	}
+	return fmt.Errorf("no alternative%s matches: %v", apathDescr, firstErr)
+}

--- a/internal/asserts/constraint_test.go
+++ b/internal/asserts/constraint_test.go
@@ -1,0 +1,556 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts_test
+
+import (
+	"fmt"
+	"regexp"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/canonical/workspace/internal/asserts"
+	"github.com/canonical/workspace/internal/metautil"
+	"github.com/canonical/workspace/internal/testutil"
+)
+
+type attrMatcherSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&attrMatcherSuite{})
+
+type testEvalAttr struct {
+	comp func(side string, arg string) (interface{}, error)
+}
+
+func (ca testEvalAttr) SlotAttr(arg string) (interface{}, error) {
+	return ca.comp("slot", arg)
+}
+
+func (ca testEvalAttr) PlugAttr(arg string) (interface{}, error) {
+	return ca.comp("plug", arg)
+}
+
+func vals(yml string) map[string]interface{} {
+	var vs map[string]interface{}
+	err := yaml.Unmarshal([]byte(yml), &vs)
+	if err != nil {
+		panic(err)
+	}
+	v, err := metautil.NormalizeValue(vs)
+	if err != nil {
+		panic(err)
+	}
+	return v.(map[string]interface{})
+}
+
+func (s *attrMatcherSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+}
+
+func (s *attrMatcherSuite) TestSimple(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: FOO
+  bar: BAR`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	values := map[string]interface{}{
+		"foo": "FOO",
+		"bar": "BAR",
+		"baz": "BAZ",
+	}
+	err = domatch(values, nil)
+	c.Check(err, IsNil)
+
+	values = map[string]interface{}{
+		"foo": "FOO",
+		"bar": "BAZ",
+		"baz": "BAZ",
+	}
+	err = domatch(values, nil)
+	c.Check(err, ErrorMatches, `field "bar" value "BAZ" does not match \^\(BAR\)\$`)
+
+	values = map[string]interface{}{
+		"foo": "FOO",
+		"baz": "BAZ",
+	}
+	err = domatch(values, nil)
+	c.Check(err, ErrorMatches, `field "bar" has constraints but is unset`)
+}
+
+func (s *attrMatcherSuite) TestSimpleAnchorsVsRegexpAlt(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  bar: BAR|BAZ`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	values := map[string]interface{}{
+		"bar": "BAR",
+	}
+	err = domatch(values, nil)
+	c.Check(err, IsNil)
+
+	values = map[string]interface{}{
+		"bar": "BARR",
+	}
+	err = domatch(values, nil)
+	c.Check(err, ErrorMatches, `field "bar" value "BARR" does not match \^\(BAR|BAZ\)\$`)
+
+	values = map[string]interface{}{
+		"bar": "BBAZ",
+	}
+	err = domatch(values, nil)
+	c.Check(err, ErrorMatches, `field "bar" value "BAZZ" does not match \^\(BAR|BAZ\)\$`)
+
+	values = map[string]interface{}{
+		"bar": "BABAZ",
+	}
+	err = domatch(values, nil)
+	c.Check(err, ErrorMatches, `field "bar" value "BABAZ" does not match \^\(BAR|BAZ\)\$`)
+
+	values = map[string]interface{}{
+		"bar": "BARAZ",
+	}
+	err = domatch(values, nil)
+	c.Check(err, ErrorMatches, `field "bar" value "BARAZ" does not match \^\(BAR|BAZ\)\$`)
+}
+
+func (s *attrMatcherSuite) TestNested(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: FOO
+  bar:
+    bar1: BAR1
+    bar2: BAR2`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatch(vals(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2: BAR2
+  bar3: BAR3
+baz: BAZ
+`), nil)
+	c.Check(err, IsNil)
+
+	err = domatch(vals(`
+foo: FOO
+bar: BAZ
+baz: BAZ
+`), nil)
+	c.Check(err, ErrorMatches, `field "bar" must be a map`)
+
+	err = domatch(vals(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2: BAR22
+  bar3: BAR3
+baz: BAZ
+`), nil)
+	c.Check(err, ErrorMatches, `field "bar\.bar2" value "BAR22" does not match \^\(BAR2\)\$`)
+
+	err = domatch(vals(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2:
+    bar22: true
+  bar3: BAR3
+baz: BAZ
+`), nil)
+	c.Check(err, ErrorMatches, `field "bar\.bar2" must be a scalar or list`)
+}
+
+func (s *attrMatcherSuite) TestAlternative(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  -
+    foo: FOO
+    bar: BAR
+  -
+    foo: FOO
+    bar: BAZ`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"], nil)
+	c.Assert(err, IsNil)
+
+	values := map[string]interface{}{
+		"foo": "FOO",
+		"bar": "BAR",
+		"baz": "BAZ",
+	}
+	err = domatch(values, nil)
+	c.Check(err, IsNil)
+
+	values = map[string]interface{}{
+		"foo": "FOO",
+		"bar": "BAZ",
+		"baz": "BAZ",
+	}
+	err = domatch(values, nil)
+	c.Check(err, IsNil)
+
+	values = map[string]interface{}{
+		"foo": "FOO",
+		"bar": "BARR",
+		"baz": "BAR",
+	}
+	err = domatch(values, nil)
+	c.Check(err, ErrorMatches, `no alternative matches: field "bar" value "BARR" does not match \^\(BAR\)\$`)
+}
+
+func (s *attrMatcherSuite) TestNestedAlternative(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: FOO
+  bar:
+    bar1: BAR1
+    bar2:
+      - BAR2
+      - BAR22`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatch(vals(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2: BAR2
+`), nil)
+	c.Check(err, IsNil)
+
+	err = domatch(vals(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2: BAR22
+`), nil)
+	c.Check(err, IsNil)
+
+	err = domatch(vals(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2: BAR3
+`), nil)
+	c.Check(err, ErrorMatches, `no alternative for field "bar\.bar2" matches: field "bar\.bar2" value "BAR3" does not match \^\(BAR2\)\$`)
+}
+
+func (s *attrMatcherSuite) TestAlternativeMatchingStringList(c *C) {
+	toMatch := vals(`
+write:
+ - /var/tmp
+ - /var/lib/snapd/snapshots
+`)
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  write: /var/(tmp|lib/snapd/snapshots)`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatch(toMatch, nil)
+	c.Check(err, IsNil)
+
+	m, err = asserts.ParseHeaders([]byte(`attrs:
+  write:
+    - /var/tmp
+    - /var/lib/snapd/snapshots`))
+	c.Assert(err, IsNil)
+
+	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatchLst(toMatch, nil)
+	c.Check(err, IsNil)
+}
+
+func (s *attrMatcherSuite) TestAlternativeMatchingComplex(c *C) {
+	toMatch := vals(`
+mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar/*", where: "/baz/*", options: ["rw", "bind"]}]
+`)
+
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  mnt:
+    -
+      what: /(bar/|dev/x)\*
+      where: /(foo|baz)/\*
+      options: rw|bind|nodev`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatch(toMatch, nil)
+	c.Check(err, IsNil)
+
+	m, err = asserts.ParseHeaders([]byte(`attrs:
+  mnt:
+    -
+      what: /dev/x\*
+      where: /foo/\*
+      options:
+        - nodev
+        - rw
+    -
+      what: /bar/\*
+      where: /baz/\*
+      options:
+        - rw
+        - bind`))
+	c.Assert(err, IsNil)
+
+	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatchExtensive(toMatch, nil)
+	c.Check(err, IsNil)
+
+	// not matching case
+	m, err = asserts.ParseHeaders([]byte(`attrs:
+  mnt:
+    -
+      what: /dev/x\*
+      where: /foo/\*
+      options:
+        - rw
+    -
+      what: /bar/\*
+      where: /baz/\*
+      options:
+        - rw
+        - bind`))
+	c.Assert(err, IsNil)
+
+	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatchExtensiveNoMatch(toMatch, nil)
+	c.Check(err, ErrorMatches, `no alternative for field "mnt\.0" matches: no alternative for field "mnt\.0.options\.1" matches:.*`)
+}
+
+func (s *attrMatcherSuite) TestOtherScalars(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: 1
+  bar: true`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatch(vals(`
+foo: 1
+bar: true
+`), nil)
+	c.Check(err, IsNil)
+
+	values := map[string]interface{}{
+		"foo": int64(1),
+		"bar": true,
+	}
+	err = domatch(values, nil)
+	c.Check(err, IsNil)
+}
+
+func (s *attrMatcherSuite) TestCompileErrors(c *C) {
+	_, err := asserts.CompileAttrMatcher(1, nil)
+	c.Check(err, ErrorMatches, `top constraint must be a key-value map, regexp or a list of alternative constraints: 1`)
+
+	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+		"foo": 1,
+	}, nil)
+	c.Check(err, ErrorMatches, `constraint "foo" must be a key-value map, regexp or a list of alternative constraints: 1`)
+
+	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+		"foo": "[",
+	}, nil)
+	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\[": error parsing regexp:.*`)
+
+	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+		"foo": []interface{}{"foo", "["},
+	}, nil)
+	c.Check(err, ErrorMatches, `cannot compile "foo/alt#2/" constraint "\[": error parsing regexp:.*`)
+
+	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+		"foo": []interface{}{"foo", []interface{}{"bar", "baz"}},
+	}, nil)
+	c.Check(err, ErrorMatches, `cannot nest alternative constraints directly at "foo/alt#2/"`)
+
+	_, err = asserts.CompileAttrMatcher("FOO", nil)
+	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+
+	_, err = asserts.CompileAttrMatcher([]interface{}{"FOO"}, nil)
+	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+
+	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+		"foo": "$FOO()",
+	}, nil)
+	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\$FOO\(\)": no \$OP\(\) constraints supported`)
+
+	wrongDollarConstraints := []string{
+		"$",
+		"$FOO(a)",
+		"$SLOT",
+		"$SLOT()",
+		"$SLOT(x,y)",
+		"$SLOT(x,y,z)",
+	}
+
+	for _, wrong := range wrongDollarConstraints {
+		_, err := asserts.CompileAttrMatcher(map[string]interface{}{
+			"foo": wrong,
+		}, []string{"SLOT", "OP"})
+		if wrong != "$SLOT(x,y)" {
+			c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$OP\(\) constraint`, regexp.QuoteMeta(wrong)))
+		} else {
+			c.Check(err, ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": \$SLOT\(\) constraint expects 1 argument`, regexp.QuoteMeta(wrong)))
+		}
+
+	}
+}
+
+func (s *attrMatcherSuite) TestMatchingListsSimple(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: /foo/.*`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatch(vals(`
+foo: ["/foo/x", "/foo/y"]
+`), nil)
+	c.Check(err, IsNil)
+
+	err = domatch(vals(`
+foo: ["/foo/x", "/foo"]
+`), nil)
+	c.Check(err, ErrorMatches, `field "foo\.1" value "/foo" does not match \^\(/foo/\.\*\)\$`)
+}
+
+func (s *attrMatcherSuite) TestMissingCheck(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: $MISSING`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatch(vals(`
+bar: baz
+`), nil)
+	c.Check(err, IsNil)
+
+	err = domatch(vals(`
+foo: ["x"]
+`), nil)
+	c.Check(err, ErrorMatches, `field "foo" is constrained to be missing but is set`)
+}
+
+func (s *attrMatcherSuite) TestEvalCheck(c *C) {
+	// TODO: consider rewriting once we have $WITHIN
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: $SLOT(foo)
+  bar: $PLUG(bar.baz)`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), []string{"SLOT", "PLUG"})
+	c.Assert(err, IsNil)
+
+	err = domatch(vals(`
+foo: foo
+bar: bar
+`), nil)
+	c.Check(err, ErrorMatches, `field "(foo|bar)" cannot be matched without context`)
+
+	calls := make(map[[2]string]bool)
+	comp1 := func(op string, arg string) (interface{}, error) {
+		calls[[2]string{op, arg}] = true
+		return arg, nil
+	}
+
+	err = domatch(vals(`
+foo: foo
+bar: bar.baz
+`), testEvalAttr{comp1})
+	c.Check(err, IsNil)
+
+	c.Check(calls, DeepEquals, map[[2]string]bool{
+		{"slot", "foo"}:     true,
+		{"plug", "bar.baz"}: true,
+	})
+
+	comp2 := func(op string, arg string) (interface{}, error) {
+		if op == "plug" {
+			return nil, fmt.Errorf("boom")
+		}
+		return arg, nil
+	}
+
+	err = domatch(vals(`
+foo: foo
+bar: bar.baz
+`), testEvalAttr{comp2})
+	c.Check(err, ErrorMatches, `field "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
+
+	comp3 := func(op string, arg string) (interface{}, error) {
+		if op == "slot" {
+			return "other-value", nil
+		}
+		return arg, nil
+	}
+
+	err = domatch(vals(`
+foo: foo
+bar: bar.baz
+`), testEvalAttr{comp3})
+	c.Check(err, ErrorMatches, `field "foo" does not match \$SLOT\(foo\): foo != other-value`)
+}
+
+func (s *attrMatcherSuite) TestMatchingListsMap(c *C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo:
+    p: /foo/.*`))
+	c.Assert(err, IsNil)
+
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	c.Assert(err, IsNil)
+
+	err = domatch(vals(`
+foo: [{p: "/foo/x"}, {p: "/foo/y"}]
+`), nil)
+	c.Check(err, IsNil)
+
+	err = domatch(vals(`
+foo: [{p: "zzz"}, {p: "/foo/y"}]
+`), nil)
+	c.Check(err, ErrorMatches, `field "foo\.0\.p" value "zzz" does not match \^\(/foo/\.\*\)\$`)
+}

--- a/internal/asserts/constraint_test.go
+++ b/internal/asserts/constraint_test.go
@@ -268,10 +268,10 @@ func (s *attrMatcherSuite) TestAlternativeMatchingStringList(c *C) {
 	toMatch := vals(`
 write:
  - /var/tmp
- - /var/lib/snapd/snapshots
+ - /var/lib/workspaced/snapshots
 `)
 	m, err := asserts.ParseHeaders([]byte(`attrs:
-  write: /var/(tmp|lib/snapd/snapshots)`))
+  write: /var/(tmp|lib/workspaced/snapshots)`))
 	c.Assert(err, IsNil)
 
 	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
@@ -283,7 +283,7 @@ write:
 	m, err = asserts.ParseHeaders([]byte(`attrs:
   write:
     - /var/tmp
-    - /var/lib/snapd/snapshots`))
+    - /var/lib/workspaced/snapshots`))
 	c.Assert(err, IsNil)
 
 	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)

--- a/internal/asserts/export_test.go
+++ b/internal/asserts/export_test.go
@@ -1,0 +1,87 @@
+package asserts
+
+import "io"
+
+// Headers helpers to test
+var (
+	ParseHeaders    = parseHeaders
+	CompileSlotRule = compileSlotRule
+)
+
+func init() {
+	maxSupportedFormat[TestOnlyType.Name] = 1
+
+	typeRegistry[TestOnlyType.Name] = TestOnlyType
+	typeRegistry[TestOnly2Type.Name] = TestOnly2Type
+	typeRegistry[TestOnlyNoAuthorityType.Name] = TestOnlyNoAuthorityType
+}
+
+// define test assertion types to use in the tests
+
+type TestOnly struct {
+	assertionBase
+}
+
+func assembleTestOnly(assert assertionBase) (Assertion, error) {
+	// for testing error cases
+	if _, err := checkIntWithDefault(assert.headers, "count", 0); err != nil {
+		return nil, err
+	}
+	return &TestOnly{assert}, nil
+}
+
+var TestOnlyType = &AssertionType{"test-only", []string{"primary-key"}, nil, assembleTestOnly, 0}
+
+type TestOnly2 struct {
+	assertionBase
+}
+
+func assembleTestOnly2(assert assertionBase) (Assertion, error) {
+	return &TestOnly2{assert}, nil
+}
+
+var TestOnly2Type = &AssertionType{"test-only-2", []string{"pk1", "pk2"}, nil, assembleTestOnly2, 0}
+
+type TestOnlyNoAuthority struct {
+	assertionBase
+}
+
+func assembleTestOnlyNoAuthority(assert assertionBase) (Assertion, error) {
+	if _, err := checkNotEmptyString(assert.headers, "hdr"); err != nil {
+		return nil, err
+	}
+	return &TestOnlyNoAuthority{assert}, nil
+}
+
+var TestOnlyNoAuthorityType = &AssertionType{"test-only-no-authority", nil, nil, assembleTestOnlyNoAuthority, noAuthority}
+
+// NewDecoderStressed makes a Decoder with a stressed setup with the given buffer and maximum sizes.
+func NewDecoderStressed(r io.Reader, bufSize, maxHeadersSize, maxBodySize, maxSigSize int) *Decoder {
+	return (&Decoder{
+		rd:                 r,
+		initialBufSize:     bufSize,
+		maxHeadersSize:     maxHeadersSize,
+		maxSigSize:         maxSigSize,
+		defaultMaxBodySize: maxBodySize,
+	}).initBuffer()
+}
+
+func CompileAttrMatcher(constraints interface{}, allowedOperations []string) (func(attrs map[string]interface{}, helper AttrMatchContext) error, error) {
+	// XXX adjust
+	cc := compileContext{
+		opts: &compileAttrMatcherOptions{
+			allowedOperations: allowedOperations,
+		},
+	}
+	matcher, err := compileAttrMatcher(cc, constraints)
+	if err != nil {
+		return nil, err
+	}
+	domatch := func(attrs map[string]interface{}, helper AttrMatchContext) error {
+		return matcher.match("", attrs, &attrMatchingContext{
+			attrWord: "field",
+			helper:   helper,
+		})
+	}
+	return domatch, nil
+}

--- a/internal/asserts/header_checks.go
+++ b/internal/asserts/header_checks.go
@@ -1,0 +1,195 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"crypto"
+	"encoding/base64"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// common checks used when decoding/assembling assertions
+
+func checkExistsStringWhat(m map[string]interface{}, name, what string) (string, error) {
+	value, ok := m[name]
+	if !ok {
+		return "", fmt.Errorf("%q %s is mandatory", name, what)
+	}
+	s, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("%q %s must be a string", name, what)
+	}
+	return s, nil
+}
+
+func checkNotEmptyString(headers map[string]interface{}, name string) (string, error) {
+	return checkNotEmptyStringWhat(headers, name, "header")
+}
+
+func checkNotEmptyStringWhat(m map[string]interface{}, name, what string) (string, error) {
+	s, err := checkExistsStringWhat(m, name, what)
+	if err != nil {
+		return "", err
+	}
+	if len(s) == 0 {
+		return "", fmt.Errorf("%q %s should not be empty", name, what)
+	}
+	return s, nil
+}
+
+func checkPrimaryKey(headers map[string]interface{}, primKey string) (string, error) {
+	value, err := checkNotEmptyString(headers, primKey)
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(value, "/") {
+		return "", fmt.Errorf("%q primary key header cannot contain '/'", primKey)
+	}
+	return value, nil
+}
+
+
+// use 'defl' default if missing
+func checkIntWithDefault(headers map[string]interface{}, name string, defl int) (int, error) {
+	value, ok := headers[name]
+	if !ok {
+		return defl, nil
+	}
+	s, ok := value.(string)
+	if !ok {
+		return -1, fmt.Errorf("%q header is not an integer: %v", name, value)
+	}
+	m, err := atoi(s, "%q %s", name, "header")
+	if err != nil {
+		return -1, err
+	}
+	return m, nil
+}
+
+type intSyntaxError string
+
+func (e intSyntaxError) Error() string {
+	return string(e)
+}
+
+func atoi(valueStr, whichFmt string, whichArgs ...interface{}) (int, error) {
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		which := fmt.Sprintf(whichFmt, whichArgs...)
+		if ne, ok := err.(*strconv.NumError); ok && ne.Err == strconv.ErrRange {
+			return -1, fmt.Errorf("%s is out of range: %v", which, valueStr)
+		}
+		return -1, intSyntaxError(fmt.Sprintf("%s is not an integer: %v", which, valueStr))
+	}
+	if prefixZeros(valueStr) {
+		return -1, fmt.Errorf("%s has invalid prefix zeros: %s", fmt.Sprintf(whichFmt, whichArgs...), valueStr)
+	}
+	return value, nil
+}
+
+func prefixZeros(s string) bool {
+	return strings.HasPrefix(s, "0") && s != "0"
+}
+
+func checkRFC3339Date(headers map[string]interface{}, name string) (time.Time, error) {
+	return checkRFC3339DateWhat(headers, name, "header")
+}
+
+func checkRFC3339DateWhat(m map[string]interface{}, name, what string) (time.Time, error) {
+	dateStr, err := checkNotEmptyStringWhat(m, name, what)
+	if err != nil {
+		return time.Time{}, err
+	}
+	date, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%q %s is not a RFC3339 date: %v", name, what, err)
+	}
+	return date, nil
+}
+
+func checkDigest(headers map[string]interface{}, name string, h crypto.Hash) ([]byte, error) {
+	return checkDigestWhat(headers, name, h, "header")
+}
+
+func checkDigestWhat(headers map[string]interface{}, name string, h crypto.Hash, what string) ([]byte, error) {
+	digestStr, err := checkNotEmptyStringWhat(headers, name, what)
+	if err != nil {
+		return nil, err
+	}
+	b, err := base64.RawURLEncoding.DecodeString(digestStr)
+	if err != nil {
+		return nil, fmt.Errorf("%q %s cannot be decoded: %v", name, what, err)
+	}
+	if len(b) != h.Size() {
+		return nil, fmt.Errorf("%q %s does not have the expected bit length: %d", name, what, len(b)*8)
+	}
+
+	return b, nil
+}
+
+// checkStringListInMap returns the `name` entry in the `m` map as a (possibly nil) `[]string`
+// if `m` has an entry for `name` and it isn't a `[]string`, an error is returned
+// if pattern is not nil, all the strings must match that pattern, otherwise an error is returned
+// `what` is a descriptor, used for error messages
+func checkStringListInMap(m map[string]interface{}, name, what string, pattern *regexp.Regexp) ([]string, error) {
+	value, ok := m[name]
+	if !ok {
+		return nil, nil
+	}
+	lst, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s must be a list of strings", what)
+	}
+	if len(lst) == 0 {
+		return nil, nil
+	}
+	res := make([]string, len(lst))
+	for i, v := range lst {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s must be a list of strings", what)
+		}
+		if pattern != nil && !pattern.MatchString(s) {
+			return nil, fmt.Errorf("%s contains an invalid element: %q", what, s)
+		}
+		res[i] = s
+	}
+	return res, nil
+}
+
+func checkMap(headers map[string]interface{}, name string) (map[string]interface{}, error) {
+	return checkMapWhat(headers, name, "header")
+}
+
+func checkMapWhat(m map[string]interface{}, name, what string) (map[string]interface{}, error) {
+	value, ok := m[name]
+	if !ok {
+		return nil, nil
+	}
+	mv, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%q %s must be a map", name, what)
+	}
+	return mv, nil
+}

--- a/internal/asserts/headers.go
+++ b/internal/asserts/headers.go
@@ -1,0 +1,267 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	nl   = []byte("\n")
+	nlnl = []byte("\n\n")
+
+	// for basic validity checking of header names
+	headerNameValidity = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
+)
+
+func parseHeaders(head []byte) (map[string]interface{}, error) {
+	if !utf8.Valid(head) {
+		return nil, fmt.Errorf("header is not utf8")
+	}
+	headers := make(map[string]interface{})
+	lines := strings.Split(string(head), "\n")
+	for i := 0; i < len(lines); {
+		entry := lines[i]
+		nameValueSplit := strings.Index(entry, ":")
+		if nameValueSplit == -1 {
+			return nil, fmt.Errorf("header entry missing ':' separator: %q", entry)
+		}
+		name := entry[:nameValueSplit]
+		if !headerNameValidity.MatchString(name) {
+			return nil, fmt.Errorf("invalid header name: %q", name)
+		}
+
+		consumed := nameValueSplit + 1
+		var value interface{}
+		var err error
+		value, i, err = parseEntry(consumed, i, lines, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := headers[name]; ok {
+			return nil, fmt.Errorf("repeated header: %q", name)
+		}
+
+		headers[name] = value
+	}
+	return headers, nil
+}
+
+const (
+	commonPrefix    = "  "
+	multilinePrefix = "    "
+	listChar        = "-"
+	listPrefix      = commonPrefix + listChar
+)
+
+func nestingPrefix(baseIndent int, prefix string) string {
+	return strings.Repeat(" ", baseIndent) + prefix
+}
+
+func parseEntry(consumedByIntro int, first int, lines []string, baseIndent int) (value interface{}, firstAfter int, err error) {
+	entry := lines[first]
+	i := first + 1
+	if consumedByIntro == len(entry) {
+		// multiline values
+		basePrefix := nestingPrefix(baseIndent, commonPrefix)
+		if i < len(lines) && strings.HasPrefix(lines[i], basePrefix) {
+			rest := lines[i][len(basePrefix):]
+			if strings.HasPrefix(rest, listChar) {
+				// list
+				return parseList(i, lines, baseIndent)
+			}
+			if len(rest) > 0 && rest[0] != ' ' {
+				// map
+				return parseMap(i, lines, baseIndent)
+			}
+		}
+
+		return parseMultilineText(i, lines, baseIndent)
+	}
+
+	// simple one-line value
+	if entry[consumedByIntro] != ' ' {
+		return nil, -1, fmt.Errorf("header entry should have a space or newline (for multiline) before value: %q", entry)
+	}
+
+	return entry[consumedByIntro+1:], i, nil
+}
+
+func parseMultilineText(first int, lines []string, baseIndent int) (value interface{}, firstAfter int, err error) {
+	size := 0
+	i := first
+	j := i
+	prefix := nestingPrefix(baseIndent, multilinePrefix)
+	for j < len(lines) {
+		iline := lines[j]
+		if !strings.HasPrefix(iline, prefix) {
+			break
+		}
+		size += len(iline) - len(prefix) + 1
+		j++
+	}
+	if j == i {
+		var cur string
+		if i == len(lines) {
+			cur = "EOF"
+		} else {
+			cur = fmt.Sprintf("%q", lines[i])
+		}
+		return nil, -1, fmt.Errorf("expected %d chars nesting prefix after multiline introduction %q: %s", len(prefix), lines[i-1], cur)
+	}
+
+	valueBuf := bytes.NewBuffer(make([]byte, 0, size-1))
+	valueBuf.WriteString(lines[i][len(prefix):])
+	i++
+	for i < j {
+		valueBuf.WriteByte('\n')
+		valueBuf.WriteString(lines[i][len(prefix):])
+		i++
+	}
+
+	return valueBuf.String(), i, nil
+}
+
+func parseList(first int, lines []string, baseIndent int) (value interface{}, firstAfter int, err error) {
+	lst := []interface{}(nil)
+	j := first
+	prefix := nestingPrefix(baseIndent, listPrefix)
+	for j < len(lines) {
+		if !strings.HasPrefix(lines[j], prefix) {
+			return lst, j, nil
+		}
+		var v interface{}
+		var err error
+		v, j, err = parseEntry(len(prefix), j, lines, baseIndent+len(listPrefix)-1)
+		if err != nil {
+			return nil, -1, err
+		}
+		lst = append(lst, v)
+	}
+	return lst, j, nil
+}
+
+func parseMap(first int, lines []string, baseIndent int) (value interface{}, firstAfter int, err error) {
+	m := make(map[string]interface{})
+	j := first
+	prefix := nestingPrefix(baseIndent, commonPrefix)
+	for j < len(lines) {
+		if !strings.HasPrefix(lines[j], prefix) {
+			return m, j, nil
+		}
+
+		entry := lines[j][len(prefix):]
+		keyValueSplit := strings.Index(entry, ":")
+		if keyValueSplit == -1 {
+			return nil, -1, fmt.Errorf("map entry missing ':' separator: %q", entry)
+		}
+		key := entry[:keyValueSplit]
+		if !headerNameValidity.MatchString(key) {
+			return nil, -1, fmt.Errorf("invalid map entry key: %q", key)
+		}
+
+		consumed := keyValueSplit + 1
+		var value interface{}
+		var err error
+		value, j, err = parseEntry(len(prefix)+consumed, j, lines, len(prefix))
+		if err != nil {
+			return nil, -1, err
+		}
+
+		if _, ok := m[key]; ok {
+			return nil, -1, fmt.Errorf("repeated map entry: %q", key)
+		}
+
+		m[key] = value
+	}
+	return m, j, nil
+}
+
+// checkHeader checks that the header values are strings, or nested lists or maps with strings as the only scalars
+func checkHeader(v interface{}) error {
+	switch x := v.(type) {
+	case string:
+		return nil
+	case []interface{}:
+		for _, elem := range x {
+			err := checkHeader(elem)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	case map[string]interface{}:
+		for _, elem := range x {
+			err := checkHeader(elem)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("header values must be strings or nested lists or maps with strings as the only scalars: %v", v)
+	}
+}
+
+// checkHeaders checks that headers are of expected types
+func checkHeaders(headers map[string]interface{}) error {
+	for name, value := range headers {
+		err := checkHeader(value)
+		if err != nil {
+			return fmt.Errorf("header %q: %v", name, err)
+		}
+	}
+	return nil
+}
+
+// copyHeader helps deep copying header values to defend against external mutations
+func copyHeader(v interface{}) interface{} {
+	switch x := v.(type) {
+	case string:
+		return x
+	case []interface{}:
+		res := make([]interface{}, len(x))
+		for i, elem := range x {
+			res[i] = copyHeader(elem)
+		}
+		return res
+	case map[string]interface{}:
+		res := make(map[string]interface{}, len(x))
+		for name, value := range x {
+			if value == nil {
+				continue // normalize nils out
+			}
+			res[name] = copyHeader(value)
+		}
+		return res
+	default:
+		panic(fmt.Sprintf("internal error: encountered unexpected value type copying headers: %v", v))
+	}
+}
+
+// copyHeader helps deep copying headers to defend against external mutations
+func copyHeaders(headers map[string]interface{}) map[string]interface{} {
+	return copyHeader(headers).(map[string]interface{})
+}

--- a/internal/asserts/headers_test.go
+++ b/internal/asserts/headers_test.go
@@ -1,0 +1,254 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts_test
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/asserts"
+)
+
+type headersSuite struct{}
+
+var _ = check.Suite(&headersSuite{})
+
+func (s *headersSuite) TestParseHeadersSimple(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`foo: 1
+bar: baz`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": "1",
+		"bar": "baz",
+	})
+}
+
+func (s *headersSuite) TestParseHeadersMultiline(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`foo:
+    abc
+    
+bar: baz`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": "abc\n",
+		"bar": "baz",
+	})
+
+	m, err = asserts.ParseHeaders([]byte(`foo: 1
+bar:
+    baz`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": "1",
+		"bar": "baz",
+	})
+
+	m, err = asserts.ParseHeaders([]byte(`foo: 1
+bar:
+    baz
+    `))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": "1",
+		"bar": "baz\n",
+	})
+
+	m, err = asserts.ParseHeaders([]byte(`foo: 1
+bar:
+    baz
+    
+    baz2`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": "1",
+		"bar": "baz\n\nbaz2",
+	})
+}
+
+func (s *headersSuite) TestParseHeadersSimpleList(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`foo:
+  - x
+  - y
+  - z
+bar: baz`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": []interface{}{"x", "y", "z"},
+		"bar": "baz",
+	})
+}
+
+func (s *headersSuite) TestParseHeadersListNestedMultiline(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`foo:
+  - x
+  -
+      y1
+      y2
+      
+  - z
+bar: baz`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": []interface{}{"x", "y1\ny2\n", "z"},
+		"bar": "baz",
+	})
+
+	m, err = asserts.ParseHeaders([]byte(`bar: baz
+foo:
+  -
+    - u1
+    - u2
+  -
+      y1
+      y2
+      `))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": []interface{}{[]interface{}{"u1", "u2"}, "y1\ny2\n"},
+		"bar": "baz",
+	})
+}
+
+func (s *headersSuite) TestParseHeadersSimpleMap(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`foo:
+  x: X
+  yy: YY
+  z5: 
+bar: baz`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": map[string]interface{}{
+			"x":  "X",
+			"yy": "YY",
+			"z5": "",
+		},
+		"bar": "baz",
+	})
+}
+
+func (s *headersSuite) TestParseHeadersMapNestedMultiline(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`foo:
+  x: X
+  yy:
+      YY1
+      YY2
+  u:
+    - u1
+    - u2
+bar: baz`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"foo": map[string]interface{}{
+			"x":  "X",
+			"yy": "YY1\nYY2",
+			"u":  []interface{}{"u1", "u2"},
+		},
+		"bar": "baz",
+	})
+
+	m, err = asserts.ParseHeaders([]byte(`one:
+  two:
+    three: `))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"one": map[string]interface{}{
+			"two": map[string]interface{}{
+				"three": "",
+			},
+		},
+	})
+
+	m, err = asserts.ParseHeaders([]byte(`one:
+  two:
+      three`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"one": map[string]interface{}{
+			"two": "three",
+		},
+	})
+
+	m, err = asserts.ParseHeaders([]byte(`map-within-map:
+  lev1:
+    lev2: x`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"map-within-map": map[string]interface{}{
+			"lev1": map[string]interface{}{
+				"lev2": "x",
+			},
+		},
+	})
+
+	m, err = asserts.ParseHeaders([]byte(`list-of-maps:
+  -
+    entry: foo
+    bar: baz
+  -
+    entry: bar`))
+	c.Assert(err, check.IsNil)
+	c.Check(m, check.DeepEquals, map[string]interface{}{
+		"list-of-maps": []interface{}{
+			map[string]interface{}{
+				"entry": "foo",
+				"bar":   "baz",
+			},
+			map[string]interface{}{
+				"entry": "bar",
+			},
+		},
+	})
+}
+
+func (s *headersSuite) TestParseHeadersMapErrors(c *check.C) {
+	_, err := asserts.ParseHeaders([]byte(`foo:
+  x X
+bar: baz`))
+	c.Check(err, check.ErrorMatches, `map entry missing ':' separator: "x X"`)
+
+	_, err = asserts.ParseHeaders([]byte(`foo:
+  0x: X
+bar: baz`))
+	c.Check(err, check.ErrorMatches, `invalid map entry key: "0x"`)
+
+	_, err = asserts.ParseHeaders([]byte(`foo:
+  a: a
+  a: b`))
+	c.Check(err, check.ErrorMatches, `repeated map entry: "a"`)
+}
+
+func (s *headersSuite) TestParseHeadersErrors(c *check.C) {
+	_, err := asserts.ParseHeaders([]byte(`foo: 1
+bar:baz`))
+	c.Check(err, check.ErrorMatches, `header entry should have a space or newline \(for multiline\) before value: "bar:baz"`)
+
+	_, err = asserts.ParseHeaders([]byte(`foo:
+ - x
+  - y
+  - z
+bar: baz`))
+	c.Check(err, check.ErrorMatches, `expected 4 chars nesting prefix after multiline introduction "foo:": " - x"`)
+
+	_, err = asserts.ParseHeaders([]byte(`foo:
+  - x
+  - y
+  - z
+bar:`))
+	c.Check(err, check.ErrorMatches, `expected 4 chars nesting prefix after multiline introduction "bar:": EOF`)
+}

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -89,7 +89,7 @@ func (ac SideArityConstraint) Any() bool {
 }
 
 // SlotConnectionConstraints specfies a set of constraints on an
-// interface slot for a snap relevant to its connection or
+// interface slot for a sdk relevant to its connection or
 // auto-connection.
 type SlotConnectionConstraints struct {
 	PlugSdkTypes []string
@@ -390,7 +390,7 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 }
 
 // PlugRule holds the rule of what is allowed, wrt installation and
-// connection, for a plug of a specific interface for a snap.
+// connection, for a plug of a specific interface for a sdk.
 type PlugRule struct {
 	Interface string
 }

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -1,0 +1,518 @@
+package asserts
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	defaultOutcome = map[string]interface{}{
+		"allow-installation":    "true",
+		"allow-connection":      "true",
+		"allow-auto-connection": "true",
+		"deny-installation":     "false",
+		"deny-connection":       "false",
+		"deny-auto-connection":  "false",
+	}
+
+	invertedOutcome = map[string]interface{}{
+		"allow-installation": "false",
+		"deny-installation":  "true",
+	}
+
+	ruleSubrules = []string{"allow-installation", "deny-installation", "allow-connection", "deny-connection", "allow-auto-connection", "deny-auto-connection"}
+
+	validWorkspaceType = regexp.MustCompile(`^(?:core|workspace)$`)
+
+	validIDConstraints = map[string]*regexp.Regexp{
+		"slot-workspace-type": validWorkspaceType,
+		"plug-sdk-type":       validWorkspaceType,
+	}
+
+	attributeConstraints = []string{"plug-attributes", "slot-attributes"}
+
+	slotIDConstraints = []string{"plug-sdk-type"}
+
+	sideArityConstraints        = []string{"slots-per-plug", "plugs-per-slot"}
+	sideArityConstraintsSetters = map[string]func(sideArityConstraintsHolder, SideArityConstraint){
+		"slots-per-plug": sideArityConstraintsHolder.setSlotsPerPlug,
+		"plugs-per-slot": sideArityConstraintsHolder.setPlugsPerSlot,
+	}
+)
+
+// SlotInstallationConstraints specifies a set of constraints on an
+// interface slot relevant to the installation of SDK.
+type SlotInstallationConstraints struct {
+	SlotWorkspaceTypes []string
+	SlotAttributes     *AttributeConstraints
+}
+
+func (c *SlotInstallationConstraints) setIDConstraints(field string, cstrs []string) {
+	switch field {
+	case "slot-workspace-type":
+		c.SlotWorkspaceTypes = cstrs
+	default:
+		panic("unknown SlotInstallationConstraints field " + field)
+	}
+}
+
+func (c *SlotInstallationConstraints) setAttributeConstraints(field string, cstrs *AttributeConstraints) {
+	switch field {
+	case "slot-attributes":
+		c.SlotAttributes = cstrs
+	default:
+		panic("unknown SlotInstallationConstraints field " + field)
+	}
+}
+
+// SideArityConstraint specifies a constraint for the overall arity of
+// the set of connected slots for a given plug or the set of
+// connected plugs for a given slot.
+// It is used to express parsed slots-per-plug and plugs-per-slot
+// constraints.
+// See https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
+type SideArityConstraint struct {
+	// N can be:
+	// =>1
+	// 0 means default and is used only internally during rule
+	// compilation or on deny- rules where these constraints are
+	// not applicable
+	// -1 represents *, that means any (number of)
+	N int
+}
+
+// Any returns whether this represents the * (any number of) constraint.
+func (ac SideArityConstraint) Any() bool {
+	return ac.N == -1
+}
+
+// SlotConnectionConstraints specfies a set of constraints on an
+// interface slot for a snap relevant to its connection or
+// auto-connection.
+type SlotConnectionConstraints struct {
+	PlugSdkTypes []string
+
+	SlotAttributes *AttributeConstraints
+	PlugAttributes *AttributeConstraints
+
+	// SlotsPerPlug defaults to 1 for auto-connection, can be * (any)
+	SlotsPerPlug SideArityConstraint
+	// PlugsPerSlot is always * (any) (for now)
+	PlugsPerSlot SideArityConstraint
+}
+
+func (c *SlotConnectionConstraints) setIDConstraints(field string, cstrs []string) {
+	switch field {
+	case "plug-sdk-type":
+		c.PlugSdkTypes = cstrs
+	default:
+		panic("unknown SlotConnectionConstraints field " + field)
+	}
+}
+
+func (c *SlotConnectionConstraints) setAttributeConstraints(field string, cstrs *AttributeConstraints) {
+	switch field {
+	case "plug-attributes":
+		c.PlugAttributes = cstrs
+	case "slot-attributes":
+		c.SlotAttributes = cstrs
+	default:
+		panic("unknown SlotConnectionConstraints field " + field)
+	}
+}
+
+func (c *SlotConnectionConstraints) setSlotsPerPlug(a SideArityConstraint) {
+	c.SlotsPerPlug = a
+}
+
+func (c *SlotConnectionConstraints) setPlugsPerSlot(a SideArityConstraint) {
+	c.PlugsPerSlot = a
+}
+
+func (c *SlotConnectionConstraints) slotsPerPlug() SideArityConstraint {
+	return c.SlotsPerPlug
+}
+
+func (c *SlotConnectionConstraints) plugsPerSlot() SideArityConstraint {
+	return c.PlugsPerSlot
+}
+
+type sideArityConstraintsHolder interface {
+	setSlotsPerPlug(SideArityConstraint)
+	setPlugsPerSlot(SideArityConstraint)
+
+	slotsPerPlug() SideArityConstraint
+	plugsPerSlot() SideArityConstraint
+}
+
+func normalizeSideArityConstraints(context *subruleContext, c sideArityConstraintsHolder) {
+	if !context.allow() {
+		return
+	}
+	any := SideArityConstraint{N: -1}
+	// normalized plugs-per-slot is always *
+	c.setPlugsPerSlot(any)
+	slotsPerPlug := c.slotsPerPlug()
+	if context.autoConnection() {
+		// auto-connection slots-per-plug can be any or 1
+		if !slotsPerPlug.Any() {
+			c.setSlotsPerPlug(SideArityConstraint{N: 1})
+		}
+	} else {
+		// connection slots-per-plug can be only any
+		c.setSlotsPerPlug(any)
+	}
+}
+
+// SlotRule holds the rule of what is allowed, wrt installation and
+// connection, for a slot of a specific interface for a SDK.
+type SlotRule struct {
+	Interface string
+
+	AllowInstallation []*SlotInstallationConstraints
+	DenyInstallation  []*SlotInstallationConstraints
+
+	AllowConnection []*SlotConnectionConstraints
+	DenyConnection  []*SlotConnectionConstraints
+
+	AllowAutoConnection []*SlotConnectionConstraints
+	DenyAutoConnection  []*SlotConnectionConstraints
+}
+
+func (r *SlotRule) setConstraints(field string, cstrs []constraintsHolder) {
+	if len(cstrs) == 0 {
+		panic(fmt.Sprintf("cannot set SlotRule field %q to empty", field))
+	}
+	switch cstrs[0].(type) {
+	case *SlotInstallationConstraints:
+		switch field {
+		case "allow-installation":
+			r.AllowInstallation = castSlotInstallationConstraints(cstrs)
+			return
+		case "deny-installation":
+			r.DenyInstallation = castSlotInstallationConstraints(cstrs)
+			return
+		}
+	case *SlotConnectionConstraints:
+		switch field {
+		case "allow-connection":
+			r.AllowConnection = castSlotConnectionConstraints(cstrs)
+			return
+		case "deny-connection":
+			r.DenyConnection = castSlotConnectionConstraints(cstrs)
+			return
+		case "allow-auto-connection":
+			r.AllowAutoConnection = castSlotConnectionConstraints(cstrs)
+			return
+		case "deny-auto-connection":
+			r.DenyAutoConnection = castSlotConnectionConstraints(cstrs)
+			return
+		}
+	}
+	panic(fmt.Sprintf("cannot set SlotRule field %q with %T elements", field, cstrs[0]))
+}
+
+func castSlotConnectionConstraints(cstrs []constraintsHolder) (res []*SlotConnectionConstraints) {
+	res = make([]*SlotConnectionConstraints, len(cstrs))
+	for i, cstr := range cstrs {
+		res[i] = cstr.(*SlotConnectionConstraints)
+	}
+	return res
+}
+
+func castSlotInstallationConstraints(cstrs []constraintsHolder) (res []*SlotInstallationConstraints) {
+	res = make([]*SlotInstallationConstraints, len(cstrs))
+	for i, cstr := range cstrs {
+		res[i] = cstr.(*SlotInstallationConstraints)
+	}
+	return res
+}
+
+func compileSlotInstallationConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
+	slotInstCstrs := &SlotInstallationConstraints{}
+	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-attributes"}, []string{"slot-workspace-type"})
+	if err != nil {
+		return nil, err
+	}
+	return slotInstCstrs, nil
+}
+
+func compileSlotConnectionConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
+	slotConnCstrs := &SlotConnectionConstraints{}
+	err := baseCompileConstraints(context, cDef, slotConnCstrs, attributeConstraints, slotIDConstraints)
+	if err != nil {
+		return nil, err
+	}
+	normalizeSideArityConstraints(context, slotConnCstrs)
+	return slotConnCstrs, nil
+}
+
+func compileSideArityConstraint(context *subruleContext, which string, v interface{}) (SideArityConstraint, error) {
+	var a SideArityConstraint
+	if context.installation() || !context.allow() {
+		return a, fmt.Errorf("%v cannot specify a %v constraint, they apply only to allow-*connection", context, which)
+	}
+	x, ok := v.(string)
+	if !ok || len(x) == 0 {
+		return a, fmt.Errorf("%v in %v must be an integer >=1 or *", which, context)
+	}
+	if x == "*" {
+		return SideArityConstraint{N: -1}, nil
+	}
+	n, err := atoi(x, "%v in %v", which, context)
+	switch _, syntax := err.(intSyntaxError); {
+	case err == nil && n < 1:
+		fallthrough
+	case syntax:
+		return a, fmt.Errorf("%v in %v must be an integer >=1 or *", which, context)
+	case err != nil:
+		return a, err
+	}
+	return SideArityConstraint{N: n}, nil
+}
+
+type fixedAttrMatcher struct {
+	result error
+}
+
+func (matcher fixedAttrMatcher) feature(flabel string) bool {
+	return false
+}
+
+func (matcher fixedAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+	return matcher.result
+}
+
+// AttrMatchContext has contextual helpers for evaluating attribute constraints.
+type AttrMatchContext interface {
+	PlugAttr(arg string) (interface{}, error)
+	SlotAttr(arg string) (interface{}, error)
+}
+
+// AttributeConstraints implements a set of constraints on the attributes of a slot or plug.
+type AttributeConstraints struct {
+	matcher attrMatcher
+}
+
+func (ac *AttributeConstraints) feature(flabel string) bool {
+	return ac.matcher.feature(flabel)
+}
+
+var (
+	AlwaysMatchAttributes = &AttributeConstraints{matcher: fixedAttrMatcher{nil}}
+	NeverMatchAttributes  = &AttributeConstraints{matcher: fixedAttrMatcher{errors.New("not allowed")}}
+)
+
+// Attrer reflects part of the Attrer interface (see interfaces.Attrer).
+type Attrer interface {
+	Lookup(path string) (interface{}, bool)
+}
+
+func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target constraintsHolder, attrConstraints, idConstraints []string) error {
+	cMap := cDef.cMap
+	if cMap == nil {
+		fixed := AlwaysMatchAttributes // "true"
+		if cDef.invert {               // "false"
+			fixed = NeverMatchAttributes
+		}
+		for _, field := range attrConstraints {
+			target.setAttributeConstraints(field, fixed)
+		}
+		return nil
+	}
+	defaultUsed := 0
+	for _, field := range idConstraints {
+		lst, err := checkStringListInMap(cMap, field, fmt.Sprintf("%s in %v", field, context), validIDConstraints[field])
+		if err != nil {
+			return err
+		}
+		if lst == nil {
+			defaultUsed++
+		}
+		target.setIDConstraints(field, lst)
+	}
+	for _, field := range sideArityConstraints {
+		v := cMap[field]
+		if v != nil {
+			c, err := compileSideArityConstraint(context, field, v)
+			if err != nil {
+				return err
+			}
+			h, ok := target.(sideArityConstraintsHolder)
+			if !ok {
+				return fmt.Errorf("internal error: side arity constraint compiled for unexpected subrule %T", target)
+			}
+			sideArityConstraintsSetters[field](h, c)
+		} else {
+			defaultUsed++
+		}
+	}
+	return nil
+}
+
+// PlugRule holds the rule of what is allowed, wrt installation and
+// connection, for a plug of a specific interface for a snap.
+type PlugRule struct {
+	Interface string
+}
+
+// subruleContext carries queryable context information about one the
+// {allow,deny}-* subrules that end up compiled as
+// Plug|Slot*Constraints.  The information includes the parent rule,
+// the introductory subrule key ({allow,deny}-*) and which alternative
+// it corresponds to if any.
+// The information is useful for constraints compilation now that we
+// have constraints with different behavior depending on the kind of
+// subrule that hosts them (e.g. slots-per-plug, plugs-per-slot).
+type subruleContext struct {
+	// rule is the parent rule context description
+	rule string
+	// subrule is the subrule key
+	subrule string
+	// alt is which alternative this is (if > 0)
+	alt int
+}
+
+func (c *subruleContext) String() string {
+	subctxt := fmt.Sprintf("%s in %s", c.subrule, c.rule)
+	if c.alt != 0 {
+		subctxt = fmt.Sprintf("alternative %d of %s", c.alt, subctxt)
+	}
+	return subctxt
+}
+
+// allow returns whether the subrule is an allow-* subrule.
+func (c *subruleContext) allow() bool {
+	return strings.HasPrefix(c.subrule, "allow-")
+}
+
+// installation returns whether the subrule is an *-installation subrule.
+func (c *subruleContext) installation() bool {
+	return strings.HasSuffix(c.subrule, "-installation")
+}
+
+// autoConnection returns whether the subrule is an *-auto-connection subrule.
+func (c *subruleContext) autoConnection() bool {
+	return strings.HasSuffix(c.subrule, "-auto-connection")
+}
+
+type constraintsDef struct {
+	cMap   map[string]interface{}
+	invert bool
+}
+
+type constraintsHolder interface {
+	setIDConstraints(field string, cstrs []string)
+	setAttributeConstraints(field string, cstrs *AttributeConstraints)
+}
+
+type rule interface {
+	setConstraints(field string, cstrs []constraintsHolder)
+}
+
+type subruleCompiler func(context *subruleContext, def constraintsDef) (constraintsHolder, error)
+
+var slotRuleCompilers = map[string]subruleCompiler{
+	"allow-installation":    compileSlotInstallationConstraints,
+	"deny-installation":     compileSlotInstallationConstraints,
+	"allow-connection":      compileSlotConnectionConstraints,
+	"deny-connection":       compileSlotConnectionConstraints,
+	"allow-auto-connection": compileSlotConnectionConstraints,
+	"deny-auto-connection":  compileSlotConnectionConstraints,
+}
+
+func compileSlotRule(interfaceName string, rule interface{}) (*SlotRule, error) {
+	context := fmt.Sprintf("slot rule for interface %q", interfaceName)
+	slotRule := &SlotRule{
+		Interface: interfaceName,
+	}
+	err := baseCompileRule(context, rule, slotRule, ruleSubrules, slotRuleCompilers, defaultOutcome, invertedOutcome)
+	if err != nil {
+		return nil, err
+	}
+	return slotRule, nil
+}
+
+func checkMapOrShortcut(v interface{}) (m map[string]interface{}, invert bool, err error) {
+	switch x := v.(type) {
+	case map[string]interface{}:
+		return x, false, nil
+	case string:
+		switch x {
+		case "true":
+			return nil, false, nil
+		case "false":
+			return nil, true, nil
+		}
+	}
+	return nil, false, errors.New("unexpected type")
+}
+
+func baseCompileRule(context string, rule interface{}, target rule, subrules []string, compilers map[string]subruleCompiler, defaultOutcome, invertedOutcome map[string]interface{}) error {
+	rMap, invert, err := checkMapOrShortcut(rule)
+	if err != nil {
+		return fmt.Errorf("%s must be a map or one of the shortcuts 'true' or 'false'", context)
+	}
+	if rMap == nil {
+		rMap = defaultOutcome // "true"
+		if invert {
+			rMap = invertedOutcome // "false"
+		}
+	}
+	defaultUsed := 0
+	// compile and set subrules
+	for _, subrule := range subrules {
+		v := rMap[subrule]
+		var lst []interface{}
+		alternatives := false
+		switch x := v.(type) {
+		case nil:
+			v = defaultOutcome[subrule]
+			defaultUsed++
+		case []interface{}:
+			alternatives = true
+			lst = x
+		}
+		if lst == nil { // v is map or a string, checked below
+			lst = []interface{}{v}
+		}
+		compiler := compilers[subrule]
+		if compiler == nil {
+			panic(fmt.Sprintf("no compiler for %s in %s", subrule, context))
+		}
+		alts := make([]constraintsHolder, len(lst))
+		for i, alt := range lst {
+			subctxt := &subruleContext{
+				rule:    context,
+				subrule: subrule,
+			}
+			if alternatives {
+				subctxt.alt = i + 1
+			}
+			cMap, invert, err := checkMapOrShortcut(alt)
+			if err != nil || (cMap == nil && alternatives) {
+				efmt := "%s must be a map"
+				if !alternatives {
+					efmt = "%s must be a map or one of the shortcuts 'true' or 'false'"
+				}
+				return fmt.Errorf(efmt, subctxt)
+			}
+
+			cstrs, err := compiler(subctxt, constraintsDef{
+				cMap:   cMap,
+				invert: invert,
+			})
+			if err != nil {
+				return err
+			}
+			alts[i] = cstrs
+		}
+		target.setConstraints(subrule, alts)
+	}
+	if defaultUsed == len(subrules) {
+		return fmt.Errorf("%s must specify at least one of %s", context, strings.Join(subrules, ", "))
+	}
+	return nil
+}

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -24,16 +24,16 @@ var (
 
 	ruleSubrules = []string{"allow-installation", "deny-installation", "allow-connection", "deny-connection", "allow-auto-connection", "deny-auto-connection"}
 
-	validWorkspaceType = regexp.MustCompile(`^(?:core|workspace)$`)
+	validWorkspaceType = regexp.MustCompile(`^(?:core|sdk)$`)
 
 	validIDConstraints = map[string]*regexp.Regexp{
-		"slot-workspace-type": validWorkspaceType,
-		"plug-sdk-type":       validWorkspaceType,
+		"slot-type": validWorkspaceType,
+		"plug-type": validWorkspaceType,
 	}
 
 	attributeConstraints = []string{"plug-attributes", "slot-attributes"}
 
-	slotIDConstraints = []string{"plug-sdk-type"}
+	slotIDConstraints = []string{"plug-type"}
 
 	sideArityConstraints        = []string{"slots-per-plug", "plugs-per-slot"}
 	sideArityConstraintsSetters = map[string]func(sideArityConstraintsHolder, SideArityConstraint){
@@ -45,14 +45,14 @@ var (
 // SlotInstallationConstraints specifies a set of constraints on an
 // interface slot relevant to the installation of SDK.
 type SlotInstallationConstraints struct {
-	SlotWorkspaceTypes []string
-	SlotAttributes     *AttributeConstraints
+	SlotTypes      []string
+	SlotAttributes *AttributeConstraints
 }
 
 func (c *SlotInstallationConstraints) setIDConstraints(field string, cstrs []string) {
 	switch field {
-	case "slot-workspace-type":
-		c.SlotWorkspaceTypes = cstrs
+	case "slot-type":
+		c.SlotTypes = cstrs
 	default:
 		panic("unknown SlotInstallationConstraints field " + field)
 	}
@@ -105,7 +105,7 @@ type SlotConnectionConstraints struct {
 
 func (c *SlotConnectionConstraints) setIDConstraints(field string, cstrs []string) {
 	switch field {
-	case "plug-sdk-type":
+	case "plug-type":
 		c.PlugSdkTypes = cstrs
 	default:
 		panic("unknown SlotConnectionConstraints field " + field)
@@ -232,7 +232,7 @@ func castSlotInstallationConstraints(cstrs []constraintsHolder) (res []*SlotInst
 
 func compileSlotInstallationConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
 	slotInstCstrs := &SlotInstallationConstraints{}
-	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-attributes"}, []string{"slot-workspace-type"})
+	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-attributes"}, []string{"slot-type"})
 	if err != nil {
 		return nil, err
 	}
@@ -300,6 +300,29 @@ func (ac *AttributeConstraints) feature(flabel string) bool {
 	return ac.matcher.feature(flabel)
 }
 
+// Check checks whether attrs don't match the constraints.
+func (c *AttributeConstraints) Check(attrer Attrer, helper AttrMatchContext) error {
+	return c.matcher.match("", attrer, &attrMatchingContext{
+		attrWord: "attribute",
+		helper:   helper,
+	})
+}
+
+// compileAttributeConstraints checks and compiles a mapping or list
+// from the assertion format into AttributeConstraints.
+func compileAttributeConstraints(constraints interface{}) (*AttributeConstraints, error) {
+	cc := compileContext{
+		opts: &compileAttrMatcherOptions{
+			allowedOperations: []string{"SLOT", "PLUG"},
+		},
+	}
+	matcher, err := compileAttrMatcher(cc, constraints)
+	if err != nil {
+		return nil, err
+	}
+	return &AttributeConstraints{matcher: matcher}, nil
+}
+
 var (
 	AlwaysMatchAttributes = &AttributeConstraints{matcher: fixedAttrMatcher{nil}}
 	NeverMatchAttributes  = &AttributeConstraints{matcher: fixedAttrMatcher{errors.New("not allowed")}}
@@ -323,6 +346,20 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 		return nil
 	}
 	defaultUsed := 0
+	for _, field := range attrConstraints {
+		cstrs := AlwaysMatchAttributes
+		v := cMap[field]
+		if v != nil {
+			var err error
+			cstrs, err = compileAttributeConstraints(cMap[field])
+			if err != nil {
+				return fmt.Errorf("cannot compile %s in %s: %v", field, context, err)
+			}
+		} else {
+			defaultUsed++
+		}
+		target.setAttributeConstraints(field, cstrs)
+	}
 	for _, field := range idConstraints {
 		lst, err := checkStringListInMap(cMap, field, fmt.Sprintf("%s in %v", field, context), validIDConstraints[field])
 		if err != nil {

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -21,14 +21,14 @@ type plugSlotRulesSuite struct{}
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstraints(c *check.C) {
 	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
 		"allow-installation": map[string]interface{}{
-			"slot-workspace-type": []interface{}{"core", "workspace"},
+			"slot-type": []interface{}{"core", "sdk"},
 		},
 	})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(rule.AllowInstallation, check.HasLen, 1)
 	cstrs := rule.AllowInstallation[0]
-	c.Check(cstrs.SlotWorkspaceTypes, check.DeepEquals, []string{"core", "workspace"})
+	c.Check(cstrs.SlotTypes, check.DeepEquals, []string{"core", "sdk"})
 }
 
 func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.SlotConnectionConstraints, always bool) {
@@ -169,12 +169,12 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
     - true`, `alternative 1 of allow-connection in slot rule for interface "iface" must be a map`},
 		{`iface:
   allow-connection:
-    plug-sdk-type:
-      - foo`, `plug-sdk-type in allow-connection in slot rule for interface "iface" contains an invalid element: "foo"`},
+    plug-type:
+      - foo`, `plug-type in allow-connection in slot rule for interface "iface" contains an invalid element: "foo"`},
 		{`iface:
   allow-connection:
-    plug-sdk-type:
-      - xapp`, `plug-sdk-type in allow-connection in slot rule for interface "iface" contains an invalid element: "xapp"`},
+    plug-type:
+      - xapp`, `plug-type in allow-connection in slot rule for interface "iface" contains an invalid element: "xapp"`},
 		{`iface:
   allow-connect: true`, `slot rule for interface "iface" must specify at least one of allow-installation, deny-installation, allow-connection, deny-connection, allow-auto-connection, deny-auto-connection`},
 		{`iface:

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -1,0 +1,210 @@
+package asserts_test
+
+import (
+	"strings"
+
+	"github.com/canonical/workspace/internal/asserts"
+	"gopkg.in/check.v1"
+)
+
+var (
+	_ = check.Suite(&plugSlotRulesSuite{})
+)
+
+var (
+	sideArityAny = asserts.SideArityConstraint{N: -1}
+	sideArityOne = asserts.SideArityConstraint{N: 1}
+)
+
+type plugSlotRulesSuite struct{}
+
+func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstraints(c *check.C) {
+	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
+		"allow-installation": map[string]interface{}{
+			"slot-workspace-type": []interface{}{"core", "workspace"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(rule.AllowInstallation, check.HasLen, 1)
+	cstrs := rule.AllowInstallation[0]
+	c.Check(cstrs.SlotWorkspaceTypes, check.DeepEquals, []string{"core", "workspace"})
+}
+
+func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.SlotConnectionConstraints, always bool) {
+	c.Assert(cstrs, check.HasLen, 1)
+	cstrs1 := cstrs[0]
+	if strings.HasPrefix(subrule, "deny-") {
+		undef := asserts.SideArityConstraint{}
+		c.Check(cstrs1.SlotsPerPlug, check.Equals, undef)
+		c.Check(cstrs1.PlugsPerSlot, check.Equals, undef)
+	} else {
+		c.Check(cstrs1.PlugsPerSlot, check.Equals, sideArityAny)
+		if strings.HasSuffix(subrule, "-auto-connection") {
+			c.Check(cstrs1.SlotsPerPlug, check.Equals, sideArityOne)
+		} else {
+			c.Check(cstrs1.SlotsPerPlug, check.Equals, sideArityAny)
+		}
+	}
+	c.Check(cstrs1.PlugSdkTypes, check.HasLen, 0)
+}
+
+func (s *plugSlotRulesSuite) TestCompileSlotRuleDefaults(c *check.C) {
+	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
+		"deny-auto-connection": "true",
+	})
+	c.Assert(err, check.IsNil)
+
+	// everything follows the defaults...
+
+	// install subrules
+	c.Assert(rule.AllowInstallation, check.HasLen, 1)
+
+	// connection subrules
+	checkBoolSlotConnConstraints(c, "allow-connection", rule.AllowConnection, true)
+	checkBoolSlotConnConstraints(c, "deny-connection", rule.DenyConnection, false)
+	// auto-connection subrules
+	checkBoolSlotConnConstraints(c, "allow-auto-connection", rule.AllowAutoConnection, true)
+	// ... but deny-auto-connection is on
+	checkBoolSlotConnConstraints(c, "deny-auto-connection", rule.DenyAutoConnection, true)
+}
+
+func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsSideArityConstraints(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`iface:
+  allow-auto-connection: true`))
+	c.Assert(err, check.IsNil)
+
+	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	// defaults
+	c.Check(rule.AllowAutoConnection[0].SlotsPerPlug, check.Equals, asserts.SideArityConstraint{N: 1})
+	c.Check(rule.AllowAutoConnection[0].PlugsPerSlot.Any(), check.Equals, true)
+
+	c.Check(rule.AllowConnection[0].SlotsPerPlug.Any(), check.Equals, true)
+	c.Check(rule.AllowConnection[0].PlugsPerSlot.Any(), check.Equals, true)
+
+	// test that the arity constraints get normalized away to any
+	// under allow-connection
+	// see https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
+	allowConnTests := []string{
+		`iface:
+  allow-connection:
+    slots-per-plug: 1
+    plugs-per-slot: 2`,
+		`iface:
+  allow-connection:
+    slots-per-plug: *
+    plugs-per-slot: 1`,
+		`iface:
+  allow-connection:
+    slots-per-plug: 2
+    plugs-per-slot: *`,
+	}
+
+	for _, t := range allowConnTests {
+		m, err = asserts.ParseHeaders([]byte(t))
+		c.Assert(err, check.IsNil)
+
+		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+		c.Assert(err, check.IsNil)
+
+		c.Check(rule.AllowConnection[0].SlotsPerPlug.Any(), check.Equals, true)
+		c.Check(rule.AllowConnection[0].PlugsPerSlot.Any(), check.Equals, true)
+	}
+
+	// test that under allow-auto-connection:
+	// slots-per-plug can be * (any) or otherwise gets normalized to 1
+	// plugs-per-slot gets normalized to any (*)
+	// see https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
+	allowAutoConnTests := []struct {
+		rule         string
+		slotsPerPlug asserts.SideArityConstraint
+	}{
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 1
+    plugs-per-slot: 2`, sideArityOne},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: *
+    plugs-per-slot: 1`, sideArityAny},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 2
+    plugs-per-slot: *`, sideArityOne},
+	}
+
+	for _, t := range allowAutoConnTests {
+		m, err = asserts.ParseHeaders([]byte(t.rule))
+		c.Assert(err, check.IsNil)
+
+		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+		c.Assert(err, check.IsNil)
+
+		c.Assert(rule.AllowAutoConnection[0].SlotsPerPlug, check.Equals, t.slotsPerPlug)
+		c.Check(rule.AllowAutoConnection[0].PlugsPerSlot.Any(), check.Equals, true)
+	}
+}
+
+func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
+	tests := []struct {
+		stanza string
+		err    string
+	}{
+		{`iface: foo`, `slot rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  - allow`, `slot rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  allow-installation: foo`, `allow-installation in slot rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  deny-installation: foo`, `deny-installation in slot rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  allow-connection: foo`, `allow-connection in slot rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  allow-connection:
+    - foo`, `alternative 1 of allow-connection in slot rule for interface "iface" must be a map`},
+		{`iface:
+  allow-connection:
+    - true`, `alternative 1 of allow-connection in slot rule for interface "iface" must be a map`},
+		{`iface:
+  allow-connection:
+    plug-sdk-type:
+      - foo`, `plug-sdk-type in allow-connection in slot rule for interface "iface" contains an invalid element: "foo"`},
+		{`iface:
+  allow-connection:
+    plug-sdk-type:
+      - xapp`, `plug-sdk-type in allow-connection in slot rule for interface "iface" contains an invalid element: "xapp"`},
+		{`iface:
+  allow-connect: true`, `slot rule for interface "iface" must specify at least one of allow-installation, deny-installation, allow-connection, deny-connection, allow-auto-connection, deny-auto-connection`},
+		{`iface:
+  allow-installation:
+    slots-per-plug: 1`, `allow-installation in slot rule for interface "iface" cannot specify a slots-per-plug constraint, they apply only to allow-\*connection`},
+		{`iface:
+  deny-auto-connection:
+    slots-per-plug: 1`, `deny-auto-connection in slot rule for interface "iface" cannot specify a slots-per-plug constraint, they apply only to allow-\*connection`},
+		{`iface:
+  allow-auto-connection:
+    plugs-per-slot: any`, `plugs-per-slot in allow-auto-connection in slot rule for interface "iface" must be an integer >=1 or \*`},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 00`, `slots-per-plug in allow-auto-connection in slot rule for interface "iface" has invalid prefix zeros: 00`},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 99999999999999999999`, `slots-per-plug in allow-auto-connection in slot rule for interface "iface" is out of range: 99999999999999999999`},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 0`, `slots-per-plug in allow-auto-connection in slot rule for interface "iface" must be an integer >=1 or \*`},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug:
+      what: 1`, `slots-per-plug in allow-auto-connection in slot rule for interface "iface" must be an integer >=1 or \*`},
+	}
+
+	for i, t := range tests {
+		m, err := asserts.ParseHeaders([]byte(t.stanza))
+		c.Assert(err, check.IsNil, check.Commentf(t.stanza))
+		_, err = asserts.CompileSlotRule("iface", m["iface"])
+		c.Assert(err, check.ErrorMatches, t.err, check.Commentf("%d: %s", i, t.stanza))
+	}
+}

--- a/internal/asserts/sdk_asserts.go
+++ b/internal/asserts/sdk_asserts.go
@@ -1,0 +1,171 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package asserts
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	// expected for digests
+
+	_ "golang.org/x/crypto/sha3"
+)
+
+func compilePlugRules(plugs map[string]interface{}, compiled func(iface string, plugRule *PlugRule)) error {
+	return nil
+}
+
+func compileSlotRules(slots map[string]interface{}, compiled func(iface string, slotRule *SlotRule)) error {
+	for iface, rule := range slots {
+		slotRule, err := compileSlotRule(iface, rule)
+		if err != nil {
+			return err
+		}
+		compiled(iface, slotRule)
+	}
+	return nil
+}
+
+// BaseDeclaration holds a base-declaration assertion, declaring the
+// policies (to start with interface ones) applying to all snaps of
+// a series.
+type BaseDeclaration struct {
+	assertionBase
+	plugRules map[string]*PlugRule
+	slotRules map[string]*SlotRule
+	timestamp time.Time
+}
+
+// Series returns the series whose snaps are governed by the declaration.
+func (basedcl *BaseDeclaration) Series() string {
+	return basedcl.HeaderString("series")
+}
+
+// Timestamp returns the time when the base-declaration was issued.
+func (basedcl *BaseDeclaration) Timestamp() time.Time {
+	return basedcl.timestamp
+}
+
+// PlugRule returns the plug-side rule about the given interface if one was included in the plugs stanza of the declaration, otherwise it returns nil.
+func (basedcl *BaseDeclaration) PlugRule(interfaceName string) *PlugRule {
+	return basedcl.plugRules[interfaceName]
+}
+
+// SlotRule returns the slot-side rule about the given interface if one was included in the slots stanza of the declaration, otherwise it returns nil.
+func (basedcl *BaseDeclaration) SlotRule(interfaceName string) *SlotRule {
+	return basedcl.slotRules[interfaceName]
+}
+
+func assembleBaseDeclaration(assert assertionBase) (Assertion, error) {
+	var plugRules map[string]*PlugRule
+	plugs, err := checkMap(assert.headers, "plugs")
+	if err != nil {
+		return nil, err
+	}
+	if plugs != nil {
+		plugRules = make(map[string]*PlugRule, len(plugs))
+		err := compilePlugRules(plugs, func(iface string, rule *PlugRule) {
+			plugRules[iface] = rule
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var slotRules map[string]*SlotRule
+	slots, err := checkMap(assert.headers, "slots")
+	if err != nil {
+		return nil, err
+	}
+	if slots != nil {
+		slotRules = make(map[string]*SlotRule, len(slots))
+		err := compileSlotRules(slots, func(iface string, rule *SlotRule) {
+			slotRules[iface] = rule
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	timestamp, err := checkRFC3339Date(assert.headers, "timestamp")
+	if err != nil {
+		return nil, err
+	}
+
+	return &BaseDeclaration{
+		assertionBase: assert,
+		plugRules:     plugRules,
+		slotRules:     slotRules,
+		timestamp:     timestamp,
+	}, nil
+}
+
+var builtinBaseDeclaration *BaseDeclaration
+
+// BuiltinBaseDeclaration exposes the initialized builtin base-declaration assertion. This is used by overlord/assertstate, other code should use assertstate.BaseDeclaration.
+func BuiltinBaseDeclaration() *BaseDeclaration {
+	return builtinBaseDeclaration
+}
+
+var (
+	builtinBaseDeclarationCheckOrder      = []string{"type", "authority-id", "series"}
+	builtinBaseDeclarationExpectedHeaders = map[string]interface{}{
+		"type":         "base-declaration",
+		"authority-id": "canonical",
+		"series":       "1",
+	}
+)
+
+// InitBuiltinBaseDeclaration initializes the builtin base-declaration based on headers (or resets it if headers is nil).
+func InitBuiltinBaseDeclaration(headers []byte) error {
+	if headers == nil {
+		builtinBaseDeclaration = nil
+		return nil
+	}
+	trimmed := bytes.TrimSpace(headers)
+	h, err := parseHeaders(trimmed)
+	if err != nil {
+		return err
+	}
+	for _, name := range builtinBaseDeclarationCheckOrder {
+		expected := builtinBaseDeclarationExpectedHeaders[name]
+		if h[name] != expected {
+			return fmt.Errorf("the builtin base-declaration %q header is not set to expected value %q", name, expected)
+		}
+	}
+	revision, err := checkRevision(h)
+	if err != nil {
+		return fmt.Errorf("cannot assemble the builtin-base declaration: %v", err)
+	}
+	h["timestamp"] = time.Now().UTC().Format(time.RFC3339)
+	a, err := assembleBaseDeclaration(assertionBase{
+		headers:   h,
+		body:      nil,
+		revision:  revision,
+		content:   trimmed,
+		signature: []byte("$builtin"),
+	})
+	if err != nil {
+		return fmt.Errorf("cannot assemble the builtin base-declaration: %v", err)
+	}
+	builtinBaseDeclaration = a.(*BaseDeclaration)
+	return nil
+}

--- a/internal/asserts/sdk_asserts.go
+++ b/internal/asserts/sdk_asserts.go
@@ -45,7 +45,7 @@ func compileSlotRules(slots map[string]interface{}, compiled func(iface string, 
 }
 
 // BaseDeclaration holds a base-declaration assertion, declaring the
-// policies (to start with interface ones) applying to all snaps of
+// policies (to start with interface ones) applying to all sdks of
 // a series.
 type BaseDeclaration struct {
 	assertionBase
@@ -54,7 +54,7 @@ type BaseDeclaration struct {
 	timestamp time.Time
 }
 
-// Series returns the series whose snaps are governed by the declaration.
+// Series returns the series whose sdks are governed by the declaration.
 func (basedcl *BaseDeclaration) Series() string {
 	return basedcl.HeaderString("series")
 }

--- a/internal/asserts/sdk_asserts_test.go
+++ b/internal/asserts/sdk_asserts_test.go
@@ -20,14 +20,15 @@ slots:
   interface3:
     deny-installation: false
     allow-auto-connection:
-      plug-sdk-type:
+      plug-type:
         - core
   interface4:
     allow-connection: true
     deny-connection: false
     allow-installation:
-      slot-snap-type:
+      slot-type:
         - core
+        - sdk
 timestamp: 2016-09-29T19:50:49Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
@@ -112,7 +113,7 @@ revision: 0
 slots:
   network:
     allow-installation:
-      slot-workspace-type:
+      slot-type:
         - core
 `
 
@@ -127,7 +128,7 @@ slots:
 
 	c.Check(baseDecl.AuthorityID(), check.Equals, "canonical")
 	c.Check(baseDecl.Series(), check.Equals, "1")
-	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotWorkspaceTypes, check.DeepEquals, []string{"core"})
+	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"core"})
 
 	enc := asserts.Encode(baseDecl)
 	// it's expected that it cannot be decoded

--- a/internal/asserts/sdk_asserts_test.go
+++ b/internal/asserts/sdk_asserts_test.go
@@ -1,0 +1,157 @@
+package asserts_test
+
+import (
+	"strings"
+	"time"
+
+	"github.com/canonical/workspace/internal/asserts"
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&baseDeclSuite{})
+
+type baseDeclSuite struct{}
+
+func (s *baseDeclSuite) TestDecodeOK(c *check.C) {
+	encoded := `type: base-declaration
+authority-id: canonical
+series: 16
+slots:
+  interface3:
+    deny-installation: false
+    allow-auto-connection:
+      plug-sdk-type:
+        - core
+  interface4:
+    allow-connection: true
+    deny-connection: false
+    allow-installation:
+      slot-snap-type:
+        - core
+timestamp: 2016-09-29T19:50:49Z
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw==`
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, check.IsNil)
+	baseDecl := a.(*asserts.BaseDeclaration)
+	c.Check(baseDecl.Series(), check.Equals, "16")
+	ts, err := time.Parse(time.RFC3339, "2016-09-29T19:50:49Z")
+	c.Assert(err, check.IsNil)
+	c.Check(baseDecl.Timestamp().Equal(ts), check.Equals, true)
+
+	c.Check(baseDecl.PlugRule("interfaceX"), check.IsNil)
+	c.Check(baseDecl.SlotRule("interfaceX"), check.IsNil)
+
+	slotRule3 := baseDecl.SlotRule("interface3")
+	c.Assert(slotRule3, check.NotNil)
+	c.Assert(slotRule3.DenyInstallation, check.HasLen, 1)
+	c.Assert(slotRule3.AllowAutoConnection, check.HasLen, 1)
+	c.Check(slotRule3.AllowAutoConnection[0].PlugSdkTypes, check.DeepEquals, []string{"core"})
+
+	// slotRule4 := baseDecl.SlotRule("interface4")
+	// c.Assert(slotRule4, check.NotNil)
+	// c.Assert(slotRule4.AllowConnection, check.HasLen, 1)
+	// c.Check(slotRule4.AllowConnection[0].PlugAttributes.Check(plug, nil), check.ErrorMatches, `attribute "c2".*`)
+	// c.Check(slotRule4.AllowConnection[0].SlotAttributes.Check(slot, nil), check.ErrorMatches, `attribute "d2".*`)
+	// c.Assert(slotRule4.DenyConnection, HasLen, 1)
+	// c.Check(slotRule4.DenyConnection[0].PlugAttributes.Check(plug, nil), check.ErrorMatches, `attribute "c2".*`)
+	// c.Check(slotRule4.DenyConnection[0].SlotAttributes.Check(slot, nil), check.ErrorMatches, `attribute "d2".*`)
+	// c.Check(slotRule4.DenyConnection[0].PlugSnapIDs, check.DeepEquals, []string{"snapidsnapidsnapidsnapidsnapid01", "snapidsnapidsnapidsnapidsnapid02"})
+	// c.Assert(slotRule4.AllowInstallation, HasLen, 1)
+	// c.Check(slotRule4.AllowInstallation[0].SlotAttributes.Check(slot, nil), check.ErrorMatches, `attribute "e1".*`)
+	// c.Check(slotRule4.AllowInstallation[0].SlotSnapTypes, check.DeepEquals, []string{"app"})
+
+}
+
+const (
+	baseDeclErrPrefix = "assertion base-declaration: "
+)
+
+func (s *baseDeclSuite) TestDecodeInvalid(c *check.C) {
+	tsLine := "timestamp: 2016-09-29T19:50:49Z\n"
+
+	encoded := "type: base-declaration\n" +
+		"authority-id: canonical\n" +
+		"series: 16\n" +
+		"plugs:\n  interface1: true\n" +
+		"slots:\n  interface2: true\n" +
+		tsLine +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+		"\n\n" +
+		"AXNpZw=="
+
+	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"series: 16\n", "", `"series" header is mandatory`},
+		{"series: 16\n", "series: \n", `"series" header should not be empty`},
+		{"slots:\n  interface2: true\n", "slots: \n", `"slots" header must be a map`},
+		{"slots:\n  interface2: true\n", "slots:\n  intf1:\n    foo: bar\n", `slot rule for interface "intf1" must specify at least one of.*`},
+		{tsLine, "", `"timestamp" header is mandatory`},
+		{tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
+	}
+
+	for _, test := range invalidTests {
+		invalid := strings.Replace(encoded, test.original, test.invalid, 1)
+		_, err := asserts.Decode([]byte(invalid))
+		c.Check(err, check.ErrorMatches, baseDeclErrPrefix+test.expectedErr)
+	}
+
+}
+
+func (s *baseDeclSuite) TestBuiltin(c *check.C) {
+	baseDecl := asserts.BuiltinBaseDeclaration()
+	c.Check(baseDecl, check.IsNil)
+
+	defer asserts.InitBuiltinBaseDeclaration(nil)
+
+	const headers = `
+type: base-declaration
+authority-id: canonical
+series: 1
+revision: 0
+slots:
+  network:
+    allow-installation:
+      slot-workspace-type:
+        - core
+`
+
+	err := asserts.InitBuiltinBaseDeclaration([]byte(headers))
+	c.Assert(err, check.IsNil)
+
+	baseDecl = asserts.BuiltinBaseDeclaration()
+	c.Assert(baseDecl, check.NotNil)
+
+	cont, _ := baseDecl.Signature()
+	c.Check(string(cont), check.Equals, strings.TrimSpace(headers))
+
+	c.Check(baseDecl.AuthorityID(), check.Equals, "canonical")
+	c.Check(baseDecl.Series(), check.Equals, "1")
+	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotWorkspaceTypes, check.DeepEquals, []string{"core"})
+
+	enc := asserts.Encode(baseDecl)
+	// it's expected that it cannot be decoded
+	_, err = asserts.Decode(enc)
+	c.Check(err, check.NotNil)
+}
+
+func (s *baseDeclSuite) TestBuiltinInitErrors(c *check.C) {
+	defer asserts.InitBuiltinBaseDeclaration(nil)
+
+	tests := []struct {
+		headers string
+		err     string
+	}{
+		{"", `header entry missing ':' separator: ""`},
+		{"type: foo\n", `the builtin base-declaration "type" header is not set to expected value "base-declaration"`},
+		{"type: base-declaration", `the builtin base-declaration "authority-id" header is not set to expected value "canonical"`},
+		{"type: base-declaration\nauthority-id: canonical", `the builtin base-declaration "series" header is not set to expected value "1"`},
+		{"type: base-declaration\nauthority-id: canonical\nseries: 1\nrevision: zzz", `cannot assemble the builtin-base declaration: "revision" header is not an integer: zzz`},
+		{"type: base-declaration\nauthority-id: canonical\nseries: 1\nplugs: foo", `cannot assemble the builtin base-declaration: "plugs" header must be a map`},
+	}
+
+	for _, t := range tests {
+		err := asserts.InitBuiltinBaseDeclaration([]byte(t.headers))
+		c.Check(err, check.ErrorMatches, t.err, check.Commentf(t.headers))
+	}
+}

--- a/internal/asserts/sdk_asserts_test.go
+++ b/internal/asserts/sdk_asserts_test.go
@@ -15,10 +15,10 @@ type baseDeclSuite struct{}
 func (s *baseDeclSuite) TestDecodeOK(c *check.C) {
 	encoded := `type: base-declaration
 authority-id: canonical
-series: 16
+series: 1
 slots:
   interface3:
-    deny-installation: false
+    deny-installation: true
     allow-auto-connection:
       plug-type:
         - core
@@ -36,7 +36,7 @@ AXNpZw==`
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, check.IsNil)
 	baseDecl := a.(*asserts.BaseDeclaration)
-	c.Check(baseDecl.Series(), check.Equals, "16")
+	c.Check(baseDecl.Series(), check.Equals, "1")
 	ts, err := time.Parse(time.RFC3339, "2016-09-29T19:50:49Z")
 	c.Assert(err, check.IsNil)
 	c.Check(baseDecl.Timestamp().Equal(ts), check.Equals, true)
@@ -50,19 +50,12 @@ AXNpZw==`
 	c.Assert(slotRule3.AllowAutoConnection, check.HasLen, 1)
 	c.Check(slotRule3.AllowAutoConnection[0].PlugSdkTypes, check.DeepEquals, []string{"core"})
 
-	// slotRule4 := baseDecl.SlotRule("interface4")
-	// c.Assert(slotRule4, check.NotNil)
-	// c.Assert(slotRule4.AllowConnection, check.HasLen, 1)
-	// c.Check(slotRule4.AllowConnection[0].PlugAttributes.Check(plug, nil), check.ErrorMatches, `attribute "c2".*`)
-	// c.Check(slotRule4.AllowConnection[0].SlotAttributes.Check(slot, nil), check.ErrorMatches, `attribute "d2".*`)
-	// c.Assert(slotRule4.DenyConnection, HasLen, 1)
-	// c.Check(slotRule4.DenyConnection[0].PlugAttributes.Check(plug, nil), check.ErrorMatches, `attribute "c2".*`)
-	// c.Check(slotRule4.DenyConnection[0].SlotAttributes.Check(slot, nil), check.ErrorMatches, `attribute "d2".*`)
-	// c.Check(slotRule4.DenyConnection[0].PlugSnapIDs, check.DeepEquals, []string{"snapidsnapidsnapidsnapidsnapid01", "snapidsnapidsnapidsnapidsnapid02"})
-	// c.Assert(slotRule4.AllowInstallation, HasLen, 1)
-	// c.Check(slotRule4.AllowInstallation[0].SlotAttributes.Check(slot, nil), check.ErrorMatches, `attribute "e1".*`)
-	// c.Check(slotRule4.AllowInstallation[0].SlotSnapTypes, check.DeepEquals, []string{"app"})
-
+	slotRule4 := baseDecl.SlotRule("interface4")
+	c.Assert(slotRule4, check.NotNil)
+	c.Check(slotRule4.AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"core", "sdk"})
+	c.Assert(slotRule4.DenyInstallation, check.HasLen, 1)
+	c.Assert(slotRule3.AllowConnection, check.HasLen, 1)
+	c.Assert(slotRule3.DenyConnection, check.HasLen, 1)
 }
 
 const (

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -13,7 +13,6 @@ import (
 	"github.com/canonical/workspace/internal/overlord/statecontext"
 	"github.com/canonical/workspace/internal/workspacebackend"
 	"github.com/canonical/x-go/strutil"
-	"golang.org/x/exp/maps"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -87,7 +86,12 @@ func v1GetProjects(c *Command, r *http.Request, _ *userState) Response {
 		return statusInternalError("cannot get projects list: %v", err)
 	}
 
-	return SyncResponse(maps.Values(projects), http.StatusOK)
+	result := make([]*workspacebackend.Project, 0)
+	for _, val := range projects {
+		result = append(result, val...)
+	}
+
+	return SyncResponse(result, http.StatusOK)
 }
 
 func v1PostProjects(c *Command, r *http.Request, _ *userState) Response {

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -29,15 +29,6 @@ func (s *apiSuite) TestProjectsGetProjects(c *check.C) {
 	req, err := s.createProjectsRequest("GET", "/v1/projects", nil)
 	c.Assert(err, check.IsNil)
 
-	b := s.d.overlord.WorkspaceBackend()
-	// will be called when project is created
-	numCalls := 0
-	ids := []string{"b8639dea", "a8639dea"}
-	restoreId := testutil.FakeFunc(func() (string, error) { numCalls = numCalls + 1; return ids[numCalls-1], nil }, &workspacebackend.NewProjectId)
-	defer restoreId()
-	b.CreateOrLoadProject(req.Context(), "/home/testuser/project")
-	b.CreateOrLoadProject(req.Context(), "/home/testuser/project2")
-
 	projectsCmd := apiCmd("/v1/projects")
 
 	// Execute
@@ -50,8 +41,7 @@ func (s *apiSuite) TestProjectsGetProjects(c *check.C) {
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
 	c.Check(rsp.Result, testutil.DeepUnsortedMatches, []*workspacebackend.Project{
-		{Path: "/home/testuser/project", ProjectId: "b8639dea"},
-		{Path: "/home/testuser/project2", ProjectId: "a8639dea"},
+		{Path: s.project.Path, ProjectId: s.project.ProjectId},
 	})
 }
 

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -118,7 +118,7 @@ base: ubuntu@20.04
 	c.Assert(err, check.IsNil)
 	ws, err := b.GetWorkspace(req.Context(), "ws-test")
 	c.Assert(err, check.IsNil)
-	ws.LinkSdk(req.Context(), &sdk.SdkInfo{Name: "go", Channel: "latest/stable", Revision: 234})
+	ws.LinkSdk(req.Context(), sdk.Setup{Name: "go", Channel: "latest/stable", Revision: 234})
 
 	// Execute
 	rsp := v1GetProjectWorkspaces(projectsCmd, req, nil).(*resp)

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -65,7 +65,8 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	ctx := context.WithValue(context.TODO(), workspacebackend.ContextProjectId, s.project.ProjectId)
 	s.ctx = context.WithValue(ctx, workspacebackend.ContextUser, "testuser")
 
-	s.b.CreateOrLoadProject(s.ctx, s.project.Path)
+	_, _, err := s.b.CreateOrLoadProject(s.ctx, s.project.Path)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *apiSuite) TearDownTest(c *check.C) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -995,13 +995,13 @@ func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *check.C) {
 	select {
 	case <-d.Dying():
 		// Pretend we got change while shutting down, this can
-		// happen when e.g. the user requested a `snap install
+		// happen when e.g. the user requested a `workspace install
 		// foo` at the same time as the code in the overlord
 		// checked that it can go into socket activated
 		// mode. I.e. the daemon was processing the request
 		// but no change was generated at the time yet.
 		st.Lock()
-		chg := st.NewChange("fake-install", "fake install some snap")
+		chg := st.NewChange("fake-install", "fake install some work")
 		chg.AddTask(st.NewTask("fake-install-task", "fake install task"))
 		chgStatus := chg.Status()
 		st.Unlock()

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -11,10 +11,15 @@ import (
 	"github.com/spf13/afero"
 )
 
-// defaultWorkspaceDir is the Workspace directory used if $WORKSPACE is not set. It is
-// created by the daemon ("workspaced run") if it doesn't exist, and also used by
-// the workspace client.
-const defaultWorkspaceDir = "/var/lib/workspace/default"
+const (
+	// defaultWorkspaceDir is the Workspace directory used if $WORKSPACE is not set. It is
+	// created by the daemon ("workspaced run") if it doesn't exist, and also used by
+	// the workspace client.
+	defaultWorkspaceDir = "/var/lib/workspace/default"
+
+	// default root directory path for the SDKs to be installed into in a workspace
+	WorkspaceSdksDir = "/var/lib/workspace/sdk"
+)
 
 var (
 	SdkDir          string

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -29,12 +29,12 @@ func (s StoreAction) String() string {
 }
 
 type StoreResult struct {
-	Sdks         []*sdk.SdkInfo
+	Sdks         []*sdk.Info
 	ActionErrors map[string]error
 }
 
 type StoreClient interface {
-	RetrieveSdk(name, channel, localSdkDir string) (*sdk.SdkInfo, error)
+	RetrieveSdk(name, channel, localSdkDir string) (sdk.Setup, error)
 }
 
 func NewStoreClient() StoreClient {
@@ -61,33 +61,33 @@ func storeConnect() (*storage.Client, error) {
 	return client, err
 }
 
-func (c *ObjectStoreClient) RetrieveSdk(name, channel, localSdkDir string) (*sdk.SdkInfo, error) {
+func (c *ObjectStoreClient) RetrieveSdk(name, channel, localSdkDir string) (sdk.Setup, error) {
 	var track, risk string
-	var s sdk.SdkInfo
+	var s sdk.Setup
 	var revision int64
 
 	if sa := strings.Split(channel, "/"); len(sa) != 2 {
-		return nil, fmt.Errorf("%s has an invalid channel %s, must take the form <track>/<risk>", name, channel)
+		return s, fmt.Errorf("%s has an invalid channel %s, must take the form <track>/<risk>", name, channel)
 	} else {
 		track, risk = sa[0], sa[1]
 	}
 
 	ctx := context.Background()
 	if client, err := storeConnect(); err != nil {
-		return &s, err
+		return s, err
 	} else {
 		bkt := client.Bucket("sdk-store")
 		defer client.Close()
 		var obj *storage.ObjectHandle = bkt.Object(fmt.Sprintf("%s/%s/%s/%s.sdk", name, track, risk, name))
 		if atr, err := obj.Attrs(ctx); err != nil {
-			return nil, err
+			return s, err
 		} else {
 			/* A simple modulo to keep revision numbers in a readble form for testing */
 			revision = atr.Generation % 1000
 		}
 
 		if r, err := obj.NewReader(ctx); err != nil {
-			return nil, err
+			return s, err
 		} else {
 			defer r.Close()
 
@@ -97,23 +97,23 @@ func (c *ObjectStoreClient) RetrieveSdk(name, channel, localSdkDir string) (*sdk
 
 			exist, err := afero.Exists(c.Fs, s.Filename())
 			if err != nil {
-				return nil, err
+				return s, err
 			}
 
 			if !exist {
 				file, err := c.Fs.Create(s.Filename())
 				if err != nil {
-					return nil, err
+					return s, err
 				}
 				defer file.Close()
 
 				if _, err = io.Copy(file, r); err != nil {
-					return nil, err
+					return s, err
 				}
 			}
 
 		}
 	}
 
-	return &s, nil
+	return s, nil
 }

--- a/internal/interfaces/backend.go
+++ b/internal/interfaces/backend.go
@@ -1,0 +1,65 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/timings"
+	"github.com/canonical/workspace/internal/workspacebackend"
+)
+
+// SecurityBackend abstracts interactions between the interface system and the
+// needs of a particular security system.
+type SecurityBackend interface {
+	// Initialize performs any initialization required by the backend.
+	// It is called during snapd startup process.
+	Initialize(backend workspacebackend.WorkspaceBackend) error
+
+	// Name returns the name of the backend.
+	// This is intended for diagnostic messages.
+	Name() SecuritySystem
+
+	// Setup creates and loads security artefacts specific to a given snap.
+	// The snap can be in one of three kids onf confinement (strict mode,
+	// developer mode or classic mode). In the last two security violations
+	// are non-fatal to the offending application process.
+	//
+	// This method should be called after changing plug, slots, connections
+	// between them or application present in the snap.
+	Setup(context context.Context, sdk *sdk.Info, repo *Repository) error
+
+	// Remove removes and unloads security artefacts of a given snap.
+	//
+	// This method should be called during the process of removing a snap.
+	Remove(sdkName string) error
+
+	// NewSpecification returns a new specification associated with this backend.
+	NewSpecification(user, pid string) Specification
+}
+
+// SecurityBackendSetupMany interface may be implemented by backends that can optimize their operations
+// when setting up multiple snaps at once.
+type SecurityBackendSetupMany interface {
+	// SetupMany creates and loads apparmor profiles of multiple snaps. It tries to process all snaps and doesn't interrupt processing
+	// on errors of individual snaps.
+	SetupMany(snaps []*sdk.Info, repo *Repository, tm timings.Measurer) []error
+}

--- a/internal/interfaces/backend.go
+++ b/internal/interfaces/backend.go
@@ -31,25 +31,21 @@ import (
 // needs of a particular security system.
 type SecurityBackend interface {
 	// Initialize performs any initialization required by the backend.
-	// It is called during snapd startup process.
+	// It is called during workspaced startup process.
 	Initialize(backend workspacebackend.WorkspaceBackend) error
 
 	// Name returns the name of the backend.
 	// This is intended for diagnostic messages.
 	Name() SecuritySystem
 
-	// Setup creates and loads security artefacts specific to a given snap.
-	// The snap can be in one of three kids onf confinement (strict mode,
-	// developer mode or classic mode). In the last two security violations
-	// are non-fatal to the offending application process.
-	//
+	// Setup creates and loads security artefacts specific to a given sdk.
 	// This method should be called after changing plug, slots, connections
-	// between them or application present in the snap.
+	// between them.
 	Setup(context context.Context, sdk *sdk.Info, repo *Repository) error
 
-	// Remove removes and unloads security artefacts of a given snap.
+	// Remove removes and unloads security artefacts of a given sdk.
 	//
-	// This method should be called during the process of removing a snap.
+	// This method should be called during the process of removing a sdk.
 	Remove(sdkName string) error
 
 	// NewSpecification returns a new specification associated with this backend.
@@ -57,9 +53,9 @@ type SecurityBackend interface {
 }
 
 // SecurityBackendSetupMany interface may be implemented by backends that can optimize their operations
-// when setting up multiple snaps at once.
+// when setting up multiple sdks at once.
 type SecurityBackendSetupMany interface {
-	// SetupMany creates and loads apparmor profiles of multiple snaps. It tries to process all snaps and doesn't interrupt processing
-	// on errors of individual snaps.
-	SetupMany(snaps []*sdk.Info, repo *Repository, tm timings.Measurer) []error
+	// SetupMany creates and loads apparmor profiles of multiple sdks. It tries to process all sdks and doesn't interrupt processing
+	// on errors of individual sdks.
+	SetupMany(sdks []*sdk.Info, repo *Repository, tm timings.Measurer) []error
 }

--- a/internal/interfaces/backend.go
+++ b/internal/interfaces/backend.go
@@ -45,8 +45,8 @@ type SecurityBackend interface {
 
 	// Remove removes and unloads security artefacts of a given sdk.
 	//
-	// This method should be called during the process of removing a sdk.
-	Remove(sdkName string) error
+	// This method should be called during the process of removing an sdk.
+	Remove(context context.Context, workspace, sdkName string) error
 
 	// NewSpecification returns a new specification associated with this backend.
 	NewSpecification(user, pid string) Specification

--- a/internal/interfaces/backends/backends.go
+++ b/internal/interfaces/backends/backends.go
@@ -1,0 +1,13 @@
+package backend
+
+import (
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/device"
+)
+
+func All() []interfaces.SecurityBackend {
+	all := []interfaces.SecurityBackend{
+		&device.Backend{},
+	}
+	return all
+}

--- a/internal/interfaces/builtin/all.go
+++ b/internal/interfaces/builtin/all.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	sdk.SanitizePlugsSlots = sanitizePlugsSlots
+	sdk.SanitizePlugsSlots = SanitizePlugsSlots
 
 	// setup the ByName function using allInterfaces
 	interfaces.ByName = func(name string) (interfaces.Interface, error) {
@@ -44,45 +44,45 @@ var (
 	allInterfaces map[string]interfaces.Interface
 )
 
-func sanitizePlugsSlots(snapInfo *sdk.Info) {
+func SanitizePlugsSlots(sdkInfo *sdk.Info) {
 	var badPlugs []string
 	var badSlots []string
 
-	for plugName, plugInfo := range snapInfo.Plugs {
+	for plugName, plugInfo := range sdkInfo.Plugs {
 		iface, ok := allInterfaces[plugInfo.Interface]
 		if !ok {
-			snapInfo.BadInterfaces[plugName] = fmt.Sprintf("unknown interface %q", plugInfo.Interface)
+			sdkInfo.BadInterfaces[plugName] = fmt.Sprintf("unknown interface %q", plugInfo.Interface)
 			badPlugs = append(badPlugs, plugName)
 			continue
 		}
 		// Reject plug with invalid name
 		if err := sdk.ValidatePlugName(plugName); err != nil {
-			snapInfo.BadInterfaces[plugName] = err.Error()
+			sdkInfo.BadInterfaces[plugName] = err.Error()
 			badPlugs = append(badPlugs, plugName)
 			continue
 		}
 		if err := interfaces.BeforePreparePlug(iface, plugInfo); err != nil {
-			snapInfo.BadInterfaces[plugName] = err.Error()
+			sdkInfo.BadInterfaces[plugName] = err.Error()
 			badPlugs = append(badPlugs, plugName)
 			continue
 		}
 	}
 
-	for slotName, slotInfo := range snapInfo.Slots {
+	for slotName, slotInfo := range sdkInfo.Slots {
 		iface, ok := allInterfaces[slotInfo.Interface]
 		if !ok {
-			snapInfo.BadInterfaces[slotName] = fmt.Sprintf("unknown interface %q", slotInfo.Interface)
+			sdkInfo.BadInterfaces[slotName] = fmt.Sprintf("unknown interface %q", slotInfo.Interface)
 			badSlots = append(badSlots, slotName)
 			continue
 		}
 		// Reject slot with invalid name
 		if err := sdk.ValidateSlotName(slotName); err != nil {
-			snapInfo.BadInterfaces[slotName] = err.Error()
+			sdkInfo.BadInterfaces[slotName] = err.Error()
 			badSlots = append(badSlots, slotName)
 			continue
 		}
 		if err := interfaces.BeforePrepareSlot(iface, slotInfo); err != nil {
-			snapInfo.BadInterfaces[slotName] = err.Error()
+			sdkInfo.BadInterfaces[slotName] = err.Error()
 			badSlots = append(badSlots, slotName)
 			continue
 		}
@@ -90,10 +90,10 @@ func sanitizePlugsSlots(snapInfo *sdk.Info) {
 
 	// remove any bad plugs and slots
 	for _, plugName := range badPlugs {
-		delete(snapInfo.Plugs, plugName)
+		delete(sdkInfo.Plugs, plugName)
 	}
 	for _, slotName := range badSlots {
-		delete(snapInfo.Slots, slotName)
+		delete(sdkInfo.Slots, slotName)
 	}
 }
 
@@ -116,59 +116,6 @@ func registerIface(iface interfaces.Interface) {
 		allInterfaces = make(map[string]interfaces.Interface)
 	}
 	allInterfaces[iface.Name()] = iface
-}
-
-func SanitizePlugsSlots(snapInfo *sdk.Info) {
-	var badPlugs []string
-	var badSlots []string
-
-	for plugName, plugInfo := range snapInfo.Plugs {
-		iface, ok := allInterfaces[plugInfo.Interface]
-		if !ok {
-			snapInfo.BadInterfaces[plugName] = fmt.Sprintf("unknown interface %q", plugInfo.Interface)
-			badPlugs = append(badPlugs, plugName)
-			continue
-		}
-		// Reject plug with invalid name
-		if err := sdk.ValidatePlugName(plugName); err != nil {
-			snapInfo.BadInterfaces[plugName] = err.Error()
-			badPlugs = append(badPlugs, plugName)
-			continue
-		}
-		if err := interfaces.BeforePreparePlug(iface, plugInfo); err != nil {
-			snapInfo.BadInterfaces[plugName] = err.Error()
-			badPlugs = append(badPlugs, plugName)
-			continue
-		}
-	}
-
-	for slotName, slotInfo := range snapInfo.Slots {
-		iface, ok := allInterfaces[slotInfo.Interface]
-		if !ok {
-			snapInfo.BadInterfaces[slotName] = fmt.Sprintf("unknown interface %q", slotInfo.Interface)
-			badSlots = append(badSlots, slotName)
-			continue
-		}
-		// Reject slot with invalid name
-		if err := sdk.ValidateSlotName(slotName); err != nil {
-			snapInfo.BadInterfaces[slotName] = err.Error()
-			badSlots = append(badSlots, slotName)
-			continue
-		}
-		if err := interfaces.BeforePrepareSlot(iface, slotInfo); err != nil {
-			snapInfo.BadInterfaces[slotName] = err.Error()
-			badSlots = append(badSlots, slotName)
-			continue
-		}
-	}
-
-	// remove any bad plugs and slots
-	for _, plugName := range badPlugs {
-		delete(snapInfo.Plugs, plugName)
-	}
-	for _, slotName := range badSlots {
-		delete(snapInfo.Slots, slotName)
-	}
 }
 
 func MockInterface(iface interfaces.Interface) func() {

--- a/internal/interfaces/builtin/all.go
+++ b/internal/interfaces/builtin/all.go
@@ -1,0 +1,188 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/sdk"
+)
+
+func init() {
+	sdk.SanitizePlugsSlots = sanitizePlugsSlots
+
+	// setup the ByName function using allInterfaces
+	interfaces.ByName = func(name string) (interfaces.Interface, error) {
+		iface, ok := allInterfaces[name]
+		if !ok {
+			return nil, fmt.Errorf("interface %q not found", name)
+		}
+		return iface, nil
+	}
+}
+
+var (
+	allInterfaces map[string]interfaces.Interface
+)
+
+func sanitizePlugsSlots(snapInfo *sdk.Info) {
+	var badPlugs []string
+	var badSlots []string
+
+	for plugName, plugInfo := range snapInfo.Plugs {
+		iface, ok := allInterfaces[plugInfo.Interface]
+		if !ok {
+			snapInfo.BadInterfaces[plugName] = fmt.Sprintf("unknown interface %q", plugInfo.Interface)
+			badPlugs = append(badPlugs, plugName)
+			continue
+		}
+		// Reject plug with invalid name
+		if err := sdk.ValidatePlugName(plugName); err != nil {
+			snapInfo.BadInterfaces[plugName] = err.Error()
+			badPlugs = append(badPlugs, plugName)
+			continue
+		}
+		if err := interfaces.BeforePreparePlug(iface, plugInfo); err != nil {
+			snapInfo.BadInterfaces[plugName] = err.Error()
+			badPlugs = append(badPlugs, plugName)
+			continue
+		}
+	}
+
+	for slotName, slotInfo := range snapInfo.Slots {
+		iface, ok := allInterfaces[slotInfo.Interface]
+		if !ok {
+			snapInfo.BadInterfaces[slotName] = fmt.Sprintf("unknown interface %q", slotInfo.Interface)
+			badSlots = append(badSlots, slotName)
+			continue
+		}
+		// Reject slot with invalid name
+		if err := sdk.ValidateSlotName(slotName); err != nil {
+			snapInfo.BadInterfaces[slotName] = err.Error()
+			badSlots = append(badSlots, slotName)
+			continue
+		}
+		if err := interfaces.BeforePrepareSlot(iface, slotInfo); err != nil {
+			snapInfo.BadInterfaces[slotName] = err.Error()
+			badSlots = append(badSlots, slotName)
+			continue
+		}
+	}
+
+	// remove any bad plugs and slots
+	for _, plugName := range badPlugs {
+		delete(snapInfo.Plugs, plugName)
+	}
+	for _, slotName := range badSlots {
+		delete(snapInfo.Slots, slotName)
+	}
+}
+
+// Interfaces returns all of the built-in interfaces.
+func Interfaces() []interfaces.Interface {
+	ifaces := make([]interfaces.Interface, 0, len(allInterfaces))
+	for _, iface := range allInterfaces {
+		ifaces = append(ifaces, iface)
+	}
+	sort.Sort(byIfaceName(ifaces))
+	return ifaces
+}
+
+// registerIface appends the given interface into the list of all known interfaces.
+func registerIface(iface interfaces.Interface) {
+	if allInterfaces[iface.Name()] != nil {
+		panic(fmt.Errorf("cannot register duplicate interface %q", iface.Name()))
+	}
+	if allInterfaces == nil {
+		allInterfaces = make(map[string]interfaces.Interface)
+	}
+	allInterfaces[iface.Name()] = iface
+}
+
+func SanitizePlugsSlots(snapInfo *sdk.Info) {
+	var badPlugs []string
+	var badSlots []string
+
+	for plugName, plugInfo := range snapInfo.Plugs {
+		iface, ok := allInterfaces[plugInfo.Interface]
+		if !ok {
+			snapInfo.BadInterfaces[plugName] = fmt.Sprintf("unknown interface %q", plugInfo.Interface)
+			badPlugs = append(badPlugs, plugName)
+			continue
+		}
+		// Reject plug with invalid name
+		if err := sdk.ValidatePlugName(plugName); err != nil {
+			snapInfo.BadInterfaces[plugName] = err.Error()
+			badPlugs = append(badPlugs, plugName)
+			continue
+		}
+		if err := interfaces.BeforePreparePlug(iface, plugInfo); err != nil {
+			snapInfo.BadInterfaces[plugName] = err.Error()
+			badPlugs = append(badPlugs, plugName)
+			continue
+		}
+	}
+
+	for slotName, slotInfo := range snapInfo.Slots {
+		iface, ok := allInterfaces[slotInfo.Interface]
+		if !ok {
+			snapInfo.BadInterfaces[slotName] = fmt.Sprintf("unknown interface %q", slotInfo.Interface)
+			badSlots = append(badSlots, slotName)
+			continue
+		}
+		// Reject slot with invalid name
+		if err := sdk.ValidateSlotName(slotName); err != nil {
+			snapInfo.BadInterfaces[slotName] = err.Error()
+			badSlots = append(badSlots, slotName)
+			continue
+		}
+		if err := interfaces.BeforePrepareSlot(iface, slotInfo); err != nil {
+			snapInfo.BadInterfaces[slotName] = err.Error()
+			badSlots = append(badSlots, slotName)
+			continue
+		}
+	}
+
+	// remove any bad plugs and slots
+	for _, plugName := range badPlugs {
+		delete(snapInfo.Plugs, plugName)
+	}
+	for _, slotName := range badSlots {
+		delete(snapInfo.Slots, slotName)
+	}
+}
+
+func MockInterface(iface interfaces.Interface) func() {
+	name := iface.Name()
+	allInterfaces[name] = iface
+	return func() {
+		delete(allInterfaces, name)
+	}
+}
+
+type byIfaceName []interfaces.Interface
+
+func (c byIfaceName) Len() int      { return len(c) }
+func (c byIfaceName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byIfaceName) Less(i, j int) bool {
+	return c[i].Name() < c[j].Name()
+}

--- a/internal/interfaces/builtin/all_test.go
+++ b/internal/interfaces/builtin/all_test.go
@@ -1,0 +1,197 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/builtin"
+	"github.com/canonical/workspace/internal/interfaces/device"
+	"github.com/canonical/workspace/internal/interfaces/ifacetest"
+	"github.com/canonical/workspace/internal/sdk"
+)
+
+type AllSuite struct{}
+
+var _ = Suite(&AllSuite{})
+
+// This section contains a list of *valid* defines that represent methods that
+// backends recognize and call. They are in individual interfaces as each snapd
+// interface can define a subset that it is interested in providing. Those are,
+// essentially, the only valid methods that a snapd interface can have, apart
+// from what is defined in the Interface golang interface.
+type mountDefiner1 interface {
+	MountConnectedPlug(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+}
+type mountDefiner2 interface {
+	MountConnectedSlot(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+}
+type mountDefiner3 interface {
+	MountPermanentPlug(spec *device.Specification, plug *sdk.PlugInfo) error
+}
+type mountDefiner4 interface {
+	MountPermanentSlot(spec *device.Specification, slot *sdk.SlotInfo) error
+}
+
+// allGoodDefiners contains all valid specification definers for all known backends.
+var allGoodDefiners = []reflect.Type{
+	// mount
+	reflect.TypeOf((*mountDefiner1)(nil)).Elem(),
+	reflect.TypeOf((*mountDefiner2)(nil)).Elem(),
+	reflect.TypeOf((*mountDefiner3)(nil)).Elem(),
+	reflect.TypeOf((*mountDefiner4)(nil)).Elem(),
+}
+
+// Check that each interface defines at least one definer method we recognize.
+func (s *AllSuite) TestEachInterfaceImplementsSomeBackendMethods(c *C) {
+	for _, iface := range builtin.Interfaces() {
+		bogus := true
+		for _, definer := range allGoodDefiners {
+			if reflect.TypeOf(iface).Implements(definer) {
+				bogus = false
+				break
+			}
+		}
+		c.Assert(bogus, Equals, false,
+			Commentf("interface %q does not implement any specification methods", iface.Name()))
+	}
+}
+
+func (s *AllSuite) TestRegisterIface(c *C) {
+	restore := builtin.MockInterfaces(nil)
+	defer restore()
+
+	// Registering an interface works correctly.
+	iface := &ifacetest.TestInterface{InterfaceName: "foo"}
+	builtin.RegisterIface(iface)
+	c.Assert(builtin.Interface("foo"), DeepEquals, iface)
+
+	// Duplicates are detected.
+	c.Assert(func() { builtin.RegisterIface(iface) }, PanicMatches, `cannot register duplicate interface "foo"`)
+}
+
+const testConsumerInvalidSlotNameYaml = `
+name: consumer
+slots:
+ ttyS5:
+  interface: iface
+`
+
+const testConsumerInvalidPlugNameYaml = `
+name: consumer
+plugs:
+ ttyS3:
+  interface: iface
+`
+
+func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotNames(c *C) {
+	restore := builtin.MockInterfaces(map[string]interfaces.Interface{
+		"iface": &ifacetest.TestInterface{InterfaceName: "iface"},
+	})
+	defer restore()
+
+	sdkInfo := sdk.MockInvalidInfo(c, testConsumerInvalidSlotNameYaml, sdk.Setup{})
+	sdk.SanitizePlugsSlots(sdkInfo)
+	c.Assert(sdkInfo.BadInterfaces, HasLen, 1)
+	c.Check(sdk.BadInterfacesSummary(sdkInfo), Matches, `sdk "consumer" has bad plugs or slots: ttyS5 \(invalid slot name: "ttyS5"\)`)
+}
+
+func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
+	restore := builtin.MockInterfaces(map[string]interfaces.Interface{
+		"iface": &ifacetest.TestInterface{InterfaceName: "iface"},
+	})
+	defer restore()
+
+	sdkInfo := sdk.MockInvalidInfo(c, testConsumerInvalidPlugNameYaml, sdk.Setup{})
+	sdk.SanitizePlugsSlots(sdkInfo)
+	c.Assert(sdkInfo.BadInterfaces, HasLen, 1)
+	c.Check(sdk.BadInterfacesSummary(sdkInfo), Matches, `sdk "consumer" has bad plugs or slots: ttyS3 \(invalid plug name: "ttyS3"\)`)
+}
+
+func (s *AllSuite) TestUnexpectedSpecSignatures(c *C) {
+	type funcSig struct {
+		name string
+		in   []string
+		out  []string
+	}
+	var sigs []funcSig
+
+	// All the valid signatures from all the specification definers from all the backends.
+	for _, backend := range []string{string(interfaces.SecurityLxdDevice)} {
+		backendLower := strings.ToLower(backend)
+		sigs = append(sigs, []funcSig{{
+			name: fmt.Sprintf("%sPermanentPlug", backend),
+			in: []string{
+				fmt.Sprintf("*%s.Specification", backendLower),
+				"*sdk.PlugInfo",
+			},
+			out: []string{"error"},
+		}, {
+			name: fmt.Sprintf("%sPermanentSlot", backend),
+			in: []string{
+				fmt.Sprintf("*%s.Specification", backendLower),
+				"*sdk.SlotInfo",
+			},
+			out: []string{"error"},
+		}, {
+			name: fmt.Sprintf("%sConnectedPlug", backend),
+			in: []string{
+				fmt.Sprintf("*%s.Specification", backendLower),
+				"*interfaces.ConnectedPlug",
+				"*interfaces.ConnectedSlot",
+			},
+			out: []string{"error"},
+		}, {
+			name: fmt.Sprintf("%sConnectedSlot", backend),
+			in: []string{
+				fmt.Sprintf("*%s.Specification", backendLower),
+				"*interfaces.ConnectedPlug",
+				"*interfaces.ConnectedSlot",
+			},
+			out: []string{"error"},
+		}}...)
+	}
+	for _, iface := range builtin.Interfaces() {
+		ifaceVal := reflect.ValueOf(iface)
+		ifaceType := ifaceVal.Type()
+		for _, sig := range sigs {
+			meth, ok := ifaceType.MethodByName(sig.name)
+			if !ok {
+				// all specification methods are optional.
+				continue
+			}
+			methType := meth.Type
+			// Check that the signature matches our expectation. The -1 and +1 below is for the receiver type.
+			c.Assert(methType.NumIn()-1, Equals, len(sig.in), Commentf("expected %s's %s method to take %d arguments", ifaceType, meth.Name, len(sig.in)))
+			for i, expected := range sig.in {
+				c.Assert(methType.In(i+1).String(), Equals, expected, Commentf("expected %s's %s method %dth argument type to be different", ifaceType, meth.Name, i))
+			}
+			c.Assert(methType.NumOut(), Equals, len(sig.out), Commentf("expected %s's %s method to return %d values", ifaceType, meth.Name, len(sig.out)))
+			for i, expected := range sig.out {
+				c.Assert(methType.Out(i).String(), Equals, expected, Commentf("expected %s's %s method %dth return value type to be different", ifaceType, meth.Name, i))
+			}
+		}
+	}
+}

--- a/internal/interfaces/builtin/all_test.go
+++ b/internal/interfaces/builtin/all_test.go
@@ -38,9 +38,9 @@ type AllSuite struct{}
 var _ = Suite(&AllSuite{})
 
 // This section contains a list of *valid* defines that represent methods that
-// backends recognize and call. They are in individual interfaces as each snapd
+// backends recognize and call. They are in individual interfaces as each
 // interface can define a subset that it is interested in providing. Those are,
-// essentially, the only valid methods that a snapd interface can have, apart
+// essentially, the only valid methods that an interface can have, apart
 // from what is defined in the Interface golang interface.
 type mountDefiner1 interface {
 	MountConnectedPlug(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -37,7 +37,7 @@ const contentSummary = `allows sharing host code and data with SDKs`
 const contentBaseDeclarationSlots = `
   content:
     allow-installation:
-      slot-workspace-type:
+      slot-type:
         - core
     allow-connection: true
     allow-auto-connection: true

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -1,0 +1,141 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/device"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/workspacebackend"
+)
+
+const contentSummary = `allows sharing host code and data with SDKs`
+
+const contentBaseDeclarationSlots = `
+  content:
+    allow-installation:
+      slot-workspace-type:
+        - core
+    allow-connection: true
+    allow-auto-connection: true
+`
+
+// contentInterface allows sharing content between snaps
+type contentInterface struct{}
+
+func (iface *contentInterface) Name() string {
+	return "content"
+}
+
+func (iface *contentInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              contentSummary,
+		BaseDeclarationSlots: contentBaseDeclarationSlots,
+
+		AffectsPlugOnRefresh: true,
+	}
+}
+
+func cleanSubPath(path string) bool {
+	return filepath.Clean(path) == path && path != ".." && !strings.HasPrefix(path, "../")
+}
+
+func validatePath(path string) error {
+	if ok := cleanSubPath(path); !ok {
+		return fmt.Errorf("content interface path is not clean: %q", path)
+	}
+	return nil
+}
+
+func (iface *contentInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
+	return nil
+}
+
+func (iface *contentInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
+	target, ok := plug.Attrs["target"].(string)
+	if !ok || len(target) == 0 {
+		return fmt.Errorf("content plug must contain target path")
+	}
+	if err := validatePath(target); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (iface *contentInterface) mount(attrs interfaces.Attrer) string {
+	var source string
+
+	if err := attrs.Attr("target", &source); err == nil {
+		return source
+	}
+	return ""
+}
+
+func (iface *contentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+// Interactions with the mount backend.
+func (iface *contentInterface) MountConnectedPlug(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	user, err := workspacebackend.LookupUsername(spec.User())
+	if err != nil {
+		return err
+	}
+
+	source := filepath.Join(user.HomeDir, ".local", "share", "workspace", "project", spec.ProjectId(), "content",
+		strings.Join([]string{plug.Sdk().Workspace, plug.Sdk().Name, plug.Name()}, "_")+".sdk")
+
+	if err = os.MkdirAll(source, 0744); err != nil {
+		return err
+	}
+
+	uid, err := strconv.Atoi(user.Uid)
+	if err != nil {
+		return err
+	}
+
+	gid, err := strconv.Atoi(user.Gid)
+	if err != nil {
+		return err
+	}
+
+	if err = os.Chown(source, uid, gid); err != nil {
+		return err
+	}
+
+	var entry = workspacebackend.WorkspaceDevice{
+		Name: plug.Name(),
+		Properties: map[string]string{"type": "disk", "source": source,
+			"path": iface.mount(plug)},
+	}
+	return spec.AddDeviceEntry(&entry)
+}
+
+func init() {
+	registerIface(&contentInterface{})
+}

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -43,7 +43,7 @@ const contentBaseDeclarationSlots = `
     allow-auto-connection: true
 `
 
-// contentInterface allows sharing content between snaps
+// contentInterface allows sharing content between sdks
 type contentInterface struct{}
 
 func (iface *contentInterface) Name() string {

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -1,0 +1,146 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/builtin"
+	"github.com/canonical/workspace/internal/interfaces/device"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/testutil"
+	"github.com/canonical/workspace/internal/workspacebackend"
+	"gopkg.in/check.v1"
+)
+
+type ContentSuite struct {
+	iface interfaces.Interface
+}
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+var _ = check.Suite(&ContentSuite{
+	iface: builtin.MustInterface("content"),
+})
+
+func (s *ContentSuite) TestName(c *check.C) {
+	c.Assert(s.iface.Name(), check.Equals, "content")
+}
+
+func (s *ContentSuite) TestSanitizeSlotSimple(c *check.C) {
+	const mockSdkYaml = `name: content-slot-sdk
+slots:
+ content-slot:
+  interface: content
+`
+	info := sdk.MockInfo(c, mockSdkYaml, sdk.Setup{})
+	slot := info.Slots["content-slot"]
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+}
+
+func (s *ContentSuite) TestSanitizePlugSimple(c *check.C) {
+	const mockSnapYaml = `name: content-slot-sdk
+plugs:
+ content-plug:
+  interface: content
+  target: import
+`
+	info := sdk.MockInfo(c, mockSnapYaml, sdk.Setup{})
+	plug := info.Plugs["content-plug"]
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+}
+
+func (s *ContentSuite) TestSanitizePlugSimpleNoTarget(c *check.C) {
+	const mockSdkYaml = `name: content-slot-sdk
+plugs:
+ content-plug:
+  interface: content
+  content: mycont
+`
+	info := sdk.MockInfo(c, mockSdkYaml, sdk.Setup{})
+	plug := info.Plugs["content-plug"]
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content plug must contain target path")
+}
+
+func (s *ContentSuite) TestSanitizePlugSimpleTargetRelative(c *check.C) {
+	const mockSdkYaml = `name: content-slot-sdk
+plugs:
+ content-plug:
+  interface: content
+  content: mycont
+  target: ../foo
+`
+	info := sdk.MockInfo(c, mockSdkYaml, sdk.Setup{})
+	plug := info.Plugs["content-plug"]
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content interface path is not clean:.*")
+}
+
+func (s *ContentSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *ContentSuite) TestContentInterface(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+plugs:
+ content:
+  target: /project/training
+`, sdk.Setup{Workspace: "ws"}, "content")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+slots:
+ content:
+`, sdk.Setup{Workspace: "ws"}, "content")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := &device.Specification{}
+
+	homeDir := c.MkDir()
+
+	restore := testutil.FakeFunc(func(name string) (*user.User, error) {
+		u := &user.User{
+			Name:     "user",
+			Username: "user",
+			Uid:      "1000",
+			Gid:      "1000",
+			HomeDir:  homeDir,
+		}
+		return u, nil
+	}, &workspacebackend.LookupUsername)
+	defer restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Analyze the mount specification.
+	expectedMnt := []*workspacebackend.WorkspaceDevice{{
+		Name: plug.Name,
+		Properties: map[string]string{
+			"type":   "disk",
+			"source": filepath.Join(homeDir, "/.local/share/workspace/project/content/ws_consumer_content.sdk"),
+			"path":   "/project/training",
+		},
+	}}
+	c.Assert(deviceSpec.DeviceEntries(), check.DeepEquals, expectedMnt)
+
+}

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -51,6 +51,7 @@ func (s *ContentSuite) TestName(c *check.C) {
 
 func (s *ContentSuite) TestSanitizeSlotSimple(c *check.C) {
 	const mockSdkYaml = `name: content-slot-sdk
+base: ubuntu@22.04
 slots:
  content-slot:
   interface: content
@@ -62,6 +63,7 @@ slots:
 
 func (s *ContentSuite) TestSanitizePlugSimple(c *check.C) {
 	const mockSnapYaml = `name: content-slot-sdk
+base: ubuntu@22.04
 plugs:
  content-plug:
   interface: content
@@ -74,6 +76,7 @@ plugs:
 
 func (s *ContentSuite) TestSanitizePlugSimpleNoTarget(c *check.C) {
 	const mockSdkYaml = `name: content-slot-sdk
+base: ubuntu@22.04
 plugs:
  content-plug:
   interface: content
@@ -86,6 +89,7 @@ plugs:
 
 func (s *ContentSuite) TestSanitizePlugSimpleTargetRelative(c *check.C) {
 	const mockSdkYaml = `name: content-slot-sdk
+base: ubuntu@22.04
 plugs:
  content-plug:
   interface: content
@@ -103,6 +107,7 @@ func (s *ContentSuite) TestInterfaces(c *check.C) {
 
 func (s *ContentSuite) TestContentInterface(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
 plugs:
  content:
   target: /project/training
@@ -110,6 +115,7 @@ plugs:
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 
 	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
 slots:
  content:
 `, sdk.Setup{Workspace: "ws"}, "content")

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -62,14 +62,14 @@ slots:
 }
 
 func (s *ContentSuite) TestSanitizePlugSimple(c *check.C) {
-	const mockSnapYaml = `name: content-slot-sdk
+	const mockSdkYaml = `name: content-slot-sdk
 base: ubuntu@22.04
 plugs:
  content-plug:
   interface: content
   target: import
 `
-	info := sdk.MockInfo(c, mockSnapYaml, sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, sdk.Setup{})
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
 }

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -123,13 +123,15 @@ slots:
 	deviceSpec := &device.Specification{}
 
 	homeDir := c.MkDir()
+	usr, err := user.Current()
+	c.Assert(err, check.IsNil)
 
 	restore := testutil.FakeFunc(func(name string) (*user.User, error) {
 		u := &user.User{
-			Name:     "user",
-			Username: "user",
-			Uid:      "1000",
-			Gid:      "1000",
+			Name:     usr.Name,
+			Username: usr.Name,
+			Uid:      usr.Uid,
+			Gid:      usr.Gid,
 			HomeDir:  homeDir,
 		}
 		return u, nil

--- a/internal/interfaces/builtin/export_test.go
+++ b/internal/interfaces/builtin/export_test.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/sdk"
+
+	"gopkg.in/check.v1"
+)
+
+var (
+	RegisterIface = registerIface
+)
+
+// MockInterfaces replaces the set of known interfaces and returns a restore function.
+func MockInterfaces(ifaces map[string]interfaces.Interface) (restore func()) {
+	old := allInterfaces
+	allInterfaces = ifaces
+	return func() { allInterfaces = old }
+}
+
+// Interface returns the interface with the given name (or nil).
+func Interface(name string) interfaces.Interface {
+	return allInterfaces[name]
+}
+
+// MustInterface returns the interface with the given name or panics.
+func MustInterface(name string) interfaces.Interface {
+	if iface, ok := allInterfaces[name]; ok {
+		return iface
+	}
+	panic(fmt.Errorf("cannot find interface with name %q", name))
+}
+
+func MockPlug(c *check.C, yaml string, si sdk.Setup, plugName string) *sdk.PlugInfo {
+	info := sdk.MockInfo(c, yaml, si)
+	if plugInfo, ok := info.Plugs[plugName]; ok {
+		return plugInfo
+	}
+	panic(fmt.Sprintf("cannot find plug %q in sdk %q", plugName, si.Name))
+}
+
+func MockSlot(c *check.C, yaml string, si sdk.Setup, slotName string) *sdk.SlotInfo {
+	info := sdk.MockInfo(c, yaml, si)
+	if slotInfo, ok := info.Slots[slotName]; ok {
+		return slotInfo
+	}
+	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, si.Name))
+}

--- a/internal/interfaces/builtin/export_test.go
+++ b/internal/interfaces/builtin/export_test.go
@@ -65,5 +65,5 @@ func MockSlot(c *check.C, yaml string, si sdk.Setup, slotName string) *sdk.SlotI
 	if slotInfo, ok := info.Slots[slotName]; ok {
 		return slotInfo
 	}
-	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, si.Name))
+	panic(fmt.Sprintf("cannot find slot %q in sdk %q", slotName, si.Name))
 }

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -1,0 +1,245 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/canonical/workspace/internal/interfaces/utils"
+	"github.com/canonical/workspace/internal/metautil"
+	"github.com/canonical/workspace/internal/sdk"
+)
+
+// Connection represents a connection between a particular plug and slot.
+type Connection struct {
+	Plug *ConnectedPlug
+	Slot *ConnectedSlot
+}
+
+// ConnectedPlug represents a plug that is connected to a slot.
+type ConnectedPlug struct {
+	plugInfo     *sdk.PlugInfo
+	staticAttrs  map[string]interface{}
+	dynamicAttrs map[string]interface{}
+}
+
+// ConnectedSlot represents a slot that is connected to a plug.
+type ConnectedSlot struct {
+	slotInfo     *sdk.SlotInfo
+	staticAttrs  map[string]interface{}
+	dynamicAttrs map[string]interface{}
+}
+
+// Attrer is an interface with Attr getter method common
+// to ConnectedSlot, ConnectedPlug, PlugInfo and SlotInfo types.
+type Attrer interface {
+	// Attr returns attribute value for given path, or an error. Dotted paths are supported.
+	Attr(path string, value interface{}) error
+	// Lookup returns attribute value for given path, or false. Dotted paths are supported.
+	Lookup(path string) (value interface{}, ok bool)
+}
+
+func lookupAttr(staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string) (interface{}, bool) {
+	var v interface{}
+	comps := strings.FieldsFunc(path, func(r rune) bool { return r == '.' })
+	if len(comps) == 0 {
+		return nil, false
+	}
+	if _, ok := dynamicAttrs[comps[0]]; ok {
+		v = dynamicAttrs
+	} else {
+		v = staticAttrs
+	}
+
+	for _, comp := range comps {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		v, ok = m[comp]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return v, true
+}
+
+func getAttribute(snapName string, ifaceName string, staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string, val interface{}) error {
+	v, ok := lookupAttr(staticAttrs, dynamicAttrs, path)
+	if !ok {
+		err := fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, path, ifaceName)
+		return sdk.AttributeNotFoundError{Err: err}
+	}
+
+	return metautil.SetValueFromAttribute(snapName, ifaceName, path, v, val)
+}
+
+// NewConnectedSlot creates an object representing a connected slot.
+func NewConnectedSlot(slot *sdk.SlotInfo, staticAttrs, dynamicAttrs map[string]interface{}) *ConnectedSlot {
+	var static map[string]interface{}
+	if staticAttrs != nil {
+		static = staticAttrs
+	} else {
+		static = slot.Attrs
+	}
+	return &ConnectedSlot{
+		slotInfo:     slot,
+		staticAttrs:  utils.CopyAttributes(static),
+		dynamicAttrs: utils.NormalizeInterfaceAttributes(dynamicAttrs).(map[string]interface{}),
+	}
+}
+
+// NewConnectedPlug creates an object representing a connected plug.
+func NewConnectedPlug(plug *sdk.PlugInfo, staticAttrs, dynamicAttrs map[string]interface{}) *ConnectedPlug {
+	var static map[string]interface{}
+	if staticAttrs != nil {
+		static = staticAttrs
+	} else {
+		static = plug.Attrs
+	}
+	return &ConnectedPlug{
+		plugInfo:     plug,
+		staticAttrs:  utils.CopyAttributes(static),
+		dynamicAttrs: utils.NormalizeInterfaceAttributes(dynamicAttrs).(map[string]interface{}),
+	}
+}
+
+// Interface returns the name of the interface for this plug.
+func (plug *ConnectedPlug) Interface() string {
+	return plug.plugInfo.Interface
+}
+
+// Name returns the name of this plug.
+func (plug *ConnectedPlug) Name() string {
+	return plug.plugInfo.Name
+}
+
+// Snap returns the snap Info of this plug.
+func (plug *ConnectedPlug) Sdk() *sdk.Info {
+	return plug.plugInfo.Sdk
+}
+
+// StaticAttr returns a static attribute with the given key, or error if attribute doesn't exist.
+func (plug *ConnectedPlug) StaticAttr(key string, val interface{}) error {
+	return getAttribute(plug.Sdk().Name, plug.Interface(), plug.staticAttrs, nil, key, val)
+}
+
+// StaticAttrs returns all static attributes.
+func (plug *ConnectedPlug) StaticAttrs() map[string]interface{} {
+	return utils.CopyAttributes(plug.staticAttrs)
+}
+
+// DynamicAttrs returns all dynamic attributes.
+func (plug *ConnectedPlug) DynamicAttrs() map[string]interface{} {
+	return utils.CopyAttributes(plug.dynamicAttrs)
+}
+
+// Attr returns a dynamic attribute with the given name. It falls back to returning static
+// attribute if dynamic one doesn't exist. Error is returned if neither dynamic nor static
+// attribute exist.
+func (plug *ConnectedPlug) Attr(key string, val interface{}) error {
+	return getAttribute(plug.Sdk().Name, plug.Interface(), plug.staticAttrs, plug.dynamicAttrs, key, val)
+}
+
+func (plug *ConnectedPlug) Lookup(path string) (interface{}, bool) {
+	return lookupAttr(plug.staticAttrs, plug.dynamicAttrs, path)
+}
+
+// SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
+func (plug *ConnectedPlug) SetAttr(key string, value interface{}) error {
+	if _, ok := plug.staticAttrs[key]; ok {
+		return fmt.Errorf("cannot change attribute %q as it was statically specified in the snap details", key)
+	}
+	if plug.dynamicAttrs == nil {
+		plug.dynamicAttrs = make(map[string]interface{})
+	}
+	plug.dynamicAttrs[key] = utils.NormalizeInterfaceAttributes(value)
+	return nil
+}
+
+// Ref returns the PlugRef for this plug.
+func (plug *ConnectedPlug) Ref() *PlugRef {
+	return &PlugRef{Sdk: plug.Sdk().Name, Name: plug.Name()}
+}
+
+// Interface returns the name of the interface for this slot.
+func (slot *ConnectedSlot) Interface() string {
+	return slot.slotInfo.Interface
+}
+
+// Name returns the name of this slot.
+func (slot *ConnectedSlot) Name() string {
+	return slot.slotInfo.Name
+}
+
+// Snap returns the snap Info of this slot.
+func (slot *ConnectedSlot) Sdk() *sdk.Info {
+	return slot.slotInfo.Sdk
+}
+
+// StaticAttr returns a static attribute with the given key, or error if attribute doesn't exist.
+func (slot *ConnectedSlot) StaticAttr(key string, val interface{}) error {
+	return getAttribute(slot.Sdk().Name, slot.Interface(), slot.staticAttrs, nil, key, val)
+}
+
+// StaticAttrs returns all static attributes.
+func (slot *ConnectedSlot) StaticAttrs() map[string]interface{} {
+	return utils.CopyAttributes(slot.staticAttrs)
+}
+
+// DynamicAttrs returns all dynamic attributes.
+func (slot *ConnectedSlot) DynamicAttrs() map[string]interface{} {
+	return utils.CopyAttributes(slot.dynamicAttrs)
+}
+
+// Attr returns a dynamic attribute with the given name. It falls back to returning static
+// attribute if dynamic one doesn't exist. Error is returned if neither dynamic nor static
+// attribute exist.
+func (slot *ConnectedSlot) Attr(key string, val interface{}) error {
+	return getAttribute(slot.Sdk().Name, slot.Interface(), slot.staticAttrs, slot.dynamicAttrs, key, val)
+}
+
+func (slot *ConnectedSlot) Lookup(path string) (interface{}, bool) {
+	return lookupAttr(slot.staticAttrs, slot.dynamicAttrs, path)
+}
+
+// SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
+func (slot *ConnectedSlot) SetAttr(key string, value interface{}) error {
+	if _, ok := slot.staticAttrs[key]; ok {
+		return fmt.Errorf("cannot change attribute %q as it was statically specified in the snap details", key)
+	}
+	if slot.dynamicAttrs == nil {
+		slot.dynamicAttrs = make(map[string]interface{})
+	}
+	slot.dynamicAttrs[key] = utils.NormalizeInterfaceAttributes(value)
+	return nil
+}
+
+// Ref returns the SlotRef for this slot.
+func (slot *ConnectedSlot) Ref() *SlotRef {
+	return &SlotRef{Sdk: slot.Sdk().Name, Name: slot.Name()}
+}
+
+// Interface returns the name of the interface for this connection.
+func (conn *Connection) Interface() string {
+	return conn.Plug.plugInfo.Interface
+}

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -83,14 +83,14 @@ func lookupAttr(staticAttrs map[string]interface{}, dynamicAttrs map[string]inte
 	return v, true
 }
 
-func getAttribute(snapName string, ifaceName string, staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string, val interface{}) error {
+func getAttribute(sdkName string, ifaceName string, staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string, val interface{}) error {
 	v, ok := lookupAttr(staticAttrs, dynamicAttrs, path)
 	if !ok {
-		err := fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, path, ifaceName)
+		err := fmt.Errorf("sdk %q does not have attribute %q for interface %q", sdkName, path, ifaceName)
 		return sdk.AttributeNotFoundError{Err: err}
 	}
 
-	return metautil.SetValueFromAttribute(snapName, ifaceName, path, v, val)
+	return metautil.SetValueFromAttribute(sdkName, ifaceName, path, v, val)
 }
 
 // NewConnectedSlot creates an object representing a connected slot.
@@ -133,7 +133,7 @@ func (plug *ConnectedPlug) Name() string {
 	return plug.plugInfo.Name
 }
 
-// Snap returns the snap Info of this plug.
+// sdk returns the sdk Info of this plug.
 func (plug *ConnectedPlug) Sdk() *sdk.Info {
 	return plug.plugInfo.Sdk
 }
@@ -167,7 +167,7 @@ func (plug *ConnectedPlug) Lookup(path string) (interface{}, bool) {
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
 func (plug *ConnectedPlug) SetAttr(key string, value interface{}) error {
 	if _, ok := plug.staticAttrs[key]; ok {
-		return fmt.Errorf("cannot change attribute %q as it was statically specified in the snap details", key)
+		return fmt.Errorf("cannot change attribute %q as it was statically specified in the sdk details", key)
 	}
 	if plug.dynamicAttrs == nil {
 		plug.dynamicAttrs = make(map[string]interface{})
@@ -191,7 +191,7 @@ func (slot *ConnectedSlot) Name() string {
 	return slot.slotInfo.Name
 }
 
-// Snap returns the snap Info of this slot.
+// sdk returns the sdk Info of this slot.
 func (slot *ConnectedSlot) Sdk() *sdk.Info {
 	return slot.slotInfo.Sdk
 }
@@ -225,7 +225,7 @@ func (slot *ConnectedSlot) Lookup(path string) (interface{}, bool) {
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
 func (slot *ConnectedSlot) SetAttr(key string, value interface{}) error {
 	if _, ok := slot.staticAttrs[key]; ok {
-		return fmt.Errorf("cannot change attribute %q as it was statically specified in the snap details", key)
+		return fmt.Errorf("cannot change attribute %q as it was statically specified in the sdk details", key)
 	}
 	if slot.dynamicAttrs == nil {
 		slot.dynamicAttrs = make(map[string]interface{})

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -39,7 +39,7 @@ var _ = check.Suite(&connSuite{})
 
 func (s *connSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
 	consumer := sdk.MockInfo(c, `
 name: consumer
 base: ubuntu@22.04
@@ -81,7 +81,7 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 
 	var val string
 	var intVal int
-	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `sdk "producer" does not have attribute "unknown" for interface "interface"`)
 
 	attrs := slot.StaticAttrs()
 	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
@@ -92,8 +92,8 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 	slot.StaticAttr("attr", &val)
 	c.Assert(val, check.Equals, "value")
 
-	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(slot.StaticAttr("attr", &intVal), check.ErrorMatches, `snap "producer" has interface "interface" with invalid value type string for "attr" attribute: \*int`)
+	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `sdk "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(slot.StaticAttr("attr", &intVal), check.ErrorMatches, `sdk "producer" has interface "interface" with invalid value type string for "attr" attribute: \*int`)
 	c.Check(slot.StaticAttr("attr", val), check.ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
 
 	// static attributes passed via args take precedence over slot.Attrs
@@ -120,7 +120,7 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 
 	var val string
 	var intVal int
-	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `sdk "consumer" does not have attribute "unknown" for interface "interface"`)
 
 	attrs := plug.StaticAttrs()
 	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
@@ -130,8 +130,8 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 	plug.StaticAttr("attr", &val)
 	c.Assert(val, check.Equals, "value")
 
-	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(plug.StaticAttr("attr", &intVal), check.ErrorMatches, `snap "consumer" has interface "interface" with invalid value type string for "attr" attribute: \*int`)
+	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `sdk "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(plug.StaticAttr("attr", &intVal), check.ErrorMatches, `sdk "consumer" has interface "interface" with invalid value type string for "attr" attribute: \*int`)
 	c.Check(plug.StaticAttr("attr", val), check.ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
 
 	// static attributes passed via args take precedence over plug.Attrs
@@ -167,8 +167,8 @@ func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
 	num := mapVal["number-two"]
 	c.Assert(num, check.Equals, int64(222))
 
-	c.Check(slot.Attr("unknown", &strVal), check.ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(slot.Attr("foo", &intVal), check.ErrorMatches, `snap "producer" has interface "interface" with invalid value type string for "foo" attribute: \*int64`)
+	c.Check(slot.Attr("unknown", &strVal), check.ErrorMatches, `sdk "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(slot.Attr("foo", &intVal), check.ErrorMatches, `sdk "producer" has interface "interface" with invalid value type string for "foo" attribute: \*int64`)
 	c.Check(slot.Attr("number", intVal), check.ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
 }
 
@@ -289,8 +289,8 @@ func (s *connSuite) TestDynamicPlugAttrs(c *check.C) {
 	num := mapVal["number-two"]
 	c.Assert(num, check.Equals, int64(222))
 
-	c.Check(plug.Attr("unknown", &strVal), check.ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(plug.Attr("foo", &intVal), check.ErrorMatches, `snap "consumer" has interface "interface" with invalid value type string for "foo" attribute: \*int64`)
+	c.Check(plug.Attr("unknown", &strVal), check.ErrorMatches, `sdk "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(plug.Attr("foo", &intVal), check.ErrorMatches, `sdk "consumer" has interface "interface" with invalid value type string for "foo" attribute: \*int64`)
 	c.Check(plug.Attr("number", intVal), check.ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
 }
 
@@ -304,11 +304,11 @@ func (s *connSuite) TestOverwriteStaticAttrError(c *check.C) {
 
 	err := plug.SetAttr("attr", "overwrite")
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the snap details`)
+	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the sdk details`)
 
 	err = slot.SetAttr("attr", "overwrite")
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the snap details`)
+	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the sdk details`)
 }
 
 func (s *connSuite) TestCopyAttributes(c *check.C) {
@@ -358,9 +358,9 @@ func (s *connSuite) TestNewConnectedSlotExplicitStaticAttrs(c *check.C) {
 func (s *connSuite) TestGetAttributeUnhappy(c *check.C) {
 	attrs := map[string]interface{}{}
 	var stringVal string
-	err := interfaces.GetAttribute("snap0", "iface0", attrs, attrs, "non-existent", &stringVal)
+	err := interfaces.GetAttribute("sdk0", "iface0", attrs, attrs, "non-existent", &stringVal)
 	c.Check(stringVal, check.Equals, "")
-	c.Check(err, check.ErrorMatches, `snap "snap0" does not have attribute "non-existent" for interface "iface0"`)
+	c.Check(err, check.ErrorMatches, `sdk "sdk0" does not have attribute "non-existent" for interface "iface0"`)
 	c.Check(errors.Is(err, sdk.AttributeNotFoundError{}), check.Equals, true)
 }
 
@@ -374,7 +374,7 @@ func (s *connSuite) TestGetAttributeHappy(c *check.C) {
 		"attr1": 42,
 	}
 	var intVal int
-	err := interfaces.GetAttribute("snap0", "iface0", staticAttrs, dynamicAttrs, "attr1", &intVal)
+	err := interfaces.GetAttribute("sdk0", "iface0", staticAttrs, dynamicAttrs, "attr1", &intVal)
 	c.Check(err, check.IsNil)
 	c.Check(intVal, check.Equals, 42)
 }

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -42,9 +42,7 @@ func (s *connSuite) SetUpTest(c *check.C) {
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 	consumer := sdk.MockInfo(c, `
 name: consumer
-version: 0
-apps:
-    app:
+base: ubuntu@22.04
 plugs:
     plug:
         interface: interface
@@ -55,9 +53,7 @@ plugs:
 	s.plug = consumer.Plugs["plug"]
 	producer := sdk.MockInfo(c, `
 name: producer
-version: 0
-apps:
-    app:
+base: ubuntu@22.04
 slots:
     slot:
         interface: interface

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -1,0 +1,384 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	"errors"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/utils"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/testutil"
+	"gopkg.in/check.v1"
+)
+
+type connSuite struct {
+	testutil.BaseTest
+	plug *sdk.PlugInfo
+	slot *sdk.SlotInfo
+}
+
+var _ = check.Suite(&connSuite{})
+
+func (s *connSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	consumer := sdk.MockInfo(c, `
+name: consumer
+version: 0
+apps:
+    app:
+plugs:
+    plug:
+        interface: interface
+        attr: value
+        complex:
+            c: d
+`, sdk.Setup{})
+	s.plug = consumer.Plugs["plug"]
+	producer := sdk.MockInfo(c, `
+name: producer
+version: 0
+apps:
+    app:
+slots:
+    slot:
+        interface: interface
+        attr: value
+        number: 100
+        complex:
+            a: b
+`, sdk.Setup{})
+	s.slot = producer.Slots["slot"]
+}
+
+func (s *connSuite) TearDownTest(c *check.C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+// Make sure ConnectedPlug,ConnectedSlot, PlugInfo, SlotInfo implement Attrer.
+var _ interfaces.Attrer = (*interfaces.ConnectedPlug)(nil)
+var _ interfaces.Attrer = (*interfaces.ConnectedSlot)(nil)
+var _ interfaces.Attrer = (*sdk.PlugInfo)(nil)
+var _ interfaces.Attrer = (*sdk.SlotInfo)(nil)
+
+func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
+	slot := interfaces.NewConnectedSlot(s.slot, nil, nil)
+	c.Assert(slot, check.NotNil)
+
+	var val string
+	var intVal int
+	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
+
+	attrs := slot.StaticAttrs()
+	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
+		"attr":    "value",
+		"number":  int64(100),
+		"complex": map[string]interface{}{"a": "b"},
+	})
+	slot.StaticAttr("attr", &val)
+	c.Assert(val, check.Equals, "value")
+
+	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(slot.StaticAttr("attr", &intVal), check.ErrorMatches, `snap "producer" has interface "interface" with invalid value type string for "attr" attribute: \*int`)
+	c.Check(slot.StaticAttr("attr", val), check.ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
+
+	// static attributes passed via args take precedence over slot.Attrs
+	slot2 := interfaces.NewConnectedSlot(s.slot, map[string]interface{}{"foo": "bar"}, nil)
+	slot2.StaticAttr("foo", &val)
+	c.Assert(val, check.Equals, "bar")
+}
+
+func (s *connSuite) TestSlotRef(c *check.C) {
+	slot := interfaces.NewConnectedSlot(s.slot, nil, nil)
+	c.Assert(slot, check.NotNil)
+	c.Assert(*slot.Ref(), check.DeepEquals, interfaces.SlotRef{Sdk: "producer", Name: "slot"})
+}
+
+func (s *connSuite) TestPlugRef(c *check.C) {
+	plug := interfaces.NewConnectedPlug(s.plug, nil, nil)
+	c.Assert(plug, check.NotNil)
+	c.Assert(*plug.Ref(), check.DeepEquals, interfaces.PlugRef{Sdk: "consumer", Name: "plug"})
+}
+
+func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
+	plug := interfaces.NewConnectedPlug(s.plug, nil, nil)
+	c.Assert(plug, check.NotNil)
+
+	var val string
+	var intVal int
+	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
+
+	attrs := plug.StaticAttrs()
+	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
+		"attr":    "value",
+		"complex": map[string]interface{}{"c": "d"},
+	})
+	plug.StaticAttr("attr", &val)
+	c.Assert(val, check.Equals, "value")
+
+	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(plug.StaticAttr("attr", &intVal), check.ErrorMatches, `snap "consumer" has interface "interface" with invalid value type string for "attr" attribute: \*int`)
+	c.Check(plug.StaticAttr("attr", val), check.ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
+
+	// static attributes passed via args take precedence over plug.Attrs
+	plug2 := interfaces.NewConnectedPlug(s.plug, map[string]interface{}{"foo": "bar"}, nil)
+	plug2.StaticAttr("foo", &val)
+	c.Assert(val, check.Equals, "bar")
+}
+
+func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
+	attrs := map[string]interface{}{
+		"foo":    "bar",
+		"number": int(100),
+	}
+	slot := interfaces.NewConnectedSlot(s.slot, nil, attrs)
+	c.Assert(slot, check.NotNil)
+
+	var strVal string
+	var intVal int64
+	var mapVal map[string]interface{}
+
+	c.Assert(slot.Attr("foo", &strVal), check.IsNil)
+	c.Assert(strVal, check.Equals, "bar")
+
+	c.Assert(slot.Attr("attr", &strVal), check.IsNil)
+	c.Assert(strVal, check.Equals, "value")
+
+	c.Assert(slot.Attr("number", &intVal), check.IsNil)
+	c.Assert(intVal, check.Equals, int64(100))
+
+	err := slot.SetAttr("other", map[string]interface{}{"number-two": int(222)})
+	c.Assert(err, check.IsNil)
+	c.Assert(slot.Attr("other", &mapVal), check.IsNil)
+	num := mapVal["number-two"]
+	c.Assert(num, check.Equals, int64(222))
+
+	c.Check(slot.Attr("unknown", &strVal), check.ErrorMatches, `snap "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(slot.Attr("foo", &intVal), check.ErrorMatches, `snap "producer" has interface "interface" with invalid value type string for "foo" attribute: \*int64`)
+	c.Check(slot.Attr("number", intVal), check.ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
+}
+
+func (s *connSuite) TestDottedPathSlot(c *check.C) {
+	attrs := map[string]interface{}{
+		"nested": map[string]interface{}{
+			"foo": "bar",
+		},
+	}
+	var strVal string
+
+	slot := interfaces.NewConnectedSlot(s.slot, nil, attrs)
+	c.Assert(slot, check.NotNil)
+
+	// static attribute complex.a
+	c.Assert(slot.Attr("complex.a", &strVal), check.IsNil)
+	c.Assert(strVal, check.Equals, "b")
+
+	v, ok := slot.Lookup("complex.a")
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v, check.Equals, "b")
+
+	// dynamic attribute nested.foo
+	c.Assert(slot.Attr("nested.foo", &strVal), check.IsNil)
+	c.Assert(strVal, check.Equals, "bar")
+
+	v, ok = slot.Lookup("nested.foo")
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v, check.Equals, "bar")
+
+	_, ok = slot.Lookup("..")
+	c.Assert(ok, check.Equals, false)
+}
+
+func (s *connSuite) TestDottedPathPlug(c *check.C) {
+	attrs := map[string]interface{}{
+		"a": "b",
+		"nested": map[string]interface{}{
+			"foo": "bar",
+		},
+	}
+	var strVal string
+
+	plug := interfaces.NewConnectedPlug(s.plug, nil, attrs)
+	c.Assert(plug, check.NotNil)
+
+	v, ok := plug.Lookup("a")
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v, check.Equals, "b")
+
+	// static attribute complex.c
+	c.Assert(plug.Attr("complex.c", &strVal), check.IsNil)
+	c.Assert(strVal, check.Equals, "d")
+
+	v, ok = plug.Lookup("complex.c")
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v, check.Equals, "d")
+
+	// dynamic attribute nested.foo
+	c.Assert(plug.Attr("nested.foo", &strVal), check.IsNil)
+	c.Assert(strVal, check.Equals, "bar")
+
+	v, ok = plug.Lookup("nested.foo")
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v, check.Equals, "bar")
+
+	_, ok = plug.Lookup("nested.x")
+	c.Assert(ok, check.Equals, false)
+
+	_, ok = plug.Lookup("nested.foo.y")
+	c.Assert(ok, check.Equals, false)
+
+	_, ok = plug.Lookup("..")
+	c.Assert(ok, check.Equals, false)
+}
+
+func (s *connSuite) TestLookupFailure(c *check.C) {
+	attrs := map[string]interface{}{}
+
+	slot := interfaces.NewConnectedSlot(s.slot, nil, attrs)
+	c.Assert(slot, check.NotNil)
+	plug := interfaces.NewConnectedPlug(s.plug, nil, attrs)
+	c.Assert(plug, check.NotNil)
+
+	v, ok := slot.Lookup("a")
+	c.Assert(ok, check.Equals, false)
+	c.Assert(v, check.IsNil)
+
+	v, ok = plug.Lookup("a")
+	c.Assert(ok, check.Equals, false)
+	c.Assert(v, check.IsNil)
+}
+
+func (s *connSuite) TestDynamicPlugAttrs(c *check.C) {
+	attrs := map[string]interface{}{
+		"foo":    "bar",
+		"number": int(100),
+	}
+	plug := interfaces.NewConnectedPlug(s.plug, nil, attrs)
+	c.Assert(plug, check.NotNil)
+
+	var strVal string
+	var intVal int64
+	var mapVal map[string]interface{}
+
+	c.Assert(plug.Attr("foo", &strVal), check.IsNil)
+	c.Assert(strVal, check.Equals, "bar")
+
+	c.Assert(plug.Attr("attr", &strVal), check.IsNil)
+	c.Assert(strVal, check.Equals, "value")
+
+	c.Assert(plug.Attr("number", &intVal), check.IsNil)
+	c.Assert(intVal, check.Equals, int64(100))
+
+	err := plug.SetAttr("other", map[string]interface{}{"number-two": int(222)})
+	c.Assert(err, check.IsNil)
+	c.Assert(plug.Attr("other", &mapVal), check.IsNil)
+	num := mapVal["number-two"]
+	c.Assert(num, check.Equals, int64(222))
+
+	c.Check(plug.Attr("unknown", &strVal), check.ErrorMatches, `snap "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(plug.Attr("foo", &intVal), check.ErrorMatches, `snap "consumer" has interface "interface" with invalid value type string for "foo" attribute: \*int64`)
+	c.Check(plug.Attr("number", intVal), check.ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
+}
+
+func (s *connSuite) TestOverwriteStaticAttrError(c *check.C) {
+	attrs := map[string]interface{}{}
+
+	plug := interfaces.NewConnectedPlug(s.plug, nil, attrs)
+	c.Assert(plug, check.NotNil)
+	slot := interfaces.NewConnectedSlot(s.slot, nil, attrs)
+	c.Assert(slot, check.NotNil)
+
+	err := plug.SetAttr("attr", "overwrite")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the snap details`)
+
+	err = slot.SetAttr("attr", "overwrite")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the snap details`)
+}
+
+func (s *connSuite) TestCopyAttributes(c *check.C) {
+	orig := map[string]interface{}{
+		"a": "A",
+		"b": true,
+		"c": int(100),
+		"d": []interface{}{"x", "y", true},
+		"e": map[string]interface{}{"e1": "E1"},
+	}
+
+	cpy := utils.CopyAttributes(orig)
+	c.Check(cpy, check.DeepEquals, orig)
+
+	cpy["d"].([]interface{})[0] = 999
+	c.Check(orig["d"].([]interface{})[0], check.Equals, "x")
+	cpy["e"].(map[string]interface{})["e1"] = "x"
+	c.Check(orig["e"].(map[string]interface{})["e1"], check.Equals, "E1")
+}
+
+func (s *connSuite) TestNewConnectedPlugExplicitStaticAttrs(c *check.C) {
+	staticAttrs := map[string]interface{}{
+		"baz": "boom",
+	}
+	dynAttrs := map[string]interface{}{
+		"foo": "bar",
+	}
+	plug := interfaces.NewConnectedPlug(s.plug, staticAttrs, dynAttrs)
+	c.Assert(plug, check.NotNil)
+	c.Assert(plug.StaticAttrs(), check.DeepEquals, map[string]interface{}{"baz": "boom"})
+	c.Assert(plug.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"foo": "bar"})
+}
+
+func (s *connSuite) TestNewConnectedSlotExplicitStaticAttrs(c *check.C) {
+	staticAttrs := map[string]interface{}{
+		"baz": "boom",
+	}
+	dynAttrs := map[string]interface{}{
+		"foo": "bar",
+	}
+	slot := interfaces.NewConnectedSlot(s.slot, staticAttrs, dynAttrs)
+	c.Assert(slot, check.NotNil)
+	c.Assert(slot.StaticAttrs(), check.DeepEquals, map[string]interface{}{"baz": "boom"})
+	c.Assert(slot.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"foo": "bar"})
+}
+
+func (s *connSuite) TestGetAttributeUnhappy(c *check.C) {
+	attrs := map[string]interface{}{}
+	var stringVal string
+	err := interfaces.GetAttribute("snap0", "iface0", attrs, attrs, "non-existent", &stringVal)
+	c.Check(stringVal, check.Equals, "")
+	c.Check(err, check.ErrorMatches, `snap "snap0" does not have attribute "non-existent" for interface "iface0"`)
+	c.Check(errors.Is(err, sdk.AttributeNotFoundError{}), check.Equals, true)
+}
+
+func (s *connSuite) TestGetAttributeHappy(c *check.C) {
+	staticAttrs := map[string]interface{}{
+		"attr0": "a string",
+		"attr1": 12,
+	}
+	dynamicAttrs := map[string]interface{}{
+		"attr0": "second string",
+		"attr1": 42,
+	}
+	var intVal int
+	err := interfaces.GetAttribute("snap0", "iface0", staticAttrs, dynamicAttrs, "attr1", &intVal)
+	c.Check(err, check.IsNil)
+	c.Check(intVal, check.Equals, 42)
+}

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -143,7 +143,7 @@ func NewConnRef(plug *sdk.PlugInfo, slot *sdk.SlotInfo) *ConnRef {
 
 // ID returns a string identifying a given connection.
 func (conn *ConnRef) ID() string {
-	return fmt.Sprintf("%s:%s %s:%s", conn.PlugRef.Sdk, conn.PlugRef.Name, conn.SlotRef.Sdk, conn.SlotRef.Name)
+	return fmt.Sprintf("%s:%s:%s %s:%s:%s", conn.PlugRef.Workspace, conn.PlugRef.Sdk, conn.PlugRef.Name, conn.SlotRef.Workspace, conn.SlotRef.Sdk, conn.SlotRef.Name)
 }
 
 // SortsBefore returns true when connection should be sorted before the other
@@ -163,13 +163,16 @@ func ParseConnRef(id string) (*ConnRef, error) {
 	}
 	plugParts := strings.Split(parts[0], ":")
 	slotParts := strings.Split(parts[1], ":")
-	if len(plugParts) != 2 || len(slotParts) != 2 {
+	if len(plugParts) != 3 || len(slotParts) != 3 {
 		return nil, fmt.Errorf("malformed connection identifier: %q", id)
 	}
-	conn.PlugRef.Sdk = plugParts[0]
-	conn.PlugRef.Name = plugParts[1]
-	conn.SlotRef.Sdk = slotParts[0]
-	conn.SlotRef.Name = slotParts[1]
+
+	conn.PlugRef.Workspace = plugParts[0]
+	conn.PlugRef.Sdk = plugParts[1]
+	conn.PlugRef.Name = plugParts[2]
+	conn.SlotRef.Workspace = slotParts[0]
+	conn.SlotRef.Sdk = slotParts[1]
+	conn.SlotRef.Name = slotParts[2]
 	return &conn, nil
 }
 

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -26,7 +26,7 @@ import (
 	"github.com/canonical/workspace/internal/sdk"
 )
 
-// BeforePreparePlug sanitizes a plug with a given snapd interface.
+// BeforePreparePlug sanitizes a plug with a given interface.
 func BeforePreparePlug(iface Interface, plugInfo *sdk.PlugInfo) error {
 	if iface.Name() != plugInfo.Interface {
 		return fmt.Errorf("cannot sanitize plug %q (interface %q) using interface %q",
@@ -65,7 +65,7 @@ type PlugRef struct {
 	Name      string `json:"plug"`
 }
 
-// String returns the "snap:plug" representation of a plug reference.
+// String returns the "sdk:plug" representation of a plug reference.
 func (ref PlugRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Sdk, ref.Name)
 }
@@ -78,7 +78,7 @@ func (ref PlugRef) SortsBefore(other PlugRef) bool {
 	return ref.Name < other.Name
 }
 
-// Sanitize slot with a given snapd interface.
+// Sanitize slot with a given interface.
 func BeforePrepareSlot(iface Interface, slotInfo *sdk.SlotInfo) error {
 	if iface.Name() != slotInfo.Interface {
 		return fmt.Errorf("cannot sanitize slot %q (interface %q) using interface %q",
@@ -98,7 +98,7 @@ type SlotRef struct {
 	Name      string `json:"slot"`
 }
 
-// String returns the "snap:slot" representation of a slot reference.
+// String returns the "sdk:slot" representation of a slot reference.
 func (ref SlotRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Sdk, ref.Name)
 }
@@ -215,15 +215,9 @@ type StaticInfo struct {
 	Summary string `json:"summary,omitempty"`
 	DocURL  string `json:"doc-url,omitempty"`
 
-	// AffectsPlugOnRefresh tells if refreshing of a snap with a slot of this interface
-	// is disruptive for the snap on the plug side (when the interface is connected),
-	// meaning that a refresh of the slot-side affects snap(s) on the plug side
-	// due to e.g. namespace changes which require freezing and thawing of the
-	// running processes. This flag is consulted when computing snaps affected
-	// by refresh for auto-refresh gating with gate-auto-refresh hooks.
-	// TODO: if we change the snap-update-ns logic to avoid the freezeing/thawing
-	// if there are no changes, there are interfaces like appstream-metadata or
-	// system-packages-doc that could get the flag set back to false.
+	// AffectsPlugOnRefresh tells if refreshing of a sdk with a slot of this interface
+	// is disruptive for the sdk on the plug side (when the interface is connected),
+	// meaning that a refresh of the slot-side affects sdk(s) on the plug side
 	AffectsPlugOnRefresh bool `json:"affects-plug-on-refresh,omitempty"`
 
 	// BaseDeclarationPlugs defines an optional extension to the base-declaration assertion relevant for this interface.
@@ -233,7 +227,7 @@ type StaticInfo struct {
 }
 
 // PermanentPlugServiceSnippets will return the set of snippets for the systemd
-// service unit that should be generated for a snap with the specified plug.
+// service unit that should be generated for a sdk with the specified plug.
 // The list returned is not unique, callers must de-duplicate themselves.
 // The plug is provided because the snippet may depend on plug attributes for
 // example. The plug is sanitized before the snippets are returned.

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -1,0 +1,282 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/canonical/workspace/internal/sdk"
+)
+
+// BeforePreparePlug sanitizes a plug with a given snapd interface.
+func BeforePreparePlug(iface Interface, plugInfo *sdk.PlugInfo) error {
+	if iface.Name() != plugInfo.Interface {
+		return fmt.Errorf("cannot sanitize plug %q (interface %q) using interface %q",
+			PlugRef{Sdk: plugInfo.Sdk.Name, Name: plugInfo.Name}, plugInfo.Interface, iface.Name())
+	}
+	var err error
+	if iface, ok := iface.(PlugSanitizer); ok {
+		err = iface.BeforePreparePlug(plugInfo)
+	}
+	return err
+}
+
+func BeforeConnectPlug(iface Interface, plug *ConnectedPlug) error {
+	if iface.Name() != plug.plugInfo.Interface {
+		return fmt.Errorf("cannot sanitize connection for plug %q (interface %q) using interface %q",
+			PlugRef{Sdk: plug.plugInfo.Sdk.Name, Name: plug.plugInfo.Name}, plug.plugInfo.Interface, iface.Name())
+	}
+	var err error
+	if iface, ok := iface.(ConnPlugSanitizer); ok {
+		err = iface.BeforeConnectPlug(plug)
+	}
+	return err
+}
+
+// ByName returns an Interface for the given interface name. Note that in order for
+// this to work properly, the package "interfaces/builtin" must also eventually be
+// imported to populate the full list of interfaces.
+var ByName = func(name string) (iface Interface, err error) {
+	panic("ByName is unset, import interfaces/builtin to initialize this")
+}
+
+// PlugRef is a reference to a plug.
+type PlugRef struct {
+	Workspace string `json:"workspace"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"plug"`
+}
+
+// String returns the "snap:plug" representation of a plug reference.
+func (ref PlugRef) String() string {
+	return fmt.Sprintf("%s:%s", ref.Sdk, ref.Name)
+}
+
+// SortsBefore returns true when plug should be sorted before the other
+func (ref PlugRef) SortsBefore(other PlugRef) bool {
+	if ref.Sdk != other.Sdk {
+		return ref.Sdk < other.Sdk
+	}
+	return ref.Name < other.Name
+}
+
+// Sanitize slot with a given snapd interface.
+func BeforePrepareSlot(iface Interface, slotInfo *sdk.SlotInfo) error {
+	if iface.Name() != slotInfo.Interface {
+		return fmt.Errorf("cannot sanitize slot %q (interface %q) using interface %q",
+			SlotRef{Sdk: slotInfo.Sdk.Name, Name: slotInfo.Name}, slotInfo.Interface, iface.Name())
+	}
+	var err error
+	if iface, ok := iface.(SlotSanitizer); ok {
+		err = iface.BeforePrepareSlot(slotInfo)
+	}
+	return err
+}
+
+// SlotRef is a reference to a slot.
+type SlotRef struct {
+	Workspace string `json:"workspace"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"slot"`
+}
+
+// String returns the "snap:slot" representation of a slot reference.
+func (ref SlotRef) String() string {
+	return fmt.Sprintf("%s:%s", ref.Sdk, ref.Name)
+}
+
+// SortsBefore returns true when slot should be sorted before the other
+func (ref SlotRef) SortsBefore(other SlotRef) bool {
+	if ref.Sdk != other.Sdk {
+		return ref.Sdk < other.Sdk
+	}
+	return ref.Name < other.Name
+}
+
+// Interfaces holds information about a list of plugs, slots and their connections.
+type Interfaces struct {
+	Plugs       []*sdk.PlugInfo
+	Slots       []*sdk.SlotInfo
+	Connections []*ConnRef
+}
+
+// Info holds information about a given interface and its instances.
+type Info struct {
+	Name    string
+	Summary string
+	DocURL  string
+	Plugs   []*sdk.PlugInfo
+	Slots   []*sdk.SlotInfo
+}
+
+// ConnRef holds information about plug and slot reference that form a particular connection.
+type ConnRef struct {
+	PlugRef PlugRef
+	SlotRef SlotRef
+}
+
+// NewConnRef creates a connection reference for given plug and slot
+func NewConnRef(plug *sdk.PlugInfo, slot *sdk.SlotInfo) *ConnRef {
+	return &ConnRef{
+		PlugRef: PlugRef{Sdk: plug.Sdk.Name, Name: plug.Name, Workspace: plug.Sdk.Workspace},
+		SlotRef: SlotRef{Sdk: slot.Sdk.Name, Name: slot.Name, Workspace: slot.Sdk.Workspace},
+	}
+}
+
+// ID returns a string identifying a given connection.
+func (conn *ConnRef) ID() string {
+	return fmt.Sprintf("%s:%s %s:%s", conn.PlugRef.Sdk, conn.PlugRef.Name, conn.SlotRef.Sdk, conn.SlotRef.Name)
+}
+
+// SortsBefore returns true when connection should be sorted before the other
+func (conn *ConnRef) SortsBefore(other *ConnRef) bool {
+	if conn.PlugRef != other.PlugRef {
+		return conn.PlugRef.SortsBefore(other.PlugRef)
+	}
+	return conn.SlotRef.SortsBefore(other.SlotRef)
+}
+
+// ParseConnRef parses an ID string
+func ParseConnRef(id string) (*ConnRef, error) {
+	var conn ConnRef
+	parts := strings.SplitN(id, " ", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("malformed connection identifier: %q", id)
+	}
+	plugParts := strings.Split(parts[0], ":")
+	slotParts := strings.Split(parts[1], ":")
+	if len(plugParts) != 2 || len(slotParts) != 2 {
+		return nil, fmt.Errorf("malformed connection identifier: %q", id)
+	}
+	conn.PlugRef.Sdk = plugParts[0]
+	conn.PlugRef.Name = plugParts[1]
+	conn.SlotRef.Sdk = slotParts[0]
+	conn.SlotRef.Name = slotParts[1]
+	return &conn, nil
+}
+
+// Interface describes a group of interchangeable capabilities with common features.
+// Interfaces act as a contract between system builders, application developers
+// and end users.
+type Interface interface {
+	// Unique and public name of this interface.
+	Name() string
+
+	// AutoConnect returns whether plug and slot should be
+	// implicitly auto-connected assuming there will be an
+	// unambiguous connection candidate and declaration-based checks
+	// allow.
+	AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool
+}
+
+// ConnPlugSanitizer can be implemented by Interfaces that have reasons to sanitize
+// their plugs specifically before a connection is performed.
+type ConnPlugSanitizer interface {
+	BeforeConnectPlug(plug *ConnectedPlug) error
+}
+
+// PlugSanitizer can be implemented by Interfaces that have reasons to sanitize their plugs.
+type PlugSanitizer interface {
+	BeforePreparePlug(plug *sdk.PlugInfo) error
+}
+
+// SlotSanitizer can be implemented by Interfaces that have reasons to sanitize their slots.
+type SlotSanitizer interface {
+	BeforePrepareSlot(slot *sdk.SlotInfo) error
+}
+
+// StaticInfo describes various static-info of a given interface.
+//
+// The Summary must be a one-line string of length suitable for listing views.
+// The DocURL can point to website (e.g. a forum thread) that goes into more
+// depth and documents the interface in detail.
+type StaticInfo struct {
+	Summary string `json:"summary,omitempty"`
+	DocURL  string `json:"doc-url,omitempty"`
+
+	// AffectsPlugOnRefresh tells if refreshing of a snap with a slot of this interface
+	// is disruptive for the snap on the plug side (when the interface is connected),
+	// meaning that a refresh of the slot-side affects snap(s) on the plug side
+	// due to e.g. namespace changes which require freezing and thawing of the
+	// running processes. This flag is consulted when computing snaps affected
+	// by refresh for auto-refresh gating with gate-auto-refresh hooks.
+	// TODO: if we change the snap-update-ns logic to avoid the freezeing/thawing
+	// if there are no changes, there are interfaces like appstream-metadata or
+	// system-packages-doc that could get the flag set back to false.
+	AffectsPlugOnRefresh bool `json:"affects-plug-on-refresh,omitempty"`
+
+	// BaseDeclarationPlugs defines an optional extension to the base-declaration assertion relevant for this interface.
+	BaseDeclarationPlugs string
+	// BaseDeclarationSlots defines an optional extension to the base-declaration assertion relevant for this interface.
+	BaseDeclarationSlots string
+}
+
+// PermanentPlugServiceSnippets will return the set of snippets for the systemd
+// service unit that should be generated for a snap with the specified plug.
+// The list returned is not unique, callers must de-duplicate themselves.
+// The plug is provided because the snippet may depend on plug attributes for
+// example. The plug is sanitized before the snippets are returned.
+func PermanentPlugServiceSnippets(iface Interface, plug *sdk.PlugInfo) (snips []string, err error) {
+	// sanitize the plug first
+	err = BeforePreparePlug(iface, plug)
+	if err != nil {
+		return nil, err
+	}
+
+	type serviceSnippetPlugger interface {
+		ServicePermanentPlug(plug *sdk.PlugInfo) []string
+	}
+	if iface, ok := iface.(serviceSnippetPlugger); ok {
+		snips = iface.ServicePermanentPlug(plug)
+	}
+	return snips, nil
+}
+
+// StaticInfoOf returns the static-info of the given interface.
+func StaticInfoOf(iface Interface) (si StaticInfo) {
+	type metaDataProvider interface {
+		StaticInfo() StaticInfo
+	}
+	if iface, ok := iface.(metaDataProvider); ok {
+		si = iface.StaticInfo()
+	}
+	return si
+}
+
+// Specification describes interactions between backends and interfaces.
+type Specification interface {
+	// AddPermanentSlot records side-effects of having a slot.
+	AddPermanentSlot(iface Interface, slot *sdk.SlotInfo) error
+	// AddPermanentPlug records side-effects of having a plug.
+	AddPermanentPlug(iface Interface, plug *sdk.PlugInfo) error
+	// AddConnectedSlot records side-effects of having a connected slot.
+	AddConnectedSlot(iface Interface, plug *ConnectedPlug, slot *ConnectedSlot) error
+	// AddConnectedPlug records side-effects of having a connected plug.
+	AddConnectedPlug(iface Interface, plug *ConnectedPlug, slot *ConnectedSlot) error
+}
+
+// SecuritySystem is a name of a security system.
+type SecuritySystem string
+
+const (
+	// SecurityPolkit identifies the polkit security system.
+	SecurityLxdDevice SecuritySystem = "lxd-device"
+)

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -277,6 +277,6 @@ type Specification interface {
 type SecuritySystem string
 
 const (
-	// SecurityPolkit identifies the polkit security system.
+	// SecurityLxdDevice creates LXD device configurations (mount, GPU, etc.)
 	SecurityLxdDevice SecuritySystem = "lxd-device"
 )

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -1,0 +1,223 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/builtin"
+	"github.com/canonical/workspace/internal/interfaces/ifacetest"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/testutil"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type CoreSuite struct {
+	testutil.BaseTest
+}
+
+var _ = Suite(&CoreSuite{})
+
+func (s *CoreSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+}
+
+func (s *CoreSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+// PlugRef.String works as expected
+func (s *CoreSuite) TestPlugRefString(c *C) {
+	ref := interfaces.PlugRef{Sdk: "snap", Name: "plug"}
+	c.Check(ref.String(), Equals, "snap:plug")
+	refPtr := &interfaces.PlugRef{Sdk: "snap", Name: "plug"}
+	c.Check(refPtr.String(), Equals, "snap:plug")
+}
+
+// SlotRef.String works as expected
+func (s *CoreSuite) TestSlotRefString(c *C) {
+	ref := interfaces.SlotRef{Sdk: "snap", Name: "slot"}
+	c.Check(ref.String(), Equals, "snap:slot")
+	refPtr := &interfaces.SlotRef{Sdk: "snap", Name: "slot"}
+	c.Check(refPtr.String(), Equals, "snap:slot")
+}
+
+// ConnRef.ID works as expected
+func (s *CoreSuite) TestConnRefID(c *C) {
+	conn := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Sdk: "producer", Name: "slot"},
+	}
+	c.Check(conn.ID(), Equals, "consumer:plug producer:slot")
+}
+
+// ParseConnRef works as expected
+func (s *CoreSuite) TestParseConnRef(c *C) {
+	ref, err := interfaces.ParseConnRef("consumer:plug producer:slot")
+	c.Assert(err, IsNil)
+	c.Check(ref, DeepEquals, &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Sdk: "producer", Name: "slot"},
+	})
+	_, err = interfaces.ParseConnRef("garbage")
+	c.Assert(err, ErrorMatches, `malformed connection identifier: "garbage"`)
+	_, err = interfaces.ParseConnRef("snap:plug:garbage snap:slot")
+	c.Assert(err, ErrorMatches, `malformed connection identifier: ".*"`)
+	_, err = interfaces.ParseConnRef("snap:plug snap:slot:garbage")
+	c.Assert(err, ErrorMatches, `malformed connection identifier: ".*"`)
+}
+
+type simpleIface struct {
+	name string
+}
+
+func (si simpleIface) Name() string                                            { return si.name }
+func (si simpleIface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool { return false }
+
+func (s *CoreSuite) TestByName(c *C) {
+	// setup a mock interface using builtin - this will also trigger init() in
+	// builtin package which set ByName to a real implementation
+	r := builtin.MockInterface(simpleIface{name: "mock-network"})
+	defer r()
+
+	_, err := interfaces.ByName("no-such-interface")
+	c.Assert(err, ErrorMatches, "interface \"no-such-interface\" not found")
+
+	iface, err := interfaces.ByName("mock-network")
+	c.Assert(err, IsNil)
+	c.Assert(iface.Name(), Equals, "mock-network")
+}
+
+type serviceSnippetIface struct {
+	simpleIface
+
+	sanitizerErr error
+
+	snips []string
+}
+
+func (ssi serviceSnippetIface) BeforePreparePlug(plug *sdk.PlugInfo) error {
+	return ssi.sanitizerErr
+}
+
+func (ssi serviceSnippetIface) ServicePermanentPlug(plug *sdk.PlugInfo) []string {
+	return ssi.snips
+}
+
+func (s *CoreSuite) TestPermanentPlugServiceSnippets(c *C) {
+	// setup a mock interface using builtin - this will also trigger init() in
+	// builtin package which set ByName to a real implementation
+	ssi := serviceSnippetIface{
+		simpleIface: simpleIface{name: "mock-service-snippets"},
+		snips:       []string{"foo1", "foo2"},
+	}
+	r := builtin.MockInterface(ssi)
+	defer r()
+
+	iface, err := interfaces.ByName("mock-service-snippets")
+	c.Assert(err, IsNil)
+	c.Assert(iface.Name(), Equals, "mock-service-snippets")
+
+	info := sdk.MockInfo(c, `
+name: sdk
+plugs:
+  plug:
+    interface: mock-service-snippets
+`, sdk.Setup{})
+	plug := info.Plugs["plug"]
+
+	snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
+	c.Assert(err, IsNil)
+	c.Assert(snips, DeepEquals, []string{"foo1", "foo2"})
+}
+
+func (s *CoreSuite) TestPermanentPlugServiceSnippetsSanitizesPlugs(c *C) {
+	// setup a mock interface using builtin - this will also trigger init() in
+	// builtin package which set ByName to a real implementation
+	ssi := serviceSnippetIface{
+		simpleIface:  simpleIface{name: "unclean-service-snippets"},
+		sanitizerErr: fmt.Errorf("cannot sanitize: foo"),
+	}
+	r := builtin.MockInterface(ssi)
+	defer r()
+
+	info := sdk.MockInfo(c, `
+name: sdk
+plugs:
+  plug:
+    interface: unclean-service-snippets
+`, sdk.Setup{})
+	plug := info.Plugs["plug"]
+
+	iface, err := interfaces.ByName("unclean-service-snippets")
+	c.Assert(err, IsNil)
+	c.Assert(iface.Name(), Equals, "unclean-service-snippets")
+
+	_, err = interfaces.PermanentPlugServiceSnippets(iface, plug)
+	c.Assert(err, ErrorMatches, "cannot sanitize: foo")
+}
+
+func (s *CoreSuite) TestSanitizePlug(c *C) {
+	info := sdk.MockInfo(c, `
+name: sdk
+plugs:
+  plug:
+    interface: iface
+`, sdk.Setup{})
+	plug := info.Plugs["plug"]
+	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
+		InterfaceName: "iface",
+	}, plug), IsNil)
+	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
+		InterfaceName:             "iface",
+		BeforePreparePlugCallback: func(plug *sdk.PlugInfo) error { return fmt.Errorf("broken") },
+	}, plug), ErrorMatches, "broken")
+	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
+		InterfaceName: "other",
+	}, plug), ErrorMatches, `cannot sanitize plug "sdk:plug" \(interface "iface"\) using interface "other"`)
+}
+
+func (s *CoreSuite) TestSanitizeSlot(c *C) {
+	info := sdk.MockInfo(c, `
+name: sdk
+slots:
+  slot:
+    interface: iface
+`, sdk.Setup{})
+	slot := info.Slots["slot"]
+	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
+		InterfaceName: "iface",
+	}, slot), IsNil)
+	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
+		InterfaceName:             "iface",
+		BeforePrepareSlotCallback: func(slot *sdk.SlotInfo) error { return fmt.Errorf("broken") },
+	}, slot), ErrorMatches, "broken")
+	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
+		InterfaceName: "other",
+	}, slot), ErrorMatches, `cannot sanitize slot "sdk:slot" \(interface "iface"\) using interface "other"`)
+}

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -70,25 +70,25 @@ func (s *CoreSuite) TestSlotRefString(c *C) {
 // ConnRef.ID works as expected
 func (s *CoreSuite) TestConnRefID(c *C) {
 	conn := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{Sdk: "producer", Name: "slot"},
+		PlugRef: interfaces.PlugRef{Workspace: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Workspace: "ws", Sdk: "producer", Name: "slot"},
 	}
-	c.Check(conn.ID(), Equals, "consumer:plug producer:slot")
+	c.Check(conn.ID(), Equals, "ws:consumer:plug ws:producer:slot")
 }
 
 // ParseConnRef works as expected
 func (s *CoreSuite) TestParseConnRef(c *C) {
-	ref, err := interfaces.ParseConnRef("consumer:plug producer:slot")
+	ref, err := interfaces.ParseConnRef("ws:consumer:plug ws:producer:slot")
 	c.Assert(err, IsNil)
 	c.Check(ref, DeepEquals, &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{Sdk: "producer", Name: "slot"},
+		PlugRef: interfaces.PlugRef{Workspace: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{Workspace: "ws", Sdk: "producer", Name: "slot"},
 	})
 	_, err = interfaces.ParseConnRef("garbage")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: "garbage"`)
-	_, err = interfaces.ParseConnRef("snap:plug:garbage snap:slot")
+	_, err = interfaces.ParseConnRef("ws:plug:garbage ws:slot")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: ".*"`)
-	_, err = interfaces.ParseConnRef("snap:plug snap:slot:garbage")
+	_, err = interfaces.ParseConnRef("ws:plug ws:slot:garbage")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: ".*"`)
 }
 

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -44,7 +44,7 @@ var _ = Suite(&CoreSuite{})
 
 func (s *CoreSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
 }
 
 func (s *CoreSuite) TearDownTest(c *C) {
@@ -53,18 +53,18 @@ func (s *CoreSuite) TearDownTest(c *C) {
 
 // PlugRef.String works as expected
 func (s *CoreSuite) TestPlugRefString(c *C) {
-	ref := interfaces.PlugRef{Sdk: "snap", Name: "plug"}
-	c.Check(ref.String(), Equals, "snap:plug")
-	refPtr := &interfaces.PlugRef{Sdk: "snap", Name: "plug"}
-	c.Check(refPtr.String(), Equals, "snap:plug")
+	ref := interfaces.PlugRef{Sdk: "sdk", Name: "plug"}
+	c.Check(ref.String(), Equals, "sdk:plug")
+	refPtr := &interfaces.PlugRef{Sdk: "sdk", Name: "plug"}
+	c.Check(refPtr.String(), Equals, "sdk:plug")
 }
 
 // SlotRef.String works as expected
 func (s *CoreSuite) TestSlotRefString(c *C) {
-	ref := interfaces.SlotRef{Sdk: "snap", Name: "slot"}
-	c.Check(ref.String(), Equals, "snap:slot")
-	refPtr := &interfaces.SlotRef{Sdk: "snap", Name: "slot"}
-	c.Check(refPtr.String(), Equals, "snap:slot")
+	ref := interfaces.SlotRef{Sdk: "sdk", Name: "slot"}
+	c.Check(ref.String(), Equals, "sdk:slot")
+	refPtr := &interfaces.SlotRef{Sdk: "sdk", Name: "slot"}
+	c.Check(refPtr.String(), Equals, "sdk:slot")
 }
 
 // ConnRef.ID works as expected

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -145,6 +145,7 @@ func (s *CoreSuite) TestPermanentPlugServiceSnippets(c *C) {
 
 	info := sdk.MockInfo(c, `
 name: sdk
+base: ubuntu@22.04
 plugs:
   plug:
     interface: mock-service-snippets
@@ -168,6 +169,7 @@ func (s *CoreSuite) TestPermanentPlugServiceSnippetsSanitizesPlugs(c *C) {
 
 	info := sdk.MockInfo(c, `
 name: sdk
+base: ubuntu@22.04
 plugs:
   plug:
     interface: unclean-service-snippets
@@ -185,6 +187,7 @@ plugs:
 func (s *CoreSuite) TestSanitizePlug(c *C) {
 	info := sdk.MockInfo(c, `
 name: sdk
+base: ubuntu@22.04
 plugs:
   plug:
     interface: iface
@@ -205,6 +208,7 @@ plugs:
 func (s *CoreSuite) TestSanitizeSlot(c *C) {
 	info := sdk.MockInfo(c, `
 name: sdk
+base: ubuntu@22.04
 slots:
   slot:
     interface: iface

--- a/internal/interfaces/device/backend.go
+++ b/internal/interfaces/device/backend.go
@@ -1,0 +1,59 @@
+package device
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/workspacebackend"
+)
+
+// Backend is responsible for maintaining mount files for snap-confine
+type Backend struct {
+	wsbackend workspacebackend.WorkspaceBackend
+}
+
+// Initialize does nothing.
+func (b *Backend) Initialize(backend workspacebackend.WorkspaceBackend) error {
+	b.wsbackend = backend
+	return nil
+}
+
+// Name returns the name of the backend.
+func (b *Backend) Name() interfaces.SecuritySystem {
+	return interfaces.SecurityLxdDevice
+}
+
+// Setup creates mount mount profile files specific to a given snap.
+func (b *Backend) Setup(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+	s, err := repo.SdkSpecification(context, b.Name(), sdkInfo)
+	if err != nil {
+		return fmt.Errorf("cannot obtain device snippets for workspace %q: %s", sdkInfo.Workspace, err)
+	}
+
+	spec := s.(*Specification)
+	for _, dev := range spec.devices {
+		err = b.wsbackend.AddWorkspaceDevice(context, sdkInfo.Workspace, *dev)
+		if err != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+// Remove removes mount configuration files of a given snap.
+//
+// This method should be called after removing a snap.
+func (b *Backend) Remove(sdkName string) error {
+	return nil
+}
+
+// NewSpecification returns a new mount specification.
+func (b *Backend) NewSpecification(user, pid string) interfaces.Specification {
+	return &Specification{
+		devices: make(map[string]*workspacebackend.WorkspaceDevice),
+		user:    user,
+		pid:     pid,
+	}
+}

--- a/internal/interfaces/device/backend.go
+++ b/internal/interfaces/device/backend.go
@@ -13,7 +13,6 @@ type Backend struct {
 	wsbackend workspacebackend.WorkspaceBackend
 }
 
-// Initialize does nothing.
 func (b *Backend) Initialize(backend workspacebackend.WorkspaceBackend) error {
 	b.wsbackend = backend
 	return nil
@@ -24,7 +23,7 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 	return interfaces.SecurityLxdDevice
 }
 
-// Setup creates mount mount profile files specific to a given sdk.
+// Setup creates mount profile specific to a given sdk.
 func (b *Backend) Setup(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(context, b.Name(), sdkInfo)
 	if err != nil {
@@ -41,10 +40,10 @@ func (b *Backend) Setup(context context.Context, sdkInfo *sdk.Info, repo *interf
 	return nil
 }
 
-// Remove removes mount configuration files of a given sdk.
+// Remove removes mount configuration of a given sdk.
 //
 // This method should be called after removing a sdk.
-func (b *Backend) Remove(sdkName string) error {
+func (b *Backend) Remove(context context.Context, workspace, sdkName string) error {
 	return nil
 }
 

--- a/internal/interfaces/device/backend.go
+++ b/internal/interfaces/device/backend.go
@@ -9,7 +9,6 @@ import (
 	"github.com/canonical/workspace/internal/workspacebackend"
 )
 
-// Backend is responsible for maintaining mount files for snap-confine
 type Backend struct {
 	wsbackend workspacebackend.WorkspaceBackend
 }
@@ -25,7 +24,7 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 	return interfaces.SecurityLxdDevice
 }
 
-// Setup creates mount mount profile files specific to a given snap.
+// Setup creates mount mount profile files specific to a given sdk.
 func (b *Backend) Setup(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(context, b.Name(), sdkInfo)
 	if err != nil {
@@ -42,9 +41,9 @@ func (b *Backend) Setup(context context.Context, sdkInfo *sdk.Info, repo *interf
 	return nil
 }
 
-// Remove removes mount configuration files of a given snap.
+// Remove removes mount configuration files of a given sdk.
 //
-// This method should be called after removing a snap.
+// This method should be called after removing a sdk.
 func (b *Backend) Remove(sdkName string) error {
 	return nil
 }

--- a/internal/interfaces/device/spec.go
+++ b/internal/interfaces/device/spec.go
@@ -1,0 +1,61 @@
+package device
+
+import (
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/workspacebackend"
+	"golang.org/x/exp/maps"
+)
+
+type Specification struct {
+	devices map[string]*workspacebackend.WorkspaceDevice
+	user    string
+	pid     string
+}
+
+func (s *Specification) User() string {
+	return s.user
+}
+
+func (s *Specification) ProjectId() string {
+	return s.pid
+}
+
+// AddPermanentSlot records side-effects of having a slot.
+func (s *Specification) AddPermanentSlot(iface interfaces.Interface, slot *sdk.SlotInfo) error {
+	return nil
+}
+
+// AddPermanentPlug records side-effects of having a plug.
+func (s *Specification) AddPermanentPlug(iface interfaces.Interface, plug *sdk.PlugInfo) error {
+	return nil
+}
+
+// AddConnectedSlot records side-effects of having a connected slot.
+func (s *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	return nil
+}
+
+// AddConnectedPlug records side-effects of having a connected plug.
+func (s *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	type definer interface {
+		MountConnectedPlug(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+
+	if iface, ok := iface.(definer); ok {
+		return iface.MountConnectedPlug(s, plug, slot)
+	}
+	return nil
+}
+
+func (s *Specification) DeviceEntries() []*workspacebackend.WorkspaceDevice {
+	return maps.Values(s.devices)
+}
+
+func (s *Specification) AddDeviceEntry(dev *workspacebackend.WorkspaceDevice) error {
+	if s.devices == nil {
+		s.devices = make(map[string]*workspacebackend.WorkspaceDevice)
+	}
+	s.devices[dev.Name] = dev
+	return nil
+}

--- a/internal/interfaces/export_test.go
+++ b/internal/interfaces/export_test.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+type ByConnRef byConnRef
+
+func (c ByConnRef) Len() int           { return byConnRef(c).Len() }
+func (c ByConnRef) Swap(i, j int)      { byConnRef(c).Swap(i, j) }
+func (c ByConnRef) Less(i, j int) bool { return byConnRef(c).Less(i, j) }
+
+type ByPlugSnapAndName byPlugWorkspaceSdkAndName
+
+func (c ByPlugSnapAndName) Len() int           { return byPlugWorkspaceSdkAndName(c).Len() }
+func (c ByPlugSnapAndName) Swap(i, j int)      { byPlugWorkspaceSdkAndName(c).Swap(i, j) }
+func (c ByPlugSnapAndName) Less(i, j int) bool { return byPlugWorkspaceSdkAndName(c).Less(i, j) }
+
+type BySlotSnapAndName bySlotWorkspaceSdkAndName
+
+func (c BySlotSnapAndName) Len() int           { return bySlotWorkspaceSdkAndName(c).Len() }
+func (c BySlotSnapAndName) Swap(i, j int)      { bySlotWorkspaceSdkAndName(c).Swap(i, j) }
+func (c BySlotSnapAndName) Less(i, j int) bool { return bySlotWorkspaceSdkAndName(c).Less(i, j) }
+
+type ByInterfaceName byInterfaceName
+
+func (c ByInterfaceName) Len() int           { return byInterfaceName(c).Len() }
+func (c ByInterfaceName) Swap(i, j int)      { byInterfaceName(c).Swap(i, j) }
+func (c ByInterfaceName) Less(i, j int) bool { return byInterfaceName(c).Less(i, j) }
+
+var (
+	GetAttribute = getAttribute
+)

--- a/internal/interfaces/export_test.go
+++ b/internal/interfaces/export_test.go
@@ -25,17 +25,17 @@ func (c ByConnRef) Len() int           { return byConnRef(c).Len() }
 func (c ByConnRef) Swap(i, j int)      { byConnRef(c).Swap(i, j) }
 func (c ByConnRef) Less(i, j int) bool { return byConnRef(c).Less(i, j) }
 
-type ByPlugSnapAndName byPlugWorkspaceSdkAndName
+type ByPlugSdkAndName byPlugWorkspaceSdkAndName
 
-func (c ByPlugSnapAndName) Len() int           { return byPlugWorkspaceSdkAndName(c).Len() }
-func (c ByPlugSnapAndName) Swap(i, j int)      { byPlugWorkspaceSdkAndName(c).Swap(i, j) }
-func (c ByPlugSnapAndName) Less(i, j int) bool { return byPlugWorkspaceSdkAndName(c).Less(i, j) }
+func (c ByPlugSdkAndName) Len() int           { return byPlugWorkspaceSdkAndName(c).Len() }
+func (c ByPlugSdkAndName) Swap(i, j int)      { byPlugWorkspaceSdkAndName(c).Swap(i, j) }
+func (c ByPlugSdkAndName) Less(i, j int) bool { return byPlugWorkspaceSdkAndName(c).Less(i, j) }
 
-type BySlotSnapAndName bySlotWorkspaceSdkAndName
+type BySlotSdkAndName bySlotWorkspaceSdkAndName
 
-func (c BySlotSnapAndName) Len() int           { return bySlotWorkspaceSdkAndName(c).Len() }
-func (c BySlotSnapAndName) Swap(i, j int)      { bySlotWorkspaceSdkAndName(c).Swap(i, j) }
-func (c BySlotSnapAndName) Less(i, j int) bool { return bySlotWorkspaceSdkAndName(c).Less(i, j) }
+func (c BySlotSdkAndName) Len() int           { return bySlotWorkspaceSdkAndName(c).Len() }
+func (c BySlotSdkAndName) Swap(i, j int)      { bySlotWorkspaceSdkAndName(c).Swap(i, j) }
+func (c BySlotSdkAndName) Less(i, j int) bool { return bySlotWorkspaceSdkAndName(c).Less(i, j) }
 
 type ByInterfaceName byInterfaceName
 

--- a/internal/interfaces/ifacetest/backend.go
+++ b/internal/interfaces/ifacetest/backend.go
@@ -37,15 +37,15 @@ type TestSecurityBackend struct {
 	// SetupCallback is an callback that is optionally called in Setup
 	SetupCallback func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error
 	// RemoveCallback is a callback that is optionally called in Remove
-	RemoveCallback func(snapName string) error
+	RemoveCallback func(sdkName string) error
 	// SandboxFeaturesCallback is a callback that is optionally called in SandboxFeatures
 	SandboxFeaturesCallback func() []string
 }
 
 // TestSetupCall stores details about calls to TestSecurityBackend.Setup
 type TestSetupCall struct {
-	// SnapInfo is a copy of the snapInfo argument to a particular call to Setup
-	SnapInfo *sdk.Info
+	// SdkInfo is a copy of the sdkInfo argument to a particular call to Setup
+	SdkInfo *sdk.Info
 }
 
 // Initialize does nothing.
@@ -60,7 +60,7 @@ func (b *TestSecurityBackend) Name() interfaces.SecuritySystem {
 
 // Setup records information about the call and calls the setup callback if one is defined.
 func (b *TestSecurityBackend) Setup(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
-	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SnapInfo: sdkInfo})
+	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SdkInfo: sdkInfo})
 	if b.SetupCallback == nil {
 		return nil
 	}
@@ -68,12 +68,12 @@ func (b *TestSecurityBackend) Setup(context context.Context, sdkInfo *sdk.Info, 
 }
 
 // Remove records information about the call and calls the remove callback if one is defined
-func (b *TestSecurityBackend) Remove(snapName string) error {
-	b.RemoveCalls = append(b.RemoveCalls, snapName)
+func (b *TestSecurityBackend) Remove(sdkName string) error {
+	b.RemoveCalls = append(b.RemoveCalls, sdkName)
 	if b.RemoveCallback == nil {
 		return nil
 	}
-	return b.RemoveCallback(snapName)
+	return b.RemoveCallback(sdkName)
 }
 
 func (b *TestSecurityBackend) NewSpecification(user, pid string) interfaces.Specification {
@@ -100,12 +100,12 @@ type TestSecurityBackendSetupMany struct {
 
 // TestSetupManyCall stores details about calls to TestSecurityBackendMany.SetupMany
 type TestSetupManyCall struct {
-	// SnapInfos is a copy of the snapInfo arguments to a particular call to SetupMany
-	SnapInfos []*sdk.Info
+	// SdkInfos is a copy of the sdkInfo arguments to a particular call to SetupMany
+	SdkInfos []*sdk.Info
 }
 
 func (b *TestSecurityBackendSetupMany) SetupMany(context context.Context, sdkInfo []*sdk.Info, repo *interfaces.Repository) []error {
-	b.SetupManyCalls = append(b.SetupManyCalls, TestSetupManyCall{SnapInfos: sdkInfo})
+	b.SetupManyCalls = append(b.SetupManyCalls, TestSetupManyCall{SdkInfos: sdkInfo})
 	if b.SetupManyCallback == nil {
 		return nil
 	}

--- a/internal/interfaces/ifacetest/backend.go
+++ b/internal/interfaces/ifacetest/backend.go
@@ -68,7 +68,7 @@ func (b *TestSecurityBackend) Setup(context context.Context, sdkInfo *sdk.Info, 
 }
 
 // Remove records information about the call and calls the remove callback if one is defined
-func (b *TestSecurityBackend) Remove(sdkName string) error {
+func (b *TestSecurityBackend) Remove(context context.Context, workspace, sdkName string) error {
 	b.RemoveCalls = append(b.RemoveCalls, sdkName)
 	if b.RemoveCallback == nil {
 		return nil

--- a/internal/interfaces/ifacetest/backend.go
+++ b/internal/interfaces/ifacetest/backend.go
@@ -1,0 +1,113 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacetest
+
+import (
+	"context"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/workspacebackend"
+)
+
+// TestSecurityBackend is a security backend intended for testing.
+type TestSecurityBackend struct {
+	BackendName interfaces.SecuritySystem
+	// SetupCalls stores information about all calls to Setup
+	SetupCalls []TestSetupCall
+	// RemoveCalls stores information about all calls to Remove
+	RemoveCalls []string
+	// SetupCallback is an callback that is optionally called in Setup
+	SetupCallback func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error
+	// RemoveCallback is a callback that is optionally called in Remove
+	RemoveCallback func(snapName string) error
+	// SandboxFeaturesCallback is a callback that is optionally called in SandboxFeatures
+	SandboxFeaturesCallback func() []string
+}
+
+// TestSetupCall stores details about calls to TestSecurityBackend.Setup
+type TestSetupCall struct {
+	// SnapInfo is a copy of the snapInfo argument to a particular call to Setup
+	SnapInfo *sdk.Info
+}
+
+// Initialize does nothing.
+func (b *TestSecurityBackend) Initialize(backend workspacebackend.WorkspaceBackend) error {
+	return nil
+}
+
+// Name returns the name of the security backend.
+func (b *TestSecurityBackend) Name() interfaces.SecuritySystem {
+	return b.BackendName
+}
+
+// Setup records information about the call and calls the setup callback if one is defined.
+func (b *TestSecurityBackend) Setup(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SnapInfo: sdkInfo})
+	if b.SetupCallback == nil {
+		return nil
+	}
+	return b.SetupCallback(context, sdkInfo, repo)
+}
+
+// Remove records information about the call and calls the remove callback if one is defined
+func (b *TestSecurityBackend) Remove(snapName string) error {
+	b.RemoveCalls = append(b.RemoveCalls, snapName)
+	if b.RemoveCallback == nil {
+		return nil
+	}
+	return b.RemoveCallback(snapName)
+}
+
+func (b *TestSecurityBackend) NewSpecification(user, pid string) interfaces.Specification {
+	return &Specification{user: user, pid: pid}
+}
+
+func (b *TestSecurityBackend) SandboxFeatures() []string {
+	if b.SandboxFeaturesCallback == nil {
+		return nil
+	}
+	return b.SandboxFeaturesCallback()
+}
+
+// TestSecurityBackendSetupMany is a security backend that implements SetupMany on top of TestSecurityBackend.
+type TestSecurityBackendSetupMany struct {
+	TestSecurityBackend
+
+	// SetupManyCalls stores information about all calls to Setup
+	SetupManyCalls []TestSetupManyCall
+
+	// SetupManyCallback is an callback that is optionally called in Setup
+	SetupManyCallback func(context context.Context, sdkInfo []*sdk.Info, repo *interfaces.Repository) []error
+}
+
+// TestSetupManyCall stores details about calls to TestSecurityBackendMany.SetupMany
+type TestSetupManyCall struct {
+	// SnapInfos is a copy of the snapInfo arguments to a particular call to SetupMany
+	SnapInfos []*sdk.Info
+}
+
+func (b *TestSecurityBackendSetupMany) SetupMany(context context.Context, sdkInfo []*sdk.Info, repo *interfaces.Repository) []error {
+	b.SetupManyCalls = append(b.SetupManyCalls, TestSetupManyCall{SnapInfos: sdkInfo})
+	if b.SetupManyCallback == nil {
+		return nil
+	}
+	return b.SetupManyCallback(context, sdkInfo, repo)
+}

--- a/internal/interfaces/ifacetest/spec.go
+++ b/internal/interfaces/ifacetest/spec.go
@@ -1,0 +1,84 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacetest
+
+import (
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/sdk"
+)
+
+// Specification is a specification intended for testing.
+type Specification struct {
+	Snippets []string
+
+	user string
+	pid  string
+}
+
+// AddSnippet appends a snippet to a list stored in the specification.
+func (spec *Specification) AddSnippet(snippet string) {
+	spec.Snippets = append(spec.Snippets, snippet)
+}
+
+// Implementation of methods required by interfaces.Specification
+
+// AddConnectedPlug records test side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	type definer interface {
+		TestConnectedPlug(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.TestConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddConnectedSlot records test side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	type definer interface {
+		TestConnectedSlot(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.TestConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddPermanentPlug records test side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *sdk.PlugInfo) error {
+	type definer interface {
+		TestPermanentPlug(spec *Specification, plug *sdk.PlugInfo) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.TestPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// AddPermanentSlot records test side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *sdk.SlotInfo) error {
+	type definer interface {
+		TestPermanentSlot(spec *Specification, slot *sdk.SlotInfo) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.TestPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/internal/interfaces/ifacetest/spec_test.go
+++ b/internal/interfaces/ifacetest/spec_test.go
@@ -1,0 +1,93 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2015-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacetest_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/ifacetest"
+	"github.com/canonical/workspace/internal/sdk"
+)
+
+type SpecificationSuite struct {
+	iface    *ifacetest.TestInterface
+	spec     *ifacetest.Specification
+	plugInfo *sdk.PlugInfo
+	plug     *interfaces.ConnectedPlug
+	slotInfo *sdk.SlotInfo
+	slot     *interfaces.ConnectedSlot
+}
+
+var _ = Suite(&SpecificationSuite{
+	iface: &ifacetest.TestInterface{
+		InterfaceName: "test",
+		TestConnectedPlugCallback: func(spec *ifacetest.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+			spec.AddSnippet("connected-plug")
+			return nil
+		},
+		TestConnectedSlotCallback: func(spec *ifacetest.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+			spec.AddSnippet("connected-slot")
+			return nil
+		},
+		TestPermanentPlugCallback: func(spec *ifacetest.Specification, plug *sdk.PlugInfo) error {
+			spec.AddSnippet("permanent-plug")
+			return nil
+		},
+		TestPermanentSlotCallback: func(spec *ifacetest.Specification, slot *sdk.SlotInfo) error {
+			spec.AddSnippet("permanent-slot")
+			return nil
+		},
+	},
+	plugInfo: &sdk.PlugInfo{
+		Sdk:       &sdk.Info{Name: "snap"},
+		Name:      "name",
+		Interface: "test",
+	},
+	slotInfo: &sdk.SlotInfo{
+		Sdk:       &sdk.Info{Name: "snap"},
+		Name:      "name",
+		Interface: "test",
+	},
+})
+
+func (s *SpecificationSuite) SetUpTest(c *C) {
+	s.spec = &ifacetest.Specification{}
+	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
+	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil, nil)
+}
+
+// AddSnippet is not broken
+func (s *SpecificationSuite) TestAddSnippet(c *C) {
+	s.spec.AddSnippet("hello")
+	s.spec.AddSnippet("world")
+	c.Assert(s.spec.Snippets, DeepEquals, []string{"hello", "world"})
+}
+
+// The Specification can be used through the interfaces.Specification interface
+func (s *SpecificationSuite) SpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface, s.plugInfo), IsNil)
+	c.Assert(r.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
+	c.Assert(s.spec.Snippets, DeepEquals, []string{
+		"connected-plug", "connected-slot", "permanent-plug", "permanent-slot"})
+}

--- a/internal/interfaces/ifacetest/spec_test.go
+++ b/internal/interfaces/ifacetest/spec_test.go
@@ -20,12 +20,19 @@
 package ifacetest_test
 
 import (
+	"testing"
+
+	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/workspace/internal/interfaces"
 	"github.com/canonical/workspace/internal/interfaces/ifacetest"
 	"github.com/canonical/workspace/internal/sdk"
 )
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
 
 type SpecificationSuite struct {
 	iface    *ifacetest.TestInterface
@@ -57,12 +64,12 @@ var _ = Suite(&SpecificationSuite{
 		},
 	},
 	plugInfo: &sdk.PlugInfo{
-		Sdk:       &sdk.Info{Name: "snap"},
+		Sdk:       &sdk.Info{Name: "sdk"},
 		Name:      "name",
 		Interface: "test",
 	},
 	slotInfo: &sdk.SlotInfo{
-		Sdk:       &sdk.Info{Name: "snap"},
+		Sdk:       &sdk.Info{Name: "sdk"},
 		Name:      "name",
 		Interface: "test",
 	},

--- a/internal/interfaces/ifacetest/spec_test.go
+++ b/internal/interfaces/ifacetest/spec_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"gopkg.in/check.v1"
-	. "gopkg.in/check.v1"
 
 	"github.com/canonical/workspace/internal/interfaces"
 	"github.com/canonical/workspace/internal/interfaces/ifacetest"
@@ -43,7 +42,7 @@ type SpecificationSuite struct {
 	slot     *interfaces.ConnectedSlot
 }
 
-var _ = Suite(&SpecificationSuite{
+var _ = check.Suite(&SpecificationSuite{
 	iface: &ifacetest.TestInterface{
 		InterfaceName: "test",
 		TestConnectedPlugCallback: func(spec *ifacetest.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
@@ -75,26 +74,26 @@ var _ = Suite(&SpecificationSuite{
 	},
 })
 
-func (s *SpecificationSuite) SetUpTest(c *C) {
+func (s *SpecificationSuite) SetUpTest(c *check.C) {
 	s.spec = &ifacetest.Specification{}
 	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil, nil)
 	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil, nil)
 }
 
 // AddSnippet is not broken
-func (s *SpecificationSuite) TestAddSnippet(c *C) {
+func (s *SpecificationSuite) TestAddSnippet(c *check.C) {
 	s.spec.AddSnippet("hello")
 	s.spec.AddSnippet("world")
-	c.Assert(s.spec.Snippets, DeepEquals, []string{"hello", "world"})
+	c.Assert(s.spec.Snippets, check.DeepEquals, []string{"hello", "world"})
 }
 
 // The Specification can be used through the interfaces.Specification interface
-func (s *SpecificationSuite) SpecificationIface(c *C) {
+func (s *SpecificationSuite) SpecificationIface(c *check.C) {
 	var r interfaces.Specification = s.spec
-	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(r.AddPermanentPlug(s.iface, s.plugInfo), IsNil)
-	c.Assert(r.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
-	c.Assert(s.spec.Snippets, DeepEquals, []string{
+	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), check.IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), check.IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface, s.plugInfo), check.IsNil)
+	c.Assert(r.AddPermanentSlot(s.iface, s.slotInfo), check.IsNil)
+	c.Assert(s.spec.Snippets, check.DeepEquals, []string{
 		"connected-plug", "connected-slot", "permanent-plug", "permanent-slot"})
 }

--- a/internal/interfaces/ifacetest/testiface.go
+++ b/internal/interfaces/ifacetest/testiface.go
@@ -39,6 +39,10 @@ type TestInterface struct {
 	TestPermanentSlotCallback func(spec *Specification, slot *sdk.SlotInfo) error
 }
 
+func (t *TestInterface) StaticInfo() interfaces.StaticInfo {
+	return t.InterfaceStaticInfo
+}
+
 func (t *TestInterface) String() string {
 	return t.Name()
 }

--- a/internal/interfaces/ifacetest/testiface.go
+++ b/internal/interfaces/ifacetest/testiface.go
@@ -49,6 +49,9 @@ func (t *TestInterface) Name() string {
 }
 
 func (t *TestInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	if t.AutoConnectCallback != nil {
+		return t.AutoConnectCallback(plug, slot)
+	}
 	return true
 }
 

--- a/internal/interfaces/ifacetest/testiface.go
+++ b/internal/interfaces/ifacetest/testiface.go
@@ -1,0 +1,113 @@
+package ifacetest
+
+import (
+	"context"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/workspacebackend"
+)
+
+func CreateTestContext(username, projectId string) context.Context {
+	ctx := context.WithValue(context.Background(), workspacebackend.ContextUser, username)
+	ctx = context.WithValue(ctx, workspacebackend.ContextProjectId, projectId)
+	return ctx
+}
+
+// TestInterface is a interface for various kind of tests.
+// It is public so that it can be consumed from other packages.
+type TestInterface struct {
+	// InterfaceName is the name of this interface
+	InterfaceName       string
+	InterfaceStaticInfo interfaces.StaticInfo
+
+	// AutoConnectCallback is the callback invoked inside AutoConnect
+	AutoConnectCallback func(*sdk.PlugInfo, *sdk.SlotInfo) bool
+
+	// BeforePreparePlugCallback is the callback invoked inside BeforePreparePlug()
+	BeforePreparePlugCallback func(plug *sdk.PlugInfo) error
+	// BeforePrepareSlotCallback is the callback invoked inside BeforePrepareSlot()
+	BeforePrepareSlotCallback func(slot *sdk.SlotInfo) error
+
+	BeforeConnectPlugCallback func(plug *interfaces.ConnectedPlug) error
+	BeforeConnectSlotCallback func(slot *interfaces.ConnectedSlot) error
+
+	// Support for interacting with the test backend.
+	TestConnectedPlugCallback func(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	TestConnectedSlotCallback func(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	TestPermanentPlugCallback func(spec *Specification, plug *sdk.PlugInfo) error
+	TestPermanentSlotCallback func(spec *Specification, slot *sdk.SlotInfo) error
+}
+
+func (t *TestInterface) String() string {
+	return t.Name()
+}
+
+// Name returns the name of the test interface.
+func (t *TestInterface) Name() string {
+	return t.InterfaceName
+}
+
+func (t *TestInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	return true
+}
+
+// BeforePreparePlug checks and possibly modifies a plug.
+func (t *TestInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
+	if t.BeforePreparePlugCallback != nil {
+		return t.BeforePreparePlugCallback(plug)
+	}
+	return nil
+}
+
+// BeforePrepareSlot checks and possibly modifies a slot.
+func (t *TestInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
+	if t.BeforePrepareSlotCallback != nil {
+		return t.BeforePrepareSlotCallback(slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) BeforeConnectPlug(plug *interfaces.ConnectedPlug) error {
+	if t.BeforeConnectPlugCallback != nil {
+		return t.BeforeConnectPlugCallback(plug)
+	}
+	return nil
+}
+
+func (t *TestInterface) BeforeConnectSlot(slot *interfaces.ConnectedSlot) error {
+	if t.BeforeConnectSlotCallback != nil {
+		return t.BeforeConnectSlotCallback(slot)
+	}
+	return nil
+}
+
+// Support for interacting with the test backend.
+
+func (t *TestInterface) TestConnectedPlug(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	if t.TestConnectedPlugCallback != nil {
+		return t.TestConnectedPlugCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) TestConnectedSlot(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	if t.TestConnectedSlotCallback != nil {
+		return t.TestConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) TestPermanentPlug(spec *Specification, plug *sdk.PlugInfo) error {
+	if t.TestPermanentPlugCallback != nil {
+		return t.TestPermanentPlugCallback(spec, plug)
+	}
+	return nil
+}
+
+func (t *TestInterface) TestPermanentSlot(spec *Specification, slot *sdk.SlotInfo) error {
+	if t.TestPermanentSlotCallback != nil {
+		return t.TestPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}

--- a/internal/interfaces/policy/basedeclaration.go
+++ b/internal/interfaces/policy/basedeclaration.go
@@ -30,9 +30,9 @@ import (
 )
 
 // The headers of the builtin base-declaration describing the default
-// interface policies for all snaps. The base declaration focuses on the slot
+// interface policies for all sdks. The base declaration focuses on the slot
 // side for almost all interfaces. Importantly, items are not merged between
-// the slots and plugs or between the base declaration and snap declaration
+// the slots and plugs or between the base declaration and sdk declaration
 // for a particular type of rule. This means that if you specify an
 // installation rule for both slots and plugs in the base declaration, only
 // the plugs side is used (plugs is preferred over slots).
@@ -50,92 +50,28 @@ import (
 //   slots:
 //     manual-connected-implicit-slot:
 //       allow-installation:
-//         slot-snap-type:
+//         slot-type:
 //           - core                     # implicit slot
 //       deny-auto-connection: true     # force manual connect
 //
 //     auto-connected-implicit-slot:
 //       allow-installation:
-//         slot-snap-type:
+//         slot-type:
 //           - core                     # implicit slot
 //       allow-auto-connection: true    # allow auto-connect
 //
 //     manual-connected-provided-slot:
 //       allow-installation:
-//         slot-snap-type:
-//           - app                      # app provided slot
-//       deny-connection: true          # require allow-connection in snap decl
+//         slot-type:
+//           - sdk                      # sdk provided slot
+//       deny-connection: true          # require allow-connection in sdk decl
 //       deny-auto-connection: true     # force manual connect
 //
 //     auto-connected-provided-slot:
 //       allow-installation:
-//         slot-snap-type:
-//           - app                      # app provided slot
-//       deny-connection: true          # require allow-connection in snap decl
-//
-// App-provided slots use 'deny-connection: true' since slot implementations
-// require privileged access to the system and the snap must be trusted. In
-// this manner a snap declaration is required to override the base declaration
-// to allow connections with the app-provided slot.
-//
-// Slots dealing with hardware typically will specify 'gadget' and 'core' as
-// the slot-snap-type (eg, serial-port). Eg:
-//
-//   slots:
-//     manual-connected-hw-slot:
-//       allow-installation:
-//         slot-snap-type:
-//           - core
-//           - gadget
-//       deny-auto-connection: true
-//
-// So called super-privileged slot implementations should also be disallowed
-// installation on a system and a snap declaration is required to override the
-// base declaration to allow installation (eg, docker). Eg:
-//
-//   slots:
-//     manual-connected-super-privileged-slot:
-//       allow-installation: false
-//       deny-connection: true
-//       deny-auto-connection: true
-//
-// Like super-privileged slot implementation, super-privileged plugs should
-// also be disallowed installation on a system and a snap declaration is
-// required to override the base declaration to allow installation (eg,
-// kernel-module-control). Eg:
-//
-//   plugs:
-//     manual-connected-super-privileged-plug:
-//       allow-installation: false
-//       deny-auto-connection: true
-//   (remember this overrides slot side rules)
-//
-// Some interfaces have policy that is meant to be used with slot
-// implementations and on classic images. Since the slot implementation is
-// privileged, we require a snap declaration to be used for app-provided slot
-// implementations on non-classic systems (eg, network-manager). Eg:
-//
-//   slots:
-//     classic-or-not-slot:
-//       allow-installation:
-//         slot-snap-type:
-//           - app
-//           - core
-//       deny-auto-connection: true
-//       deny-connection:
-//         on-classic: false
-//
-// Some interfaces have policy that is only used with implicit slots on
-// classic and should be autoconnected only there (eg, home). Eg:
-//
-//   slots:
-//     implicit-classic-slot:
-//       allow-installation:
-//         slot-snap-type:
-//           - core
-//     deny-auto-connection:
-//       on-classic: false
-//
+//         slot-type:
+//           - sdk                      # sdk provided slot
+//       deny-connection: true          # require allow-connection in sdk decl
 
 const baseDeclarationHeader = `
 type: base-declaration

--- a/internal/interfaces/policy/basedeclaration.go
+++ b/internal/interfaces/policy/basedeclaration.go
@@ -1,0 +1,190 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package policy
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/canonical/workspace/internal/asserts"
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/builtin"
+)
+
+// The headers of the builtin base-declaration describing the default
+// interface policies for all snaps. The base declaration focuses on the slot
+// side for almost all interfaces. Importantly, items are not merged between
+// the slots and plugs or between the base declaration and snap declaration
+// for a particular type of rule. This means that if you specify an
+// installation rule for both slots and plugs in the base declaration, only
+// the plugs side is used (plugs is preferred over slots).
+//
+// The interfaces listed in the base declaration can be broadly categorized
+// into:
+//
+// - manually connected implicit slots (eg, bluetooth-control)
+// - auto-connected implicit slots (eg, network)
+// - manually connected app-provided slots (eg, bluez)
+// - auto-connected app-provided slots (eg, mir)
+//
+// such that they will follow this pattern:
+//
+//   slots:
+//     manual-connected-implicit-slot:
+//       allow-installation:
+//         slot-snap-type:
+//           - core                     # implicit slot
+//       deny-auto-connection: true     # force manual connect
+//
+//     auto-connected-implicit-slot:
+//       allow-installation:
+//         slot-snap-type:
+//           - core                     # implicit slot
+//       allow-auto-connection: true    # allow auto-connect
+//
+//     manual-connected-provided-slot:
+//       allow-installation:
+//         slot-snap-type:
+//           - app                      # app provided slot
+//       deny-connection: true          # require allow-connection in snap decl
+//       deny-auto-connection: true     # force manual connect
+//
+//     auto-connected-provided-slot:
+//       allow-installation:
+//         slot-snap-type:
+//           - app                      # app provided slot
+//       deny-connection: true          # require allow-connection in snap decl
+//
+// App-provided slots use 'deny-connection: true' since slot implementations
+// require privileged access to the system and the snap must be trusted. In
+// this manner a snap declaration is required to override the base declaration
+// to allow connections with the app-provided slot.
+//
+// Slots dealing with hardware typically will specify 'gadget' and 'core' as
+// the slot-snap-type (eg, serial-port). Eg:
+//
+//   slots:
+//     manual-connected-hw-slot:
+//       allow-installation:
+//         slot-snap-type:
+//           - core
+//           - gadget
+//       deny-auto-connection: true
+//
+// So called super-privileged slot implementations should also be disallowed
+// installation on a system and a snap declaration is required to override the
+// base declaration to allow installation (eg, docker). Eg:
+//
+//   slots:
+//     manual-connected-super-privileged-slot:
+//       allow-installation: false
+//       deny-connection: true
+//       deny-auto-connection: true
+//
+// Like super-privileged slot implementation, super-privileged plugs should
+// also be disallowed installation on a system and a snap declaration is
+// required to override the base declaration to allow installation (eg,
+// kernel-module-control). Eg:
+//
+//   plugs:
+//     manual-connected-super-privileged-plug:
+//       allow-installation: false
+//       deny-auto-connection: true
+//   (remember this overrides slot side rules)
+//
+// Some interfaces have policy that is meant to be used with slot
+// implementations and on classic images. Since the slot implementation is
+// privileged, we require a snap declaration to be used for app-provided slot
+// implementations on non-classic systems (eg, network-manager). Eg:
+//
+//   slots:
+//     classic-or-not-slot:
+//       allow-installation:
+//         slot-snap-type:
+//           - app
+//           - core
+//       deny-auto-connection: true
+//       deny-connection:
+//         on-classic: false
+//
+// Some interfaces have policy that is only used with implicit slots on
+// classic and should be autoconnected only there (eg, home). Eg:
+//
+//   slots:
+//     implicit-classic-slot:
+//       allow-installation:
+//         slot-snap-type:
+//           - core
+//     deny-auto-connection:
+//       on-classic: false
+//
+
+const baseDeclarationHeader = `
+type: base-declaration
+authority-id: canonical
+series: 1
+revision: 0
+`
+
+const baseDeclarationPlugs = `
+plugs:
+`
+
+const baseDeclarationSlots = `
+slots:
+`
+
+func trimTrailingNewline(s string) string {
+	return strings.TrimRight(s, "\n")
+}
+
+func composeBaseDeclaration(ifaces []interfaces.Interface) ([]byte, error) {
+	var buf bytes.Buffer
+	// Trim newlines at the end of the string. All the elements may have
+	// spurious trailing newlines. All elements start with a leading newline.
+	// We don't want any blanks as that would no longer parse.
+	if _, err := buf.WriteString(trimTrailingNewline(baseDeclarationHeader)); err != nil {
+		return nil, err
+	}
+	if _, err := buf.WriteString(trimTrailingNewline(baseDeclarationSlots)); err != nil {
+		return nil, err
+	}
+	for _, iface := range ifaces {
+		slotPolicy := interfaces.StaticInfoOf(iface).BaseDeclarationSlots
+		if _, err := buf.WriteString(trimTrailingNewline(slotPolicy)); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := buf.WriteRune('\n'); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func init() {
+	decl, err := composeBaseDeclaration(builtin.Interfaces())
+	if err != nil {
+		panic(fmt.Sprintf("cannot compose base-declaration: %v", err))
+	}
+	if err := asserts.InitBuiltinBaseDeclaration(decl); err != nil {
+		panic(fmt.Sprintf("cannot initialize the builtin base-declaration: %v", err))
+	}
+}

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -1,0 +1,173 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package policy_test
+
+import (
+	"fmt"
+	"testing"
+
+	"gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/asserts"
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/builtin"
+	"github.com/canonical/workspace/internal/interfaces/policy"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/testutil"
+)
+
+type baseDeclSuite struct {
+	baseDecl        *asserts.BaseDeclaration
+	restoreSanitize func()
+}
+
+var _ = Suite(&baseDeclSuite{})
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+func (s *baseDeclSuite) SetUpSuite(c *C) {
+	s.restoreSanitize = sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {})
+	s.baseDecl = asserts.BuiltinBaseDeclaration()
+}
+
+func (s *baseDeclSuite) TearDownSuite(c *C) {
+	s.restoreSanitize()
+}
+
+func (s *baseDeclSuite) connectCand(c *C, iface, slotYaml, plugYaml string) *policy.ConnectCandidate {
+	if slotYaml == "" {
+		slotYaml = fmt.Sprintf(`name: slot-sdk
+base: ubuntu@22.04
+slots:
+  %s:
+`, iface)
+	}
+	if plugYaml == "" {
+		plugYaml = fmt.Sprintf(`name: plug-sdk
+base: ubuntu@22.04
+plugs:
+  %s:
+`, iface)
+	}
+	slotSnap := sdk.MockInfo(c, slotYaml, sdk.Setup{Workspace: "ws"})
+	plugSnap := sdk.MockInfo(c, plugYaml, sdk.Setup{Workspace: "ws"})
+	return &policy.ConnectCandidate{
+		Plug:            interfaces.NewConnectedPlug(plugSnap.Plugs[iface], nil, nil),
+		Slot:            interfaces.NewConnectedSlot(slotSnap.Slots[iface], nil, nil),
+		BaseDeclaration: s.baseDecl,
+	}
+}
+
+func (s *baseDeclSuite) installSlotCand(c *C, iface string, snapType sdk.Type, yaml string) *policy.InstallCandidate {
+	if yaml == "" {
+		yaml = fmt.Sprintf(`name: install-slot-sdk
+base: ubuntu@22.04
+type: %s
+slots:
+  %s:
+`, snapType, iface)
+	}
+	snap := sdk.MockInfo(c, yaml, sdk.Setup{Workspace: "ws"})
+	return &policy.InstallCandidate{
+		Sdk:             snap,
+		BaseDeclaration: s.baseDecl,
+	}
+}
+
+func (s *baseDeclSuite) installPlugCand(c *C, iface string, sdkType sdk.Type, yaml string) *policy.InstallCandidate {
+	if yaml == "" {
+		yaml = fmt.Sprintf(`name: install-plug-sdk
+base: ubuntu@22.04
+type: %s
+plugs:
+  %s:
+`, sdkType, iface)
+	}
+	snap := sdk.MockInfo(c, yaml, sdk.Setup{Workspace: "ws"})
+	return &policy.InstallCandidate{
+		Sdk:             snap,
+		BaseDeclaration: s.baseDecl,
+	}
+}
+
+func (s *baseDeclSuite) TestContentAutoConnection(c *C) {
+	slotYaml := fmt.Sprintf(`name: slot-sdk
+base: ubuntu@22.04
+slots:
+    %s:
+`, "content")
+
+	cand := s.connectCand(c, "content", slotYaml, "")
+	arity, err := cand.CheckAutoConnect()
+	c.Check(err, check.IsNil)
+	c.Check(arity.SlotsPerPlugAny(), check.Equals, false)
+}
+
+func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *C) {
+	all := builtin.Interfaces()
+
+	for _, iface := range all {
+		c.Check(iface.AutoConnect(nil, nil), Equals, true)
+	}
+}
+
+var (
+	slotInstallation = map[string][]string{
+		// other
+		"content": {"core"},
+	}
+	sdkTypeMap = map[string]sdk.Type{
+		"core": sdk.Core,
+		"sdk":  sdk.Sdk,
+	}
+)
+
+func (s *baseDeclSuite) TestContentSlotInstallation(c *C) {
+	// test content specially
+	ic := s.installSlotCand(c, "content", sdk.Sdk, ``)
+	err := ic.Check()
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, ErrorMatches, "installation not allowed by \"content\" slot rule of interface \"content\"")
+
+	ic = s.installSlotCand(c, "content", sdk.Core, ``)
+	err = ic.Check()
+	c.Assert(err, IsNil)
+}
+
+func (s *baseDeclSuite) TestComposeBaseDeclaration(c *C) {
+	decl, err := policy.ComposeBaseDeclaration(nil)
+	c.Assert(err, IsNil)
+	c.Assert(string(decl), testutil.Contains, `
+type: base-declaration
+authority-id: canonical
+series: 1
+revision: 0
+`)
+}
+
+func (s *baseDeclSuite) TestDoesNotPanic(c *C) {
+	// In case there are any issues in the actual interfaces we'd get a panic
+	// on snapd startup. This test prevents this from happing unnoticed.
+	_, err := policy.ComposeBaseDeclaration(builtin.Interfaces())
+	c.Assert(err, IsNil)
+}

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -131,17 +131,6 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *C) {
 	}
 }
 
-var (
-	slotInstallation = map[string][]string{
-		// other
-		"content": {"core"},
-	}
-	sdkTypeMap = map[string]sdk.Type{
-		"core": sdk.Core,
-		"sdk":  sdk.Sdk,
-	}
-)
-
 func (s *baseDeclSuite) TestContentSlotInstallation(c *C) {
 	// test content specially
 	ic := s.installSlotCand(c, "content", sdk.Sdk, ``)

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -46,7 +46,7 @@ func Test(t *testing.T) {
 }
 
 func (s *baseDeclSuite) SetUpSuite(c *C) {
-	s.restoreSanitize = sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {})
+	s.restoreSanitize = sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})
 	s.baseDecl = asserts.BuiltinBaseDeclaration()
 }
 
@@ -69,27 +69,27 @@ plugs:
   %s:
 `, iface)
 	}
-	slotSnap := sdk.MockInfo(c, slotYaml, sdk.Setup{Workspace: "ws"})
-	plugSnap := sdk.MockInfo(c, plugYaml, sdk.Setup{Workspace: "ws"})
+	slotSdk := sdk.MockInfo(c, slotYaml, sdk.Setup{Workspace: "ws"})
+	plugSdk := sdk.MockInfo(c, plugYaml, sdk.Setup{Workspace: "ws"})
 	return &policy.ConnectCandidate{
-		Plug:            interfaces.NewConnectedPlug(plugSnap.Plugs[iface], nil, nil),
-		Slot:            interfaces.NewConnectedSlot(slotSnap.Slots[iface], nil, nil),
+		Plug:            interfaces.NewConnectedPlug(plugSdk.Plugs[iface], nil, nil),
+		Slot:            interfaces.NewConnectedSlot(slotSdk.Slots[iface], nil, nil),
 		BaseDeclaration: s.baseDecl,
 	}
 }
 
-func (s *baseDeclSuite) installSlotCand(c *C, iface string, snapType sdk.Type, yaml string) *policy.InstallCandidate {
+func (s *baseDeclSuite) installSlotCand(c *C, iface string, sdkType sdk.Type, yaml string) *policy.InstallCandidate {
 	if yaml == "" {
 		yaml = fmt.Sprintf(`name: install-slot-sdk
 base: ubuntu@22.04
 type: %s
 slots:
   %s:
-`, snapType, iface)
+`, sdkType, iface)
 	}
-	snap := sdk.MockInfo(c, yaml, sdk.Setup{Workspace: "ws"})
+	sdk := sdk.MockInfo(c, yaml, sdk.Setup{Workspace: "ws"})
 	return &policy.InstallCandidate{
-		Sdk:             snap,
+		Sdk:             sdk,
 		BaseDeclaration: s.baseDecl,
 	}
 }
@@ -103,9 +103,9 @@ plugs:
   %s:
 `, sdkType, iface)
 	}
-	snap := sdk.MockInfo(c, yaml, sdk.Setup{Workspace: "ws"})
+	sdk := sdk.MockInfo(c, yaml, sdk.Setup{Workspace: "ws"})
 	return &policy.InstallCandidate{
-		Sdk:             snap,
+		Sdk:             sdk,
 		BaseDeclaration: s.baseDecl,
 	}
 }
@@ -156,7 +156,7 @@ revision: 0
 
 func (s *baseDeclSuite) TestDoesNotPanic(c *C) {
 	// In case there are any issues in the actual interfaces we'd get a panic
-	// on snapd startup. This test prevents this from happing unnoticed.
+	// on startup. This test prevents this from happing unnoticed.
 	_, err := policy.ComposeBaseDeclaration(builtin.Interfaces())
 	c.Assert(err, IsNil)
 }

--- a/internal/interfaces/policy/export_test.go
+++ b/internal/interfaces/policy/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package policy
+
+var (
+	ComposeBaseDeclaration = composeBaseDeclaration
+)

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -1,0 +1,88 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package policy
+
+import (
+	"fmt"
+
+	"github.com/canonical/workspace/internal/asserts"
+	"github.com/canonical/workspace/internal/sdk"
+	"golang.org/x/exp/slices"
+)
+
+// check helpers
+
+func checkSlotType(sdkInfo *sdk.Info, types []string) error {
+	if !slices.Contains(types, string(sdkInfo.Type)) {
+		return fmt.Errorf("invalid sdk type %q", sdkInfo.Type)
+	}
+	return nil
+}
+
+func checkSlotInstallationConstraints(ic *InstallCandidate, slot *sdk.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
+	if err := constraints.SlotAttributes.Check(slot, nil); err != nil {
+		return err
+	}
+
+	if err := checkSlotType(slot.Sdk, constraints.SlotTypes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkSlotInstallationAltConstraints(ic *InstallCandidate, slot *sdk.SlotInfo, altConstraints []*asserts.SlotInstallationConstraints) error {
+	var firstErr error
+	// OR of constraints
+	for _, constraints := range altConstraints {
+		err := checkSlotInstallationConstraints(ic, slot, constraints)
+		if err == nil {
+			return nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func checkSlotConnectionAltConstraints(connc *ConnectCandidate, altConstraints []*asserts.SlotConnectionConstraints) (*asserts.SlotConnectionConstraints, error) {
+	var firstErr error
+	// OR of constraints
+	for _, constraints := range altConstraints {
+		err := checkSlotConnectionConstraints1(connc, constraints)
+		if err == nil {
+			return constraints, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return nil, firstErr
+}
+
+func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asserts.SlotConnectionConstraints) error {
+	if err := constraints.PlugAttributes.Check(connc.Plug, connc); err != nil {
+		return err
+	}
+	if err := constraints.SlotAttributes.Check(connc.Slot, connc); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/interfaces/policy/policy.go
+++ b/internal/interfaces/policy/policy.go
@@ -1,0 +1,203 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package policy implements the declaration based policy checks for
+// connecting or permitting installation of snaps based on their slots
+// and plugs.
+package policy
+
+import (
+	"fmt"
+
+	"github.com/canonical/workspace/internal/asserts"
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/sdk"
+)
+
+// InstallCandidate represents a candidate SDK for installation.
+type InstallCandidate struct {
+	Sdk             *sdk.Info
+	BaseDeclaration *asserts.BaseDeclaration
+}
+
+func (ic *InstallCandidate) checkSlotRule(slot *sdk.SlotInfo, rule *asserts.SlotRule) error {
+	if checkSlotInstallationAltConstraints(ic, slot, rule.DenyInstallation) == nil {
+		return fmt.Errorf("installation denied by %q slot rule of interface %q", slot.Name, slot.Interface)
+	}
+	if checkSlotInstallationAltConstraints(ic, slot, rule.AllowInstallation) != nil {
+		return fmt.Errorf("installation not allowed by %q slot rule of interface %q", slot.Name, slot.Interface)
+	}
+	return nil
+}
+
+func (ic *InstallCandidate) checkPlugRule(plug *sdk.PlugInfo, rule *asserts.PlugRule) error {
+	return nil
+}
+
+func (ic *InstallCandidate) checkSlot(slot *sdk.SlotInfo) error {
+	iface := slot.Interface
+	if rule := ic.BaseDeclaration.SlotRule(iface); rule != nil {
+		return ic.checkSlotRule(slot, rule)
+	}
+	return nil
+}
+
+func (ic *InstallCandidate) checkPlug(plug *sdk.PlugInfo) error {
+	iface := plug.Interface
+	if rule := ic.BaseDeclaration.PlugRule(iface); rule != nil {
+		return ic.checkPlugRule(plug, rule)
+	}
+	return nil
+}
+
+// Check checks whether the installation is allowed.
+func (ic *InstallCandidate) Check() error {
+	if ic.BaseDeclaration == nil {
+		return fmt.Errorf("internal error: improperly initialized InstallCandidate")
+	}
+
+	for _, slot := range ic.Sdk.Slots {
+		err := ic.checkSlot(slot)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, plug := range ic.Sdk.Plugs {
+		err := ic.checkPlug(plug)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ConnectCandidate represents a candidate connection.
+type ConnectCandidate struct {
+	Plug            *interfaces.ConnectedPlug
+	Slot            *interfaces.ConnectedSlot
+	BaseDeclaration *asserts.BaseDeclaration
+}
+
+func nestedGet(which string, attrs interfaces.Attrer, path string) (interface{}, error) {
+	val, ok := attrs.Lookup(path)
+	if !ok {
+		return nil, fmt.Errorf("%s attribute %q not found", which, path)
+	}
+	return val, nil
+}
+
+func (connc *ConnectCandidate) PlugAttr(arg string) (interface{}, error) {
+	return nestedGet("plug", connc.Plug, arg)
+}
+
+func (connc *ConnectCandidate) SlotAttr(arg string) (interface{}, error) {
+	return nestedGet("slot", connc.Slot, arg)
+}
+
+func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule, snapRule bool) (interfaces.SideArity, error) {
+	return sideArity{asserts.SideArityConstraint{1}}, nil
+}
+
+func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule, snapRule bool) (interfaces.SideArity, error) {
+	denyConst := rule.DenyConnection
+	allowConst := rule.AllowConnection
+	if kind == "auto-connection" {
+		denyConst = rule.DenyAutoConnection
+		allowConst = rule.AllowAutoConnection
+	}
+	if _, err := checkSlotConnectionAltConstraints(connc, denyConst); err == nil {
+		return nil, fmt.Errorf("%s denied by slot rule of interface %q", kind, connc.Plug.Interface())
+	}
+
+	allowedConstraints, err := checkSlotConnectionAltConstraints(connc, allowConst)
+	if err != nil {
+		return nil, fmt.Errorf("%s not allowed by slot rule of interface %q", kind, connc.Plug.Interface())
+	}
+	return sideArity{allowedConstraints.SlotsPerPlug}, nil
+}
+
+func (connc *ConnectCandidate) check(kind string) (interfaces.SideArity, error) {
+	baseDecl := connc.BaseDeclaration
+	if baseDecl == nil {
+		return nil, fmt.Errorf("internal error: improperly initialized ConnectCandidate")
+	}
+
+	iface := connc.Plug.Interface()
+
+	if connc.Slot.Interface() != iface {
+		return nil, fmt.Errorf("cannot connect mismatched plug interface %q to slot interface %q", iface, connc.Slot.Interface())
+	}
+
+	if rule := baseDecl.PlugRule(iface); rule != nil {
+		return connc.checkPlugRule(kind, rule, false)
+	}
+	if rule := baseDecl.SlotRule(iface); rule != nil {
+		return connc.checkSlotRule(kind, rule, false)
+	}
+	return nil, nil
+}
+
+// Check checks whether the connection is allowed.
+func (connc *ConnectCandidate) Check() (interfaces.SideArity, error) {
+	arity, err := connc.check("connection")
+	return arity, err
+}
+
+// CheckAutoConnect checks whether the connection is allowed to auto-connect.
+func (connc *ConnectCandidate) CheckAutoConnect() (interfaces.SideArity, error) {
+	arity, err := connc.check("auto-connection")
+	if err != nil {
+		return nil, err
+	}
+	return arity, nil
+}
+
+// sideArity carries relevant arity constraints for successful
+// allow-auto-connection rules. It implements policy.SideArity.
+// ATM only slots-per-plug might have an interesting non-default
+// value.
+// See: https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
+type sideArity struct {
+	slotsPerPlug asserts.SideArityConstraint
+}
+
+func (a sideArity) SlotsPerPlugOne() bool {
+	return a.slotsPerPlug.N == 1
+}
+
+func (a sideArity) SlotsPerPlugAny() bool {
+	return a.slotsPerPlug.Any()
+}
+
+// CheckInterfaces checks whether plugs and slots of snap are allowed for installation.
+func CheckInterfaces(sdkInfo *sdk.Info) error {
+	baseDecl := asserts.BuiltinBaseDeclaration()
+	if baseDecl == nil {
+		return fmt.Errorf("internal error: cannot find base declaration")
+	}
+
+	ic := InstallCandidate{
+		Sdk:             sdkInfo,
+		BaseDeclaration: baseDecl,
+	}
+
+	return ic.Check()
+}

--- a/internal/interfaces/policy/policy.go
+++ b/internal/interfaces/policy/policy.go
@@ -18,7 +18,7 @@
  */
 
 // Package policy implements the declaration based policy checks for
-// connecting or permitting installation of snaps based on their slots
+// connecting or permitting installation of sdks based on their slots
 // and plugs.
 package policy
 
@@ -112,11 +112,11 @@ func (connc *ConnectCandidate) SlotAttr(arg string) (interface{}, error) {
 	return nestedGet("slot", connc.Slot, arg)
 }
 
-func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule, snapRule bool) (interfaces.SideArity, error) {
+func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule, sdkRule bool) (interfaces.SideArity, error) {
 	return sideArity{asserts.SideArityConstraint{1}}, nil
 }
 
-func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule, snapRule bool) (interfaces.SideArity, error) {
+func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule, sdkRule bool) (interfaces.SideArity, error) {
 	denyConst := rule.DenyConnection
 	allowConst := rule.AllowConnection
 	if kind == "auto-connection" {
@@ -187,7 +187,7 @@ func (a sideArity) SlotsPerPlugAny() bool {
 	return a.slotsPerPlug.Any()
 }
 
-// CheckInterfaces checks whether plugs and slots of snap are allowed for installation.
+// CheckInterfaces checks whether plugs and slots of sdk are allowed for installation.
 func CheckInterfaces(sdkInfo *sdk.Info) error {
 	baseDecl := asserts.BuiltinBaseDeclaration()
 	if baseDecl == nil {

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -839,12 +839,9 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 	return spec, nil
 }
 
-// AddSnap adds plugs and slots declared by the given snap to the repository.
+// AddSdk adds plugs and slots declared by the given snap to the repository.
 //
-// This function can be used to implement snap install or, when used along with
-// RemoveSnap, snap upgrade.
-//
-// AddSnap doesn't change existing plugs/slots. The caller is responsible for
+// AddSdk doesn't change existing plugs/slots. The caller is responsible for
 // ensuring that the snap is not present in the repository in any way prior to
 // calling this function. If this constraint is violated then no changes are
 // made and an error is returned.

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -1,0 +1,1041 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/workspacebackend"
+)
+
+// Repository stores all known snappy plugs and slots and ifaces.
+type Repository struct {
+	// Protects the internals from concurrent access.
+	m      sync.Mutex
+	ifaces map[string]Interface
+	// Indexed by [workspace-sdk-key][plugName]
+	plugs map[string]map[string]*sdk.PlugInfo
+	slots map[string]map[string]*sdk.SlotInfo
+	// given a slot and a plug, are they connected?
+	slotPlugs map[*sdk.SlotInfo]map[*sdk.PlugInfo]*Connection
+	// given a plug and a slot, are they connected?
+	plugSlots map[*sdk.PlugInfo]map[*sdk.SlotInfo]*Connection
+	backends  []SecurityBackend
+}
+
+// NewRepository creates an empty plug repository.
+func NewRepository() *Repository {
+	repo := &Repository{
+		ifaces:    make(map[string]Interface),
+		plugs:     make(map[string]map[string]*sdk.PlugInfo),
+		slots:     make(map[string]map[string]*sdk.SlotInfo),
+		slotPlugs: make(map[*sdk.SlotInfo]map[*sdk.PlugInfo]*Connection),
+		plugSlots: make(map[*sdk.PlugInfo]map[*sdk.SlotInfo]*Connection),
+	}
+
+	return repo
+}
+
+func plugOrSlotKey(workspace, sdkName string) string {
+	return strings.Join([]string{workspace, sdkName}, "-")
+}
+
+// Interface returns an interface with a given name.
+func (r *Repository) Interface(interfaceName string) Interface {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	return r.ifaces[interfaceName]
+}
+
+// AddInterface adds the provided interface to the repository.
+func (r *Repository) AddInterface(i Interface) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	interfaceName := i.Name()
+	if err := sdk.ValidateInterfaceName(interfaceName); err != nil {
+		return err
+	}
+	if _, ok := r.ifaces[interfaceName]; ok {
+		return fmt.Errorf("cannot add interface: %q, interface name is in use", interfaceName)
+	}
+	r.ifaces[interfaceName] = i
+
+	return nil
+}
+
+// AllInterfaces returns all the interfaces added to the repository, ordered by name.
+func (r *Repository) AllInterfaces() []Interface {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	ifaces := make([]Interface, 0, len(r.ifaces))
+	for _, iface := range r.ifaces {
+		ifaces = append(ifaces, iface)
+	}
+	sort.Sort(byInterfaceName(ifaces))
+	return ifaces
+}
+
+// InfoOptions describes options for Info.
+//
+// Names: return just this subset if non-empty.
+// Doc: return documentation.
+// Plugs: return information about plugs.
+// Slots: return information about slots.
+// Connected: only consider interfaces with at least one connection.
+type InfoOptions struct {
+	Names     []string
+	Doc       bool
+	Plugs     bool
+	Slots     bool
+	Connected bool
+}
+
+func (r *Repository) interfaceInfo(iface Interface, opts *InfoOptions) *Info {
+	// NOTE: InfoOptions.Connected is handled by Info
+	si := StaticInfoOf(iface)
+	ifaceName := iface.Name()
+	ii := &Info{
+		Name:    ifaceName,
+		Summary: si.Summary,
+	}
+	if opts != nil && opts.Doc {
+		// Collect documentation URL
+		ii.DocURL = si.DocURL
+	}
+	if opts != nil && opts.Plugs {
+		// Collect all plugs of this interface type.
+		for _, snapName := range sortedSnapNamesWithPlugs(r.plugs) {
+			for _, plugName := range sortedPlugNames(r.plugs[snapName]) {
+				plugInfo := r.plugs[snapName][plugName]
+				if plugInfo.Interface == ifaceName {
+					ii.Plugs = append(ii.Plugs, plugInfo)
+				}
+			}
+		}
+	}
+	if opts != nil && opts.Slots {
+		// Collect all slots of this interface type.
+		for _, snapName := range sortedSnapNamesWithSlots(r.slots) {
+			for _, slotName := range sortedSlotNames(r.slots[snapName]) {
+				slotInfo := r.slots[snapName][slotName]
+				if slotInfo.Interface == ifaceName {
+					ii.Slots = append(ii.Slots, slotInfo)
+				}
+			}
+		}
+	}
+	return ii
+}
+
+// Info returns information about interfaces in the system.
+//
+// If names is empty then all interfaces are considered. Query options decide
+// which data to return but can also skip interfaces without connections. See
+// the documentation of InfoOptions for details.
+func (r *Repository) Info(opts *InfoOptions) []*Info {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	// If necessary compute the set of interfaces with any connections.
+	var connected map[string]bool
+	if opts != nil && opts.Connected {
+		connected = make(map[string]bool)
+		for _, plugMap := range r.slotPlugs {
+			for plug, conn := range plugMap {
+				if conn != nil {
+					connected[plug.Interface] = true
+				}
+			}
+		}
+		for _, slotMap := range r.plugSlots {
+			for slot, conn := range slotMap {
+				if conn != nil {
+					connected[slot.Interface] = true
+				}
+			}
+		}
+	}
+
+	// If weren't asked about specific interfaces then query every interface.
+	var names []string
+	if opts == nil || len(opts.Names) == 0 {
+		for _, iface := range r.ifaces {
+			name := iface.Name()
+			if connected == nil || connected[name] {
+				// Optionally filter out interfaces without connections.
+				names = append(names, name)
+			}
+		}
+	} else {
+		names = make([]string, len(opts.Names))
+		copy(names, opts.Names)
+	}
+	sort.Strings(names)
+
+	// Query each interface we are interested in.
+	infos := make([]*Info, 0, len(names))
+	for _, name := range names {
+		if iface, ok := r.ifaces[name]; ok {
+			if connected == nil || connected[name] {
+				infos = append(infos, r.interfaceInfo(iface, opts))
+			}
+		}
+	}
+	return infos
+}
+
+// AddBackend adds the provided security backend to the repository.
+func (r *Repository) AddBackend(backend SecurityBackend) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	name := backend.Name()
+	for _, other := range r.backends {
+		if other.Name() == name {
+			return fmt.Errorf("cannot add backend %q, security system name is in use", name)
+		}
+	}
+	r.backends = append(r.backends, backend)
+	return nil
+}
+
+// AllPlugs returns all plugs of the given interface.
+// If interfaceName is the empty string, all plugs are returned.
+func (r *Repository) AllPlugs(interfaceName string) []*sdk.PlugInfo {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	var result []*sdk.PlugInfo
+	for _, plugsForSnap := range r.plugs {
+		for _, plug := range plugsForSnap {
+			if interfaceName == "" || plug.Interface == interfaceName {
+				result = append(result, plug)
+			}
+		}
+	}
+	sort.Sort(byPlugWorkspaceSdkAndName(result))
+	return result
+}
+
+// Plugs returns the plugs offered by the named sdk.
+func (r *Repository) Plugs(workspace, sdkName string) []*sdk.PlugInfo {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, sdkName)
+
+	var result []*sdk.PlugInfo
+	for _, plug := range r.plugs[key] {
+		result = append(result, plug)
+	}
+	sort.Sort(byPlugWorkspaceSdkAndName(result))
+	return result
+}
+
+// Plug returns the specified plug from the named sdk.
+func (r *Repository) Plug(workspace, sdkName, plugName string) *sdk.PlugInfo {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, sdkName)
+
+	return r.plugs[key][plugName]
+}
+
+// Connection returns the specified Connection object or an error.
+func (r *Repository) Connection(connRef *ConnRef) (*Connection, error) {
+	plugkey := plugOrSlotKey(connRef.PlugRef.Workspace, connRef.PlugRef.Sdk)
+	slotkey := plugOrSlotKey(connRef.SlotRef.Workspace, connRef.SlotRef.Sdk)
+
+	// Ensure that such plug exists
+	plug := r.plugs[plugkey][connRef.PlugRef.Name]
+	if plug == nil {
+		return nil, &NoPlugOrSlotError{
+			message: fmt.Sprintf("sdk %q has no plug named %q",
+				connRef.PlugRef.Sdk, connRef.PlugRef.Name)}
+	}
+	// Ensure that such slot exists
+	slot := r.slots[slotkey][connRef.SlotRef.Name]
+	if slot == nil {
+		return nil, &NoPlugOrSlotError{
+			message: fmt.Sprintf("sdk %q has no slot named %q",
+				connRef.SlotRef.Sdk, connRef.SlotRef.Name)}
+	}
+	// Ensure that slot and plug are connected
+	conn, ok := r.slotPlugs[slot][plug]
+	if !ok {
+		return nil, &NotConnectedError{
+			message: fmt.Sprintf("no connection from %s:%s to %s:%s",
+				connRef.PlugRef.Sdk, connRef.PlugRef.Name,
+				connRef.SlotRef.Sdk, connRef.SlotRef.Name)}
+	}
+
+	return conn, nil
+}
+
+// AddPlug adds a plug to the repository.
+// Plug names must be valid snap names, as defined by ValidateName.
+// Plug name must be unique within a particular sdk.
+func (r *Repository) AddPlug(plug *sdk.PlugInfo) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(plug.Sdk.Workspace, plug.Sdk.Name)
+
+	// Reject plugs with invalid names
+	if err := sdk.ValidatePlugName(plug.Name); err != nil {
+		return err
+	}
+	i := r.ifaces[plug.Interface]
+	if i == nil {
+		return fmt.Errorf("cannot add plug, interface %q is not known", plug.Interface)
+	}
+	if _, ok := r.plugs[key][plug.Name]; ok {
+		return fmt.Errorf("sdk %q has plugs conflicting on name %q", plug.Sdk.Name, plug.Name)
+	}
+	if _, ok := r.slots[key][plug.Name]; ok {
+		return fmt.Errorf("sdk %q has plug and slot conflicting on name %q", plug.Sdk.Name, plug.Name)
+	}
+	if r.plugs[key] == nil {
+		r.plugs[key] = make(map[string]*sdk.PlugInfo)
+	}
+	r.plugs[key][plug.Name] = plug
+	return nil
+}
+
+// RemovePlug removes the named plug provided by a given sdk.
+// The removed plug must exist and must not be used anywhere.
+func (r *Repository) RemovePlug(workspace, sdkName, plugName string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, sdkName)
+
+	// Ensure that such plug exists
+	plug := r.plugs[key][plugName]
+	if plug == nil {
+		return fmt.Errorf("cannot remove plug %q from snap %q, no such plug", plugName, sdkName)
+	}
+	// Ensure that the plug is not used by any slot
+	if len(r.plugSlots[plug]) > 0 {
+		return fmt.Errorf("cannot remove plug %q from snap %q, it is still connected", plugName, sdkName)
+	}
+	delete(r.plugs[key], plugName)
+	if len(r.plugs[key]) == 0 {
+		delete(r.plugs, sdkName)
+	}
+	return nil
+}
+
+// AllSlots returns all slots of the given interface.
+// If interfaceName is the empty string, all slots are returned.
+func (r *Repository) AllSlots(interfaceName string) []*sdk.SlotInfo {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	var result []*sdk.SlotInfo
+	for _, slotsForSnap := range r.slots {
+		for _, slot := range slotsForSnap {
+			if interfaceName == "" || slot.Interface == interfaceName {
+				result = append(result, slot)
+			}
+		}
+	}
+	sort.Sort(bySlotWorkspaceSdkAndName(result))
+	return result
+}
+
+// Slots returns the slots offered by the named sdk.
+func (r *Repository) Slots(workspace, sdkName string) []*sdk.SlotInfo {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, sdkName)
+
+	var result []*sdk.SlotInfo
+	for _, slot := range r.slots[key] {
+		result = append(result, slot)
+	}
+	sort.Sort(bySlotWorkspaceSdkAndName(result))
+	return result
+}
+
+// Slot returns the specified slot from the named sdk.
+func (r *Repository) Slot(workspace, sdkName, slotName string) *sdk.SlotInfo {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, sdkName)
+
+	return r.slots[key][slotName]
+}
+
+// AddSlot adds a new slot to the repository.
+// Adding a slot with invalid name returns an error.
+// Adding a slot that has the same name and snap name as another slot returns an error.
+func (r *Repository) AddSlot(slot *sdk.SlotInfo) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(slot.Sdk.Workspace, slot.Sdk.Name)
+
+	// Reject slots with invalid names
+	if err := sdk.ValidateSlotName(slot.Name); err != nil {
+		return err
+	}
+	// TODO: ensure that apps are correct
+	i := r.ifaces[slot.Interface]
+	if i == nil {
+		return fmt.Errorf("cannot add slot, interface %q is not known", slot.Interface)
+	}
+	if _, ok := r.slots[key][slot.Name]; ok {
+		return fmt.Errorf("sdk %q has slots conflicting on name %q", slot.Sdk.Name, slot.Name)
+	}
+	if _, ok := r.plugs[key][slot.Name]; ok {
+		return fmt.Errorf("sdk %q has plug and slot conflicting on name %q", slot.Sdk.Name, slot.Name)
+	}
+	if r.slots[key] == nil {
+		r.slots[key] = make(map[string]*sdk.SlotInfo)
+	}
+	r.slots[key][slot.Name] = slot
+	return nil
+}
+
+// RemoveSlot removes a named slot from the given sdk.
+// Removing a slot that doesn't exist returns an error.
+// Removing a slot that is connected to a plug returns an error.
+func (r *Repository) RemoveSlot(workspace, sdkName, slotName string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, sdkName)
+
+	// Ensure that such slot exists
+	slot := r.slots[key][slotName]
+	if slot == nil {
+		return fmt.Errorf("cannot remove slot %q from sdk %q, no such slot", slotName, sdkName)
+	}
+	// Ensure that the slot is not using any plugs
+	if len(r.slotPlugs[slot]) > 0 {
+		return fmt.Errorf("cannot remove slot %q from sdk %q, it is still connected", slotName, sdkName)
+	}
+	delete(r.slots[key], slotName)
+	if len(r.slots[key]) == 0 {
+		delete(r.slots, sdkName)
+	}
+	return nil
+}
+
+// slotValidator can be implemented by Interfaces that need to validate the slot before the security is lifted.
+type slotValidator interface {
+	BeforeConnectSlot(slot *ConnectedSlot) error
+}
+
+// plugValidator can be implemented by Interfaces that need to validate the plug before the security is lifted.
+type plugValidator interface {
+	BeforeConnectPlug(plug *ConnectedPlug) error
+}
+
+type PolicyFunc func(*ConnectedPlug, *ConnectedSlot) (bool, error)
+
+// Connect establishes a connection between a plug and a slot.
+// The plug and the slot must have the same interface.
+// When connections are reloaded policyCheck is null (we don't check policy again).
+func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, slotStaticAttrs, slotDynamicAttrs map[string]interface{}, policyCheck PolicyFunc) (*Connection, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	plugSdkName := ref.PlugRef.Sdk
+	plugName := ref.PlugRef.Name
+	slotSdkName := ref.SlotRef.Sdk
+	slotName := ref.SlotRef.Name
+
+	plugKey := plugOrSlotKey(ref.PlugRef.Workspace, plugSdkName)
+	slotKey := plugOrSlotKey(ref.SlotRef.Workspace, slotSdkName)
+
+	// Ensure that such plug exists
+	plug := r.plugs[plugKey][plugName]
+	if plug == nil {
+		return nil, &NoPlugOrSlotError{
+			message: fmt.Sprintf("cannot connect plug %q from sdk %q: no such plug",
+				plugName, plugSdkName)}
+	}
+	// Ensure that such slot exists
+	slot := r.slots[slotKey][slotName]
+	if slot == nil {
+		return nil, &NoPlugOrSlotError{
+			message: fmt.Sprintf("cannot connect slot %q from sdk %q: no such slot",
+				slotName, slotSdkName)}
+	}
+	// Ensure that plug and slot are compatible
+	if slot.Interface != plug.Interface {
+		return nil, fmt.Errorf(`cannot connect plug "%s:%s" (interface %q) to "%s:%s" (interface %q)`,
+			plugSdkName, plugName, plug.Interface, slotSdkName, slotName, slot.Interface)
+	}
+
+	iface, ok := r.ifaces[plug.Interface]
+	if !ok {
+		return nil, fmt.Errorf("internal error: unknown interface %q", plug.Interface)
+	}
+
+	cplug := NewConnectedPlug(plug, plugStaticAttrs, plugDynamicAttrs)
+	cslot := NewConnectedSlot(slot, slotStaticAttrs, slotDynamicAttrs)
+
+	// policyCheck is null when reloading connections
+	if policyCheck != nil {
+		if i, ok := iface.(plugValidator); ok {
+			if err := i.BeforeConnectPlug(cplug); err != nil {
+				return nil, fmt.Errorf("cannot connect plug %q of sdk %q: %s", plug.Name, plug.Sdk.Name, err)
+			}
+		}
+		if i, ok := iface.(slotValidator); ok {
+			if err := i.BeforeConnectSlot(cslot); err != nil {
+				return nil, fmt.Errorf("cannot connect slot %q of sdk %q: %s", slot.Name, slot.Sdk.Name, err)
+			}
+		}
+
+		// autoconnect policy checker returns false to indicate disallowed auto-connection, but it's not an error.
+		ok, err := policyCheck(cplug, cslot)
+		if !ok || err != nil {
+			return nil, err
+		}
+	}
+
+	// Connect the plug
+	if r.slotPlugs[slot] == nil {
+		r.slotPlugs[slot] = make(map[*sdk.PlugInfo]*Connection)
+	}
+	if r.plugSlots[plug] == nil {
+		r.plugSlots[plug] = make(map[*sdk.SlotInfo]*Connection)
+	}
+
+	conn := &Connection{Plug: cplug, Slot: cslot}
+	r.slotPlugs[slot][plug] = conn
+	r.plugSlots[plug][slot] = conn
+	return conn, nil
+}
+
+// NotConnectedError is returned by Disconnect() if the requested connection does
+// not exist.
+type NotConnectedError struct {
+	message string
+}
+
+func (e *NotConnectedError) Error() string {
+	return e.message
+}
+
+// NoPlugOrSlotError is returned by Disconnect() if either the plug or slot does
+// no exist.
+type NoPlugOrSlotError struct {
+	message string
+}
+
+func (e *NoPlugOrSlotError) Error() string {
+	return e.message
+}
+
+// Disconnect disconnects the named plug from the slot of the given sdk.
+//
+// Disconnect() finds a specific slot and a specific plug and disconnects that
+// plug from that slot. It is an error if plug or slot cannot be found or if
+// the connect does not exist.
+func (r *Repository) Disconnect(plugWorkspace, plugSdkName, plugName, slotWorkspace, slotSdkName, slotName string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	// Validity check
+	if plugSdkName == "" {
+		return fmt.Errorf("cannot disconnect, plug snap name is empty")
+	}
+	if plugName == "" {
+		return fmt.Errorf("cannot disconnect, plug name is empty")
+	}
+	if slotSdkName == "" {
+		return fmt.Errorf("cannot disconnect, slot snap name is empty")
+	}
+	if slotName == "" {
+		return fmt.Errorf("cannot disconnect, slot name is empty")
+	}
+
+	plugKey := plugOrSlotKey(plugWorkspace, plugSdkName)
+	slotKey := plugOrSlotKey(slotWorkspace, slotSdkName)
+
+	// Ensure that such plug exists
+	plug := r.plugs[plugKey][plugName]
+	if plug == nil {
+		return &NoPlugOrSlotError{
+			message: fmt.Sprintf("snap %q has no plug named %q",
+				plugSdkName, plugName),
+		}
+	}
+	// Ensure that such slot exists
+	slot := r.slots[slotKey][slotName]
+	if slot == nil {
+		return &NoPlugOrSlotError{
+			message: fmt.Sprintf("snap %q has no slot named %q",
+				slotSdkName, slotName),
+		}
+	}
+	// Ensure that slot and plug are connected
+	if r.slotPlugs[slot][plug] == nil {
+		return &NotConnectedError{
+			message: fmt.Sprintf("cannot disconnect %s:%s from %s:%s, it is not connected",
+				plugSdkName, plugName, slotSdkName, slotName),
+		}
+	}
+	r.disconnect(plug, slot)
+	return nil
+}
+
+// DisconnectAll disconnects all provided connection references.
+func (r *Repository) DisconnectAll(conns []*ConnRef) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	for _, conn := range conns {
+		plugkey := plugOrSlotKey(conn.PlugRef.Workspace, conn.PlugRef.Sdk)
+		slotkey := plugOrSlotKey(conn.SlotRef.Workspace, conn.SlotRef.Sdk)
+
+		plug := r.plugs[plugkey][conn.PlugRef.Name]
+		slot := r.slots[slotkey][conn.SlotRef.Name]
+		if plug != nil && slot != nil {
+			r.disconnect(plug, slot)
+		}
+	}
+}
+
+// disconnect disconnects a plug from a slot.
+func (r *Repository) disconnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) {
+	delete(r.slotPlugs[slot], plug)
+	if len(r.slotPlugs[slot]) == 0 {
+		delete(r.slotPlugs, slot)
+	}
+	delete(r.plugSlots[plug], slot)
+	if len(r.plugSlots[plug]) == 0 {
+		delete(r.plugSlots, plug)
+	}
+}
+
+// Connected returns references for all connections that are currently
+// established with the provided plug or slot.
+func (r *Repository) Connected(workspace, sdkName, plugOrSlotName string) ([]*ConnRef, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	return r.connected(workspace, sdkName, plugOrSlotName)
+}
+
+func (r *Repository) connected(workspace, sdk, plugOrSlotName string) ([]*ConnRef, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("internal error: cannot obtain workspace name while computing connections")
+	}
+
+	if sdk == "" {
+		return nil, fmt.Errorf("internal error: cannot obtain sdk name while computing connections")
+	}
+
+	key := plugOrSlotKey(workspace, sdk)
+
+	var conns []*ConnRef
+	if plugOrSlotName == "" {
+		return nil, fmt.Errorf("plug or slot name is empty")
+	}
+	// Check if plugOrSlotName actually maps to anything
+	if r.plugs[key][plugOrSlotName] == nil && r.slots[key][plugOrSlotName] == nil {
+		return nil, &NoPlugOrSlotError{
+			message: fmt.Sprintf("snap %q has no plug or slot named %q",
+				sdk, plugOrSlotName)}
+	}
+	// Collect all the relevant connections
+
+	if plug, ok := r.plugs[key][plugOrSlotName]; ok {
+		for slotInfo := range r.plugSlots[plug] {
+			connRef := NewConnRef(plug, slotInfo)
+			conns = append(conns, connRef)
+		}
+	}
+
+	if slot, ok := r.slots[key][plugOrSlotName]; ok {
+		for plugInfo := range r.slotPlugs[slot] {
+			connRef := NewConnRef(plugInfo, slot)
+			conns = append(conns, connRef)
+		}
+	}
+
+	return conns, nil
+}
+
+func (r *Repository) Connections(workspace, sdk string) ([]*ConnRef, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	if workspace == "" {
+		return nil, fmt.Errorf("internal error: cannot obtain workspace name while computing connections")
+	}
+
+	if sdk == "" {
+		return nil, fmt.Errorf("internal error: cannot obtain sdk name while computing connections")
+	}
+
+	key := plugOrSlotKey(workspace, sdk)
+
+	var conns []*ConnRef
+	for _, plugInfo := range r.plugs[key] {
+		for slotInfo := range r.plugSlots[plugInfo] {
+			connRef := NewConnRef(plugInfo, slotInfo)
+			conns = append(conns, connRef)
+		}
+	}
+	for _, slotInfo := range r.slots[key] {
+		for plugInfo := range r.slotPlugs[slotInfo] {
+			// self-connection, ignore here as we got it already in the plugs loop above
+			if plugInfo.Sdk == slotInfo.Sdk {
+				continue
+			}
+			connRef := NewConnRef(plugInfo, slotInfo)
+			conns = append(conns, connRef)
+		}
+	}
+
+	return conns, nil
+}
+
+// Backends returns all the security backends.
+// The order is the same as the order in which they were inserted.
+func (r *Repository) Backends() []SecurityBackend {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	result := make([]SecurityBackend, len(r.backends))
+	copy(result, r.backends)
+	return result
+}
+
+// Interfaces returns object holding a lists of all the plugs and slots and their connections.
+func (r *Repository) Interfaces() *Interfaces {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	ifaces := &Interfaces{}
+
+	// Copy and flatten plugs and slots
+	for _, plugs := range r.plugs {
+		for _, plugInfo := range plugs {
+			ifaces.Plugs = append(ifaces.Plugs, plugInfo)
+		}
+	}
+	for _, slots := range r.slots {
+		for _, slotInfo := range slots {
+			ifaces.Slots = append(ifaces.Slots, slotInfo)
+		}
+	}
+
+	for plug, slots := range r.plugSlots {
+		for slot := range slots {
+			ifaces.Connections = append(ifaces.Connections, NewConnRef(plug, slot))
+		}
+	}
+
+	sort.Sort(byPlugWorkspaceSdkAndName(ifaces.Plugs))
+	sort.Sort(bySlotWorkspaceSdkAndName(ifaces.Slots))
+	sort.Sort(byConnRef(ifaces.Connections))
+	return ifaces
+}
+
+// SnapSpecification returns the specification of a given snap in a given security system.
+func (r *Repository) SdkSpecification(ctx context.Context, securitySystem SecuritySystem, sdkInfo *sdk.Info) (Specification, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	var backend SecurityBackend
+	for _, b := range r.backends {
+		if b.Name() == securitySystem {
+			backend = b
+			break
+		}
+	}
+	if backend == nil {
+		return nil, fmt.Errorf("cannot handle interfaces of %q workspace, security system %q is not known", sdkInfo.Workspace, securitySystem)
+	}
+
+	user, ok := ctx.Value(workspacebackend.ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("internal error: context key %s not found", workspacebackend.ContextUser)
+	}
+
+	projectId, ok := ctx.Value(workspacebackend.ContextProjectId).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key project-id not found")
+	}
+
+	spec := backend.NewSpecification(user, projectId)
+
+	key := plugOrSlotKey(sdkInfo.Workspace, sdkInfo.Name)
+
+	// XXX: If either of the AddConnected{Plug,Slot} methods for a connection
+	// fail resiliently as-in they can never succeed (such as the case where a
+	// bit of policy generated is unable to be used on this system), we may be
+	// stuck never able to modify the policy without restarting snapd. This is
+	// because the (broken) connection is still left inside the in-memory
+	// repository so the next time we try to do any modification to this snap's
+	// plugs or slots, we will try to add that connection again and fail. It is
+	// resolved by restarting snapd since we just store the repository in-memory
+	// and don't persist new connections until after these bits are successful.
+	// We may want to consider removing connections which fail when we try to
+	// generate/add policy for them. This may just be a transitory failure
+	// however, so maybe the right thing to do is try again, but we don't know
+	// if the error is transient so we also don't want to infinitely loop trying
+	// to add a connected plug that will never work.
+
+	// slot side
+	for _, slotInfo := range r.slots[key] {
+		iface := r.ifaces[slotInfo.Interface]
+		if err := spec.AddPermanentSlot(iface, slotInfo); err != nil {
+			return nil, err
+		}
+		for _, conn := range r.slotPlugs[slotInfo] {
+			if err := spec.AddConnectedSlot(iface, conn.Plug, conn.Slot); err != nil {
+				return nil, err
+			}
+		}
+	}
+	// plug side
+	for _, plugInfo := range r.plugs[key] {
+		iface := r.ifaces[plugInfo.Interface]
+		if err := spec.AddPermanentPlug(iface, plugInfo); err != nil {
+			return nil, err
+		}
+		for _, conn := range r.plugSlots[plugInfo] {
+			if err := spec.AddConnectedPlug(iface, conn.Plug, conn.Slot); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return spec, nil
+}
+
+// AddSnap adds plugs and slots declared by the given snap to the repository.
+//
+// This function can be used to implement snap install or, when used along with
+// RemoveSnap, snap upgrade.
+//
+// AddSnap doesn't change existing plugs/slots. The caller is responsible for
+// ensuring that the snap is not present in the repository in any way prior to
+// calling this function. If this constraint is violated then no changes are
+// made and an error is returned.
+//
+// Each added plug/slot is validated according to the corresponding interface.
+// Unknown interfaces and plugs/slots that don't validate are not added.
+// Information about those failures are returned to the caller.
+func (r *Repository) AddSdk(sdkInfo *sdk.Info) error {
+	err := sdk.Validate(sdkInfo)
+	if err != nil {
+		return err
+	}
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	sdkName := plugOrSlotKey(sdkInfo.Workspace, sdkInfo.Name)
+
+	if r.plugs[sdkName] != nil || r.slots[sdkName] != nil {
+		return fmt.Errorf("cannot register interfaces for %q SDK more than once", sdkName)
+	}
+
+	for plugName, plugInfo := range sdkInfo.Plugs {
+		if _, ok := r.ifaces[plugInfo.Interface]; !ok {
+			continue
+		}
+		if r.plugs[sdkName] == nil {
+			r.plugs[sdkName] = make(map[string]*sdk.PlugInfo)
+		}
+		r.plugs[sdkName][plugName] = plugInfo
+	}
+
+	for slotName, slotInfo := range sdkInfo.Slots {
+		if _, ok := r.ifaces[slotInfo.Interface]; !ok {
+			continue
+		}
+		if r.slots[sdkName] == nil {
+			r.slots[sdkName] = make(map[string]*sdk.SlotInfo)
+		}
+		r.slots[sdkName][slotName] = slotInfo
+	}
+	return nil
+}
+
+// RemoveSnap removes all the plugs and slots associated with a given sdk.
+//
+// This function can be used to implement snap removal or, when used along with
+// AddSnap, snap upgrade.
+//
+// RemoveSnap does not remove connections. The caller is responsible for
+// ensuring that connections are broken before calling this method. If this
+// constraint is violated then no changes are made and an error is returned.
+func (r *Repository) RemoveSdk(workspace, sdkName string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, sdkName)
+
+	for plugName, plug := range r.plugs[key] {
+		if len(r.plugSlots[plug]) > 0 {
+			return fmt.Errorf("cannot remove connected plug %s.%s", sdkName, plugName)
+		}
+	}
+	for slotName, slot := range r.slots[key] {
+		if len(r.slotPlugs[slot]) > 0 {
+			return fmt.Errorf("cannot remove connected slot %s.%s", sdkName, slotName)
+		}
+	}
+
+	for _, plug := range r.plugs[key] {
+		delete(r.plugSlots, plug)
+	}
+	delete(r.plugs, key)
+	for _, slot := range r.slots[key] {
+		delete(r.slotPlugs, slot)
+	}
+	delete(r.slots, key)
+
+	return nil
+}
+
+// DisconnectSnap disconnects all the connections to and from a given sdk.
+//
+// The return value is a list of names that were affected.
+func (r *Repository) DisconnectSdk(workspace, sdkName string) ([]string, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, sdkName)
+
+	seen := make(map[*sdk.Info]bool)
+
+	for _, plug := range r.plugs[key] {
+		for slot := range r.plugSlots[plug] {
+			r.disconnect(plug, slot)
+			seen[plug.Sdk] = true
+			seen[slot.Sdk] = true
+		}
+	}
+
+	for _, slot := range r.slots[key] {
+		for plug := range r.slotPlugs[slot] {
+			r.disconnect(plug, slot)
+			seen[plug.Sdk] = true
+			seen[slot.Sdk] = true
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for info := range seen {
+		result = append(result, info.Name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+// SideArity conveys the arity constraints for an allowed auto-connection.
+// ATM only slots-per-plug might have an interesting non-default
+// value.
+// See: https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
+type SideArity interface {
+	SlotsPerPlugAny() bool
+	// TODO: consider PlugsPerSlot*
+}
+
+// AutoConnectCandidateSlots finds and returns viable auto-connection candidates
+// for a given plug.
+func (r *Repository) AutoConnectCandidateSlots(workspace, plugSdkName, plugName string, policyCheck func(*ConnectedPlug, *ConnectedSlot) (bool, error)) []*sdk.SlotInfo {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, plugSdkName)
+
+	plugInfo := r.plugs[key][plugName]
+	if plugInfo == nil {
+		return nil
+	}
+
+	var candidates []*sdk.SlotInfo
+	for _, slotsForSnap := range r.slots {
+		for _, slotInfo := range slotsForSnap {
+			if slotInfo.Interface != plugInfo.Interface {
+				continue
+			}
+			iface := slotInfo.Interface
+
+			// declaration based checks disallow
+			ok, err := policyCheck(NewConnectedPlug(plugInfo, nil, nil), NewConnectedSlot(slotInfo, nil, nil))
+			if !ok || err != nil {
+				continue
+			}
+
+			if r.ifaces[iface].AutoConnect(plugInfo, slotInfo) {
+				candidates = append(candidates, slotInfo)
+			}
+		}
+	}
+	return candidates
+}
+
+// AutoConnectCandidatePlugs finds and returns viable auto-connection candidates
+// for a given slot.
+func (r *Repository) AutoConnectCandidatePlugs(workspace, slotSdkName, slotName string, policyCheck func(*ConnectedPlug, *ConnectedSlot) (bool, error)) []*sdk.PlugInfo {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	key := plugOrSlotKey(workspace, slotSdkName)
+
+	slotInfo := r.slots[key][slotName]
+	if slotInfo == nil {
+		return nil
+	}
+
+	var candidates []*sdk.PlugInfo
+	for _, plugsForSnap := range r.plugs {
+		for _, plugInfo := range plugsForSnap {
+			if slotInfo.Interface != plugInfo.Interface {
+				continue
+			}
+			iface := slotInfo.Interface
+
+			// declaration based checks disallow
+			ok, err := policyCheck(NewConnectedPlug(plugInfo, nil, nil), NewConnectedSlot(slotInfo, nil, nil))
+			if !ok || err != nil {
+				continue
+			}
+
+			if r.ifaces[iface].AutoConnect(plugInfo, slotInfo) {
+				candidates = append(candidates, plugInfo)
+			}
+		}
+	}
+	return candidates
+}

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -30,7 +30,7 @@ import (
 	"github.com/canonical/workspace/internal/workspacebackend"
 )
 
-// Repository stores all known snappy plugs and slots and ifaces.
+// Repository stores all known plugs and slots and ifaces.
 type Repository struct {
 	// Protects the internals from concurrent access.
 	m      sync.Mutex
@@ -129,9 +129,9 @@ func (r *Repository) interfaceInfo(iface Interface, opts *InfoOptions) *Info {
 	}
 	if opts != nil && opts.Plugs {
 		// Collect all plugs of this interface type.
-		for _, snapName := range sortedSnapNamesWithPlugs(r.plugs) {
-			for _, plugName := range sortedPlugNames(r.plugs[snapName]) {
-				plugInfo := r.plugs[snapName][plugName]
+		for _, sdkName := range sortedSdkNamesWithPlugs(r.plugs) {
+			for _, plugName := range sortedPlugNames(r.plugs[sdkName]) {
+				plugInfo := r.plugs[sdkName][plugName]
 				if plugInfo.Interface == ifaceName {
 					ii.Plugs = append(ii.Plugs, plugInfo)
 				}
@@ -140,9 +140,9 @@ func (r *Repository) interfaceInfo(iface Interface, opts *InfoOptions) *Info {
 	}
 	if opts != nil && opts.Slots {
 		// Collect all slots of this interface type.
-		for _, snapName := range sortedSnapNamesWithSlots(r.slots) {
-			for _, slotName := range sortedSlotNames(r.slots[snapName]) {
-				slotInfo := r.slots[snapName][slotName]
+		for _, sdkName := range sortedSdkNamesWithSlots(r.slots) {
+			for _, slotName := range sortedSlotNames(r.slots[sdkName]) {
+				slotInfo := r.slots[sdkName][slotName]
 				if slotInfo.Interface == ifaceName {
 					ii.Slots = append(ii.Slots, slotInfo)
 				}
@@ -231,8 +231,8 @@ func (r *Repository) AllPlugs(interfaceName string) []*sdk.PlugInfo {
 	defer r.m.Unlock()
 
 	var result []*sdk.PlugInfo
-	for _, plugsForSnap := range r.plugs {
-		for _, plug := range plugsForSnap {
+	for _, plugsForSdk := range r.plugs {
+		for _, plug := range plugsForSdk {
 			if interfaceName == "" || plug.Interface == interfaceName {
 				result = append(result, plug)
 			}
@@ -299,7 +299,7 @@ func (r *Repository) Connection(connRef *ConnRef) (*Connection, error) {
 }
 
 // AddPlug adds a plug to the repository.
-// Plug names must be valid snap names, as defined by ValidateName.
+// Plug names must be valid sdk names, as defined by ValidateName.
 // Plug name must be unique within a particular sdk.
 func (r *Repository) AddPlug(plug *sdk.PlugInfo) error {
 	r.m.Lock()
@@ -339,11 +339,11 @@ func (r *Repository) RemovePlug(workspace, sdkName, plugName string) error {
 	// Ensure that such plug exists
 	plug := r.plugs[key][plugName]
 	if plug == nil {
-		return fmt.Errorf("cannot remove plug %q from snap %q, no such plug", plugName, sdkName)
+		return fmt.Errorf("cannot remove plug %q from sdk %q, no such plug", plugName, sdkName)
 	}
 	// Ensure that the plug is not used by any slot
 	if len(r.plugSlots[plug]) > 0 {
-		return fmt.Errorf("cannot remove plug %q from snap %q, it is still connected", plugName, sdkName)
+		return fmt.Errorf("cannot remove plug %q from sdk %q, it is still connected", plugName, sdkName)
 	}
 	delete(r.plugs[key], plugName)
 	if len(r.plugs[key]) == 0 {
@@ -359,8 +359,8 @@ func (r *Repository) AllSlots(interfaceName string) []*sdk.SlotInfo {
 	defer r.m.Unlock()
 
 	var result []*sdk.SlotInfo
-	for _, slotsForSnap := range r.slots {
-		for _, slot := range slotsForSnap {
+	for _, slotsForSdk := range r.slots {
+		for _, slot := range slotsForSdk {
 			if interfaceName == "" || slot.Interface == interfaceName {
 				result = append(result, slot)
 			}
@@ -397,7 +397,7 @@ func (r *Repository) Slot(workspace, sdkName, slotName string) *sdk.SlotInfo {
 
 // AddSlot adds a new slot to the repository.
 // Adding a slot with invalid name returns an error.
-// Adding a slot that has the same name and snap name as another slot returns an error.
+// Adding a slot that has the same name and sdk name as another slot returns an error.
 func (r *Repository) AddSlot(slot *sdk.SlotInfo) error {
 	r.m.Lock()
 	defer r.m.Unlock()
@@ -571,13 +571,13 @@ func (r *Repository) Disconnect(plugWorkspace, plugSdkName, plugName, slotWorksp
 
 	// Validity check
 	if plugSdkName == "" {
-		return fmt.Errorf("cannot disconnect, plug snap name is empty")
+		return fmt.Errorf("cannot disconnect, plug sdk name is empty")
 	}
 	if plugName == "" {
 		return fmt.Errorf("cannot disconnect, plug name is empty")
 	}
 	if slotSdkName == "" {
-		return fmt.Errorf("cannot disconnect, slot snap name is empty")
+		return fmt.Errorf("cannot disconnect, slot sdk name is empty")
 	}
 	if slotName == "" {
 		return fmt.Errorf("cannot disconnect, slot name is empty")
@@ -590,7 +590,7 @@ func (r *Repository) Disconnect(plugWorkspace, plugSdkName, plugName, slotWorksp
 	plug := r.plugs[plugKey][plugName]
 	if plug == nil {
 		return &NoPlugOrSlotError{
-			message: fmt.Sprintf("snap %q has no plug named %q",
+			message: fmt.Sprintf("sdk %q has no plug named %q",
 				plugSdkName, plugName),
 		}
 	}
@@ -598,7 +598,7 @@ func (r *Repository) Disconnect(plugWorkspace, plugSdkName, plugName, slotWorksp
 	slot := r.slots[slotKey][slotName]
 	if slot == nil {
 		return &NoPlugOrSlotError{
-			message: fmt.Sprintf("snap %q has no slot named %q",
+			message: fmt.Sprintf("sdk %q has no slot named %q",
 				slotSdkName, slotName),
 		}
 	}
@@ -669,7 +669,7 @@ func (r *Repository) connected(workspace, sdk, plugOrSlotName string) ([]*ConnRe
 	// Check if plugOrSlotName actually maps to anything
 	if r.plugs[key][plugOrSlotName] == nil && r.slots[key][plugOrSlotName] == nil {
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("snap %q has no plug or slot named %q",
+			message: fmt.Sprintf("sdk %q has no plug or slot named %q",
 				sdk, plugOrSlotName)}
 	}
 	// Collect all the relevant connections
@@ -767,7 +767,7 @@ func (r *Repository) Interfaces() *Interfaces {
 	return ifaces
 }
 
-// SnapSpecification returns the specification of a given snap in a given security system.
+// SdkSpecification returns the specification of a given sdk in a given security system.
 func (r *Repository) SdkSpecification(ctx context.Context, securitySystem SecuritySystem, sdkInfo *sdk.Info) (Specification, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
@@ -800,11 +800,11 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 	// XXX: If either of the AddConnected{Plug,Slot} methods for a connection
 	// fail resiliently as-in they can never succeed (such as the case where a
 	// bit of policy generated is unable to be used on this system), we may be
-	// stuck never able to modify the policy without restarting snapd. This is
+	// stuck never able to modify the policy without restarting daemon. This is
 	// because the (broken) connection is still left inside the in-memory
-	// repository so the next time we try to do any modification to this snap's
+	// repository so the next time we try to do any modification to this sdk's
 	// plugs or slots, we will try to add that connection again and fail. It is
-	// resolved by restarting snapd since we just store the repository in-memory
+	// resolved by restarting daemon since we just store the repository in-memory
 	// and don't persist new connections until after these bits are successful.
 	// We may want to consider removing connections which fail when we try to
 	// generate/add policy for them. This may just be a transitory failure
@@ -839,10 +839,10 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 	return spec, nil
 }
 
-// AddSdk adds plugs and slots declared by the given snap to the repository.
+// AddSdk adds plugs and slots declared by the given sdk to the repository.
 //
 // AddSdk doesn't change existing plugs/slots. The caller is responsible for
-// ensuring that the snap is not present in the repository in any way prior to
+// ensuring that the sdk is not present in the repository in any way prior to
 // calling this function. If this constraint is violated then no changes are
 // made and an error is returned.
 //
@@ -886,12 +886,12 @@ func (r *Repository) AddSdk(sdkInfo *sdk.Info) error {
 	return nil
 }
 
-// RemoveSnap removes all the plugs and slots associated with a given sdk.
+// RemoveSdk removes all the plugs and slots associated with a given sdk.
 //
-// This function can be used to implement snap removal or, when used along with
-// AddSnap, snap upgrade.
+// This function can be used to implement sdk removal or, when used along with
+// AddSdk, sdk upgrade.
 //
-// RemoveSnap does not remove connections. The caller is responsible for
+// RemoveSdk does not remove connections. The caller is responsible for
 // ensuring that connections are broken before calling this method. If this
 // constraint is violated then no changes are made and an error is returned.
 func (r *Repository) RemoveSdk(workspace, sdkName string) error {
@@ -923,7 +923,7 @@ func (r *Repository) RemoveSdk(workspace, sdkName string) error {
 	return nil
 }
 
-// DisconnectSnap disconnects all the connections to and from a given sdk.
+// DisconnectSdk disconnects all the connections to and from a given sdk.
 //
 // The return value is a list of names that were affected.
 func (r *Repository) DisconnectSdk(workspace, sdkName string) ([]string, error) {
@@ -981,8 +981,8 @@ func (r *Repository) AutoConnectCandidateSlots(workspace, plugSdkName, plugName 
 	}
 
 	var candidates []*sdk.SlotInfo
-	for _, slotsForSnap := range r.slots {
-		for _, slotInfo := range slotsForSnap {
+	for _, slotsForSdk := range r.slots {
+		for _, slotInfo := range slotsForSdk {
 			if slotInfo.Interface != plugInfo.Interface {
 				continue
 			}
@@ -1016,8 +1016,8 @@ func (r *Repository) AutoConnectCandidatePlugs(workspace, slotSdkName, slotName 
 	}
 
 	var candidates []*sdk.PlugInfo
-	for _, plugsForSnap := range r.plugs {
-		for _, plugInfo := range plugsForSnap {
+	for _, plugsForSdk := range r.plugs {
+		for _, plugInfo := range plugsForSdk {
 			if slotInfo.Interface != plugInfo.Interface {
 				continue
 			}

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -35,8 +35,9 @@ type Repository struct {
 	// Protects the internals from concurrent access.
 	m      sync.Mutex
 	ifaces map[string]Interface
-	// Indexed by [workspace-sdk-key][plugName]
+	// Indexed by [workspace-sdk][plugName]
 	plugs map[string]map[string]*sdk.PlugInfo
+	// Indexed by [workspace-sdk][plugName]
 	slots map[string]map[string]*sdk.SlotInfo
 	// given a slot and a plug, are they connected?
 	slotPlugs map[*sdk.SlotInfo]map[*sdk.PlugInfo]*Connection
@@ -858,30 +859,30 @@ func (r *Repository) AddSdk(sdkInfo *sdk.Info) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	sdkName := plugOrSlotKey(sdkInfo.Workspace, sdkInfo.Name)
+	key := plugOrSlotKey(sdkInfo.Workspace, sdkInfo.Name)
 
-	if r.plugs[sdkName] != nil || r.slots[sdkName] != nil {
-		return fmt.Errorf("cannot register interfaces for %q SDK more than once", sdkName)
+	if r.plugs[key] != nil || r.slots[key] != nil {
+		return fmt.Errorf("cannot register interfaces for %q SDK more than once", key)
 	}
 
 	for plugName, plugInfo := range sdkInfo.Plugs {
 		if _, ok := r.ifaces[plugInfo.Interface]; !ok {
 			continue
 		}
-		if r.plugs[sdkName] == nil {
-			r.plugs[sdkName] = make(map[string]*sdk.PlugInfo)
+		if r.plugs[key] == nil {
+			r.plugs[key] = make(map[string]*sdk.PlugInfo)
 		}
-		r.plugs[sdkName][plugName] = plugInfo
+		r.plugs[key][plugName] = plugInfo
 	}
 
 	for slotName, slotInfo := range sdkInfo.Slots {
 		if _, ok := r.ifaces[slotInfo.Interface]; !ok {
 			continue
 		}
-		if r.slots[sdkName] == nil {
-			r.slots[sdkName] = make(map[string]*sdk.SlotInfo)
+		if r.slots[key] == nil {
+			r.slots[key] = make(map[string]*sdk.SlotInfo)
 		}
-		r.slots[sdkName][slotName] = slotInfo
+		r.slots[key][slotName] = slotInfo
 	}
 	return nil
 }

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1163,7 +1163,7 @@ plugs:
 	c.Assert(candidatePlugs, HasLen, 2)
 }
 
-// Tests for AddSnap and RemoveSnap
+// Tests for AddSdk and RemoveSnap
 
 type AddRemoveSuite struct {
 	testutil.BaseTest
@@ -1560,4 +1560,98 @@ func (s *RepositorySuite) TestConnectWithStaticAttrs(c *C) {
 	c.Assert(conn.Slot.Name(), Equals, "slot")
 	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, plugAttrs)
 	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, slotAttrs)
+}
+
+func (s *RepositorySuite) TestInfo(c *C) {
+	r := s.emptyRepo
+
+	// Add some test interfaces.
+	i1 := &ifacetest.TestInterface{InterfaceName: "i1", InterfaceStaticInfo: StaticInfo{Summary: "i1 summary", DocURL: "http://example.com/i1"}}
+	i2 := &ifacetest.TestInterface{InterfaceName: "i2", InterfaceStaticInfo: StaticInfo{Summary: "i2 summary", DocURL: "http://example.com/i2"}}
+	i3 := &ifacetest.TestInterface{InterfaceName: "i3", InterfaceStaticInfo: StaticInfo{Summary: "i3 summary", DocURL: "http://example.com/i3"}}
+	c.Assert(r.AddInterface(i1), IsNil)
+	c.Assert(r.AddInterface(i2), IsNil)
+	c.Assert(r.AddInterface(i3), IsNil)
+
+	// Add some test snaps.
+	s1 := sdk.MockInfo(c, `
+name: s1
+base: ubuntu@22.04
+plugs:
+  i1:
+  i2:
+`, sdk.Setup{Workspace: "ws"})
+	c.Assert(r.AddSdk(s1), IsNil)
+
+	s2 := sdk.MockInfo(c, `
+name: s2
+base: ubuntu@22.04
+slots: 
+  i1:
+  i3:
+`, sdk.Setup{Workspace: "ws"})
+	c.Assert(r.AddSdk(s2), IsNil)
+
+	s3 := sdk.MockInfo(c, `
+name: s3
+base: ubuntu@22.04
+type: core
+slots:
+  i2:
+`, sdk.Setup{Workspace: "ws"})
+	c.Assert(r.AddSdk(s3), IsNil)
+	s4 := sdk.MockInfo(c, `
+name: s4
+base: ubuntu@22.04
+plugs:
+  i2:
+`, sdk.Setup{Workspace: "ws"})
+	c.Assert(r.AddSdk(s4), IsNil)
+
+	// Connect a few things for the tests below.
+	_, err := r.Connect(&ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s1", Name: "i1"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	_, err = r.Connect(&ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s1", Name: "i1"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	_, err = r.Connect(&ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s1", Name: "i2"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s3", Name: "i2"}}, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	// Without any names or options we get the summary of all the interfaces.
+	infos := r.Info(nil)
+	c.Assert(infos, DeepEquals, []*Info{
+		{Name: "i1", Summary: "i1 summary"},
+		{Name: "i2", Summary: "i2 summary"},
+		{Name: "i3", Summary: "i3 summary"},
+	})
+
+	// We can choose specific interfaces, unknown names are just skipped.
+	infos = r.Info(&InfoOptions{Names: []string{"i2", "i4"}})
+	c.Assert(infos, DeepEquals, []*Info{
+		{Name: "i2", Summary: "i2 summary"},
+	})
+
+	// We can ask for documentation.
+	infos = r.Info(&InfoOptions{Names: []string{"i2"}, Doc: true})
+	c.Assert(infos, DeepEquals, []*Info{
+		{Name: "i2", Summary: "i2 summary", DocURL: "http://example.com/i2"},
+	})
+
+	// We can ask for a list of plugs.
+	infos = r.Info(&InfoOptions{Names: []string{"i2"}, Plugs: true})
+	c.Assert(infos, DeepEquals, []*Info{
+		{Name: "i2", Summary: "i2 summary", Plugs: []*sdk.PlugInfo{s1.Plugs["i2"], s4.Plugs["i2"]}},
+	})
+
+	// We can ask for a list of slots.
+	infos = r.Info(&InfoOptions{Names: []string{"i2"}, Slots: true})
+	c.Assert(infos, DeepEquals, []*Info{
+		{Name: "i2", Summary: "i2 summary", Slots: []*sdk.SlotInfo{s3.Slots["i2"]}},
+	})
+
+	// We can also ask for only those interfaces that have connected plugs or slots.
+	infos = r.Info(&InfoOptions{Connected: true})
+	c.Assert(infos, DeepEquals, []*Info{
+		{Name: "i1", Summary: "i1 summary"},
+		{Name: "i2", Summary: "i2 summary"},
+	})
 }

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -51,6 +51,7 @@ var _ = Suite(&RepositorySuite{
 
 const consumerYaml = `
 name: consumer
+base: ubuntu@22.04
 plugs:
     plug:
         interface: interface
@@ -60,6 +61,7 @@ plugs:
 
 const producerYaml = `
 name: producer
+base: ubuntu@22.04
 slots:
     slot:
         interface: interface
@@ -294,6 +296,7 @@ func (s *RepositorySuite) TestPlugSearch(c *C) {
 	addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
 		{Name: "xx", Yaml: `
 name: xx
+base: ubuntu@22.04
 plugs:
     a: interface
     b: interface
@@ -301,6 +304,7 @@ plugs:
 `},
 		{Name: "yy", Yaml: `
 name: yy
+base: ubuntu@22.04
 plugs:
     a: interface
     b: interface
@@ -308,6 +312,7 @@ plugs:
 `},
 		{Name: "zz_instance", Yaml: `
 name: zz
+base: ubuntu@22.04
 plugs:
     a: interface
     b: interface
@@ -363,11 +368,13 @@ func (s *RepositorySuite) TestAllPlugsWithoutInterfaceName(c *C) {
 	sdks := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
 		{Name: "snap-a", Yaml: `
 name: snap-a
+base: ubuntu@22.04
 plugs:
     name-a: interface
 `},
 		{Name: "snap-b", Yaml: `
 name: snap-b
+base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: interface
@@ -375,6 +382,7 @@ plugs:
 `},
 		{Name: "snap-b_instance", Yaml: `
 name: snap-b
+base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: interface
@@ -402,13 +410,13 @@ func (s *RepositorySuite) TestAllPlugsWithInterfaceName(c *C) {
 	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
 		{Name: "snap-a", Yaml: `
 name: snap-a
-version: 0
+base: ubuntu@22.04
 plugs:
     name-a: interface
 `},
 		{Name: "snap-b", Yaml: `
 name: snap-b
-version: 0
+base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: other-interface
@@ -416,7 +424,7 @@ plugs:
 `},
 		{Name: "snap-b_instance", Yaml: `
 name: snap-b
-version: 0
+base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: other-interface
@@ -436,6 +444,7 @@ func (s *RepositorySuite) TestPlugs(c *C) {
 	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
 		{Name: "snap-a", Yaml: `
 name: snap-a
+base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: interface
@@ -443,6 +452,7 @@ plugs:
 `},
 		{Name: "snap-b", Yaml: `
 name: snap-b
+base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: interface
@@ -474,20 +484,20 @@ func (s *RepositorySuite) TestAllSlots(c *C) {
 	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
 		{Name: "snap-a", Yaml: `
 name: snap-a
-version: 0
+base: ubuntu@22.04
 slots:
     name-a: interface
     name-b: interface
 `},
 		{Name: "snap-b", Yaml: `
 name: snap-b
-version: 0
+base: ubuntu@22.04
 slots:
     name-a: other-interface
 `},
 		{Name: "snap-b_instance", Yaml: `
 name: snap-b
-version: 0
+base: ubuntu@22.04
 slots:
     name-a: other-interface
 `},
@@ -513,14 +523,14 @@ func (s *RepositorySuite) TestSlots(c *C) {
 	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
 		{Name: "snap-a", Yaml: `
 name: snap-a
-version: 0
+base: ubuntu@22.04
 slots:
     name-a: interface
     name-b: interface
 `},
 		{Name: "snap-b", Yaml: `
 name: snap-b
-version: 0
+base: ubuntu@22.04
 slots:
     name-a: interface
 `},
@@ -1062,12 +1072,14 @@ func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlots(c *C) {
 	// Add a pair of snaps with plugs/slots using those two interfaces
 	consumer := sdk.MockInfo(c, `
 name: consumer
+base: ubuntu@22.04
 plugs:
     auto:
     manual:
 `, sdk.Setup{Workspace: "ws", Name: "consumer"})
 	producer := sdk.MockInfo(c, `
 name: producer
+base: ubuntu@22.04
 slots:
     auto:
     manual:
@@ -1103,6 +1115,7 @@ func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlotsSymmetry(c *C) {
 	// Add a producer snap for "auto"
 	producer := sdk.MockInfo(c, `
 name: producer
+base: ubuntu@22.04
 slots:
     auto:
 `, sdk.Setup{Workspace: "ws", Name: "producer"})
@@ -1112,6 +1125,7 @@ slots:
 	// Add two consumers snaps for "auto"
 	consumer1 := sdk.MockInfo(c, `
 name: consumer1
+base: ubuntu@22.04
 plugs:
     auto:
 `, sdk.Setup{Workspace: "ws", Name: "consumer1"})
@@ -1122,6 +1136,7 @@ plugs:
 	// Add two consumers snaps for "auto"
 	consumer2 := sdk.MockInfo(c, `
 name: consumer2
+base: ubuntu@22.04
 plugs:
     auto:
 `, sdk.Setup{Workspace: "ws", Name: "consumer2"})
@@ -1184,6 +1199,7 @@ func (s *AddRemoveSuite) addSdk(c *C, yaml string) (*sdk.Info, error) {
 func (s *AddRemoveSuite) TestAddSnapSkipsUnknownInterfaces(c *C) {
 	info, err := s.addSdk(c, `
 name: bogus
+base: ubuntu@22.04
 plugs:
   bogus-plug:
 slots:
@@ -1221,6 +1237,7 @@ func (s *DisconnectSnapSuite) SetUpTest(c *C) {
 
 	s.s1 = sdk.MockInfo(c, `
 name: s1
+base: ubuntu@22.04
 plugs:
     iface-a:
 slots:
@@ -1231,6 +1248,7 @@ slots:
 
 	s.s2 = sdk.MockInfo(c, `
 name: s2
+base: ubuntu@22.04
 plugs:
     iface-b:
 slots:
@@ -1241,6 +1259,7 @@ slots:
 	c.Assert(err, IsNil)
 	s.s2Instance = sdk.MockInfo(c, `
 name: s2-instance
+base: ubuntu@22.04
 plugs:
     iface-b:
 slots:
@@ -1332,6 +1351,7 @@ func makeContentConnectionTestSnaps(c *C, plugContentToken, slotContentToken str
 
 	plugSnap := sdk.MockInfo(c, fmt.Sprintf(`
 name: content-plug-sdk
+base: ubuntu@22.04
 plugs:
   imported-content:
     interface: content
@@ -1339,6 +1359,7 @@ plugs:
 `, plugContentToken), sdk.Setup{Workspace: "ws-importer"})
 	slotSnap := sdk.MockInfo(c, fmt.Sprintf(`
 name: content-slot-sdk
+base: ubuntu@22.04
 slots:
   exported-content:
     interface: content
@@ -1391,6 +1412,7 @@ func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingDeveloper(c *
 
 const ifacehooksSnap1 = `
 name: s1
+base: ubuntu@22.04
 plugs:
   consumer:
     interface: iface2
@@ -1399,6 +1421,7 @@ plugs:
 
 const ifacehooksSnap2 = `
 name: s2
+base: ubuntu@22.04
 slots:
   producer:
     interface: iface2

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1,0 +1,1549 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	"context"
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/ifacetest"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/testutil"
+)
+
+type RepositorySuite struct {
+	testutil.BaseTest
+	iface     Interface
+	plug      *sdk.PlugInfo
+	plugSelf  *sdk.PlugInfo
+	slot      *sdk.SlotInfo
+	emptyRepo *Repository
+	// Repository pre-populated with s.iface
+	testRepo *Repository
+	context  context.Context
+}
+
+var _ = Suite(&RepositorySuite{
+	iface: &ifacetest.TestInterface{
+		InterfaceName: "interface",
+	},
+})
+
+const consumerYaml = `
+name: consumer
+plugs:
+    plug:
+        interface: interface
+        label: label
+        attr: value
+`
+
+const producerYaml = `
+name: producer
+slots:
+    slot:
+        interface: interface
+        label: label
+        attr: value
+plugs:
+    self:
+        interface: interface
+        label: label
+`
+
+func (s *RepositorySuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+
+	consumer := sdk.MockInfo(c, consumerYaml, sdk.Setup{Workspace: "ws", Name: "plug-sdk"})
+	s.plug = consumer.Plugs["plug"]
+	producer := sdk.MockInfo(c, producerYaml, sdk.Setup{Workspace: "ws", Name: "slot-sdk"})
+	s.slot = producer.Slots["slot"]
+	s.plugSelf = producer.Plugs["self"]
+
+	s.emptyRepo = NewRepository()
+	s.testRepo = NewRepository()
+	err := s.testRepo.AddInterface(s.iface)
+	c.Assert(err, IsNil)
+	s.context = ifacetest.CreateTestContext("user", "42424242")
+}
+
+func (s *RepositorySuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+type instanceNameAndYaml struct {
+	Name string
+	Yaml string
+}
+
+func addPlugsSlotsFromInstances(c *C, repo *Repository, iys []instanceNameAndYaml) []*sdk.Info {
+	result := make([]*sdk.Info, 0, len(iys))
+	for _, iy := range iys {
+		info := sdk.MockInfo(c, iy.Yaml, sdk.Setup{Workspace: "ws-" + iy.Name})
+		if iy.Name != "" {
+			c.Assert(sdk.Validate(info), IsNil)
+		}
+
+		result = append(result, info)
+		for _, plugInfo := range info.Plugs {
+			err := repo.AddPlug(plugInfo)
+			c.Assert(err, IsNil)
+		}
+		for _, slotInfo := range info.Slots {
+			err := repo.AddSlot(slotInfo)
+			c.Assert(err, IsNil)
+		}
+	}
+	return result
+}
+
+// Tests for Repository.AddInterface()
+
+func (s *RepositorySuite) TestAddInterface(c *C) {
+	// Adding a valid interfaces works
+	err := s.emptyRepo.AddInterface(s.iface)
+	c.Assert(err, IsNil)
+	c.Assert(s.emptyRepo.Interface(s.iface.Name()), Equals, s.iface)
+}
+
+func (s *RepositorySuite) TestAddInterfaceClash(c *C) {
+	iface1 := &ifacetest.TestInterface{InterfaceName: "iface"}
+	iface2 := &ifacetest.TestInterface{InterfaceName: "iface"}
+	err := s.emptyRepo.AddInterface(iface1)
+	c.Assert(err, IsNil)
+	// Adding an interface with the same name as another interface is not allowed
+	err = s.emptyRepo.AddInterface(iface2)
+	c.Assert(err, ErrorMatches, `cannot add interface: "iface", interface name is in use`)
+	c.Assert(s.emptyRepo.Interface(iface1.Name()), Equals, iface1)
+}
+
+func (s *RepositorySuite) TestAddInterfaceInvalidName(c *C) {
+	iface := &ifacetest.TestInterface{InterfaceName: "bad-name-"}
+	// Adding an interface with invalid name is not allowed
+	err := s.emptyRepo.AddInterface(iface)
+	c.Assert(err, ErrorMatches, `invalid interface name: "bad-name-"`)
+	c.Assert(s.emptyRepo.Interface(iface.Name()), IsNil)
+}
+
+// Tests for Repository.AllInterfaces()
+
+func (s *RepositorySuite) TestAllInterfaces(c *C) {
+	c.Assert(s.emptyRepo.AllInterfaces(), HasLen, 0)
+	c.Assert(s.testRepo.AllInterfaces(), DeepEquals, []Interface{s.iface})
+
+	// Add three interfaces in some non-sorted order.
+	i1 := &ifacetest.TestInterface{InterfaceName: "i1"}
+	i2 := &ifacetest.TestInterface{InterfaceName: "i2"}
+	i3 := &ifacetest.TestInterface{InterfaceName: "i3"}
+	c.Assert(s.emptyRepo.AddInterface(i3), IsNil)
+	c.Assert(s.emptyRepo.AddInterface(i1), IsNil)
+	c.Assert(s.emptyRepo.AddInterface(i2), IsNil)
+
+	// The result is always sorted.
+	c.Assert(s.emptyRepo.AllInterfaces(), DeepEquals, []Interface{i1, i2, i3})
+
+}
+
+func (s *RepositorySuite) TestAddBackend(c *C) {
+	backend := &ifacetest.TestSecurityBackend{BackendName: "test"}
+	c.Assert(s.emptyRepo.AddBackend(backend), IsNil)
+	err := s.emptyRepo.AddBackend(backend)
+	c.Assert(err, ErrorMatches, `cannot add backend "test", security system name is in use`)
+}
+
+func (s *RepositorySuite) TestBackends(c *C) {
+	b1 := &ifacetest.TestSecurityBackend{BackendName: "b1"}
+	b2 := &ifacetest.TestSecurityBackend{BackendName: "b2"}
+	c.Assert(s.emptyRepo.AddBackend(b2), IsNil)
+	c.Assert(s.emptyRepo.AddBackend(b1), IsNil)
+	// The order of insertion is retained.
+	c.Assert(s.emptyRepo.Backends(), DeepEquals, []SecurityBackend{b2, b1})
+}
+
+// Tests for Repository.Interface()
+
+func (s *RepositorySuite) TestInterface(c *C) {
+	// Interface returns nil when it cannot be found
+	iface := s.emptyRepo.Interface(s.iface.Name())
+	c.Assert(iface, IsNil)
+	c.Assert(s.emptyRepo.Interface(s.iface.Name()), IsNil)
+	err := s.emptyRepo.AddInterface(s.iface)
+	c.Assert(err, IsNil)
+	// Interface returns the found interface
+	iface = s.emptyRepo.Interface(s.iface.Name())
+	c.Assert(iface, Equals, s.iface)
+}
+
+func (s *RepositorySuite) TestInterfaceSearch(c *C) {
+	ifaceA := &ifacetest.TestInterface{InterfaceName: "a"}
+	ifaceB := &ifacetest.TestInterface{InterfaceName: "b"}
+	ifaceC := &ifacetest.TestInterface{InterfaceName: "c"}
+	err := s.emptyRepo.AddInterface(ifaceA)
+	c.Assert(err, IsNil)
+	err = s.emptyRepo.AddInterface(ifaceB)
+	c.Assert(err, IsNil)
+	err = s.emptyRepo.AddInterface(ifaceC)
+	c.Assert(err, IsNil)
+	// Interface correctly finds interfaces
+	c.Assert(s.emptyRepo.Interface("a"), Equals, ifaceA)
+	c.Assert(s.emptyRepo.Interface("b"), Equals, ifaceB)
+	c.Assert(s.emptyRepo.Interface("c"), Equals, ifaceC)
+}
+
+// Tests for Repository.AddPlug()
+
+func (s *RepositorySuite) TestAddPlug(c *C) {
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
+}
+
+func (s *RepositorySuite) TestAddPlugClashingPlug(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddPlug(s.plug)
+	c.Assert(err, ErrorMatches, `sdk "consumer" has plugs conflicting on name "plug"`)
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
+}
+
+func (s *RepositorySuite) TestAddPlugClashingSlot(c *C) {
+	snapInfo := &sdk.Info{Workspace: "ws", Name: "snap"}
+	plug := &sdk.PlugInfo{
+		Sdk:       snapInfo,
+		Name:      "clashing",
+		Interface: "interface",
+	}
+	slot := &sdk.SlotInfo{
+		Sdk:       snapInfo,
+		Name:      "clashing",
+		Interface: "interface",
+	}
+	err := s.testRepo.AddSlot(slot)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddPlug(plug)
+	c.Assert(err, ErrorMatches, `sdk "snap" has plug and slot conflicting on name "clashing"`)
+	c.Assert(s.testRepo.AllSlots(""), HasLen, 1)
+	c.Assert(s.testRepo.Slot(slot.Sdk.Workspace, slot.Sdk.Name, slot.Name), DeepEquals, slot)
+}
+
+func (s *RepositorySuite) TestAddPlugFailsWithInvalidPlugName(c *C) {
+	plug := &sdk.PlugInfo{
+		Sdk:       &sdk.Info{Name: "snap"},
+		Name:      "bad-name-",
+		Interface: "interface",
+	}
+	err := s.testRepo.AddPlug(plug)
+	c.Assert(err, ErrorMatches, `invalid plug name: "bad-name-"`)
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
+}
+
+func (s *RepositorySuite) TestAddPlugFailsWithUnknownInterface(c *C) {
+	err := s.emptyRepo.AddPlug(s.plug)
+	c.Assert(err, ErrorMatches, `cannot add plug, interface "interface" is not known`)
+	c.Assert(s.emptyRepo.AllPlugs(""), HasLen, 0)
+}
+
+func (s *RepositorySuite) TestAddPlugParallelInstance(c *C) {
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
+
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
+
+	consumer := sdk.MockInfo(c, consumerYaml, sdk.Setup{})
+	err = s.testRepo.AddPlug(consumer.Plugs["plug"])
+	c.Assert(err, IsNil)
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 2)
+
+	c.Assert(s.testRepo.Plug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name), DeepEquals, s.plug)
+	c.Assert(s.testRepo.Plug(consumer.Workspace, consumer.Name, "plug"), DeepEquals, consumer.Plugs["plug"])
+}
+
+// Tests for Repository.Plug()
+
+func (s *RepositorySuite) TestPlug(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	c.Assert(s.emptyRepo.Plug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name), IsNil)
+	c.Assert(s.testRepo.Plug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name), DeepEquals, s.plug)
+}
+
+func (s *RepositorySuite) TestPlugSearch(c *C) {
+	addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+		{Name: "xx", Yaml: `
+name: xx
+plugs:
+    a: interface
+    b: interface
+    c: interface
+`},
+		{Name: "yy", Yaml: `
+name: yy
+plugs:
+    a: interface
+    b: interface
+    c: interface
+`},
+		{Name: "zz_instance", Yaml: `
+name: zz
+plugs:
+    a: interface
+    b: interface
+    c: interface
+`},
+	})
+	// Plug() correctly finds plugs
+	c.Assert(s.testRepo.Plug("ws-xx", "xx", "a"), Not(IsNil))
+	c.Assert(s.testRepo.Plug("ws-xx", "xx", "b"), Not(IsNil))
+	c.Assert(s.testRepo.Plug("ws-xx", "xx", "c"), Not(IsNil))
+	c.Assert(s.testRepo.Plug("ws-yy", "yy", "a"), Not(IsNil))
+	c.Assert(s.testRepo.Plug("ws-yy", "yy", "b"), Not(IsNil))
+	c.Assert(s.testRepo.Plug("ws-yy", "yy", "c"), Not(IsNil))
+	c.Assert(s.testRepo.Plug("ws-zz_instance", "zz", "a"), Not(IsNil))
+	c.Assert(s.testRepo.Plug("ws-zz_instance", "zz", "b"), Not(IsNil))
+	c.Assert(s.testRepo.Plug("ws-zz_instance", "zz", "c"), Not(IsNil))
+}
+
+// Tests for Repository.RemovePlug()
+
+func (s *RepositorySuite) TestRemovePlugSucceedsWhenPlugExistsAndDisconnected(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.RemovePlug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
+	c.Assert(err, IsNil)
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
+}
+
+func (s *RepositorySuite) TestRemovePlugFailsWhenPlugDoesntExist(c *C) {
+	err := s.emptyRepo.RemovePlug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
+	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from snap "consumer", no such plug`)
+}
+
+func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Removing a plug used by a slot returns an appropriate error
+	err = s.testRepo.RemovePlug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
+	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from snap "consumer", it is still connected`)
+	// The plug is still there
+	slot := s.testRepo.Plug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
+	c.Assert(slot, Not(IsNil))
+}
+
+// Tests for Repository.AllPlugs()
+
+func (s *RepositorySuite) TestAllPlugsWithoutInterfaceName(c *C) {
+	sdks := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+		{Name: "snap-a", Yaml: `
+name: snap-a
+plugs:
+    name-a: interface
+`},
+		{Name: "snap-b", Yaml: `
+name: snap-b
+plugs:
+    name-a: interface
+    name-b: interface
+    name-c: interface
+`},
+		{Name: "snap-b_instance", Yaml: `
+name: snap-b
+plugs:
+    name-a: interface
+    name-b: interface
+    name-c: interface
+`},
+	})
+	c.Assert(sdks, HasLen, 3)
+	// The result is sorted by snap and name
+	allPlugs := s.testRepo.AllPlugs("")
+	c.Assert(allPlugs, DeepEquals, []*sdk.PlugInfo{
+		sdks[0].Plugs["name-a"],
+		sdks[1].Plugs["name-a"],
+		sdks[1].Plugs["name-b"],
+		sdks[1].Plugs["name-c"],
+		sdks[2].Plugs["name-a"],
+		sdks[2].Plugs["name-b"],
+		sdks[2].Plugs["name-c"],
+	})
+}
+
+func (s *RepositorySuite) TestAllPlugsWithInterfaceName(c *C) {
+	// Add another interface so that we can look for it
+	err := s.testRepo.AddInterface(&ifacetest.TestInterface{InterfaceName: "other-interface"})
+	c.Assert(err, IsNil)
+	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+		{Name: "snap-a", Yaml: `
+name: snap-a
+version: 0
+plugs:
+    name-a: interface
+`},
+		{Name: "snap-b", Yaml: `
+name: snap-b
+version: 0
+plugs:
+    name-a: interface
+    name-b: other-interface
+    name-c: interface
+`},
+		{Name: "snap-b_instance", Yaml: `
+name: snap-b
+version: 0
+plugs:
+    name-a: interface
+    name-b: other-interface
+    name-c: interface
+`},
+	})
+	c.Assert(snaps, HasLen, 3)
+	c.Assert(s.testRepo.AllPlugs("other-interface"), DeepEquals, []*sdk.PlugInfo{
+		snaps[1].Plugs["name-b"],
+		snaps[2].Plugs["name-b"],
+	})
+}
+
+// Tests for Repository.Plugs()
+
+func (s *RepositorySuite) TestPlugs(c *C) {
+	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+		{Name: "snap-a", Yaml: `
+name: snap-a
+plugs:
+    name-a: interface
+    name-b: interface
+    name-c: interface
+`},
+		{Name: "snap-b", Yaml: `
+name: snap-b
+plugs:
+    name-a: interface
+    name-b: interface
+    name-c: interface
+`},
+	})
+	c.Assert(snaps, HasLen, 2)
+	// The result is sorted by snap and name
+	c.Assert(s.testRepo.Plugs("ws-snap-a", "snap-a"), DeepEquals, []*sdk.PlugInfo{
+		snaps[0].Plugs["name-a"],
+		snaps[0].Plugs["name-b"],
+		snaps[0].Plugs["name-c"],
+	})
+	c.Assert(s.testRepo.Plugs("ws-snap-b", "snap-b"), DeepEquals, []*sdk.PlugInfo{
+		snaps[1].Plugs["name-a"],
+		snaps[1].Plugs["name-b"],
+		snaps[1].Plugs["name-c"],
+	})
+	// The result is empty if the snap is not known
+	c.Assert(s.testRepo.Plugs("ws-snap-a", "snap-x"), HasLen, 0)
+	c.Assert(s.testRepo.Plugs("ws-snap-b", "snap-b_other"), HasLen, 0)
+}
+
+// Tests for Repository.AllSlots()
+
+func (s *RepositorySuite) TestAllSlots(c *C) {
+	err := s.testRepo.AddInterface(&ifacetest.TestInterface{InterfaceName: "other-interface"})
+	c.Assert(err, IsNil)
+	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+		{Name: "snap-a", Yaml: `
+name: snap-a
+version: 0
+slots:
+    name-a: interface
+    name-b: interface
+`},
+		{Name: "snap-b", Yaml: `
+name: snap-b
+version: 0
+slots:
+    name-a: other-interface
+`},
+		{Name: "snap-b_instance", Yaml: `
+name: snap-b
+version: 0
+slots:
+    name-a: other-interface
+`},
+	})
+	c.Assert(snaps, HasLen, 3)
+	// AllSlots("") returns all slots, sorted by snap and slot name
+	c.Assert(s.testRepo.AllSlots(""), DeepEquals, []*sdk.SlotInfo{
+		snaps[0].Slots["name-a"],
+		snaps[0].Slots["name-b"],
+		snaps[1].Slots["name-a"],
+		snaps[2].Slots["name-a"],
+	})
+	// AllSlots("") returns all slots, sorted by snap and slot name
+	c.Assert(s.testRepo.AllSlots("other-interface"), DeepEquals, []*sdk.SlotInfo{
+		snaps[1].Slots["name-a"],
+		snaps[2].Slots["name-a"],
+	})
+}
+
+// Tests for Repository.Slots()
+
+func (s *RepositorySuite) TestSlots(c *C) {
+	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+		{Name: "snap-a", Yaml: `
+name: snap-a
+version: 0
+slots:
+    name-a: interface
+    name-b: interface
+`},
+		{Name: "snap-b", Yaml: `
+name: snap-b
+version: 0
+slots:
+    name-a: interface
+`},
+	})
+	// Slots("snap-a") returns slots present in that snap
+	c.Assert(s.testRepo.Slots("ws-snap-a", "snap-a"), DeepEquals, []*sdk.SlotInfo{
+		snaps[0].Slots["name-a"],
+		snaps[0].Slots["name-b"],
+	})
+	// Slots("snap-b") returns slots present in that snap
+	c.Assert(s.testRepo.Slots("ws-snap-b", "snap-b"), DeepEquals, []*sdk.SlotInfo{
+		snaps[1].Slots["name-a"],
+	})
+	// Slots("snap-c") returns no slots (because that sdk doesn't exist)
+	c.Assert(s.testRepo.Slots("ws-snap-a", "snap-c"), HasLen, 0)
+	// Slots("snap-b_other") returns no slots (the sdk does not exist)
+	c.Assert(s.testRepo.Slots("ws-snap-a", "snap-b_other"), HasLen, 0)
+	// Slots("") returns no slots
+	c.Assert(s.testRepo.Slots("ws-snap-a", ""), HasLen, 0)
+}
+
+// Tests for Repository.Slot()
+
+func (s *RepositorySuite) TestSlotSucceedsWhenSlotExists(c *C) {
+	err := s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	slot := s.testRepo.Slot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(slot, DeepEquals, s.slot)
+}
+
+func (s *RepositorySuite) TestSlotFailsWhenSlotDoesntExist(c *C) {
+	slot := s.testRepo.Slot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(slot, IsNil)
+}
+
+// Tests for Repository.AddSlot()
+
+func (s *RepositorySuite) TestAddSlotFailsWhenInterfaceIsUnknown(c *C) {
+	err := s.emptyRepo.AddSlot(s.slot)
+	c.Assert(err, ErrorMatches, `cannot add slot, interface "interface" is not known`)
+}
+
+func (s *RepositorySuite) TestAddSlotFailsWhenSlotNameIsInvalid(c *C) {
+	slot := &sdk.SlotInfo{
+		Sdk:       &sdk.Info{Name: "snap"},
+		Name:      "bad-name-",
+		Interface: "interface",
+	}
+	err := s.emptyRepo.AddSlot(slot)
+	c.Assert(err, ErrorMatches, `invalid slot name: "bad-name-"`)
+	c.Assert(s.emptyRepo.AllSlots(""), HasLen, 0)
+}
+
+func (s *RepositorySuite) TestAddSlotClashingSlot(c *C) {
+	// Adding the first slot succeeds
+	err := s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	// Adding the slot again fails with appropriate error
+	err = s.testRepo.AddSlot(s.slot)
+	c.Assert(err, ErrorMatches, `sdk "producer" has slots conflicting on name "slot"`)
+}
+
+func (s *RepositorySuite) TestAddSlotClashingPlug(c *C) {
+	snapInfo := &sdk.Info{Name: "snap"}
+	plug := &sdk.PlugInfo{
+		Sdk:       snapInfo,
+		Name:      "clashing",
+		Interface: "interface",
+	}
+	slot := &sdk.SlotInfo{
+		Sdk:       snapInfo,
+		Name:      "clashing",
+		Interface: "interface",
+	}
+	err := s.testRepo.AddPlug(plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddSlot(slot)
+	c.Assert(err, ErrorMatches, `sdk "snap" has plug and slot conflicting on name "clashing"`)
+	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
+	c.Assert(s.testRepo.Plug(plug.Sdk.Workspace, plug.Sdk.Name, plug.Name), DeepEquals, plug)
+}
+
+func (s *RepositorySuite) TestAddSlotStoresCorrectData(c *C) {
+	err := s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	slot := s.testRepo.Slot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	// The added slot has the same data
+	c.Assert(slot, DeepEquals, s.slot)
+}
+
+func (s *RepositorySuite) TestAddSlotParallelInstance(c *C) {
+	c.Assert(s.testRepo.AllSlots(""), HasLen, 0)
+
+	err := s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(s.testRepo.AllSlots(""), HasLen, 1)
+
+	producer := sdk.MockInfo(c, producerYaml, sdk.Setup{Workspace: "ws-instance"})
+	err = s.testRepo.AddSlot(producer.Slots["slot"])
+	c.Assert(err, IsNil)
+	c.Assert(s.testRepo.AllSlots(""), HasLen, 2)
+
+	c.Assert(s.testRepo.Slot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name), DeepEquals, s.slot)
+	c.Assert(s.testRepo.Slot(producer.Workspace, producer.Name, "slot"), DeepEquals, producer.Slots["slot"])
+}
+
+// Tests for Repository.RemoveSlot()
+
+func (s *RepositorySuite) TestRemoveSlotSuccedsWhenSlotExistsAndDisconnected(c *C) {
+	err := s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	// Removing a vacant slot simply works
+	err = s.testRepo.RemoveSlot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, IsNil)
+	// The slot is gone now
+	slot := s.testRepo.Slot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(slot, IsNil)
+}
+
+func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotDoesntExist(c *C) {
+	// Removing a slot that doesn't exist returns an appropriate error
+	err := s.testRepo.RemoveSlot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, Not(IsNil))
+	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from sdk "producer", no such slot`)
+}
+
+func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotIsConnected(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Removing a slot occupied by a plug returns an appropriate error
+	err = s.testRepo.RemoveSlot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from sdk "producer", it is still connected`)
+	// The slot is still there
+	slot := s.testRepo.Slot(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(slot, Not(IsNil))
+}
+
+// Tests for Repository.Connect()
+
+func (s *RepositorySuite) TestConnectFailsWhenPlugDoesNotExist(c *C) {
+	err := s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	// Connecting an unknown plug returns an appropriate error
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, ErrorMatches, `cannot connect plug "plug" from sdk "consumer": no such plug`)
+	e, _ := err.(*NoPlugOrSlotError)
+	c.Check(e, NotNil)
+}
+
+func (s *RepositorySuite) TestConnectFailsWhenSlotDoesNotExist(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	// Connecting to an unknown slot returns an error
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, ErrorMatches, `cannot connect slot "slot" from sdk "producer": no such slot`)
+	e, _ := err.(*NoPlugOrSlotError)
+	c.Check(e, NotNil)
+}
+
+func (s *RepositorySuite) TestConnectSucceedsWhenIdenticalConnectExists(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	connRef := NewConnRef(s.plug, s.slot)
+	conn, err := s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(conn, NotNil)
+	c.Assert(conn.Plug, NotNil)
+	c.Assert(conn.Slot, NotNil)
+	c.Assert(conn.Plug.Name(), Equals, "plug")
+	c.Assert(conn.Slot.Name(), Equals, "slot")
+	// Connecting exactly the same thing twice succeeds without an error but does nothing.
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Only one connection is actually present.
+	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
+		Plugs:       []*sdk.PlugInfo{s.plug},
+		Slots:       []*sdk.SlotInfo{s.slot},
+		Connections: []*ConnRef{NewConnRef(s.plug, s.slot)},
+	})
+}
+
+func (s *RepositorySuite) TestConnectFailsWhenSlotAndPlugAreIncompatible(c *C) {
+	otherInterface := &ifacetest.TestInterface{InterfaceName: "other-interface"}
+	err := s.testRepo.AddInterface(otherInterface)
+	plug := &sdk.PlugInfo{
+		Sdk:       &sdk.Info{Workspace: "ws", Name: "consumer"},
+		Name:      "plug",
+		Interface: "other-interface",
+	}
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddPlug(plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	// Connecting a plug to an incompatible slot fails with an appropriate error
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, ErrorMatches, `cannot connect plug "consumer:plug" \(interface "other-interface"\) to "producer:slot" \(interface "interface"\)`)
+}
+
+func (s *RepositorySuite) TestConnectSucceeds(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	// Connecting a plug works okay
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+}
+
+// Tests for Repository.Disconnect() and DisconnectAll()
+
+// Disconnect fails if any argument is empty
+func (s *RepositorySuite) TestDisconnectFailsOnEmptyArgs(c *C) {
+	err1 := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, "")
+	err2 := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, "", s.slot.Name)
+	err3 := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, "", s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	err4 := s.testRepo.Disconnect(s.plug.Sdk.Workspace, "", s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err1, ErrorMatches, `cannot disconnect, slot name is empty`)
+	c.Assert(err2, ErrorMatches, `cannot disconnect, slot snap name is empty`)
+	c.Assert(err3, ErrorMatches, `cannot disconnect, plug name is empty`)
+	c.Assert(err4, ErrorMatches, `cannot disconnect, plug snap name is empty`)
+}
+
+// Disconnect fails if plug doesn't exist
+func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+	err := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, ErrorMatches, `snap "consumer" has no plug named "plug"`)
+	e, _ := err.(*NoPlugOrSlotError)
+	c.Check(e, NotNil)
+}
+
+// Disconnect fails if slot doesn't exist
+func (s *RepositorySuite) TestDisconnectFailsWithutSlot(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
+	err := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, ErrorMatches, `snap "producer" has no slot named "slot"`)
+	e, _ := err.(*NoPlugOrSlotError)
+	c.Check(e, NotNil)
+}
+
+// Disconnect fails if there's no connection to disconnect
+func (s *RepositorySuite) TestDisconnectFailsWhenNotConnected(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+	err := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, ErrorMatches, `cannot disconnect consumer:plug from producer:slot, it is not connected`)
+	e, _ := err.(*NotConnectedError)
+	c.Check(e, NotNil)
+}
+
+// Disconnect works when plug and slot exist and are connected
+func (s *RepositorySuite) TestDisconnectSucceeds(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+	_, err := s.testRepo.Connect(NewConnRef(s.plug, s.slot), nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	_, err = s.testRepo.Connect(NewConnRef(s.plug, s.slot), nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	err = s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, IsNil)
+	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
+		Plugs: []*sdk.PlugInfo{s.plug},
+		Slots: []*sdk.SlotInfo{s.slot},
+	})
+}
+
+// Tests for Repository.Connected
+
+// Connected fails if snap name is empty and there's no core snap around
+func (s *RepositorySuite) TestConnectedFailsWithEmptyWorkspaceName(c *C) {
+	_, err := s.testRepo.Connected("ws", "", s.plug.Name)
+	c.Check(err, ErrorMatches, "internal error: cannot obtain sdk name while computing connections")
+}
+
+func (s *RepositorySuite) TestConnectedFailsWithEmptySdkName(c *C) {
+	_, err := s.testRepo.Connected("", "ws", s.plug.Name)
+	c.Check(err, ErrorMatches, "internal error: cannot obtain workspace name while computing connections")
+}
+
+// Connected fails if plug or slot name is empty
+func (s *RepositorySuite) TestConnectedFailsWithEmptyPlugSlotName(c *C) {
+	_, err := s.testRepo.Connected("ws", s.plug.Sdk.Name, "")
+	c.Check(err, ErrorMatches, "plug or slot name is empty")
+}
+
+// Connected fails if plug or slot doesn't exist
+func (s *RepositorySuite) TestConnectedFailsWithoutPlugOrSlot(c *C) {
+	_, err1 := s.testRepo.Connected(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
+	_, err2 := s.testRepo.Connected(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Check(err1, ErrorMatches, `snap "consumer" has no plug or slot named "plug"`)
+	e, _ := err1.(*NoPlugOrSlotError)
+	c.Check(e, NotNil)
+	c.Check(err2, ErrorMatches, `snap "producer" has no plug or slot named "slot"`)
+	e, _ = err1.(*NoPlugOrSlotError)
+	c.Check(e, NotNil)
+}
+
+// Connected finds connections when asked from plug or from slot side
+func (s *RepositorySuite) TestConnectedFindsConnections(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+	_, err := s.testRepo.Connect(NewConnRef(s.plug, s.slot), nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	conns, err := s.testRepo.Connected(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plug, s.slot)})
+
+	conns, err = s.testRepo.Connected(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plug, s.slot)})
+}
+
+// Connected finds connections when asked from plug or from slot side
+func (s *RepositorySuite) TestConnections(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+	_, err := s.testRepo.Connect(NewConnRef(s.plug, s.slot), nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	conns, err := s.testRepo.Connections(s.plug.Sdk.Workspace, s.plug.Sdk.Name)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plug, s.slot)})
+
+	conns, err = s.testRepo.Connections(s.slot.Sdk.Workspace, s.slot.Sdk.Name)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plug, s.slot)})
+
+	conns, err = s.testRepo.Connections("ws", "abc")
+	c.Assert(err, IsNil)
+	c.Assert(conns, HasLen, 0)
+}
+
+func (s *RepositorySuite) TestConnectionsWithSelfConnected(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plugSelf), IsNil)
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+	_, err := s.testRepo.Connect(NewConnRef(s.plugSelf, s.slot), nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	conns, err := s.testRepo.Connections(s.plug.Sdk.Workspace, s.plugSelf.Sdk.Name)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plugSelf, s.slot)})
+
+	conns, err = s.testRepo.Connections(s.slot.Sdk.Workspace, s.slot.Sdk.Name)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plugSelf, s.slot)})
+}
+
+// Tests for Repository.DisconnectAll()
+
+func (s *RepositorySuite) TestDisconnectAll(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+	_, err := s.testRepo.Connect(NewConnRef(s.plug, s.slot), nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	conns := []*ConnRef{NewConnRef(s.plug, s.slot)}
+	s.testRepo.DisconnectAll(conns)
+	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
+		Plugs: []*sdk.PlugInfo{s.plug},
+		Slots: []*sdk.SlotInfo{s.slot},
+	})
+}
+
+// Tests for Repository.Interfaces()
+
+func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
+	err := s.testRepo.AddPlug(s.plug)
+	c.Assert(err, IsNil)
+	err = s.testRepo.AddSlot(s.slot)
+	c.Assert(err, IsNil)
+	// After connecting the result is as expected
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	ifaces := s.testRepo.Interfaces()
+	c.Assert(ifaces, DeepEquals, &Interfaces{
+		Plugs:       []*sdk.PlugInfo{s.plug},
+		Slots:       []*sdk.SlotInfo{s.slot},
+		Connections: []*ConnRef{NewConnRef(s.plug, s.slot)},
+	})
+	// After disconnecting the connections become empty
+	err = s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
+	c.Assert(err, IsNil)
+	ifaces = s.testRepo.Interfaces()
+	c.Assert(ifaces, DeepEquals, &Interfaces{
+		Plugs: []*sdk.PlugInfo{s.plug},
+		Slots: []*sdk.SlotInfo{s.slot},
+	})
+}
+
+// Tests for Repository.SnapSpecification
+
+const testSecurity SecuritySystem = "test"
+
+var testInterface = &ifacetest.TestInterface{
+	InterfaceName: "interface",
+	TestPermanentPlugCallback: func(spec *ifacetest.Specification, plug *sdk.PlugInfo) error {
+		spec.AddSnippet("static plug snippet")
+		return nil
+	},
+	TestConnectedPlugCallback: func(spec *ifacetest.Specification, plug *ConnectedPlug, slot *ConnectedSlot) error {
+		spec.AddSnippet("connection-specific plug snippet")
+		return nil
+	},
+	TestPermanentSlotCallback: func(spec *ifacetest.Specification, slot *sdk.SlotInfo) error {
+		spec.AddSnippet("static slot snippet")
+		return nil
+	},
+	TestConnectedSlotCallback: func(spec *ifacetest.Specification, plug *ConnectedPlug, slot *ConnectedSlot) error {
+		spec.AddSnippet("connection-specific slot snippet")
+		return nil
+	},
+}
+
+func (s *RepositorySuite) TestSnapSpecification(c *C) {
+	repo := s.emptyRepo
+	backend := &ifacetest.TestSecurityBackend{BackendName: testSecurity}
+	c.Assert(repo.AddBackend(backend), IsNil)
+	c.Assert(repo.AddInterface(testInterface), IsNil)
+	c.Assert(repo.AddPlug(s.plug), IsNil)
+	c.Assert(repo.AddSlot(s.slot), IsNil)
+
+	// Snaps should get static security now
+	spec, err := repo.SdkSpecification(s.context, testSecurity, s.plug.Sdk)
+	c.Assert(err, IsNil)
+	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{"static plug snippet"})
+
+	spec, err = repo.SdkSpecification(s.context, testSecurity, s.slot.Sdk)
+	c.Assert(err, IsNil)
+	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{"static slot snippet"})
+
+	// Establish connection between plug and slot
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	// Snaps should get static and connection-specific security now
+	spec, err = repo.SdkSpecification(s.context, testSecurity, s.plug.Sdk)
+	c.Assert(err, IsNil)
+	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{
+		"static plug snippet",
+		"connection-specific plug snippet",
+	})
+
+	spec, err = repo.SdkSpecification(s.context, testSecurity, s.slot.Sdk)
+	c.Assert(err, IsNil)
+	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{
+		"static slot snippet",
+		"connection-specific slot snippet",
+	})
+}
+
+func (s *RepositorySuite) TestSnapSpecificationFailureWithConnectionSnippets(c *C) {
+	var testSecurity SecuritySystem = "security"
+	backend := &ifacetest.TestSecurityBackend{BackendName: testSecurity}
+	iface := &ifacetest.TestInterface{
+		InterfaceName: "interface",
+		TestConnectedSlotCallback: func(spec *ifacetest.Specification, plug *ConnectedPlug, slot *ConnectedSlot) error {
+			return fmt.Errorf("cannot compute snippet for provider")
+		},
+		TestConnectedPlugCallback: func(spec *ifacetest.Specification, plug *ConnectedPlug, slot *ConnectedSlot) error {
+			return fmt.Errorf("cannot compute snippet for consumer")
+		},
+	}
+	repo := s.emptyRepo
+
+	c.Assert(repo.AddBackend(backend), IsNil)
+	c.Assert(repo.AddInterface(iface), IsNil)
+	c.Assert(repo.AddPlug(s.plug), IsNil)
+	c.Assert(repo.AddSlot(s.slot), IsNil)
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err := repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	spec, err := repo.SdkSpecification(s.context, testSecurity, s.plug.Sdk)
+	c.Assert(err, ErrorMatches, "cannot compute snippet for consumer")
+	c.Assert(spec, IsNil)
+
+	spec, err = repo.SdkSpecification(s.context, testSecurity, s.slot.Sdk)
+	c.Assert(err, ErrorMatches, "cannot compute snippet for provider")
+	c.Assert(spec, IsNil)
+}
+
+func (s *RepositorySuite) TestSnapSpecificationFailureWithPermanentSnippets(c *C) {
+	var testSecurity SecuritySystem = "security"
+	iface := &ifacetest.TestInterface{
+		InterfaceName: "interface",
+		TestPermanentSlotCallback: func(spec *ifacetest.Specification, slot *sdk.SlotInfo) error {
+			return fmt.Errorf("cannot compute snippet for provider")
+		},
+		TestPermanentPlugCallback: func(spec *ifacetest.Specification, plug *sdk.PlugInfo) error {
+			return fmt.Errorf("cannot compute snippet for consumer")
+		},
+	}
+	backend := &ifacetest.TestSecurityBackend{BackendName: testSecurity}
+	repo := s.emptyRepo
+	c.Assert(repo.AddBackend(backend), IsNil)
+	c.Assert(repo.AddInterface(iface), IsNil)
+	c.Assert(repo.AddPlug(s.plug), IsNil)
+	c.Assert(repo.AddSlot(s.slot), IsNil)
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err := repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	spec, err := repo.SdkSpecification(s.context, testSecurity, s.plug.Sdk)
+	c.Assert(err, ErrorMatches, "cannot compute snippet for consumer")
+	c.Assert(spec, IsNil)
+
+	spec, err = repo.SdkSpecification(s.context, testSecurity, s.slot.Sdk)
+	c.Assert(err, ErrorMatches, "cannot compute snippet for provider")
+	c.Assert(spec, IsNil)
+}
+
+func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlots(c *C) {
+	// Add two interfaces, one with automatic connections, one with manual
+	repo := s.emptyRepo
+	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "auto"})
+	c.Assert(err, IsNil)
+	err = repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "manual"})
+	c.Assert(err, IsNil)
+
+	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
+		return slot.Interface() == "auto", nil
+	}
+
+	// Add a pair of snaps with plugs/slots using those two interfaces
+	consumer := sdk.MockInfo(c, `
+name: consumer
+plugs:
+    auto:
+    manual:
+`, sdk.Setup{Workspace: "ws", Name: "consumer"})
+	producer := sdk.MockInfo(c, `
+name: producer
+slots:
+    auto:
+    manual:
+`, sdk.Setup{Workspace: "ws", Name: "producer"})
+	err = repo.AddSdk(producer)
+	c.Assert(err, IsNil)
+	err = repo.AddSdk(consumer)
+	c.Assert(err, IsNil)
+
+	candidateSlots := repo.AutoConnectCandidateSlots("ws", "consumer", "auto", policyCheck)
+	c.Assert(candidateSlots, HasLen, 1)
+	c.Check(candidateSlots[0].Sdk.Name, Equals, "producer")
+	c.Check(candidateSlots[0].Interface, Equals, "auto")
+	c.Check(candidateSlots[0].Name, Equals, "auto")
+
+	candidatePlugs := repo.AutoConnectCandidatePlugs("ws", "producer", "auto", policyCheck)
+	c.Assert(candidatePlugs, HasLen, 1)
+	c.Check(candidatePlugs[0].Sdk.Name, Equals, "consumer")
+	c.Check(candidatePlugs[0].Interface, Equals, "auto")
+	c.Check(candidatePlugs[0].Name, Equals, "auto")
+}
+
+func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlotsSymmetry(c *C) {
+	repo := s.emptyRepo
+	// Add a "auto" interface
+	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "auto"})
+	c.Assert(err, IsNil)
+
+	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
+		return slot.Interface() == "auto", nil
+	}
+
+	// Add a producer snap for "auto"
+	producer := sdk.MockInfo(c, `
+name: producer
+slots:
+    auto:
+`, sdk.Setup{Workspace: "ws", Name: "producer"})
+	err = repo.AddSdk(producer)
+	c.Assert(err, IsNil)
+
+	// Add two consumers snaps for "auto"
+	consumer1 := sdk.MockInfo(c, `
+name: consumer1
+plugs:
+    auto:
+`, sdk.Setup{Workspace: "ws", Name: "consumer1"})
+
+	err = repo.AddSdk(consumer1)
+	c.Assert(err, IsNil)
+
+	// Add two consumers snaps for "auto"
+	consumer2 := sdk.MockInfo(c, `
+name: consumer2
+plugs:
+    auto:
+`, sdk.Setup{Workspace: "ws", Name: "consumer2"})
+
+	err = repo.AddSdk(consumer2)
+	c.Assert(err, IsNil)
+
+	// Both can auto-connect
+	candidateSlots := repo.AutoConnectCandidateSlots("ws", "consumer1", "auto", policyCheck)
+	c.Assert(candidateSlots, HasLen, 1)
+	c.Check(candidateSlots[0].Sdk.Name, Equals, "producer")
+	c.Check(candidateSlots[0].Interface, Equals, "auto")
+	c.Check(candidateSlots[0].Name, Equals, "auto")
+
+	candidateSlots = repo.AutoConnectCandidateSlots("ws", "consumer2", "auto", policyCheck)
+	c.Assert(candidateSlots, HasLen, 1)
+	c.Check(candidateSlots[0].Sdk.Name, Equals, "producer")
+	c.Check(candidateSlots[0].Interface, Equals, "auto")
+	c.Check(candidateSlots[0].Name, Equals, "auto")
+
+	// Plugs candidates seen from the producer (for example if
+	// it's installed after) should be the same
+	candidatePlugs := repo.AutoConnectCandidatePlugs("ws", "producer", "auto", policyCheck)
+	c.Assert(candidatePlugs, HasLen, 2)
+}
+
+// Tests for AddSnap and RemoveSnap
+
+type AddRemoveSuite struct {
+	testutil.BaseTest
+	repo *Repository
+}
+
+var _ = Suite(&AddRemoveSuite{})
+
+func (s *AddRemoveSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+
+	s.repo = NewRepository()
+	err := s.repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface"})
+	c.Assert(err, IsNil)
+	err = s.repo.AddInterface(&ifacetest.TestInterface{
+		InterfaceName:             "invalid",
+		BeforePreparePlugCallback: func(plug *sdk.PlugInfo) error { return fmt.Errorf("plug is invalid") },
+		BeforePrepareSlotCallback: func(slot *sdk.SlotInfo) error { return fmt.Errorf("slot is invalid") },
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *AddRemoveSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *AddRemoveSuite) addSdk(c *C, yaml string) (*sdk.Info, error) {
+	sdkInfo := sdk.MockInfo(c, yaml, sdk.Setup{Workspace: "ws"})
+	return sdkInfo, s.repo.AddSdk(sdkInfo)
+}
+
+func (s *AddRemoveSuite) TestAddSnapSkipsUnknownInterfaces(c *C) {
+	info, err := s.addSdk(c, `
+name: bogus
+plugs:
+  bogus-plug:
+slots:
+  bogus-slot:
+`)
+	c.Assert(err, IsNil)
+	// the snap knowns about the bogus plug and slot
+	c.Assert(info.Plugs["bogus-plug"], NotNil)
+	c.Assert(info.Slots["bogus-slot"], NotNil)
+	// but the repository ignores them
+	c.Assert(s.repo.Plug("ws", "bogus", "bogus-plug"), IsNil)
+	c.Assert(s.repo.Slot("ws", "bogus", "bogus-slot"), IsNil)
+}
+
+type DisconnectSnapSuite struct {
+	testutil.BaseTest
+	repo               *Repository
+	s1, s2, s2Instance *sdk.Info
+}
+
+var _ = Suite(&DisconnectSnapSuite{})
+
+func (s *DisconnectSnapSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+
+	s.repo = NewRepository()
+
+	err := s.repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface-a"})
+	c.Assert(err, IsNil)
+	err = s.repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface-b"})
+	c.Assert(err, IsNil)
+
+	setup := sdk.Setup{Workspace: "ws"}
+
+	s.s1 = sdk.MockInfo(c, `
+name: s1
+plugs:
+    iface-a:
+slots:
+    iface-b:
+`, setup)
+	err = s.repo.AddSdk(s.s1)
+	c.Assert(err, IsNil)
+
+	s.s2 = sdk.MockInfo(c, `
+name: s2
+plugs:
+    iface-b:
+slots:
+    iface-a:
+`, setup)
+	c.Assert(err, IsNil)
+	err = s.repo.AddSdk(s.s2)
+	c.Assert(err, IsNil)
+	s.s2Instance = sdk.MockInfo(c, `
+name: s2-instance
+plugs:
+    iface-b:
+slots:
+    iface-a:
+`, setup)
+	c.Assert(err, IsNil)
+	err = s.repo.AddSdk(s.s2Instance)
+	c.Assert(err, IsNil)
+}
+
+func (s *DisconnectSnapSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *DisconnectSnapSuite) TestNotConnected(c *C) {
+	affected, err := s.repo.DisconnectSdk("ws", "s1")
+	c.Assert(err, IsNil)
+	c.Check(affected, HasLen, 0)
+}
+
+func (s *DisconnectSnapSuite) TestOutgoingConnection(c *C) {
+	connRef := &ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s1", Name: "iface-a"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s2", Name: "iface-a"}}
+	_, err := s.repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Disconnect s1 with which has an outgoing connection to s2
+	affected, err := s.repo.DisconnectSdk("ws", "s1")
+	c.Assert(err, IsNil)
+	c.Check(affected, testutil.Contains, "s1")
+	c.Check(affected, testutil.Contains, "s2")
+}
+
+func (s *DisconnectSnapSuite) TestIncomingConnection(c *C) {
+	connRef := &ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s2", Name: "iface-b"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s1", Name: "iface-b"}}
+	_, err := s.repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	// Disconnect s1 with which has an incoming connection from s2
+	affected, err := s.repo.DisconnectSdk("ws", "s1")
+	c.Assert(err, IsNil)
+	c.Check(affected, testutil.Contains, "s1")
+	c.Check(affected, testutil.Contains, "s2")
+}
+
+func (s *DisconnectSnapSuite) TestCrossConnection(c *C) {
+	// This test is symmetric wrt s1 <-> s2 connections
+	for _, sdkName := range []string{"s1", "s2"} {
+		connRef1 := &ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s1", Name: "iface-a"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s2", Name: "iface-a"}}
+		_, err := s.repo.Connect(connRef1, nil, nil, nil, nil, nil)
+		c.Assert(err, IsNil)
+		connRef2 := &ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s2", Name: "iface-b"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s1", Name: "iface-b"}}
+		_, err = s.repo.Connect(connRef2, nil, nil, nil, nil, nil)
+		c.Assert(err, IsNil)
+		affected, err := s.repo.DisconnectSdk("ws", sdkName)
+		c.Assert(err, IsNil)
+		c.Check(affected, testutil.Contains, "s1")
+		c.Check(affected, testutil.Contains, "s2")
+	}
+}
+
+func (s *DisconnectSnapSuite) TestParallelInstances(c *C) {
+	_, err := s.repo.Connect(&ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s1", Name: "iface-a"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s2-instance", Name: "iface-a"}}, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	affected, err := s.repo.DisconnectSdk("ws", "s1")
+	c.Assert(err, IsNil)
+	c.Check(affected, testutil.Contains, "s1")
+	c.Check(affected, testutil.Contains, "s2-instance")
+
+	_, err = s.repo.Connect(&ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "s2-instance", Name: "iface-b"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "s1", Name: "iface-b"}}, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+	affected, err = s.repo.DisconnectSdk("ws", "s1")
+	c.Assert(err, IsNil)
+	c.Check(affected, testutil.Contains, "s1")
+	c.Check(affected, testutil.Contains, "s2-instance")
+}
+
+func contentPolicyCheck(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
+	return true, nil
+}
+
+func contentAutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	return plug.Attrs["content"] == slot.Attrs["content"]
+}
+
+// internal helper that creates a new repository with two snaps, one
+// is a content plug and one a content slot
+func makeContentConnectionTestSnaps(c *C, plugContentToken, slotContentToken string) (*Repository, *sdk.Info, *sdk.Info) {
+	repo := NewRepository()
+	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "content", AutoConnectCallback: contentAutoConnect})
+	c.Assert(err, IsNil)
+
+	plugSnap := sdk.MockInfo(c, fmt.Sprintf(`
+name: content-plug-sdk
+plugs:
+  imported-content:
+    interface: content
+    content: %s
+`, plugContentToken), sdk.Setup{Workspace: "ws-importer"})
+	slotSnap := sdk.MockInfo(c, fmt.Sprintf(`
+name: content-slot-sdk
+slots:
+  exported-content:
+    interface: content
+    content: %s
+`, slotContentToken), sdk.Setup{Workspace: "ws-exporter"})
+
+	err = repo.AddSdk(plugSnap)
+	c.Assert(err, IsNil)
+	err = repo.AddSdk(slotSnap)
+	c.Assert(err, IsNil)
+
+	return repo, plugSnap, slotSnap
+}
+
+func (s *RepositorySuite) TestAutoConnectContentInterfaceSimple(c *C) {
+	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "mylib")
+	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
+	c.Assert(candidateSlots, HasLen, 1)
+	c.Check(candidateSlots[0].Name, Equals, "exported-content")
+	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
+	c.Assert(candidatePlugs, HasLen, 1)
+	c.Check(candidatePlugs[0].Name, Equals, "imported-content")
+}
+
+func (s *RepositorySuite) TestAutoConnectContentInterfaceOSWorksCorrectly(c *C) {
+	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "otherlib")
+
+	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-snap", "imported-content", contentPolicyCheck)
+	c.Check(candidateSlots, HasLen, 0)
+	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-snap", "exported-content", contentPolicyCheck)
+	c.Assert(candidatePlugs, HasLen, 0)
+}
+
+func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingContent(c *C) {
+	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "otherlib")
+	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-snap", "imported-content", contentPolicyCheck)
+	c.Check(candidateSlots, HasLen, 0)
+	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-snap", "exported-content", contentPolicyCheck)
+	c.Assert(candidatePlugs, HasLen, 0)
+}
+
+func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingDeveloper(c *C) {
+	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "mylib")
+
+	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-snap", "imported-content", contentPolicyCheck)
+	c.Check(candidateSlots, HasLen, 0)
+	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-snap", "exported-content", contentPolicyCheck)
+	c.Assert(candidatePlugs, HasLen, 0)
+}
+
+const ifacehooksSnap1 = `
+name: s1
+plugs:
+  consumer:
+    interface: iface2
+    attr0: val0
+`
+
+const ifacehooksSnap2 = `
+name: s2
+slots:
+  producer:
+    interface: iface2
+    attr0: val0
+`
+
+func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
+	err := s.emptyRepo.AddInterface(&ifacetest.TestInterface{
+		InterfaceName: "iface2",
+		BeforeConnectSlotCallback: func(slot *ConnectedSlot) error {
+			var val string
+			if err := slot.Attr("attr1", &val); err != nil {
+				return err
+			}
+			return slot.SetAttr("attr1", fmt.Sprintf("%s-validated", val))
+		},
+		BeforeConnectPlugCallback: func(plug *ConnectedPlug) error {
+			var val string
+			if err := plug.Attr("attr1", &val); err != nil {
+				return err
+			}
+			return plug.SetAttr("attr1", fmt.Sprintf("%s-validated", val))
+		},
+	})
+	c.Assert(err, IsNil)
+
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, sdk.Setup{Workspace: "ws-s1"})
+	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, sdk.Setup{Workspace: "ws-s2"})
+	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
+
+	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
+	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+
+	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
+	conn, err := s.emptyRepo.Connect(&ConnRef{PlugRef: PlugRef{Workspace: "ws-s1", Sdk: "s1", Name: "consumer"}, SlotRef: SlotRef{Workspace: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+	c.Assert(err, IsNil)
+	c.Assert(conn, NotNil)
+
+	c.Assert(conn.Plug, NotNil)
+	c.Assert(conn.Slot, NotNil)
+
+	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"attr0": "val0"})
+	c.Assert(conn.Plug.DynamicAttrs(), DeepEquals, map[string]interface{}{"attr1": "val1-validated"})
+	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"attr0": "val0"})
+	c.Assert(conn.Slot.DynamicAttrs(), DeepEquals, map[string]interface{}{"attr1": "val1-validated"})
+}
+
+func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
+	err := s.emptyRepo.AddInterface(&ifacetest.TestInterface{
+		InterfaceName: "iface2",
+		BeforeConnectSlotCallback: func(slot *ConnectedSlot) error {
+			return fmt.Errorf("invalid slot")
+		},
+		BeforeConnectPlugCallback: func(plug *ConnectedPlug) error {
+			return fmt.Errorf("invalid plug")
+		},
+	})
+	c.Assert(err, IsNil)
+
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, sdk.Setup{Workspace: "ws-s1"})
+	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, sdk.Setup{Workspace: "ws-s2"})
+	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
+
+	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
+	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+
+	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
+
+	conn, err := s.emptyRepo.Connect(&ConnRef{PlugRef: PlugRef{Workspace: "ws-s1", Sdk: "s1", Name: "consumer"}, SlotRef: SlotRef{Workspace: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `cannot connect plug "consumer" of sdk "s1": invalid plug`)
+	c.Assert(conn, IsNil)
+}
+
+func (s *RepositorySuite) TestBeforeConnectValidationPolicyCheckFailure(c *C) {
+	err := s.emptyRepo.AddInterface(&ifacetest.TestInterface{
+		InterfaceName:             "iface2",
+		BeforeConnectSlotCallback: func(slot *ConnectedSlot) error { return nil },
+		BeforeConnectPlugCallback: func(plug *ConnectedPlug) error { return nil },
+	})
+	c.Assert(err, IsNil)
+
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, sdk.Setup{Workspace: "ws-s1"})
+	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, sdk.Setup{Workspace: "ws-s2"})
+	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
+
+	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
+	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+
+	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
+		return false, fmt.Errorf("policy check failed")
+	}
+
+	conn, err := s.emptyRepo.Connect(&ConnRef{PlugRef: PlugRef{Workspace: "ws-s1", Sdk: "s1", Name: "consumer"}, SlotRef: SlotRef{Workspace: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `policy check failed`)
+	c.Assert(conn, IsNil)
+}
+
+func (s *RepositorySuite) TestConnection(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+
+	connRef := NewConnRef(s.plug, s.slot)
+
+	_, err := s.testRepo.Connection(connRef)
+	c.Assert(err, ErrorMatches, `no connection from consumer:plug to producer:slot`)
+
+	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	conn, err := s.testRepo.Connection(connRef)
+	c.Assert(err, IsNil)
+	c.Assert(conn.Plug.Name(), Equals, "plug")
+	c.Assert(conn.Slot.Name(), Equals, "slot")
+
+	_, err = s.testRepo.Connection(&ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "a", Name: "b"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "producer", Name: "slot"}})
+	c.Assert(err, ErrorMatches, `sdk "a" has no plug named "b"`)
+	e, _ := err.(*NoPlugOrSlotError)
+	c.Check(e, NotNil)
+
+	_, err = s.testRepo.Connection(&ConnRef{PlugRef: PlugRef{Workspace: "ws", Sdk: "consumer", Name: "plug"}, SlotRef: SlotRef{Workspace: "ws", Sdk: "a", Name: "b"}})
+	c.Assert(err, ErrorMatches, `sdk "a" has no slot named "b"`)
+	e, _ = err.(*NoPlugOrSlotError)
+	c.Check(e, NotNil)
+}
+
+func (s *RepositorySuite) TestConnectWithStaticAttrs(c *C) {
+	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
+	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
+
+	connRef := NewConnRef(s.plug, s.slot)
+
+	plugAttrs := map[string]interface{}{"foo": "bar"}
+	slotAttrs := map[string]interface{}{"boo": "baz"}
+	_, err := s.testRepo.Connect(connRef, plugAttrs, nil, slotAttrs, nil, nil)
+	c.Assert(err, IsNil)
+
+	conn, err := s.testRepo.Connection(connRef)
+	c.Assert(err, IsNil)
+	c.Assert(conn.Plug.Name(), Equals, "plug")
+	c.Assert(conn.Slot.Name(), Equals, "slot")
+	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, plugAttrs)
+	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, slotAttrs)
+}

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -231,7 +231,7 @@ func (s *RepositorySuite) TestAddPlugClashingPlug(c *C) {
 }
 
 func (s *RepositorySuite) TestAddPlugClashingSlot(c *C) {
-	snapInfo := &sdk.Info{Workspace: "ws", Name: "snap"}
+	snapInfo := &sdk.Info{Workspace: "ws", Name: "sdk"}
 	plug := &sdk.PlugInfo{
 		Sdk:       snapInfo,
 		Name:      "clashing",
@@ -245,14 +245,14 @@ func (s *RepositorySuite) TestAddPlugClashingSlot(c *C) {
 	err := s.testRepo.AddSlot(slot)
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddPlug(plug)
-	c.Assert(err, ErrorMatches, `sdk "snap" has plug and slot conflicting on name "clashing"`)
+	c.Assert(err, ErrorMatches, `sdk "sdk" has plug and slot conflicting on name "clashing"`)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 1)
 	c.Assert(s.testRepo.Slot(slot.Sdk.Workspace, slot.Sdk.Name, slot.Name), DeepEquals, slot)
 }
 
 func (s *RepositorySuite) TestAddPlugFailsWithInvalidPlugName(c *C) {
 	plug := &sdk.PlugInfo{
-		Sdk:       &sdk.Info{Name: "snap"},
+		Sdk:       &sdk.Info{Name: "sdk"},
 		Name:      "bad-name-",
 		Interface: "interface",
 	}
@@ -343,7 +343,7 @@ func (s *RepositorySuite) TestRemovePlugSucceedsWhenPlugExistsAndDisconnected(c 
 
 func (s *RepositorySuite) TestRemovePlugFailsWhenPlugDoesntExist(c *C) {
 	err := s.emptyRepo.RemovePlug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
-	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from snap "consumer", no such plug`)
+	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from sdk "consumer", no such plug`)
 }
 
 func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
@@ -356,7 +356,7 @@ func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
 	c.Assert(err, IsNil)
 	// Removing a plug used by a slot returns an appropriate error
 	err = s.testRepo.RemovePlug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
-	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from snap "consumer", it is still connected`)
+	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from sdk "consumer", it is still connected`)
 	// The plug is still there
 	slot := s.testRepo.Plug(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
 	c.Assert(slot, Not(IsNil))
@@ -366,22 +366,22 @@ func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
 
 func (s *RepositorySuite) TestAllPlugsWithoutInterfaceName(c *C) {
 	sdks := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
-		{Name: "snap-a", Yaml: `
-name: snap-a
+		{Name: "sdk-a", Yaml: `
+name: sdk-a
 base: ubuntu@22.04
 plugs:
     name-a: interface
 `},
-		{Name: "snap-b", Yaml: `
-name: snap-b
+		{Name: "sdk-b", Yaml: `
+name: sdk-b
 base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: interface
     name-c: interface
 `},
-		{Name: "snap-b_instance", Yaml: `
-name: snap-b
+		{Name: "sdk-b_instance", Yaml: `
+name: sdk-b
 base: ubuntu@22.04
 plugs:
     name-a: interface
@@ -390,7 +390,7 @@ plugs:
 `},
 	})
 	c.Assert(sdks, HasLen, 3)
-	// The result is sorted by snap and name
+	// The result is sorted by sdk and name
 	allPlugs := s.testRepo.AllPlugs("")
 	c.Assert(allPlugs, DeepEquals, []*sdk.PlugInfo{
 		sdks[0].Plugs["name-a"],
@@ -408,22 +408,22 @@ func (s *RepositorySuite) TestAllPlugsWithInterfaceName(c *C) {
 	err := s.testRepo.AddInterface(&ifacetest.TestInterface{InterfaceName: "other-interface"})
 	c.Assert(err, IsNil)
 	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
-		{Name: "snap-a", Yaml: `
-name: snap-a
+		{Name: "sdk-a", Yaml: `
+name: sdk-a
 base: ubuntu@22.04
 plugs:
     name-a: interface
 `},
-		{Name: "snap-b", Yaml: `
-name: snap-b
+		{Name: "sdk-b", Yaml: `
+name: sdk-b
 base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: other-interface
     name-c: interface
 `},
-		{Name: "snap-b_instance", Yaml: `
-name: snap-b
+		{Name: "sdk-b_instance", Yaml: `
+name: sdk-b
 base: ubuntu@22.04
 plugs:
     name-a: interface
@@ -442,16 +442,16 @@ plugs:
 
 func (s *RepositorySuite) TestPlugs(c *C) {
 	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
-		{Name: "snap-a", Yaml: `
-name: snap-a
+		{Name: "sdk-a", Yaml: `
+name: sdk-a
 base: ubuntu@22.04
 plugs:
     name-a: interface
     name-b: interface
     name-c: interface
 `},
-		{Name: "snap-b", Yaml: `
-name: snap-b
+		{Name: "sdk-b", Yaml: `
+name: sdk-b
 base: ubuntu@22.04
 plugs:
     name-a: interface
@@ -460,20 +460,20 @@ plugs:
 `},
 	})
 	c.Assert(snaps, HasLen, 2)
-	// The result is sorted by snap and name
-	c.Assert(s.testRepo.Plugs("ws-snap-a", "snap-a"), DeepEquals, []*sdk.PlugInfo{
+	// The result is sorted by sdk and name
+	c.Assert(s.testRepo.Plugs("ws-sdk-a", "sdk-a"), DeepEquals, []*sdk.PlugInfo{
 		snaps[0].Plugs["name-a"],
 		snaps[0].Plugs["name-b"],
 		snaps[0].Plugs["name-c"],
 	})
-	c.Assert(s.testRepo.Plugs("ws-snap-b", "snap-b"), DeepEquals, []*sdk.PlugInfo{
+	c.Assert(s.testRepo.Plugs("ws-sdk-b", "sdk-b"), DeepEquals, []*sdk.PlugInfo{
 		snaps[1].Plugs["name-a"],
 		snaps[1].Plugs["name-b"],
 		snaps[1].Plugs["name-c"],
 	})
-	// The result is empty if the snap is not known
-	c.Assert(s.testRepo.Plugs("ws-snap-a", "snap-x"), HasLen, 0)
-	c.Assert(s.testRepo.Plugs("ws-snap-b", "snap-b_other"), HasLen, 0)
+	// The result is empty if the sdk is not known
+	c.Assert(s.testRepo.Plugs("ws-sdk-a", "sdk-x"), HasLen, 0)
+	c.Assert(s.testRepo.Plugs("ws-sdk-b", "sdk-b_other"), HasLen, 0)
 }
 
 // Tests for Repository.AllSlots()
@@ -482,35 +482,35 @@ func (s *RepositorySuite) TestAllSlots(c *C) {
 	err := s.testRepo.AddInterface(&ifacetest.TestInterface{InterfaceName: "other-interface"})
 	c.Assert(err, IsNil)
 	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
-		{Name: "snap-a", Yaml: `
-name: snap-a
+		{Name: "sdk-a", Yaml: `
+name: sdk-a
 base: ubuntu@22.04
 slots:
     name-a: interface
     name-b: interface
 `},
-		{Name: "snap-b", Yaml: `
-name: snap-b
+		{Name: "sdk-b", Yaml: `
+name: sdk-b
 base: ubuntu@22.04
 slots:
     name-a: other-interface
 `},
-		{Name: "snap-b_instance", Yaml: `
-name: snap-b
+		{Name: "sdk-b_instance", Yaml: `
+name: sdk-b
 base: ubuntu@22.04
 slots:
     name-a: other-interface
 `},
 	})
 	c.Assert(snaps, HasLen, 3)
-	// AllSlots("") returns all slots, sorted by snap and slot name
+	// AllSlots("") returns all slots, sorted by sdk and slot name
 	c.Assert(s.testRepo.AllSlots(""), DeepEquals, []*sdk.SlotInfo{
 		snaps[0].Slots["name-a"],
 		snaps[0].Slots["name-b"],
 		snaps[1].Slots["name-a"],
 		snaps[2].Slots["name-a"],
 	})
-	// AllSlots("") returns all slots, sorted by snap and slot name
+	// AllSlots("") returns all slots, sorted by sdk and slot name
 	c.Assert(s.testRepo.AllSlots("other-interface"), DeepEquals, []*sdk.SlotInfo{
 		snaps[1].Slots["name-a"],
 		snaps[2].Slots["name-a"],
@@ -521,35 +521,35 @@ slots:
 
 func (s *RepositorySuite) TestSlots(c *C) {
 	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
-		{Name: "snap-a", Yaml: `
-name: snap-a
+		{Name: "sdk-a", Yaml: `
+name: sdk-a
 base: ubuntu@22.04
 slots:
     name-a: interface
     name-b: interface
 `},
-		{Name: "snap-b", Yaml: `
-name: snap-b
+		{Name: "sdk-b", Yaml: `
+name: sdk-b
 base: ubuntu@22.04
 slots:
     name-a: interface
 `},
 	})
-	// Slots("snap-a") returns slots present in that snap
-	c.Assert(s.testRepo.Slots("ws-snap-a", "snap-a"), DeepEquals, []*sdk.SlotInfo{
+	// Slots("sdk-a") returns slots present in that sdk
+	c.Assert(s.testRepo.Slots("ws-sdk-a", "sdk-a"), DeepEquals, []*sdk.SlotInfo{
 		snaps[0].Slots["name-a"],
 		snaps[0].Slots["name-b"],
 	})
-	// Slots("snap-b") returns slots present in that snap
-	c.Assert(s.testRepo.Slots("ws-snap-b", "snap-b"), DeepEquals, []*sdk.SlotInfo{
+	// Slots("sdk-b") returns slots present in that sdk
+	c.Assert(s.testRepo.Slots("ws-sdk-b", "sdk-b"), DeepEquals, []*sdk.SlotInfo{
 		snaps[1].Slots["name-a"],
 	})
-	// Slots("snap-c") returns no slots (because that sdk doesn't exist)
-	c.Assert(s.testRepo.Slots("ws-snap-a", "snap-c"), HasLen, 0)
-	// Slots("snap-b_other") returns no slots (the sdk does not exist)
-	c.Assert(s.testRepo.Slots("ws-snap-a", "snap-b_other"), HasLen, 0)
+	// Slots("sdk-c") returns no slots (because that sdk doesn't exist)
+	c.Assert(s.testRepo.Slots("ws-sdk-a", "sdk-c"), HasLen, 0)
+	// Slots("sdk-b_other") returns no slots (the sdk does not exist)
+	c.Assert(s.testRepo.Slots("ws-sdk-a", "sdk-b_other"), HasLen, 0)
 	// Slots("") returns no slots
-	c.Assert(s.testRepo.Slots("ws-snap-a", ""), HasLen, 0)
+	c.Assert(s.testRepo.Slots("ws-sdk-a", ""), HasLen, 0)
 }
 
 // Tests for Repository.Slot()
@@ -575,7 +575,7 @@ func (s *RepositorySuite) TestAddSlotFailsWhenInterfaceIsUnknown(c *C) {
 
 func (s *RepositorySuite) TestAddSlotFailsWhenSlotNameIsInvalid(c *C) {
 	slot := &sdk.SlotInfo{
-		Sdk:       &sdk.Info{Name: "snap"},
+		Sdk:       &sdk.Info{Name: "sdk"},
 		Name:      "bad-name-",
 		Interface: "interface",
 	}
@@ -594,7 +594,7 @@ func (s *RepositorySuite) TestAddSlotClashingSlot(c *C) {
 }
 
 func (s *RepositorySuite) TestAddSlotClashingPlug(c *C) {
-	snapInfo := &sdk.Info{Name: "snap"}
+	snapInfo := &sdk.Info{Name: "sdk"}
 	plug := &sdk.PlugInfo{
 		Sdk:       snapInfo,
 		Name:      "clashing",
@@ -608,7 +608,7 @@ func (s *RepositorySuite) TestAddSlotClashingPlug(c *C) {
 	err := s.testRepo.AddPlug(plug)
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(slot)
-	c.Assert(err, ErrorMatches, `sdk "snap" has plug and slot conflicting on name "clashing"`)
+	c.Assert(err, ErrorMatches, `sdk "sdk" has plug and slot conflicting on name "clashing"`)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
 	c.Assert(s.testRepo.Plug(plug.Sdk.Workspace, plug.Sdk.Name, plug.Name), DeepEquals, plug)
 }
@@ -760,16 +760,16 @@ func (s *RepositorySuite) TestDisconnectFailsOnEmptyArgs(c *C) {
 	err3 := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, "", s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
 	err4 := s.testRepo.Disconnect(s.plug.Sdk.Workspace, "", s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err1, ErrorMatches, `cannot disconnect, slot name is empty`)
-	c.Assert(err2, ErrorMatches, `cannot disconnect, slot snap name is empty`)
+	c.Assert(err2, ErrorMatches, `cannot disconnect, slot sdk name is empty`)
 	c.Assert(err3, ErrorMatches, `cannot disconnect, plug name is empty`)
-	c.Assert(err4, ErrorMatches, `cannot disconnect, plug snap name is empty`)
+	c.Assert(err4, ErrorMatches, `cannot disconnect, plug sdk name is empty`)
 }
 
 // Disconnect fails if plug doesn't exist
 func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
 	err := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `snap "consumer" has no plug named "plug"`)
+	c.Assert(err, ErrorMatches, `sdk "consumer" has no plug named "plug"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -778,7 +778,7 @@ func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
 func (s *RepositorySuite) TestDisconnectFailsWithutSlot(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	err := s.testRepo.Disconnect(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `snap "producer" has no slot named "slot"`)
+	c.Assert(err, ErrorMatches, `sdk "producer" has no slot named "slot"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -811,7 +811,7 @@ func (s *RepositorySuite) TestDisconnectSucceeds(c *C) {
 
 // Tests for Repository.Connected
 
-// Connected fails if snap name is empty and there's no core snap around
+// Connected fails if sdk name is empty
 func (s *RepositorySuite) TestConnectedFailsWithEmptyWorkspaceName(c *C) {
 	_, err := s.testRepo.Connected("ws", "", s.plug.Name)
 	c.Check(err, ErrorMatches, "internal error: cannot obtain sdk name while computing connections")
@@ -832,10 +832,10 @@ func (s *RepositorySuite) TestConnectedFailsWithEmptyPlugSlotName(c *C) {
 func (s *RepositorySuite) TestConnectedFailsWithoutPlugOrSlot(c *C) {
 	_, err1 := s.testRepo.Connected(s.plug.Sdk.Workspace, s.plug.Sdk.Name, s.plug.Name)
 	_, err2 := s.testRepo.Connected(s.slot.Sdk.Workspace, s.slot.Sdk.Name, s.slot.Name)
-	c.Check(err1, ErrorMatches, `snap "consumer" has no plug or slot named "plug"`)
+	c.Check(err1, ErrorMatches, `sdk "consumer" has no plug or slot named "plug"`)
 	e, _ := err1.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
-	c.Check(err2, ErrorMatches, `snap "producer" has no plug or slot named "slot"`)
+	c.Check(err2, ErrorMatches, `sdk "producer" has no plug or slot named "slot"`)
 	e, _ = err1.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -1112,7 +1112,7 @@ func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlotsSymmetry(c *C) {
 		return slot.Interface() == "auto", nil
 	}
 
-	// Add a producer snap for "auto"
+	// Add a producer sdk for "auto"
 	producer := sdk.MockInfo(c, `
 name: producer
 base: ubuntu@22.04
@@ -1206,7 +1206,7 @@ slots:
   bogus-slot:
 `)
 	c.Assert(err, IsNil)
-	// the snap knowns about the bogus plug and slot
+	// the sdk knowns about the bogus plug and slot
 	c.Assert(info.Plugs["bogus-plug"], NotNil)
 	c.Assert(info.Slots["bogus-slot"], NotNil)
 	// but the repository ignores them
@@ -1344,7 +1344,7 @@ func contentAutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
 
 // internal helper that creates a new repository with two snaps, one
 // is a content plug and one a content slot
-func makeContentConnectionTestSnaps(c *C, plugContentToken, slotContentToken string) (*Repository, *sdk.Info, *sdk.Info) {
+func makeContentConnectionTestSdks(c *C, plugContentToken, slotContentToken string) (*Repository, *sdk.Info, *sdk.Info) {
 	repo := NewRepository()
 	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "content", AutoConnectCallback: contentAutoConnect})
 	c.Assert(err, IsNil)
@@ -1375,7 +1375,7 @@ slots:
 }
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceSimple(c *C) {
-	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "mylib")
+	repo, _, _ := makeContentConnectionTestSdks(c, "mylib", "mylib")
 	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Name, Equals, "exported-content")
@@ -1385,28 +1385,19 @@ func (s *RepositorySuite) TestAutoConnectContentInterfaceSimple(c *C) {
 }
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceOSWorksCorrectly(c *C) {
-	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "otherlib")
+	repo, _, _ := makeContentConnectionTestSdks(c, "mylib", "otherlib")
 
-	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-snap", "imported-content", contentPolicyCheck)
+	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)
-	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-snap", "exported-content", contentPolicyCheck)
+	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
 	c.Assert(candidatePlugs, HasLen, 0)
 }
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingContent(c *C) {
-	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "otherlib")
-	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-snap", "imported-content", contentPolicyCheck)
+	repo, _, _ := makeContentConnectionTestSdks(c, "mylib", "otherlib")
+	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)
-	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-snap", "exported-content", contentPolicyCheck)
-	c.Assert(candidatePlugs, HasLen, 0)
-}
-
-func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingDeveloper(c *C) {
-	repo, _, _ := makeContentConnectionTestSnaps(c, "mylib", "mylib")
-
-	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-snap", "imported-content", contentPolicyCheck)
-	c.Check(candidateSlots, HasLen, 0)
-	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-snap", "exported-content", contentPolicyCheck)
+	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
 	c.Assert(candidatePlugs, HasLen, 0)
 }
 

--- a/internal/interfaces/sorting.go
+++ b/internal/interfaces/sorting.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"sort"
+
+	"github.com/canonical/workspace/internal/sdk"
+)
+
+type byConnRef []*ConnRef
+
+func (c byConnRef) Len() int      { return len(c) }
+func (c byConnRef) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byConnRef) Less(i, j int) bool {
+	return c[i].SortsBefore(c[j])
+}
+
+type byPlugWorkspaceSdkAndName []*sdk.PlugInfo
+
+func (c byPlugWorkspaceSdkAndName) Len() int      { return len(c) }
+func (c byPlugWorkspaceSdkAndName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byPlugWorkspaceSdkAndName) Less(i, j int) bool {
+	if c[i].Sdk.Workspace != c[j].Sdk.Workspace {
+		return c[i].Sdk.Workspace < c[j].Sdk.Workspace
+	}
+	if c[i].Sdk.Name != c[j].Sdk.Name {
+		return c[i].Sdk.Name < c[j].Sdk.Name
+	}
+	return c[i].Name < c[j].Name
+}
+
+type bySlotWorkspaceSdkAndName []*sdk.SlotInfo
+
+func (c bySlotWorkspaceSdkAndName) Len() int      { return len(c) }
+func (c bySlotWorkspaceSdkAndName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c bySlotWorkspaceSdkAndName) Less(i, j int) bool {
+	if c[i].Sdk.Workspace != c[j].Sdk.Workspace {
+		return c[i].Sdk.Workspace < c[j].Sdk.Workspace
+	}
+	if c[i].Sdk.Name != c[j].Sdk.Name {
+		return c[i].Sdk.Name < c[j].Sdk.Name
+	}
+	return c[i].Name < c[j].Name
+}
+
+func sortedSnapNamesWithPlugs(m map[string]map[string]*sdk.PlugInfo) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedPlugNames(m map[string]*sdk.PlugInfo) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedSnapNamesWithSlots(m map[string]map[string]*sdk.SlotInfo) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedSlotNames(m map[string]*sdk.SlotInfo) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+type byInterfaceName []Interface
+
+func (c byInterfaceName) Len() int      { return len(c) }
+func (c byInterfaceName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byInterfaceName) Less(i, j int) bool {
+	return c[i].Name() < c[j].Name()
+}

--- a/internal/interfaces/sorting.go
+++ b/internal/interfaces/sorting.go
@@ -61,7 +61,7 @@ func (c bySlotWorkspaceSdkAndName) Less(i, j int) bool {
 	return c[i].Name < c[j].Name
 }
 
-func sortedSnapNamesWithPlugs(m map[string]map[string]*sdk.PlugInfo) []string {
+func sortedSdkNamesWithPlugs(m map[string]map[string]*sdk.PlugInfo) []string {
 	keys := make([]string, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)
@@ -79,7 +79,7 @@ func sortedPlugNames(m map[string]*sdk.PlugInfo) []string {
 	return keys
 }
 
-func sortedSnapNamesWithSlots(m map[string]map[string]*sdk.SlotInfo) []string {
+func sortedSdkNamesWithSlots(m map[string]map[string]*sdk.SlotInfo) []string {
 	keys := make([]string, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)

--- a/internal/interfaces/sorting_test.go
+++ b/internal/interfaces/sorting_test.go
@@ -32,8 +32,8 @@ type SortingSuite struct{}
 
 var _ = Suite(&SortingSuite{})
 
-func newConnRef(plugSnap, plug, slotSnap, slot string) *interfaces.ConnRef {
-	return &interfaces.ConnRef{PlugRef: interfaces.PlugRef{Sdk: plugSnap, Name: plug}, SlotRef: interfaces.SlotRef{Sdk: slotSnap, Name: slot}}
+func newConnRef(plugSdk, plug, slotSdk, slot string) *interfaces.ConnRef {
+	return &interfaces.ConnRef{PlugRef: interfaces.PlugRef{Sdk: plugSdk, Name: plug}, SlotRef: interfaces.SlotRef{Sdk: slotSdk, Name: slot}}
 }
 
 func (s *SortingSuite) TestByInterfaceName(c *C) {
@@ -71,8 +71,8 @@ func (s *SortingSuite) TestByConnRef(c *C) {
 	})
 }
 
-func newSlotRef(snap, name string) *interfaces.SlotRef {
-	return &interfaces.SlotRef{Sdk: snap, Name: name}
+func newSlotRef(sdk, name string) *interfaces.SlotRef {
+	return &interfaces.SlotRef{Sdk: sdk, Name: name}
 }
 
 type bySlotRef []*interfaces.SlotRef
@@ -110,8 +110,8 @@ func (b byPlugRef) Less(i, j int) bool {
 	return b[i].SortsBefore(*b[j])
 }
 
-func newPlugRef(snap, name string) *interfaces.PlugRef {
-	return &interfaces.PlugRef{Sdk: snap, Name: name}
+func newPlugRef(sdk, name string) *interfaces.PlugRef {
+	return &interfaces.PlugRef{Sdk: sdk, Name: name}
 }
 
 func (s *SortingSuite) TestSortPlugRef(c *C) {

--- a/internal/interfaces/sorting_test.go
+++ b/internal/interfaces/sorting_test.go
@@ -1,0 +1,134 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	"sort"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/ifacetest"
+)
+
+type SortingSuite struct{}
+
+var _ = Suite(&SortingSuite{})
+
+func newConnRef(plugSnap, plug, slotSnap, slot string) *interfaces.ConnRef {
+	return &interfaces.ConnRef{PlugRef: interfaces.PlugRef{Sdk: plugSnap, Name: plug}, SlotRef: interfaces.SlotRef{Sdk: slotSnap, Name: slot}}
+}
+
+func (s *SortingSuite) TestByInterfaceName(c *C) {
+	list := []interfaces.Interface{
+		&ifacetest.TestInterface{InterfaceName: "iface-2"},
+		&ifacetest.TestInterface{InterfaceName: "iface-1"},
+	}
+	sort.Sort(interfaces.ByInterfaceName(list))
+	c.Assert(list, DeepEquals, []interfaces.Interface{
+		&ifacetest.TestInterface{InterfaceName: "iface-1"},
+		&ifacetest.TestInterface{InterfaceName: "iface-2"},
+	})
+}
+
+func (s *SortingSuite) TestByConnRef(c *C) {
+	list := []*interfaces.ConnRef{
+		newConnRef("name-1", "plug-3", "name-2", "slot-1"),
+		newConnRef("name-1", "plug-1", "name-2", "slot-3"),
+		newConnRef("name-1", "plug-2", "name-2", "slot-2"),
+		newConnRef("name-1", "plug-1", "name-2", "slot-4"),
+		newConnRef("name-1", "plug-1", "name-2", "slot-1"),
+		newConnRef("name-1", "plug-1", "name-2_instance", "slot-1"),
+		newConnRef("name-1_instance", "plug-1", "name-2", "slot-1"),
+	}
+	sort.Sort(interfaces.ByConnRef(list))
+
+	c.Assert(list, DeepEquals, []*interfaces.ConnRef{
+		newConnRef("name-1", "plug-1", "name-2", "slot-1"),
+		newConnRef("name-1", "plug-1", "name-2", "slot-3"),
+		newConnRef("name-1", "plug-1", "name-2", "slot-4"),
+		newConnRef("name-1", "plug-1", "name-2_instance", "slot-1"),
+		newConnRef("name-1", "plug-2", "name-2", "slot-2"),
+		newConnRef("name-1", "plug-3", "name-2", "slot-1"),
+		newConnRef("name-1_instance", "plug-1", "name-2", "slot-1"),
+	})
+}
+
+func newSlotRef(snap, name string) *interfaces.SlotRef {
+	return &interfaces.SlotRef{Sdk: snap, Name: name}
+}
+
+type bySlotRef []*interfaces.SlotRef
+
+func (b bySlotRef) Len() int      { return len(b) }
+func (b bySlotRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b bySlotRef) Less(i, j int) bool {
+	return b[i].SortsBefore(*b[j])
+}
+
+func (s *SortingSuite) TestSortSlotRef(c *C) {
+	list := []*interfaces.SlotRef{
+		newSlotRef("name-2", "slot-3"),
+		newSlotRef("name-2_instance", "slot-1"),
+		newSlotRef("name-2", "slot-2"),
+		newSlotRef("name-2", "slot-4"),
+		newSlotRef("name-2", "slot-1"),
+	}
+	sort.Sort(bySlotRef(list))
+
+	c.Assert(list, DeepEquals, []*interfaces.SlotRef{
+		newSlotRef("name-2", "slot-1"),
+		newSlotRef("name-2", "slot-2"),
+		newSlotRef("name-2", "slot-3"),
+		newSlotRef("name-2", "slot-4"),
+		newSlotRef("name-2_instance", "slot-1"),
+	})
+}
+
+type byPlugRef []*interfaces.PlugRef
+
+func (b byPlugRef) Len() int      { return len(b) }
+func (b byPlugRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b byPlugRef) Less(i, j int) bool {
+	return b[i].SortsBefore(*b[j])
+}
+
+func newPlugRef(snap, name string) *interfaces.PlugRef {
+	return &interfaces.PlugRef{Sdk: snap, Name: name}
+}
+
+func (s *SortingSuite) TestSortPlugRef(c *C) {
+	list := []*interfaces.PlugRef{
+		newPlugRef("name-2", "plug-3"),
+		newPlugRef("name-2_instance", "plug-1"),
+		newPlugRef("name-2", "plug-4"),
+		newPlugRef("name-2", "plug-2"),
+		newPlugRef("name-2", "plug-1"),
+	}
+	sort.Sort(byPlugRef(list))
+
+	c.Assert(list, DeepEquals, []*interfaces.PlugRef{
+		newPlugRef("name-2", "plug-1"),
+		newPlugRef("name-2", "plug-2"),
+		newPlugRef("name-2", "plug-3"),
+		newPlugRef("name-2", "plug-4"),
+		newPlugRef("name-2_instance", "plug-1"),
+	})
+}

--- a/internal/interfaces/utils/utils.go
+++ b/internal/interfaces/utils/utils.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package utils
+
+import (
+	"encoding/json"
+)
+
+// NormalizeInterfaceAttributes normalises types of an attribute values.
+// The following transformations are applied: int -> int64, float32 -> float64.
+// The normalisation proceeds recursively through maps and slices.
+func NormalizeInterfaceAttributes(value interface{}) interface{} {
+	// Normalize ints/floats using their 64-bit variants.
+	switch v := value.(type) {
+	case int:
+		return int64(v)
+	case float32:
+		return float64(v)
+	case []interface{}:
+		vc := make([]interface{}, len(v))
+		for i, el := range v {
+			vc[i] = NormalizeInterfaceAttributes(el)
+		}
+		return vc
+	case map[string]interface{}:
+		vc := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			vc[key] = NormalizeInterfaceAttributes(item)
+		}
+		return vc
+	case json.Number:
+		jsonval := value.(json.Number)
+		if asInt, err := jsonval.Int64(); err == nil {
+			return asInt
+		}
+		asFloat, _ := jsonval.Float64()
+		return asFloat
+	}
+	return value
+}
+
+// CopyAttributes makes a deep copy of the attributes map.
+func CopyAttributes(value map[string]interface{}) map[string]interface{} {
+	return copyRecursive(value).(map[string]interface{})
+}
+
+func copyRecursive(value interface{}) interface{} {
+	// note: ensure all the mutable types (or types that need a conversion)
+	// are handled here.
+	switch v := value.(type) {
+	case []interface{}:
+		arr := make([]interface{}, len(v))
+		for i, el := range v {
+			arr[i] = copyRecursive(el)
+		}
+		return arr
+	case map[string]interface{}:
+		mp := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			mp[key] = copyRecursive(item)
+		}
+		return mp
+	}
+	return value
+}

--- a/internal/interfaces/utils/utils_test.go
+++ b/internal/interfaces/utils/utils_test.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package utils_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/interfaces/utils"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type utilsSuite struct{}
+
+var _ = Suite(&utilsSuite{})
+
+func (s *utilsSuite) TestNormalizeInterfaceAttributes(c *C) {
+	normalize := utils.NormalizeInterfaceAttributes
+	c.Assert(normalize(false), Equals, false)
+	c.Assert(normalize(nil), Equals, nil)
+	c.Assert(normalize(42), Equals, int64(42))
+	c.Assert(normalize(3.14), Equals, float64(3.14))
+	// Funny that, I noticed it only because of missing test coverage.
+	c.Assert(normalize(float32(3.14)), Equals, float64(3.140000104904175))
+	c.Assert(normalize("banana"), Equals, "banana")
+	c.Assert(normalize([]interface{}{42, 3.14, "banana", json.Number("21"), json.Number("0.5")}), DeepEquals,
+		[]interface{}{int64(42), float64(3.14), "banana", int64(21), float64(0.5)})
+	c.Assert(normalize(map[string]interface{}{"i": 42, "f": 3.14, "s": "banana"}),
+		DeepEquals, map[string]interface{}{"i": int64(42), "f": float64(3.14), "s": "banana"})
+	c.Assert(normalize(json.Number("1")), Equals, int64(1))
+	c.Assert(normalize(json.Number("2.5")), Equals, float64(2.5))
+
+	// Normalize doesn't mutate slices it is given
+	sliceIn := []interface{}{42}
+	sliceOut := normalize(sliceIn)
+	c.Assert(sliceIn, DeepEquals, []interface{}{42})
+	c.Assert(sliceOut, DeepEquals, []interface{}{int64(42)})
+
+	// Normalize doesn't mutate maps it is given
+	mapIn := map[string]interface{}{"i": 42}
+	mapOut := normalize(mapIn)
+	c.Assert(mapIn, DeepEquals, map[string]interface{}{"i": 42})
+	c.Assert(mapOut, DeepEquals, map[string]interface{}{"i": int64(42)})
+}
+
+func (s *utilsSuite) TestCopyAttributes(c *C) {
+	cpattr := utils.CopyAttributes
+
+	attrsIn := map[string]interface{}{"i": 42}
+	attrsOut := cpattr(attrsIn)
+	attrsIn["i"] = "changed"
+	c.Assert(attrsIn, DeepEquals, map[string]interface{}{"i": "changed"})
+	c.Assert(attrsOut, DeepEquals, map[string]interface{}{"i": 42})
+
+	attrsIn = map[string]interface{}{"ao": []interface{}{1, 2, 3}}
+	attrsOut = cpattr(attrsIn)
+	attrsIn["ao"].([]interface{})[1] = "changed"
+	c.Assert(attrsIn, DeepEquals, map[string]interface{}{"ao": []interface{}{1, "changed", 3}})
+	c.Assert(attrsOut, DeepEquals, map[string]interface{}{"ao": []interface{}{1, 2, 3}})
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -145,7 +145,7 @@ func (l *Log) debugEnabled() bool {
 	return l.debug || osutil.GetenvBool("WORKSPACED_DEBUG")
 }
 
-// Debug only prints if SNAPD_DEBUG is set
+// Debug only prints if WORKSPACED_DEBUG is set
 func (l *Log) Debug(msg string) {
 	if l.debugEnabled() {
 		l.NoGuardDebug(msg)
@@ -177,7 +177,7 @@ func New(w io.Writer, flag int) (Logger, error) {
 func buildFlags() int {
 	flags := log.Lshortfile
 	if term := os.Getenv("TERM"); term != "" {
-		// snapd is probably not running under systemd
+		// daemon is probably not running under systemd
 		flags = DefaultFlags
 	}
 	return flags
@@ -221,9 +221,9 @@ func debugEnabledOnKernelCmdline() bool {
 
 var timeNow = time.Now
 
-// StartupStageTimestamp produce snap startup timings message.
+// StartupStageTimestamp produce sdk startup timings message.
 func StartupStageTimestamp(stage string) {
 	now := timeNow()
-	Debugf(`-- snap startup {"stage":"%s", "time":"%v.%06d"}`,
+	Debugf(`-- sdk startup {"stage":"%s", "time":"%v.%06d"}`,
 		stage, now.Unix(), (now.UnixNano()/1e3)%1e6)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -203,7 +203,7 @@ func (s *LogSuite) TestStartupTimestampMsg(c *C) {
 	})
 	logger.StartupStageTimestamp("foo to bar")
 	msg := strings.TrimSpace(s.logbuf.String())
-	c.Assert(msg, Matches, `.* DEBUG: -- snap startup \{"stage":"foo to bar", "time":"1652697792.022312"\}$`)
+	c.Assert(msg, Matches, `.* DEBUG: -- sdk startup \{"stage":"foo to bar", "time":"1652697792.022312"\}$`)
 
 	var m msgTimestamp
 	start := strings.LastIndex(msg, "{")

--- a/internal/metautil/export_test.go
+++ b/internal/metautil/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil
+
+var (
+	ConvertValue = convertValue
+)

--- a/internal/metautil/normalize.go
+++ b/internal/metautil/normalize.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package metautil takes care of basic details of working with snap metadata formats.
+package metautil
+
+import (
+	"fmt"
+)
+
+// NormalizeValue validates values and returns a normalized version of it
+// (map[interface{}]interface{} is turned into map[string]interface{})
+func NormalizeValue(v interface{}) (interface{}, error) {
+	switch x := v.(type) {
+	case string:
+		return x, nil
+	case bool:
+		return x, nil
+	case int:
+		return int64(x), nil
+	case int64:
+		return x, nil
+	case float64:
+		return x, nil
+	case float32:
+		return float64(x), nil
+	case []interface{}:
+		l := make([]interface{}, len(x))
+		for i, el := range x {
+			el, err := NormalizeValue(el)
+			if err != nil {
+				return nil, err
+			}
+			l[i] = el
+		}
+		return l, nil
+	case map[interface{}]interface{}:
+		m := make(map[string]interface{}, len(x))
+		for k, item := range x {
+			kStr, ok := k.(string)
+			if !ok {
+				return nil, fmt.Errorf("non-string key: %v", k)
+			}
+			item, err := NormalizeValue(item)
+			if err != nil {
+				return nil, err
+			}
+			m[kStr] = item
+		}
+		return m, nil
+	case map[string]interface{}:
+		m := make(map[string]interface{}, len(x))
+		for k, item := range x {
+			item, err := NormalizeValue(item)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = item
+		}
+		return m, nil
+	default:
+		return nil, fmt.Errorf("invalid scalar: %v", v)
+	}
+}

--- a/internal/metautil/normalize.go
+++ b/internal/metautil/normalize.go
@@ -17,7 +17,7 @@
  *
  */
 
-// Package metautil takes care of basic details of working with snap metadata formats.
+// Package metautil takes care of basic details of working with sdk metadata formats.
 package metautil
 
 import (

--- a/internal/metautil/normalize_test.go
+++ b/internal/metautil/normalize_test.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/metautil"
+)
+
+type normalizeTestSuite struct {
+}
+
+var _ = Suite(&normalizeTestSuite{})
+
+func TestMain(t *testing.T) { TestingT(t) }
+
+func (s *normalizeTestSuite) TestNormalize(c *C) {
+	for _, tc := range []struct {
+		v   interface{}
+		exp interface{}
+		err string
+	}{
+		{v: "foo", exp: "foo"},
+		{v: 1, exp: int64(1)},
+		{v: int64(1), exp: int64(1)},
+		{v: true, exp: true},
+		{v: 0.5, exp: float64(0.5)},
+		{v: float32(0.5), exp: float64(0.5)},
+		{v: float64(0.5), exp: float64(0.5)},
+		{v: []interface{}{1, 0.5, "foo"}, exp: []interface{}{int64(1), float64(0.5), "foo"}},
+		{v: map[string]interface{}{"foo": 1}, exp: map[string]interface{}{"foo": int64(1)}},
+		{v: map[interface{}]interface{}{"foo": 1}, exp: map[string]interface{}{"foo": int64(1)}},
+		{
+			v:   map[interface{}]interface{}{"foo": map[interface{}]interface{}{"bar": 0.5}},
+			exp: map[string]interface{}{"foo": map[string]interface{}{"bar": float64(0.5)}},
+		},
+		{v: uint(1), err: "invalid scalar: 1"},
+		{v: map[interface{}]interface{}{2: 1}, err: "non-string key: 2"},
+		{v: []interface{}{uint(1)}, err: "invalid scalar: 1"},
+		{v: map[string]interface{}{"foo": uint(1)}, err: "invalid scalar: 1"},
+		{v: map[interface{}]interface{}{"foo": uint(1)}, err: "invalid scalar: 1"},
+	} {
+		res, err := metautil.NormalizeValue(tc.v)
+		if tc.err == "" {
+			c.Assert(err, IsNil)
+			c.Assert(res, DeepEquals, tc.exp)
+		} else {
+			c.Assert(err, ErrorMatches, tc.err)
+		}
+	}
+}

--- a/internal/metautil/type_conversions.go
+++ b/internal/metautil/type_conversions.go
@@ -80,7 +80,7 @@ type AttributeNotCompatibleError struct {
 }
 
 func (e AttributeNotCompatibleError) Error() string {
-	return fmt.Sprintf("snap %q has interface %q with invalid value type %s for %q attribute: %s", e.SdkName, e.InterfaceName, e.AttributeType, e.AttributeName, e.ExpectedType)
+	return fmt.Sprintf("sdk %q has interface %q with invalid value type %s for %q attribute: %s", e.SdkName, e.InterfaceName, e.AttributeType, e.AttributeName, e.ExpectedType)
 }
 
 func (e AttributeNotCompatibleError) Is(target error) bool {
@@ -89,13 +89,13 @@ func (e AttributeNotCompatibleError) Is(target error) bool {
 }
 
 // SetValueFromAttribute attempts to convert the attribute value read from the
-// given snap/interface into the desired type.
+// given sdk/interface into the desired type.
 //
-// The snapName, ifaceName and attrName are only used to produce contextual
+// The sdkName, ifaceName and attrName are only used to produce contextual
 // error messages, but are not otherwise significant. This function only
 // operates converting the attrVal parameter into a value which can fit into
 // the val parameter, which therefore must be a pointer.
-func SetValueFromAttribute(snapName string, ifaceName string, attrName string, attrVal interface{}, val interface{}) error {
+func SetValueFromAttribute(sdkName string, ifaceName string, attrName string, attrVal interface{}, val interface{}) error {
 	rt := reflect.TypeOf(val)
 	if rt.Kind() != reflect.Ptr || val == nil {
 		return fmt.Errorf("internal error: cannot get %q attribute of interface %q with non-pointer value", attrName, ifaceName)
@@ -104,7 +104,7 @@ func SetValueFromAttribute(snapName string, ifaceName string, attrName string, a
 	converted, err := convertValue(reflect.ValueOf(attrVal), rt.Elem())
 	if err != nil {
 		return AttributeNotCompatibleError{
-			SdkName:       snapName,
+			SdkName:       sdkName,
 			InterfaceName: ifaceName,
 			AttributeName: attrName,
 			AttributeType: reflect.TypeOf(attrVal),

--- a/internal/metautil/type_conversions.go
+++ b/internal/metautil/type_conversions.go
@@ -1,0 +1,117 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, error) {
+	inputType := value.Type()
+	if inputType == outputType {
+		return value, nil
+	}
+
+	var nullValue reflect.Value
+	switch value.Kind() {
+	case reflect.Slice, reflect.Array:
+		if outputType.Kind() != reflect.Array && outputType.Kind() != reflect.Slice {
+			break
+		}
+		outputValue := reflect.MakeSlice(outputType, 0, value.Len())
+		for i := 0; i < value.Len(); i++ {
+			convertedElem, err := convertValue(value.Index(i), outputType.Elem())
+			if err != nil {
+				return nullValue, err
+			}
+			outputValue = reflect.Append(outputValue, convertedElem)
+		}
+		return outputValue, nil
+	case reflect.Interface:
+		return convertValue(value.Elem(), outputType)
+	case reflect.Map:
+		if outputType.Kind() != reflect.Map {
+			break
+		}
+		outputValue := reflect.MakeMapWithSize(outputType, value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			convertedKey, err := convertValue(iter.Key(), outputType.Key())
+			if err != nil {
+				return nullValue, err
+			}
+			convertedValue, err := convertValue(iter.Value(), outputType.Elem())
+			if err != nil {
+				return nullValue, err
+			}
+			outputValue.SetMapIndex(convertedKey, convertedValue)
+		}
+		return outputValue, nil
+	}
+	return nullValue, fmt.Errorf(`cannot convert value "%v" into a %v`, value, outputType)
+}
+
+// AttributeNotCompatibleError represents a type mismatch error between an interface
+// attribute and an expected type.
+type AttributeNotCompatibleError struct {
+	SdkName       string
+	InterfaceName string
+	AttributeName string
+	AttributeType reflect.Type
+	ExpectedType  reflect.Type
+}
+
+func (e AttributeNotCompatibleError) Error() string {
+	return fmt.Sprintf("snap %q has interface %q with invalid value type %s for %q attribute: %s", e.SdkName, e.InterfaceName, e.AttributeType, e.AttributeName, e.ExpectedType)
+}
+
+func (e AttributeNotCompatibleError) Is(target error) bool {
+	_, ok := target.(AttributeNotCompatibleError)
+	return ok
+}
+
+// SetValueFromAttribute attempts to convert the attribute value read from the
+// given snap/interface into the desired type.
+//
+// The snapName, ifaceName and attrName are only used to produce contextual
+// error messages, but are not otherwise significant. This function only
+// operates converting the attrVal parameter into a value which can fit into
+// the val parameter, which therefore must be a pointer.
+func SetValueFromAttribute(snapName string, ifaceName string, attrName string, attrVal interface{}, val interface{}) error {
+	rt := reflect.TypeOf(val)
+	if rt.Kind() != reflect.Ptr || val == nil {
+		return fmt.Errorf("internal error: cannot get %q attribute of interface %q with non-pointer value", attrName, ifaceName)
+	}
+
+	converted, err := convertValue(reflect.ValueOf(attrVal), rt.Elem())
+	if err != nil {
+		return AttributeNotCompatibleError{
+			SdkName:       snapName,
+			InterfaceName: ifaceName,
+			AttributeName: attrName,
+			AttributeType: reflect.TypeOf(attrVal),
+			ExpectedType:  reflect.TypeOf(val),
+		}
+	}
+	rv := reflect.ValueOf(val)
+	rv.Elem().Set(converted)
+	return nil
+}

--- a/internal/metautil/type_conversions_test.go
+++ b/internal/metautil/type_conversions_test.go
@@ -1,0 +1,149 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil_test
+
+import (
+	"errors"
+	"reflect"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workspace/internal/metautil"
+	"github.com/canonical/workspace/internal/testutil"
+)
+
+type conversionssSuite struct{}
+
+var _ = Suite(&conversionssSuite{})
+
+func (s *conversionssSuite) TestConvertHappy(c *C) {
+	data := []struct {
+		inputValue    interface{}
+		expectedValue interface{}
+	}{
+		// Basic types
+		{"a string", "a string"},
+		{42, 42},
+		{true, true},
+
+		// Complex types with no conversion
+		{[]string{"one", "two"}, []string{"one", "two"}},
+		{[]int{24, 42}, []int{24, 42}},
+
+		// Complex types with conversion
+		{[]interface{}{"one", "two"}, []string{"one", "two"}},
+		{[]interface{}{24, 42}, []int{24, 42}},
+		{[]interface{}{[]string{"one"}, []string{"two"}}, [][]string{{"one"}, {"two"}}},
+		{[]interface{}{map[string]int{"one": 1}, map[string]int{"two": 2}}, []map[string]int{{"one": 1}, {"two": 2}}},
+		{map[interface{}]interface{}{"one": 1, "two": 2}, map[string]int{"one": 1, "two": 2}},
+	}
+
+	for _, testData := range data {
+		inputValue := reflect.ValueOf(testData.inputValue)
+		outputType := reflect.TypeOf(testData.expectedValue)
+		expectedValue := testData.expectedValue
+		outputValue, err := metautil.ConvertValue(inputValue, outputType)
+		testTag := Commentf("%v -> %v", inputValue, expectedValue)
+		c.Check(err, IsNil, testTag)
+		c.Check(outputValue.Interface(), DeepEquals, expectedValue, testTag)
+	}
+}
+
+func (s *conversionssSuite) TestConvertUnhappy(c *C) {
+	t := reflect.TypeOf
+	data := []struct {
+		inputValue    interface{}
+		outputType    reflect.Type
+		expectedError string
+	}{
+		// Basic types
+		{"a string", t(42), `cannot convert value "a string" into a int`},
+		{true, t(""), `cannot convert value "true" into a string`},
+
+		// Complex types
+		{[]interface{}{"one", "two", 3}, t([]string{}), `cannot convert value "3" into a string`},
+		{[]interface{}{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
+		{[]int{1, 2}, t([]string{}), `cannot convert value "1" into a string`},
+		{[]int{1, 2}, t(1), `cannot convert value "\[1 2\]" into a int`},
+		{map[interface{}]interface{}{"one": 1}, t(map[int]int{}), `cannot convert value "one" into a int`},
+		{map[interface{}]interface{}{1: 2}, t(map[int]string{}), `cannot convert value "2" into a string`},
+		{map[interface{}]interface{}{"one": 1}, t([]string{}), `cannot convert value "map\[one:1\]" into a \[\]string`},
+	}
+
+	for _, testData := range data {
+		inputValue := reflect.ValueOf(testData.inputValue)
+		outputType := testData.outputType
+		expectedError := testData.expectedError
+		outputValue, err := metautil.ConvertValue(inputValue, outputType)
+		testTag := Commentf("%v -> %T", inputValue, outputType)
+		c.Check(err, ErrorMatches, expectedError, testTag)
+		c.Check(outputValue.IsValid(), Equals, false, testTag)
+	}
+}
+
+func (s *conversionssSuite) TestSetValueFromAttributeHappy(c *C) {
+	interfaceArray := []interface{}{12, -3}
+	var outputValue []int
+	err := metautil.SetValueFromAttribute("snap0", "iface0", "attr0", interfaceArray, &outputValue)
+	c.Assert(err, IsNil)
+	c.Check(outputValue, DeepEquals, []int{12, -3})
+}
+
+func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
+	var outputBool bool
+	data := []struct {
+		snapName      string
+		ifaceName     string
+		attrName      string
+		inputValue    interface{}
+		outputValue   interface{}
+		expectedError string
+	}{
+		// error if output value parameter is not a pointer
+		{
+			"snap1",
+			"iface1",
+			"attr1",
+			"input value",
+			"I'm not a pointer",
+			`internal error: cannot get "attr1" attribute of interface "iface1" with non-pointer value`,
+		},
+
+		// error if value cannot be converted
+		{
+			"snap2",
+			"iface2",
+			"attr2",
+			"input value",
+			&outputBool,
+			`snap "snap2" has interface "iface2" with invalid value type string for "attr2" attribute: \*bool`,
+		},
+	}
+
+	for _, td := range data {
+		err := metautil.SetValueFromAttribute(td.snapName, td.ifaceName, td.attrName, td.inputValue, td.outputValue)
+		c.Check(err, ErrorMatches, td.expectedError, Commentf("input value %v", td.inputValue))
+	}
+}
+
+func (s *conversionssSuite) TestAttributeNotCompatibleIsTypeCheck(c *C) {
+	c.Assert(metautil.AttributeNotCompatibleError{}, testutil.ErrorIs, metautil.AttributeNotCompatibleError{})
+	c.Assert(metautil.AttributeNotCompatibleError{}, Not(testutil.ErrorIs), errors.New(""))
+}

--- a/internal/metautil/type_conversions_test.go
+++ b/internal/metautil/type_conversions_test.go
@@ -101,7 +101,7 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 func (s *conversionssSuite) TestSetValueFromAttributeHappy(c *C) {
 	interfaceArray := []interface{}{12, -3}
 	var outputValue []int
-	err := metautil.SetValueFromAttribute("snap0", "iface0", "attr0", interfaceArray, &outputValue)
+	err := metautil.SetValueFromAttribute("sdk0", "iface0", "attr0", interfaceArray, &outputValue)
 	c.Assert(err, IsNil)
 	c.Check(outputValue, DeepEquals, []int{12, -3})
 }
@@ -109,7 +109,7 @@ func (s *conversionssSuite) TestSetValueFromAttributeHappy(c *C) {
 func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 	var outputBool bool
 	data := []struct {
-		snapName      string
+		sdkName       string
 		ifaceName     string
 		attrName      string
 		inputValue    interface{}
@@ -118,7 +118,7 @@ func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 	}{
 		// error if output value parameter is not a pointer
 		{
-			"snap1",
+			"sdk1",
 			"iface1",
 			"attr1",
 			"input value",
@@ -128,17 +128,17 @@ func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 
 		// error if value cannot be converted
 		{
-			"snap2",
+			"sdk2",
 			"iface2",
 			"attr2",
 			"input value",
 			&outputBool,
-			`snap "snap2" has interface "iface2" with invalid value type string for "attr2" attribute: \*bool`,
+			`sdk "sdk2" has interface "iface2" with invalid value type string for "attr2" attribute: \*bool`,
 		},
 	}
 
 	for _, td := range data {
-		err := metautil.SetValueFromAttribute(td.snapName, td.ifaceName, td.attrName, td.inputValue, td.outputValue)
+		err := metautil.SetValueFromAttribute(td.sdkName, td.ifaceName, td.attrName, td.inputValue, td.outputValue)
 		c.Check(err, ErrorMatches, td.expectedError, Commentf("input value %v", td.inputValue))
 	}
 }

--- a/internal/osutil/env_test.go
+++ b/internal/osutil/env_test.go
@@ -157,20 +157,20 @@ func (s *envSuite) TestOSEnvironment(c *C) {
 }
 
 func (s *envSuite) TestOSEnvironmentUnescapeUnsafe(c *C) {
-	os.Setenv("SNAPD_UNSAFE_PREFIX_A", "a")
-	defer os.Unsetenv("SNAPD_UNSAFE_PREFIX_A")
-	os.Setenv("SNAPDEXTRA", "2")
-	defer os.Unsetenv("SNAPDEXTRA")
-	os.Setenv("SNAPD_UNSAFE_PREFIX_SNAPDEXTRA", "1")
-	defer os.Unsetenv("SNAPD_UNSAFE_PREFIX_SNAPDEXTRA")
+	os.Setenv("WORKSPACED_UNSAFE_PREFIX_A", "a")
+	defer os.Unsetenv("WORKSPACED_UNSAFE_PREFIX_A")
+	os.Setenv("SDKDEXTRA", "2")
+	defer os.Unsetenv("SDKDEXTRA")
+	os.Setenv("WORKSPACED_UNSAFE_PREFIX_SDKDEXTRA", "1")
+	defer os.Unsetenv("WORKSPACED_UNSAFE_PREFIX_SDKDEXTRA")
 
-	env, err := osutil.OSEnvironmentUnescapeUnsafe("SNAPD_UNSAFE_PREFIX_")
+	env, err := osutil.OSEnvironmentUnescapeUnsafe("WORKSPACED_UNSAFE_PREFIX_")
 	c.Assert(err, IsNil)
-	// -1 because only the unescaped SNAPDEXTRA is kept
+	// -1 because only the unescaped SDKDEXTRA is kept
 	c.Check(len(os.Environ())-1, Equals, len(env.ForExec()))
 	c.Check(os.Getenv("PATH"), Equals, env["PATH"])
 	c.Check("a", Equals, env["A"])
-	c.Check("2", Equals, env["SNAPDEXTRA"])
+	c.Check("2", Equals, env["SDKDEXTRA"])
 }
 
 func (s *envSuite) TestGet(c *C) {
@@ -245,16 +245,16 @@ func (s *envSuite) TestExtendWithExpandedOfNil(c *C) {
 
 func (s *envSuite) TestExtendWithExpandedForEnvOverride(c *C) {
 	env := osutil.Environment{"PATH": "system-value"}
-	env.ExtendWithExpanded(osutil.NewExpandableEnv("PATH", "snap-level-override"))
+	env.ExtendWithExpanded(osutil.NewExpandableEnv("PATH", "sdk-level-override"))
 	env.ExtendWithExpanded(osutil.NewExpandableEnv("PATH", "app-level-override"))
 	c.Check(env, DeepEquals, osutil.Environment{"PATH": "app-level-override"})
 }
 
 func (s *envSuite) TestExtendWithExpandedForEnvExpansion(c *C) {
 	env := osutil.Environment{"PATH": "system-value"}
-	env.ExtendWithExpanded(osutil.NewExpandableEnv("PATH", "snap-ext:$PATH"))
+	env.ExtendWithExpanded(osutil.NewExpandableEnv("PATH", "sdk-ext:$PATH"))
 	env.ExtendWithExpanded(osutil.NewExpandableEnv("PATH", "app-ext:$PATH"))
-	c.Check(env, DeepEquals, osutil.Environment{"PATH": "app-ext:snap-ext:system-value"})
+	c.Check(env, DeepEquals, osutil.Environment{"PATH": "app-ext:sdk-ext:system-value"})
 }
 
 func (s *envSuite) TestExtendWithExpandedVarious(c *C) {
@@ -291,42 +291,42 @@ func (s *envSuite) TestExtendWithExpandedVarious(c *C) {
 
 func (s *envSuite) TestForExecEscapeUnsafe(c *C) {
 	env := osutil.Environment{
-		"FOO":             "foo",
-		"LD_PRELOAD":      "/opt/lib/libfunky.so",
-		"SNAP_DATA":       "snap-data",
-		"SNAP_SAVED_WHAT": "what", // will be dropped
-		"SNAP_SAVED":      "snap-saved",
-		"SNAP_S":          "snap-s",
-		"XDG_STUFF":       "xdg-stuff", // will be prefixed
-		"TMPDIR":          "/var/tmp",  // will be prefixed
+		"FOO":            "foo",
+		"LD_PRELOAD":     "/opt/lib/libfunky.so",
+		"SDK_DATA":       "sdk-data",
+		"SDK_SAVED_WHAT": "what", // will be dropped
+		"SDK_SAVED":      "sdk-saved",
+		"SDK_S":          "sdk-s",
+		"XDG_STUFF":      "xdg-stuff", // will be prefixed
+		"TMPDIR":         "/var/tmp",  // will be prefixed
 	}
-	raw := env.ForExecEscapeUnsafe("SNAP_SAVED_")
+	raw := env.ForExecEscapeUnsafe("SDK_SAVED_")
 	c.Check(raw, DeepEquals, []string{
 		"FOO=foo",
-		"SNAP_DATA=snap-data",
-		"SNAP_S=snap-s",
-		"SNAP_SAVED=snap-saved",
-		"SNAP_SAVED_LD_PRELOAD=/opt/lib/libfunky.so",
-		"SNAP_SAVED_TMPDIR=/var/tmp",
+		"SDK_DATA=sdk-data",
+		"SDK_S=sdk-s",
+		"SDK_SAVED=sdk-saved",
+		"SDK_SAVED_LD_PRELOAD=/opt/lib/libfunky.so",
+		"SDK_SAVED_TMPDIR=/var/tmp",
 		"XDG_STUFF=xdg-stuff",
 	})
 }
 
 func (s *envSuite) TestForExecEscapeUnsafeNothingToEscape(c *C) {
 	env := osutil.Environment{
-		"FOO":             "foo",
-		"SNAP_DATA":       "snap-data",
-		"SNAP_SAVED_WHAT": "what",
-		"SNAP_SAVED":      "snap-saved",
-		"SNAP_S":          "snap-s",
-		"XDG_STUFF":       "xdg-stuff",
+		"FOO":            "foo",
+		"SDK_DATA":       "sdk-data",
+		"SDK_SAVED_WHAT": "what",
+		"SDK_SAVED":      "sdk-saved",
+		"SDK_S":          "sdk-s",
+		"XDG_STUFF":      "xdg-stuff",
 	}
-	raw := env.ForExecEscapeUnsafe("SNAP_SAVED_")
+	raw := env.ForExecEscapeUnsafe("SDK_SAVED_")
 	c.Check(raw, DeepEquals, []string{
 		"FOO=foo",
-		"SNAP_DATA=snap-data",
-		"SNAP_S=snap-s",
-		"SNAP_SAVED=snap-saved",
+		"SDK_DATA=sdk-data",
+		"SDK_S=sdk-s",
+		"SDK_SAVED=sdk-saved",
 		"XDG_STUFF=xdg-stuff",
 	})
 }

--- a/internal/osutil/mount_linux_test.go
+++ b/internal/osutil/mount_linux_test.go
@@ -27,20 +27,20 @@ var _ = Suite(&mountSuite{})
 func (s *mountSuite) TestIsMountedHappyish(c *C) {
 	// note the different optional fields
 	const content = "" +
-		"44 24 7:1 / /snap/ubuntu-core/855 rw,relatime shared:27 - squashfs /dev/loop1 ro\n" +
-		"44 24 7:1 / /snap/something/123 rw,relatime - squashfs /dev/loop2 ro\n" +
-		"44 24 7:1 / /snap/random/456 rw,relatime opt:1 shared:27 - squashfs /dev/loop1 ro\n"
+		"44 24 7:1 / /sdk/ubuntu-core/855 rw,relatime shared:27 - squashfs /dev/loop1 ro\n" +
+		"44 24 7:1 / /sdk/something/123 rw,relatime - squashfs /dev/loop2 ro\n" +
+		"44 24 7:1 / /sdk/random/456 rw,relatime opt:1 shared:27 - squashfs /dev/loop1 ro\n"
 	defer osutil.FakeMountInfo(content)()
 
-	mounted, err := osutil.IsMounted("/snap/ubuntu-core/855")
+	mounted, err := osutil.IsMounted("/sdk/ubuntu-core/855")
 	c.Check(err, IsNil)
 	c.Check(mounted, Equals, true)
 
-	mounted, err = osutil.IsMounted("/snap/something/123")
+	mounted, err = osutil.IsMounted("/sdk/something/123")
 	c.Check(err, IsNil)
 	c.Check(mounted, Equals, true)
 
-	mounted, err = osutil.IsMounted("/snap/random/456")
+	mounted, err = osutil.IsMounted("/sdk/random/456")
 	c.Check(err, IsNil)
 	c.Check(mounted, Equals, true)
 
@@ -52,7 +52,7 @@ func (s *mountSuite) TestIsMountedHappyish(c *C) {
 func (s *mountSuite) TestIsMountedBroken(c *C) {
 	defer osutil.FakeMountInfo("44 24 7:1 ...truncated-stuff")()
 
-	mounted, err := osutil.IsMounted("/snap/ubuntu-core/855")
+	mounted, err := osutil.IsMounted("/sdk/ubuntu-core/855")
 	c.Check(err, ErrorMatches, "incorrect number of fields, .*")
 	c.Check(mounted, Equals, false)
 }

--- a/internal/osutil/mountentry_linux_test.go
+++ b/internal/osutil/mountentry_linux_test.go
@@ -30,12 +30,12 @@ func (s *entrySuite) TestString(c *C) {
 	ent0 := osutil.MountEntry{}
 	c.Assert(ent0.String(), Equals, "none none none defaults 0 0")
 	ent1 := osutil.MountEntry{
-		Name:    "/var/snap/foo/common",
-		Dir:     "/var/snap/bar/common",
+		Name:    "/var/sdk/foo/common",
+		Dir:     "/var/sdk/bar/common",
 		Options: []string{"bind"},
 	}
 	c.Assert(ent1.String(), Equals,
-		"/var/snap/foo/common /var/snap/bar/common none bind 0 0")
+		"/var/sdk/foo/common /var/sdk/bar/common none bind 0 0")
 	ent2 := osutil.MountEntry{
 		Name:    "/dev/sda5",
 		Dir:     "/media/foo",

--- a/internal/osutil/testhelper_test.go
+++ b/internal/osutil/testhelper_test.go
@@ -56,8 +56,8 @@ func (s *testhelperSuite) TestMustBeTestBinary(c *C) {
 }
 
 func (s *testhelperSuite) TestBinaryNoRegressionWithValidApp(c *C) {
-	// a snap app named 'test' is valid, we must not be confused here
-	defer mockOsArgs([]string{"/snap/bin/some-snap.test", "bar", "baz"})()
+	// a sdk app named 'test' is valid, we must not be confused here
+	defer mockOsArgs([]string{"/sdk/bin/some-sdk.test", "bar", "baz"})()
 	// must not be considered a test binary
 	c.Assert(osutil.IsTestBinary(), Equals, false)
 	// must panic since binary is a non-test one

--- a/internal/overlord/cmdstate/manager.go
+++ b/internal/overlord/cmdstate/manager.go
@@ -29,8 +29,8 @@ type CommandManager struct {
 	backend         workspacebackend.WorkspaceBackend
 }
 
-// NewManager creates a new CommandManager.
-func NewManager(runner *state.TaskRunner, backend workspacebackend.WorkspaceBackend) *CommandManager {
+// New creates a new CommandManager.
+func New(runner *state.TaskRunner, backend workspacebackend.WorkspaceBackend) *CommandManager {
 	manager := &CommandManager{
 		executions:     make(map[string]*execution),
 		executionsCond: sync.NewCond(&sync.Mutex{}),

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -83,7 +83,7 @@ func (s *hookSuite) TearDownTest(c *check.C) {
 func (s *hookSuite) TestExecSetupBaseNoHook(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := workspacebackend.Sdk{Name: "new", Channel: "latest/stable"}
+	newSdk := workspacebackend.SdkRecord{Name: "new", Channel: "latest/stable"}
 
 	t1 := hookstate.SetupHook(s.state, &newSdk, hookstate.SetupBase)
 
@@ -114,7 +114,7 @@ base: ubuntu@20.04
 func (s *hookSuite) TestExecSaveState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := workspacebackend.Sdk{Name: "one", Channel: "latest/stable"}
+	newSdk := workspacebackend.SdkRecord{Name: "one", Channel: "latest/stable"}
 	t1 := hookstate.SetupHook(s.state, &newSdk, hookstate.SaveState)
 
 	chg := s.state.NewChange("sample", "...")
@@ -145,7 +145,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := workspacebackend.Sdk{Name: "one", Channel: "latest/stable"}
+	newSdk := workspacebackend.SdkRecord{Name: "one", Channel: "latest/stable"}
 	t1 := hookstate.SetupHook(s.state, &newSdk, hookstate.RestoreState)
 
 	chg := s.state.NewChange("sample", "...")
@@ -173,7 +173,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, testutil.DeepUnsortedMatches, map[string]string{"SDK_STATE_DIR": "/var/lib/workspace/state/sdk/one"})
 }
 
-func (s *hookSuite) launchWorkspace(c *check.C, newSdk workspacebackend.Sdk) {
+func (s *hookSuite) launchWorkspace(c *check.C, newSdk workspacebackend.SdkRecord) {
 	err := os.WriteFile(filepath.Join(s.project.Path, ".workspace.ws.yaml"), []byte(`name: ws
 base: ubuntu@20.04
 sdks:

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -62,7 +62,7 @@ func (s *hookSuite) SetUpTest(c *check.C) {
 
 	// empty task handler
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
-	s.hookmgr = hookstate.NewHookManager(s.runner, s.backend)
+	s.hookmgr = hookstate.New(s.runner, s.backend)
 
 	// error-provoking task handler
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -7,9 +7,9 @@ import (
 )
 
 type HookSetup struct {
-	Sdk         workspacebackend.Sdk `json:"sdk"`
-	HookType    WorkspaceHookType    `json:"type"`
-	Environment map[string]string    `json:"environment"`
+	Sdk         workspacebackend.SdkRecord `json:"sdk"`
+	HookType    WorkspaceHookType          `json:"type"`
+	Environment map[string]string          `json:"environment"`
 }
 
 type WorkspaceHookType int

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -32,7 +32,7 @@ type HookManager struct {
 	backend workspacebackend.WorkspaceBackend
 }
 
-func NewHookManager(runner *state.TaskRunner, server workspacebackend.WorkspaceBackend) *HookManager {
+func New(runner *state.TaskRunner, server workspacebackend.WorkspaceBackend) *HookManager {
 	manager := &HookManager{
 		backend: server,
 	}

--- a/internal/overlord/hookstate/request.go
+++ b/internal/overlord/hookstate/request.go
@@ -8,7 +8,7 @@ import (
 	"github.com/canonical/workspace/internal/workspacebackend"
 )
 
-func SetupHook(st *state.State, sdk *workspacebackend.Sdk, hook WorkspaceHookType) *state.Task {
+func SetupHook(st *state.State, sdk *workspacebackend.SdkRecord, hook WorkspaceHookType) *state.Task {
 	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk.Name))
 
 	setup := HookSetup{HookType: hook, Sdk: *sdk, Environment: map[string]string{}}

--- a/internal/overlord/hookstate/request_test.go
+++ b/internal/overlord/hookstate/request_test.go
@@ -25,7 +25,7 @@ func (s *S) TestCreateHook(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var sdk = workspacebackend.Sdk{Name: "go", Channel: "latest/stable"}
+	var sdk = workspacebackend.SdkRecord{Name: "go", Channel: "latest/stable"}
 
 	envs := []map[string]string{
 		{},

--- a/internal/overlord/ifacestate/export_test.go
+++ b/internal/overlord/ifacestate/export_test.go
@@ -1,0 +1,7 @@
+package ifacestate
+
+var (
+	GetConns          = getConns
+	SetConns          = setConns
+	ReloadConnections = (*InterfaceManager).reloadConnections
+)

--- a/internal/overlord/ifacestate/helpers.go
+++ b/internal/overlord/ifacestate/helpers.go
@@ -1,0 +1,76 @@
+package ifacestate
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/canonical/workspace/internal/asserts"
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/interfaces/policy"
+	"github.com/canonical/workspace/internal/interfaces/utils"
+	"github.com/canonical/workspace/internal/jsonutil"
+	"github.com/canonical/workspace/internal/overlord/ifacestate/schema"
+	"github.com/canonical/workspace/internal/overlord/state"
+)
+
+func autoConnectCheck(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	baseDecl := asserts.BuiltinBaseDeclaration()
+	if baseDecl == nil {
+		return fmt.Errorf("internal error: cannot find base declaration")
+	}
+
+	ic := policy.ConnectCandidate{
+		Plug:            plug,
+		Slot:            slot,
+		BaseDeclaration: baseDecl,
+	}
+	_, err := ic.CheckAutoConnect()
+	return err
+}
+
+// getConns returns information about connections from the state.
+func getConns(st *state.State) (conns map[string]*schema.ConnState, err error) {
+	var raw *json.RawMessage
+	err = st.Get("conns", &raw)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return nil, fmt.Errorf("cannot obtain raw data about existing connections: %s", err)
+	}
+	if raw != nil {
+		err = jsonutil.DecodeWithNumber(bytes.NewReader(*raw), &conns)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode data about existing connections: %s", err)
+		}
+	}
+	if conns == nil {
+		conns = make(map[string]*schema.ConnState)
+	}
+	remapped := make(map[string]*schema.ConnState, len(conns))
+	for id, cstate := range conns {
+		cref, err := interfaces.ParseConnRef(id)
+		if err != nil {
+			return nil, err
+		}
+		cstate.StaticSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticSlotAttrs).(map[string]interface{})
+		cstate.DynamicSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicSlotAttrs).(map[string]interface{})
+		cstate.StaticPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticPlugAttrs).(map[string]interface{})
+		cstate.DynamicPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicPlugAttrs).(map[string]interface{})
+		remapped[cref.ID()] = cstate
+	}
+	return remapped, nil
+}
+
+// setConns sets information about connections in the state.
+func setConns(st *state.State, conns map[string]*schema.ConnState) {
+	remapped := make(map[string]*schema.ConnState, len(conns))
+	for id, cstate := range conns {
+		cref, err := interfaces.ParseConnRef(id)
+		if err != nil {
+			// We cannot fail here
+			panic(err)
+		}
+		remapped[cref.ID()] = cstate
+	}
+	st.Set("conns", remapped)
+}

--- a/internal/overlord/ifacestate/helpers_test.go
+++ b/internal/overlord/ifacestate/helpers_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/canonical/workspace/internal/overlord/state"
 
 	"gopkg.in/check.v1"
-	. "gopkg.in/check.v1"
 )
 
 type helpersSuite struct {
@@ -36,13 +35,13 @@ type helpersSuite struct {
 
 func Test(t *testing.T) { check.TestingT(t) }
 
-var _ = Suite(&helpersSuite{})
+var _ = check.Suite(&helpersSuite{})
 
-func (s *helpersSuite) SetUpTest(c *C) {
+func (s *helpersSuite) SetUpTest(c *check.C) {
 	s.st = state.New(nil)
 }
 
-func (s *helpersSuite) TestGetConns(c *C) {
+func (s *helpersSuite) TestGetConns(c *check.C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 	s.st.Set("conns", map[string]interface{}{
@@ -56,16 +55,16 @@ func (s *helpersSuite) TestGetConns(c *C) {
 	})
 
 	conns, err := ifacestate.GetConns(s.st)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	for id, connState := range conns {
-		c.Assert(id, Equals, "ws:app:content ws:core:content")
-		c.Assert(connState.Auto, Equals, true)
-		c.Assert(connState.Interface, Equals, "content")
-		c.Assert(connState.StaticSlotAttrs["number"], Equals, int64(78))
+		c.Assert(id, check.Equals, "ws:app:content ws:core:content")
+		c.Assert(connState.Auto, check.Equals, true)
+		c.Assert(connState.Interface, check.Equals, "content")
+		c.Assert(connState.StaticSlotAttrs["number"], check.Equals, int64(78))
 	}
 }
 
-func (s *helpersSuite) TestSetConns(c *C) {
+func (s *helpersSuite) TestSetConns(c *check.C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
@@ -76,8 +75,8 @@ func (s *helpersSuite) TestSetConns(c *C) {
 	ifacestate.SetConns(s.st, conns)
 	var readconns map[string]interface{}
 	err := s.st.Get("conns", &readconns)
-	c.Assert(err, IsNil)
-	c.Assert(readconns, DeepEquals, map[string]interface{}{
+	c.Assert(err, check.IsNil)
+	c.Assert(readconns, check.DeepEquals, map[string]interface{}{
 		"ws:app:content ws:core:content": map[string]interface{}{
 			"auto":      true,
 			"interface": "content",

--- a/internal/overlord/ifacestate/helpers_test.go
+++ b/internal/overlord/ifacestate/helpers_test.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"testing"
+
+	"github.com/canonical/workspace/internal/overlord/ifacestate"
+	"github.com/canonical/workspace/internal/overlord/ifacestate/schema"
+	"github.com/canonical/workspace/internal/overlord/state"
+
+	"gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
+)
+
+type helpersSuite struct {
+	st *state.State
+}
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+var _ = Suite(&helpersSuite{})
+
+func (s *helpersSuite) SetUpTest(c *C) {
+	s.st = state.New(nil)
+}
+
+func (s *helpersSuite) TestGetConns(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+	s.st.Set("conns", map[string]interface{}{
+		"ws:app:content ws:core:content": map[string]interface{}{
+			"auto":      true,
+			"interface": "content",
+			"slot-static": map[string]interface{}{
+				"number": int(78),
+			},
+		},
+	})
+
+	conns, err := ifacestate.GetConns(s.st)
+	c.Assert(err, IsNil)
+	for id, connState := range conns {
+		c.Assert(id, Equals, "ws:app:content ws:core:content")
+		c.Assert(connState.Auto, Equals, true)
+		c.Assert(connState.Interface, Equals, "content")
+		c.Assert(connState.StaticSlotAttrs["number"], Equals, int64(78))
+	}
+}
+
+func (s *helpersSuite) TestSetConns(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	conns := map[string]*schema.ConnState{
+		"ws:app:content ws:core:content": {Auto: true, Interface: "content"},
+	}
+
+	ifacestate.SetConns(s.st, conns)
+	var readconns map[string]interface{}
+	err := s.st.Get("conns", &readconns)
+	c.Assert(err, IsNil)
+	c.Assert(readconns, DeepEquals, map[string]interface{}{
+		"ws:app:content ws:core:content": map[string]interface{}{
+			"auto":      true,
+			"interface": "content",
+		}})
+}

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -1,0 +1,155 @@
+package ifacestate
+
+import (
+	"context"
+
+	"github.com/canonical/workspace/internal/interfaces"
+
+	backend "github.com/canonical/workspace/internal/interfaces/backends"
+	"github.com/canonical/workspace/internal/interfaces/builtin"
+	"github.com/canonical/workspace/internal/logger"
+	"github.com/canonical/workspace/internal/overlord/state"
+	"github.com/canonical/workspace/internal/workspacebackend"
+)
+
+type InterfaceManager struct {
+	state     *state.State
+	wsbackend workspacebackend.WorkspaceBackend
+	repo      *interfaces.Repository
+}
+
+func New(s *state.State, r *state.TaskRunner, be workspacebackend.WorkspaceBackend) *InterfaceManager {
+	m := &InterfaceManager{
+		state:     s,
+		wsbackend: be,
+		repo:      interfaces.NewRepository(),
+	}
+
+	return m
+}
+
+func (m *InterfaceManager) Repository() *interfaces.Repository {
+	return m.repo
+}
+
+func (m *InterfaceManager) StartUp() error {
+	m.state.Lock()
+	defer m.state.Unlock()
+	for _, backend := range backend.All() {
+		if err := backend.Initialize(m.wsbackend); err != nil {
+			return err
+		}
+		if err := m.repo.AddBackend(backend); err != nil {
+			return err
+		}
+	}
+
+	for _, iface := range builtin.Interfaces() {
+		if err := m.repo.AddInterface(iface); err != nil {
+			return err
+		}
+	}
+
+	allprojects, err := m.wsbackend.Projects(context.Background())
+	if err != nil {
+		return err
+	}
+
+	for user, projects := range allprojects {
+		ctx := context.WithValue(context.Background(), workspacebackend.ContextUser, user)
+		for _, prj := range projects {
+			prjctx := context.WithValue(ctx, workspacebackend.ContextProjectId, prj.ProjectId)
+			_, wrksps, err := m.wsbackend.GetProjectWorkspaces(prjctx)
+			if err != nil {
+				return err
+			}
+			for _, wrksp := range wrksps {
+				infos, err := wrksp.ContentInfo(prjctx)
+				if err != nil {
+					return err
+				}
+
+				for _, info := range infos {
+					if err = m.repo.AddSdk(info); err != nil {
+						return err
+					}
+				}
+			}
+		}
+
+	}
+
+	if _, err := m.reloadConnections("", ""); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *InterfaceManager) Ensure() error {
+	return nil
+}
+
+// reloadConnections reloads connections stored in the state in the repository.
+// Using non-empty snapName the operation can be scoped to connections
+// affecting a given snap.
+//
+// The return value is the list of affected snap names.
+func (m *InterfaceManager) reloadConnections(workspace, sdkName string) (map[string]string, error) {
+	conns, err := getConns(m.state)
+	if err != nil {
+		return nil, err
+	}
+	connStateChanged := false
+	affected := make(map[string]string)
+	for connId, connState := range conns {
+		// Skip entries that just mark a connection as undesired. Those don't
+		// carry attributes that can go stale.
+		if connState.Undesired {
+			continue
+		}
+		connRef, err := interfaces.ParseConnRef(connId)
+		if err != nil {
+			return nil, err
+		}
+		// Apply filtering, this allows us to reload only a subset of
+		// connections (and similarly, refresh the static attributes of only a
+		// subset of connections).
+		if workspace != "" && connRef.PlugRef.Workspace != workspace && connRef.SlotRef.Workspace != workspace {
+			continue
+		}
+
+		plugInfo := m.repo.Plug(connRef.PlugRef.Workspace, connRef.PlugRef.Sdk, connRef.PlugRef.Name)
+		slotInfo := m.repo.Slot(connRef.SlotRef.Workspace, connRef.SlotRef.Sdk, connRef.SlotRef.Name)
+
+		// The connection refers to a plug or slot that doesn't exist anymore, e.g. because of a refresh
+		// to a new sdk revision that doesn't have the given plug/slot.
+		if plugInfo == nil || slotInfo == nil {
+			// automatic connection can simply be removed (it will be re-created automatically if needed)
+			// as long as it wasn't disconnected manually; note that undesired flag is taken care of at
+			// the beginning of the loop.
+			if connState.Auto {
+				delete(conns, connId)
+				connStateChanged = true
+			}
+			// otherwise keep it and silently ignore, e.g. in case of a revert.
+			continue
+		}
+
+		staticPlugAttrs := connState.StaticPlugAttrs
+		staticSlotAttrs := connState.StaticSlotAttrs
+
+		// Note: reloaded connections are not checked against policy again, and also we don't call BeforeConnect* methods on them.
+		if _, err := m.repo.Connect(connRef, staticPlugAttrs, connState.DynamicPlugAttrs, staticSlotAttrs, connState.DynamicSlotAttrs, nil); err != nil {
+			logger.Noticef("%s", err)
+		} else {
+			// If the connection succeeded update the connection state and keep
+			// track of the sdks that were affected.
+			affected[connRef.PlugRef.Workspace] = connRef.PlugRef.Sdk
+			affected[connRef.SlotRef.Workspace] = connRef.SlotRef.Sdk
+		}
+	}
+	if connStateChanged {
+		setConns(m.state, conns)
+	}
+	return affected, nil
+}

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -90,10 +90,10 @@ func (m *InterfaceManager) Ensure() error {
 }
 
 // reloadConnections reloads connections stored in the state in the repository.
-// Using non-empty snapName the operation can be scoped to connections
-// affecting a given snap.
+// Using non-empty sdkName the operation can be scoped to connections
+// affecting a given sdk.
 //
-// The return value is the list of affected snap names.
+// The return value is the list of affected sdk names.
 func (m *InterfaceManager) reloadConnections(workspace, sdkName string) (map[string]string, error) {
 	conns, err := getConns(m.state)
 	if err != nil {

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -41,7 +41,7 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 	s.prj, _, err = s.wsbackend.CreateOrLoadProject(s.ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
 
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
 }
 
 func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
@@ -142,8 +142,8 @@ slots:
 
 // func (s *interfaceManagerSuite) TestManagerDoesntReloadUndesiredAutoconnections(c *C) {
 // 	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
-// 	s.mockSnap(c, consumerYaml)
-// 	s.mockSnap(c, producerYaml)
+// 	s.mockSdk(c, consumerYaml)
+// 	s.mockSdk(c, producerYaml)
 
 // 	s.state.Lock()
 // 	s.state.Set("conns", map[string]interface{}{

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -1,0 +1,160 @@
+package ifacestate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/workspace/internal/dirs"
+	"github.com/canonical/workspace/internal/interfaces"
+	"github.com/canonical/workspace/internal/overlord"
+	"github.com/canonical/workspace/internal/overlord/ifacestate"
+	"github.com/canonical/workspace/internal/overlord/state"
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/testutil"
+	"github.com/canonical/workspace/internal/workspacebackend"
+	"github.com/spf13/afero"
+	"gopkg.in/check.v1"
+)
+
+type interfaceManagerSuite struct {
+	testutil.BaseTest
+	o         *overlord.Overlord
+	state     *state.State
+	se        *overlord.StateEngine
+	ctx       context.Context
+	wsbackend workspacebackend.WorkspaceBackend
+	prj       *workspacebackend.Project
+}
+
+var _ = check.Suite(&interfaceManagerSuite{})
+
+func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+	var err error
+
+	s.o = overlord.Fake()
+	s.state = s.o.State()
+	s.se = s.o.StateEngine()
+	s.wsbackend = workspacebackend.NewFakeWorkspaceBackend()
+	s.ctx = context.WithValue(context.Background(), workspacebackend.ContextUser, "testuser")
+	s.prj, _, err = s.wsbackend.CreateOrLoadProject(s.ctx, c.MkDir())
+	c.Assert(err, check.IsNil)
+
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+}
+
+func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *interfaceManagerSuite) mockWorkspaceWithSDKs(c *check.C, ws string, sdkYamls map[string]string) {
+	ctx := context.WithValue(s.ctx, workspacebackend.ContextProjectId, s.prj.ProjectId)
+
+	err := os.WriteFile(filepath.Join(s.prj.Path, ".workspace.ws.yaml"), []byte(`name: ws
+base: ubuntu@22.04
+sdks:
+  consumer:
+    channel: latest/stable
+  producer:
+    channel: latest/stable
+`), 0644)
+	c.Assert(err, check.IsNil)
+
+	err = s.wsbackend.LaunchWorkspace(ctx, ws, "ubuntu@22.04")
+	c.Assert(err, check.IsNil)
+
+	wsfs, err := s.wsbackend.GetWorkspaceFs(ctx, ws)
+	c.Assert(err, check.IsNil)
+	defer wsfs.Close()
+
+	for name, sdk := range sdkYamls {
+		sdkPath := filepath.Join(dirs.WorkspaceSdksDir, name, "current", "meta", "sdk.yaml")
+		err = afero.WriteFile(wsfs, sdkPath, []byte(sdk), 0644)
+		c.Assert(err, check.IsNil)
+	}
+}
+
+func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *check.C) {
+	var consumerYaml = `
+name: consumer
+base: ubuntu@22.04
+plugs:
+ plug:
+  interface: content
+  attr: plug-value
+`
+	var producerYaml = `
+name: producer
+base: ubuntu@22.04
+type: core
+slots:
+ slot:
+  interface: content
+  attr: slot-value
+`
+
+	s.mockWorkspaceWithSDKs(c, "ws", map[string]string{
+		"consumer": consumerYaml,
+		"producer": producerYaml,
+	})
+
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		"ws:consumer:plug ws:producer:slot": map[string]interface{}{
+			"interface": "content",
+			"plug-static": map[string]interface{}{
+				"content": "foo",
+				"attr":    "stored-value",
+			},
+			"slot-static": map[string]interface{}{
+				"content": "foo",
+				"attr":    "stored-value",
+			},
+		},
+	})
+	s.state.Unlock()
+
+	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
+	err := mgr.StartUp()
+	c.Assert(err, check.IsNil)
+
+	repo := mgr.Repository()
+
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, check.HasLen, 1)
+	cref := &interfaces.ConnRef{PlugRef: interfaces.PlugRef{Workspace: "ws", Sdk: "consumer", Name: "plug"}, SlotRef: interfaces.SlotRef{Workspace: "ws", Sdk: "producer", Name: "slot"}}
+	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{cref})
+
+	conn, err := repo.Connection(cref)
+	c.Assert(err, check.IsNil)
+	c.Assert(conn.Plug.Name(), check.Equals, "plug")
+	c.Assert(conn.Plug.StaticAttrs(), check.DeepEquals, map[string]interface{}{
+		"content": "foo",
+		"attr":    "stored-value",
+	})
+	c.Assert(conn.Slot.Name(), check.Equals, "slot")
+	c.Assert(conn.Slot.StaticAttrs(), check.DeepEquals, map[string]interface{}{
+		"content": "foo",
+		"attr":    "stored-value",
+	})
+}
+
+// func (s *interfaceManagerSuite) TestManagerDoesntReloadUndesiredAutoconnections(c *C) {
+// 	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
+// 	s.mockSnap(c, consumerYaml)
+// 	s.mockSnap(c, producerYaml)
+
+// 	s.state.Lock()
+// 	s.state.Set("conns", map[string]interface{}{
+// 		"consumer:plug producer:slot": map[string]interface{}{
+// 			"interface": "test",
+// 			"auto":      true,
+// 			"undesired": true,
+// 		},
+// 	})
+// 	s.state.Unlock()
+
+// 	mgr := s.manager(c)
+// 	c.Assert(mgr.Repository().Interfaces().Connections, HasLen, 0)
+// }

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -41,7 +41,7 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 	s.prj, _, err = s.wsbackend.CreateOrLoadProject(s.ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
 
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 }
 
 func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
@@ -140,21 +140,85 @@ slots:
 	})
 }
 
-// func (s *interfaceManagerSuite) TestManagerDoesntReloadUndesiredAutoconnections(c *C) {
-// 	s.mockIfaces(&ifacetest.TestInterface{InterfaceName: "test"}, &ifacetest.TestInterface{InterfaceName: "test2"})
-// 	s.mockSdk(c, consumerYaml)
-// 	s.mockSdk(c, producerYaml)
+func (s *interfaceManagerSuite) TestManagerDoesntReloadUndesiredAutoconnections(c *check.C) {
+	var consumerYaml = `
+name: consumer
+base: ubuntu@22.04
+plugs:
+ plug:
+  interface: content
+  attr1: value1
+ otherplug:
+  interface: content
+`
 
-// 	s.state.Lock()
-// 	s.state.Set("conns", map[string]interface{}{
-// 		"consumer:plug producer:slot": map[string]interface{}{
-// 			"interface": "test",
-// 			"auto":      true,
-// 			"undesired": true,
-// 		},
-// 	})
-// 	s.state.Unlock()
+	var producerYaml = `
+name: producer
+base: ubuntu@22.04
+slots:
+ slot:
+  interface: content
+  attr2: value2
+`
+	s.mockWorkspaceWithSDKs(c, "ws", map[string]string{
+		"consumer": consumerYaml,
+		"producer": producerYaml,
+	})
 
-// 	mgr := s.manager(c)
-// 	c.Assert(mgr.Repository().Interfaces().Connections, HasLen, 0)
-// }
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		"ws:consumer:plug core:producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+			"undesired": true,
+		},
+	})
+	s.state.Unlock()
+
+	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
+	err := mgr.StartUp()
+	c.Assert(err, check.IsNil)
+
+	c.Assert(mgr.Repository().Interfaces().Connections, check.HasLen, 0)
+}
+
+func (s *interfaceManagerSuite) TestManagerRemovesNonexistingAutoConnectionss(c *check.C) {
+	var consumerYaml = `
+name: consumer
+base: ubuntu@22.04
+plugs:
+ plug:
+  interface: content
+  attr1: value1
+ otherplug:
+  interface: content
+`
+
+	var producerYaml = `
+name: producer
+base: ubuntu@22.04
+slots:
+ slot:
+  interface: content
+  attr2: value2
+`
+	s.mockWorkspaceWithSDKs(c, "ws", map[string]string{
+		"consumer": consumerYaml,
+		"producer": producerYaml,
+	})
+
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		"ws:consumer:plug-1 core:producer:slot-1": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+		},
+	})
+	s.state.Unlock()
+
+	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
+	err := mgr.StartUp()
+	c.Assert(err, check.IsNil)
+
+	c.Assert(mgr.Repository().Interfaces().Connections, check.HasLen, 0)
+}

--- a/internal/overlord/ifacestate/schema/schema.go
+++ b/internal/overlord/ifacestate/schema/schema.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package schema holds structs for reading and writing interface-related state data.
+package schema
+
+// ConnState holds properties of an interface connection.
+type ConnState struct {
+	Auto      bool   `json:"auto,omitempty" yaml:"auto"`
+	Interface string `json:"interface,omitempty" yaml:"interface"`
+	// Undesired tracks connections that were manually disconnected after being auto-connected,
+	// so that they are not automatically reconnected again in the future.
+	Undesired        bool                   `json:"undesired,omitempty" yaml:"undesired"`
+	StaticPlugAttrs  map[string]interface{} `json:"plug-static,omitempty" yaml:"plug-static,omitempty"`
+	DynamicPlugAttrs map[string]interface{} `json:"plug-dynamic,omitempty" yaml:"plug-dynamic,omitempty"`
+	StaticSlotAttrs  map[string]interface{} `json:"slot-static,omitempty" yaml:"slot-static,omitempty"`
+	DynamicSlotAttrs map[string]interface{} `json:"slot-dynamic,omitempty" yaml:"slot-dynamic,omitempty"`
+}

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -142,16 +142,16 @@ func New(dir string, b workspacebackend.WorkspaceBackend, restartHandler restart
 	}
 	o.runner.AddOptionalHandler(matchAnyUnknownTask, handleUnknownTask, nil)
 
-	o.workspace = workspace.NewWorkspaceManager(s, o.runner, o.workspaceBackend)
+	o.workspace = workspace.New(s, o.runner, o.workspaceBackend)
 	o.addManager(o.workspace)
 
 	o.sdk = sdkstate.New(o.runner, o.workspaceBackend)
 	o.addManager(o.sdk)
 
-	o.hook = hookstate.NewHookManager(o.runner, o.workspaceBackend)
+	o.hook = hookstate.New(o.runner, o.workspaceBackend)
 	o.addManager(o.hook)
 
-	o.command = cmdstate.NewManager(o.runner, o.workspaceBackend)
+	o.command = cmdstate.New(o.runner, o.workspaceBackend)
 	o.addManager(o.command)
 
 	// the shared task runner should be added last!

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -30,6 +30,7 @@ import (
 	"github.com/canonical/workspace/internal/osutil"
 	"github.com/canonical/workspace/internal/overlord/cmdstate"
 	"github.com/canonical/workspace/internal/overlord/hookstate"
+	"github.com/canonical/workspace/internal/overlord/ifacestate"
 	"github.com/canonical/workspace/internal/overlord/patch"
 	"github.com/canonical/workspace/internal/overlord/restart"
 	"github.com/canonical/workspace/internal/overlord/sdkstate"
@@ -75,6 +76,7 @@ type Overlord struct {
 	workspace *workspace.WorkspaceManager
 	hook      *hookstate.HookManager
 	command   *cmdstate.CommandManager
+	ifacemgr  *ifacestate.InterfaceManager
 	runner    *state.TaskRunner
 
 	startOfOperationTime time.Time
@@ -153,6 +155,9 @@ func New(dir string, b workspacebackend.WorkspaceBackend, restartHandler restart
 
 	o.command = cmdstate.New(o.runner, o.workspaceBackend)
 	o.addManager(o.command)
+
+	o.ifacemgr = ifacestate.New(s, o.runner, o.workspaceBackend)
+	o.addManager(o.ifacemgr)
 
 	// the shared task runner should be added last!
 	o.stateEng.AddManager(o.runner)

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -145,7 +145,7 @@ func New(dir string, b workspacebackend.WorkspaceBackend, restartHandler restart
 	o.workspace = workspace.NewWorkspaceManager(s, o.runner, o.workspaceBackend)
 	o.addManager(o.workspace)
 
-	o.sdk = sdkstate.NewSdkManager(o.runner, o.workspaceBackend)
+	o.sdk = sdkstate.New(o.runner, o.workspaceBackend)
 	o.addManager(o.sdk)
 
 	o.hook = hookstate.NewHookManager(o.runner, o.workspaceBackend)

--- a/internal/overlord/overlord_test.go
+++ b/internal/overlord/overlord_test.go
@@ -202,7 +202,7 @@ func (wm *witnessManager) Ensure() error {
 }
 
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, workspacebackend.NewFakeWorkspaceBackend(), nil)
 	c.Assert(err, IsNil)
 
 	err = o.StartUp()
@@ -215,7 +215,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 }
 
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, workspacebackend.NewFakeWorkspaceBackend(), nil)
 	c.Assert(err, IsNil)
 
 	// unknown tasks are ignored and succeed
@@ -537,7 +537,7 @@ func (ovs *overlordSuite) TestOverlordStartUpSetsStartOfOperation(c *C) {
 	restoreIntv := overlord.FakePruneInterval(100*time.Millisecond, 1000*time.Millisecond, 1*time.Hour)
 	defer restoreIntv()
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, workspacebackend.NewFakeWorkspaceBackend(), nil)
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -559,7 +559,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneDoesntAbortShortlyAfterStartOfOpera
 	w, restoreTicker := fakePruneTicker()
 	defer restoreTicker()
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, workspacebackend.NewFakeWorkspaceBackend(), nil)
 	c.Assert(err, IsNil)
 
 	// avoid immediate transition to Done due to unknown kind
@@ -610,7 +610,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneAbortsOld(c *C) {
 	w, restoreTicker := fakePruneTicker()
 	defer restoreTicker()
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, workspacebackend.NewFakeWorkspaceBackend(), nil)
 	c.Assert(err, IsNil)
 
 	// avoid immediate transition to Done due to having unknown kind

--- a/internal/overlord/patch/patch.go
+++ b/internal/overlord/patch/patch.go
@@ -73,7 +73,7 @@ func applySublevelPatches(level, firstSublevel int, s *state.State) error {
 }
 
 // maybeResetSublevelForLevel60 checks if we're coming from a different version
-// of snapd and if so, reset sublevel back to 0 to re-apply sublevel patches.
+// of workspaced and if so, reset sublevel back to 0 to re-apply sublevel patches.
 func maybeResetSublevelForLevel60(s *state.State, sublevel *int) error {
 	s.Lock()
 	defer s.Unlock()
@@ -87,7 +87,7 @@ func maybeResetSublevelForLevel60(s *state.State, sublevel *int) error {
 		*sublevel = 0
 		s.Set("patch-sublevel", *sublevel)
 		// unset old reset key in case of revert into old version.
-		// TODO: this can go away if we go through a snapd epoch.
+		// TODO: this can go away if we go through a workspaced epoch.
 		s.Set("patch-sublevel-reset", nil)
 	}
 
@@ -110,7 +110,7 @@ func Apply(s *state.State) error {
 	}
 
 	if stateLevel > Level {
-		return fmt.Errorf("cannot downgrade: snapd is too old for the current system state (patch level %d)", stateLevel)
+		return fmt.Errorf("cannot downgrade: workspaced is too old for the current system state (patch level %d)", stateLevel)
 	}
 
 	// check if we refreshed from 6.0 which was not aware of sublevels
@@ -147,7 +147,7 @@ func Apply(s *state.State) error {
 		sublevels := patches[level]
 		logger.Noticef("Patching system state from level %d to %d", level-1, level)
 		if sublevels == nil {
-			return fmt.Errorf("cannot upgrade: snapd is too new for the current system state (patch level %d)", level-1)
+			return fmt.Errorf("cannot upgrade: workspaced is too new for the current system state (patch level %d)", level-1)
 		}
 		if err := applySublevelPatches(level, 0, s); err != nil {
 			return err
@@ -155,7 +155,7 @@ func Apply(s *state.State) error {
 	}
 
 	s.Lock()
-	// store last snapd version last in case system is restarted before patches are applied
+	// store last workspaced version last in case system is restarted before patches are applied
 	s.Set("patch-sublevel-last-version", version.Version)
 	s.Unlock()
 

--- a/internal/overlord/patch/patch_test.go
+++ b/internal/overlord/patch/patch_test.go
@@ -86,7 +86,7 @@ func (s *patchSuite) TestNoDowngrade(c *C) {
 	st.Set("patch-level", 3)
 	st.Unlock()
 	err := patch.Apply(st)
-	c.Assert(err, ErrorMatches, `cannot downgrade: snapd is too old for the current system state \(patch level 3\)`)
+	c.Assert(err, ErrorMatches, `cannot downgrade: workspaced is too old for the current system state \(patch level 3\)`)
 }
 
 func (s *patchSuite) TestApply(c *C) {
@@ -238,7 +238,7 @@ func (s *patchSuite) TestMissing(c *C) {
 	st.Set("patch-level", 1)
 	st.Unlock()
 	err := patch.Apply(st)
-	c.Assert(err, ErrorMatches, `cannot upgrade: snapd is too new for the current system state \(patch level 1\)`)
+	c.Assert(err, ErrorMatches, `cannot upgrade: workspaced is too new for the current system state \(patch level 1\)`)
 }
 
 func (s *patchSuite) TestDowngradeSublevel(c *C) {
@@ -350,22 +350,22 @@ func (s *patchSuite) testMaybeResetPatchLevel6(c *C, snapdVersion, lastVersion s
 	c.Assert(st.Get("patch-sublevel", &sublevel), IsNil)
 	c.Assert(st.Get("patch-sublevel-last-version", &ver), IsNil)
 	c.Assert(st.Get("patch-sublevel-reset", &lastRefresh), testutil.ErrorIs, state.ErrNoState)
-	c.Check(ver, Equals, "snapd-version-1")
+	c.Check(ver, Equals, "workspaced-version-1")
 	c.Check(level, Equals, 6)
 	c.Check(sublevel, Equals, 2)
 }
 
 func (s *patchSuite) TestSameSnapdVersionLvl60PatchesNotApplied(c *C) {
-	// sublevel patches not applied if snapd version is same
-	s.testMaybeResetPatchLevel6(c, "snapd-version-1", "snapd-version-1", nil)
+	// sublevel patches not applied if workspaced version is same
+	s.testMaybeResetPatchLevel6(c, "workspaced-version-1", "workspaced-version-1", nil)
 }
 
 func (s *patchSuite) TestDifferentSnapdVersionPatchLevel6NoLastVersion(c *C) {
-	s.testMaybeResetPatchLevel6(c, "snapd-version-1", "", []int{61, 62})
+	s.testMaybeResetPatchLevel6(c, "workspaced-version-1", "", []int{61, 62})
 }
 
 func (s *patchSuite) TestDifferentSnapdVersionPatchLevel6(c *C) {
-	s.testMaybeResetPatchLevel6(c, "snapd-version-1", "snapd-version-2", []int{61, 62})
+	s.testMaybeResetPatchLevel6(c, "workspaced-version-1", "workspaced-version-2", []int{61, 62})
 }
 
 func (s *patchSuite) TestValidity(c *C) {

--- a/internal/overlord/restart/restart.go
+++ b/internal/overlord/restart/restart.go
@@ -44,10 +44,10 @@ const (
 type Handler interface {
 	HandleRestart(t RestartType)
 	// RebootIsFine is called early when either a reboot was
-	// requested by snapd and happened or no reboot was expected at all.
+	// requested by workspaced and happened or no reboot was expected at all.
 	RebootIsFine(st *state.State) error
 	// RebootIsMissing is called early instead when a reboot was
-	// requested by snapd but did not happen.
+	// requested by workspaced but did not happen.
 	RebootIsMissing(st *state.State) error
 }
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/canonical/workspace/internal/dirs"
 	store "github.com/canonical/workspace/internal/fakestore"
+	"github.com/canonical/workspace/internal/interfaces/policy"
 	"github.com/canonical/workspace/internal/logger"
 	"github.com/canonical/workspace/internal/overlord/state"
 	"github.com/canonical/workspace/internal/sdk"
@@ -171,10 +172,6 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	st := task.State()
-	st.Lock()
-	defer st.Unlock()
-
 	sdkMount := sdkBlobDevice(blob)
 
 	fs, err := m.backend.GetWorkspaceFs(ctx, workspace)
@@ -197,24 +194,39 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	blob, err := SdkSetup(task)
+	setup, err := SdkSetup(task)
 	if err != nil {
 		return err
 	}
-
-	st := task.State()
-	st.Lock()
-	defer st.Unlock()
 
 	ctx, cancel := BackendContext(tomb, user, project)
 	defer cancel()
 
-	props, err := m.backend.GetWorkspace(ctx, workspace)
+	inst, err := m.backend.GetWorkspace(ctx, workspace)
 	if err != nil {
 		return err
 	}
 
-	return props.LinkSdk(ctx, blob)
+	if err = inst.LinkSdk(ctx, setup); err != nil {
+		return err
+	}
+
+	wsfs, err := m.backend.GetWorkspaceFs(ctx, workspace)
+	if err != nil {
+		return err
+	}
+	defer wsfs.Close()
+
+	sdkInfo, err := inst.SdkInfo(wsfs, setup)
+	if err != nil {
+		return nil
+	}
+
+	if err = policy.CheckInterfaces(sdkInfo); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (m *SdkManager) undoLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -228,17 +240,13 @@ func (m *SdkManager) undoLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	st := task.State()
-	st.Lock()
-	defer st.Unlock()
-
 	ctx, cancel := BackendContext(tomb, user, project)
 	defer cancel()
 
-	props, err := m.backend.GetWorkspace(ctx, workspace)
+	inst, err := m.backend.GetWorkspace(ctx, workspace)
 	if err != nil {
 		return err
 	}
 
-	return props.UnlinkSdk(ctx, blob)
+	return inst.UnlinkSdk(ctx, blob)
 }

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -46,7 +46,7 @@ func SdkSetup(task *state.Task) (sdk.Setup, error) {
 
 func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	st := task.State()
-	var sdk workspacebackend.Sdk
+	var sdk workspacebackend.SdkRecord
 
 	st.Lock()
 	err := task.Get("sdk-setup", &sdk)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -110,7 +110,7 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 	defer cleanup()
 
 	// example: /var/lib/workspace/sdk/cuda/712/
-	sdkPath := filepath.Join(sdk.WorkspaceSdksDir, sdkSetup.Name,
+	sdkPath := filepath.Join(dirs.WorkspaceSdksDir, sdkSetup.Name,
 		strconv.Itoa(int(sdkSetup.Revision)))
 
 	// create a memory out/err to log the hook output into the task's log
@@ -180,7 +180,7 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	}
 	defer fs.Close()
 
-	err = fs.RemoveAll(filepath.Join(sdk.WorkspaceSdksDir, blob.Name))
+	err = fs.RemoveAll(filepath.Join(dirs.WorkspaceSdksDir, blob.Name))
 	if err != nil {
 		return fmt.Errorf("cannot undo SDK %q installation: %w", sdkMount.Name, err)
 	}
@@ -211,13 +211,7 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	wsfs, err := m.backend.GetWorkspaceFs(ctx, workspace)
-	if err != nil {
-		return err
-	}
-	defer wsfs.Close()
-
-	sdkInfo, err := inst.SdkInfo(wsfs, setup)
+	sdkInfo, err := inst.SdkInfo(ctx, setup)
 	if err != nil {
 		return nil
 	}

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -19,29 +19,29 @@ import (
 	"gopkg.in/tomb.v2"
 )
 
-func SdkSetup(task *state.Task) (*sdk.SdkInfo, error) {
+func SdkSetup(task *state.Task) (sdk.Setup, error) {
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
 
 	var retrieveId string
-	var blob sdk.SdkInfo
+	var blob sdk.Setup
 
 	err := task.Get("sdk-retrieve-task", &retrieveId)
 
 	if err != nil {
-		return nil, err
+		return sdk.Setup{}, err
 	}
 
 	retrieve := task.State().Task(retrieveId)
 	if retrieve == nil {
-		return nil, fmt.Errorf("internal error: no corresponding retrieve-sdk task found")
+		return sdk.Setup{}, fmt.Errorf("internal error: no corresponding retrieve-sdk task found")
 	}
 
 	if err = retrieve.Get("sdk-setup", &blob); err != nil {
-		return nil, err
+		return sdk.Setup{}, err
 	}
-	return &blob, nil
+	return blob, nil
 }
 
 func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -70,7 +70,7 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
-func sdkBlobDevice(sdk *sdk.SdkInfo) workspacebackend.WorkspaceDevice {
+func sdkBlobDevice(sdk sdk.Setup) workspacebackend.WorkspaceDevice {
 	/* Bind-mount the SDK to the workspace */
 	return workspacebackend.WorkspaceDevice{
 		Name: sdk.Name,

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -85,7 +85,7 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	blob, err := SdkSetup(task)
+	sdkSetup, err := SdkSetup(task)
 	if err != nil {
 		return err
 	}
@@ -93,10 +93,9 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project)
 	defer cancel()
 
-	sdkMount := sdkBlobDevice(blob)
+	sdkMount := sdkBlobDevice(sdkSetup)
 
-	err = m.backend.AddWorkspaceDevice(ctx, workspace, sdkMount)
-	if err != nil {
+	if err = m.backend.AddWorkspaceDevice(ctx, workspace, sdkMount); err != nil {
 		return err
 	}
 
@@ -109,19 +108,19 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 
 	defer cleanup()
 
-	/* example: /var/lib/workspace/sdk/cuda/712/ */
-	sdkPath := filepath.Join(sdk.WorkspaceSdksDir, blob.Name,
-		strconv.Itoa(int(blob.Revision)))
+	// example: /var/lib/workspace/sdk/cuda/712/
+	sdkPath := filepath.Join(sdk.WorkspaceSdksDir, sdkSetup.Name,
+		strconv.Itoa(int(sdkSetup.Revision)))
 
-	/* create a memory out/err to log the hook output into the task's log */
+	// create a memory out/err to log the hook output into the task's log
 	memFs := afero.NewMemMapFs()
 	out, err := memFs.Create(workspacebackend.InstanceName(workspace, project.ProjectId))
 	if err != nil {
 		return err
 	}
 
-	/* Unpack the SDK to the desired location in the workspace
-	   Note: the following command requires ~ tar >= 1.29 due to --one-top-level */
+	// Unpack the SDK to the desired location in the workspace
+	//   Note: the following command requires ~ tar >= 1.29 due to --one-top-level
 	args := workspacebackend.Execution{
 		ExecArgs: workspacebackend.ExecArgs{
 			UserId:  0,
@@ -175,6 +174,7 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
+
 	sdkMount := sdkBlobDevice(blob)
 
 	fs, err := m.backend.GetWorkspaceFs(ctx, workspace)

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/canonical/workspace/internal/dirs"
 	"github.com/canonical/workspace/internal/overlord"
 	"github.com/canonical/workspace/internal/overlord/sdkstate"
 	"github.com/canonical/workspace/internal/overlord/state"
@@ -193,7 +194,7 @@ func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
 	/* emulate install behaviour that unpacks an SDK to a certain directory */
 	s.backend.DoExec = func(ctx context.Context, name string, args *workspacebackend.Execution) (workspacebackend.ExecContext, error) {
 		fs, _ := s.backend.GetWorkspaceFs(ctx, name)
-		fs.MkdirAll(filepath.Join(sdk.WorkspaceSdksDir, "new"), 0755)
+		fs.MkdirAll(filepath.Join(dirs.WorkspaceSdksDir, "new"), 0755)
 		return workspacebackend.ExecContext{}, nil
 	}
 
@@ -210,7 +211,7 @@ func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
 	/* make sure SDK dir was removed */
 	fs, err := s.backend.GetWorkspaceFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
-	exist, _ := afero.Exists(fs, filepath.Join(sdk.WorkspaceSdksDir, "new"))
+	exist, _ := afero.Exists(fs, filepath.Join(dirs.WorkspaceSdksDir, "new"))
 	c.Check(exist, check.Equals, false)
 }
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -90,9 +90,29 @@ func (s *H) SetUpTest(c *check.C) {
 
 	err := os.WriteFile(filepath.Join(s.project.Path, ".workspace.ws.yaml"), []byte(`name: ws
 base: ubuntu@20.04
+sdks:
+  test:
+    channel: latest/stable
 `), 0644)
 	c.Assert(err, check.IsNil)
 	err = s.backend.LaunchWorkspace(s.ctx, "ws", "ubuntu@20.04")
+	c.Assert(err, check.IsNil)
+
+	var sdkYaml = `
+name: test
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: content
+`
+	s.mockTestSdk(c, sdkYaml)
+}
+
+func (s *H) mockTestSdk(c *check.C, sdkYaml string) {
+	sdkPath := filepath.Join(dirs.WorkspaceSdksDir, "test", "current", "meta", "sdk.yaml")
+	fs, err := s.backend.GetWorkspaceFs(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	err = afero.WriteFile(fs, sdkPath, []byte(sdkYaml), 0644)
 	c.Assert(err, check.IsNil)
 }
 
@@ -104,7 +124,7 @@ func (s *H) TearDownTest(c *check.C) {
 func (s *H) TestDoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.Info{Name: "new", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Name: "test", Channel: "latest/stable", Revision: 2}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -128,8 +148,8 @@ func (s *H) TestDoInstallSdkSuccess(c *check.C) {
 		"tar",
 		"--extract",
 		"--file",
-		"/root/new_2.sdk",
-		"--one-top-level=/var/lib/workspace/sdk/new/2",
+		"/root/test_2.sdk",
+		"--one-top-level=/var/lib/workspace/sdk/test/2",
 		"--no-same-owner",
 	})
 
@@ -142,7 +162,7 @@ func (s *H) TestDoInstallSdkExecFail(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Info{Name: "new", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Name: "test", Channel: "latest/stable", Revision: 2}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -174,7 +194,7 @@ func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Info{Name: "new", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Name: "test", Channel: "latest/stable", Revision: 2}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -219,9 +239,10 @@ func (s *H) TestDoLinkSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Setup{Name: "new", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+	testSdk := sdk.Setup{Workspace: "ws", Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+
 	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", testSdk)
 	t1 := s.state.NewTask("link-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
 
@@ -241,14 +262,49 @@ func (s *H) TestDoLinkSdkSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	info := props.Content()
 	c.Check(info, check.HasLen, 1)
-	c.Check(info[0], check.DeepEquals, newSdk)
+	c.Check(info[0], check.DeepEquals, testSdk)
+}
+
+func (s *H) TestDoLinkSdkFailPolicyCheck(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var sdkYaml = `
+name: test
+base: ubuntu@22.04
+slots:
+  slot:
+    interface: content
+`
+	s.mockTestSdk(c, sdkYaml)
+
+	testSdk := sdk.Setup{Workspace: "ws", Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+
+	t := s.state.NewTask("fake-task", "retrieve")
+	t.Set("sdk-setup", testSdk)
+	t1 := s.state.NewTask("link-sdk", "test")
+	t1.Set("sdk-retrieve-task", t.ID())
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkspaceProject("ws", s.project, t, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Assert(t1.Log()[0], check.Matches, ".*installation not allowed.*")
 }
 
 func (s *H) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Info{Name: "new", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Workspace: "ws", Name: "test", Channel: "latest/stable", Revision: 2}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	link := s.state.NewTask("link-sdk", "test")

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -104,6 +104,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: content
+    target: /project/sub
 `
 	s.mockTestSdk(c, sdkYaml)
 }
@@ -263,6 +264,11 @@ func (s *H) TestDoLinkSdkSuccess(c *check.C) {
 	info := props.Content()
 	c.Check(info, check.HasLen, 1)
 	c.Check(info[0], check.DeepEquals, testSdk)
+
+	sdkInfo, err := props.SdkInfo(s.ctx, info[0])
+	c.Assert(err, check.IsNil)
+	c.Assert(sdkInfo.Plugs, check.HasLen, 1)
+	c.Assert(sdkInfo.Slots, check.HasLen, 0)
 }
 
 func (s *H) TestDoLinkSdkFailPolicyCheck(c *check.C) {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -103,7 +103,7 @@ func (s *H) TearDownTest(c *check.C) {
 func (s *H) TestDoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.SdkInfo{Name: "new", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Name: "new", Channel: "latest/stable", Revision: 2}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -141,7 +141,7 @@ func (s *H) TestDoInstallSdkExecFail(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.SdkInfo{Name: "new", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Name: "new", Channel: "latest/stable", Revision: 2}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -173,7 +173,7 @@ func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.SdkInfo{Name: "new", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Name: "new", Channel: "latest/stable", Revision: 2}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -218,7 +218,7 @@ func (s *H) TestDoLinkSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.SdkInfo{Name: "new", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+	newSdk := sdk.Setup{Name: "new", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("link-sdk", "test")
@@ -240,14 +240,14 @@ func (s *H) TestDoLinkSdkSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	info := props.Content()
 	c.Check(info, check.HasLen, 1)
-	c.Check(*info[0], check.DeepEquals, newSdk)
+	c.Check(info[0], check.DeepEquals, newSdk)
 }
 
 func (s *H) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.SdkInfo{Name: "new", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Name: "new", Channel: "latest/stable", Revision: 2}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	link := s.state.NewTask("link-sdk", "test")

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -71,7 +71,7 @@ func (s *H) SetUpTest(c *check.C) {
 
 	/* empty task handler */
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
-	s.wsmgr = sdkstate.NewSdkManager(s.runner, s.backend)
+	s.wsmgr = sdkstate.New(s.runner, s.backend)
 
 	/* error-provoking task handler */
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -15,7 +15,7 @@ type SdkSequenceRecord struct {
 	Revision int64  `json:"revision"`
 }
 
-func NewSdkManager(runner *state.TaskRunner, server backend.WorkspaceBackend) *SdkManager {
+func New(runner *state.TaskRunner, server backend.WorkspaceBackend) *SdkManager {
 	manager := &SdkManager{backend: server}
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -7,7 +7,7 @@ import (
 	"github.com/canonical/workspace/internal/workspacebackend"
 )
 
-func Retrieve(st *state.State, sdk *workspacebackend.Sdk) *state.Task {
+func Retrieve(st *state.State, sdk *workspacebackend.SdkRecord) *state.Task {
 	download := st.NewTask("retrieve-sdk", fmt.Sprintf("Retrieve %q SDK from channel %q", sdk.Name, sdk.Channel))
 	download.Set("sdk-setup", sdk)
 	return download

--- a/internal/overlord/sdkstate/request_test.go
+++ b/internal/overlord/sdkstate/request_test.go
@@ -21,7 +21,7 @@ func (i *SdkStateTasks) TestInstall(c *check.C) {
 	i.state.Lock()
 	defer i.state.Unlock()
 
-	sdk := workspacebackend.Sdk{Name: "sdk", Channel: "latest/stable"}
+	sdk := workspacebackend.SdkRecord{Name: "sdk", Channel: "latest/stable"}
 
 	tasks := sdkstate.Install(i.state, sdk.Name, "retrieve").Tasks()
 
@@ -40,11 +40,11 @@ func (i *SdkStateTasks) TestRetrieve(c *check.C) {
 	i.state.Lock()
 	defer i.state.Unlock()
 
-	sdk := workspacebackend.Sdk{Name: "sdk", Channel: "latest/stable"}
+	sdk := workspacebackend.SdkRecord{Name: "sdk", Channel: "latest/stable"}
 
 	task := sdkstate.Retrieve(i.state, &sdk)
 
-	var s workspacebackend.Sdk
+	var s workspacebackend.SdkRecord
 	task.Get("sdk-setup", &s)
 	c.Check(s, check.DeepEquals, sdk)
 	c.Check(task.Kind(), check.Equals, "retrieve-sdk")

--- a/internal/overlord/state/change.go
+++ b/internal/overlord/state/change.go
@@ -305,7 +305,7 @@ func (c *Change) isTaskWaiting(visited map[string]taskWaitComputeStatus, t *Task
 	case taskWaitStatusComputing:
 		// Cyclic dependency detected, return false to short-circuit.
 		logger.Noticef("detected cyclic dependencies for task %q in change %q", t.Kind(), t.Change().Kind())
-		// Make sure errors show up in "snap change <id>" too
+		// Make sure errors show up in "workspace change <id>" too
 		t.Logf("detected cyclic dependencies for task %q in change %q", t.Kind(), t.Change().Kind())
 		return false
 	case taskWaitStatusWaiting, taskWaitStatusNotWaiting:

--- a/internal/overlord/workspacestate/handlers_test.go
+++ b/internal/overlord/workspacestate/handlers_test.go
@@ -59,7 +59,7 @@ func (s *workspaceHandlers) SetUpTest(c *check.C) {
 
 	// empty task handler
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
-	s.wrkmgr = workspacestate.NewWorkspaceManager(s.state, s.runner, s.backend)
+	s.wrkmgr = workspacestate.New(s.state, s.runner, s.backend)
 
 	// error-provoking task handler
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {

--- a/internal/overlord/workspacestate/manager.go
+++ b/internal/overlord/workspacestate/manager.go
@@ -13,7 +13,7 @@ type WorkspaceManager struct {
 	state   *state.State
 }
 
-func NewWorkspaceManager(st *state.State, runner *state.TaskRunner, server workspacebackend.WorkspaceBackend) *WorkspaceManager {
+func New(st *state.State, runner *state.TaskRunner, server workspacebackend.WorkspaceBackend) *WorkspaceManager {
 	manager := &WorkspaceManager{
 		backend: server,
 		state:   st,

--- a/internal/overlord/workspacestate/manager_test.go
+++ b/internal/overlord/workspacestate/manager_test.go
@@ -29,14 +29,14 @@ func (s *ManagerSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.backend = workspacebackend.NewFakeWorkspaceBackend()
 	s.runner = state.NewTaskRunner(s.state)
-	s.manager = workspacestate.NewWorkspaceManager(s.state, s.runner, s.backend)
+	s.manager = workspacestate.New(s.state, s.runner, s.backend)
 	ctx := context.WithValue(context.TODO(), workspacebackend.ContextUser, "testuser")
 	s.project, _, _ = s.backend.CreateOrLoadProject(ctx, c.MkDir())
 	s.ctx = context.WithValue(ctx, workspacebackend.ContextProjectId, s.project.ProjectId)
 }
 
 func (s *ManagerSuite) TestAddHandlers(c *check.C) {
-	workspacestate.NewWorkspaceManager(s.state, s.runner, s.backend)
+	workspacestate.New(s.state, s.runner, s.backend)
 
 	c.Assert(s.runner.KnownTaskKinds(), testutil.DeepUnsortedMatches, []string{
 		"create-workspace",

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -22,16 +22,21 @@ const (
 )
 
 func (w *WorkspaceManager) loadProject(ctx context.Context, id string) (*workspacebackend.Project, error) {
-	projects, err := w.backend.Projects(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("no project found with \"id\" %v", id)
+	username, ok := ctx.Value(workspacebackend.ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key user not found")
 	}
 
-	prj, ok := projects[id]
-	if !ok {
+	projects, err := w.backend.Projects(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	idx := slices.IndexFunc(projects[username], func(p *workspacebackend.Project) bool { return p.ProjectId == id })
+	if idx == -1 {
 		return nil, fmt.Errorf("no project found with \"id\" %v", id)
 	}
-	return prj, nil
+	return projects[username][idx], nil
 }
 
 func (w *WorkspaceManager) LaunchMany(ctx context.Context, names []string, projectId string, opChangeId string) ([]*state.TaskSet, error) {

--- a/internal/overlord/workspacestate/request.go
+++ b/internal/overlord/workspacestate/request.go
@@ -176,7 +176,7 @@ func (w *WorkspaceManager) RefreshMany(ctx context.Context,
 	}
 
 	files := make([]*workspacebackend.WorkspaceFile, 0)
-	content := make([][]*sdk.SdkInfo, 0)
+	content := make([][]sdk.Setup, 0)
 	for _, i := range names {
 		idx := slices.IndexFunc(workspaces, func(w *workspacebackend.Workspace) bool { return w.Name == i })
 		if idx == -1 {
@@ -205,7 +205,7 @@ func (w *WorkspaceManager) RefreshMany(ctx context.Context,
 	return taskset, nil
 }
 
-func refreshMany(st *state.State, w []*workspacebackend.WorkspaceFile, content [][]*sdk.SdkInfo,
+func refreshMany(st *state.State, w []*workspacebackend.WorkspaceFile, content [][]sdk.Setup,
 	project *workspacebackend.Project) ([]*state.TaskSet, error) {
 	taskset := make([]*state.TaskSet, 0, len(w))
 
@@ -260,7 +260,7 @@ func refreshMany(st *state.State, w []*workspacebackend.WorkspaceFile, content [
 	return taskset, nil
 }
 
-func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*sdk.SdkInfo, p *workspacebackend.Project) (*state.TaskSet, error) {
+func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []sdk.Setup, p *workspacebackend.Project) (*state.TaskSet, error) {
 	// 1. Save previous state
 	// 2. Stop previous workspace
 	// 3. Put to stash
@@ -333,12 +333,12 @@ func refresh(st *state.State, file *workspacebackend.WorkspaceFile, content []*s
 	return refresh, nil
 }
 
-func saveStateHooks(st *state.State, content []*sdk.SdkInfo, newContent workspacebackend.SdkList,
+func saveStateHooks(st *state.State, content []sdk.Setup, newContent workspacebackend.SdkList,
 ) *state.TaskSet {
 	return createStateHooks(st, content, newContent, hookstate.SaveState)
 }
 
-func restoreStateHooks(st *state.State, content []*sdk.SdkInfo, newContent workspacebackend.SdkList) *state.TaskSet {
+func restoreStateHooks(st *state.State, content []sdk.Setup, newContent workspacebackend.SdkList) *state.TaskSet {
 	stateHooks := createStateHooks(st, content, newContent, hookstate.RestoreState)
 
 	// if the restore hooks are not present (i.e. workspace has no SDKs after
@@ -354,13 +354,13 @@ func restoreStateHooks(st *state.State, content []*sdk.SdkInfo, newContent works
 	return stateHooks
 }
 
-func createStateHooks(st *state.State, content []*sdk.SdkInfo, newContent workspacebackend.SdkList, hooktype hookstate.WorkspaceHookType) *state.TaskSet {
+func createStateHooks(st *state.State, content []sdk.Setup, newContent workspacebackend.SdkList, hooktype hookstate.WorkspaceHookType) *state.TaskSet {
 	stateHooks := state.NewTaskSet([]*state.Task{}...)
 	prevRestore := (*state.Task)(nil)
 	for _, newsdk := range newContent {
 		// the state hooks will only be set for the SDKs that were installed AND
 		// were not removed from the workspace file at the time of refresh
-		if slices.IndexFunc(content, func(s *sdk.SdkInfo) bool { return s.Name == newsdk.Name }) == -1 {
+		if slices.IndexFunc(content, func(s sdk.Setup) bool { return s.Name == newsdk.Name }) == -1 {
 			continue
 		}
 

--- a/internal/overlord/workspacestate/request_test.go
+++ b/internal/overlord/workspacestate/request_test.go
@@ -146,7 +146,7 @@ func (s *S) TestRefreshEmptyWorkspace(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workspacebackend.SdkList{}}
 
-	ts, err := workspacestate.Refresh(s.state, file, []*sdk.SdkInfo{}, s.project)
+	ts, err := workspacestate.Refresh(s.state, file, []sdk.Setup{}, s.project)
 	c.Assert(err, check.IsNil)
 
 	expected := []string{
@@ -184,7 +184,7 @@ func (s *S) TestRefreshManyEmptyWorkspaceMany(c *check.C) {
 			Sdks: workspacebackend.SdkList{test_sdk}},
 	}
 
-	content := [][]*sdk.SdkInfo{
+	content := [][]sdk.Setup{
 		nil,
 		{{
 			Name:    "sdk",
@@ -255,7 +255,7 @@ func (s *S) TestRefreshWithAnSDK(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workspacebackend.SdkList{testSdk}}
 
-	ts, err := workspacestate.Refresh(s.state, file, []*sdk.SdkInfo{
+	ts, err := workspacestate.Refresh(s.state, file, []sdk.Setup{
 		{
 			Name:    "sdk",
 			Channel: "latest/stable",
@@ -306,7 +306,7 @@ func (s *S) TestRefreshManyTasktest(c *check.C) {
 		},
 	}
 
-	content := [][]*sdk.SdkInfo{
+	content := [][]sdk.Setup{
 		{{
 			Name:    "sdk",
 			Channel: "latest/stable",
@@ -365,7 +365,7 @@ func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 		},
 	}
 
-	content := [][]*sdk.SdkInfo{
+	content := [][]sdk.Setup{
 		{{
 			Name:    "sdk",
 			Channel: "latest/stable",
@@ -428,11 +428,11 @@ func (s *S) TestRefreshManyRestoreStateHooksExecutedSequentially(c *check.C) {
 	twoinst := workspacebackend.Sdk{Name: "two", Channel: "latest/stable"}
 
 	// installed SDKs
-	one := &sdk.SdkInfo{Name: "one", Channel: "latest/stable"}
-	two := &sdk.SdkInfo{Name: "two", Channel: "latest/stable"}
+	one := sdk.Setup{Name: "one", Channel: "latest/stable"}
+	two := sdk.Setup{Name: "two", Channel: "latest/stable"}
 
 	ts := workspacestate.RestoreStateHooks(s.state,
-		[]*sdk.SdkInfo{one, two}, workspacebackend.SdkList{oneinst, twoinst})
+		[]sdk.Setup{one, two}, workspacebackend.SdkList{oneinst, twoinst})
 	c.Assert(ts.Tasks(), check.HasLen, 2)
 
 	prev := (*state.Task)(nil)
@@ -454,10 +454,10 @@ func (s *S) TestRefreshManySaveStateHooksExecutedSequentially(c *check.C) {
 		workspacebackend.Sdk{Name: "two"}}
 
 	// installed SDKs
-	one := &sdk.SdkInfo{Name: "one", Channel: "latest/stable"}
-	two := &sdk.SdkInfo{Name: "two", Channel: "latest/stable"}
+	one := sdk.Setup{Name: "one", Channel: "latest/stable"}
+	two := sdk.Setup{Name: "two", Channel: "latest/stable"}
 
-	ts := workspacestate.SaveStateHooks(s.state, []*sdk.SdkInfo{one, two}, installed)
+	ts := workspacestate.SaveStateHooks(s.state, []sdk.Setup{one, two}, installed)
 	c.Assert(ts.Tasks(), check.HasLen, 2)
 
 	prev := (*state.Task)(nil)
@@ -479,7 +479,7 @@ func (s *S) TestRefreshManyNoRestoreStateHooks(c *check.C) {
 		Sdks: workspacebackend.SdkList{},
 	}
 
-	ts := workspacestate.RestoreStateHooks(s.state, []*sdk.SdkInfo{}, file.Sdks)
+	ts := workspacestate.RestoreStateHooks(s.state, []sdk.Setup{}, file.Sdks)
 	c.Assert(ts.Tasks(), check.HasLen, 0)
 }
 

--- a/internal/overlord/workspacestate/request_test.go
+++ b/internal/overlord/workspacestate/request_test.go
@@ -76,8 +76,8 @@ func (s *S) TestLaunchWorkspaceNoSdk(c *check.C) {
 func (s *S) TestLaunchWorkspaceWithSdks(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	sdk := workspacebackend.Sdk{Name: "sdk", Channel: "latest/stable"}
-	sdk_2 := workspacebackend.Sdk{Name: "sdk_2", Channel: "latest/stable"}
+	sdk := workspacebackend.SdkRecord{Name: "sdk", Channel: "latest/stable"}
+	sdk_2 := workspacebackend.SdkRecord{Name: "sdk_2", Channel: "latest/stable"}
 
 	file := &workspacebackend.WorkspaceFile{
 		Name: "test",
@@ -104,7 +104,7 @@ func (s *S) TestLaunchWorkspaceWithSdks(c *check.C) {
 	c.Assert(err, check.Equals, nil)
 	verifyExpectedTasks(c, tasks, expected)
 
-	var s1, s2 workspacebackend.Sdk
+	var s1, s2 workspacebackend.SdkRecord
 	err = tasks[3].Get("sdk-setup", &s1)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(s1, check.Equals, sdk)
@@ -171,7 +171,7 @@ func (s *S) TestRefreshManyEmptyWorkspaceMany(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	test_sdk := workspacebackend.Sdk{Name: "sdk", Channel: "latest/stable"}
+	test_sdk := workspacebackend.SdkRecord{Name: "sdk", Channel: "latest/stable"}
 
 	files := []*workspacebackend.WorkspaceFile{
 		{
@@ -248,7 +248,7 @@ func (s *S) TestRefreshWithAnSDK(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	testSdk := workspacebackend.Sdk{Name: "sdk", Channel: "latest/stable"}
+	testSdk := workspacebackend.SdkRecord{Name: "sdk", Channel: "latest/stable"}
 
 	file := &workspacebackend.WorkspaceFile{
 		Name: "ws",
@@ -291,7 +291,7 @@ func (s *S) TestRefreshManyTasktest(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	testSdk := workspacebackend.Sdk{Name: "sdk", Channel: "latest/stable"}
+	testSdk := workspacebackend.SdkRecord{Name: "sdk", Channel: "latest/stable"}
 
 	files := []*workspacebackend.WorkspaceFile{
 		{
@@ -350,7 +350,7 @@ func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	testSdk := workspacebackend.Sdk{Name: "sdk", Channel: "latest/stable"}
+	testSdk := workspacebackend.SdkRecord{Name: "sdk", Channel: "latest/stable"}
 
 	files := []*workspacebackend.WorkspaceFile{
 		{
@@ -424,8 +424,8 @@ func (s *S) TestRefreshManyRestoreStateHooksExecutedSequentially(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	oneinst := workspacebackend.Sdk{Name: "one", Channel: "latest/stable"}
-	twoinst := workspacebackend.Sdk{Name: "two", Channel: "latest/stable"}
+	oneinst := workspacebackend.SdkRecord{Name: "one", Channel: "latest/stable"}
+	twoinst := workspacebackend.SdkRecord{Name: "two", Channel: "latest/stable"}
 
 	// installed SDKs
 	one := sdk.Setup{Name: "one", Channel: "latest/stable"}
@@ -450,8 +450,8 @@ func (s *S) TestRefreshManySaveStateHooksExecutedSequentially(c *check.C) {
 	defer s.state.Unlock()
 
 	// the SDK list to be refreshed (i.e. coming from a workspace file)
-	installed := workspacebackend.SdkList{workspacebackend.Sdk{Name: "one"},
-		workspacebackend.Sdk{Name: "two"}}
+	installed := workspacebackend.SdkList{workspacebackend.SdkRecord{Name: "one"},
+		workspacebackend.SdkRecord{Name: "two"}}
 
 	// installed SDKs
 	one := sdk.Setup{Name: "one", Channel: "latest/stable"}

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -29,14 +29,27 @@ type Setup struct {
 type sdkYaml struct {
 	Name  string                 `json:"name"`
 	Base  string                 `json:"base"`
+	Type  string                 `json:"type"`
 	Plugs map[string]interface{} `yaml:"plugs,omitempty"`
 	Slots map[string]interface{} `yaml:"slots,omitempty"`
+}
+
+type Type string
+
+const (
+	Sdk  Type = "sdk"
+	Core Type = "core"
+)
+
+func (t Type) String() string {
+	return string(t)
 }
 
 type Info struct {
 	Workspace string
 	Name      string
 	Base      string
+	Type      Type
 	Channel   string
 	Revision  int64
 
@@ -57,10 +70,15 @@ func ReadSdkInfo(yamlData []byte, setup Setup) (*Info, error) {
 		return &Info{}, err
 	}
 
+	if sdkYaml.Type == "" {
+		sdkYaml.Type = Sdk.String()
+	}
+
 	sdkInfo := &Info{
 		Workspace:     setup.Workspace,
 		Name:          sdkYaml.Name,
 		Base:          sdkYaml.Base,
+		Type:          Type(sdkYaml.Type),
 		Plugs:         make(map[string]*PlugInfo),
 		Slots:         make(map[string]*SlotInfo),
 		BadInterfaces: make(map[string]string),

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -3,20 +3,237 @@ package sdk
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/canonical/workspace/internal/dirs"
+	"github.com/canonical/workspace/internal/metautil"
+	"gopkg.in/yaml.v2"
 )
 
 const (
 	WorkspaceSdksDir = "/var/lib/workspace/sdk"
 )
 
-type SdkInfo struct {
+type Setup struct {
+	Workspace   string    `json:"workspace"`
 	Name        string    `json:"name"`
 	Channel     string    `json:"channel"`
 	Revision    int64     `json:"revision"`
 	InstallTime time.Time `json:"install-time"`
+}
+
+type sdkYaml struct {
+	Name  string                 `json:"name"`
+	Base  string                 `json:"base"`
+	Plugs map[string]interface{} `yaml:"plugs,omitempty"`
+	Slots map[string]interface{} `yaml:"slots,omitempty"`
+}
+
+type Info struct {
+	Workspace string
+	Name      string
+	Base      string
+	Channel   string
+	Revision  int64
+
+	Plugs map[string]*PlugInfo
+	Slots map[string]*SlotInfo
+	// Plugs or slots with issues (they are not included in Plugs or Slots)
+	BadInterfaces map[string]string
+}
+
+func ReadSdkInfo(yamlData []byte, setup Setup) (*Info, error) {
+	var sdkYaml sdkYaml
+	err := yaml.Unmarshal(yamlData, &sdkYaml)
+	if err != nil {
+		return &Info{}, err
+	}
+
+	sdkInfo := &Info{
+		Workspace: setup.Workspace,
+		Name:      sdkYaml.Name,
+		Base:      sdkYaml.Base,
+		Plugs:     make(map[string]*PlugInfo),
+		Slots:     make(map[string]*SlotInfo),
+		Revision:  setup.Revision,
+		Channel:   setup.Channel,
+	}
+
+	if err := setPlugsFromSnapYaml(&sdkYaml, sdkInfo); err != nil {
+		return nil, err
+	}
+
+	if err := setSlotsFromSnapYaml(&sdkYaml, sdkInfo); err != nil {
+		return nil, err
+	}
+	return sdkInfo, nil
+}
+
+func setPlugsFromSnapYaml(y *sdkYaml, sdk *Info) error {
+	for name, data := range y.Plugs {
+		iface, label, attrs, err := convertToSlotOrPlugData("plug", name, data)
+		if err != nil {
+			return err
+		}
+		sdk.Plugs[name] = &PlugInfo{
+			Sdk:       sdk,
+			Name:      name,
+			Interface: iface,
+			Attrs:     attrs,
+			Label:     label,
+		}
+	}
+
+	return nil
+}
+
+func setSlotsFromSnapYaml(y *sdkYaml, sdk *Info) error {
+	for name, data := range y.Slots {
+		iface, label, attrs, err := convertToSlotOrPlugData("slot", name, data)
+		if err != nil {
+			return err
+		}
+		sdk.Slots[name] = &SlotInfo{
+			Sdk:       sdk,
+			Name:      name,
+			Interface: iface,
+			Attrs:     attrs,
+			Label:     label,
+		}
+	}
+
+	return nil
+}
+
+func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, label string, attrs map[string]interface{}, err error) {
+	iface = name
+	switch data.(type) {
+	case string:
+		return data.(string), "", nil, nil
+	case nil:
+		return name, "", nil, nil
+	case map[interface{}]interface{}:
+		for keyData, valueData := range data.(map[interface{}]interface{}) {
+			key, ok := keyData.(string)
+			if !ok {
+				err := fmt.Errorf("%s %q has attribute key that is not a string (found %T)",
+					plugOrSlot, name, keyData)
+				return "", "", nil, err
+			}
+			if strings.HasPrefix(key, "$") {
+				err := fmt.Errorf("%s %q uses reserved attribute %q", plugOrSlot, name, key)
+				return "", "", nil, err
+			}
+			switch key {
+			case "":
+				return "", "", nil, fmt.Errorf("%s %q has an empty attribute key", plugOrSlot, name)
+			case "interface":
+				value, ok := valueData.(string)
+				if !ok {
+					err := fmt.Errorf("interface name on %s %q is not a string (found %T)",
+						plugOrSlot, name, valueData)
+					return "", "", nil, err
+				}
+				iface = value
+			case "label":
+				value, ok := valueData.(string)
+				if !ok {
+					err := fmt.Errorf("label of %s %q is not a string (found %T)",
+						plugOrSlot, name, valueData)
+					return "", "", nil, err
+				}
+				label = value
+			default:
+				if attrs == nil {
+					attrs = make(map[string]interface{})
+				}
+				value, err := metautil.NormalizeValue(valueData)
+				if err != nil {
+					return "", "", nil, fmt.Errorf("attribute %q of %s %q: %v", key, plugOrSlot, name, err)
+				}
+				attrs[key] = value
+			}
+		}
+		return iface, label, attrs, nil
+	default:
+		err := fmt.Errorf("%s %q has malformed definition (found %T)", plugOrSlot, name, data)
+		return "", "", nil, err
+	}
+}
+
+// SlotInfo provides information about a slot.
+type SlotInfo struct {
+	Sdk *Info
+
+	Name      string
+	Interface string
+	Attrs     map[string]interface{}
+	Label     string
+}
+
+type AttributeNotFoundError struct{ Err error }
+
+func (e AttributeNotFoundError) Error() string {
+	return e.Err.Error()
+}
+
+func (e AttributeNotFoundError) Is(target error) bool {
+	_, ok := target.(AttributeNotFoundError)
+	return ok
+}
+
+func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
+	var v interface{}
+	comps := strings.FieldsFunc(path, func(r rune) bool { return r == '.' })
+	if len(comps) == 0 {
+		return nil, false
+	}
+	v = attrs
+	for _, comp := range comps {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		v, ok = m[comp]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return v, true
+}
+
+func getAttribute(snapName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
+	v, ok := lookupAttr(attrs, key)
+	if !ok {
+		return AttributeNotFoundError{fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName)}
+	}
+
+	return metautil.SetValueFromAttribute(snapName, ifaceName, key, v, val)
+}
+
+func (slot *SlotInfo) Attr(key string, val interface{}) error {
+	return getAttribute(slot.Sdk.Name, slot.Interface, slot.Attrs, key, val)
+}
+
+func (slot *SlotInfo) Lookup(key string) (interface{}, bool) {
+	return lookupAttr(slot.Attrs, key)
+}
+
+// String returns the representation of the slot as snap:slot string.
+func (slot *SlotInfo) String() string {
+	return fmt.Sprintf("%s:%s", slot.Sdk.Name, slot.Name)
+}
+
+// PlugInfo provides information about a plug.
+type PlugInfo struct {
+	Sdk *Info
+
+	Name      string
+	Interface string
+	Attrs     map[string]interface{}
+	Label     string
 }
 
 func SdkCurrentPath(sdkName string) string {
@@ -31,6 +248,6 @@ func SdkHookPath(sdkName, hookName string) string {
 	return filepath.Join(SdkHooksDir(sdkName), hookName)
 }
 
-func (s *SdkInfo) Filename() string {
+func (s *Setup) Filename() string {
 	return filepath.Join(dirs.SdkDir, fmt.Sprintf("%s_%d.sdk", s.Name, s.Revision))
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -231,7 +231,7 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 func getAttribute(snapName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := lookupAttr(attrs, key)
 	if !ok {
-		return AttributeNotFoundError{fmt.Errorf("snap %q does not have attribute %q for interface %q", snapName, key, ifaceName)}
+		return AttributeNotFoundError{fmt.Errorf("sdk %q does not have attribute %q for interface %q", snapName, key, ifaceName)}
 	}
 
 	return metautil.SetValueFromAttribute(snapName, ifaceName, key, v, val)
@@ -245,7 +245,7 @@ func (slot *SlotInfo) Lookup(key string) (interface{}, bool) {
 	return lookupAttr(slot.Attrs, key)
 }
 
-// String returns the representation of the slot as snap:slot string.
+// String returns the representation of the slot as sdk:slot string.
 func (slot *SlotInfo) String() string {
 	return fmt.Sprintf("%s:%s", slot.Sdk.Name, slot.Name)
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canonical/workspace/internal/dirs"
 	"github.com/canonical/workspace/internal/metautil"
+	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -41,6 +42,10 @@ type Info struct {
 	Slots map[string]*SlotInfo
 	// Plugs or slots with issues (they are not included in Plugs or Slots)
 	BadInterfaces map[string]string
+}
+
+var SanitizePlugsSlots = func(snapInfo *Info) {
+	panic("SanitizePlugsSlots function not set")
 }
 
 func ReadSdkInfo(yamlData []byte, setup Setup) (*Info, error) {
@@ -236,6 +241,14 @@ type PlugInfo struct {
 	Label     string
 }
 
+func (plug *PlugInfo) Attr(key string, val interface{}) error {
+	return getAttribute(plug.Sdk.Name, plug.Interface, plug.Attrs, key, val)
+}
+
+func (plug *PlugInfo) Lookup(key string) (interface{}, bool) {
+	return lookupAttr(plug.Attrs, key)
+}
+
 func SdkCurrentPath(sdkName string) string {
 	return filepath.Join(WorkspaceSdksDir, sdkName, "current")
 }
@@ -250,4 +263,21 @@ func SdkHookPath(sdkName, hookName string) string {
 
 func (s *Setup) Filename() string {
 	return filepath.Join(dirs.SdkDir, fmt.Sprintf("%s_%d.sdk", s.Name, s.Revision))
+}
+
+func MockSanitizePlugsSlots(f func(snapInfo *Info)) (restore func()) {
+	old := SanitizePlugsSlots
+	SanitizePlugsSlots = f
+	return func() { SanitizePlugsSlots = old }
+}
+
+func MockInfo(c *check.C, yamlText string, setup Setup) *Info {
+	restoreSanitize := MockSanitizePlugsSlots(func(snapInfo *Info) {})
+	defer restoreSanitize()
+	info, err := ReadSdkInfo([]byte(yamlText), setup)
+	c.Assert(err, check.IsNil)
+
+	err = Validate(info)
+	c.Assert(err, check.IsNil)
+	return info
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -1,8 +1,10 @@
 package sdk
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -56,13 +58,14 @@ func ReadSdkInfo(yamlData []byte, setup Setup) (*Info, error) {
 	}
 
 	sdkInfo := &Info{
-		Workspace: setup.Workspace,
-		Name:      sdkYaml.Name,
-		Base:      sdkYaml.Base,
-		Plugs:     make(map[string]*PlugInfo),
-		Slots:     make(map[string]*SlotInfo),
-		Revision:  setup.Revision,
-		Channel:   setup.Channel,
+		Workspace:     setup.Workspace,
+		Name:          sdkYaml.Name,
+		Base:          sdkYaml.Base,
+		Plugs:         make(map[string]*PlugInfo),
+		Slots:         make(map[string]*SlotInfo),
+		BadInterfaces: make(map[string]string),
+		Revision:      setup.Revision,
+		Channel:       setup.Channel,
 	}
 
 	if err := setPlugsFromSnapYaml(&sdkYaml, sdkInfo); err != nil {
@@ -72,6 +75,8 @@ func ReadSdkInfo(yamlData []byte, setup Setup) (*Info, error) {
 	if err := setSlotsFromSnapYaml(&sdkYaml, sdkInfo); err != nil {
 		return nil, err
 	}
+
+	SanitizePlugsSlots(sdkInfo)
 	return sdkInfo, nil
 }
 
@@ -280,4 +285,43 @@ func MockInfo(c *check.C, yamlText string, setup Setup) *Info {
 	err = Validate(info)
 	c.Assert(err, check.IsNil)
 	return info
+}
+
+func MockInvalidInfo(c *check.C, yamlText string, setup Setup) *Info {
+	restoreSanitize := MockSanitizePlugsSlots(func(snapInfo *Info) {})
+	defer restoreSanitize()
+
+	sdkInfo, err := ReadSdkInfo([]byte(yamlText), setup)
+	c.Assert(err, check.IsNil)
+	err = Validate(sdkInfo)
+	c.Assert(err, check.NotNil)
+	return sdkInfo
+}
+
+// BadInterfacesSummary returns a summary of the problems of bad plugs
+// and slots in the sdk.
+func BadInterfacesSummary(sdkInfo *Info) string {
+	inverted := make(map[string][]string)
+	for name, reason := range sdkInfo.BadInterfaces {
+		inverted[reason] = append(inverted[reason], name)
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "sdk %q has bad plugs or slots: ", sdkInfo.Name)
+	reasons := make([]string, 0, len(inverted))
+	for reason := range inverted {
+		reasons = append(reasons, reason)
+	}
+	sort.Strings(reasons)
+	for _, reason := range reasons {
+		names := inverted[reason]
+		sort.Strings(names)
+		for i, name := range names {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(name)
+		}
+		fmt.Fprintf(&buf, " (%s); ", reason)
+	}
+	return strings.TrimSuffix(buf.String(), "; ")
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -14,10 +14,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const (
-	WorkspaceSdksDir = "/var/lib/workspace/sdk"
-)
-
 type Setup struct {
 	Workspace   string    `json:"workspace"`
 	Name        string    `json:"name"`
@@ -273,7 +269,7 @@ func (plug *PlugInfo) Lookup(key string) (interface{}, bool) {
 }
 
 func SdkCurrentPath(sdkName string) string {
-	return filepath.Join(WorkspaceSdksDir, sdkName, "current")
+	return filepath.Join(dirs.WorkspaceSdksDir, sdkName, "current")
 }
 
 func SdkHooksDir(sdkName string) string {

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -28,6 +28,8 @@ func (s *SdkSuite) SetUpTest(c *check.C) {
 		Revision:    1,
 		InstallTime: time.Now(),
 	}
+
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 }
 
 func (s *SdkSuite) TearDownTest(c *check.C) {
@@ -126,10 +128,10 @@ func (s *SdkSuite) TestUnmarshalLastPlugDefinitionWins(c *check.C) {
 name: sdk
 plugs:
     net:
-        interface: network-client
+        interface: content
         attr: 1
     net:
-        interface: network-client
+        interface: content
         attr: 2
 `), s.setup)
 	c.Assert(err, check.IsNil)
@@ -138,7 +140,7 @@ plugs:
 	c.Assert(info.Plugs["net"], check.DeepEquals, &sdk.PlugInfo{
 		Sdk:       info,
 		Name:      "net",
-		Interface: "network-client",
+		Interface: "content",
 		Attrs:     map[string]interface{}{"attr": int64(2)},
 	})
 }
@@ -148,16 +150,16 @@ func (s *SdkSuite) TestUnmarshalPlugWithoutInterfaceName(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`
 name: sdk
 plugs:
-    network-client:
+    content:
         ipv6-aware: true
 `), s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 1)
 	c.Check(info.Slots, check.HasLen, 0)
-	c.Assert(info.Plugs["network-client"], check.DeepEquals, &sdk.PlugInfo{
+	c.Assert(info.Plugs["content"], check.DeepEquals, &sdk.PlugInfo{
 		Sdk:       info,
-		Name:      "network-client",
-		Interface: "network-client",
+		Name:      "content",
+		Interface: "content",
 		Attrs:     map[string]interface{}{"ipv6-aware": true},
 	})
 }
@@ -283,15 +285,15 @@ func (s *SdkSuite) TestUnmarshalStandaloneImplicitSlot(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`
 name: sdk
 slots:
-    network-client:
+    content:
 `), s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
-	c.Assert(info.Slots["network-client"], check.DeepEquals, &sdk.SlotInfo{
+	c.Assert(info.Slots["content"], check.DeepEquals, &sdk.SlotInfo{
 		Sdk:       info,
-		Name:      "network-client",
-		Interface: "network-client",
+		Name:      "content",
+		Interface: "content",
 	})
 }
 
@@ -300,7 +302,7 @@ func (s *SdkSuite) TestUnmarshalStandaloneAbbreviatedSlot(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`
 name: sdk
 slots:
-    net: network-client
+    net: content
 `), s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
@@ -308,7 +310,7 @@ slots:
 	c.Assert(info.Slots["net"], check.DeepEquals, &sdk.SlotInfo{
 		Sdk:       info,
 		Name:      "net",
-		Interface: "network-client",
+		Interface: "content",
 	})
 }
 
@@ -318,7 +320,7 @@ func (s *SdkSuite) TestUnmarshalStandaloneCompleteSlot(c *check.C) {
 name: sdk
 slots:
     net:
-        interface: network-client
+        interface: content
         ipv6-aware: true
 `), s.setup)
 	c.Assert(err, check.IsNil)
@@ -327,7 +329,7 @@ slots:
 	c.Assert(info.Slots["net"], check.DeepEquals, &sdk.SlotInfo{
 		Sdk:       info,
 		Name:      "net",
-		Interface: "network-client",
+		Interface: "content",
 		Attrs:     map[string]interface{}{"ipv6-aware": true},
 	})
 }
@@ -365,10 +367,10 @@ func (s *SdkSuite) TestUnmarshalLastSlotDefinitionWins(c *check.C) {
 name: sdk
 slots:
     net:
-        interface: network-client
+        interface: content
         attr: 1
     net:
-        interface: network-client
+        interface: content
         attr: 2
 `), s.setup)
 	c.Assert(err, check.IsNil)
@@ -377,7 +379,7 @@ slots:
 	c.Assert(info.Slots["net"], check.DeepEquals, &sdk.SlotInfo{
 		Sdk:       info,
 		Name:      "net",
-		Interface: "network-client",
+		Interface: "content",
 		Attrs:     map[string]interface{}{"attr": int64(2)},
 	})
 }
@@ -387,16 +389,16 @@ func (s *SdkSuite) TestUnmarshalSlotWithoutInterfaceName(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`
 name: sdk
 slots:
-    network-client:
+    content:
         ipv6-aware: true
 `), s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
-	c.Assert(info.Slots["network-client"], check.DeepEquals, &sdk.SlotInfo{
+	c.Assert(info.Slots["content"], check.DeepEquals, &sdk.SlotInfo{
 		Sdk:       info,
-		Name:      "network-client",
-		Interface: "network-client",
+		Name:      "content",
+		Interface: "content",
 		Attrs:     map[string]interface{}{"ipv6-aware": true},
 	})
 }

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -1,0 +1,501 @@
+package sdk_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/testutil"
+	"gopkg.in/check.v1"
+)
+
+type SdkSuite struct {
+	testutil.BaseTest
+	setup sdk.Setup
+}
+
+var _ = check.Suite(&SdkSuite{})
+
+func TestSdkSuite(t *testing.T) { check.TestingT(t) }
+
+func (s *SdkSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.setup = sdk.Setup{
+		Workspace:   "ws",
+		Name:        "sdk",
+		Channel:     "latest/stable",
+		Revision:    1,
+		InstallTime: time.Now(),
+	}
+}
+
+func (s *SdkSuite) TearDownTest(c *check.C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *SdkSuite) TestSimple(c *check.C) {
+	var mockYaml = []byte(`name: sdk
+base: ubuntu@20.04
+`)
+
+	info, err := sdk.ReadSdkInfo(mockYaml, s.setup)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Base, check.Equals, "ubuntu@20.04")
+	c.Assert(info.Name, check.Equals, "sdk")
+	c.Assert(info.Channel, check.Equals, "latest/stable")
+	c.Assert(info.Revision, check.Equals, int64(1))
+	c.Assert(info.Workspace, check.Equals, "ws")
+	c.Assert(info.Plugs, check.HasLen, 0)
+	c.Assert(info.Slots, check.HasLen, 0)
+}
+
+func (s *SdkSuite) TestMinimalisticPlug(c *check.C) {
+	var mockYaml = []byte(`name: sdk
+base: ubuntu@20.04
+plugs:
+  training:
+    interface: content
+    target: /project
+`)
+
+	info, err := sdk.ReadSdkInfo(mockYaml, s.setup)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Plugs, check.HasLen, 1)
+	c.Assert(info.Slots, check.HasLen, 0)
+	c.Assert(*info.Plugs["training"], check.DeepEquals, sdk.PlugInfo{
+		Sdk:       info,
+		Name:      "training",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"target": "/project"},
+	})
+}
+
+func (s *SdkSuite) TestMinimalisticSlot(c *check.C) {
+	var mockYaml = []byte(`name: sdk
+base: ubuntu@20.04
+slots:
+  training:
+    interface: content
+    source: /project
+`)
+
+	info, err := sdk.ReadSdkInfo(mockYaml, s.setup)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Slots, check.HasLen, 1)
+	c.Assert(info.Plugs, check.HasLen, 0)
+	c.Assert(*info.Slots["training"], check.DeepEquals, sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "training",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"source": "/project"},
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalStandalonePlugWithIntAndListAndMap(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    iface:
+        interface: complex
+        i: 3
+        l: [1,2,3]
+        m:
+          a: A
+          b: B
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Plugs, check.HasLen, 1)
+	c.Assert(info.Slots, check.HasLen, 0)
+	c.Assert(info.Plugs["iface"], check.DeepEquals, &sdk.PlugInfo{
+		Sdk:       info,
+		Name:      "iface",
+		Interface: "complex",
+		Attrs: map[string]interface{}{
+			"i": int64(3),
+			"l": []interface{}{int64(1), int64(2), int64(3)},
+			"m": map[string]interface{}{"a": "A", "b": "B"},
+		},
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalLastPlugDefinitionWins(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    net:
+        interface: network-client
+        attr: 1
+    net:
+        interface: network-client
+        attr: 2
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Plugs, check.HasLen, 1)
+	c.Assert(info.Slots, check.HasLen, 0)
+	c.Assert(info.Plugs["net"], check.DeepEquals, &sdk.PlugInfo{
+		Sdk:       info,
+		Name:      "net",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"attr": int64(2)},
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalPlugWithoutInterfaceName(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    network-client:
+        ipv6-aware: true
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Check(info.Plugs, check.HasLen, 1)
+	c.Check(info.Slots, check.HasLen, 0)
+	c.Assert(info.Plugs["network-client"], check.DeepEquals, &sdk.PlugInfo{
+		Sdk:       info,
+		Name:      "network-client",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"ipv6-aware": true},
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalPlugWithLabel(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    bool-file:
+        label: Disk I/O indicator
+`), s.setup)
+	c.Assert(err, check.IsNil)
+
+	c.Check(info.Plugs, check.HasLen, 1)
+	c.Check(info.Slots, check.HasLen, 0)
+
+	c.Assert(info.Plugs["bool-file"], check.DeepEquals, &sdk.PlugInfo{
+		Sdk:       info,
+		Name:      "bool-file",
+		Interface: "bool-file",
+		Label:     "Disk I/O indicator",
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedPlugWithNonStringInterfaceName(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    net:
+        interface: 1.0
+        ipv6-aware: true
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `interface name on plug "net" is not a string \(found float64\)`)
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedPlugWithNonStringLabel(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    bool-file:
+        label: 1.0
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `label of plug "bool-file" is not a string \(found float64\)`)
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedPlugWithNonStringAttributes(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    net:
+        1: ok
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `plug "net" has attribute key that is not a string \(found int\)`)
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedPlugWithEmptyAttributeKey(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    net:
+        "": ok
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `plug "net" has an empty attribute key`)
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedPlugWithUnexpectedType(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    net: 5
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `plug "net" has malformed definition \(found int\)`)
+}
+
+func (s *SdkSuite) TestUnmarshalReservedPlugAttribute(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    serial:
+        interface: serial-port
+        $baud-rate: [9600]
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `plug "serial" uses reserved attribute "\$baud-rate"`)
+}
+
+func (s *SdkSuite) TestUnmarshalInvalidPlugAttribute(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    serial:
+        interface: serial-port
+        foo: null
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `attribute "foo" of plug \"serial\": invalid scalar:.*`)
+}
+
+func (s *SdkSuite) TestUnmarshalInvalidAttributeMapKey(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+plugs:
+    serial:
+        interface: serial-port
+        bar:
+          baz:
+          - 1: A
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `attribute "bar" of plug \"serial\": non-string key: 1`)
+}
+
+// Tests focusing on slots
+
+func (s *SdkSuite) TestUnmarshalStandaloneImplicitSlot(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    network-client:
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Check(info.Plugs, check.HasLen, 0)
+	c.Check(info.Slots, check.HasLen, 1)
+	c.Assert(info.Slots["network-client"], check.DeepEquals, &sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "network-client",
+		Interface: "network-client",
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalStandaloneAbbreviatedSlot(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    net: network-client
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Check(info.Plugs, check.HasLen, 0)
+	c.Check(info.Slots, check.HasLen, 1)
+	c.Assert(info.Slots["net"], check.DeepEquals, &sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "net",
+		Interface: "network-client",
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalStandaloneCompleteSlot(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    net:
+        interface: network-client
+        ipv6-aware: true
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Check(info.Plugs, check.HasLen, 0)
+	c.Check(info.Slots, check.HasLen, 1)
+	c.Assert(info.Slots["net"], check.DeepEquals, &sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "net",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"ipv6-aware": true},
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalStandaloneSlotWithIntAndListAndMap(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    iface:
+        interface: complex
+        i: 3
+        l: [1,2]
+        m:
+          a: "A"
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Check(info.Plugs, check.HasLen, 0)
+	c.Check(info.Slots, check.HasLen, 1)
+	c.Assert(info.Slots["iface"], check.DeepEquals, &sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "iface",
+		Interface: "complex",
+		Attrs: map[string]interface{}{
+			"i": int64(3),
+			"l": []interface{}{int64(1), int64(2)},
+			"m": map[string]interface{}{"a": "A"},
+		},
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalLastSlotDefinitionWins(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    net:
+        interface: network-client
+        attr: 1
+    net:
+        interface: network-client
+        attr: 2
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Check(info.Plugs, check.HasLen, 0)
+	c.Check(info.Slots, check.HasLen, 1)
+	c.Assert(info.Slots["net"], check.DeepEquals, &sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "net",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"attr": int64(2)},
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalSlotWithoutInterfaceName(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    network-client:
+        ipv6-aware: true
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Check(info.Plugs, check.HasLen, 0)
+	c.Check(info.Slots, check.HasLen, 1)
+	c.Assert(info.Slots["network-client"], check.DeepEquals, &sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "network-client",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"ipv6-aware": true},
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalSlotWithLabel(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    led0:
+        interface: bool-file
+        label: Front panel LED (red)
+`), s.setup)
+	c.Assert(err, check.IsNil)
+	c.Check(info.Plugs, check.HasLen, 0)
+	c.Check(info.Slots, check.HasLen, 1)
+	c.Assert(info.Slots["led0"], check.DeepEquals, &sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "led0",
+		Interface: "bool-file",
+		Label:     "Front panel LED (red)",
+	})
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedSlotWithNonStringInterfaceName(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    net:
+        interface: 1.0
+        ipv6-aware: true
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `interface name on slot "net" is not a string \(found float64\)`)
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedSlotWithNonStringLabel(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    bool-file:
+        label: 1.0
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `label of slot "bool-file" is not a string \(found float64\)`)
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedSlotWithNonStringAttributes(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    net:
+        1: ok
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `slot "net" has attribute key that is not a string \(found int\)`)
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedSlotWithEmptyAttributeKey(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    net:
+        "": ok
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `slot "net" has an empty attribute key`)
+}
+
+func (s *SdkSuite) TestUnmarshalCorruptedSlotWithUnexpectedType(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    net: 5
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `slot "net" has malformed definition \(found int\)`)
+}
+
+func (s *SdkSuite) TestUnmarshalReservedSlotAttribute(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    serial:
+        interface: serial-port
+        $baud-rate: [9600]
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `slot "serial" uses reserved attribute "\$baud-rate"`)
+}
+
+func (s *SdkSuite) TestUnmarshalInvalidSlotAttribute(c *check.C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := sdk.ReadSdkInfo([]byte(`
+name: sdk
+slots:
+    serial:
+        interface: serial-port
+        foo: null
+`), s.setup)
+	c.Assert(err, check.ErrorMatches, `attribute "foo" of slot \"serial\": invalid scalar:.*`)
+}

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -3,12 +3,44 @@ package sdk
 import (
 	"fmt"
 	"regexp"
+
+	"golang.org/x/exp/slices"
 )
 
-// Regular expression describing correct plug, slot and interface names.
-var validPlugSlotIface = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
+var (
+	ValidBases   = []string{"ubuntu@20.04", "ubuntu@22.04"}
+	ValidName    = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+	ValidChannel = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
+	// Regular expression describing correct plug, slot and interface names.
+	validPlugSlotIface = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
+)
 
 func Validate(sdk *Info) error {
+
+	if !ValidName.MatchString(sdk.Name) {
+		return fmt.Errorf("invalid sdk name: %q", sdk.Name)
+	}
+
+	if !slices.Contains(ValidBases, sdk.Base) {
+		return fmt.Errorf("invalid sdk base: %q", sdk.Base)
+	}
+
+	for plugName, plug := range sdk.Plugs {
+		if err := ValidatePlugName(plugName); err != nil {
+			return err
+		}
+		if err := ValidateInterfaceName(plug.Interface); err != nil {
+			return fmt.Errorf("invalid interface name %q for plug %q", plug.Interface, plugName)
+		}
+	}
+	for slotName, slot := range sdk.Slots {
+		if err := ValidateSlotName(slotName); err != nil {
+			return err
+		}
+		if err := ValidateInterfaceName(slot.Interface); err != nil {
+			return fmt.Errorf("invalid interface name %q for slot %q", slot.Interface, slotName)
+		}
+	}
 	return nil
 }
 

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -1,0 +1,45 @@
+package sdk
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Regular expression describing correct plug, slot and interface names.
+var validPlugSlotIface = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
+
+func Validate(sdk *Info) error {
+	return nil
+}
+
+// ValidatePlug checks if a string can be used as a slot name.
+//
+// Slot names and plug names within one snap must have unique names.
+// This is not enforced by this function but is enforced by snap-level
+// validation.
+func ValidatePlugName(name string) error {
+	if !validPlugSlotIface.MatchString(name) {
+		return fmt.Errorf("invalid plug name: %q", name)
+	}
+	return nil
+}
+
+// ValidateSlot checks if a string can be used as a slot name.
+//
+// Slot names and plug names within one snap must have unique names.
+// This is not enforced by this function but is enforced by snap-level
+// validation.
+func ValidateSlotName(name string) error {
+	if !validPlugSlotIface.MatchString(name) {
+		return fmt.Errorf("invalid slot name: %q", name)
+	}
+	return nil
+}
+
+// ValidateInterface checks if a string can be used as an interface name.
+func ValidateInterfaceName(name string) error {
+	if !validPlugSlotIface.MatchString(name) {
+		return fmt.Errorf("invalid interface name: %q", name)
+	}
+	return nil
+}

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -46,9 +46,7 @@ func Validate(sdk *Info) error {
 
 // ValidatePlug checks if a string can be used as a slot name.
 //
-// Slot names and plug names within one snap must have unique names.
-// This is not enforced by this function but is enforced by snap-level
-// validation.
+// Slot names and plug names within one sdk must have unique names.
 func ValidatePlugName(name string) error {
 	if !validPlugSlotIface.MatchString(name) {
 		return fmt.Errorf("invalid plug name: %q", name)
@@ -58,9 +56,7 @@ func ValidatePlugName(name string) error {
 
 // ValidateSlot checks if a string can be used as a slot name.
 //
-// Slot names and plug names within one snap must have unique names.
-// This is not enforced by this function but is enforced by snap-level
-// validation.
+// Slot names and plug names within one sdk must have unique names.
 func ValidateSlotName(name string) error {
 	if !validPlugSlotIface.MatchString(name) {
 		return fmt.Errorf("invalid slot name: %q", name)

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -14,6 +14,7 @@ var _ = check.Suite(&ValidateSuite{})
 
 func (s *ValidateSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 }
 
 func (s *ValidateSuite) TearDownTest(c *check.C) {
@@ -58,4 +59,23 @@ func (s *ValidateSuite) TestValidateSlotPlugInterfaceName(c *check.C) {
 		err = sdk.ValidateInterfaceName(name)
 		c.Assert(err, check.ErrorMatches, `invalid interface name: ".*"`)
 	}
+}
+
+func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
+	info, err := sdk.ReadSdkInfo([]byte(`name: foo.something
+`), sdk.Setup{})
+	c.Assert(err, check.IsNil)
+
+	err = sdk.Validate(info)
+	c.Check(err, check.ErrorMatches, `invalid sdk name: "foo.something"`)
+}
+
+func (s *ValidateSuite) TestIllegalSdkBase(c *check.C) {
+	info, err := sdk.ReadSdkInfo([]byte(`name: foo.something
+base: ubuntu@20.04
+`), sdk.Setup{})
+	c.Assert(err, check.IsNil)
+
+	err = sdk.Validate(info)
+	c.Check(err, check.ErrorMatches, `invalid sdk name: "foo.something"`)
 }

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -1,0 +1,61 @@
+package sdk_test
+
+import (
+	"github.com/canonical/workspace/internal/sdk"
+	"github.com/canonical/workspace/internal/testutil"
+	"gopkg.in/check.v1"
+)
+
+type ValidateSuite struct {
+	testutil.BaseTest
+}
+
+var _ = check.Suite(&ValidateSuite{})
+
+func (s *ValidateSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+}
+
+func (s *ValidateSuite) TearDownTest(c *check.C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *ValidateSuite) TestValidateSlotPlugInterfaceName(c *check.C) {
+	valid := []string{
+		"a",
+		"aaa",
+		"a-a",
+		"aa-a",
+		"a-aa",
+		"a-b-c",
+		"valid",
+		"valid-123",
+	}
+	for _, name := range valid {
+		err := sdk.ValidateSlotName(name)
+		c.Assert(err, check.IsNil)
+		err = sdk.ValidatePlugName(name)
+		c.Assert(err, check.IsNil)
+		err = sdk.ValidateInterfaceName(name)
+		c.Assert(err, check.IsNil)
+	}
+	invalid := []string{
+		"",
+		"a a",
+		"a--a",
+		"-a",
+		"a-",
+		"0",
+		"123",
+		"123abc",
+		"日本語",
+	}
+	for _, name := range invalid {
+		err := sdk.ValidateSlotName(name)
+		c.Assert(err, check.ErrorMatches, `invalid slot name: ".*"`)
+		err = sdk.ValidatePlugName(name)
+		c.Assert(err, check.ErrorMatches, `invalid plug name: ".*"`)
+		err = sdk.ValidateInterfaceName(name)
+		c.Assert(err, check.ErrorMatches, `invalid interface name: ".*"`)
+	}
+}

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -505,10 +505,10 @@ func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
 	restore := squashfs.FakeUseFuse(false)
 	defer restore()
 
-	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
+	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.sdk")
 	makeFakeFile(c, fakeSnapPath)
 
-	mountUnitName, err := systemd.New(s.rootDir, systemd.SystemMode, nil).AddMountUnitFile("foo", "42", fakeSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := systemd.New(s.rootDir, systemd.SystemMode, nil).AddMountUnitFile("foo", "42", fakeSnapPath, "/sdk/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -519,7 +519,7 @@ Before=snapd.service
 
 [Mount]
 What=%s
-Where=/snap/snapname/123
+Where=/sdk/snapname/123
 Type=squashfs
 Options=nodev,ro,x-gdu.hide
 
@@ -529,8 +529,8 @@ WantedBy=multi-user.target
 
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
-		{"--root", s.rootDir, "enable", "snap-snapname-123.mount"},
-		{"start", "snap-snapname-123.mount"},
+		{"--root", s.rootDir, "enable", "sdk-snapname-123.mount"},
+		{"start", "sdk-snapname-123.mount"},
 	})
 }
 
@@ -540,7 +540,7 @@ func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
 
 	// a directory instead of a file produces a different output
 	snapDir := c.MkDir()
-	mountUnitName, err := systemd.New("", systemd.SystemMode, nil).AddMountUnitFile("foodir", "x1", snapDir, "/snap/snapname/x1", "squashfs")
+	mountUnitName, err := systemd.New("", systemd.SystemMode, nil).AddMountUnitFile("foodir", "x1", snapDir, "/sdk/snapname/x1", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -551,7 +551,7 @@ Before=snapd.service
 
 [Mount]
 What=%s
-Where=/snap/snapname/x1
+Where=/sdk/snapname/x1
 Type=none
 Options=nodev,ro,x-gdu.hide,bind
 
@@ -561,8 +561,8 @@ WantedBy=multi-user.target
 
 	c.Assert(s.argses, DeepEquals, [][]string{
 		{"daemon-reload"},
-		{"--root", "", "enable", "snap-snapname-x1.mount"},
-		{"start", "snap-snapname-x1.mount"},
+		{"--root", "", "enable", "sdk-snapname-x1.mount"},
+		{"start", "sdk-snapname-x1.mount"},
 	})
 }
 
@@ -582,13 +582,13 @@ exit 0
 	`)
 	defer fuseCmd.Restore()
 
-	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
+	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.sdk")
 	err := os.MkdirAll(filepath.Dir(fakeSnapPath), 0755)
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(fakeSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := systemd.New("", systemd.SystemMode, nil).AddMountUnitFile("foo", "x1", fakeSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := systemd.New("", systemd.SystemMode, nil).AddMountUnitFile("foo", "x1", fakeSnapPath, "/sdk/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -599,7 +599,7 @@ Before=snapd.service
 
 [Mount]
 What=%s
-Where=/snap/snapname/123
+Where=/sdk/snapname/123
 Type=fuse.squashfuse
 Options=nodev,ro,x-gdu.hide,allow_other
 
@@ -620,13 +620,13 @@ exit 0
 	`)
 	defer fuseCmd.Restore()
 
-	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
+	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.sdk")
 	err := os.MkdirAll(filepath.Dir(fakeSnapPath), 0755)
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(fakeSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := systemd.New("", systemd.SystemMode, nil).AddMountUnitFile("foo", "x1", fakeSnapPath, "/snap/snapname/123", "squashfs")
+	mountUnitName, err := systemd.New("", systemd.SystemMode, nil).AddMountUnitFile("foo", "x1", fakeSnapPath, "/sdk/snapname/123", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -637,7 +637,7 @@ Before=snapd.service
 
 [Mount]
 What=%s
-Where=/snap/snapname/123
+Where=/sdk/snapname/123
 Type=squashfs
 Options=nodev,ro,x-gdu.hide
 
@@ -707,8 +707,8 @@ func makeFakeMountUnit(c *C, mountDir string) string {
 
 // FIXME: also test for the "IsMounted" case
 func (s *SystemdTestSuite) TestRemoveMountUnit(c *C) {
-	mountDir := s.rootDir + "/snap/foo/42"
-	mountUnit := makeFakeMountUnit(c, "/snap/foo/42")
+	mountDir := s.rootDir + "/sdk/foo/42"
+	mountUnit := makeFakeMountUnit(c, "/sdk/foo/42")
 	err := systemd.New(s.rootDir, systemd.SystemMode, nil).RemoveMountUnitFile(mountDir)
 	c.Assert(err, IsNil)
 
@@ -716,7 +716,7 @@ func (s *SystemdTestSuite) TestRemoveMountUnit(c *C) {
 	c.Check(osutil.FileExists(mountUnit), Equals, false)
 	// and the unit is disabled and the daemon reloaded
 	c.Check(s.argses, DeepEquals, [][]string{
-		{"--root", s.rootDir, "disable", "snap-foo-42.mount"},
+		{"--root", s.rootDir, "disable", "sdk-foo-42.mount"},
 		{"daemon-reload"},
 	})
 }
@@ -724,7 +724,7 @@ func (s *SystemdTestSuite) TestRemoveMountUnit(c *C) {
 func (s *SystemdTestSuite) TestDaemonReloadMutex(c *C) {
 	sysd := systemd.New(s.rootDir, systemd.SystemMode, nil)
 
-	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
+	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.sdk")
 	makeFakeFile(c, fakeSnapPath)
 
 	// create a go-routine that will try to daemon-reload like crazy
@@ -747,7 +747,7 @@ func (s *SystemdTestSuite) TestDaemonReloadMutex(c *C) {
 	// daemon-reload. This will be serialized, if not this would
 	// panic because systemd.daemonReloadNoLock ensures the lock is
 	// taken when this happens.
-	_, err := sysd.AddMountUnitFile("foo", "42", fakeSnapPath, "/snap/foo/42", "squashfs")
+	_, err := sysd.AddMountUnitFile("foo", "42", fakeSnapPath, "/sdk/foo/42", "squashfs")
 	c.Assert(err, IsNil)
 	close(stopCh)
 	<-stoppedCh

--- a/internal/workspacebackend/backend.go
+++ b/internal/workspacebackend/backend.go
@@ -54,8 +54,9 @@ type WorkspaceBackend interface {
 	// If unsuccessful, a new project will be created for the path provided.
 	CreateOrLoadProject(ctx context.Context, path string) (*Project, bool, error)
 
-	// Returns a list of projects known to the backend.
-	Projects(ctx context.Context) (map[string]*Project, error)
+	// Returns a list of projects known to the backend. The returned map
+	// has a username that the corresponding projects belong to as a key.
+	Projects(ctx context.Context) (map[string][]*Project, error)
 
 	// Launch a barebone workspace instance using the base provided. The
 	// supported bases are ubuntu@20.04 and ubuntu@22.04.

--- a/internal/workspacebackend/lxd_backend.go
+++ b/internal/workspacebackend/lxd_backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -85,6 +84,14 @@ func LxdProjectName(user string) string {
 	return "workspace." + user
 }
 
+func LxdProjectUser(project string) string {
+	parts := strings.Split(project, ".")
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[1]
+}
+
 func LxdSystemProjectName(user string) string {
 	return LxdProjectName(user) + ".system"
 }
@@ -118,11 +125,9 @@ func (s *LxdBackend) loadProject(client lxd.InstanceServer, ctx context.Context,
 		return nil, err
 	}
 
-	var projects map[string]*Project = make(map[string]*Project, 0)
-	if buf, ok := lxdPrj.Config["user.workspace.projects"]; ok {
-		if err = json.Unmarshal([]byte(buf), &projects); err != nil {
-			return nil, err
-		}
+	projects, err := ReadProjects([]byte(lxdPrj.Config["user.workspace.projects"]))
+	if err != nil {
+		return nil, err
 	}
 
 	// did we find a .workspace.lock in the path?
@@ -137,8 +142,9 @@ func (s *LxdBackend) loadProject(client lxd.InstanceServer, ctx context.Context,
 			}
 		}
 	} else {
-		if val, ok := projects[pId]; ok {
-			return val, nil
+		idx := slices.IndexFunc(projects, func(p *Project) bool { return p.ProjectId == pId })
+		if idx != -1 {
+			return projects[idx], nil
 		}
 	}
 	return nil, ErrProjectNotFound
@@ -155,20 +161,22 @@ func (s *LxdBackend) untrackProject(client lxd.InstanceServer, ctx context.Conte
 		return err
 	}
 
-	var projects map[string]*Project = make(map[string]*Project, 0)
-	if buf, ok := lxdPrj.Config["user.workspace.projects"]; ok {
-		if err = json.Unmarshal([]byte(buf), &projects); err != nil {
-			return err
-		}
-	}
-
-	delete(projects, prj.ProjectId)
-
-	buf, err := json.Marshal(projects)
+	projects, err := ReadProjects([]byte(lxdPrj.Config["user.workspace.projects"]))
 	if err != nil {
 		return err
 	}
-	lxdPrj.ProjectPut.Config["user.workspace.projects"] = string(buf)
+
+	idx := slices.IndexFunc(projects, func(p *Project) bool { return p.ProjectId == prj.ProjectId })
+	if idx == -1 {
+		return fmt.Errorf("project %q at %q not found", prj.ProjectId, prj.Path)
+	}
+
+	projects = slices.Delete(projects, idx, idx+1)
+	projectsJson, err := SaveProjects(projects)
+	if err != nil {
+		return err
+	}
+	lxdPrj.ProjectPut.Config["user.workspace.projects"] = projectsJson
 
 	return client.UpdateProject(LxdProjectName(user), lxdPrj.ProjectPut, etag)
 }
@@ -184,20 +192,23 @@ func (s *LxdBackend) trackProject(client lxd.InstanceServer, ctx context.Context
 		return err
 	}
 
-	var projects map[string]*Project = make(map[string]*Project, 0)
-	if buf, ok := lxdPrj.Config["user.workspace.projects"]; ok {
-		if err = json.Unmarshal([]byte(buf), &projects); err != nil {
-			return err
-		}
-	}
-
-	projects[prj.ProjectId] = prj
-
-	buf, err := json.Marshal(projects)
+	projects, err := ReadProjects([]byte(lxdPrj.Config["user.workspace.projects"]))
 	if err != nil {
 		return err
 	}
-	lxdPrj.ProjectPut.Config["user.workspace.projects"] = string(buf)
+
+	idx := slices.IndexFunc(projects, func(p *Project) bool { return p.ProjectId == prj.ProjectId })
+	if idx == -1 {
+		projects = append(projects, prj)
+	} else {
+		projects[idx] = prj
+	}
+
+	projectsJson, err := SaveProjects(projects)
+	if err != nil {
+		return err
+	}
+	lxdPrj.ProjectPut.Config["user.workspace.projects"] = projectsJson
 
 	return client.UpdateProject(LxdProjectName(user), lxdPrj.ProjectPut, etag)
 }
@@ -354,30 +365,71 @@ func (s *LxdBackend) updateWorkspacesProjectPath(conn lxd.InstanceServer, ctx co
 	return nil
 }
 
-func (s *LxdBackend) Projects(ctx context.Context) (map[string]*Project, error) {
-	client, err := s.LxdClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	user, ok := ctx.Value(ContextUser).(string)
-	if !ok {
-		return nil, fmt.Errorf("context key %s not found", ContextUser)
-	}
-
-	lxdPrj, _, err := client.GetProject(LxdProjectName(user))
-	if err != nil {
-		return nil, err
-	}
-
-	var projects map[string]*Project = make(map[string]*Project, 0)
-	if buf, ok := lxdPrj.Config["user.workspace.projects"]; ok {
-		if err = json.Unmarshal([]byte(buf), &projects); err != nil {
+func (s *LxdBackend) Projects(ctx context.Context) (map[string][]*Project, error) {
+	if user, ok := ctx.Value(ContextUser).(string); ok {
+		client, err := s.LxdClient(ctx)
+		if err != nil {
 			return nil, err
 		}
-	}
+		lxdPrj, _, err := client.GetProject(LxdProjectName(user))
+		if err != nil {
+			return nil, err
+		}
 
-	for _, prj := range projects {
+		projects, err := ReadProjects([]byte(lxdPrj.Config["user.workspace.projects"]))
+		if err != nil {
+			return nil, err
+		}
+
+		checked, err := s.checkAndRecoverProjectPaths(client, ctx, projects)
+		if err != nil {
+			return nil, err
+		}
+		return map[string][]*Project{user: checked}, nil
+	} else {
+		// get a default connection without preseting the LXD project as we are
+		// going over all the LXD projects to filter the ones managed by
+		// workspace and reload every interface connection for every SDK of
+		// every workspace
+		client, err := lxd.ConnectLXDUnixWithContext(ctx, LxdSock, nil)
+		if err != nil {
+			return nil, err
+		}
+		// list all projects for all users if the user is not provided
+		lxdProjects, err := client.GetProjects()
+		if err != nil {
+			return nil, err
+		}
+		allProjects := make(map[string][]*Project)
+		for _, prj := range lxdProjects {
+			username := LxdProjectUser(prj.Name)
+			_, err := LookupUsername(username)
+			// if the project is created by workspace, the key must be present
+			if _, ok := prj.Config["user.workspace.projects"]; ok && err == nil {
+				prjctx := context.WithValue(ctx, ContextUser, username)
+				projects, err := ReadProjects([]byte(prj.Config["user.workspace.projects"]))
+				if err != nil {
+					return nil, err
+				}
+
+				checked, err := s.checkAndRecoverProjectPaths(client, prjctx, projects)
+				if err != nil {
+					return nil, err
+				}
+
+				allProjects[username] = checked
+			}
+		}
+		return allProjects, nil
+	}
+}
+
+// Ensures that every project has a valid existing path. If not, tries to
+// recover the path from the actual bind mount of the '/project'. If recovery
+// went unsuccessful, stop project tracking (it is likely that the directory was
+// removed already)
+func (s *LxdBackend) checkAndRecoverProjectPaths(client lxd.InstanceServer, ctx context.Context, projects []*Project) ([]*Project, error) {
+	for idx, prj := range projects {
 		if ok, _, err := osutil.ExistsIsDir(prj.Path); !ok && err == nil {
 			// If got here then there is no project directory for the projectId
 			// anymore. It can mean moving or deletion happened in the past. Try
@@ -402,11 +454,10 @@ func (s *LxdBackend) Projects(ctx context.Context) (map[string]*Project, error) 
 				if err = s.untrackProject(client, ctx, prj); err != nil {
 					return nil, err
 				}
-				delete(projects, prj.ProjectId)
+				projects = slices.Delete(projects, idx, idx+1)
 			}
 		}
 	}
-
 	return projects, nil
 }
 
@@ -802,9 +853,16 @@ func (s *LxdBackend) GetWorkspace(ctx context.Context, name string) (*Workspace,
 		return nil, err
 	}
 
-	if p, ok = projects[projectId]; !ok {
-		return nil, fmt.Errorf("project is not available: %v", projectId)
+	user, ok := ctx.Value(ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key %s not found", ContextUser)
 	}
+
+	idx := slices.IndexFunc(projects[user], func(p *Project) bool { return p.ProjectId == projectId })
+	if idx == -1 {
+		return nil, fmt.Errorf("project %q is not found", projectId)
+	}
+	p = projects[user][idx]
 
 	inst, _, err := conn.GetInstance(InstanceName(name, projectId))
 	if err != nil {
@@ -892,6 +950,11 @@ func (s *LxdBackend) GetProjectWorkspaces(ctx context.Context) ([]*WorkspaceFile
 		return nil, nil, fmt.Errorf("context key project-id not found")
 	}
 
+	user, ok := ctx.Value(ContextUser).(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("context key %s not found", ContextUser)
+	}
+
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -902,9 +965,13 @@ func (s *LxdBackend) GetProjectWorkspaces(ctx context.Context) ([]*WorkspaceFile
 	if err != nil {
 		return nil, nil, err
 	}
-	if p, ok = projects[projectId]; !ok {
-		return nil, nil, fmt.Errorf("project is not available: %v", projectId)
+
+	idx := slices.IndexFunc(projects[user], func(p *Project) bool { return p.ProjectId == projectId })
+	if idx == -1 {
+		return nil, nil, fmt.Errorf("project %q is not found", projectId)
 	}
+
+	p = projects[user][idx]
 
 	files, err := p.EnumWorkspaceFiles()
 	// if the dir does not exist it does not mean there are no workspaces. It

--- a/internal/workspacebackend/lxd_backend_mock.go
+++ b/internal/workspacebackend/lxd_backend_mock.go
@@ -2,12 +2,12 @@ package workspacebackend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/canonical/workspace/internal/sdk"
 	"github.com/lxc/lxd/shared/api"
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
 
@@ -28,7 +28,8 @@ type ExecCall struct {
 
 type FakeWorkspaceBackend struct {
 	Workspaces map[string]map[string]*FakeWorkspace
-	projects   map[string]map[string]*Project
+	// the key is a username
+	projects map[string][]*Project
 
 	DoExec    ExecFunc
 	ExecCalls []*ExecCall
@@ -37,7 +38,7 @@ type FakeWorkspaceBackend struct {
 func NewFakeWorkspaceBackend() *FakeWorkspaceBackend {
 	var be FakeWorkspaceBackend
 	be.Workspaces = make(map[string]map[string]*FakeWorkspace)
-	be.projects = make(map[string]map[string]*Project)
+	be.projects = make(map[string][]*Project)
 
 	be.DoExec = DoExecDefault
 
@@ -45,40 +46,53 @@ func NewFakeWorkspaceBackend() *FakeWorkspaceBackend {
 }
 
 func (s *FakeWorkspaceBackend) CreateOrLoadProject(ctx context.Context, path string) (*Project, bool, error) {
-	username := ctx.Value(ContextUser).(string)
+	username, ok := ctx.Value(ContextUser).(string)
+	if !ok {
+		return nil, false, errors.New("user not found")
+	}
 	if val, ok := s.projects[username]; ok {
-		idx := slices.IndexFunc(maps.Values(val), func(p *Project) bool { return p.Path == path })
+		idx := slices.IndexFunc(val, func(p *Project) bool { return p.Path == path })
 		if idx != -1 {
-			return maps.Values(val)[idx], false, nil
+			return val[idx], false, nil
 		}
 	} else {
-		s.projects[username] = make(map[string]*Project)
+		s.projects[username] = make([]*Project, 0)
 	}
 
 	prjId, _ := NewProjectId()
 	newPrj := &Project{ProjectId: prjId, Path: path}
-	s.projects[username][prjId] = newPrj
+	s.projects[username] = append(s.projects[username], newPrj)
 	return newPrj, true, nil
 }
 
-func (f *FakeWorkspaceBackend) Projects(ctx context.Context) (map[string]*Project, error) {
-	username, _, err := f.userProject(ctx)
-	if err != nil {
-		return nil, err
+func (f *FakeWorkspaceBackend) Projects(ctx context.Context) (map[string][]*Project, error) {
+	userName, ok := ctx.Value(ContextUser).(string)
+	if ok {
+		return map[string][]*Project{userName: f.projects[userName]}, nil
 	}
-	return f.projects[username], nil
+	all := map[string][]*Project{}
+	for name, prjs := range f.projects {
+		all[name] = prjs
+	}
+	return all, nil
+}
+
+func (f *FakeWorkspaceBackend) project(user, id string) *Project {
+	prjs := f.projects[user]
+	idx := slices.IndexFunc(prjs, func(p *Project) bool { return p.ProjectId == id })
+	if idx != -1 {
+		return prjs[idx]
+	}
+	return nil
 }
 
 func (f *FakeWorkspaceBackend) LaunchWorkspace(ctx context.Context, name, base string) error {
-	_, projectId, err := f.userProject(ctx)
+	user, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
 	}
-	projects, err := f.Projects(ctx)
-	if err != nil {
-		return err
-	}
-	prj := projects[projectId]
+
+	prj := f.project(user, projectId)
 
 	if f.Workspaces[projectId] == nil {
 		f.Workspaces[projectId] = make(map[string]*FakeWorkspace)
@@ -109,8 +123,9 @@ func (f *FakeWorkspaceBackend) LaunchWorkspace(ctx context.Context, name, base s
 
 	for _, s := range ws.File().Sdks {
 		ws.LinkSdk(ctx, sdk.Setup{
-			Name:    s.Name,
-			Channel: s.Channel,
+			Workspace: name,
+			Name:      s.Name,
+			Channel:   s.Channel,
 		})
 	}
 	return nil
@@ -183,7 +198,7 @@ func (f *FakeWorkspaceBackend) GetWorkspace(ctx context.Context, name string) (*
 		return nil, err
 	}
 
-	project := f.projects[user][projectId]
+	project := f.project(user, projectId)
 	if project == nil {
 		return nil, api.StatusErrorf(404, "project not found")
 	}

--- a/internal/workspacebackend/lxd_backend_mock.go
+++ b/internal/workspacebackend/lxd_backend_mock.go
@@ -101,14 +101,14 @@ func (f *FakeWorkspaceBackend) LaunchWorkspace(ctx context.Context, name, base s
 		Devices:   defaultDevices(),
 		running:   true,
 		projectId: projectId,
-		content:   make(map[string]*sdk.SdkInfo),
+		content:   make(map[string]sdk.Setup),
 		file:      file,
 	}
 
 	f.Workspaces[projectId][name] = ws
 
 	for _, s := range ws.File().Sdks {
-		ws.LinkSdk(ctx, &sdk.SdkInfo{
+		ws.LinkSdk(ctx, sdk.Setup{
 			Name:    s.Name,
 			Channel: s.Channel,
 		})

--- a/internal/workspacebackend/lxd_backend_test.go
+++ b/internal/workspacebackend/lxd_backend_test.go
@@ -56,7 +56,7 @@ sdks:
 	c.Assert(ws.IsRunning(), check.Equals, true)
 	c.Assert(ws.Errors(), check.HasLen, 0)
 	c.Assert(ws.ProjectId(), check.Equals, f.project.ProjectId)
-	c.Assert(ws.Content(), testutil.DeepUnsortedMatches, []*sdk.SdkInfo{{
+	c.Assert(ws.Content(), testutil.DeepUnsortedMatches, []sdk.Setup{{
 		Name:     "go",
 		Channel:  "latest/stable",
 		Revision: 277,

--- a/internal/workspacebackend/lxd_backend_test.go
+++ b/internal/workspacebackend/lxd_backend_test.go
@@ -208,3 +208,30 @@ func (f *LxdBeTests) TestProjectSubDirectoryProvideAsPath(c *check.C) {
 		os.RemoveAll(filepath.Join(root, i.cwd))
 	}
 }
+
+func (f *LxdBeTests) TestReadProjectsSuccess(c *check.C) {
+	configData := `[{"path":"/home/dmitry/Work/ros-tutorials","id":"01ac7c0e"},{"path":"/home/dmitry/Work/ros2-tutorials","id":"47b66ebc"}]`
+
+	projects, err := workspacebackend.ReadProjects([]byte(configData))
+	c.Assert(err, check.IsNil)
+	c.Assert(projects, testutil.DeepUnsortedMatches, []*workspacebackend.Project{
+		{
+			Path:      "/home/dmitry/Work/ros-tutorials",
+			ProjectId: "01ac7c0e",
+		},
+		{
+			Path:      "/home/dmitry/Work/ros2-tutorials",
+			ProjectId: "47b66ebc",
+		},
+	})
+
+	projects, err = workspacebackend.ReadProjects([]byte("[]"))
+	c.Assert(err, check.IsNil)
+	c.Assert(projects, check.NotNil)
+	c.Assert(projects, check.HasLen, 0)
+
+	projects, err = workspacebackend.ReadProjects(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(projects, check.NotNil)
+	c.Assert(projects, check.HasLen, 0)
+}

--- a/internal/workspacebackend/lxd_project.go
+++ b/internal/workspacebackend/lxd_project.go
@@ -7,7 +7,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-/* Initialise the Workspace project namespace. */
+// Initialise the Workspace project namespace. 
 func InitProject(conn lxd.InstanceServer, username string) error {
 	if err := createOrLoadLxdProject(conn, LxdProjectName(username)); err != nil {
 		return err

--- a/internal/workspacebackend/lxd_workspace_config.go
+++ b/internal/workspacebackend/lxd_workspace_config.go
@@ -6,8 +6,8 @@ import (
 	"github.com/canonical/workspace/internal/sdk"
 )
 
-func InstalledContent(lxdConfig map[string]string) (map[string]*sdk.SdkInfo, error) {
-	content := make(map[string]*sdk.SdkInfo)
+func InstalledContent(lxdConfig map[string]string) (map[string]sdk.Setup, error) {
+	content := make(map[string]sdk.Setup)
 	if sdks, ok := lxdConfig["user.workspace.content"]; ok {
 		err := json.Unmarshal([]byte(sdks), &content)
 		if err != nil {

--- a/internal/workspacebackend/project.go
+++ b/internal/workspacebackend/project.go
@@ -1,7 +1,9 @@
 package workspacebackend
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -24,6 +26,25 @@ var validWorkspaceFilename = regexp.MustCompile(`^\.workspace\.(?P<name>[a-z_][a
 type Project struct {
 	Path      string `json:"path"`
 	ProjectId string `json:"id"`
+}
+
+func ReadProjects(jsonData []byte) ([]*Project, error) {
+	var projects = make([]*Project, 0)
+	if len(jsonData) == 0 {
+		return projects, nil
+	}
+	if err := json.Unmarshal([]byte(jsonData), &projects); err != nil {
+		return nil, fmt.Errorf("invalid projects record: %w", err)
+	}
+	return projects, nil
+}
+
+func SaveProjects(projects []*Project) (string, error) {
+	buf, err := json.Marshal(projects)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
 }
 
 func LockPath(path string) string {

--- a/internal/workspacebackend/tests/integration/project_test.go
+++ b/internal/workspacebackend/tests/integration/project_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"testing"
 
@@ -23,6 +24,10 @@ type wsProject struct {
 	client   lxd.InstanceServer
 	username string
 }
+
+var workspaceMock = `name: test
+base: ubuntu@22.04
+`
 
 var _ = check.Suite(&wsProject{})
 
@@ -96,7 +101,7 @@ func (f *wsProject) TestLxdBackendCreateProjectNoWorkspaceFiles(c *check.C) {
 	c.Assert(err, check.Equals, workspacebackend.ErrNotAProject)
 	c.Assert(workspacebackend.LockPath(projectDir), testutil.FileAbsent)
 	projects, _ := be.Projects(f.ctx)
-	c.Assert(projects, check.HasLen, 0)
+	c.Assert(projects[f.username], check.HasLen, 0)
 }
 
 func (f *wsProject) TestLxdBackendCreateProject(c *check.C) {
@@ -107,11 +112,9 @@ func (f *wsProject) TestLxdBackendCreateProject(c *check.C) {
 	restore := testutil.FakeFunc(func() (string, error) { numCalls = numCalls + 1; return ids[numCalls-1], nil }, &workspacebackend.NewProjectId)
 	defer restore()
 	projectDir, projectDir2 := c.MkDir(), c.MkDir()
-	workspace := `name: test
-base: ubuntu@22.04
-`
-	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspace), 0644)
-	os.WriteFile(filepath.Join(projectDir2, ".workspace.test.yaml"), []byte(workspace), 0644)
+
+	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
+	os.WriteFile(filepath.Join(projectDir2, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
 
 	// Execute
 	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
@@ -123,7 +126,7 @@ base: ubuntu@22.04
 
 	lxdProject, _, _ := f.client.GetProject(workspacebackend.LxdProjectName("testuser"))
 	c.Assert(workspacebackend.LockPath(projectDir), testutil.FilePresent)
-	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"}}`, projectDir))
+	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, projectDir))
 
 	// Execute
 	prj, _, err = be.CreateOrLoadProject(f.ctx, projectDir2)
@@ -133,7 +136,7 @@ base: ubuntu@22.04
 	// Validate
 	lxdProject, _, _ = f.client.GetProject(workspacebackend.LxdProjectName("testuser"))
 	c.Assert(workspacebackend.LockPath(projectDir2), testutil.FilePresent)
-	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"},"d4352dea":{"path":"%s","id":"d4352dea"}}`, projectDir, projectDir2))
+	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"b8639dea"},{"path":"%s","id":"d4352dea"}]`, projectDir, projectDir2))
 }
 
 func (f *wsProject) TestLxdBackendLoadProject(c *check.C) {
@@ -141,10 +144,8 @@ func (f *wsProject) TestLxdBackendLoadProject(c *check.C) {
 	be := workspacebackend.LxdBackend{}
 	restore := testutil.FakeFunc(func() (string, error) { return "b8639dea", nil }, &workspacebackend.NewProjectId)
 	projectDir := c.MkDir()
-	workspace := `name: test
-base: ubuntu@22.04
-`
-	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspace), 0644)
+
+	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
 	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
 	c.Assert(prj, check.NotNil)
 	c.Assert(prj.Path, check.Equals, projectDir)
@@ -163,7 +164,7 @@ base: ubuntu@22.04
 	c.Assert(created, check.Equals, false)
 	lxdProject, _, _ := f.client.GetProject(workspacebackend.LxdProjectName("testuser"))
 
-	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"}}`, projectDir))
+	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, projectDir))
 }
 
 func (f *wsProject) TestLxdBackendLoadProjectDirectoryMoved(c *check.C) {
@@ -177,14 +178,11 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryMoved(c *check.C) {
 	f.client.UpdateProject(workspacebackend.LxdProjectName(f.username),
 		api.ProjectPut{
 			Config: map[string]string{
-				"user.workspace.projects": fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"}}`, projectDir),
+				"user.workspace.projects": fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, projectDir),
 			},
 		}, "")
 
-	workspace := `name: test
-base: ubuntu@22.04
-`
-	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspace), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
 	os.WriteFile(filepath.Join(projectDir, ".workspace.lock"), []byte("b8639dea"), 0644)
 	err := os.Rename(projectDir, newDir)
 	c.Assert(err, check.IsNil)
@@ -195,7 +193,7 @@ base: ubuntu@22.04
 	c.Assert(err, check.IsNil)
 	c.Assert(created, check.Equals, false)
 	lxdProject, _, _ := f.client.GetProject(workspacebackend.LxdProjectName(f.username))
-	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"}}`, newDir))
+	c.Assert(lxdProject.Config["user.workspace.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, newDir))
 }
 
 func (f *wsProject) TestLxdBackendLoadProjectDirectoryCopied(c *check.C) {
@@ -211,15 +209,12 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryCopied(c *check.C) {
 	f.client.UpdateProject(workspacebackend.LxdProjectName(f.username),
 		api.ProjectPut{
 			Config: map[string]string{
-				"user.workspace.projects": fmt.Sprintf(`{"b8639dea":{"path":"%s","id":"b8639dea"}}`, projectDir),
+				"user.workspace.projects": fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, projectDir),
 			},
 		}, "")
 
-	workspace := `name: test
-base: ubuntu@22.04
-`
-	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspace), 0644)
-	os.WriteFile(filepath.Join(newDir, ".workspace.test.yaml"), []byte(workspace), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
+	os.WriteFile(filepath.Join(newDir, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
 	os.WriteFile(filepath.Join(projectDir, ".workspace.lock"), []byte("b8639dea"), 0644)
 	os.WriteFile(filepath.Join(newDir, ".workspace.lock"), []byte("b8639dea"), 0644)
 
@@ -230,7 +225,7 @@ base: ubuntu@22.04
 	c.Assert(created, check.Equals, true)
 	c.Assert(filepath.Join(newDir, ".workspace.lock"), testutil.FileEquals, "abcdefgi")
 	lxdProject, _, _ := f.client.GetProject(workspacebackend.LxdProjectName(f.username))
-	c.Assert(lxdProject.Config["user.workspace.projects"], check.Matches, fmt.Sprintf(`.*"abcdefgi":{"path":"%s","id":"abcdefgi"}.*`, newDir))
+	c.Assert(lxdProject.Config["user.workspace.projects"], check.Matches, fmt.Sprintf(`.*{"path":"%s","id":"abcdefgi"}.*`, newDir))
 }
 
 func (f *wsProject) TestLxdBackendListAvailableProjects(c *check.C) {
@@ -241,11 +236,9 @@ func (f *wsProject) TestLxdBackendListAvailableProjects(c *check.C) {
 	restore := testutil.FakeFunc(func() (string, error) { numCalls = numCalls + 1; return ids[numCalls-1], nil }, &workspacebackend.NewProjectId)
 	defer restore()
 	projectDir, projectDir2 := c.MkDir(), c.MkDir()
-	workspace := `name: test
-base: ubuntu@22.04
-`
-	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspace), 0644)
-	os.WriteFile(filepath.Join(projectDir2, ".workspace.test.yaml"), []byte(workspace), 0644)
+
+	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
+	os.WriteFile(filepath.Join(projectDir2, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
 
 	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
 	c.Assert(prj, check.NotNil)
@@ -259,9 +252,11 @@ base: ubuntu@22.04
 
 	// Validate
 	c.Assert(err, check.IsNil)
-	c.Assert(projects, check.DeepEquals, map[string]*workspacebackend.Project{
-		"b8639dea": {ProjectId: "b8639dea", Path: projectDir},
-		"d4352dea": {ProjectId: "d4352dea", Path: projectDir2},
+	c.Assert(projects, check.DeepEquals, map[string][]*workspacebackend.Project{
+		f.username: {
+			{ProjectId: "b8639dea", Path: projectDir},
+			{ProjectId: "d4352dea", Path: projectDir2},
+		},
 	})
 	c.Assert(workspacebackend.LockPath(projectDir), testutil.FilePresent)
 	c.Assert(workspacebackend.LockPath(projectDir2), testutil.FilePresent)
@@ -273,10 +268,8 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryRemoved(c *check.C) {
 	// the directory was removed
 	be := workspacebackend.LxdBackend{}
 	projectDir := c.MkDir()
-	workspace := `name: test
-base: ubuntu@22.04
-`
-	err := os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspace), 0644)
+
+	err := os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
 	c.Assert(err, check.IsNil)
 	_, _, err = be.CreateOrLoadProject(f.ctx, projectDir)
 	c.Assert(err, check.IsNil)
@@ -289,5 +282,37 @@ base: ubuntu@22.04
 	// Validate (if the directory does not exist, the project
 	// needs to be removed from tracking)
 	c.Assert(err, check.IsNil)
-	c.Assert(projects, check.HasLen, 0)
+	c.Assert(projects[f.username], check.HasLen, 0)
+}
+
+func (f *wsProject) TestLxdBackendLoadProjectsAllUsers(c *check.C) {
+	// Setup
+	be := workspacebackend.LxdBackend{}
+	restoreId := testutil.FakeFunc(func() (string, error) { return "b8639dea", nil }, &workspacebackend.NewProjectId)
+	defer restoreId()
+
+	restoreLookup := testutil.FakeFunc(func(username string) (*user.User, error) {
+		if username == f.username {
+			return &user.User{Name: username}, nil
+		}
+		return nil, user.UnknownUserError("not found")
+	}, &workspacebackend.LookupUsername)
+	defer restoreLookup()
+
+	projectDir := c.MkDir()
+
+	os.WriteFile(filepath.Join(projectDir, ".workspace.test.yaml"), []byte(workspaceMock), 0644)
+	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
+	c.Assert(prj, check.NotNil)
+	c.Assert(err, check.IsNil)
+
+	// Execute (this time the project must be loaded)
+	projects, err := be.Projects(context.Background())
+
+	// Validate
+	c.Assert(err, check.IsNil)
+	c.Assert(projects, testutil.DeepUnsortedMatches, map[string][]*workspacebackend.Project{
+		f.username: {{ProjectId: "b8639dea", Path: projectDir}},
+	})
+
 }

--- a/internal/workspacebackend/tests/integration/workspace_exec_test.go
+++ b/internal/workspacebackend/tests/integration/workspace_exec_test.go
@@ -1,0 +1,236 @@
+//go:build integration
+// +build integration
+
+package lxdbackend_integration_test
+
+import (
+	"bytes"
+	"context"
+	"os/user"
+	"strings"
+	"time"
+
+	"github.com/canonical/workspace/client"
+	"github.com/canonical/workspace/internal/daemon"
+	"github.com/canonical/workspace/internal/testutil"
+	"github.com/canonical/workspace/internal/workspacebackend"
+	lxd "github.com/lxc/lxd/client"
+	"gopkg.in/check.v1"
+)
+
+type wsExec struct {
+	// per suite
+	lxdClient lxd.InstanceServer
+	be        workspacebackend.WorkspaceBackend
+
+	// per test
+	ctx                 context.Context
+	username            string
+	client              *client.Client
+	daemon              *daemon.Daemon
+	project             *workspacebackend.Project
+	lookupUserRestore   func()
+	lookupUserIdRestore func()
+	newProjectidRestore func()
+}
+
+var _ = check.Suite(&wsExec{})
+
+func (f *wsExec) SetUpSuite(c *check.C) {
+	socketPath := c.MkDir() + ".workspace.socket"
+	f.be = workspacebackend.New()
+
+	d, err := daemon.New(&daemon.Options{
+		Dir:        c.MkDir(),
+		SocketPath: socketPath,
+	}, f.be)
+	c.Assert(err, check.IsNil)
+	err = d.Init()
+	c.Assert(err, check.IsNil)
+	d.Start()
+	f.daemon = d
+
+	c.Check(err, check.IsNil)
+	f.client, err = client.New(&client.Config{
+		Socket: socketPath,
+	})
+	c.Assert(err, check.IsNil)
+
+	f.project = &workspacebackend.Project{
+		ProjectId: "42424242",
+		Path:      c.MkDir(),
+	}
+	f.username = "testuser"
+	f.ctx = createTestContext(f.username, f.project.ProjectId)
+
+	f.lxdClient, _ = f.be.(*workspacebackend.LxdBackend).LxdClient(f.ctx)
+	err = workspacebackend.InitProject(f.lxdClient, f.username)
+	c.Check(err, check.IsNil)
+
+	f.lookupUserRestore = testutil.FakeFunc(func(name string) (*user.User, error) {
+		u := &user.User{
+			Name:     f.username,
+			Username: f.username,
+			Uid:      "1000",
+			Gid:      "1000",
+		}
+		return u, nil
+	}, &workspacebackend.LookupUsername)
+
+	f.lookupUserIdRestore = testutil.FakeFunc(func(uid string) (*user.User, error) {
+		u := &user.User{
+			Name:     f.username,
+			Username: f.username,
+			Uid:      "1000",
+			Gid:      "1000",
+		}
+		return u, nil
+	}, &daemon.LookupUserId)
+
+	f.newProjectidRestore = testutil.FakeFunc(func() (string, error) {
+		return f.project.ProjectId, nil
+	}, &workspacebackend.NewProjectId)
+
+	launchTestWorkspace(c, f.ctx, f.be, f.project.Path, f.username)
+}
+
+func (f *wsExec) TearDownSuite(c *check.C) {
+	err := f.be.RemoveWorkspace(f.ctx, "test")
+	c.Check(err, check.IsNil)
+	err = f.daemon.Stop(nil)
+	c.Check(err, check.IsNil)
+	f.lookupUserRestore()
+	f.lookupUserIdRestore()
+	f.newProjectidRestore()
+
+	cleanUpLxdProject(c, f.lxdClient, workspacebackend.LxdProjectName(f.username))
+	cleanUpLxdProject(c, f.lxdClient, workspacebackend.LxdSystemProjectName(f.username))
+}
+
+func (f *wsExec) exec(c *check.C, stdin string, workspace, projectId string, opts *client.ExecOptions) (stdout, stderr string, waitErr error) {
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	opts.Stdin = strings.NewReader(stdin)
+	opts.Stdout = outBuf
+	opts.Stderr = errBuf
+	process, err := f.client.Exec(opts, workspace, projectId)
+	if err != nil {
+		return "", "", err
+	}
+	waitErr = process.Wait()
+	return outBuf.String(), errBuf.String(), waitErr
+}
+
+func (f *wsExec) TestLxdBackendExecTrivial(c *check.C) {
+	// Setup
+	opts := &client.ExecOptions{
+		Command:    []string{"ls"},
+		WorkingDir: "/",
+	}
+	_, _, err := f.exec(c, "", "test", f.project.ProjectId, opts)
+	c.Assert(err, check.IsNil)
+}
+
+func (f *wsExec) TestLxdBackendExecWorkingDirectoryDoesNotExist(c *check.C) {
+	// Setup
+	opts := &client.ExecOptions{
+		Command:    []string{"ls"},
+		WorkingDir: "/no/such/dir",
+	}
+
+	// Exec
+	_, _, err := f.exec(c, "", "test", f.project.ProjectId, opts)
+
+	// Validate
+	c.Assert(err, check.ErrorMatches, ".*/no/such/dir does not exist")
+}
+
+func (f *wsExec) TestLxdBackendExecDefaultUserGroup(c *check.C) {
+	// Setup
+	opts := &client.ExecOptions{
+		Command:    []string{"/bin/sh", "-c", "id -n -u && id -n -g"},
+		WorkingDir: "/",
+	}
+
+	// Exec
+	stdout, stderr, err := f.exec(c, "", "test", f.project.ProjectId, opts)
+
+	// Validate
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout, check.Equals, "workspace\nworkspace\n")
+	c.Assert(stderr, check.Equals, "")
+}
+
+func (f *wsExec) TestLxdBackendExecCustomUserGroup(c *check.C) {
+	// Setup
+	opts := &client.ExecOptions{
+		Command:    []string{"/bin/sh", "-c", "id -n -u && id -n -g"},
+		WorkingDir: "/",
+		UserId:     new(int),
+		GroupId:    new(int),
+	}
+
+	// Exec
+	stdout, stderr, err := f.exec(c, "", "test", f.project.ProjectId, opts)
+
+	// Validate
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout, check.Equals, "root\nroot\n")
+	c.Assert(stderr, check.Equals, "")
+}
+
+func (f *wsExec) TestLxdBackendExecAddEnvVar(c *check.C) {
+	// Setup
+	opts := &client.ExecOptions{
+		Command:     []string{"/bin/sh", "-c", "echo -n $FOO"},
+		WorkingDir:  "/",
+		Environment: map[string]string{"FOO": "BAR"},
+	}
+
+	// Exec
+	stdout, stderr, err := f.exec(c, "", "test", f.project.ProjectId, opts)
+
+	// Validate
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout, check.Equals, "BAR")
+	c.Assert(stderr, check.Equals, "")
+}
+
+func (f *wsExec) TestLxdBackendExecNoninteractive(c *check.C) {
+	// Setup
+	opts := &client.ExecOptions{
+		Command:    []string{"/bin/sh", "-c", "echo -n STDOUT; echo -n STDERR >&2; exit 42"},
+		WorkingDir: "/",
+		UserId:     new(int),
+		GroupId:    new(int),
+	}
+
+	// Exec
+	stdout, stderr, err := f.exec(c, "", "test", f.project.ProjectId, opts)
+
+	// Validate
+	var exitCode int
+	if exitError, ok := err.(*client.ExitError); ok {
+		exitCode = exitError.ExitCode()
+	}
+	c.Check(exitCode, check.Equals, 42)
+	c.Assert(stdout, check.Equals, "STDOUT")
+	c.Assert(stderr, check.Equals, "STDERR")
+}
+
+func (f *wsExec) TestLxdBackendExecTimeout(c *check.C) {
+	// Setup
+	opts := &client.ExecOptions{
+		Command:    []string{"/bin/bash", "-c", "sleep 5"},
+		WorkingDir: "/",
+		UserId:     new(int),
+		GroupId:    new(int),
+		Timeout:    100 * time.Millisecond,
+	}
+
+	// Exec
+	_, _, err := f.exec(c, "", "test", f.project.ProjectId, opts)
+
+	// Validate
+	c.Assert(err, check.ErrorMatches, "(?s).*timed out after 100ms.*")
+}

--- a/internal/workspacebackend/tests/integration/workspace_test.go
+++ b/internal/workspacebackend/tests/integration/workspace_test.go
@@ -4,13 +4,10 @@
 package lxdbackend_integration_test
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"os/user"
 	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/canonical/workspace/client"
 	"github.com/canonical/workspace/internal/daemon"
@@ -40,7 +37,7 @@ type wsOps struct {
 var _ = check.Suite(&wsOps{})
 
 func (f *wsOps) SetUpTest(c *check.C) {
-	socketPath := c.MkDir() + ".pebble.socket"
+	socketPath := c.MkDir() + ".workspace.socket"
 	f.be = workspacebackend.New()
 
 	d, err := daemon.New(&daemon.Options{
@@ -93,14 +90,18 @@ func (f *wsOps) SetUpTest(c *check.C) {
 	f.newProjectidRestore = testutil.FakeFunc(func() (string, error) {
 		return f.project.ProjectId, nil
 	}, &workspacebackend.NewProjectId)
-
+	launchTestWorkspace(c, f.ctx, f.be, f.project.Path, f.username)
 }
 
 func (f *wsOps) TearDownTest(c *check.C) {
+	defer f.be.RemoveWorkspace(f.ctx, "test")
 	err := f.daemon.Stop(nil)
 	c.Check(err, check.IsNil)
 	f.lookupUserRestore()
 	f.lookupUserIdRestore()
+	f.newProjectidRestore()
+	err = os.RemoveAll(f.project.Path)
+	c.Check(err, check.IsNil)
 }
 
 func createTestContext(username, projectId string) context.Context {
@@ -109,11 +110,11 @@ func createTestContext(username, projectId string) context.Context {
 	return ctx
 }
 
-func (f *wsOps) launchTestWorkspace(c *check.C, ctx context.Context, dir string) {
+func launchTestWorkspace(c *check.C, ctx context.Context, be workspacebackend.WorkspaceBackend, dir, username string) {
 	restore := testutil.FakeFunc(func(name string) (*user.User, error) {
 		u := &user.User{
-			Name:     f.username,
-			Username: f.username,
+			Name:     username,
+			Username: username,
 			Uid:      "1000",
 			Gid:      "1000",
 		}
@@ -127,11 +128,11 @@ func (f *wsOps) launchTestWorkspace(c *check.C, ctx context.Context, dir string)
 base: ubuntu@22.04
 `), 0644)
 
-	f.project, _, err = f.be.CreateOrLoadProject(ctx, dir)
+	_, _, err = be.CreateOrLoadProject(ctx, dir)
 	c.Assert(err, check.IsNil)
-	err = f.be.LaunchWorkspace(ctx, "test", "ubuntu@22.04")
+	err = be.LaunchWorkspace(ctx, "test", "ubuntu@22.04")
 	c.Assert(err, check.IsNil)
-	err = f.be.StartWorkspace(ctx, "test")
+	err = be.StartWorkspace(ctx, "test")
 	c.Assert(err, check.IsNil)
 }
 
@@ -152,10 +153,6 @@ func (f *wsOps) TestLxdBackendTrivialLaunch(c *check.C) {
 }
 
 func (f *wsOps) TestLxdBackendUnstashWorkspace(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-
 	// Execute
 	err := f.be.StashWorkspace(f.ctx, "test")
 
@@ -175,10 +172,6 @@ func (f *wsOps) TestLxdBackendUnstashWorkspace(c *check.C) {
 }
 
 func (f *wsOps) TestLxdBackendStateStorageVolumeAddRemove(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-
 	// Execute
 	err := f.be.CreateStateStorage(f.ctx, "test")
 
@@ -272,167 +265,4 @@ func (f *wsOps) TestLxdBackendDeleteWorkspace(c *check.C) {
 	//Validate
 	err = f.be.RemoveWorkspace(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
-}
-
-func (f *wsOps) exec(c *check.C, stdin string, workspace, projectId string, opts *client.ExecOptions) (stdout, stderr string, waitErr error) {
-	outBuf := &bytes.Buffer{}
-	errBuf := &bytes.Buffer{}
-	opts.Stdin = strings.NewReader(stdin)
-	opts.Stdout = outBuf
-	opts.Stderr = errBuf
-	process, err := f.client.Exec(opts, workspace, projectId)
-	if err != nil {
-		return "", "", err
-	}
-	waitErr = process.Wait()
-	return outBuf.String(), errBuf.String(), waitErr
-}
-
-func (f *wsOps) TestLxdBackendExecTrivial(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-
-	opts := &client.ExecOptions{
-		Command:    []string{"ls"},
-		WorkingDir: "/",
-	}
-	_, _, err := f.exec(c, "", "test", f.project.ProjectId, opts)
-	c.Assert(err, check.IsNil)
-}
-
-func (f *wsOps) TestLxdBackendExecWorkingDirectoryDoesNotExist(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-	opts := &client.ExecOptions{
-		Command:    []string{"ls"},
-		WorkingDir: "/no/such/dir",
-	}
-
-	// Exec
-	_, _, err := f.exec(c, "", "test", f.project.ProjectId, opts)
-
-	// Validate
-	c.Assert(err, check.ErrorMatches, ".*/no/such/dir does not exist")
-}
-
-func (f *wsOps) TestLxdBackendExecDefaultUserGroup(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-	opts := &client.ExecOptions{
-		Command:    []string{"/bin/sh", "-c", "id -n -u && id -n -g"},
-		WorkingDir: "/",
-	}
-
-	// Exec
-	stdout, stderr, err := f.exec(c, "", "test", f.project.ProjectId, opts)
-
-	// Validate
-	c.Assert(err, check.IsNil)
-	c.Assert(stdout, check.Equals, "workspace\nworkspace\n")
-	c.Assert(stderr, check.Equals, "")
-}
-
-func (f *wsOps) TestLxdBackendExecCustomUserGroup(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-	opts := &client.ExecOptions{
-		Command:    []string{"/bin/sh", "-c", "id -n -u && id -n -g"},
-		WorkingDir: "/",
-		UserId:     new(int),
-		GroupId:    new(int),
-	}
-
-	// Exec
-	stdout, stderr, err := f.exec(c, "", "test", f.project.ProjectId, opts)
-
-	// Validate
-	c.Assert(err, check.IsNil)
-	c.Assert(stdout, check.Equals, "root\nroot\n")
-	c.Assert(stderr, check.Equals, "")
-}
-
-func (f *wsOps) TestLxdBackendExecAddEnvVar(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-	opts := &client.ExecOptions{
-		Command:     []string{"/bin/sh", "-c", "echo -n $FOO"},
-		WorkingDir:  "/",
-		Environment: map[string]string{"FOO": "BAR"},
-	}
-
-	// Exec
-	stdout, stderr, err := f.exec(c, "", "test", f.project.ProjectId, opts)
-
-	// Validate
-	c.Assert(err, check.IsNil)
-	c.Assert(stdout, check.Equals, "BAR")
-	c.Assert(stderr, check.Equals, "")
-}
-
-func (f *wsOps) TestLxdBackendExecNoninteractive(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-	opts := &client.ExecOptions{
-		Command:    []string{"/bin/sh", "-c", "echo -n STDOUT; echo -n STDERR >&2; exit 42"},
-		WorkingDir: "/",
-		UserId:     new(int),
-		GroupId:    new(int),
-	}
-
-	// Exec
-	stdout, stderr, err := f.exec(c, "", "test", f.project.ProjectId, opts)
-
-	// Validate
-	var exitCode int
-	if exitError, ok := err.(*client.ExitError); ok {
-		exitCode = exitError.ExitCode()
-	}
-	c.Check(exitCode, check.Equals, 42)
-	c.Assert(stdout, check.Equals, "STDOUT")
-	c.Assert(stderr, check.Equals, "STDERR")
-}
-
-func (f *wsOps) TestLxdBackendExecInteractive(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-	opts := &client.ExecOptions{
-		Command:     []string{"/bin/sh", "-c", "[[ -t 1 ]] && echo -n terminal"},
-		WorkingDir:  "/",
-		UserId:      new(int),
-		GroupId:     new(int),
-		Interactive: true,
-	}
-
-	// Exec
-	stdout, _, err := f.exec(c, "", "test", f.project.ProjectId, opts)
-
-	// Validate
-	c.Assert(err, check.IsNil)
-	c.Assert(stdout, check.Equals, "terminal")
-}
-
-func (f *wsOps) TestLxdBackendExecTimeout(c *check.C) {
-	// Setup
-	f.launchTestWorkspace(c, f.ctx, f.project.Path)
-	defer f.be.RemoveWorkspace(f.ctx, "test")
-	opts := &client.ExecOptions{
-		Command:    []string{"/bin/bash", "-c", "sleep 5"},
-		WorkingDir: "/",
-		UserId:     new(int),
-		GroupId:    new(int),
-		Timeout:    100 * time.Millisecond,
-	}
-
-	// Exec
-	_, _, err := f.exec(c, "", "test", f.project.ProjectId, opts)
-
-	// Validate
-	c.Assert(err, check.ErrorMatches, "(?s).*timed out after 100ms.*")
 }

--- a/internal/workspacebackend/workspace.go
+++ b/internal/workspacebackend/workspace.go
@@ -220,7 +220,13 @@ func WorkspaceStateVolumeName(ws, pid string) string {
 	return fmt.Sprintf("%s-state-volume", InstanceName(ws, pid))
 }
 
-func SdkInfo(wsfs WorkspaceFs, s sdk.Setup) (*sdk.Info, error) {
+// Reads information about the installed SDK from its meta file
+
+// NOTE: we have to accept the filesystem as an argument to ensure it is the
+// callers responsibility to get and close the filesystem due to the LXD's bug:
+// if the filesystem of the container is not closed, it maintains the underlying
+// SFTP connection which stops the container from stoppping.
+func (w *Workspace) SdkInfo(wsfs WorkspaceFs, s sdk.Setup) (*sdk.Info, error) {
 	sdkPath := sdk.SdkCurrentPath(s.Name)
 	sdkYamlFile, err := wsfs.Open(filepath.Join(sdkPath, "meta/sdk.yaml"))
 	if err != nil {

--- a/internal/workspacebackend/workspace.go
+++ b/internal/workspacebackend/workspace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -61,7 +62,7 @@ type Workspace struct {
 	base      string
 	Name      string
 	Devices   map[string]map[string]string
-	content   map[string]*sdk.SdkInfo
+	content   map[string]sdk.Setup
 	errs      []WorkspaceErrorType
 	running   bool
 	state     WorkspaceState
@@ -91,7 +92,7 @@ func (w *Workspace) AddError(err WorkspaceErrorType) {
 	w.errs = append(w.errs, err)
 }
 
-func (w *Workspace) Content() []*sdk.SdkInfo {
+func (w *Workspace) Content() []sdk.Setup {
 	return maps.Values(w.content)
 }
 
@@ -111,7 +112,34 @@ func (w *Workspace) SetState(st WorkspaceState) {
 	w.state = st
 }
 
-func (w *Workspace) LinkSdk(ctx context.Context, s *sdk.SdkInfo) error {
+func (w *Workspace) SdkInfo(ctx context.Context, s sdk.Setup) (*sdk.Info, error) {
+	wsfs, err := w.backend.GetWorkspaceFs(ctx, w.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer wsfs.Close()
+
+	sdkPath := sdk.SdkCurrentPath(s.Name)
+	sdkYamlFile, err := wsfs.Open(filepath.Join(sdkPath, "meta/sdk.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	defer sdkYamlFile.Close()
+
+	yamlData, err := io.ReadAll(sdkYamlFile)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := sdk.ReadSdkInfo(yamlData, s)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}
+
+func (w *Workspace) LinkSdk(ctx context.Context, s sdk.Setup) error {
 	s.InstallTime = InstallTimeNow()
 	w.content[s.Name] = s
 
@@ -130,7 +158,7 @@ func (w *Workspace) LinkSdk(ctx context.Context, s *sdk.SdkInfo) error {
 		return err
 	}
 
-	/* Update the current link to point out to the newly installed SDK */
+	// Update the current link to point out to the newly installed SDK
 	sdkPath := filepath.Join(sdk.WorkspaceSdksDir, s.Name)
 
 	fs, err := w.backend.GetWorkspaceFs(ctx, w.Name)
@@ -143,7 +171,7 @@ func (w *Workspace) LinkSdk(ctx context.Context, s *sdk.SdkInfo) error {
 		filepath.Join(sdkPath, "current"), true)
 }
 
-func (w *Workspace) UnlinkSdk(ctx context.Context, s *sdk.SdkInfo) error {
+func (w *Workspace) UnlinkSdk(ctx context.Context, s sdk.Setup) error {
 	delete(w.content, s.Name)
 	newSequence, err := json.Marshal(w.content)
 	if err != nil {

--- a/internal/workspacebackend/workspace.go
+++ b/internal/workspacebackend/workspace.go
@@ -112,33 +112,6 @@ func (w *Workspace) SetState(st WorkspaceState) {
 	w.state = st
 }
 
-func (w *Workspace) SdkInfo(ctx context.Context, s sdk.Setup) (*sdk.Info, error) {
-	wsfs, err := w.backend.GetWorkspaceFs(ctx, w.Name)
-	if err != nil {
-		return nil, err
-	}
-	defer wsfs.Close()
-
-	sdkPath := sdk.SdkCurrentPath(s.Name)
-	sdkYamlFile, err := wsfs.Open(filepath.Join(sdkPath, "meta/sdk.yaml"))
-	if err != nil {
-		return nil, err
-	}
-	defer sdkYamlFile.Close()
-
-	yamlData, err := io.ReadAll(sdkYamlFile)
-	if err != nil {
-		return nil, err
-	}
-
-	info, err := sdk.ReadSdkInfo(yamlData, s)
-	if err != nil {
-		return nil, err
-	}
-
-	return info, nil
-}
-
 func (w *Workspace) LinkSdk(ctx context.Context, s sdk.Setup) error {
 	s.InstallTime = InstallTimeNow()
 	w.content[s.Name] = s
@@ -245,4 +218,25 @@ func WorkspaceName(instance string) string {
 
 func WorkspaceStateVolumeName(ws, pid string) string {
 	return fmt.Sprintf("%s-state-volume", InstanceName(ws, pid))
+}
+
+func SdkInfo(wsfs WorkspaceFs, s sdk.Setup) (*sdk.Info, error) {
+	sdkPath := sdk.SdkCurrentPath(s.Name)
+	sdkYamlFile, err := wsfs.Open(filepath.Join(sdkPath, "meta/sdk.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	defer sdkYamlFile.Close()
+
+	yamlData, err := io.ReadAll(sdkYamlFile)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := sdk.ReadSdkInfo(yamlData, s)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }

--- a/internal/workspacebackend/workspace.go
+++ b/internal/workspacebackend/workspace.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/canonical/workspace/internal/dirs"
 	"github.com/canonical/workspace/internal/sdk"
 	"golang.org/x/exp/maps"
 )
@@ -132,7 +133,7 @@ func (w *Workspace) LinkSdk(ctx context.Context, s sdk.Setup) error {
 	}
 
 	// Update the current link to point out to the newly installed SDK
-	sdkPath := filepath.Join(sdk.WorkspaceSdksDir, s.Name)
+	sdkPath := filepath.Join(dirs.WorkspaceSdksDir, s.Name)
 
 	fs, err := w.backend.GetWorkspaceFs(ctx, w.Name)
 	if err != nil {
@@ -226,7 +227,13 @@ func WorkspaceStateVolumeName(ws, pid string) string {
 // callers responsibility to get and close the filesystem due to the LXD's bug:
 // if the filesystem of the container is not closed, it maintains the underlying
 // SFTP connection which stops the container from stoppping.
-func (w *Workspace) SdkInfo(wsfs WorkspaceFs, s sdk.Setup) (*sdk.Info, error) {
+func (w *Workspace) SdkInfo(ctx context.Context, s sdk.Setup) (*sdk.Info, error) {
+	wsfs, err := w.backend.GetWorkspaceFs(ctx, w.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer wsfs.Close()
+
 	sdkPath := sdk.SdkCurrentPath(s.Name)
 	sdkYamlFile, err := wsfs.Open(filepath.Join(sdkPath, "meta/sdk.yaml"))
 	if err != nil {
@@ -245,4 +252,16 @@ func (w *Workspace) SdkInfo(wsfs WorkspaceFs, s sdk.Setup) (*sdk.Info, error) {
 	}
 
 	return info, nil
+}
+
+func (w *Workspace) ContentInfo(ctx context.Context) ([]*sdk.Info, error) {
+	var infos = make([]*sdk.Info, 0, len(w.content))
+	for _, sdk := range w.content {
+		info, err := w.SdkInfo(ctx, sdk)
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
 }

--- a/internal/workspacebackend/workspace_file.go
+++ b/internal/workspacebackend/workspace_file.go
@@ -4,22 +4,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/workspace/internal/sdk"
 )
 
-var SupportedBases = []string{"ubuntu@20.04", "ubuntu@22.04"}
-var validName = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
-var validChannel = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
-
-type Sdk struct {
+type SdkRecord struct {
 	Name    string `json:"name"`
 	Channel string `json:"channel"`
 }
 
-type SdkList []Sdk
+type SdkList []SdkRecord
 
 type WorkspaceFile struct {
 	Name string `yaml:"name" json:"name"`
@@ -31,7 +28,7 @@ func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind != yaml.MappingNode {
 		return fmt.Errorf("`sdks` must contain YAML mapping, has %v", value.Kind)
 	}
-	*p = make([]Sdk, len(value.Content)/2)
+	*p = make([]SdkRecord, len(value.Content)/2)
 	for i := 0; i < len(value.Content); i += 2 {
 		var res = &(*p)[i/2]
 		if err := value.Content[i].Decode(&res.Name); err != nil {
@@ -41,7 +38,7 @@ func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
 			return err
 		}
 	}
-	slices.SortFunc(*p, func(a, b Sdk) bool {
+	slices.SortFunc(*p, func(a, b SdkRecord) bool {
 		return a.Name < b.Name
 	})
 	return nil
@@ -63,11 +60,11 @@ func ReadWorkspace(pathname string) (*WorkspaceFile, error) {
 	}
 
 	/* Validate workspace properties */
-	if !validName.MatchString(file.Name) {
+	if !sdk.ValidName.MatchString(file.Name) {
 		return nil, fmt.Errorf("a workspace's name must: (1) start with a letter, (2) include only lower case alpha-numeric or an underscore symbol(s)")
 	}
 
-	if !slices.Contains(SupportedBases, file.Base) {
+	if !slices.Contains(sdk.ValidBases, file.Base) {
 		return nil, fmt.Errorf("unsupported base: %s", file.Base)
 	}
 
@@ -76,7 +73,7 @@ func ReadWorkspace(pathname string) (*WorkspaceFile, error) {
 	}
 
 	for _, k := range file.Sdks {
-		if matches := validChannel.FindStringSubmatch(k.Channel); matches != nil {
+		if matches := sdk.ValidChannel.FindStringSubmatch(k.Channel); matches != nil {
 			continue
 		} else {
 			return nil, fmt.Errorf("unsupported channel %s for \"%s\"", k.Channel, k.Name)

--- a/internal/workspacebackend/workspace_file_test.go
+++ b/internal/workspacebackend/workspace_file_test.go
@@ -39,7 +39,7 @@ sdks:
 	c.Assert(err, check.Equals, nil)
 	c.Assert(file.Name, check.Equals, "xbert-gpu")
 	c.Assert(file.Base, check.Equals, "ubuntu@20.04")
-	c.Assert(slices.IsSortedFunc(file.Sdks, func(a, b workspacebackend.Sdk) bool {
+	c.Assert(slices.IsSortedFunc(file.Sdks, func(a, b workspacebackend.SdkRecord) bool {
 		return a.Name < b.Name
 	}), check.Equals, true)
 	c.Assert(file.Sdks[0].Name, check.Equals, "automotive")

--- a/internal/workspacebackend/workspace_fs.go
+++ b/internal/workspacebackend/workspace_fs.go
@@ -57,12 +57,11 @@ func NewFakeWorkspaceFs() WorkspaceFs {
 
 func (w *FakeInstanceFs) Symlink(source, target string, force bool) error {
 	if force {
-		err := w.Remove(target)
+		_, err := w.Stat(target)
 		if errors.Is(err, afero.ErrFileNotFound) {
 			return w.Fs.Mkdir(target, os.ModeSymlink)
-		} else {
-			return err
 		}
+		return nil
 	}
 	return w.Fs.Mkdir(target, os.ModeSymlink)
 }

--- a/tests/integration/workspace-exec/task.yaml
+++ b/tests/integration/workspace-exec/task.yaml
@@ -1,0 +1,4 @@
+summary: Run LXD integration tests for workspace exec 
+
+execute: |
+  go test $SPREAD_PATH/internal/workspacebackend/tests/integration -tags=integration -check.f wsExec

--- a/tests/integration/workspace-ops/task.yaml
+++ b/tests/integration/workspace-ops/task.yaml
@@ -1,4 +1,4 @@
 summary: Run LXD integration tests for workspace operations (launch, delete, attach storage, etc.)
 
 execute: |
-  go test $SPREAD_PATH/internal/workspacebackend/tests/integration -tags=integration -check.f WsOps
+  go test $SPREAD_PATH/internal/workspacebackend/tests/integration -tags=integration -check.f wsOps


### PR DESCRIPTION
Introduce a new state manager - Interface Manager. The manager's primary responsibility is to maintain connections for the interfaces that expose host resources to SDKs. 

This change adopts several essential snapd packages: interfaces, asserts, policy. Those allow to introduce interfaces, define base declarations (assertions) for plugs and slots and connect them based on the results from the policy check. The interface manager supports only the content interface with a base declaration that will be validated during the SDK installation task.

The change allows for the next step which is to add "(auto)-connect" and "disconnect" tasks to the workshop's launch, refresh and remove operations.