### PR TITLE
Fix unclean project paths tracked in certain scenarios

### DIFF
--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -61,7 +61,6 @@ type LxdBackend struct {
 
 const (
 	LxdSock = "/var/snap/lxd/common/lxd/unix.socket"
-	// name prefix for the workshops that were made unavailable
 )
 
 var (
@@ -212,6 +211,125 @@ func (s *LxdBackend) trackProject(client lxd.InstanceServer, ctx context.Context
 	return client.UpdateProject(LxdProjectName(user), lxdPrj.ProjectPut, etag)
 }
 
+func (s *LxdBackend) updateWorkshopsProjectPath(conn lxd.InstanceServer, ctx context.Context, existingProject *Project) error {
+	workshops, err := s.filterLxdInstancesByConfig(conn, NewWorkshopConfigFilter(ProjectIdConfig, existingProject.ProjectId))
+	if err != nil {
+		return err
+	}
+
+	for _, i := range workshops {
+		project := Mount(ProjectPathDevice, existingProject.Path, WorkshopProjectPath)
+		err = s.AddWorkshopDevice(ctx, WorkshopName(i.Name), project)
+		if err != nil {
+			return fmt.Errorf("cannot update workshop \"%v\" project directory", i.Name)
+		}
+	}
+	return nil
+}
+
+func (s *LxdBackend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx context.Context, p *Project) (path string, err error) {
+	workshops, err := s.filterLxdInstancesByConfig(conn, NewWorkshopConfigFilter(ProjectIdConfig, p.ProjectId))
+	if err != nil {
+		return "", err
+	}
+
+	/* memFs to story temporary results of the commands execution output */
+	memFs := afero.NewMemMapFs()
+	for _, i := range workshops {
+		// attempt to execute the command only in a running instance
+		if i.StatusCode != api.Ready && i.StatusCode != api.Running {
+			continue
+		}
+
+		/* Take the first instance from the group, we need any running
+		and ready to execute commands to validate the project directory */
+		out, err := memFs.Create(i.Name)
+		if err != nil {
+			return "", err
+		}
+		defer out.Close()
+
+		/* Get the mount point device/directory from findmnt and extract the path without a device
+		using awk */
+		args := Execution{
+			ExecArgs: ExecArgs{
+				UserId:  0,
+				GroupId: 0,
+				Command: []string{"bash", "-c",
+					"findmnt --mountpoint /project -o source -n | awk -F\"[][]\" '{printf $2}'"},
+				WorkDir: "/",
+			},
+			ExecControls: ExecControls{
+				Stdin:  nil,
+				Stdout: out,
+				Stderr: out,
+			},
+		}
+
+		execCtx := context.WithValue(ctx, ContextProjectId, p.ProjectId)
+		meta, err := s.execCommand(conn, execCtx, WorkshopName(i.Name), &args)
+		if err == nil {
+			err = meta.WaitExecution(ctx)
+			if err != nil {
+				outbuf, _ := afero.ReadFile(memFs, out.Name())
+				logger.Debugf("cannot check %q bind-mounts: %v, findmnt output: %s", i.Name, err, string(outbuf))
+				continue
+			}
+		} else {
+			logger.Debugf("cannot check %q bind-mounts: %v", i.Name, err)
+			continue
+		}
+
+		/* Process the findmnt results */
+		if currentPath, err := afero.ReadFile(memFs, i.Name); err == nil {
+			/* check if the path is not //deleted, i.e. the project directory still exists on the host */
+			if ok, isDir, err := osutil.ExistsIsDir(string(currentPath)); ok && isDir {
+				return string(currentPath), nil
+			} else if err != nil && !osutil.IsDirNotExist(err) {
+				return "", nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// Ensures that every project has a valid existing path. If not, tries to
+// recover the path from the actual bind mount of the '/project'. If recovery
+// went unsuccessful, stop project tracking (it is likely that the directory was
+// removed already)
+func (s *LxdBackend) checkAndRecoverProjectPaths(client lxd.InstanceServer, ctx context.Context, projects []*Project) ([]*Project, error) {
+	for idx, prj := range projects {
+		if ok, _, err := osutil.ExistsIsDir(prj.Path); !ok {
+			// If got here then there is no project directory for the projectId
+			// anymore. It can mean moving or deletion happened in the past. Try
+			// to recover the new project path
+			newPath, _ := s.findProjectPathFromBindMounts(client, ctx, prj)
+			if newPath != "" {
+				// start tracking this project under a new path
+				prj.Path = newPath
+				if err = s.trackProject(client, ctx, prj); err == nil {
+					// update the workshops configuration with the new path
+					s.updateWorkshopsProjectPath(client, ctx, prj)
+				}
+				continue
+			}
+			// Could not recover the directory, reconcile the project from the
+			// list of projects that we track (only if there are no remaining
+			// workshops for this project)
+			inst, err := s.filterLxdInstancesByConfig(client, func(config map[string]string) bool {
+				return config["user.workshop.project-id"] == prj.ProjectId
+			})
+			if err == nil && len(inst) == 0 {
+				if err = s.untrackProject(client, ctx, prj); err != nil {
+					return nil, err
+				}
+				projects = slices.Delete(projects, idx, idx+1)
+			}
+		}
+	}
+	return projects, nil
+}
+
 // projectPath returns a project path for the cwd provided
 // if cwd is a sub-directory of the project. Otherwise, cwd
 // is returned unchanged
@@ -239,6 +357,9 @@ func ProjectPath(cwd string) (string, error) {
 		path = filepath.Join(path, "..", string(os.PathSeparator))
 	}
 
+	if cwd, err = filepath.EvalSymlinks(cwd); err != nil {
+		return "", err
+	}
 	return cwd, nil
 }
 
@@ -346,22 +467,6 @@ func (s *LxdBackend) CreateOrLoadProject(ctx context.Context, path string) (*Pro
 	return &project, true, nil
 }
 
-func (s *LxdBackend) updateWorkshopsProjectPath(conn lxd.InstanceServer, ctx context.Context, existingProject *Project) error {
-	workshops, err := s.filterLxdInstancesByConfig(conn, NewWorkshopConfigFilter(ProjectIdConfig, existingProject.ProjectId))
-	if err != nil {
-		return err
-	}
-
-	for _, i := range workshops {
-		project := Mount(ProjectPathDevice, existingProject.Path, WorkshopProjectPath)
-		err = s.AddWorkshopDevice(ctx, WorkshopName(i.Name), project)
-		if err != nil {
-			return fmt.Errorf("cannot update workshop \"%v\" project directory", i.Name)
-		}
-	}
-	return nil
-}
-
 func (s *LxdBackend) Projects(ctx context.Context) (map[string][]*Project, error) {
 	if user, ok := ctx.Value(ContextUser).(string); ok {
 		client, err := s.LxdClient(ctx)
@@ -419,109 +524,6 @@ func (s *LxdBackend) Projects(ctx context.Context) (map[string][]*Project, error
 		}
 		return allProjects, nil
 	}
-}
-
-// Ensures that every project has a valid existing path. If not, tries to
-// recover the path from the actual bind mount of the '/project'. If recovery
-// went unsuccessful, stop project tracking (it is likely that the directory was
-// removed already)
-func (s *LxdBackend) checkAndRecoverProjectPaths(client lxd.InstanceServer, ctx context.Context, projects []*Project) ([]*Project, error) {
-	for idx, prj := range projects {
-		if ok, _, err := osutil.ExistsIsDir(prj.Path); !ok && err == nil {
-			// If got here then there is no project directory for the projectId
-			// anymore. It can mean moving or deletion happened in the past. Try
-			// to recover the new project path
-			newPath, _ := s.findProjectPathFromBindMounts(client, ctx, prj)
-			if newPath != "" {
-				// start tracking this project under a new path
-				prj.Path = newPath
-				if err = s.trackProject(client, ctx, prj); err == nil {
-					// update the workshops configuration with the new path
-					s.updateWorkshopsProjectPath(client, ctx, prj)
-				}
-				continue
-			}
-			// Could not recover the directory, reconcile the project from the
-			// list of projects that we track (only if there are no remaining
-			// workshops for this project)
-			inst, err := s.filterLxdInstancesByConfig(client, func(config map[string]string) bool {
-				return config["user.workshop.project-id"] == prj.ProjectId
-			})
-			if err == nil && len(inst) == 0 {
-				if err = s.untrackProject(client, ctx, prj); err != nil {
-					return nil, err
-				}
-				projects = slices.Delete(projects, idx, idx+1)
-			}
-		}
-	}
-	return projects, nil
-}
-
-func (s *LxdBackend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx context.Context, p *Project) (path string, err error) {
-	workshops, err := s.filterLxdInstancesByConfig(conn, NewWorkshopConfigFilter(ProjectIdConfig, p.ProjectId))
-	if err != nil {
-		return "", err
-	}
-
-	/* memFs to story temporary results of the commands execution output */
-	memFs := afero.NewMemMapFs()
-	for _, i := range workshops {
-		// attempt to execute the command only in a running instance
-		if i.StatusCode != api.Ready && i.StatusCode != api.Running {
-			continue
-		}
-
-		/* Take the first instance from the group, we need any running
-		and ready to execute commands to validate the project directory */
-		out, err := memFs.Create(i.Name)
-		if err != nil {
-			return "", err
-		}
-		defer out.Close()
-
-		/* Get the mount point device/directory from findmnt and extract the path without a device
-		using awk */
-		args := Execution{
-			ExecArgs: ExecArgs{
-				UserId:  0,
-				GroupId: 0,
-				Command: []string{"bash", "-c",
-					"findmnt --mountpoint /project -o source -n | awk -F\"[][]\" '{printf $2}'"},
-				WorkDir: "/",
-			},
-			ExecControls: ExecControls{
-				Stdin:  nil,
-				Stdout: out,
-				Stderr: out,
-			},
-		}
-
-		execCtx := context.WithValue(ctx, ContextProjectId, p.ProjectId)
-		meta, err := s.execCommand(conn, execCtx, WorkshopName(i.Name), &args)
-		if err == nil {
-			err = meta.WaitExecution(ctx)
-			if err != nil {
-				outbuf, _ := afero.ReadFile(memFs, out.Name())
-				logger.Debugf("cannot check %q bind-mounts: %v, findmnt output: %s", i.Name, err, string(outbuf))
-				continue
-			}
-		} else {
-			logger.Debugf("cannot check %q bind-mounts: %v", i.Name, err)
-			continue
-		}
-
-		/* Process the findmnt results */
-		if currentPath, err := afero.ReadFile(memFs, i.Name); err == nil {
-			/* check if the path is not //deleted, i.e. the project directory still exists on the host */
-			if ok, isDir, err := osutil.ExistsIsDir(string(currentPath)); ok && isDir {
-				return string(currentPath), nil
-			} else if err != nil && !osutil.IsDirNotExist(err) {
-				return "", nil
-			}
-		}
-	}
-	return "", nil
 }
 
 func (s *LxdBackend) LaunchWorkshop(ctx context.Context, name, base string) error {
@@ -1028,7 +1030,7 @@ func mergeInstancesAndFiles(f []*WorkshopFile, instances []*Workshop) ([]*Worksh
 	return files, instances
 }
 
-func (s *LxdBackend) RemoveWorkshop(ctx context.Context, name string) error {
+func (s *LxdBackend) RemoveWorkshop(ctx context.Context, name string) (err error) {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -1055,7 +1057,10 @@ func (s *LxdBackend) RemoveWorkshop(ctx context.Context, name string) error {
 		return err
 	}
 
-	return op.WaitContext(ctx)
+	if err = op.WaitContext(ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *LxdBackend) WorkshopFs(ctx context.Context, name string) (WorkshopFs, error) {

--- a/internal/workshopbackend/lxd_backend_test.go
+++ b/internal/workshopbackend/lxd_backend_test.go
@@ -1,6 +1,7 @@
 package workshopbackend_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -167,42 +168,61 @@ base: ubuntu@20.04`), 0644)
 func (f *LxdBeTests) TestProjectSubDirectoryProvideAsPath(c *check.C) {
 	root := c.MkDir()
 	cases := []struct {
-		project  string
-		lockFile bool
-		cwd      string
-		expected string
-		err      error
+		project   string
+		lockFile  bool
+		cwd       string
+		isSymlink bool
+		expected  string
+		err       error
 	}{
+		// nested directory
+		{"/home/user", true, "/home/user/nested", false, "/home/user", nil},
 
 		// nested directory
-		{"/home/user/", true, "/home/user/nested", "/home/user", nil},
-
-		// nested directory
-		{"/home/user/", true, "/home/user/test/very/deeply", "/home/user", nil},
+		{"/home/user", true, "/home/user/test/very/deeply", false, "/home/user", nil},
 
 		// same level
-		{"/home/user/same", true, "/home/user/same", "/home/user/same", nil},
+		{"/home/user/same", true, "/home/user/same", false, "/home/user/same", nil},
+
+		// same level, symlink
+		{"/home/user/same", true, "/home/user/samelink", true, "/home/user/same", nil},
 
 		// different cwd
-		{"/home/user/different", true, "/home", "/home", nil},
+		{"/home/user/different", true, "/home", false, "/home", nil},
 
 		// project is in root
-		{"/", true, "/home/user/notroot", "/", nil},
+		{"/", true, "/home/user/notroot", false, "", nil},
 
 		// .lock does not exist
-		{"/home/user/nolock", false, "/home/user/test/nolock", "/home/user/test/nolock", nil},
+		{"/home/user/nolock", false, "/home/user/test/nolock", false, "/home/user/test/nolock", nil},
+
+		// path is unclean (lock exists)
+		{"/home/user/unclean", true, "/home/user/unclean/", false, "/home/user/unclean", nil},
+
+		// path is unclean (no lock)
+		{"/home/user/unclean", false, "/home/user/unclean/", false, "/home/user/unclean", nil},
+
+		// path is unclean (no lock, symlink)
+		{"/home/user/projectdir", false, "/home/user/symlinktest/", true, "/home/user/projectdir", nil},
 	}
 
 	for _, i := range cases {
 		os.MkdirAll(filepath.Join(root, i.project), 0755)
-		os.MkdirAll(filepath.Join(root, i.cwd), 0755)
 		if i.lockFile == true {
 			os.Create(workshopbackend.LockPath(filepath.Join(root, i.project)))
 		}
+		if i.isSymlink == true {
+			err := os.Symlink(filepath.Join(root, i.project), filepath.Join(root, i.cwd))
+			c.Assert(err, check.IsNil)
+		} else {
+			os.MkdirAll(filepath.Join(root, i.cwd), 0755)
+		}
+		// note: no filepath.join here as it calls Clean on exist for the path
+		// the data must come unclean for the ProjectPath input and the test
+		// must ensure it returns a clean one on every condition
+		path, err := workshopbackend.ProjectPath(fmt.Sprintf("%s%s", root, i.cwd))
 
-		path, err := workshopbackend.ProjectPath(filepath.Join(root, i.cwd))
-
-		c.Assert(path, check.Equals, filepath.Join(root, i.expected))
+		c.Assert(path, check.Equals, fmt.Sprintf("%s%s", root, i.expected))
 		c.Assert(err, check.Equals, i.err)
 		os.RemoveAll(filepath.Join(root, i.project))
 		os.RemoveAll(filepath.Join(root, i.cwd))

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -11,24 +11,37 @@ restore: |
   . "$TESTSLIB"/utils.sh
   cleanup "$WORKSHOPS"
   uninstall_workshopd
-
-debug: |
-  lxc project switch workshop.ubuntu
-  lxc list -f compact
-  ls "$WORKSHOPS"/*
+  rm -rf "$WORKSHOPS"/new-project
 
 execute: |
   . "$TESTSLIB"/utils.sh
 
   launch "$PROJECT" ws
 
-  echo "Should recover .lock file if removed for an existing project"
+  echo "Check recover .lock file if removed for an existing project"
   rm -f "$PROJECT"/.workshop.lock
   list "$PROJECT"
   test -f "$PROJECT"/.workshop.lock
 
-  echo "Should report a workshop state as Error if there is no workshop file"
+  echo "Check report a workshop state as Error if there is no workshop file"
   mv "$PROJECT"/.workshop.ws.yaml "$PROJECT"/.workshop.ws.yaml.bak
   list "$PROJECT" | MATCH "^$PROJECT[[:space:]]+ws[[:space:]]+Error[[:space:]]+missing-file$"
   mv "$PROJECT"/.workshop.ws.yaml.bak "$PROJECT"/.workshop.ws.yaml
   list "$PROJECT" | MATCH "^$PROJECT[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+  
+  workshop_exec remove --project "$PROJECT" ws
+  
+  echo "Check recreating project dir with the same name"
+  mkdir -p "$WORKSHOPS"/new-project
+  cp "$PROJECT"/.workshop.ws.yaml "$WORKSHOPS"/new-project/
+  workshop_exec launch --project "$WORKSHOPS"/new-project/ ws
+  workshop_exec remove --project "$WORKSHOPS"/new-project/ ws
+  rm -rf "$WORKSHOPS"/new-project/
+  mkdir -p "$WORKSHOPS"/new-project/
+  cp "$PROJECT"/.workshop.ws.yaml "$WORKSHOPS"/new-project/
+  workshop_exec launch --project "$WORKSHOPS"/new-project/  ws
+  workshop_exec list --project "$WORKSHOPS"/new-project | MATCH "^$WORKSHOPS/new-project[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+
+  
+  
+  


### PR DESCRIPTION
Fixes the issue when workshop was misled by an unclean project path provided with --project in some cases. E.g. when the path ends with a slash and there is no .lock file in the new (or recreated with the same name) project directory yet.