### PR TITLE
Docs: Implement accessibility findings

### DIFF
--- a/docs/.sphinx/_static/custom.css
+++ b/docs/.sphinx/_static/custom.css
@@ -187,3 +187,25 @@ details summary {
     color: var(--color-version-popup);
     font-weight: bolder;
 }
+
+input[type=submit] {
+    border: 2px solid #d6410d;
+    padding: var(--sidebar-search-input-spacing-vertical) var(--sidebar-search-input-spacing-horizontal);
+    background: #d6410d;
+    font-weight: bold;
+    font-size: var(--font-size--small);
+    cursor: pointer;
+}
+
+input[type=submit]:hover {
+    text-decoration: underline;
+}
+
+.highlight .o {
+    color: #bb5400;
+}
+
+.highlight .s,
+.highlight .s2 {
+    color: #3f8100;
+}

--- a/docs/.sphinx/_static/github_issue_links.css
+++ b/docs/.sphinx/_static/github_issue_links.css
@@ -4,7 +4,7 @@
 .github-issue-link {
     font-size: var(--font-size--small);
     font-weight: bold;
-    background-color: #DD4814;
+    background-color: #d6410d;
     padding: 13px 23px;
     text-decoration: none;
 }

--- a/docs/.sphinx/_templates/sidebar/search.html
+++ b/docs/.sphinx/_templates/sidebar/search.html
@@ -1,0 +1,7 @@
+<form class="sidebar-search-container" method="get" action="{{ pathto('search') }}" role="search">
+    <input class="sidebar-search" placeholder="{{ _("Search") }}" name="q" aria-label="{{ _("Search" ) }}">
+    <input type="submit" value="Go">
+    <input type="hidden" name="check_keywords" value="yes">
+    <input type="hidden" name="area" value="default">
+  </form>
+  <div id="searchbox"></div>

--- a/docs/pa11y.json
+++ b/docs/pa11y.json
@@ -5,5 +5,5 @@
     ]
   },
   "reporter": "cli",
-  "standard": "WCAG2A"
+  "standard": "WCAG2AA"
 }


### PR DESCRIPTION
Switched to the next stringent a11y standard and implemented all findings reported by `make pa11y`.

Aside from minor pygments tweaks, here's the main addition - the 'Go' search button:

![image](https://github.com/canonical/workshop/assets/141050460/db528ce1-828c-48c2-8940-32e85ad1e167)

It's deliberately styled after the 'Give feedback' button on the right, although the choice of on-hover behaviour is not very idiomatic IMO.
