### PR TITLE
Docs: Switch to external check workflows, expand tutorial with interface info

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -9,65 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  spellcheck:
-    name: Spelling check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Aspell
-        run: |
-          sudo apt-get install aspell aspell-en
-
-      - name: Install the doc framework
-        run: |
-          make -C docs install
-
-      - name: Build docs and run spelling checker
-        run: |
-          make -C docs spelling
-
-  woke:
-    name: Inclusive language check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: woke
-        uses: get-woke/woke-action@v0
-        with:
-          # Cause the check to fail on any broke rules
-          fail-on-error: true
-          woke-args: "*.rst **/*.rst -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml"
-
-  linkcheck:
-    name: Link check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install the doc framework
-        run: |
-          make -C docs install
-
-      - name: Run linkchecker
-        run: |
-          make -C docs linkcheck
-
-  pa11y:
-    name: Accessibility check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install the doc framework
-        run: |
-          make -C docs install
-
-      - name: Run pa11y
-        run: |
-          make -C docs pa11y
+  documentation-checks:
+    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
+    with:
+      working-directory: './docs/'

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ docs/.sphinx/warnings.txt
 docs/.sphinx/.wordlist.dic
 docs/.sphinx/.doctrees/
 docs/.sphinx/node_modules/
+docs/__pycache__/
 package*.json
 docs/_build

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,8 +1,0 @@
-/*env*/
-.sphinx/venv
-.sphinx/warnings.txt
-.sphinx/.wordlist.dic
-_build
-.DS_Store
-__pycache__
-.idea/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -122,7 +122,7 @@ woke:
 
 .PHONY: pa11y
 pa11y: html
-	find $(BUILDDIR) -name *.html -exec $(PA11Y) {} \;
+	find $(BUILDDIR) -name *.html -print0 | xargs -n 1 -0 $(PA11Y)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/explanation/essentials/project-workshop-sdks.rst
+++ b/docs/explanation/essentials/project-workshop-sdks.rst
@@ -147,6 +147,8 @@ SDKs are distributed via channels similar to
 `snap channels <https://snapcraft.io/docs/channels>`_.
 
 
+.. _exp_sdk_state:
+
 SDK state
 ~~~~~~~~~
 
@@ -254,7 +256,8 @@ and connecting the two.
 Upon :ref:`refresh <ref_workshop_refresh>`,
 existing connections are preserved in the refreshed workshop
 if their plugs were connected before the operation.
-Stale connections are removed,
+A newer version of an SDK may drop a plug that was previously connected;
+such connections are removed,
 but the content remains.
 
 On :ref:`remove <ref_workshop_remove>`,

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -142,6 +142,8 @@ use it to define, launch, start and stop your first
 :ref:`workshop <exp_workshop>`.
 
 
+.. _tut_define:
+
 Define
 ~~~~~~
 
@@ -185,6 +187,8 @@ Define
    Note that a newly created workshop is *Off*.
 
 
+.. _tut_launch:
+
 Launch
 ~~~~~~
 
@@ -212,7 +216,48 @@ move it, then run :command:`workshop list`:
        Project                Workshop   Status  Notes
        ~/hi-workshop          golang     Ready   -
 
-Note that the workshop stays operational with no extra steps.
+Mind that the workshop stays operational with no extra steps.
+
+.. note::
+
+   Check the recent :ref:`changes <ref_workshop_changes>`
+   to see what goes into launching a workshop:
+
+   .. code-block:: console
+
+      $ workshop changes
+
+         ID  Status  Spawn               Ready               Summary
+         34  Done    today at 11:32 GMT  today at 11:33 GMT  Launch "golang" workshop
+
+   To investigate this change in detail,
+   supply its ID to the
+   :ref:`tasks <ref_workshop_tasks>`
+   command:
+
+   .. code-block:: console
+
+      $ workshop tasks 34
+
+         ID   Status  Spawn               Ready               Summary
+         133  Done    today at 11:32 GMT  today at 11:32 GMT  Create new "golang" workshop
+         134  Done    today at 11:32 GMT  today at 11:32 GMT  Mount project directory "hello-workshop"
+         135  Done    today at 11:32 GMT  today at 11:32 GMT  Start "golang" workshop
+         136  Done    today at 11:32 GMT  today at 11:32 GMT  Retrieve "go" SDK from channel "latest/stable"
+         137  Done    today at 11:32 GMT  today at 11:32 GMT  Install "go" SDK
+         138  Done    today at 11:32 GMT  today at 11:33 GMT  Link "go" SDK
+         139  Done    today at 11:33 GMT  today at 11:33 GMT  Run hook "setup-base" for "go" SDK
+         140  Done    today at 11:33 GMT  today at 11:33 GMT  Auto-connect interfaces of "go" SDK
+
+   Here, the project directory is mounted to the workshop as :file:`/project/`;
+   the workshop is *started*, in other words, brought online;
+   then the :samp:`go` SDK,
+   which was referenced in the :ref:`definition <tut_define>`,
+   is retrieved, installed and set up inside the workshop;
+   finally, the SDK is connected to the host system
+   via an :ref:`interface <exp_interfaces_plugs_slots>`.
+
+   For details, see :ref:`exp_changes_tasks`.
 
 
 Start and stop
@@ -226,7 +271,7 @@ If you're done with the workshop for now,
    $ workshop stop golang
 
 
-To resume, *start* the workshop again:
+To resume, start the workshop again:
 
 .. code-block:: console
 
@@ -369,6 +414,56 @@ To abort the operation and recover the last operational state:
    $ workshop refresh --abort golang
 
 
+.. note::
+
+   Even with no errors,
+   check the recent changes
+   to see what goes into refreshing a workshop:
+
+   .. code-block:: console
+
+      $ workshop changes
+
+         ID  Status  Spawn               Ready               Summary
+         35  Done    today at 12:15 GMT  today at 12:16 GMT  Launch "golang" workshop
+
+   To investigate this change in detail,
+   supply its ID to the
+   :ref:`tasks <ref_workshop_tasks>`
+   command:
+
+   .. code-block:: console
+
+      $ workshop tasks 35
+
+          ID   Status  Spawn               Ready               Summary
+          141  Done    today at 12:15 GMT  today at 12:15 GMT  Create SDK state storage
+          142  Done    today at 12:15 GMT  today at 12:15 GMT  Run hook "save-state" for "go" SDK
+          143  Done    today at 12:15 GMT  today at 12:15 GMT  Disconnect interfaces of "go" SDK
+          144  Done    today at 12:15 GMT  today at 12:15 GMT  Stash previous "golang" workshop
+          145  Done    today at 12:15 GMT  today at 12:16 GMT  Create new "golang" workshop
+          146  Done    today at 12:15 GMT  today at 12:16 GMT  Mount project directory "hi-workshop"
+          147  Done    today at 12:15 GMT  today at 12:16 GMT  Start "golang" workshop
+          148  Done    today at 12:15 GMT  today at 12:15 GMT  Retrieve "go" SDK from channel "latest/stable"
+          149  Done    today at 12:15 GMT  today at 12:16 GMT  Install "go" SDK
+          150  Done    today at 12:15 GMT  today at 12:16 GMT  Link "go" SDK
+          151  Done    today at 12:15 GMT  today at 12:16 GMT  Run hook "setup-base" for "go" SDK
+          152  Done    today at 12:15 GMT  today at 12:16 GMT  Auto-connect interfaces of "go" SDK
+          153  Done    today at 12:15 GMT  today at 12:16 GMT  Run hook "restore-state" for "go" SDK
+          154  Done    today at 12:15 GMT  today at 12:16 GMT  Remove SDK state storage
+          155  Done    today at 12:15 GMT  today at 12:16 GMT  Remove "golang" workshop from stash
+
+
+   This largely resembles the events at :ref:`launch <tut_launch>`;
+   however, :ref:`SDK states <exp_sdk_state>` are *stashed*
+   and :ref:`interfaces <exp_interfaces_plugs_slots>` are disconnected
+   before the refresh actually starts.
+   After updating the workshop on success
+   or rolling back to the stashed version on failure,
+   |project_markup| recovers SDK states
+   and reconnects the interfaces.
+
+
 .. _tut_exec:
 
 Execute commands
@@ -431,7 +526,10 @@ If you don't need a workshop anymore,
    $ workshop remove golang
 
 
-This leaves the workshop definition intact.
+This doesn't affect the files in the project directory,
+including the workshop definition,
+and any other content that was stored outside the workshop,
+e.g. via the :ref:`content interface <exp_content_interface>`.
 
 .. attention::
 

--- a/tests/lib/documentation/tutorial.sh
+++ b/tests/lib/documentation/tutorial.sh
@@ -51,6 +51,12 @@ cd hi-workshop
 workshop list
 
 
+# Note: Changes and tasks after launch
+
+workshop changes
+workshop tasks $(workshop changes | awk 'END{print $1}')
+
+
 # Start and stop
 
 workshop stop nimble
@@ -76,7 +82,7 @@ EOF
 workshop refresh --wait-on-error nimble || true
 
 
-# Wait on error
+# Wait on error/Note: Changes and tasks after refresh
 
 workshop changes
 workshop tasks $(workshop changes | awk 'END{print $1}')


### PR DESCRIPTION
This partially relies on canonical/documentation-workflows#12 and can only be committed after it's merged.