### PR TITLE
Set HOME, LANG and USER env vars for the default 'workshop' user

### DIFF
--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -24,6 +24,8 @@ type execPayload struct {
 	Height      int               `json:"height"`
 }
 
+var defaultUID, defaultGID = 1000, 1000
+
 func normaliseUserGroupIds(usrId, grpId *int) (int, int, error) {
 	if usrId != nil && grpId == nil {
 		return 0, 0, errors.New("must specify group, not just user")
@@ -33,11 +35,11 @@ func normaliseUserGroupIds(usrId, grpId *int) (int, int, error) {
 		return 0, 0, errors.New("must specify user, not just group")
 	}
 
-	userId := 1000
+	userId := defaultUID
 	if usrId != nil {
 		userId = *usrId
 	}
-	groupId := 1000
+	groupId := defaultGID
 	if grpId != nil {
 		groupId = *grpId
 	}
@@ -71,6 +73,12 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 		reqData.WorkingDir = workshopbackend.WorkshopProjectPath
 	}
 
+	var environment = make(map[string]string)
+
+	for k, e := range reqData.Environment {
+		environment[k] = e
+	}
+
 	var timeout time.Duration
 	if reqData.Timeout != "" {
 		var err error
@@ -85,6 +93,23 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("cannot exec: %v", err)
 	}
 
+	// We do not set PATH here as it's something LXD takes care of. Set HOME and
+	// USER if the user is a known default user.
+	if userId == defaultUID {
+		if environment["HOME"] == "" {
+			environment["HOME"] = "/home/workshop"
+		}
+		if environment["USER"] == "" {
+			environment["USER"] = "workshop"
+		}
+	}
+
+	// Set default value for LANG.
+	_, ok := environment["LANG"]
+	if !ok {
+		environment["LANG"] = "C.UTF-8"
+	}
+
 	user, ok := r.Context().Value(workshopbackend.ContextUser).(string)
 	if !ok {
 		return statusBadRequest("cannot exec: user is not in context")
@@ -92,7 +117,7 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 
 	var execArgs = &workshopbackend.ExecArgs{
 		Command:     reqData.Command,
-		Environment: reqData.Environment,
+		Environment: environment,
 		WorkDir:     reqData.WorkingDir,
 		UserId:      userId,
 		GroupId:     groupId,

--- a/internal/workshopbackend/tests/integration/workshop_exec_test.go
+++ b/internal/workshopbackend/tests/integration/workshop_exec_test.go
@@ -182,7 +182,7 @@ func (f *wsExec) TestLxdBackendExecCustomUserGroup(c *check.C) {
 func (f *wsExec) TestLxdBackendExecAddEnvVar(c *check.C) {
 	// Setup
 	opts := &client.ExecOptions{
-		Command:     []string{"/bin/sh", "-c", "echo -n $FOO"},
+		Command:     []string{"/bin/sh", "-c", "printenv"},
 		WorkingDir:  "/",
 		Environment: map[string]string{"FOO": "BAR"},
 	}
@@ -192,7 +192,14 @@ func (f *wsExec) TestLxdBackendExecAddEnvVar(c *check.C) {
 
 	// Validate
 	c.Assert(err, check.IsNil)
-	c.Assert(stdout, check.Equals, "BAR")
+	c.Assert(stdout, check.Equals, `USER=workshop
+HOME=/home/workshop
+container=lxc
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+FOO=BAR
+LANG=C.UTF-8
+PWD=/
+`)
 	c.Assert(stderr, check.Equals, "")
 }
 


### PR DESCRIPTION
LXD takes care of those only for the root user. Workshop runs commands with the 'workshop' user by default, hence it is important for the API to handle this before the execution starts on the LXD side.