### PR TITLE
Update SdkSetup and SdkRecord data layout for the download and install tasks

### DIFF
--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -82,7 +82,7 @@ func (c *ObjectStoreClient) RetrieveSdk(name, channel, localSdkDir string) (sdk.
 		if atr, err := obj.Attrs(ctx); err != nil {
 			return s, err
 		} else {
-			/* A simple modulo to keep revision numbers in a readble form for testing */
+			// A simple modulo to keep revision numbers in a readble form for testing
 			revision = atr.Generation % 1000
 		}
 

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -56,7 +56,7 @@ slots:
  content-slot:
   interface: content
 `
-	info := sdk.MockInfo(c, mockSdkYaml, sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, "ws", sdk.Setup{})
 	slot := info.Slots["content-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
 }
@@ -69,7 +69,7 @@ plugs:
   interface: content
   target: import
 `
-	info := sdk.MockInfo(c, mockSdkYaml, sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, "ws", sdk.Setup{})
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
 }
@@ -82,7 +82,7 @@ plugs:
   interface: content
   content: mycont
 `
-	info := sdk.MockInfo(c, mockSdkYaml, sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, "ws", sdk.Setup{})
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content plug must contain target path")
 }
@@ -96,7 +96,7 @@ plugs:
   content: mycont
   target: ../foo
 `
-	info := sdk.MockInfo(c, mockSdkYaml, sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, "ws", sdk.Setup{})
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content interface path is not clean:.*")
 }
@@ -111,14 +111,14 @@ base: ubuntu@22.04
 plugs:
  content:
   target: /project/training
-`, sdk.Setup{Workshop: "ws"}, "content")
+`, "ws", sdk.Setup{}, "content")
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 
 	slot := builtin.MockSlot(c, `name: producer
 base: ubuntu@22.04
 slots:
  content:
-`, sdk.Setup{Workshop: "ws"}, "content")
+`, "ws", sdk.Setup{}, "content")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 	deviceSpec := &device.Specification{}
 

--- a/internal/interfaces/builtin/export_test.go
+++ b/internal/interfaces/builtin/export_test.go
@@ -52,16 +52,16 @@ func MustInterface(name string) interfaces.Interface {
 	panic(fmt.Errorf("cannot find interface with name %q", name))
 }
 
-func MockPlug(c *check.C, yaml string, si sdk.Setup, plugName string) *sdk.PlugInfo {
-	info := sdk.MockInfo(c, yaml, si)
+func MockPlug(c *check.C, yaml string, workshop string, si sdk.Setup, plugName string) *sdk.PlugInfo {
+	info := sdk.MockInfo(c, yaml, workshop, si)
 	if plugInfo, ok := info.Plugs[plugName]; ok {
 		return plugInfo
 	}
 	panic(fmt.Sprintf("cannot find plug %q in sdk %q", plugName, si.Name))
 }
 
-func MockSlot(c *check.C, yaml string, si sdk.Setup, slotName string) *sdk.SlotInfo {
-	info := sdk.MockInfo(c, yaml, si)
+func MockSlot(c *check.C, yaml string, workshop string, si sdk.Setup, slotName string) *sdk.SlotInfo {
+	info := sdk.MockInfo(c, yaml, workshop, si)
 	if slotInfo, ok := info.Slots[slotName]; ok {
 		return slotInfo
 	}

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -49,7 +49,7 @@ plugs:
         attr: value
         complex:
             c: d
-`, sdk.Setup{})
+`, "ws", sdk.Setup{})
 	s.plug = consumer.Plugs["plug"]
 	producer := sdk.MockInfo(c, `
 name: producer
@@ -61,7 +61,7 @@ slots:
         number: 100
         complex:
             a: b
-`, sdk.Setup{})
+`, "ws", sdk.Setup{})
 	s.slot = producer.Slots["slot"]
 }
 

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -149,7 +149,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: mock-service-snippets
-`, sdk.Setup{})
+`, "ws", sdk.Setup{})
 	plug := info.Plugs["plug"]
 
 	snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
@@ -173,7 +173,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: unclean-service-snippets
-`, sdk.Setup{})
+`, "ws", sdk.Setup{})
 	plug := info.Plugs["plug"]
 
 	iface, err := interfaces.ByName("unclean-service-snippets")
@@ -191,7 +191,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: iface
-`, sdk.Setup{})
+`, "ws", sdk.Setup{})
 	plug := info.Plugs["plug"]
 	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
 		InterfaceName: "iface",
@@ -212,7 +212,7 @@ base: ubuntu@22.04
 slots:
   slot:
     interface: iface
-`, sdk.Setup{})
+`, "ws", sdk.Setup{})
 	slot := info.Slots["slot"]
 	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
 		InterfaceName: "iface",

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -69,8 +69,8 @@ plugs:
   %s:
 `, iface)
 	}
-	slotSdk := sdk.MockInfo(c, slotYaml, sdk.Setup{Workshop: "ws"})
-	plugSdk := sdk.MockInfo(c, plugYaml, sdk.Setup{Workshop: "ws"})
+	slotSdk := sdk.MockInfo(c, slotYaml, "ws", sdk.Setup{})
+	plugSdk := sdk.MockInfo(c, plugYaml, "ws", sdk.Setup{})
 	return &policy.ConnectCandidate{
 		Plug:            interfaces.NewConnectedPlug(plugSdk.Plugs[iface], nil, nil),
 		Slot:            interfaces.NewConnectedSlot(slotSdk.Slots[iface], nil, nil),
@@ -87,7 +87,7 @@ slots:
   %s:
 `, sdkType, iface)
 	}
-	sdk := sdk.MockInfo(c, yaml, sdk.Setup{Workshop: "ws"})
+	sdk := sdk.MockInfo(c, yaml, "ws", sdk.Setup{})
 	return &policy.InstallCandidate{
 		Sdk:             sdk,
 		BaseDeclaration: s.baseDecl,
@@ -103,7 +103,7 @@ plugs:
   %s:
 `, sdkType, iface)
 	}
-	sdk := sdk.MockInfo(c, yaml, sdk.Setup{Workshop: "ws"})
+	sdk := sdk.MockInfo(c, yaml, "ws", sdk.Setup{})
 	return &policy.InstallCandidate{
 		Sdk:             sdk,
 		BaseDeclaration: s.baseDecl,

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -77,9 +77,9 @@ func (s *RepositorySuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 
-	consumer := sdk.MockInfo(c, consumerYaml, sdk.Setup{Workshop: "ws", Name: "plug-sdk"})
+	consumer := sdk.MockInfo(c, consumerYaml, "ws", sdk.Setup{Name: "plug-sdk"})
 	s.plug = consumer.Plugs["plug"]
-	producer := sdk.MockInfo(c, producerYaml, sdk.Setup{Workshop: "ws", Name: "slot-sdk"})
+	producer := sdk.MockInfo(c, producerYaml, "ws", sdk.Setup{Name: "slot-sdk"})
 	s.slot = producer.Slots["slot"]
 	s.plugSelf = producer.Plugs["self"]
 
@@ -102,7 +102,7 @@ type instanceNameAndYaml struct {
 func addPlugsSlotsFromInstances(c *C, repo *Repository, iys []instanceNameAndYaml) []*sdk.Info {
 	result := make([]*sdk.Info, 0, len(iys))
 	for _, iy := range iys {
-		info := sdk.MockInfo(c, iy.Yaml, sdk.Setup{Workshop: "ws-" + iy.Name})
+		info := sdk.MockInfo(c, iy.Yaml, "ws-"+iy.Name, sdk.Setup{})
 		if iy.Name != "" {
 			c.Assert(sdk.Validate(info), IsNil)
 		}
@@ -231,7 +231,7 @@ func (s *RepositorySuite) TestAddPlugClashingPlug(c *C) {
 }
 
 func (s *RepositorySuite) TestAddPlugClashingSlot(c *C) {
-	snapInfo := &sdk.Info{Workshop: "ws", Name: "sdk"}
+	snapInfo := &sdk.Info{Name: "sdk"}
 	plug := &sdk.PlugInfo{
 		Sdk:       snapInfo,
 		Name:      "clashing",
@@ -274,7 +274,7 @@ func (s *RepositorySuite) TestAddPlugParallelInstance(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
 
-	consumer := sdk.MockInfo(c, consumerYaml, sdk.Setup{})
+	consumer := sdk.MockInfo(c, consumerYaml, "ws-instance", sdk.Setup{})
 	err = s.testRepo.AddPlug(consumer.Plugs["plug"])
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 2)
@@ -628,7 +628,7 @@ func (s *RepositorySuite) TestAddSlotParallelInstance(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 1)
 
-	producer := sdk.MockInfo(c, producerYaml, sdk.Setup{Workshop: "ws-instance"})
+	producer := sdk.MockInfo(c, producerYaml, "ws-instance", sdk.Setup{})
 	err = s.testRepo.AddSlot(producer.Slots["slot"])
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 2)
@@ -725,7 +725,9 @@ func (s *RepositorySuite) TestConnectFailsWhenSlotAndPlugAreIncompatible(c *C) {
 	otherInterface := &ifacetest.TestInterface{InterfaceName: "other-interface"}
 	err := s.testRepo.AddInterface(otherInterface)
 	plug := &sdk.PlugInfo{
-		Sdk:       &sdk.Info{Workshop: "ws", Name: "consumer"},
+		Sdk: &sdk.Info{
+			Workshop: "ws",
+			Name:     "consumer"},
 		Name:      "plug",
 		Interface: "other-interface",
 	}
@@ -1076,14 +1078,14 @@ base: ubuntu@22.04
 plugs:
     auto:
     manual:
-`, sdk.Setup{Workshop: "ws", Name: "consumer"})
+`, "ws", sdk.Setup{Name: "consumer"})
 	producer := sdk.MockInfo(c, `
 name: producer
 base: ubuntu@22.04
 slots:
     auto:
     manual:
-`, sdk.Setup{Workshop: "ws", Name: "producer"})
+`, "ws", sdk.Setup{Name: "producer"})
 	err = repo.AddSdk(producer)
 	c.Assert(err, IsNil)
 	err = repo.AddSdk(consumer)
@@ -1118,7 +1120,7 @@ name: producer
 base: ubuntu@22.04
 slots:
     auto:
-`, sdk.Setup{Workshop: "ws", Name: "producer"})
+`, "ws", sdk.Setup{Name: "producer"})
 	err = repo.AddSdk(producer)
 	c.Assert(err, IsNil)
 
@@ -1128,7 +1130,7 @@ name: consumer1
 base: ubuntu@22.04
 plugs:
     auto:
-`, sdk.Setup{Workshop: "ws", Name: "consumer1"})
+`, "ws", sdk.Setup{Name: "consumer1"})
 
 	err = repo.AddSdk(consumer1)
 	c.Assert(err, IsNil)
@@ -1139,7 +1141,7 @@ name: consumer2
 base: ubuntu@22.04
 plugs:
     auto:
-`, sdk.Setup{Workshop: "ws", Name: "consumer2"})
+`, "ws", sdk.Setup{Name: "consumer2"})
 
 	err = repo.AddSdk(consumer2)
 	c.Assert(err, IsNil)
@@ -1192,7 +1194,7 @@ func (s *AddRemoveSuite) TearDownTest(c *C) {
 }
 
 func (s *AddRemoveSuite) addSdk(c *C, yaml string) (*sdk.Info, error) {
-	sdkInfo := sdk.MockInfo(c, yaml, sdk.Setup{Workshop: "ws"})
+	sdkInfo := sdk.MockInfo(c, yaml, "ws", sdk.Setup{})
 	return sdkInfo, s.repo.AddSdk(sdkInfo)
 }
 
@@ -1233,7 +1235,7 @@ func (s *DisconnectSnapSuite) SetUpTest(c *C) {
 	err = s.repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface-b"})
 	c.Assert(err, IsNil)
 
-	setup := sdk.Setup{Workshop: "ws"}
+	setup := sdk.Setup{}
 
 	s.s1 = sdk.MockInfo(c, `
 name: s1
@@ -1242,7 +1244,7 @@ plugs:
     iface-a:
 slots:
     iface-b:
-`, setup)
+`, "ws", setup)
 	err = s.repo.AddSdk(s.s1)
 	c.Assert(err, IsNil)
 
@@ -1253,7 +1255,7 @@ plugs:
     iface-b:
 slots:
     iface-a:
-`, setup)
+`, "ws", setup)
 	c.Assert(err, IsNil)
 	err = s.repo.AddSdk(s.s2)
 	c.Assert(err, IsNil)
@@ -1264,7 +1266,7 @@ plugs:
     iface-b:
 slots:
     iface-a:
-`, setup)
+`, "ws", setup)
 	c.Assert(err, IsNil)
 	err = s.repo.AddSdk(s.s2Instance)
 	c.Assert(err, IsNil)
@@ -1356,7 +1358,7 @@ plugs:
   imported-content:
     interface: content
     content: %s
-`, plugContentToken), sdk.Setup{Workshop: "ws-importer"})
+`, plugContentToken), "ws-importer", sdk.Setup{})
 	slotSnap := sdk.MockInfo(c, fmt.Sprintf(`
 name: content-slot-sdk
 base: ubuntu@22.04
@@ -1364,7 +1366,7 @@ slots:
   exported-content:
     interface: content
     content: %s
-`, slotContentToken), sdk.Setup{Workshop: "ws-exporter"})
+`, slotContentToken), "ws-exporter", sdk.Setup{})
 
 	err = repo.AddSdk(plugSnap)
 	c.Assert(err, IsNil)
@@ -1439,9 +1441,9 @@ func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, sdk.Setup{Workshop: "ws-s1"})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, "ws-s1", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, sdk.Setup{Workshop: "ws-s2"})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, "ws-s2", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
@@ -1473,9 +1475,9 @@ func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, sdk.Setup{Workshop: "ws-s1"})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, "ws-s1", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, sdk.Setup{Workshop: "ws-s2"})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, "ws-s2", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
@@ -1497,9 +1499,9 @@ func (s *RepositorySuite) TestBeforeConnectValidationPolicyCheckFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, sdk.Setup{Workshop: "ws-s1"})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, "ws-s1", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, sdk.Setup{Workshop: "ws-s2"})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, "ws-s2", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
@@ -1580,7 +1582,7 @@ base: ubuntu@22.04
 plugs:
   i1:
   i2:
-`, sdk.Setup{Workshop: "ws"})
+`, "ws", sdk.Setup{})
 	c.Assert(r.AddSdk(s1), IsNil)
 
 	s2 := sdk.MockInfo(c, `
@@ -1589,7 +1591,7 @@ base: ubuntu@22.04
 slots: 
   i1:
   i3:
-`, sdk.Setup{Workshop: "ws"})
+`, "ws", sdk.Setup{})
 	c.Assert(r.AddSdk(s2), IsNil)
 
 	s3 := sdk.MockInfo(c, `
@@ -1598,14 +1600,14 @@ base: ubuntu@22.04
 type: core
 slots:
   i2:
-`, sdk.Setup{Workshop: "ws"})
+`, "ws", sdk.Setup{})
 	c.Assert(r.AddSdk(s3), IsNil)
 	s4 := sdk.MockInfo(c, `
 name: s4
 base: ubuntu@22.04
 plugs:
   i2:
-`, sdk.Setup{Workshop: "ws"})
+`, "ws", sdk.Setup{})
 	c.Assert(r.AddSdk(s4), IsNil)
 
 	// Connect a few things for the tests below.

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -26,7 +26,7 @@ func SdkSetup(task *state.Task) (sdk.Setup, error) {
 	defer st.Unlock()
 
 	var retrieveId string
-	var blob sdk.Setup
+	var sdkSetup sdk.Setup
 
 	err := task.Get("sdk-retrieve-task", &retrieveId)
 
@@ -39,10 +39,10 @@ func SdkSetup(task *state.Task) (sdk.Setup, error) {
 		return sdk.Setup{}, fmt.Errorf("internal error: no corresponding retrieve-sdk task found")
 	}
 
-	if err = retrieve.Get("sdk-setup", &blob); err != nil {
+	if err = retrieve.Get("sdk-setup", &sdkSetup); err != nil {
 		return sdk.Setup{}, err
 	}
-	return blob, nil
+	return sdkSetup, nil
 }
 
 func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -50,7 +50,7 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	var sdk workshopbackend.SdkRecord
 
 	st.Lock()
-	err := task.Get("sdk-setup", &sdk)
+	err := task.Get("sdk-record", &sdk)
 	st.Unlock()
 
 	if err != nil {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -71,15 +71,6 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
-func sdkBlobDevice(sdk sdk.Setup) workshopbackend.WorkshopDevice {
-	/* Bind-mount the SDK to the workshop */
-	return workshopbackend.WorkshopDevice{
-		Name: sdk.Name,
-		Properties: map[string]string{"type": "disk", "source": sdk.Filename(),
-			"path": filepath.Join("/root", filepath.Base(sdk.Filename()))},
-	}
-}
-
 func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, workshop, err := UserProjectWorkshop(task)
 	if err != nil {
@@ -94,14 +85,18 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project)
 	defer cancel()
 
-	sdkMount := sdkBlobDevice(sdkSetup)
+	sdkMount := workshopbackend.WorkshopDevice{
+		Name: sdkSetup.Name,
+		Properties: map[string]string{"type": "disk", "source": sdkSetup.Filename(),
+			"path": filepath.Join("/root", filepath.Base(sdkSetup.Filename()))},
+	}
 
 	if err = m.backend.AddWorkshopDevice(ctx, workshop, sdkMount); err != nil {
 		return err
 	}
 
 	cleanup := func() {
-		/* Make sure the SDK file will be unmounted once installed into the workshop */
+		// Make sure the SDK file will be unmounted once installed into the workshop
 		if err := m.backend.RemoveWorkshopDevice(ctx, workshop, sdkMount.Name); err != nil {
 			logger.Debugf("cannot unmount SDK %q from workshop %q: %v", sdkMount.Name, workshop, err)
 		}
@@ -148,9 +143,7 @@ func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	err = exectx.WaitExecution(ctx)
-
-	if err != nil {
+	if err = exectx.WaitExecution(ctx); err != nil {
 		hookLog, _ := afero.ReadFile(memFs, out.Name())
 		return fmt.Errorf("%w: %v", err, string(hookLog))
 	}
@@ -167,12 +160,10 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project)
 	defer cancel()
 
-	blob, err := SdkSetup(task)
+	sdkSetup, err := SdkSetup(task)
 	if err != nil {
 		return err
 	}
-
-	sdkMount := sdkBlobDevice(blob)
 
 	fs, err := m.backend.GetWorkshopFs(ctx, workshop)
 	if err != nil {
@@ -180,9 +171,9 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	}
 	defer fs.Close()
 
-	err = fs.RemoveAll(filepath.Join(dirs.WorkshopSdksDir, blob.Name))
+	err = fs.RemoveAll(filepath.Join(dirs.WorkshopSdksDir, sdkSetup.Name))
 	if err != nil {
-		return fmt.Errorf("cannot undo SDK %q installation: %w", sdkMount.Name, err)
+		return fmt.Errorf("cannot undo SDK %q installation: %w", sdkSetup.Name, err)
 	}
 
 	return nil

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -240,7 +240,7 @@ func (s *H) TestDoLinkSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	testSdk := sdk.Setup{Workshop: "ws", Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+	testSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
 
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", testSdk)
@@ -284,7 +284,7 @@ slots:
 `
 	s.mockTestSdk(c, sdkYaml)
 
-	testSdk := sdk.Setup{Workshop: "ws", Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+	testSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
 
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", testSdk)

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -9,7 +9,7 @@ import (
 
 func Retrieve(st *state.State, sdk *workshopbackend.SdkRecord) *state.Task {
 	download := st.NewTask("retrieve-sdk", fmt.Sprintf("Retrieve %q SDK from channel %q", sdk.Name, sdk.Channel))
-	download.Set("sdk-setup", sdk)
+	download.Set("sdk-record", sdk)
 	return download
 }
 

--- a/internal/overlord/sdkstate/request_test.go
+++ b/internal/overlord/sdkstate/request_test.go
@@ -45,7 +45,7 @@ func (i *SdkStateTasks) TestRetrieve(c *check.C) {
 	task := sdkstate.Retrieve(i.state, &sdk)
 
 	var s workshopbackend.SdkRecord
-	task.Get("sdk-setup", &s)
+	task.Get("sdk-record", &s)
 	c.Check(s, check.DeepEquals, sdk)
 	c.Check(task.Kind(), check.Equals, "retrieve-sdk")
 	c.Check(task.Summary(), check.Equals, "Retrieve \"sdk\" SDK from channel \"latest/stable\"")

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -232,7 +232,7 @@ func refreshMany(st *state.State, w []*workshopbackend.WorkshopFile, content [][
 		// task of our refresh will wait until all the other refresh operations
 		// finished. This will ensure that we start to remove the workshops'
 		// previous copies once all the refresh operations were successful (at
-		// this stage, we only need to remove a copy, the newly refreshed
+		// this stage, we only need to remove a stashed copy, the newly refreshed
 		// workshop is already up and running). Thus, every CleanupEdge will
 		// wait for ALL the LastBeforeRefreshIrreversibleEdge tasks of all the
 		// other changes before execution.
@@ -249,7 +249,7 @@ func refreshMany(st *state.State, w []*workshopbackend.WorkshopFile, content [][
 				// start to Undo those workshops' refresh progress we will
 				// endup deleting the workshops that finished their refresh.
 				// Given that they have no copy already, the undo logic
-				// (undoMakeWorkshopCopy) will delete the existing workshop
+				// (stash-workshop) will delete the existing workshop
 				// and fail to restore from the copy. We don't want that. Hence,
 				// all the cleanup tasks are extracted into a separate lane. If
 				// any problem happens, the workshops which had finished their

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -105,11 +105,11 @@ func (s *S) TestLaunchWorkshopWithSdks(c *check.C) {
 	verifyExpectedTasks(c, tasks, expected)
 
 	var s1, s2 workshopbackend.SdkRecord
-	err = tasks[3].Get("sdk-setup", &s1)
+	err = tasks[3].Get("sdk-record", &s1)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(s1, check.Equals, sdk)
 
-	err = tasks[4].Get("sdk-setup", &s2)
+	err = tasks[4].Get("sdk-record", &s2)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(s2, check.Equals, sdk_2)
 

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -15,7 +15,6 @@ import (
 )
 
 type Setup struct {
-	Workshop    string    `json:"workshop"`
 	Name        string    `json:"name"`
 	Channel     string    `json:"channel"`
 	Revision    int64     `json:"revision"`
@@ -59,7 +58,7 @@ var SanitizePlugsSlots = func(snapInfo *Info) {
 	panic("SanitizePlugsSlots function not set")
 }
 
-func ReadSdkInfo(yamlData []byte, setup Setup) (*Info, error) {
+func ReadSdkInfo(yamlData []byte, workshop string, setup Setup) (*Info, error) {
 	var sdkYaml sdkYaml
 	err := yaml.Unmarshal(yamlData, &sdkYaml)
 	if err != nil {
@@ -71,7 +70,7 @@ func ReadSdkInfo(yamlData []byte, setup Setup) (*Info, error) {
 	}
 
 	sdkInfo := &Info{
-		Workshop:      setup.Workshop,
+		Workshop:      workshop,
 		Name:          sdkYaml.Name,
 		Base:          sdkYaml.Base,
 		Type:          Type(sdkYaml.Type),
@@ -290,10 +289,10 @@ func MockSanitizePlugsSlots(f func(snapInfo *Info)) (restore func()) {
 	return func() { SanitizePlugsSlots = old }
 }
 
-func MockInfo(c *check.C, yamlText string, setup Setup) *Info {
+func MockInfo(c *check.C, yamlText string, workshop string, setup Setup) *Info {
 	restoreSanitize := MockSanitizePlugsSlots(func(snapInfo *Info) {})
 	defer restoreSanitize()
-	info, err := ReadSdkInfo([]byte(yamlText), setup)
+	info, err := ReadSdkInfo([]byte(yamlText), workshop, setup)
 	c.Assert(err, check.IsNil)
 
 	err = Validate(info)
@@ -305,7 +304,7 @@ func MockInvalidInfo(c *check.C, yamlText string, setup Setup) *Info {
 	restoreSanitize := MockSanitizePlugsSlots(func(snapInfo *Info) {})
 	defer restoreSanitize()
 
-	sdkInfo, err := ReadSdkInfo([]byte(yamlText), setup)
+	sdkInfo, err := ReadSdkInfo([]byte(yamlText), "ws", setup)
 	c.Assert(err, check.IsNil)
 	err = Validate(sdkInfo)
 	c.Assert(err, check.NotNil)

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -22,7 +22,6 @@ func (s *SdkSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
 
 	s.setup = sdk.Setup{
-		Workshop:    "ws",
 		Name:        "sdk",
 		Channel:     "latest/stable",
 		Revision:    1,
@@ -41,7 +40,7 @@ func (s *SdkSuite) TestSimple(c *check.C) {
 base: ubuntu@20.04
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Base, check.Equals, "ubuntu@20.04")
 	c.Assert(info.Name, check.Equals, "sdk")
@@ -61,7 +60,7 @@ plugs:
     target: /project
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -82,7 +81,7 @@ slots:
     source: /project
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Slots, check.HasLen, 1)
 	c.Assert(info.Plugs, check.HasLen, 0)
@@ -106,7 +105,7 @@ plugs:
         m:
           a: A
           b: B
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -133,7 +132,7 @@ plugs:
     net:
         interface: content
         attr: 2
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -152,7 +151,7 @@ name: sdk
 plugs:
     content:
         ipv6-aware: true
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 1)
 	c.Check(info.Slots, check.HasLen, 0)
@@ -171,7 +170,7 @@ name: sdk
 plugs:
     bool-file:
         label: Disk I/O indicator
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 
 	c.Check(info.Plugs, check.HasLen, 1)
@@ -193,7 +192,7 @@ plugs:
     net:
         interface: 1.0
         ipv6-aware: true
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `interface name on plug "net" is not a string \(found float64\)`)
 }
 
@@ -204,7 +203,7 @@ name: sdk
 plugs:
     bool-file:
         label: 1.0
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `label of plug "bool-file" is not a string \(found float64\)`)
 }
 
@@ -215,7 +214,7 @@ name: sdk
 plugs:
     net:
         1: ok
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `plug "net" has attribute key that is not a string \(found int\)`)
 }
 
@@ -226,7 +225,7 @@ name: sdk
 plugs:
     net:
         "": ok
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `plug "net" has an empty attribute key`)
 }
 
@@ -236,7 +235,7 @@ func (s *SdkSuite) TestUnmarshalCorruptedPlugWithUnexpectedType(c *check.C) {
 name: sdk
 plugs:
     net: 5
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `plug "net" has malformed definition \(found int\)`)
 }
 
@@ -248,7 +247,7 @@ plugs:
     serial:
         interface: serial-port
         $baud-rate: [9600]
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `plug "serial" uses reserved attribute "\$baud-rate"`)
 }
 
@@ -260,7 +259,7 @@ plugs:
     serial:
         interface: serial-port
         foo: null
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `attribute "foo" of plug \"serial\": invalid scalar:.*`)
 }
 
@@ -274,7 +273,7 @@ plugs:
         bar:
           baz:
           - 1: A
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `attribute "bar" of plug \"serial\": non-string key: 1`)
 }
 
@@ -286,7 +285,7 @@ func (s *SdkSuite) TestUnmarshalStandaloneImplicitSlot(c *check.C) {
 name: sdk
 slots:
     content:
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -303,7 +302,7 @@ func (s *SdkSuite) TestUnmarshalStandaloneAbbreviatedSlot(c *check.C) {
 name: sdk
 slots:
     net: content
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -322,7 +321,7 @@ slots:
     net:
         interface: content
         ipv6-aware: true
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -345,7 +344,7 @@ slots:
         l: [1,2]
         m:
           a: "A"
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -372,7 +371,7 @@ slots:
     net:
         interface: content
         attr: 2
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -391,7 +390,7 @@ name: sdk
 slots:
     content:
         ipv6-aware: true
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -411,7 +410,7 @@ slots:
     led0:
         interface: bool-file
         label: Front panel LED (red)
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -431,7 +430,7 @@ slots:
     net:
         interface: 1.0
         ipv6-aware: true
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `interface name on slot "net" is not a string \(found float64\)`)
 }
 
@@ -442,7 +441,7 @@ name: sdk
 slots:
     bool-file:
         label: 1.0
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `label of slot "bool-file" is not a string \(found float64\)`)
 }
 
@@ -453,7 +452,7 @@ name: sdk
 slots:
     net:
         1: ok
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `slot "net" has attribute key that is not a string \(found int\)`)
 }
 
@@ -464,7 +463,7 @@ name: sdk
 slots:
     net:
         "": ok
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `slot "net" has an empty attribute key`)
 }
 
@@ -474,7 +473,7 @@ func (s *SdkSuite) TestUnmarshalCorruptedSlotWithUnexpectedType(c *check.C) {
 name: sdk
 slots:
     net: 5
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `slot "net" has malformed definition \(found int\)`)
 }
 
@@ -486,7 +485,7 @@ slots:
     serial:
         interface: serial-port
         $baud-rate: [9600]
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `slot "serial" uses reserved attribute "\$baud-rate"`)
 }
 
@@ -498,6 +497,6 @@ slots:
     serial:
         interface: serial-port
         foo: null
-`), s.setup)
+`), "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `attribute "foo" of slot \"serial\": invalid scalar:.*`)
 }

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -63,7 +63,7 @@ func (s *ValidateSuite) TestValidateSlotPlugInterfaceName(c *check.C) {
 
 func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo.something
-`), sdk.Setup{})
+`), "ws", sdk.Setup{})
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)
@@ -73,7 +73,7 @@ func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
 func (s *ValidateSuite) TestIllegalSdkBase(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo.something
 base: ubuntu@20.04
-`), sdk.Setup{})
+`), "ws", sdk.Setup{})
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)

--- a/internal/workshopbackend/backend.go
+++ b/internal/workshopbackend/backend.go
@@ -22,12 +22,6 @@ func NewWorkshopConfigFilter(key string, value string) WorkshopConfigFilter {
 	}
 }
 
-func EveryWorkshop() WorkshopConfigFilter {
-	return func(config map[string]string) bool {
-		return true
-	}
-}
-
 type ErrExec struct {
 	Status int
 }

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -720,7 +720,10 @@ func (s *LxdBackend) RemoveWorkshopConfig(ctx context.Context, name string, key 
 	}
 
 	delete(inst.Config, key)
-	op, _ := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+	op, err := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+	if err != nil {
+		return err
+	}
 
 	return op.Wait()
 }
@@ -741,7 +744,10 @@ func (s *LxdBackend) AddWorkshopDevice(ctx context.Context, name string, device 
 		return err
 	}
 	inst.Devices[device.Name] = device.Properties
-	op, _ := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+	op, err := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+	if err != nil {
+		return err
+	}
 
 	return op.Wait()
 }

--- a/internal/workshopbackend/lxd_backend_mock.go
+++ b/internal/workshopbackend/lxd_backend_mock.go
@@ -123,9 +123,8 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, name, base str
 
 	for _, s := range ws.File().Sdks {
 		ws.LinkSdk(ctx, sdk.Setup{
-			Workshop: name,
-			Name:     s.Name,
-			Channel:  s.Channel,
+			Name:    s.Name,
+			Channel: s.Channel,
 		})
 	}
 	return nil

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -246,7 +246,7 @@ func (w *Workshop) SdkInfo(ctx context.Context, s sdk.Setup) (*sdk.Info, error) 
 		return nil, err
 	}
 
-	info, err := sdk.ReadSdkInfo(yamlData, s)
+	info, err := sdk.ReadSdkInfo(yamlData, w.Name, s)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The SDK data stored in the tasks shall not store the workshop name as it is already known from the change data.