### PR TITLE
Add project ID to the plug and slot keys in Repository

### DIFF
--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -34,7 +34,8 @@ import (
 )
 
 type ContentSuite struct {
-	iface interfaces.Interface
+	iface     interfaces.Interface
+	projectId string
 }
 
 func Test(t *testing.T) {
@@ -44,6 +45,10 @@ func Test(t *testing.T) {
 var _ = check.Suite(&ContentSuite{
 	iface: builtin.MustInterface("content"),
 })
+
+func (s *ContentSuite) SetUpTest(c *check.C) {
+	s.projectId = "42424242"
+}
 
 func (s *ContentSuite) TestName(c *check.C) {
 	c.Assert(s.iface.Name(), check.Equals, "content")
@@ -56,7 +61,7 @@ slots:
  content-slot:
   interface: content
 `
-	info := sdk.MockInfo(c, mockSdkYaml, "ws", sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws", sdk.Setup{})
 	slot := info.Slots["content-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
 }
@@ -69,7 +74,7 @@ plugs:
   interface: content
   target: import
 `
-	info := sdk.MockInfo(c, mockSdkYaml, "ws", sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws", sdk.Setup{})
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
 }
@@ -82,7 +87,7 @@ plugs:
   interface: content
   content: mycont
 `
-	info := sdk.MockInfo(c, mockSdkYaml, "ws", sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws", sdk.Setup{})
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content plug must contain target path")
 }
@@ -96,7 +101,7 @@ plugs:
   content: mycont
   target: ../foo
 `
-	info := sdk.MockInfo(c, mockSdkYaml, "ws", sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws", sdk.Setup{})
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content interface path is not clean:.*")
 }
@@ -111,14 +116,14 @@ base: ubuntu@22.04
 plugs:
  content:
   target: /project/training
-`, "ws", sdk.Setup{}, "content")
+`, s.projectId, "ws", sdk.Setup{}, "content")
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 
 	slot := builtin.MockSlot(c, `name: producer
 base: ubuntu@22.04
 slots:
  content:
-`, "ws", sdk.Setup{}, "content")
+`, s.projectId, "ws", sdk.Setup{}, "content")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 	deviceSpec := &device.Specification{}
 

--- a/internal/interfaces/builtin/export_test.go
+++ b/internal/interfaces/builtin/export_test.go
@@ -52,16 +52,16 @@ func MustInterface(name string) interfaces.Interface {
 	panic(fmt.Errorf("cannot find interface with name %q", name))
 }
 
-func MockPlug(c *check.C, yaml string, workshop string, si sdk.Setup, plugName string) *sdk.PlugInfo {
-	info := sdk.MockInfo(c, yaml, workshop, si)
+func MockPlug(c *check.C, yaml string, projectId, workshop string, si sdk.Setup, plugName string) *sdk.PlugInfo {
+	info := sdk.MockInfo(c, yaml, projectId, workshop, si)
 	if plugInfo, ok := info.Plugs[plugName]; ok {
 		return plugInfo
 	}
 	panic(fmt.Sprintf("cannot find plug %q in sdk %q", plugName, si.Name))
 }
 
-func MockSlot(c *check.C, yaml string, workshop string, si sdk.Setup, slotName string) *sdk.SlotInfo {
-	info := sdk.MockInfo(c, yaml, workshop, si)
+func MockSlot(c *check.C, yaml string, projectId, workshop string, si sdk.Setup, slotName string) *sdk.SlotInfo {
+	info := sdk.MockInfo(c, yaml, projectId, workshop, si)
 	if slotInfo, ok := info.Slots[slotName]; ok {
 		return slotInfo
 	}

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -31,8 +31,9 @@ import (
 
 type connSuite struct {
 	testutil.BaseTest
-	plug *sdk.PlugInfo
-	slot *sdk.SlotInfo
+	plug      *sdk.PlugInfo
+	slot      *sdk.SlotInfo
+	projectId string
 }
 
 var _ = check.Suite(&connSuite{})
@@ -40,6 +41,7 @@ var _ = check.Suite(&connSuite{})
 func (s *connSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
+	s.projectId = "42424242"
 	consumer := sdk.MockInfo(c, `
 name: consumer
 base: ubuntu@22.04
@@ -49,7 +51,7 @@ plugs:
         attr: value
         complex:
             c: d
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	s.plug = consumer.Plugs["plug"]
 	producer := sdk.MockInfo(c, `
 name: producer
@@ -61,7 +63,7 @@ slots:
         number: 100
         complex:
             a: b
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	s.slot = producer.Slots["slot"]
 }
 

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -60,9 +60,10 @@ var ByName = func(name string) (iface Interface, err error) {
 
 // PlugRef is a reference to a plug.
 type PlugRef struct {
-	Workshop string `json:"workshop"`
-	Sdk      string `json:"sdk"`
-	Name     string `json:"plug"`
+	ProjectId string `json:"project-id"`
+	Workshop  string `json:"workshop"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"plug"`
 }
 
 // String returns the "sdk:plug" representation of a plug reference.
@@ -93,9 +94,10 @@ func BeforePrepareSlot(iface Interface, slotInfo *sdk.SlotInfo) error {
 
 // SlotRef is a reference to a slot.
 type SlotRef struct {
-	Workshop string `json:"workshop"`
-	Sdk      string `json:"sdk"`
-	Name     string `json:"slot"`
+	ProjectId string `json:"project-id"`
+	Workshop  string `json:"workshop"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"slot"`
 }
 
 // String returns the "sdk:slot" representation of a slot reference.
@@ -136,14 +138,16 @@ type ConnRef struct {
 // NewConnRef creates a connection reference for given plug and slot
 func NewConnRef(plug *sdk.PlugInfo, slot *sdk.SlotInfo) *ConnRef {
 	return &ConnRef{
-		PlugRef: PlugRef{Sdk: plug.Sdk.Name, Name: plug.Name, Workshop: plug.Sdk.Workshop},
-		SlotRef: SlotRef{Sdk: slot.Sdk.Name, Name: slot.Name, Workshop: slot.Sdk.Workshop},
+		PlugRef: PlugRef{ProjectId: plug.Sdk.ProjectId, Sdk: plug.Sdk.Name, Name: plug.Name, Workshop: plug.Sdk.Workshop},
+		SlotRef: SlotRef{ProjectId: slot.Sdk.ProjectId, Sdk: slot.Sdk.Name, Name: slot.Name, Workshop: slot.Sdk.Workshop},
 	}
 }
 
 // ID returns a string identifying a given connection.
 func (conn *ConnRef) ID() string {
-	return fmt.Sprintf("%s:%s:%s %s:%s:%s", conn.PlugRef.Workshop, conn.PlugRef.Sdk, conn.PlugRef.Name, conn.SlotRef.Workshop, conn.SlotRef.Sdk, conn.SlotRef.Name)
+	return fmt.Sprintf("%s:%s:%s:%s %s:%s:%s:%s",
+		conn.PlugRef.ProjectId, conn.PlugRef.Workshop, conn.PlugRef.Sdk, conn.PlugRef.Name,
+		conn.SlotRef.ProjectId, conn.SlotRef.Workshop, conn.SlotRef.Sdk, conn.SlotRef.Name)
 }
 
 // SortsBefore returns true when connection should be sorted before the other
@@ -163,16 +167,19 @@ func ParseConnRef(id string) (*ConnRef, error) {
 	}
 	plugParts := strings.Split(parts[0], ":")
 	slotParts := strings.Split(parts[1], ":")
-	if len(plugParts) != 3 || len(slotParts) != 3 {
+	if len(plugParts) != 4 || len(slotParts) != 4 {
 		return nil, fmt.Errorf("malformed connection identifier: %q", id)
 	}
 
-	conn.PlugRef.Workshop = plugParts[0]
-	conn.PlugRef.Sdk = plugParts[1]
-	conn.PlugRef.Name = plugParts[2]
-	conn.SlotRef.Workshop = slotParts[0]
-	conn.SlotRef.Sdk = slotParts[1]
-	conn.SlotRef.Name = slotParts[2]
+	conn.PlugRef.ProjectId = plugParts[0]
+	conn.PlugRef.Workshop = plugParts[1]
+	conn.PlugRef.Sdk = plugParts[2]
+	conn.PlugRef.Name = plugParts[3]
+
+	conn.SlotRef.ProjectId = slotParts[0]
+	conn.SlotRef.Workshop = slotParts[1]
+	conn.SlotRef.Sdk = slotParts[2]
+	conn.SlotRef.Name = slotParts[3]
 	return &conn, nil
 }
 

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -38,6 +38,7 @@ func Test(t *testing.T) {
 
 type CoreSuite struct {
 	testutil.BaseTest
+	projectId string
 }
 
 var _ = Suite(&CoreSuite{})
@@ -45,6 +46,7 @@ var _ = Suite(&CoreSuite{})
 func (s *CoreSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
+	s.projectId = "42424242"
 }
 
 func (s *CoreSuite) TearDownTest(c *C) {
@@ -70,19 +72,19 @@ func (s *CoreSuite) TestSlotRefString(c *C) {
 // ConnRef.ID works as expected
 func (s *CoreSuite) TestConnRefID(c *C) {
 	conn := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{Workshop: "ws", Sdk: "producer", Name: "slot"},
+		PlugRef: interfaces.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"},
 	}
-	c.Check(conn.ID(), Equals, "ws:consumer:plug ws:producer:slot")
+	c.Check(conn.ID(), Equals, fmt.Sprintf("%s:ws:consumer:plug %s:ws:producer:slot", s.projectId, s.projectId))
 }
 
 // ParseConnRef works as expected
 func (s *CoreSuite) TestParseConnRef(c *C) {
-	ref, err := interfaces.ParseConnRef("ws:consumer:plug ws:producer:slot")
+	ref, err := interfaces.ParseConnRef("42424242:ws:consumer:plug 42424242:ws:producer:slot")
 	c.Assert(err, IsNil)
 	c.Check(ref, DeepEquals, &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{Workshop: "ws", Sdk: "producer", Name: "slot"},
+		PlugRef: interfaces.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"},
 	})
 	_, err = interfaces.ParseConnRef("garbage")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: "garbage"`)
@@ -149,7 +151,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: mock-service-snippets
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	plug := info.Plugs["plug"]
 
 	snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
@@ -173,7 +175,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: unclean-service-snippets
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	plug := info.Plugs["plug"]
 
 	iface, err := interfaces.ByName("unclean-service-snippets")
@@ -191,7 +193,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: iface
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	plug := info.Plugs["plug"]
 	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
 		InterfaceName: "iface",
@@ -212,7 +214,7 @@ base: ubuntu@22.04
 slots:
   slot:
     interface: iface
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	slot := info.Slots["slot"]
 	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
 		InterfaceName: "iface",

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -69,8 +69,8 @@ plugs:
   %s:
 `, iface)
 	}
-	slotSdk := sdk.MockInfo(c, slotYaml, "ws", sdk.Setup{})
-	plugSdk := sdk.MockInfo(c, plugYaml, "ws", sdk.Setup{})
+	slotSdk := sdk.MockInfo(c, slotYaml, "mock424242", "ws", sdk.Setup{})
+	plugSdk := sdk.MockInfo(c, plugYaml, "mock424242", "ws", sdk.Setup{})
 	return &policy.ConnectCandidate{
 		Plug:            interfaces.NewConnectedPlug(plugSdk.Plugs[iface], nil, nil),
 		Slot:            interfaces.NewConnectedSlot(slotSdk.Slots[iface], nil, nil),
@@ -87,7 +87,7 @@ slots:
   %s:
 `, sdkType, iface)
 	}
-	sdk := sdk.MockInfo(c, yaml, "ws", sdk.Setup{})
+	sdk := sdk.MockInfo(c, yaml, "mock424242", "ws", sdk.Setup{})
 	return &policy.InstallCandidate{
 		Sdk:             sdk,
 		BaseDeclaration: s.baseDecl,
@@ -103,7 +103,7 @@ plugs:
   %s:
 `, sdkType, iface)
 	}
-	sdk := sdk.MockInfo(c, yaml, "ws", sdk.Setup{})
+	sdk := sdk.MockInfo(c, yaml, "mock424242", "ws", sdk.Setup{})
 	return &policy.InstallCandidate{
 		Sdk:             sdk,
 		BaseDeclaration: s.baseDecl,

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -35,9 +35,9 @@ type Repository struct {
 	// Protects the internals from concurrent access.
 	m      sync.Mutex
 	ifaces map[string]Interface
-	// Indexed by [workshop-sdk][plugName]
+	// Indexed by [project-id-workshop-sdk][plugName]
 	plugs map[string]map[string]*sdk.PlugInfo
-	// Indexed by [workshop-sdk][plugName]
+	// Indexed by [project-id-workshop-sdk][slotName]
 	slots map[string]map[string]*sdk.SlotInfo
 	// given a slot and a plug, are they connected?
 	slotPlugs map[*sdk.SlotInfo]map[*sdk.PlugInfo]*Connection
@@ -59,8 +59,8 @@ func NewRepository() *Repository {
 	return repo
 }
 
-func plugOrSlotKey(workshop, sdkName string) string {
-	return strings.Join([]string{workshop, sdkName}, "-")
+func plugOrSlotKey(projectId, workshop, sdkName string) string {
+	return strings.Join([]string{projectId, workshop, sdkName}, "-")
 }
 
 // Interface returns an interface with a given name.
@@ -244,11 +244,11 @@ func (r *Repository) AllPlugs(interfaceName string) []*sdk.PlugInfo {
 }
 
 // Plugs returns the plugs offered by the named sdk.
-func (r *Repository) Plugs(workshop, sdkName string) []*sdk.PlugInfo {
+func (r *Repository) Plugs(projectId, workshop, sdkName string) []*sdk.PlugInfo {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, sdkName)
+	key := plugOrSlotKey(projectId, workshop, sdkName)
 
 	var result []*sdk.PlugInfo
 	for _, plug := range r.plugs[key] {
@@ -259,19 +259,19 @@ func (r *Repository) Plugs(workshop, sdkName string) []*sdk.PlugInfo {
 }
 
 // Plug returns the specified plug from the named sdk.
-func (r *Repository) Plug(workshop, sdkName, plugName string) *sdk.PlugInfo {
+func (r *Repository) Plug(projectId, workshop, sdkName, plugName string) *sdk.PlugInfo {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, sdkName)
+	key := plugOrSlotKey(projectId, workshop, sdkName)
 
 	return r.plugs[key][plugName]
 }
 
 // Connection returns the specified Connection object or an error.
 func (r *Repository) Connection(connRef *ConnRef) (*Connection, error) {
-	plugkey := plugOrSlotKey(connRef.PlugRef.Workshop, connRef.PlugRef.Sdk)
-	slotkey := plugOrSlotKey(connRef.SlotRef.Workshop, connRef.SlotRef.Sdk)
+	plugkey := plugOrSlotKey(connRef.PlugRef.ProjectId, connRef.PlugRef.Workshop, connRef.PlugRef.Sdk)
+	slotkey := plugOrSlotKey(connRef.SlotRef.ProjectId, connRef.SlotRef.Workshop, connRef.SlotRef.Sdk)
 
 	// Ensure that such plug exists
 	plug := r.plugs[plugkey][connRef.PlugRef.Name]
@@ -306,7 +306,7 @@ func (r *Repository) AddPlug(plug *sdk.PlugInfo) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(plug.Sdk.Workshop, plug.Sdk.Name)
+	key := plugOrSlotKey(plug.Sdk.ProjectId, plug.Sdk.Workshop, plug.Sdk.Name)
 
 	// Reject plugs with invalid names
 	if err := sdk.ValidatePlugName(plug.Name); err != nil {
@@ -331,11 +331,11 @@ func (r *Repository) AddPlug(plug *sdk.PlugInfo) error {
 
 // RemovePlug removes the named plug provided by a given sdk.
 // The removed plug must exist and must not be used anywhere.
-func (r *Repository) RemovePlug(workshop, sdkName, plugName string) error {
+func (r *Repository) RemovePlug(projectId, workshop, sdkName, plugName string) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, sdkName)
+	key := plugOrSlotKey(projectId, workshop, sdkName)
 
 	// Ensure that such plug exists
 	plug := r.plugs[key][plugName]
@@ -372,11 +372,11 @@ func (r *Repository) AllSlots(interfaceName string) []*sdk.SlotInfo {
 }
 
 // Slots returns the slots offered by the named sdk.
-func (r *Repository) Slots(workshop, sdkName string) []*sdk.SlotInfo {
+func (r *Repository) Slots(projectId, workshop, sdkName string) []*sdk.SlotInfo {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, sdkName)
+	key := plugOrSlotKey(projectId, workshop, sdkName)
 
 	var result []*sdk.SlotInfo
 	for _, slot := range r.slots[key] {
@@ -387,11 +387,11 @@ func (r *Repository) Slots(workshop, sdkName string) []*sdk.SlotInfo {
 }
 
 // Slot returns the specified slot from the named sdk.
-func (r *Repository) Slot(workshop, sdkName, slotName string) *sdk.SlotInfo {
+func (r *Repository) Slot(projectId, workshop, sdkName, slotName string) *sdk.SlotInfo {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, sdkName)
+	key := plugOrSlotKey(projectId, workshop, sdkName)
 
 	return r.slots[key][slotName]
 }
@@ -403,7 +403,7 @@ func (r *Repository) AddSlot(slot *sdk.SlotInfo) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(slot.Sdk.Workshop, slot.Sdk.Name)
+	key := plugOrSlotKey(slot.Sdk.ProjectId, slot.Sdk.Workshop, slot.Sdk.Name)
 
 	// Reject slots with invalid names
 	if err := sdk.ValidateSlotName(slot.Name); err != nil {
@@ -430,11 +430,11 @@ func (r *Repository) AddSlot(slot *sdk.SlotInfo) error {
 // RemoveSlot removes a named slot from the given sdk.
 // Removing a slot that doesn't exist returns an error.
 // Removing a slot that is connected to a plug returns an error.
-func (r *Repository) RemoveSlot(workshop, sdkName, slotName string) error {
+func (r *Repository) RemoveSlot(projectId, workshop, sdkName, slotName string) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, sdkName)
+	key := plugOrSlotKey(projectId, workshop, sdkName)
 
 	// Ensure that such slot exists
 	slot := r.slots[key][slotName]
@@ -476,8 +476,8 @@ func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, sl
 	slotSdkName := ref.SlotRef.Sdk
 	slotName := ref.SlotRef.Name
 
-	plugKey := plugOrSlotKey(ref.PlugRef.Workshop, plugSdkName)
-	slotKey := plugOrSlotKey(ref.SlotRef.Workshop, slotSdkName)
+	plugKey := plugOrSlotKey(ref.PlugRef.ProjectId, ref.PlugRef.Workshop, plugSdkName)
+	slotKey := plugOrSlotKey(ref.SlotRef.ProjectId, ref.SlotRef.Workshop, slotSdkName)
 
 	// Ensure that such plug exists
 	plug := r.plugs[plugKey][plugName]
@@ -566,7 +566,7 @@ func (e *NoPlugOrSlotError) Error() string {
 // Disconnect() finds a specific slot and a specific plug and disconnects that
 // plug from that slot. It is an error if plug or slot cannot be found or if
 // the connect does not exist.
-func (r *Repository) Disconnect(plugWorkshop, plugSdkName, plugName, slotWorkshop, slotSdkName, slotName string) error {
+func (r *Repository) Disconnect(plugProjectId, plugWorkshop, plugSdkName, plugName, slotProjectId, slotWorkshop, slotSdkName, slotName string) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
@@ -584,8 +584,8 @@ func (r *Repository) Disconnect(plugWorkshop, plugSdkName, plugName, slotWorksho
 		return fmt.Errorf("cannot disconnect, slot name is empty")
 	}
 
-	plugKey := plugOrSlotKey(plugWorkshop, plugSdkName)
-	slotKey := plugOrSlotKey(slotWorkshop, slotSdkName)
+	plugKey := plugOrSlotKey(plugProjectId, plugWorkshop, plugSdkName)
+	slotKey := plugOrSlotKey(slotProjectId, slotWorkshop, slotSdkName)
 
 	// Ensure that such plug exists
 	plug := r.plugs[plugKey][plugName]
@@ -620,8 +620,8 @@ func (r *Repository) DisconnectAll(conns []*ConnRef) {
 	defer r.m.Unlock()
 
 	for _, conn := range conns {
-		plugkey := plugOrSlotKey(conn.PlugRef.Workshop, conn.PlugRef.Sdk)
-		slotkey := plugOrSlotKey(conn.SlotRef.Workshop, conn.SlotRef.Sdk)
+		plugkey := plugOrSlotKey(conn.PlugRef.ProjectId, conn.PlugRef.Workshop, conn.PlugRef.Sdk)
+		slotkey := plugOrSlotKey(conn.SlotRef.ProjectId, conn.SlotRef.Workshop, conn.SlotRef.Sdk)
 
 		plug := r.plugs[plugkey][conn.PlugRef.Name]
 		slot := r.slots[slotkey][conn.SlotRef.Name]
@@ -645,14 +645,14 @@ func (r *Repository) disconnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) {
 
 // Connected returns references for all connections that are currently
 // established with the provided plug or slot.
-func (r *Repository) Connected(workshop, sdkName, plugOrSlotName string) ([]*ConnRef, error) {
+func (r *Repository) Connected(projectId, workshop, sdkName, plugOrSlotName string) ([]*ConnRef, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	return r.connected(workshop, sdkName, plugOrSlotName)
+	return r.connected(projectId, workshop, sdkName, plugOrSlotName)
 }
 
-func (r *Repository) connected(workshop, sdk, plugOrSlotName string) ([]*ConnRef, error) {
+func (r *Repository) connected(projectId, workshop, sdk, plugOrSlotName string) ([]*ConnRef, error) {
 	if workshop == "" {
 		return nil, fmt.Errorf("internal error: cannot obtain workshop name while computing connections")
 	}
@@ -661,7 +661,7 @@ func (r *Repository) connected(workshop, sdk, plugOrSlotName string) ([]*ConnRef
 		return nil, fmt.Errorf("internal error: cannot obtain sdk name while computing connections")
 	}
 
-	key := plugOrSlotKey(workshop, sdk)
+	key := plugOrSlotKey(projectId, workshop, sdk)
 
 	var conns []*ConnRef
 	if plugOrSlotName == "" {
@@ -692,7 +692,7 @@ func (r *Repository) connected(workshop, sdk, plugOrSlotName string) ([]*ConnRef
 	return conns, nil
 }
 
-func (r *Repository) Connections(workshop, sdk string) ([]*ConnRef, error) {
+func (r *Repository) Connections(projectId, workshop, sdk string) ([]*ConnRef, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 	if workshop == "" {
@@ -703,7 +703,7 @@ func (r *Repository) Connections(workshop, sdk string) ([]*ConnRef, error) {
 		return nil, fmt.Errorf("internal error: cannot obtain sdk name while computing connections")
 	}
 
-	key := plugOrSlotKey(workshop, sdk)
+	key := plugOrSlotKey(projectId, workshop, sdk)
 
 	var conns []*ConnRef
 	for _, plugInfo := range r.plugs[key] {
@@ -796,7 +796,7 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 
 	spec := backend.NewSpecification(user, projectId)
 
-	key := plugOrSlotKey(sdkInfo.Workshop, sdkInfo.Name)
+	key := plugOrSlotKey(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name)
 
 	// XXX: If either of the AddConnected{Plug,Slot} methods for a connection
 	// fail resiliently as-in they can never succeed (such as the case where a
@@ -859,7 +859,7 @@ func (r *Repository) AddSdk(sdkInfo *sdk.Info) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(sdkInfo.Workshop, sdkInfo.Name)
+	key := plugOrSlotKey(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name)
 
 	if r.plugs[key] != nil || r.slots[key] != nil {
 		return fmt.Errorf("cannot register interfaces for %q SDK more than once", key)
@@ -895,11 +895,11 @@ func (r *Repository) AddSdk(sdkInfo *sdk.Info) error {
 // RemoveSdk does not remove connections. The caller is responsible for
 // ensuring that connections are broken before calling this method. If this
 // constraint is violated then no changes are made and an error is returned.
-func (r *Repository) RemoveSdk(workshop, sdkName string) error {
+func (r *Repository) RemoveSdk(projectId, workshop, sdkName string) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, sdkName)
+	key := plugOrSlotKey(projectId, workshop, sdkName)
 
 	for plugName, plug := range r.plugs[key] {
 		if len(r.plugSlots[plug]) > 0 {
@@ -927,11 +927,11 @@ func (r *Repository) RemoveSdk(workshop, sdkName string) error {
 // DisconnectSdk disconnects all the connections to and from a given sdk.
 //
 // The return value is a list of names that were affected.
-func (r *Repository) DisconnectSdk(workshop, sdkName string) ([]string, error) {
+func (r *Repository) DisconnectSdk(projectId, workshop, sdkName string) ([]string, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, sdkName)
+	key := plugOrSlotKey(projectId, workshop, sdkName)
 
 	seen := make(map[*sdk.Info]bool)
 
@@ -970,11 +970,11 @@ type SideArity interface {
 
 // AutoConnectCandidateSlots finds and returns viable auto-connection candidates
 // for a given plug.
-func (r *Repository) AutoConnectCandidateSlots(workshop, plugSdkName, plugName string, policyCheck func(*ConnectedPlug, *ConnectedSlot) (bool, error)) []*sdk.SlotInfo {
+func (r *Repository) AutoConnectCandidateSlots(projectId, workshop, plugSdkName, plugName string, policyCheck func(*ConnectedPlug, *ConnectedSlot) (bool, error)) []*sdk.SlotInfo {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, plugSdkName)
+	key := plugOrSlotKey(projectId, workshop, plugSdkName)
 
 	plugInfo := r.plugs[key][plugName]
 	if plugInfo == nil {
@@ -1005,11 +1005,11 @@ func (r *Repository) AutoConnectCandidateSlots(workshop, plugSdkName, plugName s
 
 // AutoConnectCandidatePlugs finds and returns viable auto-connection candidates
 // for a given slot.
-func (r *Repository) AutoConnectCandidatePlugs(workshop, slotSdkName, slotName string, policyCheck func(*ConnectedPlug, *ConnectedSlot) (bool, error)) []*sdk.PlugInfo {
+func (r *Repository) AutoConnectCandidatePlugs(projectId, workshop, slotSdkName, slotName string, policyCheck func(*ConnectedPlug, *ConnectedSlot) (bool, error)) []*sdk.PlugInfo {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	key := plugOrSlotKey(workshop, slotSdkName)
+	key := plugOrSlotKey(projectId, workshop, slotSdkName)
 
 	slotInfo := r.slots[key][slotName]
 	if slotInfo == nil {

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -39,8 +39,9 @@ type RepositorySuite struct {
 	slot      *sdk.SlotInfo
 	emptyRepo *Repository
 	// Repository pre-populated with s.iface
-	testRepo *Repository
-	context  context.Context
+	testRepo  *Repository
+	context   context.Context
+	projectId string
 }
 
 var _ = Suite(&RepositorySuite{
@@ -77,9 +78,9 @@ func (s *RepositorySuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 
-	consumer := sdk.MockInfo(c, consumerYaml, "ws", sdk.Setup{Name: "plug-sdk"})
+	consumer := sdk.MockInfo(c, consumerYaml, s.projectId, "ws", sdk.Setup{Name: "plug-sdk"})
 	s.plug = consumer.Plugs["plug"]
-	producer := sdk.MockInfo(c, producerYaml, "ws", sdk.Setup{Name: "slot-sdk"})
+	producer := sdk.MockInfo(c, producerYaml, s.projectId, "ws", sdk.Setup{Name: "slot-sdk"})
 	s.slot = producer.Slots["slot"]
 	s.plugSelf = producer.Plugs["self"]
 
@@ -87,7 +88,8 @@ func (s *RepositorySuite) SetUpTest(c *C) {
 	s.testRepo = NewRepository()
 	err := s.testRepo.AddInterface(s.iface)
 	c.Assert(err, IsNil)
-	s.context = ifacetest.CreateTestContext("user", "42424242")
+	s.projectId = "42424242"
+	s.context = ifacetest.CreateTestContext("user", s.projectId)
 }
 
 func (s *RepositorySuite) TearDownTest(c *C) {
@@ -99,10 +101,10 @@ type instanceNameAndYaml struct {
 	Yaml string
 }
 
-func addPlugsSlotsFromInstances(c *C, repo *Repository, iys []instanceNameAndYaml) []*sdk.Info {
+func addPlugsSlotsFromInstances(c *C, repo *Repository, projectId string, iys []instanceNameAndYaml) []*sdk.Info {
 	result := make([]*sdk.Info, 0, len(iys))
 	for _, iy := range iys {
-		info := sdk.MockInfo(c, iy.Yaml, "ws-"+iy.Name, sdk.Setup{})
+		info := sdk.MockInfo(c, iy.Yaml, projectId, "ws-"+iy.Name, sdk.Setup{})
 		if iy.Name != "" {
 			c.Assert(sdk.Validate(info), IsNil)
 		}
@@ -231,14 +233,14 @@ func (s *RepositorySuite) TestAddPlugClashingPlug(c *C) {
 }
 
 func (s *RepositorySuite) TestAddPlugClashingSlot(c *C) {
-	snapInfo := &sdk.Info{Name: "sdk"}
+	sdkInfo := &sdk.Info{ProjectId: s.projectId, Workshop: "ws", Name: "sdk"}
 	plug := &sdk.PlugInfo{
-		Sdk:       snapInfo,
+		Sdk:       sdkInfo,
 		Name:      "clashing",
 		Interface: "interface",
 	}
 	slot := &sdk.SlotInfo{
-		Sdk:       snapInfo,
+		Sdk:       sdkInfo,
 		Name:      "clashing",
 		Interface: "interface",
 	}
@@ -247,7 +249,7 @@ func (s *RepositorySuite) TestAddPlugClashingSlot(c *C) {
 	err = s.testRepo.AddPlug(plug)
 	c.Assert(err, ErrorMatches, `sdk "sdk" has plug and slot conflicting on name "clashing"`)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 1)
-	c.Assert(s.testRepo.Slot(slot.Sdk.Workshop, slot.Sdk.Name, slot.Name), DeepEquals, slot)
+	c.Assert(s.testRepo.Slot(slot.Sdk.ProjectId, slot.Sdk.Workshop, slot.Sdk.Name, slot.Name), DeepEquals, slot)
 }
 
 func (s *RepositorySuite) TestAddPlugFailsWithInvalidPlugName(c *C) {
@@ -274,13 +276,13 @@ func (s *RepositorySuite) TestAddPlugParallelInstance(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
 
-	consumer := sdk.MockInfo(c, consumerYaml, "ws-instance", sdk.Setup{})
+	consumer := sdk.MockInfo(c, consumerYaml, s.projectId, "ws-instance", sdk.Setup{})
 	err = s.testRepo.AddPlug(consumer.Plugs["plug"])
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 2)
 
-	c.Assert(s.testRepo.Plug(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name), DeepEquals, s.plug)
-	c.Assert(s.testRepo.Plug(consumer.Workshop, consumer.Name, "plug"), DeepEquals, consumer.Plugs["plug"])
+	c.Assert(s.testRepo.Plug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name), DeepEquals, s.plug)
+	c.Assert(s.testRepo.Plug(consumer.ProjectId, consumer.Workshop, consumer.Name, "plug"), DeepEquals, consumer.Plugs["plug"])
 }
 
 // Tests for Repository.Plug()
@@ -288,12 +290,12 @@ func (s *RepositorySuite) TestAddPlugParallelInstance(c *C) {
 func (s *RepositorySuite) TestPlug(c *C) {
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
-	c.Assert(s.emptyRepo.Plug(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name), IsNil)
-	c.Assert(s.testRepo.Plug(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name), DeepEquals, s.plug)
+	c.Assert(s.emptyRepo.Plug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name), IsNil)
+	c.Assert(s.testRepo.Plug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name), DeepEquals, s.plug)
 }
 
 func (s *RepositorySuite) TestPlugSearch(c *C) {
-	addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+	addPlugsSlotsFromInstances(c, s.testRepo, s.projectId, []instanceNameAndYaml{
 		{Name: "xx", Yaml: `
 name: xx
 base: ubuntu@22.04
@@ -320,15 +322,15 @@ plugs:
 `},
 	})
 	// Plug() correctly finds plugs
-	c.Assert(s.testRepo.Plug("ws-xx", "xx", "a"), Not(IsNil))
-	c.Assert(s.testRepo.Plug("ws-xx", "xx", "b"), Not(IsNil))
-	c.Assert(s.testRepo.Plug("ws-xx", "xx", "c"), Not(IsNil))
-	c.Assert(s.testRepo.Plug("ws-yy", "yy", "a"), Not(IsNil))
-	c.Assert(s.testRepo.Plug("ws-yy", "yy", "b"), Not(IsNil))
-	c.Assert(s.testRepo.Plug("ws-yy", "yy", "c"), Not(IsNil))
-	c.Assert(s.testRepo.Plug("ws-zz_instance", "zz", "a"), Not(IsNil))
-	c.Assert(s.testRepo.Plug("ws-zz_instance", "zz", "b"), Not(IsNil))
-	c.Assert(s.testRepo.Plug("ws-zz_instance", "zz", "c"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "a"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "b"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "c"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "a"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "b"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "c"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "a"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "b"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "c"), Not(IsNil))
 }
 
 // Tests for Repository.RemovePlug()
@@ -336,13 +338,13 @@ plugs:
 func (s *RepositorySuite) TestRemovePlugSucceedsWhenPlugExistsAndDisconnected(c *C) {
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
-	err = s.testRepo.RemovePlug(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
+	err = s.testRepo.RemovePlug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 0)
 }
 
 func (s *RepositorySuite) TestRemovePlugFailsWhenPlugDoesntExist(c *C) {
-	err := s.emptyRepo.RemovePlug(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
+	err := s.emptyRepo.RemovePlug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
 	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from sdk "consumer", no such plug`)
 }
 
@@ -355,17 +357,17 @@ func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
 	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	// Removing a plug used by a slot returns an appropriate error
-	err = s.testRepo.RemovePlug(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
+	err = s.testRepo.RemovePlug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
 	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from sdk "consumer", it is still connected`)
 	// The plug is still there
-	slot := s.testRepo.Plug(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
+	slot := s.testRepo.Plug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
 	c.Assert(slot, Not(IsNil))
 }
 
 // Tests for Repository.AllPlugs()
 
 func (s *RepositorySuite) TestAllPlugsWithoutInterfaceName(c *C) {
-	sdks := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+	sdks := addPlugsSlotsFromInstances(c, s.testRepo, s.projectId, []instanceNameAndYaml{
 		{Name: "sdk-a", Yaml: `
 name: sdk-a
 base: ubuntu@22.04
@@ -407,7 +409,7 @@ func (s *RepositorySuite) TestAllPlugsWithInterfaceName(c *C) {
 	// Add another interface so that we can look for it
 	err := s.testRepo.AddInterface(&ifacetest.TestInterface{InterfaceName: "other-interface"})
 	c.Assert(err, IsNil)
-	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+	snaps := addPlugsSlotsFromInstances(c, s.testRepo, s.projectId, []instanceNameAndYaml{
 		{Name: "sdk-a", Yaml: `
 name: sdk-a
 base: ubuntu@22.04
@@ -441,7 +443,7 @@ plugs:
 // Tests for Repository.Plugs()
 
 func (s *RepositorySuite) TestPlugs(c *C) {
-	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+	snaps := addPlugsSlotsFromInstances(c, s.testRepo, s.projectId, []instanceNameAndYaml{
 		{Name: "sdk-a", Yaml: `
 name: sdk-a
 base: ubuntu@22.04
@@ -461,19 +463,19 @@ plugs:
 	})
 	c.Assert(snaps, HasLen, 2)
 	// The result is sorted by sdk and name
-	c.Assert(s.testRepo.Plugs("ws-sdk-a", "sdk-a"), DeepEquals, []*sdk.PlugInfo{
+	c.Assert(s.testRepo.Plugs(s.projectId, "ws-sdk-a", "sdk-a"), DeepEquals, []*sdk.PlugInfo{
 		snaps[0].Plugs["name-a"],
 		snaps[0].Plugs["name-b"],
 		snaps[0].Plugs["name-c"],
 	})
-	c.Assert(s.testRepo.Plugs("ws-sdk-b", "sdk-b"), DeepEquals, []*sdk.PlugInfo{
+	c.Assert(s.testRepo.Plugs(s.projectId, "ws-sdk-b", "sdk-b"), DeepEquals, []*sdk.PlugInfo{
 		snaps[1].Plugs["name-a"],
 		snaps[1].Plugs["name-b"],
 		snaps[1].Plugs["name-c"],
 	})
 	// The result is empty if the sdk is not known
-	c.Assert(s.testRepo.Plugs("ws-sdk-a", "sdk-x"), HasLen, 0)
-	c.Assert(s.testRepo.Plugs("ws-sdk-b", "sdk-b_other"), HasLen, 0)
+	c.Assert(s.testRepo.Plugs(s.projectId, "ws-sdk-a", "sdk-x"), HasLen, 0)
+	c.Assert(s.testRepo.Plugs(s.projectId, "ws-sdk-b", "sdk-b_other"), HasLen, 0)
 }
 
 // Tests for Repository.AllSlots()
@@ -481,7 +483,7 @@ plugs:
 func (s *RepositorySuite) TestAllSlots(c *C) {
 	err := s.testRepo.AddInterface(&ifacetest.TestInterface{InterfaceName: "other-interface"})
 	c.Assert(err, IsNil)
-	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+	snaps := addPlugsSlotsFromInstances(c, s.testRepo, s.projectId, []instanceNameAndYaml{
 		{Name: "sdk-a", Yaml: `
 name: sdk-a
 base: ubuntu@22.04
@@ -520,7 +522,7 @@ slots:
 // Tests for Repository.Slots()
 
 func (s *RepositorySuite) TestSlots(c *C) {
-	snaps := addPlugsSlotsFromInstances(c, s.testRepo, []instanceNameAndYaml{
+	snaps := addPlugsSlotsFromInstances(c, s.testRepo, s.projectId, []instanceNameAndYaml{
 		{Name: "sdk-a", Yaml: `
 name: sdk-a
 base: ubuntu@22.04
@@ -536,20 +538,20 @@ slots:
 `},
 	})
 	// Slots("sdk-a") returns slots present in that sdk
-	c.Assert(s.testRepo.Slots("ws-sdk-a", "sdk-a"), DeepEquals, []*sdk.SlotInfo{
+	c.Assert(s.testRepo.Slots(s.projectId, "ws-sdk-a", "sdk-a"), DeepEquals, []*sdk.SlotInfo{
 		snaps[0].Slots["name-a"],
 		snaps[0].Slots["name-b"],
 	})
 	// Slots("sdk-b") returns slots present in that sdk
-	c.Assert(s.testRepo.Slots("ws-sdk-b", "sdk-b"), DeepEquals, []*sdk.SlotInfo{
+	c.Assert(s.testRepo.Slots(s.projectId, "ws-sdk-b", "sdk-b"), DeepEquals, []*sdk.SlotInfo{
 		snaps[1].Slots["name-a"],
 	})
 	// Slots("sdk-c") returns no slots (because that sdk doesn't exist)
-	c.Assert(s.testRepo.Slots("ws-sdk-a", "sdk-c"), HasLen, 0)
+	c.Assert(s.testRepo.Slots(s.projectId, "ws-sdk-a", "sdk-c"), HasLen, 0)
 	// Slots("sdk-b_other") returns no slots (the sdk does not exist)
-	c.Assert(s.testRepo.Slots("ws-sdk-a", "sdk-b_other"), HasLen, 0)
+	c.Assert(s.testRepo.Slots(s.projectId, "ws-sdk-a", "sdk-b_other"), HasLen, 0)
 	// Slots("") returns no slots
-	c.Assert(s.testRepo.Slots("ws-sdk-a", ""), HasLen, 0)
+	c.Assert(s.testRepo.Slots(s.projectId, "ws-sdk-a", ""), HasLen, 0)
 }
 
 // Tests for Repository.Slot()
@@ -557,12 +559,12 @@ slots:
 func (s *RepositorySuite) TestSlotSucceedsWhenSlotExists(c *C) {
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	slot := s.testRepo.Slot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(slot, DeepEquals, s.slot)
 }
 
 func (s *RepositorySuite) TestSlotFailsWhenSlotDoesntExist(c *C) {
-	slot := s.testRepo.Slot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(slot, IsNil)
 }
 
@@ -610,13 +612,13 @@ func (s *RepositorySuite) TestAddSlotClashingPlug(c *C) {
 	err = s.testRepo.AddSlot(slot)
 	c.Assert(err, ErrorMatches, `sdk "sdk" has plug and slot conflicting on name "clashing"`)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
-	c.Assert(s.testRepo.Plug(plug.Sdk.Workshop, plug.Sdk.Name, plug.Name), DeepEquals, plug)
+	c.Assert(s.testRepo.Plug(plug.Sdk.ProjectId, plug.Sdk.Workshop, plug.Sdk.Name, plug.Name), DeepEquals, plug)
 }
 
 func (s *RepositorySuite) TestAddSlotStoresCorrectData(c *C) {
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
-	slot := s.testRepo.Slot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	// The added slot has the same data
 	c.Assert(slot, DeepEquals, s.slot)
 }
@@ -628,13 +630,13 @@ func (s *RepositorySuite) TestAddSlotParallelInstance(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 1)
 
-	producer := sdk.MockInfo(c, producerYaml, "ws-instance", sdk.Setup{})
+	producer := sdk.MockInfo(c, producerYaml, s.projectId, "ws-instance", sdk.Setup{})
 	err = s.testRepo.AddSlot(producer.Slots["slot"])
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 2)
 
-	c.Assert(s.testRepo.Slot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name), DeepEquals, s.slot)
-	c.Assert(s.testRepo.Slot(producer.Workshop, producer.Name, "slot"), DeepEquals, producer.Slots["slot"])
+	c.Assert(s.testRepo.Slot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name), DeepEquals, s.slot)
+	c.Assert(s.testRepo.Slot(producer.ProjectId, producer.Workshop, producer.Name, "slot"), DeepEquals, producer.Slots["slot"])
 }
 
 // Tests for Repository.RemoveSlot()
@@ -643,16 +645,16 @@ func (s *RepositorySuite) TestRemoveSlotSuccedsWhenSlotExistsAndDisconnected(c *
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Removing a vacant slot simply works
-	err = s.testRepo.RemoveSlot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err = s.testRepo.RemoveSlot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	// The slot is gone now
-	slot := s.testRepo.Slot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(slot, IsNil)
 }
 
 func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotDoesntExist(c *C) {
 	// Removing a slot that doesn't exist returns an appropriate error
-	err := s.testRepo.RemoveSlot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err := s.testRepo.RemoveSlot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from sdk "producer", no such slot`)
 }
@@ -666,10 +668,10 @@ func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotIsConnected(c *C) {
 	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	// Removing a slot occupied by a plug returns an appropriate error
-	err = s.testRepo.RemoveSlot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err = s.testRepo.RemoveSlot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from sdk "producer", it is still connected`)
 	// The slot is still there
-	slot := s.testRepo.Slot(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	slot := s.testRepo.Slot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(slot, Not(IsNil))
 }
 
@@ -726,8 +728,9 @@ func (s *RepositorySuite) TestConnectFailsWhenSlotAndPlugAreIncompatible(c *C) {
 	err := s.testRepo.AddInterface(otherInterface)
 	plug := &sdk.PlugInfo{
 		Sdk: &sdk.Info{
-			Workshop: "ws",
-			Name:     "consumer"},
+			ProjectId: s.projectId,
+			Workshop:  "ws",
+			Name:      "consumer"},
 		Name:      "plug",
 		Interface: "other-interface",
 	}
@@ -757,10 +760,10 @@ func (s *RepositorySuite) TestConnectSucceeds(c *C) {
 
 // Disconnect fails if any argument is empty
 func (s *RepositorySuite) TestDisconnectFailsOnEmptyArgs(c *C) {
-	err1 := s.testRepo.Disconnect(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workshop, s.slot.Sdk.Name, "")
-	err2 := s.testRepo.Disconnect(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workshop, "", s.slot.Name)
-	err3 := s.testRepo.Disconnect(s.plug.Sdk.Workshop, s.plug.Sdk.Name, "", s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	err4 := s.testRepo.Disconnect(s.plug.Sdk.Workshop, "", s.plug.Name, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err1 := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, "")
+	err2 := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, "", s.slot.Name)
+	err3 := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, "", s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err4 := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, "", s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err1, ErrorMatches, `cannot disconnect, slot name is empty`)
 	c.Assert(err2, ErrorMatches, `cannot disconnect, slot sdk name is empty`)
 	c.Assert(err3, ErrorMatches, `cannot disconnect, plug name is empty`)
@@ -770,7 +773,7 @@ func (s *RepositorySuite) TestDisconnectFailsOnEmptyArgs(c *C) {
 // Disconnect fails if plug doesn't exist
 func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
-	err := s.testRepo.Disconnect(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `sdk "consumer" has no plug named "plug"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
@@ -779,7 +782,7 @@ func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
 // Disconnect fails if slot doesn't exist
 func (s *RepositorySuite) TestDisconnectFailsWithutSlot(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
-	err := s.testRepo.Disconnect(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `sdk "producer" has no slot named "slot"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
@@ -789,7 +792,7 @@ func (s *RepositorySuite) TestDisconnectFailsWithutSlot(c *C) {
 func (s *RepositorySuite) TestDisconnectFailsWhenNotConnected(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
-	err := s.testRepo.Disconnect(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, ErrorMatches, `cannot disconnect consumer:plug from producer:slot, it is not connected`)
 	e, _ := err.(*NotConnectedError)
 	c.Check(e, NotNil)
@@ -803,7 +806,7 @@ func (s *RepositorySuite) TestDisconnectSucceeds(c *C) {
 	c.Assert(err, IsNil)
 	_, err = s.testRepo.Connect(NewConnRef(s.plug, s.slot), nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
-	err = s.testRepo.Disconnect(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err = s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
 		Plugs: []*sdk.PlugInfo{s.plug},
@@ -815,25 +818,25 @@ func (s *RepositorySuite) TestDisconnectSucceeds(c *C) {
 
 // Connected fails if sdk name is empty
 func (s *RepositorySuite) TestConnectedFailsWithEmptyWorkshopName(c *C) {
-	_, err := s.testRepo.Connected("ws", "", s.plug.Name)
+	_, err := s.testRepo.Connected(s.projectId, "ws", "", s.plug.Name)
 	c.Check(err, ErrorMatches, "internal error: cannot obtain sdk name while computing connections")
 }
 
 func (s *RepositorySuite) TestConnectedFailsWithEmptySdkName(c *C) {
-	_, err := s.testRepo.Connected("", "ws", s.plug.Name)
+	_, err := s.testRepo.Connected(s.projectId, "", "ws", s.plug.Name)
 	c.Check(err, ErrorMatches, "internal error: cannot obtain workshop name while computing connections")
 }
 
 // Connected fails if plug or slot name is empty
 func (s *RepositorySuite) TestConnectedFailsWithEmptyPlugSlotName(c *C) {
-	_, err := s.testRepo.Connected("ws", s.plug.Sdk.Name, "")
+	_, err := s.testRepo.Connected(s.projectId, "ws", s.plug.Sdk.Name, "")
 	c.Check(err, ErrorMatches, "plug or slot name is empty")
 }
 
 // Connected fails if plug or slot doesn't exist
 func (s *RepositorySuite) TestConnectedFailsWithoutPlugOrSlot(c *C) {
-	_, err1 := s.testRepo.Connected(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
-	_, err2 := s.testRepo.Connected(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	_, err1 := s.testRepo.Connected(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
+	_, err2 := s.testRepo.Connected(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Check(err1, ErrorMatches, `sdk "consumer" has no plug or slot named "plug"`)
 	e, _ := err1.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
@@ -849,11 +852,11 @@ func (s *RepositorySuite) TestConnectedFindsConnections(c *C) {
 	_, err := s.testRepo.Connect(NewConnRef(s.plug, s.slot), nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	conns, err := s.testRepo.Connected(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
+	conns, err := s.testRepo.Connected(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plug, s.slot)})
 
-	conns, err = s.testRepo.Connected(s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	conns, err = s.testRepo.Connected(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plug, s.slot)})
 }
@@ -865,15 +868,15 @@ func (s *RepositorySuite) TestConnections(c *C) {
 	_, err := s.testRepo.Connect(NewConnRef(s.plug, s.slot), nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	conns, err := s.testRepo.Connections(s.plug.Sdk.Workshop, s.plug.Sdk.Name)
+	conns, err := s.testRepo.Connections(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plug, s.slot)})
 
-	conns, err = s.testRepo.Connections(s.slot.Sdk.Workshop, s.slot.Sdk.Name)
+	conns, err = s.testRepo.Connections(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plug, s.slot)})
 
-	conns, err = s.testRepo.Connections("ws", "abc")
+	conns, err = s.testRepo.Connections(s.projectId, "ws", "abc")
 	c.Assert(err, IsNil)
 	c.Assert(conns, HasLen, 0)
 }
@@ -884,11 +887,11 @@ func (s *RepositorySuite) TestConnectionsWithSelfConnected(c *C) {
 	_, err := s.testRepo.Connect(NewConnRef(s.plugSelf, s.slot), nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	conns, err := s.testRepo.Connections(s.plug.Sdk.Workshop, s.plugSelf.Sdk.Name)
+	conns, err := s.testRepo.Connections(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plugSelf.Sdk.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plugSelf, s.slot)})
 
-	conns, err = s.testRepo.Connections(s.slot.Sdk.Workshop, s.slot.Sdk.Name)
+	conns, err = s.testRepo.Connections(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []*ConnRef{NewConnRef(s.plugSelf, s.slot)})
 }
@@ -927,7 +930,7 @@ func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
 		Connections: []*ConnRef{NewConnRef(s.plug, s.slot)},
 	})
 	// After disconnecting the connections become empty
-	err = s.testRepo.Disconnect(s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
+	err = s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, IsNil)
 	ifaces = s.testRepo.Interfaces()
 	c.Assert(ifaces, DeepEquals, &Interfaces{
@@ -1078,26 +1081,26 @@ base: ubuntu@22.04
 plugs:
     auto:
     manual:
-`, "ws", sdk.Setup{Name: "consumer"})
+`, s.projectId, "ws", sdk.Setup{Name: "consumer"})
 	producer := sdk.MockInfo(c, `
 name: producer
 base: ubuntu@22.04
 slots:
     auto:
     manual:
-`, "ws", sdk.Setup{Name: "producer"})
+`, s.projectId, "ws", sdk.Setup{Name: "producer"})
 	err = repo.AddSdk(producer)
 	c.Assert(err, IsNil)
 	err = repo.AddSdk(consumer)
 	c.Assert(err, IsNil)
 
-	candidateSlots := repo.AutoConnectCandidateSlots("ws", "consumer", "auto", policyCheck)
+	candidateSlots := repo.AutoConnectCandidateSlots(s.projectId, "ws", "consumer", "auto", policyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Sdk.Name, Equals, "producer")
 	c.Check(candidateSlots[0].Interface, Equals, "auto")
 	c.Check(candidateSlots[0].Name, Equals, "auto")
 
-	candidatePlugs := repo.AutoConnectCandidatePlugs("ws", "producer", "auto", policyCheck)
+	candidatePlugs := repo.AutoConnectCandidatePlugs(s.projectId, "ws", "producer", "auto", policyCheck)
 	c.Assert(candidatePlugs, HasLen, 1)
 	c.Check(candidatePlugs[0].Sdk.Name, Equals, "consumer")
 	c.Check(candidatePlugs[0].Interface, Equals, "auto")
@@ -1120,7 +1123,7 @@ name: producer
 base: ubuntu@22.04
 slots:
     auto:
-`, "ws", sdk.Setup{Name: "producer"})
+`, s.projectId, "ws", sdk.Setup{Name: "producer"})
 	err = repo.AddSdk(producer)
 	c.Assert(err, IsNil)
 
@@ -1130,7 +1133,7 @@ name: consumer1
 base: ubuntu@22.04
 plugs:
     auto:
-`, "ws", sdk.Setup{Name: "consumer1"})
+`, s.projectId, "ws", sdk.Setup{Name: "consumer1"})
 
 	err = repo.AddSdk(consumer1)
 	c.Assert(err, IsNil)
@@ -1141,19 +1144,19 @@ name: consumer2
 base: ubuntu@22.04
 plugs:
     auto:
-`, "ws", sdk.Setup{Name: "consumer2"})
+`, s.projectId, "ws", sdk.Setup{Name: "consumer2"})
 
 	err = repo.AddSdk(consumer2)
 	c.Assert(err, IsNil)
 
 	// Both can auto-connect
-	candidateSlots := repo.AutoConnectCandidateSlots("ws", "consumer1", "auto", policyCheck)
+	candidateSlots := repo.AutoConnectCandidateSlots(s.projectId, "ws", "consumer1", "auto", policyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Sdk.Name, Equals, "producer")
 	c.Check(candidateSlots[0].Interface, Equals, "auto")
 	c.Check(candidateSlots[0].Name, Equals, "auto")
 
-	candidateSlots = repo.AutoConnectCandidateSlots("ws", "consumer2", "auto", policyCheck)
+	candidateSlots = repo.AutoConnectCandidateSlots(s.projectId, "ws", "consumer2", "auto", policyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Sdk.Name, Equals, "producer")
 	c.Check(candidateSlots[0].Interface, Equals, "auto")
@@ -1161,7 +1164,7 @@ plugs:
 
 	// Plugs candidates seen from the producer (for example if
 	// it's installed after) should be the same
-	candidatePlugs := repo.AutoConnectCandidatePlugs("ws", "producer", "auto", policyCheck)
+	candidatePlugs := repo.AutoConnectCandidatePlugs(s.projectId, "ws", "producer", "auto", policyCheck)
 	c.Assert(candidatePlugs, HasLen, 2)
 }
 
@@ -1169,7 +1172,8 @@ plugs:
 
 type AddRemoveSuite struct {
 	testutil.BaseTest
-	repo *Repository
+	repo      *Repository
+	projectId string
 }
 
 var _ = Suite(&AddRemoveSuite{})
@@ -1191,10 +1195,11 @@ func (s *AddRemoveSuite) SetUpTest(c *C) {
 
 func (s *AddRemoveSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
+	s.projectId = "42424242"
 }
 
-func (s *AddRemoveSuite) addSdk(c *C, yaml string) (*sdk.Info, error) {
-	sdkInfo := sdk.MockInfo(c, yaml, "ws", sdk.Setup{})
+func (s *AddRemoveSuite) addSdk(c *C, yaml string, projectId string) (*sdk.Info, error) {
+	sdkInfo := sdk.MockInfo(c, yaml, projectId, "ws", sdk.Setup{})
 	return sdkInfo, s.repo.AddSdk(sdkInfo)
 }
 
@@ -1206,25 +1211,25 @@ plugs:
   bogus-plug:
 slots:
   bogus-slot:
-`)
+`, s.projectId)
 	c.Assert(err, IsNil)
 	// the sdk knowns about the bogus plug and slot
 	c.Assert(info.Plugs["bogus-plug"], NotNil)
 	c.Assert(info.Slots["bogus-slot"], NotNil)
 	// but the repository ignores them
-	c.Assert(s.repo.Plug("ws", "bogus", "bogus-plug"), IsNil)
-	c.Assert(s.repo.Slot("ws", "bogus", "bogus-slot"), IsNil)
+	c.Assert(s.repo.Plug(s.projectId, "ws", "bogus", "bogus-plug"), IsNil)
+	c.Assert(s.repo.Slot(s.projectId, "ws", "bogus", "bogus-slot"), IsNil)
 }
 
-type DisconnectSnapSuite struct {
+type DisconnectSdkSuite struct {
 	testutil.BaseTest
 	repo               *Repository
 	s1, s2, s2Instance *sdk.Info
 }
 
-var _ = Suite(&DisconnectSnapSuite{})
+var _ = Suite(&DisconnectSdkSuite{})
 
-func (s *DisconnectSnapSuite) SetUpTest(c *C) {
+func (s *DisconnectSdkSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 
@@ -1244,7 +1249,7 @@ plugs:
     iface-a:
 slots:
     iface-b:
-`, "ws", setup)
+`, "42424242", "ws", setup)
 	err = s.repo.AddSdk(s.s1)
 	c.Assert(err, IsNil)
 
@@ -1255,7 +1260,7 @@ plugs:
     iface-b:
 slots:
     iface-a:
-`, "ws", setup)
+`, "42424242", "ws", setup)
 	c.Assert(err, IsNil)
 	err = s.repo.AddSdk(s.s2)
 	c.Assert(err, IsNil)
@@ -1266,71 +1271,83 @@ plugs:
     iface-b:
 slots:
     iface-a:
-`, "ws", setup)
+`, "42424242", "ws", setup)
 	c.Assert(err, IsNil)
 	err = s.repo.AddSdk(s.s2Instance)
 	c.Assert(err, IsNil)
 }
 
-func (s *DisconnectSnapSuite) TearDownTest(c *C) {
+func (s *DisconnectSdkSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-func (s *DisconnectSnapSuite) TestNotConnected(c *C) {
-	affected, err := s.repo.DisconnectSdk("ws", "s1")
+func (s *DisconnectSdkSuite) TestNotConnected(c *C) {
+	affected, err := s.repo.DisconnectSdk("42424242", "ws", "s1")
 	c.Assert(err, IsNil)
 	c.Check(affected, HasLen, 0)
 }
 
-func (s *DisconnectSnapSuite) TestOutgoingConnection(c *C) {
-	connRef := &ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s1", Name: "iface-a"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s2", Name: "iface-a"}}
+func (s *DisconnectSdkSuite) TestOutgoingConnection(c *C) {
+	connRef := &ConnRef{
+		PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
+		SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-a"}}
 	_, err := s.repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	// Disconnect s1 with which has an outgoing connection to s2
-	affected, err := s.repo.DisconnectSdk("ws", "s1")
+	affected, err := s.repo.DisconnectSdk("42424242", "ws", "s1")
 	c.Assert(err, IsNil)
 	c.Check(affected, testutil.Contains, "s1")
 	c.Check(affected, testutil.Contains, "s2")
 }
 
-func (s *DisconnectSnapSuite) TestIncomingConnection(c *C) {
-	connRef := &ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s2", Name: "iface-b"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s1", Name: "iface-b"}}
+func (s *DisconnectSdkSuite) TestIncomingConnection(c *C) {
+	connRef := &ConnRef{
+		PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-b"},
+		SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}
 	_, err := s.repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	// Disconnect s1 with which has an incoming connection from s2
-	affected, err := s.repo.DisconnectSdk("ws", "s1")
+	affected, err := s.repo.DisconnectSdk("42424242", "ws", "s1")
 	c.Assert(err, IsNil)
 	c.Check(affected, testutil.Contains, "s1")
 	c.Check(affected, testutil.Contains, "s2")
 }
 
-func (s *DisconnectSnapSuite) TestCrossConnection(c *C) {
+func (s *DisconnectSdkSuite) TestCrossConnection(c *C) {
 	// This test is symmetric wrt s1 <-> s2 connections
 	for _, sdkName := range []string{"s1", "s2"} {
-		connRef1 := &ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s1", Name: "iface-a"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s2", Name: "iface-a"}}
+		connRef1 := &ConnRef{
+			PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
+			SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-a"}}
 		_, err := s.repo.Connect(connRef1, nil, nil, nil, nil, nil)
 		c.Assert(err, IsNil)
-		connRef2 := &ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s2", Name: "iface-b"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s1", Name: "iface-b"}}
+		connRef2 := &ConnRef{
+			PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-b"},
+			SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}
 		_, err = s.repo.Connect(connRef2, nil, nil, nil, nil, nil)
 		c.Assert(err, IsNil)
-		affected, err := s.repo.DisconnectSdk("ws", sdkName)
+		affected, err := s.repo.DisconnectSdk("42424242", "ws", sdkName)
 		c.Assert(err, IsNil)
 		c.Check(affected, testutil.Contains, "s1")
 		c.Check(affected, testutil.Contains, "s2")
 	}
 }
 
-func (s *DisconnectSnapSuite) TestParallelInstances(c *C) {
-	_, err := s.repo.Connect(&ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s1", Name: "iface-a"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s2-instance", Name: "iface-a"}}, nil, nil, nil, nil, nil)
+func (s *DisconnectSdkSuite) TestParallelInstances(c *C) {
+	_, err := s.repo.Connect(&ConnRef{
+		PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
+		SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2-instance", Name: "iface-a"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
-	affected, err := s.repo.DisconnectSdk("ws", "s1")
+	affected, err := s.repo.DisconnectSdk("42424242", "ws", "s1")
 	c.Assert(err, IsNil)
 	c.Check(affected, testutil.Contains, "s1")
 	c.Check(affected, testutil.Contains, "s2-instance")
 
-	_, err = s.repo.Connect(&ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s2-instance", Name: "iface-b"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s1", Name: "iface-b"}}, nil, nil, nil, nil, nil)
+	_, err = s.repo.Connect(&ConnRef{
+		PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2-instance", Name: "iface-b"},
+		SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
-	affected, err = s.repo.DisconnectSdk("ws", "s1")
+	affected, err = s.repo.DisconnectSdk("42424242", "ws", "s1")
 	c.Assert(err, IsNil)
 	c.Check(affected, testutil.Contains, "s1")
 	c.Check(affected, testutil.Contains, "s2-instance")
@@ -1346,7 +1363,7 @@ func contentAutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
 
 // internal helper that creates a new repository with two snaps, one
 // is a content plug and one a content slot
-func makeContentConnectionTestSdks(c *C, plugContentToken, slotContentToken string) (*Repository, *sdk.Info, *sdk.Info) {
+func makeContentConnectionTestSdks(c *C, projectId, plugContentToken, slotContentToken string) (*Repository, *sdk.Info, *sdk.Info) {
 	repo := NewRepository()
 	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "content", AutoConnectCallback: contentAutoConnect})
 	c.Assert(err, IsNil)
@@ -1358,7 +1375,7 @@ plugs:
   imported-content:
     interface: content
     content: %s
-`, plugContentToken), "ws-importer", sdk.Setup{})
+`, plugContentToken), projectId, "ws-importer", sdk.Setup{})
 	slotSnap := sdk.MockInfo(c, fmt.Sprintf(`
 name: content-slot-sdk
 base: ubuntu@22.04
@@ -1366,7 +1383,7 @@ slots:
   exported-content:
     interface: content
     content: %s
-`, slotContentToken), "ws-exporter", sdk.Setup{})
+`, slotContentToken), projectId, "ws-exporter", sdk.Setup{})
 
 	err = repo.AddSdk(plugSnap)
 	c.Assert(err, IsNil)
@@ -1377,29 +1394,29 @@ slots:
 }
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceSimple(c *C) {
-	repo, _, _ := makeContentConnectionTestSdks(c, "mylib", "mylib")
-	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
+	repo, _, _ := makeContentConnectionTestSdks(c, s.projectId, "mylib", "mylib")
+	candidateSlots := repo.AutoConnectCandidateSlots(s.projectId, "ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Name, Equals, "exported-content")
-	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
+	candidatePlugs := repo.AutoConnectCandidatePlugs(s.projectId, "ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
 	c.Assert(candidatePlugs, HasLen, 1)
 	c.Check(candidatePlugs[0].Name, Equals, "imported-content")
 }
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceOSWorksCorrectly(c *C) {
-	repo, _, _ := makeContentConnectionTestSdks(c, "mylib", "otherlib")
+	repo, _, _ := makeContentConnectionTestSdks(c, s.projectId, "mylib", "otherlib")
 
-	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
+	candidateSlots := repo.AutoConnectCandidateSlots(s.projectId, "ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)
-	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
+	candidatePlugs := repo.AutoConnectCandidatePlugs(s.projectId, "ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
 	c.Assert(candidatePlugs, HasLen, 0)
 }
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingContent(c *C) {
-	repo, _, _ := makeContentConnectionTestSdks(c, "mylib", "otherlib")
-	candidateSlots := repo.AutoConnectCandidateSlots("ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
+	repo, _, _ := makeContentConnectionTestSdks(c, s.projectId, "mylib", "otherlib")
+	candidateSlots := repo.AutoConnectCandidateSlots(s.projectId, "ws-importer", "content-plug-sdk", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)
-	candidatePlugs := repo.AutoConnectCandidatePlugs("ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
+	candidatePlugs := repo.AutoConnectCandidatePlugs(s.projectId, "ws-exporter", "content-slot-sdk", "exported-content", contentPolicyCheck)
 	c.Assert(candidatePlugs, HasLen, 0)
 }
 
@@ -1441,16 +1458,18 @@ func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, "ws-s1", sdk.Setup{})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, "ws-s2", sdk.Setup{})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
 	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
-	conn, err := s.emptyRepo.Connect(&ConnRef{PlugRef: PlugRef{Workshop: "ws-s1", Sdk: "s1", Name: "consumer"}, SlotRef: SlotRef{Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+	conn, err := s.emptyRepo.Connect(&ConnRef{
+		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
+		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
 	c.Assert(err, IsNil)
 	c.Assert(conn, NotNil)
 
@@ -1475,9 +1494,9 @@ func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, "ws-s1", sdk.Setup{})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, "ws-s2", sdk.Setup{})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
@@ -1485,7 +1504,9 @@ func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
 
-	conn, err := s.emptyRepo.Connect(&ConnRef{PlugRef: PlugRef{Workshop: "ws-s1", Sdk: "s1", Name: "consumer"}, SlotRef: SlotRef{Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+	conn, err := s.emptyRepo.Connect(&ConnRef{
+		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
+		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot connect plug "consumer" of sdk "s1": invalid plug`)
 	c.Assert(conn, IsNil)
@@ -1499,9 +1520,9 @@ func (s *RepositorySuite) TestBeforeConnectValidationPolicyCheckFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, "ws-s1", sdk.Setup{})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, "ws-s2", sdk.Setup{})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2", sdk.Setup{})
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
@@ -1511,7 +1532,9 @@ func (s *RepositorySuite) TestBeforeConnectValidationPolicyCheckFailure(c *C) {
 		return false, fmt.Errorf("policy check failed")
 	}
 
-	conn, err := s.emptyRepo.Connect(&ConnRef{PlugRef: PlugRef{Workshop: "ws-s1", Sdk: "s1", Name: "consumer"}, SlotRef: SlotRef{Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+	conn, err := s.emptyRepo.Connect(&ConnRef{
+		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
+		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `policy check failed`)
 	c.Assert(conn, IsNil)
@@ -1534,12 +1557,16 @@ func (s *RepositorySuite) TestConnection(c *C) {
 	c.Assert(conn.Plug.Name(), Equals, "plug")
 	c.Assert(conn.Slot.Name(), Equals, "slot")
 
-	_, err = s.testRepo.Connection(&ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "a", Name: "b"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "producer", Name: "slot"}})
+	_, err = s.testRepo.Connection(&ConnRef{
+		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"},
+		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"}})
 	c.Assert(err, ErrorMatches, `sdk "a" has no plug named "b"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 
-	_, err = s.testRepo.Connection(&ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "consumer", Name: "plug"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "a", Name: "b"}})
+	_, err = s.testRepo.Connection(&ConnRef{
+		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"}})
 	c.Assert(err, ErrorMatches, `sdk "a" has no slot named "b"`)
 	e, _ = err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
@@ -1582,7 +1609,7 @@ base: ubuntu@22.04
 plugs:
   i1:
   i2:
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	c.Assert(r.AddSdk(s1), IsNil)
 
 	s2 := sdk.MockInfo(c, `
@@ -1591,7 +1618,7 @@ base: ubuntu@22.04
 slots: 
   i1:
   i3:
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	c.Assert(r.AddSdk(s2), IsNil)
 
 	s3 := sdk.MockInfo(c, `
@@ -1600,22 +1627,28 @@ base: ubuntu@22.04
 type: core
 slots:
   i2:
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	c.Assert(r.AddSdk(s3), IsNil)
 	s4 := sdk.MockInfo(c, `
 name: s4
 base: ubuntu@22.04
 plugs:
   i2:
-`, "ws", sdk.Setup{})
+`, s.projectId, "ws", sdk.Setup{})
 	c.Assert(r.AddSdk(s4), IsNil)
 
 	// Connect a few things for the tests below.
-	_, err := r.Connect(&ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s1", Name: "i1"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
+	_, err := r.Connect(&ConnRef{
+		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i1"},
+		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
-	_, err = r.Connect(&ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s1", Name: "i1"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
+	_, err = r.Connect(&ConnRef{
+		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i1"},
+		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
-	_, err = r.Connect(&ConnRef{PlugRef: PlugRef{Workshop: "ws", Sdk: "s1", Name: "i2"}, SlotRef: SlotRef{Workshop: "ws", Sdk: "s3", Name: "i2"}}, nil, nil, nil, nil, nil)
+	_, err = r.Connect(&ConnRef{
+		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i2"},
+		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s3", Name: "i2"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	// Without any names or options we get the summary of all the interfaces.

--- a/internal/overlord/ifacestate/helpers_test.go
+++ b/internal/overlord/ifacestate/helpers_test.go
@@ -45,7 +45,7 @@ func (s *helpersSuite) TestGetConns(c *check.C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 	s.st.Set("conns", map[string]interface{}{
-		"ws:app:content ws:core:content": map[string]interface{}{
+		"42424242:ws:app:content 42424242:ws:core:content": map[string]interface{}{
 			"auto":      true,
 			"interface": "content",
 			"slot-static": map[string]interface{}{
@@ -57,7 +57,7 @@ func (s *helpersSuite) TestGetConns(c *check.C) {
 	conns, err := ifacestate.GetConns(s.st)
 	c.Assert(err, check.IsNil)
 	for id, connState := range conns {
-		c.Assert(id, check.Equals, "ws:app:content ws:core:content")
+		c.Assert(id, check.Equals, "42424242:ws:app:content 42424242:ws:core:content")
 		c.Assert(connState.Auto, check.Equals, true)
 		c.Assert(connState.Interface, check.Equals, "content")
 		c.Assert(connState.StaticSlotAttrs["number"], check.Equals, int64(78))
@@ -69,7 +69,7 @@ func (s *helpersSuite) TestSetConns(c *check.C) {
 	defer s.st.Unlock()
 
 	conns := map[string]*schema.ConnState{
-		"ws:app:content ws:core:content": {Auto: true, Interface: "content"},
+		"42424242:ws:app:content 42424242:ws:core:content": {Auto: true, Interface: "content"},
 	}
 
 	ifacestate.SetConns(s.st, conns)
@@ -77,7 +77,7 @@ func (s *helpersSuite) TestSetConns(c *check.C) {
 	err := s.st.Get("conns", &readconns)
 	c.Assert(err, check.IsNil)
 	c.Assert(readconns, check.DeepEquals, map[string]interface{}{
-		"ws:app:content ws:core:content": map[string]interface{}{
+		"42424242:ws:app:content 42424242:ws:core:content": map[string]interface{}{
 			"auto":      true,
 			"interface": "content",
 		}})

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -79,7 +79,7 @@ func (m *InterfaceManager) StartUp() error {
 
 	}
 
-	if _, err := m.reloadConnections("", ""); err != nil {
+	if _, err := m.reloadConnections(""); err != nil {
 		return err
 	}
 	return nil
@@ -94,7 +94,7 @@ func (m *InterfaceManager) Ensure() error {
 // affecting a given sdk.
 //
 // The return value is the list of affected sdk names.
-func (m *InterfaceManager) reloadConnections(workshop, sdkName string) (map[string]string, error) {
+func (m *InterfaceManager) reloadConnections(workshop string) (map[string]string, error) {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return nil, err
@@ -118,8 +118,8 @@ func (m *InterfaceManager) reloadConnections(workshop, sdkName string) (map[stri
 			continue
 		}
 
-		plugInfo := m.repo.Plug(connRef.PlugRef.Workshop, connRef.PlugRef.Sdk, connRef.PlugRef.Name)
-		slotInfo := m.repo.Slot(connRef.SlotRef.Workshop, connRef.SlotRef.Sdk, connRef.SlotRef.Name)
+		plugInfo := m.repo.Plug(connRef.PlugRef.ProjectId, connRef.PlugRef.Workshop, connRef.PlugRef.Sdk, connRef.PlugRef.Name)
+		slotInfo := m.repo.Slot(connRef.SlotRef.ProjectId, connRef.SlotRef.Workshop, connRef.SlotRef.Sdk, connRef.SlotRef.Name)
 
 		// The connection refers to a plug or slot that doesn't exist anymore, e.g. because of a refresh
 		// to a new sdk revision that doesn't have the given plug/slot.

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -2,6 +2,7 @@ package ifacestate_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -100,8 +101,9 @@ slots:
 	})
 
 	s.state.Lock()
+	key := fmt.Sprintf("%s:ws:consumer:plug %s:ws:producer:slot", s.prj.ProjectId, s.prj.ProjectId)
 	s.state.Set("conns", map[string]interface{}{
-		"ws:consumer:plug ws:producer:slot": map[string]interface{}{
+		key: map[string]interface{}{
 			"interface": "content",
 			"plug-static": map[string]interface{}{
 				"content": "foo",
@@ -123,7 +125,9 @@ slots:
 
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, check.HasLen, 1)
-	cref := &interfaces.ConnRef{PlugRef: interfaces.PlugRef{Workshop: "ws", Sdk: "consumer", Name: "plug"}, SlotRef: interfaces.SlotRef{Workshop: "ws", Sdk: "producer", Name: "slot"}}
+	cref := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"}}
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{cref})
 
 	conn, err := repo.Connection(cref)
@@ -166,8 +170,9 @@ slots:
 	})
 
 	s.state.Lock()
+	key := fmt.Sprintf("%s:ws:consumer:plug %s:core:producer:slot", s.prj.ProjectId, s.prj.ProjectId)
 	s.state.Set("conns", map[string]interface{}{
-		"ws:consumer:plug core:producer:slot": map[string]interface{}{
+		key: map[string]interface{}{
 			"interface": "test",
 			"auto":      true,
 			"undesired": true,
@@ -208,8 +213,10 @@ slots:
 	})
 
 	s.state.Lock()
+	key := fmt.Sprintf("%s:ws:consumer:plug-1 %s:core:producer:slot-1", s.prj.ProjectId, s.prj.ProjectId)
+
 	s.state.Set("conns", map[string]interface{}{
-		"ws:consumer:plug-1 core:producer:slot-1": map[string]interface{}{
+		key: map[string]interface{}{
 			"interface": "test",
 			"auto":      true,
 		},

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -41,12 +41,13 @@ func (t Type) String() string {
 }
 
 type Info struct {
-	Workshop string
-	Name     string
-	Base     string
-	Type     Type
-	Channel  string
-	Revision int64
+	ProjectId string
+	Workshop  string
+	Name      string
+	Base      string
+	Type      Type
+	Channel   string
+	Revision  int64
 
 	Plugs map[string]*PlugInfo
 	Slots map[string]*SlotInfo
@@ -58,7 +59,7 @@ var SanitizePlugsSlots = func(snapInfo *Info) {
 	panic("SanitizePlugsSlots function not set")
 }
 
-func ReadSdkInfo(yamlData []byte, workshop string, setup Setup) (*Info, error) {
+func ReadSdkInfo(yamlData []byte, projectId, workshop string, setup Setup) (*Info, error) {
 	var sdkYaml sdkYaml
 	err := yaml.Unmarshal(yamlData, &sdkYaml)
 	if err != nil {
@@ -70,6 +71,7 @@ func ReadSdkInfo(yamlData []byte, workshop string, setup Setup) (*Info, error) {
 	}
 
 	sdkInfo := &Info{
+		ProjectId:     projectId,
 		Workshop:      workshop,
 		Name:          sdkYaml.Name,
 		Base:          sdkYaml.Base,
@@ -289,10 +291,10 @@ func MockSanitizePlugsSlots(f func(snapInfo *Info)) (restore func()) {
 	return func() { SanitizePlugsSlots = old }
 }
 
-func MockInfo(c *check.C, yamlText string, workshop string, setup Setup) *Info {
+func MockInfo(c *check.C, yamlText string, projectId, workshop string, setup Setup) *Info {
 	restoreSanitize := MockSanitizePlugsSlots(func(snapInfo *Info) {})
 	defer restoreSanitize()
-	info, err := ReadSdkInfo([]byte(yamlText), workshop, setup)
+	info, err := ReadSdkInfo([]byte(yamlText), projectId, workshop, setup)
 	c.Assert(err, check.IsNil)
 
 	err = Validate(info)
@@ -304,7 +306,7 @@ func MockInvalidInfo(c *check.C, yamlText string, setup Setup) *Info {
 	restoreSanitize := MockSanitizePlugsSlots(func(snapInfo *Info) {})
 	defer restoreSanitize()
 
-	sdkInfo, err := ReadSdkInfo([]byte(yamlText), "ws", setup)
+	sdkInfo, err := ReadSdkInfo([]byte(yamlText), "invalid", "ws", setup)
 	c.Assert(err, check.IsNil)
 	err = Validate(sdkInfo)
 	c.Assert(err, check.NotNil)

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -11,7 +11,8 @@ import (
 
 type SdkSuite struct {
 	testutil.BaseTest
-	setup sdk.Setup
+	setup     sdk.Setup
+	projectId string
 }
 
 var _ = check.Suite(&SdkSuite{})
@@ -28,6 +29,8 @@ func (s *SdkSuite) SetUpTest(c *check.C) {
 		InstallTime: time.Now(),
 	}
 
+	s.projectId = "prj42prj42"
+
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 }
 
@@ -40,8 +43,9 @@ func (s *SdkSuite) TestSimple(c *check.C) {
 base: ubuntu@20.04
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, "ws", s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
+	c.Assert(info.ProjectId, check.Equals, s.projectId)
 	c.Assert(info.Base, check.Equals, "ubuntu@20.04")
 	c.Assert(info.Name, check.Equals, "sdk")
 	c.Assert(info.Channel, check.Equals, "latest/stable")
@@ -60,7 +64,7 @@ plugs:
     target: /project
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, "ws", s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -81,7 +85,7 @@ slots:
     source: /project
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, "ws", s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Slots, check.HasLen, 1)
 	c.Assert(info.Plugs, check.HasLen, 0)
@@ -105,7 +109,7 @@ plugs:
         m:
           a: A
           b: B
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -132,7 +136,7 @@ plugs:
     net:
         interface: content
         attr: 2
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -151,7 +155,7 @@ name: sdk
 plugs:
     content:
         ipv6-aware: true
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 1)
 	c.Check(info.Slots, check.HasLen, 0)
@@ -170,7 +174,7 @@ name: sdk
 plugs:
     bool-file:
         label: Disk I/O indicator
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 
 	c.Check(info.Plugs, check.HasLen, 1)
@@ -192,7 +196,7 @@ plugs:
     net:
         interface: 1.0
         ipv6-aware: true
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `interface name on plug "net" is not a string \(found float64\)`)
 }
 
@@ -203,7 +207,7 @@ name: sdk
 plugs:
     bool-file:
         label: 1.0
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `label of plug "bool-file" is not a string \(found float64\)`)
 }
 
@@ -214,7 +218,7 @@ name: sdk
 plugs:
     net:
         1: ok
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `plug "net" has attribute key that is not a string \(found int\)`)
 }
 
@@ -225,7 +229,7 @@ name: sdk
 plugs:
     net:
         "": ok
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `plug "net" has an empty attribute key`)
 }
 
@@ -235,7 +239,7 @@ func (s *SdkSuite) TestUnmarshalCorruptedPlugWithUnexpectedType(c *check.C) {
 name: sdk
 plugs:
     net: 5
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `plug "net" has malformed definition \(found int\)`)
 }
 
@@ -247,7 +251,7 @@ plugs:
     serial:
         interface: serial-port
         $baud-rate: [9600]
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `plug "serial" uses reserved attribute "\$baud-rate"`)
 }
 
@@ -259,7 +263,7 @@ plugs:
     serial:
         interface: serial-port
         foo: null
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `attribute "foo" of plug \"serial\": invalid scalar:.*`)
 }
 
@@ -273,7 +277,7 @@ plugs:
         bar:
           baz:
           - 1: A
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `attribute "bar" of plug \"serial\": non-string key: 1`)
 }
 
@@ -285,7 +289,7 @@ func (s *SdkSuite) TestUnmarshalStandaloneImplicitSlot(c *check.C) {
 name: sdk
 slots:
     content:
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -302,7 +306,7 @@ func (s *SdkSuite) TestUnmarshalStandaloneAbbreviatedSlot(c *check.C) {
 name: sdk
 slots:
     net: content
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -321,7 +325,7 @@ slots:
     net:
         interface: content
         ipv6-aware: true
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -344,7 +348,7 @@ slots:
         l: [1,2]
         m:
           a: "A"
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -371,7 +375,7 @@ slots:
     net:
         interface: content
         attr: 2
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -390,7 +394,7 @@ name: sdk
 slots:
     content:
         ipv6-aware: true
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -410,7 +414,7 @@ slots:
     led0:
         interface: bool-file
         label: Front panel LED (red)
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -430,7 +434,7 @@ slots:
     net:
         interface: 1.0
         ipv6-aware: true
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `interface name on slot "net" is not a string \(found float64\)`)
 }
 
@@ -441,7 +445,7 @@ name: sdk
 slots:
     bool-file:
         label: 1.0
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `label of slot "bool-file" is not a string \(found float64\)`)
 }
 
@@ -452,7 +456,7 @@ name: sdk
 slots:
     net:
         1: ok
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `slot "net" has attribute key that is not a string \(found int\)`)
 }
 
@@ -463,7 +467,7 @@ name: sdk
 slots:
     net:
         "": ok
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `slot "net" has an empty attribute key`)
 }
 
@@ -473,7 +477,7 @@ func (s *SdkSuite) TestUnmarshalCorruptedSlotWithUnexpectedType(c *check.C) {
 name: sdk
 slots:
     net: 5
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `slot "net" has malformed definition \(found int\)`)
 }
 
@@ -485,7 +489,7 @@ slots:
     serial:
         interface: serial-port
         $baud-rate: [9600]
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `slot "serial" uses reserved attribute "\$baud-rate"`)
 }
 
@@ -497,6 +501,6 @@ slots:
     serial:
         interface: serial-port
         foo: null
-`), "ws", s.setup)
+`), s.projectId, "ws", s.setup)
 	c.Assert(err, check.ErrorMatches, `attribute "foo" of slot \"serial\": invalid scalar:.*`)
 }

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -8,6 +8,7 @@ import (
 
 type ValidateSuite struct {
 	testutil.BaseTest
+	projectId string
 }
 
 var _ = check.Suite(&ValidateSuite{})
@@ -15,6 +16,7 @@ var _ = check.Suite(&ValidateSuite{})
 func (s *ValidateSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.projectId = "prj-4242"
 }
 
 func (s *ValidateSuite) TearDownTest(c *check.C) {
@@ -63,7 +65,7 @@ func (s *ValidateSuite) TestValidateSlotPlugInterfaceName(c *check.C) {
 
 func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo.something
-`), "ws", sdk.Setup{})
+`), s.projectId, "ws", sdk.Setup{})
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)
@@ -73,7 +75,7 @@ func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
 func (s *ValidateSuite) TestIllegalSdkBase(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo.something
 base: ubuntu@20.04
-`), "ws", sdk.Setup{})
+`), s.projectId, "ws", sdk.Setup{})
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -228,6 +228,11 @@ func WorkshopStateVolumeName(ws, pid string) string {
 // if the filesystem of the container is not closed, it maintains the underlying
 // SFTP connection which stops the container from stoppping.
 func (w *Workshop) SdkInfo(ctx context.Context, s sdk.Setup) (*sdk.Info, error) {
+	projectId, ok := ctx.Value(ContextProjectId).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key project-id not found")
+	}
+
 	wsfs, err := w.backend.GetWorkshopFs(ctx, w.Name)
 	if err != nil {
 		return nil, err
@@ -246,7 +251,7 @@ func (w *Workshop) SdkInfo(ctx context.Context, s sdk.Setup) (*sdk.Info, error) 
 		return nil, err
 	}
 
-	info, err := sdk.ReadSdkInfo(yamlData, w.Name, s)
+	info, err := sdk.ReadSdkInfo(yamlData, projectId, w.Name, s)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two separate projects can have workshops with exactly the same the workshop/SDK/{plug,slot} names. Thus, only the combination of the project id, workshop and SDK name identifies the plug/slot uniquely.