### PR TITLE
Rename workshop state to status

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -13,7 +13,7 @@ type Workshop struct {
 	ProjectId string   `json:"project-id"`
 	Name      string   `json:"name"`
 	Base      string   `json:"base"`
-	State     string   `json:"state"`
+	Status    string   `json:"status"`
 	Content   []*Sdk   `json:"content,omitempty"`
 	Notes     []string `json:"notes,omitempty"`
 }

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
-	cs.rsp = `{"type": "sync", "result": [{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","state":"Ready",
+	cs.rsp = `{"type": "sync", "result": [{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready",
 	"notes":["missing-project"],
 	"content":[{"name":"go","channel":"latest/stable","revision":"453","install-time":"2023-04-25T01:02:03Z"}]
 	}]}`
@@ -19,7 +19,7 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 			ProjectId: "42ws42ws",
 			Name:      "workshop",
 			Base:      "ubuntu@20.04",
-			State:     "Ready",
+			Status:    "Ready",
 			Notes:     []string{"missing-project"},
 			Content: []*client.Sdk{
 				{Name: "go", Channel: "latest/stable", Revision: "453", InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)},

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -61,7 +61,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	fmt.Fprintf(w, "name:\t%s\n", workshop.Name)
 	fmt.Fprintf(w, "base:\t%s\n", workshop.Base)
 	fmt.Fprintf(w, "project:\t%s\n", project.Path)
-	fmt.Fprintf(w, "status:\t%s\n", strings.ToLower(workshop.State))
+	fmt.Fprintf(w, "status:\t%s\n", strings.ToLower(workshop.Status))
 	notes := strings.Join(workshop.Notes, ",")
 	if len(workshop.Notes) == 0 {
 		notes = "-"

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -21,7 +21,7 @@ func (m *WorkshopInfo) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
-var mockWorkshopWithContent = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","state":"Error","content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-file"]}}`
+var mockWorkshopWithContent = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-file"]}}`
 
 func (m *WorkshopInfo) TestWorkshopInfo(c *check.C) {
 	cmd := &CmdInfo{}

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -46,11 +46,14 @@ Notes:
 }
 
 func (c *CmdList) Run(cmd *cobra.Command, av []string) error {
-	/* check if both --project and --global were provided */
+	// check if both --project and --global were provided
 	if cmd.Parent().Flag("project").Changed && cmd.Flag("global").Changed {
 		return fmt.Errorf("cannot list: '--project' incompatible with '--global'")
 	}
+	return c.runList()
+}
 
+func (c *CmdList) runList() error {
 	var err error
 
 	cli, err := client.New(&ClientConfig)

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -28,7 +28,7 @@ This command enumerates all workshops in the project, printing a compact list:
 
 - Project: absolute pathname of the project where this workshop belongs
 - Workshop: workshop name, as set by its definition
-- State: workshop status, such as *Off*, *Ready*, *Pending* and so on
+- Status: workshop status, such as *Off*, *Ready*, *Pending* and so on
 - Notes: internal remarks on the overall state of the workshop
 
 The '--global' option lists all workshops from *all* projects in the system;
@@ -80,7 +80,7 @@ func (c *CmdList) Run(cmd *cobra.Command, av []string) error {
 		return err
 	} else {
 		w := tabWriter()
-		fmt.Fprintf(w, "Project\tWorkshop\tState\tNotes\n")
+		fmt.Fprintf(w, "Project\tWorkshop\tStatus\tNotes\n")
 
 		projects, err := c.client.Projects()
 		slices.SortFunc(projects, func(a, b *client.Project) bool { return a.Path < b.Path })
@@ -102,7 +102,7 @@ func (c *CmdList) Run(cmd *cobra.Command, av []string) error {
 				// and, thus, will not know all the available Off workshops (contrary
 				// to the workshops that are in any other state, i.e. running instances, which we always know
 				// about from the workshop backend)
-				if j.State != "Off" {
+				if j.Status != "Off" {
 					fmt.Fprintln(w, strings.Join(printWorkshop(j, i), "\t"))
 				}
 			}
@@ -116,7 +116,7 @@ func (c *CmdList) Run(cmd *cobra.Command, av []string) error {
 
 func printWorkshops(wsList []*client.Workshop, prj *client.Project) {
 	w := tabWriter()
-	fmt.Fprintf(w, "Project\tWorkshop\tState\tNotes\n")
+	fmt.Fprintf(w, "Project\tWorkshop\tStatus\tNotes\n")
 
 	for _, val := range wsList {
 		line := printWorkshop(val, prj)
@@ -133,7 +133,7 @@ func printWorkshop(j *client.Workshop, prj *client.Project) []string {
 	line := []string{
 		contractHomeDirectory(prj.Path),
 		j.Name,
-		j.State,
+		j.Status,
 		comment,
 	}
 	return line

--- a/cmd/workshop/list_test.go
+++ b/cmd/workshop/list_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 )
 
@@ -30,4 +33,73 @@ func (m *WorkshopList) TestHomeDirectoryPathContraction(c *C) {
 	r = contractHomeDirectory(home + "4")
 	assert.Equal(t, "~", r)
 	*/
+}
+
+var mockWorkshopList = `{"type":"sync","status-code":200,"status":"OK","result":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","notes":["missing-file"]}, {"name":"as-1","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"}]}`
+
+var mockWorkshopList2 = `{"type":"sync","status-code":200,"status":"OK","result":[{"name":"ws","base":"ubuntu@22.04","project-id":"2","status":"Ready"}]}`
+
+func (m *WorkshopInfo) TestWorkshopList(c *check.C) {
+	cmd := &CmdList{}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, "/home/project")
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopList)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.runList()
+	c.Assert(err, check.IsNil)
+	c.Assert(m.stdout.String(), check.Matches, `Project        Workshop  Status  Notes
+/home/project  as-1      Ready   -
+/home/project  ws        Error   missing-file
+`)
+}
+
+func (m *WorkshopInfo) TestWorkshopListGlobal(c *check.C) {
+	cmd := &CmdList{}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := `{"type": "sync", "result": [{"id":"1","path":"/home/project-1"}, {"id":"2","path":"/home/project-2"}]}`
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects/1/workshops")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopList)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects/2/workshops")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopList2)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	cmd.global = true
+	err := cmd.runList()
+	c.Assert(err, check.IsNil)
+	c.Assert(m.stdout.String(), check.Matches, `Project          Workshop  Status  Notes
+/home/project-1  as-1      Ready   -
+/home/project-1  ws        Error   missing-file
+/home/project-2  ws        Ready   -
+`)
 }

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -28,7 +28,7 @@ type WorkshopInfo struct {
 	Name      string     `json:"name"`
 	Base      string     `json:"base"`
 	ProjectId string     `json:"project-id"`
-	State     string     `json:"state"`
+	Status    string     `json:"status"`
 	Content   []*SdkInfo `json:"content,omitempty"`
 	Notes     []string   `json:"notes,omitempty"`
 }
@@ -40,7 +40,7 @@ func workshopFileToInfo(file *workshopbackend.WorkshopFile, pid string) *Worksho
 	ws.Name = file.Name
 	ws.Base = file.Base
 	ws.ProjectId = pid
-	ws.State = workshopbackend.WorkshopOff.String()
+	ws.Status = workshopbackend.WorkshopOff.String()
 	for _, i := range file.Sdks {
 		ws.Content = append(ws.Content, &SdkInfo{
 			Name:    i.Name,
@@ -68,7 +68,7 @@ func workshopPropsToInfo(props *workshopbackend.Workshop) *WorkshopInfo {
 		ws.Notes = append(ws.Notes, err.String())
 	}
 
-	ws.State = props.State().String()
+	ws.Status = props.Status().String()
 
 	return &ws
 }
@@ -144,7 +144,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 
 	var infoLst = make([]*WorkshopInfo, 0)
 	for _, w := range workshops {
-		if wstate != "all" && strings.ToLower(w.State().String()) != wstate {
+		if wstate != "all" && strings.ToLower(w.Status().String()) != wstate {
 			continue
 		}
 		info := workshopPropsToInfo(w)

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -123,7 +123,7 @@ base: ubuntu@20.04
 		{
 			Name:      "ws-test",
 			ProjectId: s.project.ProjectId,
-			State:     "Ready",
+			Status:    "Ready",
 			Content: []*SdkInfo{
 				{
 					Name:        "go",
@@ -164,7 +164,7 @@ base: ubuntu@20.04
 	c.Check(rsp.Result, check.DeepEquals, &WorkshopInfo{
 		Name:      "ws-test",
 		ProjectId: s.project.ProjectId,
-		State:     "Ready",
+		Status:    "Ready",
 	})
 }
 
@@ -458,7 +458,7 @@ base: ubuntu@20.04`), 0644)
 	s.d.overlord.State().Lock()
 	ws, err := s.d.overlord.WorkshopManager().Workshop(s.ctx, "ws", s.project.ProjectId)
 	c.Assert(err, check.IsNil)
-	c.Assert(ws.State(), check.Equals, workshopbackend.WorkshopPending)
+	c.Assert(ws.Status(), check.Equals, workshopbackend.WorkshopPending)
 	s.d.overlord.State().Unlock()
 
 	// all successful responses must initiate the ensure call

--- a/internal/overlord/workshopstate/export_test.go
+++ b/internal/overlord/workshopstate/export_test.go
@@ -10,5 +10,5 @@ var (
 	RemoveManyImpl    = removeMany
 
 	Launch        = launch
-	WorkshopState = (*WorkshopManager).workshopState
+	WorkshopState = (*WorkshopManager).workshopStatus
 )

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -41,14 +41,14 @@ func (w *WorkshopManager) Ensure() error {
 // per the matchStatus predicate. It returns the first workshop that does NOT
 // meet the predicate's condition.
 func (w *WorkshopManager) CheckStatus(ctx context.Context, names []string, pId string,
-	matchStatus func(status workshopbackend.WorkshopState) bool) (string, workshopbackend.WorkshopState, error) {
+	matchStatus func(status workshopbackend.WorkshopStatus) bool) (string, workshopbackend.WorkshopStatus, error) {
 	for _, name := range names {
 		wrkspc, err := w.Workshop(ctx, name, pId)
 		if err != nil {
 			return "", workshopbackend.WorkshopOff, err
 		}
 
-		status := w.workshopState(wrkspc)
+		status := w.workshopStatus(wrkspc)
 		if !matchStatus(status) {
 			return name, status, nil
 		}
@@ -67,7 +67,7 @@ func (w *WorkshopManager) Workshop(ctx context.Context, name, pId string) (*work
 		return nil, err
 	}
 
-	wrkspc.SetState(w.workshopState(wrkspc))
+	wrkspc.SetStatus(w.workshopStatus(wrkspc))
 	return wrkspc, nil
 }
 
@@ -83,7 +83,7 @@ func (w *WorkshopManager) Workshops(ctx context.Context, pId string) ([]*worksho
 	}
 
 	for _, wrkspc := range workshops {
-		wrkspc.SetState(w.workshopState(wrkspc))
+		wrkspc.SetStatus(w.workshopStatus(wrkspc))
 	}
 
 	return files, workshops, nil
@@ -92,7 +92,7 @@ func (w *WorkshopManager) Workshops(ctx context.Context, pId string) ([]*worksho
 // Infers the state of a workshop based on the container's state and any of the
 // operations in progress for the workshop. The state must be locked before the
 // call.
-func (w *WorkshopManager) workshopState(ws *workshopbackend.Workshop) workshopbackend.WorkshopState {
+func (w *WorkshopManager) workshopStatus(ws *workshopbackend.Workshop) workshopbackend.WorkshopStatus {
 	op := OperationInProgress(w.state, ws.Name, ws.ProjectId())
 	if op != nil {
 		if ws.IsRunning() {

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -63,7 +63,7 @@ func (s *ManagerSuite) TestWorkshopStateChanges(c *check.C) {
 		running           bool
 		refreshInProgress bool
 		hasErrors         bool
-		expectedState     workshopbackend.WorkshopState
+		expectedState     workshopbackend.WorkshopStatus
 		expectedErrors    []workshopbackend.WorkshopErrorType
 	}
 	cases := []stateSetup{

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -164,7 +164,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		ctx,
 		names,
 		projectId,
-		func(status workshopbackend.WorkshopState) bool {
+		func(status workshopbackend.WorkshopStatus) bool {
 			return status == workshopbackend.WorkshopReady
 		})
 	if err != nil {
@@ -385,7 +385,7 @@ func (w *WorkshopManager) StartMany(ctx context.Context, names []string, project
 		ctx,
 		names,
 		projectId,
-		func(status workshopbackend.WorkshopState) bool {
+		func(status workshopbackend.WorkshopStatus) bool {
 			return status == workshopbackend.WorkshopStopped
 		})
 	if err != nil {
@@ -440,7 +440,7 @@ func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectI
 		ctx,
 		names,
 		projectId,
-		func(status workshopbackend.WorkshopState) bool {
+		func(status workshopbackend.WorkshopStatus) bool {
 			return status == workshopbackend.WorkshopStopped || status == workshopbackend.WorkshopReady
 		})
 	if err != nil {
@@ -501,7 +501,7 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 		ctx,
 		[]string{name},
 		projectId,
-		func(status workshopbackend.WorkshopState) bool {
+		func(status workshopbackend.WorkshopStatus) bool {
 			return status == workshopbackend.WorkshopReady || status == workshopbackend.WorkshopPending
 		})
 	if err != nil {
@@ -546,7 +546,7 @@ func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projec
 		ctx,
 		names,
 		projectId,
-		func(status workshopbackend.WorkshopState) bool {
+		func(status workshopbackend.WorkshopStatus) bool {
 			return status != workshopbackend.WorkshopPending && status != workshopbackend.WorkshopOff
 		})
 	if err != nil {

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -23,22 +23,22 @@ const (
 
 var InstallTimeNow = time.Now
 
-type WorkshopState int
+type WorkshopStatus int
 
 const (
-	WorkshopOff WorkshopState = iota
+	WorkshopOff WorkshopStatus = iota
 	WorkshopReady
 	WorkshopStopped
 	WorkshopPending
 	WorkshopError
 )
 
-func (s WorkshopState) String() string {
+func (s WorkshopStatus) String() string {
 	return [...]string{"Off", "Ready", "Stopped", "Pending", "Error"}[s]
 }
 
-func ParseWorkshopState(s string) WorkshopState {
-	refreshMap := map[string]WorkshopState{
+func ParseWorkshopStatus(s string) WorkshopStatus {
+	refreshMap := map[string]WorkshopStatus{
 		WorkshopOff.String():     WorkshopOff,
 		WorkshopReady.String():   WorkshopReady,
 		WorkshopStopped.String(): WorkshopStopped,
@@ -66,7 +66,7 @@ type Workshop struct {
 	content   map[string]sdk.Setup
 	errs      []WorkshopErrorType
 	running   bool
-	state     WorkshopState
+	status    WorkshopStatus
 }
 
 func (w *Workshop) Base() string {
@@ -105,12 +105,12 @@ func (w *Workshop) SetFile(f *WorkshopFile) {
 	w.file = f
 }
 
-func (w *Workshop) State() WorkshopState {
-	return w.state
+func (w *Workshop) Status() WorkshopStatus {
+	return w.status
 }
 
-func (w *Workshop) SetState(st WorkshopState) {
-	w.state = st
+func (w *Workshop) SetStatus(st WorkshopStatus) {
+	w.status = st
 }
 
 func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {


### PR DESCRIPTION
Rename the workshop state (one of Off, Stopped, Pending, Ready or Error) to workshop status.

This is done to avoid confusion with the SDK state (or a workshop state in the future) which is stored and retrieved in the corresponding hooks. Another reason to rename is that `workshop info` uses the word "status" to describe it, hence the list's command output updated for consistency too. 