### PR TITLE
Workshopctl API endpoint

### DIFF
--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -38,7 +38,7 @@ var Project string
 // ClientConfig is the configuration of the Client used by all commands.
 var ClientConfig = client.Config{
 	// we need the powerful socket
-	Socket: dirs.WorkshopSocket,
+	Socket: dirs.SocketPath,
 }
 
 func main() {

--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -137,7 +137,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	}
 	dopts := daemon.Options{
 		Dir:        dirs.BaseDir,
-		SocketPath: dirs.WorkshopSocket,
+		SocketPath: dirs.SocketPath,
 	}
 
 	dopts.HTTPAddress = rcmd.HTTP

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jessevdk/go-flags v1.5.0
 	github.com/juju/webbrowser v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03D
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -96,6 +97,7 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -168,6 +170,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208/go.mod h1:0OChplkvPTZ174D2FYZXg4IB9hbEwyHkD+zT+/eK+Fg=
@@ -397,6 +401,7 @@ golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -60,12 +60,15 @@ var api = []*Command{{
 	Path:   "/v1/tasks/{task-id}/websocket/{websocket-id}",
 	UserOK: true,
 	GET:    v1GetTaskWebsocket,
-}}
+}, {
+	Path:        "/v1/workshopctl",
+	UserOK:      true,
+	UntrustedOK: true,
+	POST:        v1PostWorkshopCtl,
+},
+}
 
 var (
-	stateOkayWarnings    = (*state.State).OkayWarnings
-	stateAllWarnings     = (*state.State).AllWarnings
-	statePendingWarnings = (*state.State).PendingWarnings
-	stateEnsureBefore    = (*state.State).EnsureBefore
-	muxVars              = mux.Vars
+	stateEnsureBefore = (*state.State).EnsureBefore
+	muxVars           = mux.Vars
 )

--- a/internal/daemon/api_workshopctl.go
+++ b/internal/daemon/api_workshopctl.go
@@ -5,26 +5,56 @@ import (
 	"net/http"
 )
 
-func v1PostWorkshopCtl(c *Command, r *http.Request, _ *userState) Response {
-	state := c.d.overlord.State()
-	state.Lock()
-	defer state.Unlock()
+// workshopCtlOptions holds the various options with which workshopctl is invoked.
+type workshopCtlOptions struct {
+	// ContextID is a string used to determine the context of this call (e.g.
+	// which context and handler should be used, etc.)
+	ContextID string `json:"context-id"`
 
-	var reqData struct {
-		Context string   `json:"context"`
-		Args    []string `json:"args"`
-	}
+	// Args contains a list of parameters to use for this invocation.
+	Args []string `json:"args"`
+}
+
+// workshopCtlPostData is the data posted to the daemon /v2/workshopctl endpoint
+// TODO: this can be removed once we no longer need to pass stdin data
+// but instead use a real stdin stream
+type workshopCtlPostData struct {
+	workshopCtlOptions
+
+	Stdin []byte `json:"stdin,omitempty"`
+}
+
+type snapctlOutput struct {
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+}
+
+func v1PostWorkshopCtl(c *Command, r *http.Request, _ *userState) Response {
+	var reqData workshopCtlPostData
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
 		return statusBadRequest("cannot decode data from request body: %v", err)
 	}
 
+	// Ignore missing context error to allow 'workshopctl -h' without a context;
+	// Actual context is validated later by get/set.
+	context, err := c.d.overlord.HookManager().Context(reqData.ContextID)
+	if err != nil {
+		return statusNotFound(err.Error())
+	}
+
+	if reqData.Stdin != nil {
+		context.Lock()
+		context.Set("stdin", reqData.Stdin)
+		context.Unlock()
+	}
+
 	var stdout, stderr []byte
 
-	result := map[string]string{
-		"stdout": string(stdout),
-		"stderr": string(stderr),
+	result := snapctlOutput{
+		Stdout: string(stdout),
+		Stderr: string(stderr),
 	}
 
 	return SyncResponse(result, http.StatusOK)

--- a/internal/daemon/api_workshopctl.go
+++ b/internal/daemon/api_workshopctl.go
@@ -1,0 +1,31 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func v1PostWorkshopCtl(c *Command, r *http.Request, _ *userState) Response {
+	state := c.d.overlord.State()
+	state.Lock()
+	defer state.Unlock()
+
+	var reqData struct {
+		Context string   `json:"context"`
+		Args    []string `json:"args"`
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&reqData); err != nil {
+		return statusBadRequest("cannot decode data from request body: %v", err)
+	}
+
+	var stdout, stderr []byte
+
+	result := map[string]string{
+		"stdout": string(stdout),
+		"stderr": string(stderr),
+	}
+
+	return SyncResponse(result, http.StatusOK)
+}

--- a/internal/daemon/api_workshopctl_test.go
+++ b/internal/daemon/api_workshopctl_test.go
@@ -1,0 +1,30 @@
+package daemon
+
+import (
+	"bytes"
+	"net/http"
+
+	"gopkg.in/check.v1"
+)
+
+func (s *apiSuite) TestWorkshopCtlNoContext(c *check.C) {
+	// Setup
+	s.daemon(c)
+	wctl := apiCmd("/v1/workshopctl")
+
+	buf := bytes.NewBufferString(`{"context-id": "some-context"}`)
+
+	req, err := s.createProjectsRequest("POST", "/v1/workshopctl", buf)
+	c.Assert(err, check.IsNil)
+
+	// Execute
+	rsp := v1PostWorkshopCtl(wctl, req, nil).(*resp)
+
+	// Verify
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Assert(rsp.Status, check.Equals, http.StatusNotFound)
+
+	res, err := rsp.MarshalJSON()
+	c.Assert(err, check.IsNil)
+	c.Check(string(res), check.Matches, `.*cannot get workshop cookies.*`)
+}

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -11,37 +11,40 @@ import (
 	"github.com/spf13/afero"
 )
 
-const (
-	// defaultWorkshopDir is the Workshop directory used if $WORKSHOP is not set. It is
+var (
+	// defaultWorkshopdDir is the Workshop directory used if $WORKSHOP is not set. It is
 	// created by the daemon ("workshopd run") if it doesn't exist, and also used by
 	// the workshop client.
-	defaultWorkshopDir = "/var/lib/workshop/default"
+	defaultWorkshopdDir = "/var/lib/workshop/default"
 
-	// default root directory path for the SDKs to be installed into in a workshop
-	WorkshopSdksDir = "/var/lib/workshop/sdk"
+	// base directory inside a workshop
+	WorkshopBaseDir = "/var/lib/workshop"
+
+	// SDKs directory to install an SDK in a workshop
+	WorkshopSdksDir = filepath.Join(WorkshopBaseDir, "sdk")
 )
 
 var (
-	SdkDir         string
-	StateDir       string
-	BaseDir        string
-	WorkshopSocket string
+	SdkDir     string
+	StateDir   string
+	BaseDir    string
+	SocketPath string
 )
 
-func getEnvPaths() (workshopDir string, socketPath string) {
-	workshopDir = os.Getenv("WORKSHOP")
-	if workshopDir == "" {
-		workshopDir = defaultWorkshopDir
+func getEnvPaths() (workshopdDir string, socketPath string) {
+	workshopdDir = os.Getenv("WORKSHOP")
+	if workshopdDir == "" {
+		workshopdDir = defaultWorkshopdDir
 	}
 	socketPath = os.Getenv("WORKSHOP_SOCKET")
 	if socketPath == "" {
-		socketPath = filepath.Join(workshopDir, ".workshop.socket")
+		socketPath = filepath.Join(workshopdDir, ".workshop.socket")
 	}
-	return workshopDir, socketPath
+	return workshopdDir, socketPath
 }
 
 func init() {
-	BaseDir, WorkshopSocket = getEnvPaths()
+	BaseDir, SocketPath = getEnvPaths()
 	SetRootDir(BaseDir)
 
 	var b [8]byte

--- a/internal/overlord/hookstate/context.go
+++ b/internal/overlord/hookstate/context.go
@@ -32,7 +32,7 @@ import (
 	"github.com/canonical/x-go/randutil"
 )
 
-// Context represents the context under which the snap is calling back into snapd.
+// Context represents the context under which the workshop is calling back into workshopd.
 // It is associated with a task when the callback is happening from within a hook,
 // or otherwise considered an ephemeral context in that its associated data will
 // be discarded once that individual call is finished.

--- a/internal/overlord/hookstate/context.go
+++ b/internal/overlord/hookstate/context.go
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hookstate
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/canonical/workshop/internal/jsonutil"
+	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/x-go/randutil"
+)
+
+// Context represents the context under which the snap is calling back into snapd.
+// It is associated with a task when the callback is happening from within a hook,
+// or otherwise considered an ephemeral context in that its associated data will
+// be discarded once that individual call is finished.
+type Context struct {
+	task    *state.Task
+	state   *state.State
+	setup   *HookSetup
+	id      string
+	handler Handler
+
+	cache  map[interface{}]interface{}
+	onDone []func() error
+
+	mutex        sync.Mutex
+	mutexChecker int32
+}
+
+// NewContext returns a new context associated with the provided task or
+// an ephemeral context if task is nil.
+//
+// A random ID is generated if contextID is empty.
+func NewContext(task *state.Task, state *state.State, setup *HookSetup, handler Handler, contextID string) (*Context, error) {
+	if contextID == "" {
+		var err error
+		contextID, err = randutil.CryptoToken(32)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Context{
+		task:    task,
+		state:   state,
+		setup:   setup,
+		id:      contextID,
+		handler: handler,
+		cache:   make(map[interface{}]interface{}),
+	}, nil
+}
+
+func newEphemeralHookContextWithData(st *state.State, setup *HookSetup, contextData map[string]interface{}) (*Context, error) {
+	context, err := NewContext(nil, st, setup, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	if contextData != nil {
+		serialized, err := json.Marshal(contextData)
+		if err != nil {
+			return nil, err
+		}
+		var data map[string]*json.RawMessage
+		if err := json.Unmarshal(serialized, &data); err != nil {
+			return nil, err
+		}
+		context.cache["ephemeral-context"] = data
+	}
+	return context, nil
+}
+
+// Task returns the task associated with the hook or (nil, false) if the context is ephemeral
+// and task is not available.
+func (c *Context) Task() (*state.Task, bool) {
+	return c.task, c.task != nil
+}
+
+// HookName returns the name of the hook in this context.
+func (c *Context) HookName() string {
+	return c.setup.Type()
+}
+
+// Timeout returns the maximum time this hook can run
+func (c *Context) Timeout() time.Duration {
+	return c.setup.Timeout
+}
+
+// ID returns the ID of the context.
+func (c *Context) ID() string {
+	return c.id
+}
+
+// Handler returns the handler for this context
+func (c *Context) Handler() Handler {
+	return c.handler
+}
+
+// Lock acquires the lock for this context (required for Set/Get, Cache/Cached, Logf/Errorf),
+// and OnDone/Done).
+func (c *Context) Lock() {
+	c.mutex.Lock()
+	c.state.Lock()
+	atomic.AddInt32(&c.mutexChecker, 1)
+}
+
+// Unlock releases the lock for this context.
+func (c *Context) Unlock() {
+	atomic.AddInt32(&c.mutexChecker, -1)
+	c.state.Unlock()
+	c.mutex.Unlock()
+}
+
+func (c *Context) reading() {
+	if atomic.LoadInt32(&c.mutexChecker) != 1 {
+		panic("internal error: accessing context without lock")
+	}
+}
+
+func (c *Context) writing() {
+	if atomic.LoadInt32(&c.mutexChecker) != 1 {
+		panic("internal error: accessing context without lock")
+	}
+}
+
+// Set associates value with key. The provided value must properly marshal and
+// unmarshal with encoding/json. Note that the context needs to be locked and
+// unlocked by the caller.
+func (c *Context) Set(key string, value interface{}) {
+	c.writing()
+
+	var data map[string]*json.RawMessage
+	if c.IsEphemeral() {
+		data, _ = c.cache["ephemeral-context"].(map[string]*json.RawMessage)
+	} else {
+		if err := c.task.Get("hook-context", &data); err != nil && !errors.Is(err, state.ErrNoState) {
+			panic(fmt.Sprintf("internal error: cannot unmarshal context: %v", err))
+		}
+	}
+	if data == nil {
+		data = make(map[string]*json.RawMessage)
+	}
+
+	marshalledValue, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Sprintf("internal error: cannot marshal context value for %q: %s", key, err))
+	}
+	raw := json.RawMessage(marshalledValue)
+	data[key] = &raw
+
+	if c.IsEphemeral() {
+		c.cache["ephemeral-context"] = data
+	} else {
+		c.task.Set("hook-context", data)
+	}
+}
+
+// Get unmarshals the stored value associated with the provided key into the
+// value parameter. Note that the context needs to be locked/unlocked by the
+// caller.
+func (c *Context) Get(key string, value interface{}) error {
+	c.reading()
+
+	var data map[string]*json.RawMessage
+	if c.IsEphemeral() {
+		data, _ = c.cache["ephemeral-context"].(map[string]*json.RawMessage)
+		if data == nil {
+			return state.ErrNoState
+		}
+	} else {
+		if err := c.task.Get("hook-context", &data); err != nil {
+			return err
+		}
+	}
+
+	raw, ok := data[key]
+	if !ok {
+		return state.ErrNoState
+	}
+
+	err := jsonutil.DecodeWithNumber(bytes.NewReader(*raw), &value)
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal context value for %q: %s", key, err)
+	}
+
+	return nil
+}
+
+// State returns the state contained within the context
+func (c *Context) State() *state.State {
+	return c.state
+}
+
+// Cached returns the cached value associated with the provided key. It returns
+// nil if there is no entry for key. Note that the context needs to be locked
+// and unlocked by the caller.
+func (c *Context) Cached(key interface{}) interface{} {
+	c.reading()
+
+	return c.cache[key]
+}
+
+// Cache associates value with key. The cached value is not persisted. Note that
+// the context needs to be locked/unlocked by the caller.
+func (c *Context) Cache(key, value interface{}) {
+	c.writing()
+
+	c.cache[key] = value
+}
+
+// OnDone requests the provided function to be run once the context knows it's
+// complete. This can be called multiple times; each function will be called in
+// the order in which they were added. Note that the context needs to be locked
+// and unlocked by the caller.
+func (c *Context) OnDone(f func() error) {
+	c.writing()
+
+	c.onDone = append(c.onDone, f)
+}
+
+// Done is called to notify the context that its hook has exited successfully.
+// It will call all of the functions added in OnDone (even if one of them
+// returns an error) and will return the first error encountered. Note that the
+// context needs to be locked/unlocked by the caller.
+func (c *Context) Done() error {
+	c.reading()
+
+	var firstErr error
+	for _, f := range c.onDone {
+		if err := f(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+func (c *Context) IsEphemeral() bool {
+	return c.task == nil
+}
+
+// ChangeID returns change ID for non-ephemeral context
+// or empty string otherwise.
+func (c *Context) ChangeID() string {
+	if task, ok := c.Task(); ok {
+		if chg := task.Change(); chg != nil {
+			return chg.ID()
+		}
+	}
+	return ""
+}
+
+// Logf logs to the context, either to the logger for ephemeral contexts
+// or the task log.
+//
+// Context must be locked.
+func (c *Context) Logf(fmt string, args ...interface{}) {
+	c.writing()
+	if c.IsEphemeral() {
+		logger.Noticef(fmt, args...)
+	} else {
+		c.task.Logf(fmt, args...)
+	}
+}
+
+// Errorf logs errors to the context, either to the logger for
+// ephemeral contexts or the task log.
+//
+// Context must be locked.
+func (c *Context) Errorf(format string, args ...interface{}) {
+	c.writing()
+	if c.IsEphemeral() {
+		// XXX: loger has no Errorf() :/
+		logger.Noticef(format, args...)
+	} else {
+		c.task.Errorf(format, args...)
+		// If errors are ignored the task will not be in "Error"
+		// state so the error is hard to find. In this case also
+		// log errors to the journal to ensure that e.g. seeding
+		// configure errors are observable.
+		if c.setup != nil && c.setup.IgnoreError {
+			msg := fmt.Sprintf(format, args...)
+			logger.Noticef("ERROR task %v (%v): %v", c.task.ID(), c.task.Summary(), msg)
+		}
+	}
+}

--- a/internal/overlord/hookstate/context_test.go
+++ b/internal/overlord/hookstate/context_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
 type contextSuite struct {
@@ -45,7 +44,7 @@ func (s *contextSuite) SetUpTest(c *C) {
 	defer s.state.Unlock()
 
 	s.task = s.state.NewTask("test-task", "my test task")
-	s.setup = &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}, HookType: SetupBase}
+	s.setup = &HookSetup{Workshop: "ws", Sdk: "test-sdk", HookType: SetupBase}
 	var err error
 	s.context, err = NewContext(s.task, s.task.State(), s.setup, nil, "")
 	c.Check(err, IsNil)
@@ -150,7 +149,7 @@ func (s *contextSuite) TestDone(c *C) {
 }
 
 func (s *contextSuite) TestEphemeralContextGetSet(c *C) {
-	context, err := NewContext(nil, s.state, &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}}, nil, "")
+	context, err := NewContext(nil, s.state, &HookSetup{Workshop: "ws", Sdk: "test-sdk"}, nil, "")
 	c.Assert(err, IsNil)
 	context.Lock()
 	defer context.Unlock()
@@ -167,7 +166,7 @@ func (s *contextSuite) TestEphemeralContextGetSet(c *C) {
 }
 
 func (s *contextSuite) TestChangeID(c *C) {
-	context, err := NewContext(nil, s.state, &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}}, nil, "")
+	context, err := NewContext(nil, s.state, &HookSetup{Workshop: "ws", Sdk: "test-sdk"}, nil, "")
 	c.Assert(err, IsNil)
 	c.Check(context.ChangeID(), Equals, "")
 
@@ -175,13 +174,13 @@ func (s *contextSuite) TestChangeID(c *C) {
 	defer s.state.Unlock()
 
 	task := s.state.NewTask("foo", "")
-	context, err = NewContext(task, s.state, &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}}, nil, "")
+	context, err = NewContext(task, s.state, &HookSetup{Workshop: "ws", Sdk: "test-sdk"}, nil, "")
 	c.Assert(err, IsNil)
 	c.Check(context.ChangeID(), Equals, "")
 
 	chg := s.state.NewChange("bar", "")
 	chg.AddTask(task)
-	context, err = NewContext(task, s.state, &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}}, nil, "")
+	context, err = NewContext(task, s.state, &HookSetup{Workshop: "ws", Sdk: "test-sdk"}, nil, "")
 	c.Assert(err, IsNil)
 	c.Check(context.ChangeID(), Equals, chg.ID())
 }
@@ -213,7 +212,7 @@ func (s *contextSuite) TestChangeErrorf(c *C) {
 		// normal hooks only log errors to the task
 		{task2, false, ``, `.* ERROR some error`},
 	} {
-		hs := &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}, IgnoreError: tc.ignoreError}
+		hs := &HookSetup{Workshop: "ws", Sdk: "test-sdk", IgnoreError: tc.ignoreError}
 		context, err := NewContext(tc.task, s.state, hs, nil, "")
 		c.Assert(err, IsNil)
 		context.Lock()

--- a/internal/overlord/hookstate/context_test.go
+++ b/internal/overlord/hookstate/context_test.go
@@ -1,0 +1,250 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hookstate
+
+import (
+	"encoding/json"
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/workshopbackend"
+)
+
+type contextSuite struct {
+	context *Context
+	task    *state.Task
+	state   *state.State
+	setup   *HookSetup
+}
+
+var _ = Suite(&contextSuite{})
+
+func (s *contextSuite) SetUpTest(c *C) {
+	s.state = state.New(nil)
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.task = s.state.NewTask("test-task", "my test task")
+	s.setup = &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}, HookType: SetupBase}
+	var err error
+	s.context, err = NewContext(s.task, s.task.State(), s.setup, nil, "")
+	c.Check(err, IsNil)
+}
+
+func (s *contextSuite) TestHookSetup(c *C) {
+	c.Check(s.context.HookName(), Equals, "setup-base")
+}
+
+func (s *contextSuite) TestSetAndGet(c *C) {
+	s.context.Lock()
+	defer s.context.Unlock()
+
+	var output string
+	c.Check(s.context.Get("foo", &output), NotNil)
+
+	s.context.Set("foo", "bar")
+	c.Check(s.context.Get("foo", &output), IsNil, Commentf("Expected context to contain 'foo'"))
+	c.Check(output, Equals, "bar")
+
+	// Test another non-existing key, but after the context data was created.
+	c.Check(s.context.Get("baz", &output), NotNil)
+}
+
+func (s *contextSuite) TestSetAndGetNumber(c *C) {
+	s.context.Lock()
+	defer s.context.Unlock()
+
+	s.context.Set("num", 1234567890)
+
+	var output interface{}
+	c.Check(s.context.Get("num", &output), IsNil)
+	c.Assert(output, Equals, json.Number("1234567890"))
+}
+
+func (s *contextSuite) TestSetPersistence(c *C) {
+	s.context.Lock()
+	s.context.Set("foo", "bar")
+	s.context.Unlock()
+
+	// Verify that "foo" is still "bar" within another context of the same hook
+	// on the same task.
+	anotherContext := &Context{task: s.task, state: s.task.State(), setup: s.setup}
+	anotherContext.Lock()
+	defer anotherContext.Unlock()
+
+	var output string
+	c.Check(anotherContext.Get("foo", &output), IsNil, Commentf("Expected new context to also contain 'foo'"))
+	c.Check(output, Equals, "bar")
+}
+
+func (s *contextSuite) TestSetUnmarshalable(c *C) {
+	s.context.Lock()
+	defer s.context.Unlock()
+
+	defer func() {
+		c.Check(recover(), Matches, ".*cannot marshal context value.*", Commentf("Expected panic when attempting install"))
+	}()
+
+	s.context.Set("foo", func() {})
+}
+
+func (s *contextSuite) TestGetIsolatedFromTask(c *C) {
+	// Set data in the task itself
+	s.task.State().Lock()
+	s.task.Set("foo", "bar")
+	s.task.State().Unlock()
+
+	s.context.Lock()
+	defer s.context.Unlock()
+
+	// Verify that "foo" is not set when asking for data from the hook context
+	var output string
+	c.Check(s.context.Get("foo", &output), NotNil, Commentf("Expected context data to be isolated from task"))
+}
+
+func (s *contextSuite) TestCache(c *C) {
+	s.context.Lock()
+	defer s.context.Unlock()
+
+	c.Check(s.context.Cached("foo"), IsNil)
+
+	s.context.Cache("foo", "bar")
+	c.Check(s.context.Cached("foo"), Equals, "bar")
+
+	// Test another non-existing key, but after the context cache was created.
+	c.Check(s.context.Cached("baz"), IsNil)
+}
+
+func (s *contextSuite) TestDone(c *C) {
+	s.context.Lock()
+	defer s.context.Unlock()
+
+	called := false
+	s.context.OnDone(func() error {
+		called = true
+		return nil
+	})
+
+	s.context.Done()
+	c.Check(called, Equals, true, Commentf("Expected finalizer to be called"))
+}
+
+func (s *contextSuite) TestEphemeralContextGetSet(c *C) {
+	context, err := NewContext(nil, s.state, &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}}, nil, "")
+	c.Assert(err, IsNil)
+	context.Lock()
+	defer context.Unlock()
+
+	var output string
+	c.Check(context.Get("foo", &output), NotNil)
+
+	context.Set("foo", "bar")
+	c.Check(context.Get("foo", &output), IsNil, Commentf("Expected context to contain 'foo'"))
+	c.Check(output, Equals, "bar")
+
+	// Test another non-existing key, but after the context data was created.
+	c.Check(context.Get("baz", &output), NotNil)
+}
+
+func (s *contextSuite) TestChangeID(c *C) {
+	context, err := NewContext(nil, s.state, &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}}, nil, "")
+	c.Assert(err, IsNil)
+	c.Check(context.ChangeID(), Equals, "")
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	task := s.state.NewTask("foo", "")
+	context, err = NewContext(task, s.state, &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}}, nil, "")
+	c.Assert(err, IsNil)
+	c.Check(context.ChangeID(), Equals, "")
+
+	chg := s.state.NewChange("bar", "")
+	chg.AddTask(task)
+	context, err = NewContext(task, s.state, &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}}, nil, "")
+	c.Assert(err, IsNil)
+	c.Check(context.ChangeID(), Equals, chg.ID())
+}
+
+func (s *contextSuite) TestChangeErrorf(c *C) {
+	mockLog, restore := logger.MockLogger()
+	defer restore()
+
+	if v, ok := os.LookupEnv("SNAPD_DEBUG"); ok {
+		os.Unsetenv("SNAPD_DEBUG")
+		defer os.Setenv("SNAPD_DEBUG=%v", v)
+	}
+
+	s.state.Lock()
+	task1 := s.state.NewTask("foo1", "summary foo1")
+	task2 := s.state.NewTask("foo2", "summary foo2")
+	s.state.Unlock()
+
+	for _, tc := range []struct {
+		task                 *state.Task
+		ignoreError          bool
+		expectedLoggerOutput string
+		expectedTaskLog      string
+	}{
+		{nil, false, `.* context.go:.*: some error\n`, ``},
+		{nil, true, `.* context.go:.*: some error\n`, ``},
+		// ignore error hooks log errors to both logger and task
+		{task1, true, `.* context.go:.*: ERROR task ` + task1.ID() + ` \(summary foo1\): some error\n`, `.* ERROR some error`},
+		// normal hooks only log errors to the task
+		{task2, false, ``, `.* ERROR some error`},
+	} {
+		hs := &HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}, IgnoreError: tc.ignoreError}
+		context, err := NewContext(tc.task, s.state, hs, nil, "")
+		c.Assert(err, IsNil)
+		context.Lock()
+		context.Errorf("some error")
+		context.Unlock()
+		c.Check(mockLog.String(), Matches, tc.expectedLoggerOutput)
+		mockLog.Reset()
+		if tc.task != nil {
+			s.state.Lock()
+			taskLog := tc.task.Log()
+			s.state.Unlock()
+			if tc.expectedTaskLog != "" {
+				c.Assert(taskLog, HasLen, 1)
+				c.Check(taskLog[0], Matches, tc.expectedTaskLog)
+			} else {
+				c.Assert(taskLog, HasLen, 0)
+			}
+		}
+	}
+}
+
+func (s *contextSuite) TestChangeErrorfHookSetupNilPointerDoesNotCausePanic(c *C) {
+	s.state.Lock()
+	task := s.state.NewTask("foo", "")
+	s.state.Unlock()
+
+	var hookSetup *HookSetup = nil
+	context, err := NewContext(task, s.state, hookSetup, nil, "")
+	c.Assert(err, IsNil)
+	// it's enough to check here that there is no panic from "nil" hookSetup
+	context.Lock()
+	context.Errorf("some error")
+	context.Unlock()
+}

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -35,7 +35,7 @@ type MissingContextError struct {
 }
 
 func (e *MissingContextError) Error() string {
-	return fmt.Sprintf(`cannot invoke workshopctl operation commands (here %q) from outside of a snap`, e.subcommand)
+	return fmt.Sprintf(`cannot invoke workshopctl operation commands (here %q) from outside of a workshop`, e.subcommand)
 }
 
 type baseCommand struct {
@@ -135,7 +135,7 @@ func (f ForbiddenCommandError) Error() string {
 
 // nonRootAllowed lists the commands that can be performed even when workshopctl
 // is invoked not by root.
-var nonRootAllowed = []string{"get", "services", "set-health", "is-connected", "system-mode", "model"}
+var nonRootAllowed = []string{"set-health"}
 
 // Run runs the requested command.
 func Run(context *hookstate.Context, args []string, uid uint32) (stdout, stderr []byte, err error) {
@@ -175,7 +175,7 @@ func isAllowedToRun(uid uint32, args []string) bool {
 	//	* It runs as root
 	//	* It's contained in nonRootAllowed
 	//	* It's used with the -h or --help flags
-	// note: commands still need valid context and snaps can only access own config.
+	// note: commands still need valid context and workshops can only access own config.
 	return uid == 0 ||
 		strutil.ListContains(nonRootAllowed, args[0]) ||
 		strutil.ListContains(args, "-h") ||

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package ctlcmd contains the various workshopctl subcommands.
+package ctlcmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/x-go/strutil"
+)
+
+type MissingContextError struct {
+	subcommand string
+}
+
+func (e *MissingContextError) Error() string {
+	return fmt.Sprintf(`cannot invoke workshopctl operation commands (here %q) from outside of a snap`, e.subcommand)
+}
+
+type baseCommand struct {
+	stdout io.Writer
+	stderr io.Writer
+	c      *hookstate.Context
+	name   string
+}
+
+func (c *baseCommand) setName(name string) {
+	c.name = name
+}
+
+func (c *baseCommand) setStdout(w io.Writer) {
+	c.stdout = w
+}
+
+func (c *baseCommand) printf(format string, a ...interface{}) {
+	if c.stdout != nil {
+		fmt.Fprintf(c.stdout, format, a...)
+	}
+}
+
+func (c *baseCommand) setStderr(w io.Writer) {
+	c.stderr = w
+}
+
+func (c *baseCommand) errorf(format string, a ...interface{}) {
+	if c.stderr != nil {
+		fmt.Fprintf(c.stderr, format, a...)
+	}
+}
+
+func (c *baseCommand) setContext(context *hookstate.Context) {
+	c.c = context
+}
+
+func (c *baseCommand) context() *hookstate.Context {
+	return c.c
+}
+
+func (c *baseCommand) ensureContext() (context *hookstate.Context, err error) {
+	if c.c == nil {
+		err = &MissingContextError{c.name}
+	}
+	return c.c, err
+}
+
+type command interface {
+	setName(name string)
+
+	setStdout(w io.Writer)
+	setStderr(w io.Writer)
+
+	setContext(context *hookstate.Context)
+	context() *hookstate.Context
+
+	Execute(args []string) error
+}
+
+type commandInfo struct {
+	shortHelp string
+	longHelp  string
+	generator func() command
+	hidden    bool
+}
+
+var commands = make(map[string]*commandInfo)
+
+func addCommand(name, shortHelp, longHelp string, generator func() command) *commandInfo {
+	cmd := &commandInfo{
+		shortHelp: shortHelp,
+		longHelp:  longHelp,
+		generator: generator,
+	}
+	commands[name] = cmd
+	return cmd
+}
+
+// UnsuccessfulError carries a specific exit code to be returned to the client.
+type UnsuccessfulError struct {
+	ExitCode int
+}
+
+func (e UnsuccessfulError) Error() string {
+	return fmt.Sprintf("unsuccessful with exit code: %d", e.ExitCode)
+}
+
+// ForbiddenCommandError conveys that a command cannot be invoked in some context
+type ForbiddenCommandError struct {
+	Message string
+}
+
+func (f ForbiddenCommandError) Error() string {
+	return f.Message
+}
+
+// nonRootAllowed lists the commands that can be performed even when workshopctl
+// is invoked not by root.
+var nonRootAllowed = []string{"get", "services", "set-health", "is-connected", "system-mode", "model"}
+
+// Run runs the requested command.
+func Run(context *hookstate.Context, args []string, uid uint32) (stdout, stderr []byte, err error) {
+	if len(args) == 0 {
+		return nil, nil, fmt.Errorf("internal error: workshopctl cannot run without args")
+	}
+
+	if !isAllowedToRun(uid, args) {
+		return nil, nil, &ForbiddenCommandError{Message: fmt.Sprintf("cannot use %q with uid %d, try with sudo", args[0], uid)}
+	}
+
+	parser := flags.NewNamedParser("workshopctl", flags.PassDoubleDash|flags.HelpFlag)
+
+	// Create stdout/stderr buffers, and make sure commands use them.
+	var stdoutBuffer bytes.Buffer
+	var stderrBuffer bytes.Buffer
+	for name, cmdInfo := range commands {
+		cmd := cmdInfo.generator()
+		cmd.setName(name)
+		cmd.setStdout(&stdoutBuffer)
+		cmd.setStderr(&stderrBuffer)
+		cmd.setContext(context)
+
+		theCmd, err := parser.AddCommand(name, cmdInfo.shortHelp, cmdInfo.longHelp, cmd)
+		theCmd.Hidden = cmdInfo.hidden
+		if err != nil {
+			logger.Panicf("cannot add command %q: %s", name, err)
+		}
+	}
+
+	_, err = parser.ParseArgs(args)
+	return stdoutBuffer.Bytes(), stderrBuffer.Bytes(), err
+}
+
+func isAllowedToRun(uid uint32, args []string) bool {
+	// A command can run if any of the following are true:
+	//	* It runs as root
+	//	* It's contained in nonRootAllowed
+	//	* It's used with the -h or --help flags
+	// note: commands still need valid context and snaps can only access own config.
+	return uid == 0 ||
+		strutil.ListContains(nonRootAllowed, args[0]) ||
+		strutil.ListContains(args, "-h") ||
+		strutil.ListContains(args, "--help")
+}

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/canonical/workshop/internal/overlord/hookstate/hooktest"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/testutil"
-	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -48,7 +47,7 @@ func (s *ctlcmdSuite) SetUpTest(c *C) {
 	defer state.Unlock()
 
 	task := state.NewTask("test-task", "my test task")
-	setup := &hookstate.HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}, HookType: hookstate.SetupBase}
+	setup := &hookstate.HookSetup{Workshop: "ws", Sdk: "test-sdk", HookType: hookstate.SetupBase}
 
 	var err error
 	s.mockContext, err = hookstate.NewContext(task, task.State(), setup, handler, "")
@@ -88,7 +87,7 @@ func (s *ctlcmdSuite) TestHiddenCommand(c *C) {
 	// Type as flags.ErrHelp
 	c.Assert(err, FitsTypeOf, &flags.Error{})
 	c.Check(err.(*flags.Error).Type, Equals, flags.ErrHelp)
-	// workshopctl is mentioned (not snapd)
+	// workshopctl is mentioned (not workshopd)
 	c.Check(err.Error(), testutil.Contains, "workshopctl")
 	// mock-shown is in the help message
 	c.Check(err.Error(), testutil.Contains, "  mock-shown\n")

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jessevdk/go-flags"
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/workshop/internal/overlord/hookstate/ctlcmd"
+	"github.com/canonical/workshop/internal/overlord/hookstate/hooktest"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshopbackend"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type ctlcmdSuite struct {
+	mockContext *hookstate.Context
+}
+
+var _ = Suite(&ctlcmdSuite{})
+
+func (s *ctlcmdSuite) SetUpTest(c *C) {
+	handler := hooktest.NewMockHandler()
+
+	state := state.New(nil)
+	state.Lock()
+	defer state.Unlock()
+
+	task := state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Sdk: workshopbackend.SdkRecord{Name: "test-sdk", Channel: "latest/stable"}, HookType: hookstate.SetupBase}
+
+	var err error
+	s.mockContext, err = hookstate.NewContext(task, task.State(), setup, handler, "")
+	c.Assert(err, IsNil)
+}
+
+func (s *ctlcmdSuite) TestNonExistingCommand(c *C) {
+	c.Skip("Need at least one command added to the parser")
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"foo"}, 0)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Equals, "")
+	c.Check(err, ErrorMatches, ".*[Uu]nknown command.*")
+}
+
+func (s *ctlcmdSuite) TestCommandOutput(c *C) {
+	mockCommand := ctlcmd.AddMockCommand("mock")
+	defer ctlcmd.RemoveCommand("mock")
+
+	mockCommand.FakeStdout = "test stdout"
+	mockCommand.FakeStderr = "test stderr"
+
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"mock", "foo"}, 0)
+	c.Check(err, IsNil)
+	c.Check(string(stdout), Equals, "test stdout")
+	c.Check(string(stderr), Equals, "test stderr")
+	c.Check(mockCommand.Args, DeepEquals, []string{"foo"})
+}
+
+func (s *ctlcmdSuite) TestHiddenCommand(c *C) {
+	ctlcmd.AddHiddenMockCommand("mock-hidden")
+	ctlcmd.AddMockCommand("mock-shown")
+	defer ctlcmd.RemoveCommand("mock-hidden")
+	defer ctlcmd.RemoveCommand("mock-shown")
+
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"--help"}, 0)
+	// help message output is returned as *flags.Error with
+	// Type as flags.ErrHelp
+	c.Assert(err, FitsTypeOf, &flags.Error{})
+	c.Check(err.(*flags.Error).Type, Equals, flags.ErrHelp)
+	// workshopctl is mentioned (not snapd)
+	c.Check(err.Error(), testutil.Contains, "workshopctl")
+	// mock-shown is in the help message
+	c.Check(err.Error(), testutil.Contains, "  mock-shown\n")
+	// mock-hidden is not in the help message
+	c.Check(err.Error(), Not(testutil.Contains), "  mock-hidden\n")
+}
+
+func (s *ctlcmdSuite) TestRootRequiredCommandFailure(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"start"}, 1000)
+
+	c.Check(err, FitsTypeOf, &ctlcmd.ForbiddenCommandError{})
+	c.Check(err.Error(), Equals, `cannot use "start" with uid 1000, try with sudo`)
+}
+
+func (s *ctlcmdSuite) TestRunNoArgsFailure(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{}, 0)
+	c.Check(err, NotNil)
+}
+
+func (s *ctlcmdSuite) TestRunOnlyHelp(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"-h"}, 1000)
+	c.Check(err, NotNil)
+	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
+
+	_, _, err = ctlcmd.Run(s.mockContext, []string{"--help"}, 1000)
+	c.Check(err, NotNil)
+	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
+}
+
+func (s *ctlcmdSuite) TestRunHelpAtAnyPosition(c *C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"start", "a", "-h"}, 1000)
+	c.Check(err, NotNil)
+	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
+
+	_, _, err = ctlcmd.Run(s.mockContext, []string{"start", "a", "b", "--help"}, 1000)
+	c.Check(err, NotNil)
+	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
+}
+
+func (s *ctlcmdSuite) TestRunNonRootAllowedCommandWithAllowedCmdAsArg(c *C) {
+	// this test protects us against a future refactor introducing a bug that allows
+	// a root-only command to run without root if an arg is in the nonRootAllowed list
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"set", "get", "a"}, 1000)
+	c.Check(err, FitsTypeOf, &ctlcmd.ForbiddenCommandError{})
+	c.Check(err.Error(), Equals, `cannot use "set" with uid 1000, try with sudo`)
+}

--- a/internal/overlord/hookstate/ctlcmd/export_test.go
+++ b/internal/overlord/hookstate/ctlcmd/export_test.go
@@ -1,0 +1,56 @@
+package ctlcmd
+
+import "fmt"
+
+func AddMockCommand(name string) *MockCommand {
+	return addMockCmd(name, false)
+}
+
+func addMockCmd(name string, hidden bool) *MockCommand {
+	mockCommand := NewMockCommand()
+	cmd := addCommand(name, "", "", func() command { return mockCommand })
+	cmd.hidden = hidden
+	return mockCommand
+}
+
+func AddHiddenMockCommand(name string) *MockCommand {
+	return addMockCmd(name, true)
+}
+
+func RemoveCommand(name string) {
+	delete(commands, name)
+}
+
+func NewMockCommand() *MockCommand {
+	return &MockCommand{
+		ExecuteError: false,
+	}
+}
+
+func (c *MockCommand) Execute(args []string) error {
+	c.Args = args
+
+	if c.FakeStdout != "" {
+		c.printf(c.FakeStdout)
+	}
+
+	if c.FakeStderr != "" {
+		c.errorf(c.FakeStderr)
+	}
+
+	if c.ExecuteError {
+		return fmt.Errorf("failed at user request")
+	}
+
+	return nil
+}
+
+type MockCommand struct {
+	baseCommand
+
+	ExecuteError bool
+	FakeStdout   string
+	FakeStderr   string
+
+	Args []string
+}

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -36,7 +36,7 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	if hook.HookType == SaveState || hook.HookType == RestoreState {
 		volume := workshopbackend.WorkshopStateVolumeName(workshop, prj.ProjectId)
 		if err := h.backend.AddWorkshopDevice(ctx, workshop, workshopbackend.Volume(volume, workshopbackend.WorkshopStateDir, volume)); err != nil {
-			return fmt.Errorf("cannot run hook %q for SDK %q: %w", hook.Type(), hook.Sdk.Name, err)
+			return fmt.Errorf("cannot run hook %q for SDK %q: %w", hook.Type(), hook.Sdk, err)
 		}
 
 		defer func() {
@@ -51,12 +51,12 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		{
 			fs, err := h.backend.WorkshopFs(ctx, workshop)
 			if err != nil {
-				return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk.Name, err)
+				return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
 			}
 			err = fs.MkdirAll(hook.Environment["SDK_STATE_DIR"], 0755)
 			fs.Close()
 			if err != nil {
-				return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk.Name, err)
+				return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
 			}
 		}
 		return h.executeHook(ctx, task, workshop, prj.ProjectId, &hook)
@@ -64,16 +64,16 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		{
 			fs, err := h.backend.WorkshopFs(ctx, workshop)
 			if err != nil {
-				return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk.Name, err)
+				return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
 			}
 			info, err := fs.Stat(hook.Environment["SDK_STATE_DIR"])
 			fs.Close()
 			if err != nil {
-				return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk.Name, err)
+				return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
 			}
 
 			if !info.IsDir() {
-				return fmt.Errorf("cannot run hook \"restore-sate\" for %q SDK: state storage path is not a directory", hook.Sdk.Name)
+				return fmt.Errorf("cannot run hook \"restore-sate\" for %q SDK: state storage path is not a directory", hook.Sdk)
 			}
 		}
 		return h.executeHook(ctx, task, workshop, prj.ProjectId, &hook)
@@ -83,9 +83,8 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 }
 
 func (h *HookManager) executeHook(ctx context.Context, task *state.Task, workshop, projectId string, hook *HookSetup) error {
-	hookPath := sdk.SdkHookPath(hook.Sdk.Name, hook.Type())
+	hookPath := sdk.SdkHookPath(hook.Sdk, hook.Type())
 
-	//
 	wsFs, err := h.backend.WorkshopFs(ctx, workshop)
 	if err != nil {
 		return err
@@ -94,11 +93,11 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, worksho
 	info, err := wsFs.Stat(hookPath)
 	wsFs.Close()
 	if errors.Is(err, afero.ErrFileNotFound) || !info.Mode().IsRegular() {
-		logger.Debugf("%q SDK does not provide %q hook", hook.Sdk.Name, hook.Type())
+		logger.Debugf("%q SDK does not provide %q hook", hook.Sdk, hook.Type())
 		return nil
 	}
 
-	/* create a memory out/err to log the hook output into the task's log */
+	// create a memory out/err to log the hook output into the task's log
 	memFs := afero.NewMemMapFs()
 	out, err := memFs.Create(workshopbackend.InstanceName(workshop, projectId))
 	if err != nil {
@@ -118,7 +117,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, worksho
 				hookPath,
 			},
 			Environment: hook.Environment,
-			WorkDir:     sdk.SdkHooksDir(hook.Sdk.Name),
+			WorkDir:     sdk.SdkHooksDir(hook.Sdk),
 		},
 		ExecControls: workshopbackend.ExecControls{
 			Stdin:  nil,

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -62,7 +62,7 @@ func (s *hookSuite) SetUpTest(c *check.C) {
 
 	// empty task handler
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
-	s.hookmgr = hookstate.New(s.runner, s.backend)
+	s.hookmgr = hookstate.New(s.state, s.runner, s.backend)
 
 	// error-provoking task handler
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
@@ -83,9 +83,8 @@ func (s *hookSuite) TearDownTest(c *check.C) {
 func (s *hookSuite) TestExecSetupBaseNoHook(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := workshopbackend.SdkRecord{Name: "new", Channel: "latest/stable"}
 
-	t1 := hookstate.SetupHook(s.state, &newSdk, hookstate.SetupBase)
+	t1 := hookstate.SetupHook(s.state, "ws", "new", hookstate.SetupBase)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -114,15 +113,14 @@ base: ubuntu@20.04
 func (s *hookSuite) TestExecSaveState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := workshopbackend.SdkRecord{Name: "one", Channel: "latest/stable"}
-	t1 := hookstate.SetupHook(s.state, &newSdk, hookstate.SaveState)
+	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.SaveState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.launchWorkshop(c, newSdk)
+	s.launchWorkshop(c, "one")
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
@@ -146,15 +144,14 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := workshopbackend.SdkRecord{Name: "one", Channel: "latest/stable"}
-	t1 := hookstate.SetupHook(s.state, &newSdk, hookstate.RestoreState)
+	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.RestoreState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.launchWorkshop(c, newSdk)
+	s.launchWorkshop(c, "one")
 
 	// setup state storage (usually already set by the save-state)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
@@ -177,15 +174,14 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 func (s *hookSuite) TestHookFailed(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := workshopbackend.SdkRecord{Name: "one", Channel: "latest/stable"}
-	t1 := hookstate.SetupHook(s.state, &newSdk, hookstate.SaveState)
+	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.SaveState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.launchWorkshop(c, newSdk)
+	s.launchWorkshop(c, "one")
 	s.backend.DoExec = func(ctx context.Context, name string, args *workshopbackend.Execution) (workshopbackend.ExecContext, error) {
 		return workshopbackend.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
@@ -217,7 +213,7 @@ func (s *hookSuite) TestHookFailed(c *check.C) {
 	c.Assert(t1.Log()[0], check.Matches, ".*hook execution error")
 }
 
-func (s *hookSuite) launchWorkshop(c *check.C, newSdk workshopbackend.SdkRecord) {
+func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
 	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
 base: ubuntu@20.04
 sdks:
@@ -229,12 +225,12 @@ sdks:
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
-	err = ws.MkdirAll(sdk.SdkHooksDir(newSdk.Name), 0744)
+	err = ws.MkdirAll(sdk.SdkHooksDir(newsdk), 0744)
 	c.Check(err, check.IsNil)
-	_, err = ws.Create(sdk.SdkHookPath(newSdk.Name, hookstate.SaveState.String()))
+	_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.SaveState.String()))
 	c.Check(err, check.IsNil)
-	_, err = ws.Create(sdk.SdkHookPath(newSdk.Name, hookstate.RestoreState.String()))
+	_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.RestoreState.String()))
 	c.Check(err, check.IsNil)
-	_, err = ws.Create(sdk.SdkHookPath(newSdk.Name, hookstate.SetupBase.String()))
+	_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.SetupBase.String()))
 	c.Check(err, check.IsNil)
 }

--- a/internal/overlord/hookstate/hooktest/handler.go
+++ b/internal/overlord/hookstate/hooktest/handler.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hooktest
+
+import "fmt"
+
+// MockHandler is a mock hookstate.Handler.
+type MockHandler struct {
+	BeforeCalled bool
+	BeforeError  bool
+
+	DoneCalled bool
+	DoneError  bool
+
+	ErrorCalled       bool
+	ErrorError        bool
+	IgnoreOriginalErr bool
+	Err               error
+
+	// callbacks useful for testing
+	BeforeCallback func()
+	DoneCallback   func()
+}
+
+// NewMockHandler returns a new MockHandler.
+func NewMockHandler() *MockHandler {
+	return &MockHandler{}
+}
+
+// Before satisfies hookstate.Handler.Before
+func (h *MockHandler) Before() error {
+	if h.BeforeCallback != nil {
+		h.BeforeCallback()
+	}
+	h.BeforeCalled = true
+	if h.BeforeError {
+		return fmt.Errorf("Before failed at user request")
+	}
+	return nil
+}
+
+// Done satisfies hookstate.Handler.Done
+func (h *MockHandler) Done() error {
+	if h.DoneCallback != nil {
+		h.DoneCallback()
+	}
+	h.DoneCalled = true
+	if h.DoneError {
+		return fmt.Errorf("Done failed at user request")
+	}
+	return nil
+}
+
+// Error satisfies hookstate.Handler.Error
+func (h *MockHandler) Error(err error) (bool, error) {
+	h.Err = err
+	h.ErrorCalled = true
+	if h.ErrorError {
+		return false, fmt.Errorf("Error failed at user request")
+	}
+	return h.IgnoreOriginalErr, nil
+}

--- a/internal/overlord/hookstate/hooktest/handler_test.go
+++ b/internal/overlord/hookstate/hooktest/handler_test.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hooktest_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/overlord/hookstate/hooktest"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type hooktestSuite struct {
+	mockHandler *hooktest.MockHandler
+}
+
+var _ = Suite(&hooktestSuite{})
+
+func (s *hooktestSuite) SetUpTest(c *C) {
+	s.mockHandler = hooktest.NewMockHandler()
+}
+
+func (s *hooktestSuite) TestBefore(c *C) {
+	var callbackCalled = false
+	s.mockHandler.BeforeCallback = func() {
+		callbackCalled = true
+	}
+	c.Check(s.mockHandler.BeforeCalled, Equals, false)
+	c.Check(s.mockHandler.Before(), IsNil)
+	c.Check(s.mockHandler.BeforeCalled, Equals, true)
+	c.Check(callbackCalled, Equals, true)
+}
+
+func (s *hooktestSuite) TestBeforeError(c *C) {
+	s.mockHandler.BeforeError = true
+	c.Check(s.mockHandler.Before(), NotNil)
+	c.Check(s.mockHandler.BeforeCalled, Equals, true)
+}
+
+func (s *hooktestSuite) TestDone(c *C) {
+	var callbackCalled = false
+	s.mockHandler.DoneCallback = func() {
+		callbackCalled = true
+	}
+	c.Check(s.mockHandler.DoneCalled, Equals, false)
+	c.Check(s.mockHandler.Done(), IsNil)
+	c.Check(s.mockHandler.DoneCalled, Equals, true)
+	c.Check(callbackCalled, Equals, true)
+}
+
+func (s *hooktestSuite) TestDoneError(c *C) {
+	s.mockHandler.DoneError = true
+	c.Check(s.mockHandler.Done(), NotNil)
+	c.Check(s.mockHandler.DoneCalled, Equals, true)
+}
+
+func (s *hooktestSuite) TestError(c *C) {
+	err := fmt.Errorf("test error")
+	c.Check(s.mockHandler.ErrorCalled, Equals, false)
+	ignore, herr := s.mockHandler.Error(err)
+	c.Check(ignore, Equals, false)
+	c.Check(herr, IsNil)
+	c.Check(s.mockHandler.ErrorCalled, Equals, true)
+	c.Check(s.mockHandler.Err, Equals, err)
+}
+
+func (s *hooktestSuite) TestErrorError(c *C) {
+	s.mockHandler.ErrorError = true
+	err := fmt.Errorf("test error")
+	ignore, herr := s.mockHandler.Error(err)
+	c.Check(ignore, Equals, false)
+	c.Check(herr, NotNil)
+	c.Check(s.mockHandler.ErrorCalled, Equals, true)
+	c.Check(s.mockHandler.Err, Equals, err)
+}
+
+func (s *hooktestSuite) TestIgnoreError(c *C) {
+	s.mockHandler.IgnoreOriginalErr = true
+	err := fmt.Errorf("test error")
+	ignore, herr := s.mockHandler.Error(err)
+	c.Check(ignore, Equals, true)
+	c.Check(herr, IsNil)
+	c.Check(s.mockHandler.ErrorCalled, Equals, true)
+	c.Check(s.mockHandler.Err, Equals, err)
+}

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -1,6 +1,8 @@
 package hookstate
 
 import (
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -23,11 +25,12 @@ type Handler interface {
 }
 
 type HookSetup struct {
-	Sdk         workshopbackend.SdkRecord `json:"sdk"`
-	HookType    WorkshopHookType          `json:"type"`
-	Environment map[string]string         `json:"environment"`
-	Timeout     time.Duration             `json:"timeout"`
-	IgnoreError bool                      `json:"bool"`
+	Workshop    string            `json:"workshop"`
+	Sdk         string            `json:"sdk"`
+	HookType    WorkshopHookType  `json:"type"`
+	Environment map[string]string `json:"environment"`
+	Timeout     time.Duration     `json:"timeout"`
+	IgnoreError bool              `json:"bool"`
 }
 
 type WorkshopHookType int
@@ -47,11 +50,16 @@ func (h *HookSetup) Type() string {
 }
 
 type HookManager struct {
+	state   *state.State
 	backend workshopbackend.WorkshopBackend
+
+	contextsMutex sync.RWMutex
+	contexts      map[string]*Context
 }
 
-func New(runner *state.TaskRunner, server workshopbackend.WorkshopBackend) *HookManager {
+func New(s *state.State, runner *state.TaskRunner, server workshopbackend.WorkshopBackend) *HookManager {
 	manager := &HookManager{
+		state:   s,
 		backend: server,
 	}
 
@@ -62,4 +70,37 @@ func New(runner *state.TaskRunner, server workshopbackend.WorkshopBackend) *Hook
 
 func (w *HookManager) Ensure() error {
 	return nil
+}
+
+func (m *HookManager) ephemeralContext(cookieID string) (context *Context, err error) {
+	var contexts map[string]string
+	m.state.Lock()
+	defer m.state.Unlock()
+	err = m.state.Get("workshop-cookies", &contexts)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get workshop cookies: %v", err)
+	}
+	if workshop, ok := contexts[cookieID]; ok {
+		// create new ephemeral context
+		context, err = NewContext(nil, m.state, &HookSetup{Workshop: workshop}, nil, cookieID)
+		return context, err
+	}
+	return nil, fmt.Errorf("invalid workshop cookie requested")
+}
+
+// Context obtains the context for the given cookie ID.
+func (m *HookManager) Context(cookieID string) (*Context, error) {
+	m.contextsMutex.RLock()
+	defer m.contextsMutex.RUnlock()
+
+	var err error
+	context, ok := m.contexts[cookieID]
+	if !ok {
+		context, err = m.ephemeralContext(cookieID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return context, nil
 }

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -1,15 +1,33 @@
 package hookstate
 
 import (
+	"time"
+
 	"github.com/canonical/workshop/internal/overlord/state"
 	. "github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
+// Handler is the interface a client must satify to handle hooks.
+type Handler interface {
+	// Before is called right before the hook is to be run.
+	Before() error
+
+	// Done is called right after the hook has finished successfully.
+	Done() error
+
+	// Error is called if the hook encounters an error while running.
+	// The returned bool flag indicates if the original hook error should be
+	// ignored by hook manager.
+	Error(hookErr error) (ignoreHookErr bool, err error)
+}
+
 type HookSetup struct {
 	Sdk         workshopbackend.SdkRecord `json:"sdk"`
 	HookType    WorkshopHookType          `json:"type"`
 	Environment map[string]string         `json:"environment"`
+	Timeout     time.Duration             `json:"timeout"`
+	IgnoreError bool                      `json:"bool"`
 }
 
 type WorkshopHookType int

--- a/internal/overlord/hookstate/request.go
+++ b/internal/overlord/hookstate/request.go
@@ -8,12 +8,12 @@ import (
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
-func SetupHook(st *state.State, sdk *workshopbackend.SdkRecord, hook WorkshopHookType) *state.Task {
-	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk.Name))
+func SetupHook(st *state.State, workshop, sdk string, hook WorkshopHookType) *state.Task {
+	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
 
-	setup := HookSetup{HookType: hook, Sdk: *sdk, Environment: map[string]string{}}
+	setup := HookSetup{HookType: hook, Workshop: workshop, Sdk: sdk, Environment: map[string]string{}}
 	if hook == SaveState || hook == RestoreState {
-		setup.Environment["SDK_STATE_DIR"] = filepath.Join(workshopbackend.WorkshopStateDir, "sdk", sdk.Name)
+		setup.Environment["SDK_STATE_DIR"] = filepath.Join(workshopbackend.WorkshopStateDir, "sdk", sdk)
 	}
 	setup_hook.Set("hook-setup", &setup)
 	return setup_hook

--- a/internal/overlord/hookstate/request_test.go
+++ b/internal/overlord/hookstate/request_test.go
@@ -25,8 +25,6 @@ func (s *S) TestCreateHook(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var sdk = workshopbackend.SdkRecord{Name: "go", Channel: "latest/stable"}
-
 	envs := []map[string]string{
 		{},
 		{"SDK_STATE_DIR": "/var/lib/workshop/state/sdk/go"},
@@ -38,13 +36,14 @@ func (s *S) TestCreateHook(c *check.C) {
 		hookstate.SaveState,
 		hookstate.RestoreState,
 	} {
-		task := hookstate.SetupHook(s.state, &sdk, i)
+		task := hookstate.SetupHook(s.state, "test", "go", i)
 
 		var hookSetup hookstate.HookSetup
 		err := task.Get("hook-setup", &hookSetup)
 		c.Assert(err, check.IsNil)
 		c.Assert(hookSetup.Type(), check.Equals, i.String())
-		c.Assert(hookSetup.Sdk, check.DeepEquals, sdk)
+		c.Assert(hookSetup.Workshop, check.DeepEquals, "test")
+		c.Assert(hookSetup.Sdk, check.DeepEquals, "go")
 		c.Assert(hookSetup.Environment, check.DeepEquals, envs[num])
 		c.Check(task.Summary(), check.Equals, fmt.Sprintf("Run hook %q for \"go\" SDK", hookSetup.Type()))
 	}

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -58,7 +58,7 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.ctx = context.WithValue(s.ctx, workshopbackend.ContextProjectId, s.prj.ProjectId)
 
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
 }
 
 func (s *interfaceManagerSuite) TearDownTest(c *check.C) {

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -46,8 +46,6 @@ var (
 	abortWait      = 24 * time.Hour * 7
 
 	pruneMaxChanges = 500
-
-	defaultCachedDownloads = 5
 )
 
 var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
@@ -70,14 +68,14 @@ type Overlord struct {
 	pruneTicker *time.Ticker
 
 	// managers
-	inited    bool
-	startedUp bool
-	sdk       *sdkstate.SdkManager
-	workshop  *workshop.WorkshopManager
-	hook      *hookstate.HookManager
-	command   *cmdstate.CommandManager
-	ifacemgr  *ifacestate.InterfaceManager
-	runner    *state.TaskRunner
+	inited      bool
+	startedUp   bool
+	sdk         *sdkstate.SdkManager
+	workshopmgr *workshop.WorkshopManager
+	hookmgr     *hookstate.HookManager
+	commandmgr  *cmdstate.CommandManager
+	ifacemgr    *ifacestate.InterfaceManager
+	runner      *state.TaskRunner
 
 	startOfOperationTime time.Time
 
@@ -144,17 +142,17 @@ func New(dir string, b workshopbackend.WorkshopBackend, restartHandler restart.H
 	}
 	o.runner.AddOptionalHandler(matchAnyUnknownTask, handleUnknownTask, nil)
 
-	o.workshop = workshop.New(s, o.runner, o.workshopBackend)
-	o.addManager(o.workshop)
+	o.workshopmgr = workshop.New(s, o.runner, o.workshopBackend)
+	o.addManager(o.workshopmgr)
 
 	o.sdk = sdkstate.New(o.runner, o.workshopBackend)
 	o.addManager(o.sdk)
 
-	o.hook = hookstate.New(o.runner, o.workshopBackend)
-	o.addManager(o.hook)
+	o.hookmgr = hookstate.New(s, o.runner, o.workshopBackend)
+	o.addManager(o.hookmgr)
 
-	o.command = cmdstate.New(o.runner, o.workshopBackend)
-	o.addManager(o.command)
+	o.commandmgr = cmdstate.New(o.runner, o.workshopBackend)
+	o.addManager(o.commandmgr)
 
 	o.ifacemgr = ifacestate.New(s, o.runner, o.workshopBackend)
 	o.addManager(o.ifacemgr)
@@ -462,11 +460,15 @@ func (o *Overlord) WorkshopBackend() workshopbackend.WorkshopBackend {
 }
 
 func (o *Overlord) WorkshopManager() *workshop.WorkshopManager {
-	return o.workshop
+	return o.workshopmgr
 }
 
 func (o *Overlord) CommandManager() *cmdstate.CommandManager {
-	return o.command
+	return o.commandmgr
+}
+
+func (o *Overlord) HookManager() *hookstate.HookManager {
+	return o.hookmgr
 }
 
 // Fake creates an Overlord without any managers and with a backend

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -219,9 +219,9 @@ func (*ManagerSuite) validateStateHooksTasksSetup(c *check.C, ts []*state.TaskSe
 			c.Assert(err, check.IsNil)
 			switch setup.HookType {
 			case hookstate.SaveState:
-				obtainedSave = append(obtainedSave, setup.Sdk.Name)
+				obtainedSave = append(obtainedSave, setup.Sdk)
 			case hookstate.RestoreState:
-				obtainedRestore = append(obtainedRestore, setup.Sdk.Name)
+				obtainedRestore = append(obtainedRestore, setup.Sdk)
 			}
 		}
 	}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -123,7 +123,7 @@ func launch(st *state.State, file *workshopbackend.WorkshopFile, project *worksh
 		install.AddAll(installTaskSet)
 
 		// Make sure that the hook tasks are not concurrent
-		setupHookTask := hookstate.SetupHook(st, &sdk, hookstate.SetupBase)
+		setupHookTask := hookstate.SetupHook(st, file.Name, sdk.Name, hookstate.SetupBase)
 		if prevSetup != nil {
 			setupHookTask.WaitFor(prevSetup)
 		}
@@ -275,7 +275,7 @@ func refresh(st *state.State, file *workshopbackend.WorkshopFile, content []sdk.
 	// 6. Delete the old workshop
 
 	createStateStorage := st.NewTask("create-state-storage", "Create SDK state storage")
-	saveStateHooks := saveStateHooks(st, content, file.Sdks)
+	saveStateHooks := saveStateHooks(st, file.Name, content, file.Sdks)
 	saveStateHooks.WaitFor(createStateStorage)
 
 	// disconnect and remove SDKs plugs and slots
@@ -292,7 +292,7 @@ func refresh(st *state.State, file *workshopbackend.WorkshopFile, content []sdk.
 		return nil, err
 	}
 
-	restoreStateHooks := restoreStateHooks(st, content, file.Sdks)
+	restoreStateHooks := restoreStateHooks(st, file.Name, content, file.Sdks)
 
 	removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
 	removeFromStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", file.Name))
@@ -358,13 +358,13 @@ func disconnectSdks(content []sdk.Setup, st *state.State) *state.TaskSet {
 	return state.NewTaskSet(disconnectSet...)
 }
 
-func saveStateHooks(st *state.State, content []sdk.Setup, newContent workshopbackend.SdkList,
+func saveStateHooks(st *state.State, workshop string, content []sdk.Setup, newContent workshopbackend.SdkList,
 ) *state.TaskSet {
-	return createStateHooks(st, content, newContent, hookstate.SaveState)
+	return createStateHooks(st, workshop, content, newContent, hookstate.SaveState)
 }
 
-func restoreStateHooks(st *state.State, content []sdk.Setup, newContent workshopbackend.SdkList) *state.TaskSet {
-	stateHooks := createStateHooks(st, content, newContent, hookstate.RestoreState)
+func restoreStateHooks(st *state.State, workshop string, content []sdk.Setup, newContent workshopbackend.SdkList) *state.TaskSet {
+	stateHooks := createStateHooks(st, workshop, content, newContent, hookstate.RestoreState)
 
 	// if the restore hooks are not present (i.e. workshop has no SDKs after
 	// the refresh), we should mark the last launch task as last before the
@@ -379,7 +379,7 @@ func restoreStateHooks(st *state.State, content []sdk.Setup, newContent workshop
 	return stateHooks
 }
 
-func createStateHooks(st *state.State, content []sdk.Setup, newContent workshopbackend.SdkList, hooktype hookstate.WorkshopHookType) *state.TaskSet {
+func createStateHooks(st *state.State, workshop string, content []sdk.Setup, newContent workshopbackend.SdkList, hooktype hookstate.WorkshopHookType) *state.TaskSet {
 	stateHooks := state.NewTaskSet([]*state.Task{}...)
 	prevRestore := (*state.Task)(nil)
 	for _, newsdk := range newContent {
@@ -389,7 +389,7 @@ func createStateHooks(st *state.State, content []sdk.Setup, newContent workshopb
 			continue
 		}
 
-		stateHook := hookstate.SetupHook(st, &newsdk, hooktype)
+		stateHook := hookstate.SetupHook(st, workshop, newsdk.Name, hooktype)
 		stateHooks.AddTask(stateHook)
 		if prevRestore != nil {
 			stateHook.WaitFor(prevRestore)

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -492,7 +492,7 @@ func (s *S) TestRefreshManyRestoreStateHooksExecutedSequentially(c *check.C) {
 	one := sdk.Setup{Name: "one", Channel: "latest/stable"}
 	two := sdk.Setup{Name: "two", Channel: "latest/stable"}
 
-	ts := workshopstate.RestoreStateHooks(s.state,
+	ts := workshopstate.RestoreStateHooks(s.state, "ws",
 		[]sdk.Setup{one, two}, workshopbackend.SdkList{oneinst, twoinst})
 	c.Assert(ts.Tasks(), check.HasLen, 2)
 
@@ -518,7 +518,7 @@ func (s *S) TestRefreshManySaveStateHooksExecutedSequentially(c *check.C) {
 	one := sdk.Setup{Name: "one", Channel: "latest/stable"}
 	two := sdk.Setup{Name: "two", Channel: "latest/stable"}
 
-	ts := workshopstate.SaveStateHooks(s.state, []sdk.Setup{one, two}, installed)
+	ts := workshopstate.SaveStateHooks(s.state, "ws", []sdk.Setup{one, two}, installed)
 	c.Assert(ts.Tasks(), check.HasLen, 2)
 
 	prev := (*state.Task)(nil)
@@ -540,7 +540,7 @@ func (s *S) TestRefreshManyNoRestoreStateHooks(c *check.C) {
 		Sdks: workshopbackend.SdkList{},
 	}
 
-	ts := workshopstate.RestoreStateHooks(s.state, []sdk.Setup{}, file.Sdks)
+	ts := workshopstate.RestoreStateHooks(s.state, "ws", []sdk.Setup{}, file.Sdks)
 	c.Assert(ts.Tasks(), check.HasLen, 0)
 }
 

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/gorilla/websocket"
@@ -1137,6 +1138,7 @@ func createDefaultDevices() map[string]map[string]string {
 	return map[string]map[string]string{
 		"root":             {"type": "disk", "pool": "default", "path": "/"},
 		"workshop.network": {"type": "nic", "network": "lxdbr0", "name": "eth0"},
+		"workshop.socket":  {"type": "disk", "source": dirs.SocketPath + ".untrusted", "path": filepath.Join(dirs.WorkshopBaseDir, ".workshop.socket.untrusted")},
 	}
 }
 

--- a/internal/workshopbackend/lxd_project.go
+++ b/internal/workshopbackend/lxd_project.go
@@ -1,6 +1,7 @@
 package workshopbackend
 
 import (
+	"fmt"
 	"net/http"
 
 	lxd "github.com/lxc/lxd/client"
@@ -9,6 +10,9 @@ import (
 
 // Initialise the Workshop project namespace.
 func InitProject(conn lxd.InstanceServer, username string) error {
+	if username == "" {
+		return fmt.Errorf("cannot init LXD project: username is empty")
+	}
 	if err := createOrLoadLxdProject(conn, LxdProjectName(username)); err != nil {
 		return err
 	}

--- a/internal/workshopbackend/tests/integration/workshop_exec_test.go
+++ b/internal/workshopbackend/tests/integration/workshop_exec_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
 	lxd "github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/shared/api"
 	"gopkg.in/check.v1"
 )
 
@@ -33,6 +34,7 @@ type wsExec struct {
 	lookupUserIdRestore func()
 	newProjectidRestore func()
 	restoreImageServer  func()
+	restoreDevices      func()
 }
 
 var _ = check.Suite(&wsExec{})
@@ -90,6 +92,11 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 		return u, nil
 	}, &daemon.LookupUserId)
 
+	f.restoreDevices = workshopbackend.FakeDefaultDevices(defaultTestDevices)
+
+	err = f.lxdClient.CreateStoragePool(api.StoragePoolsPost{StoragePoolPut: api.StoragePoolPut{Config: map[string]string{"volume.size": "1GiB"}}, Name: "testZfsProfile", Driver: "zfs"})
+	c.Assert(err, check.IsNil)
+
 	f.newProjectidRestore = testutil.FakeFunc(func() (string, error) {
 		return f.project.ProjectId, nil
 	}, &workshopbackend.NewProjectId)
@@ -102,10 +109,13 @@ func (f *wsExec) TearDownSuite(c *check.C) {
 	c.Check(err, check.IsNil)
 	err = f.daemon.Stop(nil)
 	c.Check(err, check.IsNil)
+	err = f.lxdClient.DeleteStoragePool("testZfsProfile")
+	c.Check(err, check.IsNil)
 	f.lookupUserRestore()
 	f.lookupUserIdRestore()
 	f.newProjectidRestore()
 	f.restoreImageServer()
+	f.restoreDevices()
 	cleanUpLxdProject(c, f.lxdClient, workshopbackend.LxdProjectName(f.username))
 	cleanUpLxdProject(c, f.lxdClient, workshopbackend.LxdSystemProjectName(f.username))
 }

--- a/internal/workshopbackend/tests/integration/workshop_test.go
+++ b/internal/workshopbackend/tests/integration/workshop_test.go
@@ -62,7 +62,6 @@ func (f *wsOps) SetUpTest(c *check.C) {
 		ProjectId: "42424242",
 		Path:      c.MkDir(),
 	}
-	f.username = "testuser"
 	f.ctx = createTestContext(f.username, f.project.ProjectId)
 
 	f.lxdClient, _ = f.be.(*workshopbackend.LxdBackend).LxdClient(f.ctx)
@@ -107,12 +106,14 @@ func (f *wsOps) TearDownTest(c *check.C) {
 }
 
 func (f *wsOps) SetUpSuite(c *check.C) {
+	f.username = "testuser"
 	f.restoreDevices = workshopbackend.FakeDefaultDevices(defaultTestDevices)
 	f.restoreImageServer = workshopbackend.FakeImageServer(minimalImageServer)
 	ctx := createTestContext(f.username, "42424242")
 	be := &workshopbackend.LxdBackend{}
-	client, _ := be.LxdClient(ctx)
-	err := client.CreateStoragePool(api.StoragePoolsPost{StoragePoolPut: api.StoragePoolPut{Config: map[string]string{"volume.size": "1GiB"}}, Name: "testZfsProfile", Driver: "zfs"})
+	client, err := be.LxdClient(ctx)
+	c.Assert(err, check.IsNil)
+	err = client.CreateStoragePool(api.StoragePoolsPost{StoragePoolPut: api.StoragePoolPut{Config: map[string]string{"volume.size": "1GiB"}}, Name: "testZfsProfile", Driver: "zfs"})
 	c.Assert(err, check.IsNil)
 }
 
@@ -123,17 +124,6 @@ func (f *wsOps) TearDownSuite(c *check.C) {
 	cleanUpLxdProject(c, f.lxdClient, workshopbackend.LxdSystemProjectName(f.username))
 	f.restoreDevices()
 	f.restoreImageServer()
-}
-
-func (f *wsOps) TestLxdBackendTrivialLaunch(c *check.C) {
-	// Execute
-	err := f.be.LaunchWorkshop(f.ctx, "test-1", "ubuntu@22.04")
-	defer f.be.RemoveWorkshop(f.ctx, "test-1")
-
-	//Validate
-	c.Assert(err, check.IsNil)
-	_, err = f.be.Workshop(f.ctx, "test-1")
-	c.Assert(err, check.IsNil)
 }
 
 func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {

--- a/tests/main/launch/.workshop.ws-20.yaml
+++ b/tests/main/launch/.workshop.ws-20.yaml
@@ -1,0 +1,2 @@
+name: ws-20
+base: ubuntu@20.04

--- a/tests/main/launch/.workshop.ws-22.yaml
+++ b/tests/main/launch/.workshop.ws-22.yaml
@@ -1,0 +1,2 @@
+name: ws-22
+base: ubuntu@22.04

--- a/tests/main/launch/task.yaml
+++ b/tests/main/launch/task.yaml
@@ -9,19 +9,26 @@ prepare: |
 
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup "$WORKSHOPS"
+  cleanup ./
   uninstall_workshopd
 
 debug: |
   lxc project switch workshop.ubuntu
   lxc list -f compact
-  ls "$WORKSHOPS"/*
+  ls ./*
 
 execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Test launch for all the supported bases"
-  for path in "$WORKSHOPS"/*; do
-    launch "$path" ws
-    list "$path" | MATCH "$path[[:space:]]*ws[[:space:]]*Ready[[:space:]]*-"
-  done
+  
+  function launch_and_validate() {
+    workshop_exec launch "$1"
+    workshop_exec list | MATCH "$(pwd)[[:space:]]*$1[[:space:]]*Ready[[:space:]]*-"
+    # ensure the workshop has a socket for workshopctl
+    workshop_exec exec "$1" -- test -S /var/lib/workshop/.workshop.socket.untrusted
+  }
+  
+  launch_and_validate ws-20
+  launch_and_validate ws-22
+  


### PR DESCRIPTION
# Description

- Cross-port the hook context and command interfaces to support future work on the workshopctl and check-health implementation. 
- Every workshop has the untrusted workshop socked bind mounted on launch or refresh. 
- Add /v1/workshopctl endpoint placeholder.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put a blank line between two logically different chunks of code.
