### PR TITLE
Docs: Command sample tweaks to improve UX with recent findings

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -160,3 +160,5 @@ disable_feedback_button = False
 # Note that this explicitly violates the SG, but does so for a reason:
 # https://docs.ubuntu.com/styleguide/en#code-examples-in-documentation
 copybutton_prompt_text = "$ "
+copybutton_here_doc_delimiter = "EOF"
+copybutton_line_continuation_character = "\\"

--- a/docs/how-to/debug-workshop-issues.rst
+++ b/docs/how-to/debug-workshop-issues.rst
@@ -34,7 +34,7 @@ Suppose something goes during a
 :ref:`refresh <tut_refresh>`
 operation:
 
-.. code:: shell
+.. code:: console
 
    $ workshop refresh ml-transformer
 
@@ -46,7 +46,7 @@ operation:
 To investigate the failure,
 list the *changes* in the workshop to find the one that failed:
 
-.. code:: shell
+.. code:: console
 
    $ workshop changes
 
@@ -61,7 +61,7 @@ List tasks in a change
 When the problematic change is found,
 list its *tasks* to see the cause:
 
-.. code:: shell
+.. code:: console
 
    $ workshop tasks 81
 

--- a/docs/reference/workshop-changes.rst
+++ b/docs/reference/workshop-changes.rst
@@ -5,7 +5,7 @@ workshop changes
 
 Lists recent changes to the workshops in a project.
 
-.. code:: shell
+.. code:: console
 
    $ workshop changes [global options]
 

--- a/docs/reference/workshop-exec.rst
+++ b/docs/reference/workshop-exec.rst
@@ -5,7 +5,7 @@ workshop exec
 
 Runs a command and waits for it to complete.
 
-.. code:: shell
+.. code:: console
 
    $ workshop exec <WORKSHOP> [-i|-I] [--timeout <TIME>] [-w <DIR>] [-uid <USER>] [-gid <GROUP>] <COMMAND>
 
@@ -34,7 +34,7 @@ If neither is supplied,
 To separate the :program:`exec` subcommand from the command itself,
 use shell syntax such as :samp:`--`:
 
-.. code:: shell
+.. code:: console
 
    workshop exec nimble -- echo -n foo bar
 

--- a/docs/reference/workshop-info.rst
+++ b/docs/reference/workshop-info.rst
@@ -5,7 +5,7 @@ workshop info
 
 Prints the current status and details of a workshop as YAML.
 
-.. code:: shell
+.. code:: console
 
    $ workshop info <WORKSHOP> [global options]
 

--- a/docs/reference/workshop-launch.rst
+++ b/docs/reference/workshop-launch.rst
@@ -5,7 +5,7 @@ workshop launch
 
 Constructs one or many workshops using their definitions.
 
-.. code:: shell
+.. code:: console
 
    $ workshop launch <WORKSHOP>... [global options]
 

--- a/docs/reference/workshop-list.rst
+++ b/docs/reference/workshop-list.rst
@@ -5,7 +5,7 @@ workshop list
 
 Lists project workshops.
 
-.. code:: shell
+.. code:: console
 
    $ workshop list [--global] [global options]
 

--- a/docs/reference/workshop-refresh.rst
+++ b/docs/reference/workshop-refresh.rst
@@ -5,7 +5,7 @@ workshop refresh
 
 Updates workshops according to their definitions.
 
-.. code:: shell
+.. code:: console
 
    $ workshop refresh [--abort|--continue|--wait-on-error] <WORKSHOP>... [global options]
 

--- a/docs/reference/workshop-remove.rst
+++ b/docs/reference/workshop-remove.rst
@@ -5,7 +5,7 @@ workshop remove
 
 Removes one or many workshops.
 
-.. code:: shell
+.. code:: console
 
    $ workshop remove <WORKSHOP>... [global options]
 

--- a/docs/reference/workshop-start.rst
+++ b/docs/reference/workshop-start.rst
@@ -5,7 +5,7 @@ workshop start
 
 Starts one or many workshops.
 
-.. code:: shell
+.. code:: console
 
    $ workshop start <WORKSHOP>... [global options]
 

--- a/docs/reference/workshop-stop.rst
+++ b/docs/reference/workshop-stop.rst
@@ -5,7 +5,7 @@ workshop stop
 
 Stops one or many workshops.
 
-.. code:: shell
+.. code:: console
 
    $ workshop stop <WORKSHOP>... [global options]
 

--- a/docs/reference/workshop-tasks.rst
+++ b/docs/reference/workshop-tasks.rst
@@ -5,7 +5,7 @@ workshop tasks
 
 Lists tasks for a specific change.
 
-.. code:: shell
+.. code:: console
 
    $ workshop tasks <CHANGE ID> [global options]
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -34,7 +34,7 @@ It's available as a snap:
 .. tabs::
    .. group-tab:: Using :program:`snap`
 
-      .. code:: shell
+      .. code:: console
 
          $ sudo snap install lxd
          $ sudo lxd init --auto
@@ -55,7 +55,7 @@ is enabled and running:
 .. tabs::
    .. group-tab:: Using :program:`snap`
 
-      .. code:: shell
+      .. code:: console
 
          $ sudo snap start --enable lxd.daemon
          $ snap services lxd.daemon
@@ -76,7 +76,7 @@ from the |project| source code on
 `GitHub
 <https://github.com/canonical/workshop>`_:
 
-.. code:: shell
+.. code:: console
 
    $ git clone git@github.com:canonical/workshop.git
    # -- or --
@@ -88,7 +88,7 @@ from the |project| source code on
 Install the resulting :file:`.snap` file,
 for example:
 
-.. code:: shell
+.. code:: console
 
    $ sudo snap install --devmode ./workshop_0.1.0_amd64.snap
 
@@ -106,7 +106,7 @@ The snap installs two major components:
 The daemon starts automatically after installation;
 the CLI tool is run manually:
 
-.. code:: shell
+.. code:: console
 
    $ workshop --help
 
@@ -126,7 +126,7 @@ Define
    :ref:`project directory <exp_project>`
    named :file:`hello-workshop`:
 
-   .. code:: shell
+   .. code:: console
 
       $ mkdir hello-workshop
       $ cd hello-workshop
@@ -150,7 +150,7 @@ Define
    by *listing* the workshops
    in the project directory:
 
-   .. code:: shell
+   .. code:: console
 
       $ workshop list
 
@@ -167,7 +167,7 @@ Launch
 To prepare a workshop for action,
 you :ref:`launch <ref_workshop_launch>` it:
 
-.. code:: shell
+.. code:: console
 
    $ workshop launch nimble
 
@@ -180,7 +180,7 @@ to build, debug and run code.
 To make sure |project| watches the changes in the project directory,
 move it, then run :command:`workshop list`:
 
-.. code:: shell
+.. code:: console
 
    $ cd ..
    $ mv hello-workshop hi-workshop
@@ -197,7 +197,7 @@ Start and stop
 If you're done with the workshop for now,
 *stop* it to conserve resources:
 
-.. code:: shell
+.. code:: console
 
    $ workshop stop nimble
 
@@ -206,7 +206,7 @@ If you're done with the workshop for now,
 
 To resume, *start* the workshop again:
 
-.. code:: shell
+.. code:: console
 
    $ workshop start nimble
 
@@ -236,7 +236,7 @@ listed in the
 are updated,
 :ref:`refresh <ref_workshop_refresh>` the workshop to apply the changes:
 
-.. code:: shell
+.. code:: console
 
    $ workshop refresh nimble
 
@@ -248,7 +248,7 @@ then the SDKs are updated from their respective channels.
 
 To refresh multiple workshops at once:
 
-.. code:: shell
+.. code:: console
 
    $ workshop refresh nimble huggingface ...
 
@@ -275,7 +275,7 @@ update the definition file and refresh the workshop:
        channel: latest/edge
 
 
-.. code:: shell
+.. code:: console
 
    $ workshop refresh nimble
 
@@ -295,7 +295,7 @@ To pause the refresh operation on error
 instead of cancelling it outright,
 add the :option:`!--wait-on-error` option:
 
-.. code:: shell
+.. code:: console
 
    $ workshop refresh --wait-on-error nimble
 
@@ -312,7 +312,7 @@ and choose to abort or continue the refresh operation.
 To investigate the issue, check the recent
 :ref:`changes <ref_workshop_changes>`:
 
-.. code:: shell
+.. code:: console
 
    $ workshop changes
 
@@ -324,7 +324,7 @@ To investigate the issue, check the recent
 Having found the problematic change, explore its
 :ref:`tasks <ref_workshop_tasks>`:
 
-.. code:: shell
+.. code:: console
 
    $ workshop tasks 81
 
@@ -341,7 +341,7 @@ Having found the problematic change, explore its
 
 To continue the refresh operation:
 
-.. code:: shell
+.. code:: console
 
    $ workshop refresh --continue nimble
 
@@ -350,7 +350,7 @@ To continue the refresh operation:
 
 To abort the operation and recover the last operational state:
 
-.. code:: shell
+.. code:: console
 
    $ workshop refresh --abort nimble
 
@@ -365,21 +365,21 @@ Execute commands
 When the workshop is ready,
 execute arbitrary commands in it using :ref:`ref_workshop_exec`:
 
-.. code:: shell
+.. code:: console
 
    $ workshop exec nimble go build
 
 
 To define environment variables and visibly separate the command's options:
 
-.. code:: shell
+.. code:: console
 
    $ workshop exec nimble --env GOARCH=linux -- go build -x nimble.go
 
 
 You can run an interactive shell as well:
 
-.. code:: shell
+.. code:: console
 
    $ workshop exec nimble bash
    $ uname -a
@@ -398,7 +398,7 @@ Remove a workshop
 If you don't need a workshop anymore,
 :ref:`remove <ref_workshop_remove>` it:
 
-.. code:: shell
+.. code:: console
 
    $ workshop remove nimble
 


### PR DESCRIPTION
As we saw in a recent round of UX testing, users may choose to avoid the copy button in samples for various reasons (not sure if it works properly, don't want to bulk-copy commands, etc.).

Thus, we need to maintain the existing sphinx-copybutton but make the user's life easier if they choose to copy the commands manually.