### PR TITLE
check-health hook

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -33,7 +33,10 @@ backends:
         sudo sh -c "echo root:ubuntu | sudo chpasswd"
       multipass exec "$instance_name" -- \
         sudo sh -c \
-        "sed -i /etc/ssh/sshd_config -e 's/^PasswordAuthentication.*/PasswordAuthentication yes/' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/'"
+        "sed -i /etc/ssh/sshd_config -e 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' -e 's/^KbdInteractiveAuthentication.*/KbdInteractiveAuthentication yes/'"
+      multipass exec "$instance_name" -- \
+        sudo sh -c \
+        "sed -i /etc/ssh/sshd_config.d/60-cloudimg-settings.conf -e 's/^PasswordAuthentication.*/PasswordAuthentication yes/'"
       multipass exec "$instance_name" -- \
         sudo systemctl restart ssh
       ADDRESS "$ip:22"

--- a/.spread.yaml
+++ b/.spread.yaml
@@ -50,7 +50,7 @@ backends:
       if [ -z "${image}" ]; then
         FATAL "$SPREAD_SYSTEM is not supported!"
       fi
-      #multipass delete --purge "$instance_name"
+      multipass delete --purge "$instance_name"
     systems:
       - ubuntu-22.04-64:
           workers: 1

--- a/.spread.yaml
+++ b/.spread.yaml
@@ -85,3 +85,4 @@ exclude:
   - .git
   - .workshop.lock
   - docs
+  - __debug_bin*

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -2,11 +2,18 @@ package client
 
 import "time"
 
+type HealthCheck struct {
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message,omitempty"`
+	Code      string    `json:"code,omitempty"`
+}
+
 type Sdk struct {
-	Name        string    `json:"name"`
-	Channel     string    `json:"channel"`
-	Revision    string    `json:"revision"`
-	InstallTime time.Time `json:"install-time"`
+	Name        string       `json:"name"`
+	Channel     string       `json:"channel"`
+	Revision    string       `json:"revision"`
+	InstallTime time.Time    `json:"install-time"`
+	Health      *HealthCheck `json:"health-check,omitempty"`
 }
 
 type Workshop struct {

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -10,7 +10,7 @@ import (
 func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 	cs.rsp = `{"type": "sync", "result": [{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready",
 	"notes":["missing-project"],
-	"content":[{"name":"go","channel":"latest/stable","revision":"453","install-time":"2023-04-25T01:02:03Z"}]
+	"content":[{"name":"go","channel":"latest/stable","revision":"453","install-time":"2023-04-25T01:02:03Z", "health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"}}]
 	}]}`
 	prj, err := cs.cli.ListWorkshops(&client.ListOptions{ProjectId: "42ws42ws"})
 	c.Assert(err, check.IsNil)
@@ -22,7 +22,17 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 			Status:    "Ready",
 			Notes:     []string{"missing-project"},
 			Content: []*client.Sdk{
-				{Name: "go", Channel: "latest/stable", Revision: "453", InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)},
+				{
+					Name:        "go",
+					Channel:     "latest/stable",
+					Revision:    "453",
+					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+					Health: &client.HealthCheck{
+						Timestamp: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+						Message:   "hello from health-check",
+						Code:      "check-waiting",
+					},
+				},
 			},
 		},
 	})

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -62,15 +62,27 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	fmt.Fprintf(w, "base:\t%s\n", workshop.Base)
 	fmt.Fprintf(w, "project:\t%s\n", project.Path)
 	fmt.Fprintf(w, "status:\t%s\n", strings.ToLower(workshop.Status))
-	notes := strings.Join(workshop.Notes, ",")
-	if len(workshop.Notes) == 0 {
-		notes = "-"
+
+	// get the workshop notes
+	notes := workshop.Notes
+
+	// get the SDKs notes (if there is an ongoing health check)
+	for _, sdk := range workshop.Content {
+		if sdk.Health != nil && sdk.Health.Code != "" {
+			notes = append(notes, sdk.Health.Code)
+		}
 	}
-	fmt.Fprintf(w, "notes:\t%s\n", notes)
+
+	// combine notes from workshop and its SDKs
+	notesFormatted := strings.Join(notes, ",")
+	if len(workshop.Notes) == 0 {
+		notesFormatted = "-"
+	}
+
+	fmt.Fprintf(w, "notes:\t%s\n", notesFormatted)
 
 	if len(workshop.Content) > 0 {
 		fmt.Fprintf(w, "content:\n")
-
 		for _, sdk := range workshop.Content {
 			fmt.Fprintf(w, "\t%s:\n", sdk.Name)
 			installTime := sdk.InstallTime.Format("2006-01-02")
@@ -78,6 +90,9 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 				installTime = ""
 			}
 			fmt.Fprintf(w, "\t\tchannel:\t%s\t%s\t%s\n", sdk.Channel, installTime, sdk.Revision)
+			if sdk.Health != nil {
+				fmt.Fprintf(w, "\t\tmessage:\t%s\n", sdk.Health.Message)
+			}
 		}
 	}
 

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -57,3 +57,41 @@ content:
         channel:  latest/edge  2017-03-22  1
 `, m.prjDir))
 }
+
+var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Pending","notes":["workshop-note"],"content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z","health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}}]}}`
+
+func (m *WorkshopInfo) TestWorkshopInfoWithSdkHealthReport(c *check.C) {
+	cmd := &CmdInfo{}
+	workshop := "ws"
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithHealth)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{workshop})
+	c.Assert(err, check.IsNil)
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`name:     ws
+base:     ubuntu@22.04
+project:  %s
+status:   pending
+notes:    workshop-note,try-later
+content:
+    go:
+        channel:  latest/edge  2017-03-22  1
+        message:  Waiting for all required modules to be installed
+`, m.prjDir))
+}

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -38,6 +38,10 @@ Notes:
 		RunE: c.Run,
 	}
 
+	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
+		false,
+		"Do not wait for the operation to finish but just print the change id")
+
 	return cmd
 }
 

--- a/cmd/workshopctl/main.go
+++ b/cmd/workshopctl/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/dirs"
@@ -34,6 +35,15 @@ var clientConfig = client.Config{
 }
 
 func main() {
+	// Set the user and group IDs to the workshop user
+	uid := uint32(1000) // Change this to the workshop UID
+
+	// Change the user IDs for this process
+	if err := syscall.Setuid(int(uid)); err != nil {
+		fmt.Println("Error setting UID:", err)
+		return
+	}
+
 	stdout, stderr, err := run(nil)
 	if err != nil {
 		if e, ok := err.(*client.Error); ok {

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -10,19 +10,27 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/internal/overlord/healthstate"
+	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/overlord/statecontext"
+	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/workshopbackend"
 	"github.com/canonical/x-go/strutil"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
+type HealthCheckInfo struct {
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message,omitempty"`
+	Code      string    `json:"code,omitempty"`
+}
+
 type SdkInfo struct {
-	Name        string    `json:"name"`
-	Channel     string    `json:"channel"`
-	Revision    string    `json:"revision"`
-	InstallTime time.Time `json:"install-time"`
+	Name        string           `json:"name"`
+	Channel     string           `json:"channel"`
+	Revision    string           `json:"revision"`
+	InstallTime time.Time        `json:"install-time"`
+	Health      *HealthCheckInfo `json:"health-check,omitempty"`
 }
 
 type WorkshopInfo struct {
@@ -52,22 +60,33 @@ func workshopFileToInfo(file *workshopbackend.WorkshopFile, pid string) *Worksho
 }
 
 func workshopPropsToInfo(props *workshopbackend.Workshop, health healthstate.HealthState) *WorkshopInfo {
-	var ws WorkshopInfo
-	ws.Name = props.Name
-	ws.ProjectId = props.Project().ProjectId
-	ws.Base = props.Base()
+	var info WorkshopInfo
+	info.Name = props.Name
+	info.ProjectId = props.Project().ProjectId
+	info.Base = props.Base()
 
 	for _, val := range props.Content() {
-		ws.Content = append(ws.Content, &SdkInfo{
+		var healthInfo *HealthCheckInfo
+		if sdkHealth, ok := health.SdkHealth[val.Name]; ok {
+			healthInfo = &HealthCheckInfo{
+				Timestamp: sdkHealth.Timestamp,
+				Message:   sdkHealth.Message,
+				Code:      sdkHealth.Code,
+			}
+		}
+
+		info.Content = append(info.Content, &SdkInfo{
 			Name:        val.Name,
 			Channel:     val.Channel,
 			Revision:    strconv.FormatInt(val.Revision, 10),
-			InstallTime: val.InstallTime})
+			InstallTime: val.InstallTime,
+			Health:      healthInfo,
+		})
 	}
 
-	ws.Notes = append(ws.Notes, health.Code)
-	ws.Status = health.Status.String()
-	return &ws
+	info.Notes = append(info.Notes, health.Code)
+	info.Status = health.Status.String()
+	return &info
 }
 
 func v1GetProjects(c *Command, r *http.Request, _ *userState) Response {
@@ -213,13 +232,13 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 			change.AddAll(tset)
 		}
 	case "refresh":
-		refreshMode := statecontext.ParseRefreshMode(reqData.Options.Mode)
+		refreshMode := operation.ParseRefreshMode(reqData.Options.Mode)
 
-		if len(reqData.Names) > 1 && refreshMode != statecontext.RefreshTransactional {
+		if len(reqData.Names) > 1 && refreshMode != operation.RefreshTransactional {
 			return statusBadRequest("wait-on-error is not supported for multiple workshops")
 		}
 
-		if refreshMode == statecontext.RefreshTransactional || refreshMode == statecontext.RefreshWaitOnError {
+		if refreshMode == operation.RefreshTransactional || refreshMode == operation.RefreshWaitOnError {
 			change = st.NewChange("refresh", summary)
 			taskset, err := wsmgr.RefreshMany(r.Context(), reqData.Names, projectId, refreshMode, change.ID())
 			if err != nil {
@@ -230,9 +249,9 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 			}
 		}
 
-		if refreshMode == statecontext.RefreshContinue || refreshMode == statecontext.RefreshAbort {
+		if refreshMode == operation.RefreshContinue || refreshMode == operation.RefreshAbort {
 			var err error
-			change, err = statecontext.ResumeRefresh(st, reqData.Names[0], projectId, refreshMode)
+			change, err = operation.ResumeRefresh(st, reqData.Names[0], projectId, refreshMode)
 			if err != nil {
 				return statusBadRequest(err.Error())
 			}
@@ -276,6 +295,8 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	return AsyncResponse(nil, change.ID())
 }
 
+var workshopHealth = (*workshopstate.WorkshopManager).WorkshopHealth
+
 func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	projectId := muxVars(r)["id"]
 	name := muxVars(r)["name"]
@@ -293,13 +314,10 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	defer state.Unlock()
 
 	wrkmgr := c.d.overlord.WorkshopManager()
-
 	workshop, err := wrkmgr.Workshop(r.Context(), name, projectId)
 	if err != nil {
 		return statusNotFound("cannot load workshop: %v", err)
 	}
-
-	health := wrkmgr.WorkshopHealth(workshop)
-
+	health := workshopHealth(wrkmgr, workshop)
 	return SyncResponse(workshopPropsToInfo(workshop, health), http.StatusOK)
 }

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/workshopbackend"
@@ -40,7 +41,7 @@ func workshopFileToInfo(file *workshopbackend.WorkshopFile, pid string) *Worksho
 	ws.Name = file.Name
 	ws.Base = file.Base
 	ws.ProjectId = pid
-	ws.Status = workshopbackend.WorkshopOff.String()
+	ws.Status = healthstate.OffStatus.String()
 	for _, i := range file.Sdks {
 		ws.Content = append(ws.Content, &SdkInfo{
 			Name:    i.Name,
@@ -50,10 +51,10 @@ func workshopFileToInfo(file *workshopbackend.WorkshopFile, pid string) *Worksho
 	return &ws
 }
 
-func workshopPropsToInfo(props *workshopbackend.Workshop) *WorkshopInfo {
+func workshopPropsToInfo(props *workshopbackend.Workshop, health healthstate.HealthState) *WorkshopInfo {
 	var ws WorkshopInfo
 	ws.Name = props.Name
-	ws.ProjectId = props.ProjectId()
+	ws.ProjectId = props.Project().ProjectId
 	ws.Base = props.Base()
 
 	for _, val := range props.Content() {
@@ -64,12 +65,8 @@ func workshopPropsToInfo(props *workshopbackend.Workshop) *WorkshopInfo {
 			InstallTime: val.InstallTime})
 	}
 
-	for _, err := range props.Errors() {
-		ws.Notes = append(ws.Notes, err.String())
-	}
-
-	ws.Status = props.Status().String()
-
+	ws.Notes = append(ws.Notes, health.Code)
+	ws.Status = health.Status.String()
 	return &ws
 }
 
@@ -141,10 +138,11 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 
 	var infoLst = make([]*WorkshopInfo, 0)
 	for _, w := range workshops {
-		if wstate != "all" && strings.ToLower(w.Status().String()) != wstate {
+		health := wrkmgr.WorkshopHealth(w)
+		if wstate != "all" && strings.ToLower(health.Status.String()) != wstate {
 			continue
 		}
-		info := workshopPropsToInfo(w)
+		info := workshopPropsToInfo(w, health)
 		infoLst = append(infoLst, info)
 	}
 
@@ -301,5 +299,7 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return statusNotFound("cannot load workshop: %v", err)
 	}
 
-	return SyncResponse(workshopPropsToInfo(workshop), http.StatusOK)
+	health := wrkmgr.WorkshopHealth(workshop)
+
+	return SyncResponse(workshopPropsToInfo(workshop, health), http.StatusOK)
 }

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -84,7 +84,9 @@ func workshopPropsToInfo(props *workshopbackend.Workshop, health healthstate.Hea
 		})
 	}
 
-	info.Notes = append(info.Notes, health.Code)
+	if len(health.Code) > 0 {
+		info.Notes = append(info.Notes, health.Code)
+	}
 	info.Status = health.Status.String()
 	return &info
 }

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,8 +11,9 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/internal/overlord/healthstate"
+	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/overlord/statecontext"
+	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
@@ -68,7 +70,7 @@ func (s *apiSuite) TestProjectsPostProjectDoesNotExist(c *check.C) {
 	c.Check(string(res), check.Matches, `.*{"path":"/home/testuser/project","id":"b8639dea"}.*`)
 }
 
-func (s *apiSuite) TestProjectsPostProjectExists(c *check.C) {
+func (s *apiSuite) TestProjectsPostProjectExist(c *check.C) {
 	// Setup
 	s.daemon(c)
 	projectsCmd := apiCmd("/v1/projects")
@@ -90,26 +92,32 @@ func (s *apiSuite) TestProjectsPostProjectExists(c *check.C) {
 		fmt.Sprintf(`.*{"path":"%s","id":"%s"}.*`, s.project.Path, s.project.ProjectId))
 }
 
+func (s *apiSuite) launchWorkshop(ctx context.Context, name string, c *check.C) *workshopbackend.Workshop {
+	b := s.d.overlord.WorkshopBackend()
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
+base: ubuntu@20.04
+`, name)), 0644)
+	c.Assert(err, check.IsNil)
+	err = b.LaunchWorkshop(ctx, name, "ubuntu@20.04")
+	c.Assert(err, check.IsNil)
+	ws, err := b.Workshop(ctx, name)
+	c.Assert(err, check.IsNil)
+	return ws
+}
+
 func (s *apiSuite) TestProjectsGetWorkshops(c *check.C) {
 	// Setup
 	s.daemon(c)
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	s.vars = map[string]string{"id": s.project.ProjectId}
+	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops", nil)
+	c.Assert(err, check.IsNil)
+
 	restore := testutil.FakeFunc(func() time.Time { return time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC) }, &workshopbackend.InstallTimeNow)
 	defer restore()
 
-	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops", nil)
-	c.Assert(err, check.IsNil)
-	b := s.d.overlord.WorkshopBackend()
-	err = os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws-test.yaml"), []byte(`name: ws-test
-base: ubuntu@20.04
-`), 0644)
-	c.Assert(err, check.IsNil)
-	err = b.LaunchWorkshop(req.Context(), "ws-test", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
-	ws, err := b.Workshop(req.Context(), "ws-test")
-	c.Assert(err, check.IsNil)
-	ws.LinkSdk(req.Context(), sdk.Setup{Name: "go", Channel: "latest/stable", Revision: 234})
+	workshop := s.launchWorkshop(s.ctx, "ws-test", c)
+	workshop.LinkSdk(s.ctx, sdk.Setup{Name: "go", Channel: "latest/stable", Revision: 234})
 
 	// Execute
 	rsp := v1GetProjectWorkshops(projectsCmd, req, nil).(*resp)
@@ -134,7 +142,7 @@ base: ubuntu@20.04
 					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 				},
 			},
-			Notes: []string{"-"},
+			Notes: []string{""},
 		},
 	})
 }
@@ -144,19 +152,22 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 	s.daemon(c)
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}")
 	s.vars = map[string]string{"id": s.project.ProjectId, "name": "ws-test"}
-
 	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops/ws-test", nil)
 	c.Assert(err, check.IsNil)
-	b := s.d.overlord.WorkshopBackend()
-	err = os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws-test.yaml"), []byte(`name: ws-test
-base: ubuntu@20.04
-`), 0644)
-	c.Assert(err, check.IsNil)
-	err = b.LaunchWorkshop(s.ctx, "ws-test", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
+
+	workshop := s.launchWorkshop(s.ctx, "ws-test", c)
+	restore := testutil.FakeFunc(func() time.Time { return time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC) }, &workshopbackend.InstallTimeNow)
+	workshop.LinkSdk(s.ctx, sdk.Setup{Name: "go", Channel: "latest/stable", Revision: 234})
+	restore()
 
 	// Execute
+	restore = FakeWorkshopHealth(func(mgr *workshopstate.WorkshopManager, w *workshopbackend.Workshop) healthstate.HealthState {
+		return healthstate.HealthState{Status: healthstate.ReadyStatus, SdkHealth: map[string]healthstate.HealthCheck{
+			"go": {Sdk: "go", Message: "test health check message", Code: "check-waiting", CheckResult: healthstate.CheckWaiting},
+		}}
+	})
 	rsp := v1GetProjectWorkshop(projectsCmd, req, nil).(*resp)
+	restore()
 
 	// Verify
 	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
@@ -169,7 +180,19 @@ base: ubuntu@20.04
 		Base:      "ubuntu@20.04",
 		ProjectId: s.project.ProjectId,
 		Status:    "Ready",
-		Notes:     []string{"-"},
+		Notes:     []string{""},
+		Content: []*SdkInfo{
+			{
+				Name:        "go",
+				Channel:     "latest/stable",
+				Revision:    "234",
+				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+				Health: &HealthCheckInfo{
+					Message: "test health check message",
+					Code:    "check-waiting",
+				},
+			},
+		},
 	})
 }
 
@@ -179,16 +202,11 @@ func (s *apiSuite) TestProjectsPostProjectWorkshopLaunch(c *check.C) {
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	s.vars = map[string]string{"id": s.project.ProjectId}
 
-	// Mock workshop files
-	err := os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04`), 0644)
-	c.Assert(err, check.IsNil)
+	s.launchWorkshop(s.ctx, "ws", c)
 
-	err = os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws1.yaml"), []byte(`name: ws1
+	// Mock another workshop file
+	err := os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws1.yaml"), []byte(`name: ws1
 base: ubuntu@20.04`), 0644)
-	c.Assert(err, check.IsNil)
-
-	err = s.b.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
 	c.Assert(err, check.IsNil)
 
 	buffers := []*bytes.Buffer{
@@ -253,10 +271,6 @@ func (s *apiSuite) TestProjectsPostProjectRefreshWorkshopContinue(c *check.C) {
 	s.daemon(c)
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	s.vars = map[string]string{"id": s.project.ProjectId}
-	os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04`), 0644)
-	os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws1.yaml"), []byte(`name: ws1
-base: ubuntu@20.04`), 0644)
 
 	buffers := []*bytes.Buffer{
 		// try continue without starting wait-on-error
@@ -363,17 +377,14 @@ base: ubuntu@20.04`), 0644)
 	soon := 0
 	restoreEnsure := testutil.FakeFunc(func(st *state.State, d time.Duration) {
 		if mockRefreshChanges[soon] == state.DoneStatus {
-			statecontext.StopOperation(st, "ws", s.project.ProjectId, statecontext.OperationRefresh)
+			operation.StopOperation(st, "ws", s.project.ProjectId, operation.OperationRefresh)
 		}
 		soon++
 	}, &ensureStateSoon)
 	defer restoreEnsure()
 
-	err := s.b.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
-
-	err = s.b.LaunchWorkshop(s.ctx, "ws1", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
+	s.launchWorkshop(s.ctx, "ws", c)
+	s.launchWorkshop(s.ctx, "ws1", c)
 
 	for num, i := range requests {
 		// Execute
@@ -397,12 +408,9 @@ func (s *apiSuite) TestProjectsPostProjectWorkshopStart(c *check.C) {
 	s.daemon(c)
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	s.vars = map[string]string{"id": s.project.ProjectId}
-	os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04`), 0644)
 
-	err := s.b.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
-	err = s.b.StopWorkshop(s.ctx, "ws", false)
+	s.launchWorkshop(s.ctx, "ws", c)
+	err := s.b.StopWorkshop(s.ctx, "ws", false)
 	c.Assert(err, check.IsNil)
 
 	buffers := []*bytes.Buffer{
@@ -476,11 +484,8 @@ func (s *apiSuite) TestProjectsPostProjectWorkshopStop(c *check.C) {
 	s.daemon(c)
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	s.vars = map[string]string{"id": s.project.ProjectId}
-	os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04`), 0644)
 
-	err := s.b.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
+	s.launchWorkshop(s.ctx, "ws", c)
 
 	buffers := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["ws"],"action":"stop"}`),
@@ -535,7 +540,7 @@ base: ubuntu@20.04`), 0644)
 
 			s.d.state.Lock()
 			// stop the workshop stop operation here, so it is ready for the next command
-			err := statecontext.StopOperation(s.d.state, "ws", s.project.ProjectId, statecontext.OperationStop)
+			err := operation.StopOperation(s.d.state, "ws", s.project.ProjectId, operation.OperationStop)
 			c.Assert(err, check.IsNil)
 			s.b.StopWorkshop(s.ctx, "ws", false)
 			s.d.state.Unlock()
@@ -550,11 +555,8 @@ func (s *apiSuite) TestProjectsPostProjectWorkshopRemove(c *check.C) {
 	s.daemon(c)
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	s.vars = map[string]string{"id": s.project.ProjectId}
-	os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04`), 0644)
 
-	err := s.b.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
+	s.launchWorkshop(s.ctx, "ws", c)
 
 	buffers := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["ws"],"action":"remove"}`),
@@ -602,9 +604,9 @@ base: ubuntu@20.04`), 0644)
 		}
 
 		s.d.state.Lock()
-		op := statecontext.OperationInProgress(s.d.state, "ws", s.project.ProjectId)
+		op := operation.OperationInProgress(s.d.state, "ws", s.project.ProjectId)
 		c.Assert(op, check.NotNil)
-		c.Assert(op.Operation, check.Equals, statecontext.OperationRemove)
+		c.Assert(op.Operation, check.Equals, operation.OperationRemove)
 		s.d.state.Unlock()
 	}
 	// all successful responses must initiate the ensure call

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -142,7 +142,7 @@ func (s *apiSuite) TestProjectsGetWorkshops(c *check.C) {
 					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 				},
 			},
-			Notes: []string{""},
+			Notes: nil,
 		},
 	})
 }
@@ -158,6 +158,7 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 	workshop := s.launchWorkshop(s.ctx, "ws-test", c)
 	restore := testutil.FakeFunc(func() time.Time { return time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC) }, &workshopbackend.InstallTimeNow)
 	workshop.LinkSdk(s.ctx, sdk.Setup{Name: "go", Channel: "latest/stable", Revision: 234})
+	workshop.LinkSdk(s.ctx, sdk.Setup{Name: "java", Channel: "latest/stable", Revision: 324})
 	restore()
 
 	// Execute
@@ -180,7 +181,7 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 		Base:      "ubuntu@20.04",
 		ProjectId: s.project.ProjectId,
 		Status:    "Ready",
-		Notes:     []string{""},
+		Notes:     nil,
 		Content: []*SdkInfo{
 			{
 				Name:        "go",
@@ -191,6 +192,12 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 					Message: "test health check message",
 					Code:    "check-waiting",
 				},
+			},
+			{
+				Name:        "java",
+				Channel:     "latest/stable",
+				Revision:    "324",
+				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 			},
 		},
 	})

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/sdk"
@@ -122,6 +123,7 @@ base: ubuntu@20.04
 	c.Check(rsp.Result, check.DeepEquals, []*WorkshopInfo{
 		{
 			Name:      "ws-test",
+			Base:      "ubuntu@20.04",
 			ProjectId: s.project.ProjectId,
 			Status:    "Ready",
 			Content: []*SdkInfo{
@@ -132,6 +134,7 @@ base: ubuntu@20.04
 					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 				},
 			},
+			Notes: []string{"-"},
 		},
 	})
 }
@@ -163,8 +166,10 @@ base: ubuntu@20.04
 	c.Assert(err, check.IsNil)
 	c.Check(rsp.Result, check.DeepEquals, &WorkshopInfo{
 		Name:      "ws-test",
+		Base:      "ubuntu@20.04",
 		ProjectId: s.project.ProjectId,
 		Status:    "Ready",
+		Notes:     []string{"-"},
 	})
 }
 
@@ -312,7 +317,7 @@ base: ubuntu@20.04`), 0644)
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot refresh: \"ws\" is in pending; must be ready",
+			Message: `cannot refresh: "ws" status is "Pending", must be one of: "Ready"`,
 		},
 		{
 			Type:   ResponseTypeAsync,
@@ -421,12 +426,12 @@ base: ubuntu@20.04`), 0644)
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot start: \"ws\" is in pending; must be stopped",
+			Message: `cannot start: "ws" status is "Pending", must be one of: "Stopped"`,
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot refresh: \"ws\" is in pending; must be ready",
+			Message: `cannot refresh: "ws" status is "Pending", must be one of: "Ready"`,
 		},
 	}
 
@@ -456,9 +461,10 @@ base: ubuntu@20.04`), 0644)
 	}
 
 	s.d.overlord.State().Lock()
-	ws, err := s.d.overlord.WorkshopManager().Workshop(s.ctx, "ws", s.project.ProjectId)
+	workshopMgr := s.d.overlord.WorkshopManager()
+	ws, err := workshopMgr.Workshop(s.ctx, "ws", s.project.ProjectId)
 	c.Assert(err, check.IsNil)
-	c.Assert(ws.Status(), check.Equals, workshopbackend.WorkshopPending)
+	c.Assert(workshopMgr.WorkshopHealth(ws).Status, check.Equals, healthstate.PendingStatus)
 	s.d.overlord.State().Unlock()
 
 	// all successful responses must initiate the ensure call
@@ -497,7 +503,7 @@ base: ubuntu@20.04`), 0644)
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot stop: \"ws\" is in pending; must be stopped or ready",
+			Message: `cannot stop: "ws" status is "Pending", must be one of: "Ready", "Stopped"`,
 		},
 		{
 			Type:   ResponseTypeAsync,
@@ -568,7 +574,7 @@ base: ubuntu@20.04`), 0644)
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot stop: \"ws\" is in pending; must be ready, stopped or error",
+			Message: `cannot remove: "ws" status is "Pending", must be one of: "Ready", "Error", "Stopped"`,
 		},
 	}
 
@@ -591,6 +597,9 @@ base: ubuntu@20.04`), 0644)
 		// Verify
 		c.Check(rsp.Type, check.Equals, expected[num].Type)
 		c.Assert(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v, msg: %v", num, rsp.Result))
+		if rsp.Type == ResponseTypeError {
+			c.Assert(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
+		}
 
 		s.d.state.Lock()
 		op := statecontext.OperationInProgress(s.d.state, "ws", s.project.ProjectId)

--- a/internal/daemon/export_test.go
+++ b/internal/daemon/export_test.go
@@ -18,7 +18,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/overlord/workshopstate"
+	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
 func FakeMuxVars(f func(*http.Request) map[string]string) (restore func()) {
@@ -34,5 +37,13 @@ func FakeStateEnsureBefore(f func(st *state.State, d time.Duration)) (restore fu
 	stateEnsureBefore = f
 	return func() {
 		stateEnsureBefore = old
+	}
+}
+
+func FakeWorkshopHealth(f func(mgr *workshopstate.WorkshopManager, w *workshopbackend.Workshop) healthstate.HealthState) (restore func()) {
+	old := workshopHealth
+	workshopHealth = f
+	return func() {
+		workshopHealth = old
 	}
 }

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/spf13/afero"
 	"google.golang.org/api/option"
 )
 
@@ -38,11 +38,10 @@ type StoreClient interface {
 }
 
 func NewStoreClient() StoreClient {
-	return &ObjectStoreClient{Fs: afero.NewOsFs()}
+	return &ObjectStoreClient{}
 }
 
 type ObjectStoreClient struct {
-	Fs afero.Fs
 }
 
 func storeConnect(ctx context.Context) (*storage.Client, error) {
@@ -91,14 +90,8 @@ func (c *ObjectStoreClient) RetrieveSdk(ctx context.Context, name, channel, loca
 			s.Name = name
 			s.Channel = channel
 			s.Revision = revision
-
-			exist, err := afero.Exists(c.Fs, s.Filename())
-			if err != nil {
-				return s, err
-			}
-
-			if !exist {
-				file, err := c.Fs.Create(s.Filename())
+			if !osutil.FileExists(s.Filename()) {
+				file, err := os.Create(s.Filename())
 				if err != nil {
 					return s, err
 				}

--- a/internal/overlord/healthstate/export_test.go
+++ b/internal/overlord/healthstate/export_test.go
@@ -13,3 +13,11 @@ func FakeRetryTimeout(t time.Duration) (restore func()) {
 		retryTimeout = old
 	}
 }
+
+func FakeRetryAttempts(t int) (restore func()) {
+	old := retriesAllowed
+	retriesAllowed = t
+	return func() {
+		retriesAllowed = old
+	}
+}

--- a/internal/overlord/healthstate/export_test.go
+++ b/internal/overlord/healthstate/export_test.go
@@ -1,0 +1,15 @@
+package healthstate
+
+import "time"
+
+var (
+	KnownStatuses = knownStatuses
+)
+
+func FakeRetryTimeout(t time.Duration) (restore func()) {
+	old := retryTimeout
+	retryTimeout = t
+	return func() {
+		retryTimeout = old
+	}
+}

--- a/internal/overlord/healthstate/export_test.go
+++ b/internal/overlord/healthstate/export_test.go
@@ -3,7 +3,7 @@ package healthstate
 import "time"
 
 var (
-	KnownStatuses = knownStatuses
+	KnownStatuses = knownSetHealthStatuses
 )
 
 func FakeRetryTimeout(t time.Duration) (restore func()) {

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -161,6 +161,15 @@ func (h *healthHandler) Done() (err error) {
 	}
 
 	if retryCounter >= retriesAllowed && health.CheckResult == CheckWaiting {
+		// if reached the maximum possible retries, reset the counter. This is
+		// required for scenarios when a user provided --wait-on-error to
+		// workshop refresh. If provided and check-health failed after multiple
+		// attemps, refresh will wait on this error allowing to repeat the task
+		// with --continue. In this case, we must to re-run the health check
+		// from scratch.
+		h.context.Lock()
+		h.context.Set("retry-counter", 0)
+		h.context.Unlock()
 		return fmt.Errorf("SDK %q is not healthy after multiple checks", h.context.Sdk())
 	}
 
@@ -169,6 +178,10 @@ func (h *healthHandler) Done() (err error) {
 	}
 
 	if health.CheckResult == CheckError {
+		// see the comment about the maximum possible retries above
+		h.context.Lock()
+		h.context.Set("retry-counter", 0)
+		h.context.Unlock()
 		return errors.New(health.Message)
 	}
 

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -66,14 +66,14 @@ func (s HealthCheckResult) String() string {
 
 type HealthCheck struct {
 	Sdk         string            `json:"sdk"`
-	Timestamp   time.Time         `json:"timestamp"`
+	Timestamp   time.Time         `json:"timestamp,omitzero"`
 	CheckResult HealthCheckResult `json:"check-result"`
 	Message     string            `json:"message,omitempty"`
 	Code        string            `json:"code,omitempty"`
 }
 
 type HealthState struct {
-	Timestamp time.Time              `json:"timestamp"`
+	Timestamp time.Time              `json:"timestamp,omitzero"`
 	Status    Status                 `json:"status"`
 	Message   string                 `json:"message,omitempty"`
 	Code      string                 `json:"code,omitempty"`

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -1,0 +1,114 @@
+package healthstate
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/x-go/strutil"
+)
+
+type HealthStatus int
+
+const (
+	UnknownStatus = HealthStatus(iota)
+	OkayStatus
+	WaitingStatus
+	ErrorStatus
+)
+
+var knownStatuses = []string{"unknown", "okay", "waiting", "error"}
+
+func StatusLookup(str string) (HealthStatus, error) {
+	for i, k := range knownStatuses {
+		if k == str {
+			return HealthStatus(i), nil
+		}
+	}
+	return -1, fmt.Errorf("invalid status %q, must be one of %s", str, strutil.Quoted(knownStatuses))
+}
+
+func (s HealthStatus) String() string {
+	if s < 0 || s >= HealthStatus(len(knownStatuses)) {
+		return fmt.Sprintf("invalid (%d)", s)
+	}
+	return knownStatuses[s]
+}
+
+type HealthState struct {
+	Timestamp time.Time    `json:"timestamp"`
+	Status    HealthStatus `json:"status"`
+	Message   string       `json:"message,omitempty"`
+	Code      string       `json:"code,omitempty"`
+	Retries   int          `json:"retries,omitempty"`
+}
+
+func Init(hookManager *hookstate.HookManager) {
+	hookManager.Register(regexp.MustCompile("^check-health$"), newHealthHandler)
+}
+
+func newHealthHandler(ctx *hookstate.Context) hookstate.Handler {
+	return &healthHandler{context: ctx}
+}
+
+type healthHandler struct {
+	context *hookstate.Context
+}
+
+// Before is called just before the hook runs -- nothing to do beyond setting a marker
+func (h *healthHandler) Before() error {
+	h.context.Lock()
+	defer h.context.Unlock()
+	var health HealthState
+	err := h.context.Get("health", &health)
+	// the handler is being called for the first time
+	// (the health is set already if it is a retry)
+	if errors.Is(err, state.ErrNoState) {
+		h.context.Set("health", HealthState{
+			Status:  UnknownStatus,
+			Message: "The health status is unknown",
+		})
+	}
+	return nil
+}
+
+var retryTimeout = 1 * time.Second
+var retriesAllowed = 10
+
+func (h *healthHandler) Done() error {
+	var health HealthState
+
+	h.context.Lock()
+	err := h.context.Get("health", &health)
+	h.context.Unlock()
+
+	if err != nil {
+		// note it can't actually be state.ErrNoState because Before sets it
+		return err
+	}
+
+	if health.Retries >= retriesAllowed && (health.Status == WaitingStatus || health.Status == UnknownStatus) {
+		return fmt.Errorf("SDK %q status is not healthy after multiple checks", h.context.Sdk())
+	}
+
+	if health.Status == WaitingStatus || health.Status == UnknownStatus {
+		health.Retries = health.Retries + 1
+		h.context.Lock()
+		h.context.Set("health", health)
+		h.context.Unlock()
+		return &state.Retry{After: retryTimeout, Reason: health.Message}
+	}
+
+	if health.Status == ErrorStatus {
+		return errors.New(health.Message)
+	}
+
+	return nil
+}
+
+func (h *healthHandler) Error(err error) (bool, error) {
+	return false, nil
+}

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -14,28 +14,37 @@ import (
 type HealthStatus int
 
 const (
-	UnknownStatus = HealthStatus(iota)
-	OkayStatus
-	WaitingStatus
+	UnknownStatus HealthStatus = iota
+	ReadyStatus
+	PendingStatus
 	ErrorStatus
+	StoppedStatus
+	OffStatus
 )
 
-var knownStatuses = []string{"unknown", "okay", "waiting", "error"}
-
-func StatusLookup(str string) (HealthStatus, error) {
-	for i, k := range knownStatuses {
-		if k == str {
-			return HealthStatus(i), nil
-		}
-	}
-	return -1, fmt.Errorf("invalid status %q, must be one of %s", str, strutil.Quoted(knownStatuses))
-}
-
 func (s HealthStatus) String() string {
-	if s < 0 || s >= HealthStatus(len(knownStatuses)) {
+	statuses := [...]string{"Unknown", "Ready", "Pending", "Error", "Stopped", "Off"}
+	if s < 0 || int(s) >= len(statuses) {
 		return fmt.Sprintf("invalid (%d)", s)
 	}
-	return knownStatuses[s]
+	return statuses[s]
+}
+
+var knownSetHealthStatuses = []string{"unknown", "okay", "waiting", "error"}
+
+func SetHealthStatusLookup(str string) (HealthStatus, error) {
+	switch str {
+	case "okay":
+		return ReadyStatus, nil
+	case "waiting":
+		return PendingStatus, nil
+	case "error":
+		return ErrorStatus, nil
+	case "unknown":
+		return UnknownStatus, nil
+	}
+
+	return -1, fmt.Errorf("invalid status %q, must be one of %s", str, strutil.Quoted(knownSetHealthStatuses))
 }
 
 type HealthState struct {
@@ -43,7 +52,7 @@ type HealthState struct {
 	Status    HealthStatus `json:"status"`
 	Message   string       `json:"message,omitempty"`
 	Code      string       `json:"code,omitempty"`
-	Retries   int          `json:"retries,omitempty"`
+	Sdk       string       `json:"sdk,omitempty"`
 }
 
 func Init(hookManager *hookstate.HookManager) {
@@ -70,7 +79,13 @@ func (h *healthHandler) Before() error {
 		h.context.Set("health", HealthState{
 			Status:  UnknownStatus,
 			Message: "The health status is unknown",
+			Sdk:     h.context.Sdk(),
 		})
+	}
+	var counter int
+	err = h.context.Get("retry-counter", &counter)
+	if errors.Is(err, state.ErrNoState) {
+		h.context.Set("retry-counter", 0)
 	}
 	return nil
 }
@@ -80,6 +95,7 @@ var retriesAllowed = 10
 
 func (h *healthHandler) Done() error {
 	var health HealthState
+	var retryCounter int
 
 	h.context.Lock()
 	err := h.context.Get("health", &health)
@@ -90,14 +106,22 @@ func (h *healthHandler) Done() error {
 		return err
 	}
 
-	if health.Retries >= retriesAllowed && (health.Status == WaitingStatus || health.Status == UnknownStatus) {
+	h.context.Lock()
+	err = h.context.Get("retry-counter", &retryCounter)
+	h.context.Unlock()
+
+	if err != nil {
+		// note it can't actually be state.ErrNoState because Before sets it
+		return err
+	}
+
+	if retryCounter >= retriesAllowed && (health.Status == PendingStatus || health.Status == UnknownStatus) {
 		return fmt.Errorf("SDK %q status is not healthy after multiple checks", h.context.Sdk())
 	}
 
-	if health.Status == WaitingStatus || health.Status == UnknownStatus {
-		health.Retries = health.Retries + 1
+	if health.Status == PendingStatus || health.Status == UnknownStatus {
 		h.context.Lock()
-		h.context.Set("health", health)
+		h.context.Set("retry-counter", retryCounter+1)
 		h.context.Unlock()
 		return &state.Retry{After: retryTimeout, Reason: health.Message}
 	}

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -11,10 +11,10 @@ import (
 	"github.com/canonical/x-go/strutil"
 )
 
-type HealthStatus int
+type Status int
 
 const (
-	UnknownStatus HealthStatus = iota
+	UnknownStatus Status = iota
 	ReadyStatus
 	PendingStatus
 	ErrorStatus
@@ -22,7 +22,7 @@ const (
 	OffStatus
 )
 
-func (s HealthStatus) String() string {
+func (s Status) String() string {
 	statuses := [...]string{"Unknown", "Ready", "Pending", "Error", "Stopped", "Off"}
 	if s < 0 || int(s) >= len(statuses) {
 		return fmt.Sprintf("invalid (%d)", s)
@@ -30,29 +30,53 @@ func (s HealthStatus) String() string {
 	return statuses[s]
 }
 
-var knownSetHealthStatuses = []string{"unknown", "okay", "waiting", "error"}
+type HealthCheckResult int
 
-func SetHealthStatusLookup(str string) (HealthStatus, error) {
+const (
+	CheckUnknown HealthCheckResult = iota
+	CheckWaiting
+	CheckOkay
+	CheckError
+)
+
+var knownSetHealthStatuses = []string{"unknown", "waiting", "okay", "error"}
+
+func SetHealthLookup(str string) (HealthCheckResult, error) {
 	switch str {
 	case "okay":
-		return ReadyStatus, nil
+		return CheckOkay, nil
 	case "waiting":
-		return PendingStatus, nil
+		return CheckWaiting, nil
 	case "error":
-		return ErrorStatus, nil
+		return CheckError, nil
 	case "unknown":
-		return UnknownStatus, nil
+		return CheckUnknown, nil
 	}
 
 	return -1, fmt.Errorf("invalid status %q, must be one of %s", str, strutil.Quoted(knownSetHealthStatuses))
 }
 
+func (s HealthCheckResult) String() string {
+	if s < 0 || int(s) >= len(knownSetHealthStatuses) {
+		return fmt.Sprintf("invalid (%d)", s)
+	}
+	return knownSetHealthStatuses[s]
+}
+
+type HealthCheck struct {
+	Sdk         string            `json:"sdk"`
+	Timestamp   time.Time         `json:"timestamp"`
+	CheckResult HealthCheckResult `json:"check-result"`
+	Message     string            `json:"message,omitempty"`
+	Code        string            `json:"code,omitempty"`
+}
+
 type HealthState struct {
-	Timestamp time.Time    `json:"timestamp"`
-	Status    HealthStatus `json:"status"`
-	Message   string       `json:"message,omitempty"`
-	Code      string       `json:"code,omitempty"`
-	Sdk       string       `json:"sdk,omitempty"`
+	Timestamp time.Time              `json:"timestamp"`
+	Status    Status                 `json:"status"`
+	Message   string                 `json:"message,omitempty"`
+	Code      string                 `json:"code,omitempty"`
+	SdkHealth map[string]HealthCheck `json:"sdk-health,omitempty"`
 }
 
 func Init(hookManager *hookstate.HookManager) {
@@ -71,15 +95,14 @@ type healthHandler struct {
 func (h *healthHandler) Before() error {
 	h.context.Lock()
 	defer h.context.Unlock()
-	var health HealthState
+	var health HealthCheck
 	err := h.context.Get("health", &health)
 	// the handler is being called for the first time
 	// (the health is set already if it is a retry)
 	if errors.Is(err, state.ErrNoState) {
-		h.context.Set("health", HealthState{
-			Status:  UnknownStatus,
-			Message: "The health status is unknown",
-			Sdk:     h.context.Sdk(),
+		h.context.Set("health", HealthCheck{
+			Sdk:         h.context.Sdk(),
+			CheckResult: CheckUnknown,
 		})
 	}
 	var counter int
@@ -94,7 +117,7 @@ var retryTimeout = 1 * time.Second
 var retriesAllowed = 10
 
 func (h *healthHandler) Done() error {
-	var health HealthState
+	var health HealthCheck
 	var retryCounter int
 
 	h.context.Lock()
@@ -115,18 +138,18 @@ func (h *healthHandler) Done() error {
 		return err
 	}
 
-	if retryCounter >= retriesAllowed && (health.Status == PendingStatus || health.Status == UnknownStatus) {
-		return fmt.Errorf("SDK %q status is not healthy after multiple checks", h.context.Sdk())
+	if retryCounter >= retriesAllowed && (health.CheckResult == CheckWaiting || health.CheckResult == CheckUnknown) {
+		return fmt.Errorf("SDK %q is not healthy after multiple checks", h.context.Sdk())
 	}
 
-	if health.Status == PendingStatus || health.Status == UnknownStatus {
+	if health.CheckResult == CheckWaiting || health.CheckResult == CheckUnknown {
 		h.context.Lock()
 		h.context.Set("retry-counter", retryCounter+1)
 		h.context.Unlock()
 		return &state.Retry{After: retryTimeout, Reason: health.Message}
 	}
 
-	if health.Status == ErrorStatus {
+	if health.CheckResult == CheckError {
 		return errors.New(health.Message)
 	}
 

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -1,6 +1,7 @@
 package healthstate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -101,6 +102,7 @@ func (h *healthHandler) Before() error {
 	// (the health is set already if it is a retry)
 	if errors.Is(err, state.ErrNoState) {
 		h.context.Set("health", HealthCheck{
+			Timestamp:   time.Now(),
 			Sdk:         h.context.Sdk(),
 			CheckResult: CheckUnknown,
 		})
@@ -116,12 +118,12 @@ func (h *healthHandler) Before() error {
 var retryTimeout = 1 * time.Second
 var retriesAllowed = 10
 
-func (h *healthHandler) Done() error {
+func (h *healthHandler) Done() (err error) {
 	var health HealthCheck
 	var retryCounter int
 
 	h.context.Lock()
-	err := h.context.Get("health", &health)
+	err = h.context.Get("health", &health)
 	h.context.Unlock()
 
 	if err != nil {
@@ -138,14 +140,31 @@ func (h *healthHandler) Done() error {
 		return err
 	}
 
-	if retryCounter >= retriesAllowed && (health.CheckResult == CheckWaiting || health.CheckResult == CheckUnknown) {
+	defer func() {
+		if !h.context.IsEphemeral() {
+			task, _ := h.context.Task()
+			h.context.Lock()
+			// update the hook's task to contain the latest health check result
+			// this is used by external parties to read and report the health
+			// check statuses e.g. workshop info command.
+			task.Set("health", health)
+			if retry, ok := err.(*state.Retry); ok {
+				h.context.Set("retry-counter", retryCounter+1)
+				task.Logf("Retrying check-health in %v, reason: %s", retry.After, health.Message)
+			}
+			h.context.Unlock()
+		}
+	}()
+
+	if health.CheckResult == CheckUnknown {
+		return fmt.Errorf("SDK %q health status is unknown", h.context.Sdk())
+	}
+
+	if retryCounter >= retriesAllowed && health.CheckResult == CheckWaiting {
 		return fmt.Errorf("SDK %q is not healthy after multiple checks", h.context.Sdk())
 	}
 
-	if health.CheckResult == CheckWaiting || health.CheckResult == CheckUnknown {
-		h.context.Lock()
-		h.context.Set("retry-counter", retryCounter+1)
-		h.context.Unlock()
+	if health.CheckResult == CheckWaiting {
 		return &state.Retry{After: retryTimeout, Reason: health.Message}
 	}
 
@@ -153,9 +172,14 @@ func (h *healthHandler) Done() error {
 		return errors.New(health.Message)
 	}
 
+	// the health check was reported as 'okay', we consider the check-health hook successful.
 	return nil
 }
 
 func (h *healthHandler) Error(err error) (bool, error) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false, fmt.Errorf("SDK %q health status check timed out", h.context.Sdk())
+	}
+
 	return false, nil
 }

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package healthstate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/overlord"
+	"github.com/canonical/workshop/internal/overlord/healthstate"
+	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshopbackend"
+)
+
+func TestHealthState(t *testing.T) { check.TestingT(t) }
+
+type healthSuite struct {
+	testutil.BaseTest
+	se      *overlord.StateEngine
+	state   *state.State
+	runner  *state.TaskRunner
+	backend *workshopbackend.FakeWorkshopBackend
+	hookMgr *hookstate.HookManager
+	project *workshopbackend.Project
+	ctx     context.Context
+}
+
+var _ = check.Suite(&healthSuite{})
+
+func (s *healthSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+
+	s.state = state.New(nil)
+	s.runner = state.NewTaskRunner(s.state)
+
+	s.backend = workshopbackend.NewFakeWorkshopBackend()
+	ctx := context.WithValue(context.Background(), workshopbackend.ContextUser, "testuser")
+	var err error
+	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())
+	c.Assert(err, check.IsNil)
+	s.ctx = context.WithValue(ctx, workshopbackend.ContextProjectId, s.project.ProjectId)
+
+	s.hookMgr = hookstate.New(s.state, s.runner, s.backend)
+
+	s.se = overlord.NewStateEngine(s.state)
+	s.se.AddManager(s.hookMgr)
+	s.se.AddManager(s.runner)
+
+	s.se.AddManager(s.hookMgr)
+	s.se.AddManager(s.runner)
+
+	healthstate.Init(s.hookMgr)
+
+	c.Assert(s.se.StartUp(), check.IsNil)
+}
+
+func (s *healthSuite) TearDownTest(c *check.C) {
+	s.se.Stop()
+	s.BaseTest.TearDownTest(c)
+}
+
+func setWorkshopProject(w string, p *workshopbackend.Project, tasks ...*state.Task) {
+	for _, i := range tasks {
+		i.Set("workshop", w)
+		i.Set("project", *p)
+	}
+}
+
+func (s *healthSuite) launchWorkshop(c *check.C, newsdk string, createHealthCheck bool) {
+	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
+base: ubuntu@20.04
+sdks:
+  one:
+    channel: latest/stable
+`), 0644)
+	c.Check(err, check.IsNil)
+	err = s.backend.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	c.Check(err, check.IsNil)
+	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Check(err, check.IsNil)
+	err = ws.MkdirAll(sdk.SdkHooksDir(newsdk), 0744)
+	c.Check(err, check.IsNil)
+
+	if createHealthCheck {
+		_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.CheckHealth.String()))
+		c.Check(err, check.IsNil)
+	}
+}
+
+func (*healthSuite) TestStatusHappy(c *check.C) {
+	for i, str := range healthstate.KnownStatuses {
+		status, err := healthstate.StatusLookup(str)
+		c.Check(err, check.IsNil, check.Commentf("%v", str))
+		c.Check(status, check.Equals, healthstate.HealthStatus(i), check.Commentf("%v", str))
+		c.Check(healthstate.HealthStatus(i).String(), check.Equals, str, check.Commentf("%v", str))
+	}
+}
+
+func (*healthSuite) TestStatusUnhappy(c *check.C) {
+	status, err := healthstate.StatusLookup("rabbits")
+	c.Check(status, check.Equals, healthstate.HealthStatus(-1))
+	c.Check(err, check.ErrorMatches, `invalid status "rabbits".*`)
+	c.Check(status.String(), check.Equals, "invalid (-1)")
+}
+
+func (s *healthSuite) TestExecCheckHealthNotProvided(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.launchWorkshop(c, "one", false)
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Assert(s.backend.ExecCalls, check.HasLen, 0)
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+}
+
+func (s *healthSuite) TestExecCheckHealthSetHealthNotCalled(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.launchWorkshop(c, "one", true)
+	restore := healthstate.FakeRetryTimeout(0 * time.Second)
+	defer restore()
+
+	s.state.Unlock()
+	for i := 0; i < 11; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(s.backend.ExecCalls, check.HasLen, 11)
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Assert(t1.Log()[0], check.Matches, `.*SDK "one" status is not healthy after multiple checks`)
+}

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -91,6 +91,13 @@ func setWorkshopProject(w string, p *workshopbackend.Project, tasks ...*state.Ta
 	}
 }
 
+func ensureTaskHealthIsSet(t *state.Task, expected *healthstate.HealthCheck, c *check.C) {
+	var health healthstate.HealthCheck
+	err := t.Get("health", &health)
+	c.Assert(err, check.IsNil)
+	c.Assert(expected, check.DeepEquals, &health)
+}
+
 func (s *healthSuite) launchWorkshop(c *check.C, newsdk string, createHealthCheck bool) {
 	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
 base: ubuntu@20.04
@@ -163,13 +170,156 @@ func (s *healthSuite) TestExecCheckHealthSetHealthNotCalled(c *check.C) {
 	defer restore()
 
 	s.state.Unlock()
-	for i := 0; i < 11; i = i + 1 {
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Assert(t1.Log()[0], check.Matches, `.*SDK "one" health status is unknown`)
+}
+
+func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	now := time.Now().Round(0)
+	result := healthstate.HealthCheck{
+		Timestamp:   now,
+		Sdk:         "one",
+		CheckResult: healthstate.CheckError,
+		Message:     "something went wrong",
+		Code:        "error-error",
+	}
+
+	s.backend.DoExec = func(ctx context.Context, name string, args *workshopbackend.Execution) (workshopbackend.ExecContext, error) {
+		return workshopbackend.ExecContext{
+			WaitExecution: func(ctx context.Context) error {
+				// emulate workshopctl set-health --code=<code> error <message>
+				hookCtx, err := s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
+				c.Assert(err, check.IsNil)
+				hookCtx.Lock()
+				hookCtx.Set("health", result)
+				hookCtx.Unlock()
+				return nil
+			},
+		}, nil
+	}
+	defer func() {
+		s.backend.DoExec = workshopbackend.DoExecDefault
+	}()
+
+	s.launchWorkshop(c, "one", true)
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Assert(t1.Log()[0], check.Matches, `.*something went wrong`)
+	ensureTaskHealthIsSet(t1, &result, c)
+}
+
+func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	restore := healthstate.FakeRetryTimeout(0 * time.Second)
+	defer restore()
+
+	now := time.Now().Round(0)
+	resultWait := healthstate.HealthCheck{
+		Timestamp:   now,
+		Sdk:         "one",
+		CheckResult: healthstate.CheckWaiting,
+		Message:     "not ready yet",
+		Code:        "wait-for-me",
+	}
+
+	nowOkay := time.Now().Round(0)
+	resultOkay := healthstate.HealthCheck{
+		Timestamp:   nowOkay,
+		Sdk:         "one",
+		CheckResult: healthstate.CheckOkay,
+	}
+
+	s.backend.DoExec = func(ctx context.Context, name string, args *workshopbackend.Execution) (workshopbackend.ExecContext, error) {
+		return workshopbackend.ExecContext{
+			WaitExecution: func(ctx context.Context) error {
+				hookCtx, err := s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
+				c.Assert(err, check.IsNil)
+				hookCtx.Lock()
+				var counter int
+				hookCtx.Get("retry-counter", &counter)
+				if counter == 0 {
+					// emulate workshopctl set-health --code=<code> error <message>
+					hookCtx.Set("health", resultWait)
+				} else {
+					// emulate workshopctl set-health okay
+					hookCtx.Set("health", resultOkay)
+				}
+				hookCtx.Unlock()
+				return nil
+			},
+		}, nil
+	}
+	defer func() {
+		s.backend.DoExec = workshopbackend.DoExecDefault
+	}()
+
+	s.launchWorkshop(c, "one", true)
+	s.state.Unlock()
+	for i := 0; i < 2; i = i + 1 {
 		s.se.Ensure()
 		s.se.Wait()
 	}
 	s.state.Lock()
 
-	c.Assert(s.backend.ExecCalls, check.HasLen, 11)
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	c.Assert(t1.Log()[0], check.Matches, `.*not ready yet`)
+	c.Assert(t1.Log(), check.HasLen, 1)
+	ensureTaskHealthIsSet(t1, &resultOkay, c)
+}
+
+func (s *healthSuite) TestExecCheckHealthTimeout(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.backend.DoExec = func(ctx context.Context, name string, args *workshopbackend.Execution) (workshopbackend.ExecContext, error) {
+		return workshopbackend.ExecContext{
+			WaitExecution: func(ctx context.Context) error {
+				return context.DeadlineExceeded
+			},
+		}, nil
+	}
+	defer func() {
+		s.backend.DoExec = workshopbackend.DoExecDefault
+	}()
+
+	s.launchWorkshop(c, "one", true)
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
 	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
-	c.Assert(t1.Log()[0], check.Matches, `.*SDK "one" is not healthy after multiple checks`)
+	c.Assert(t1.Log()[0], check.Matches, `.*SDK "one" health status check timed out`)
 }

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -198,15 +198,17 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 		Code:        "error-error",
 	}
 
+	var hookContext *hookstate.Context
 	s.backend.DoExec = func(ctx context.Context, name string, args *workshopbackend.Execution) (workshopbackend.ExecContext, error) {
 		return workshopbackend.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				// emulate workshopctl set-health --code=<code> error <message>
-				hookCtx, err := s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
+				var err error
+				hookContext, err = s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
 				c.Assert(err, check.IsNil)
-				hookCtx.Lock()
-				hookCtx.Set("health", result)
-				hookCtx.Unlock()
+				hookContext.Lock()
+				hookContext.Set("health", result)
+				hookContext.Unlock()
 				return nil
 			},
 		}, nil
@@ -223,6 +225,15 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 
 	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Assert(t1.Log()[0], check.Matches, `.*something went wrong`)
+	s.state.Unlock()
+	hookContext.Lock()
+	var counter int
+	err := hookContext.Get("retry-counter", &counter)
+	hookContext.Unlock()
+	s.state.Lock()
+	c.Assert(err, check.IsNil)
+	c.Assert(counter, check.Equals, 0)
+
 	ensureTaskHealthIsSet(t1, &result, c)
 }
 
@@ -291,6 +302,72 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 	c.Assert(t1.Log()[0], check.Matches, `.*not ready yet`)
 	c.Assert(t1.Log(), check.HasLen, 1)
 	ensureTaskHealthIsSet(t1, &resultOkay, c)
+}
+
+func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	restore := healthstate.FakeRetryTimeout(0 * time.Second)
+	defer restore()
+
+	restoreAttempts := healthstate.FakeRetryAttempts(2)
+	defer restoreAttempts()
+
+	now := time.Now().UTC()
+	resultWait := healthstate.HealthCheck{
+		Timestamp:   now,
+		Sdk:         "one",
+		CheckResult: healthstate.CheckWaiting,
+		Message:     "not ready yet",
+		Code:        "wait-for-me",
+	}
+
+	var hookContext *hookstate.Context
+	s.backend.DoExec = func(ctx context.Context, name string, args *workshopbackend.Execution) (workshopbackend.ExecContext, error) {
+		return workshopbackend.ExecContext{
+			WaitExecution: func(ctx context.Context) error {
+				var err error
+				hookContext, err = s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
+				c.Assert(err, check.IsNil)
+				hookContext.Lock()
+				// emulate workshopctl set-health --code=<code> error <message>
+				hookContext.Set("health", resultWait)
+				hookContext.Unlock()
+				return nil
+			},
+		}, nil
+	}
+	defer func() {
+		s.backend.DoExec = workshopbackend.DoExecDefault
+	}()
+
+	s.launchWorkshop(c, "one", true)
+	s.state.Unlock()
+	for i := 0; i < 3; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Assert(t1.Log()[2], check.Matches, `.*SDK \"one\" is not healthy after multiple checks`)
+	c.Assert(t1.Log(), check.HasLen, 3)
+
+	s.state.Unlock()
+	hookContext.Lock()
+	var counter int
+	err := hookContext.Get("retry-counter", &counter)
+	hookContext.Unlock()
+	s.state.Lock()
+	c.Assert(err, check.IsNil)
+	c.Assert(counter, check.Equals, 0)
 }
 
 func (s *healthSuite) TestExecCheckHealthTimeout(c *check.C) {

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -114,15 +114,14 @@ sdks:
 
 func (*healthSuite) TestStatusHappy(c *check.C) {
 	for i, str := range healthstate.KnownStatuses {
-		status, err := healthstate.StatusLookup(str)
+		status, err := healthstate.SetHealthStatusLookup(str)
 		c.Check(err, check.IsNil, check.Commentf("%v", str))
 		c.Check(status, check.Equals, healthstate.HealthStatus(i), check.Commentf("%v", str))
-		c.Check(healthstate.HealthStatus(i).String(), check.Equals, str, check.Commentf("%v", str))
 	}
 }
 
 func (*healthSuite) TestStatusUnhappy(c *check.C) {
-	status, err := healthstate.StatusLookup("rabbits")
+	status, err := healthstate.SetHealthStatusLookup("rabbits")
 	c.Check(status, check.Equals, healthstate.HealthStatus(-1))
 	c.Check(err, check.ErrorMatches, `invalid status "rabbits".*`)
 	c.Check(status.String(), check.Equals, "invalid (-1)")

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -114,15 +114,15 @@ sdks:
 
 func (*healthSuite) TestStatusHappy(c *check.C) {
 	for i, str := range healthstate.KnownStatuses {
-		status, err := healthstate.SetHealthStatusLookup(str)
+		status, err := healthstate.SetHealthLookup(str)
 		c.Check(err, check.IsNil, check.Commentf("%v", str))
-		c.Check(status, check.Equals, healthstate.HealthStatus(i), check.Commentf("%v", str))
+		c.Check(status, check.Equals, healthstate.HealthCheckResult(i), check.Commentf("%v", str))
 	}
 }
 
 func (*healthSuite) TestStatusUnhappy(c *check.C) {
-	status, err := healthstate.SetHealthStatusLookup("rabbits")
-	c.Check(status, check.Equals, healthstate.HealthStatus(-1))
+	status, err := healthstate.SetHealthLookup("rabbits")
+	c.Check(status, check.Equals, healthstate.HealthCheckResult(-1))
 	c.Check(err, check.ErrorMatches, `invalid status "rabbits".*`)
 	c.Check(status.String(), check.Equals, "invalid (-1)")
 }
@@ -171,5 +171,5 @@ func (s *healthSuite) TestExecCheckHealthSetHealthNotCalled(c *check.C) {
 
 	c.Assert(s.backend.ExecCalls, check.HasLen, 11)
 	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
-	c.Assert(t1.Log()[0], check.Matches, `.*SDK "one" status is not healthy after multiple checks`)
+	c.Assert(t1.Log()[0], check.Matches, `.*SDK "one" is not healthy after multiple checks`)
 }

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -189,7 +189,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	now := time.Now().Round(0)
+	now := time.Now().UTC()
 	result := healthstate.HealthCheck{
 		Timestamp:   now,
 		Sdk:         "one",
@@ -239,7 +239,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 	restore := healthstate.FakeRetryTimeout(0 * time.Second)
 	defer restore()
 
-	now := time.Now().Round(0)
+	now := time.Now().UTC()
 	resultWait := healthstate.HealthCheck{
 		Timestamp:   now,
 		Sdk:         "one",
@@ -248,7 +248,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 		Code:        "wait-for-me",
 	}
 
-	nowOkay := time.Now().Round(0)
+	nowOkay := time.Now().UTC()
 	resultOkay := healthstate.HealthCheck{
 		Timestamp:   nowOkay,
 		Sdk:         "one",

--- a/internal/overlord/hookstate/context.go
+++ b/internal/overlord/hookstate/context.go
@@ -92,6 +92,11 @@ func newEphemeralHookContextWithData(st *state.State, setup *HookSetup, contextD
 	return context, nil
 }
 
+// Sdk returns the name of the SDK in this context.
+func (c *Context) Sdk() string {
+	return c.setup.Sdk
+}
+
 // Task returns the task associated with the hook or (nil, false) if the context is ephemeral
 // and task is not available.
 func (c *Context) Task() (*state.Task, bool) {

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -55,7 +55,6 @@ func (s *ctlcmdSuite) SetUpTest(c *C) {
 }
 
 func (s *ctlcmdSuite) TestNonExistingCommand(c *C) {
-	c.Skip("Need at least one command added to the parser")
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"foo"}, 0)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
@@ -118,11 +117,11 @@ func (s *ctlcmdSuite) TestRunOnlyHelp(c *C) {
 }
 
 func (s *ctlcmdSuite) TestRunHelpAtAnyPosition(c *C) {
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"start", "a", "-h"}, 1000)
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"set-health", "a", "-h"}, 1000)
 	c.Check(err, NotNil)
 	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
 
-	_, _, err = ctlcmd.Run(s.mockContext, []string{"start", "a", "b", "--help"}, 1000)
+	_, _, err = ctlcmd.Run(s.mockContext, []string{"set-health", "a", "b", "--help"}, 1000)
 	c.Check(err, NotNil)
 	c.Assert(strings.HasPrefix(err.Error(), "Usage:"), Equals, true)
 }

--- a/internal/overlord/hookstate/ctlcmd/health.go
+++ b/internal/overlord/hookstate/ctlcmd/health.go
@@ -70,7 +70,7 @@ func (c *healthCommand) Execute([]string) error {
 		return fmt.Errorf(`when status is "okay", message and code must be empty`)
 	}
 
-	status, err := healthstate.StatusLookup(c.Status)
+	status, err := healthstate.SetHealthStatusLookup(c.Status)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (c *healthCommand) Execute([]string) error {
 		}
 	}
 
-	if status != healthstate.OkayStatus {
+	if status != healthstate.ReadyStatus {
 		if len(c.Message) == 0 {
 			return fmt.Errorf(`when status is not "okay", message is required`)
 		}

--- a/internal/overlord/hookstate/ctlcmd/health.go
+++ b/internal/overlord/hookstate/ctlcmd/health.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/canonical/workshop/internal/overlord/healthstate"
+)
+
+var (
+	shortHealthHelp = "Report the health status of an SDK"
+	longHealthHelp  = `
+ The set-health command is called from within a workshop to inform the system of the
+ SDK's overall health.
+ 
+ It can be called from any hook. An SDK can
+ optionally provide a 'check-health' hook to manage these calls, which is
+ then called periodically and with increased frequency while the SDK is
+ "waiting". Any health regression will issue a warning to the user.
+ 
+ - status: One of okay, waiting, error.
+ 
+ - error-code: An optional note matching regex '[a-z](?:-?[a-z0-9])+', e.g. missing-cuda; up to 20 symbols.
+ 
+ - message: A user-friendly message expanding the status, 7-70 lines long. Required if the status is 'waiting' or 'error'.
+ `
+)
+
+func init() {
+	addCommand("set-health", shortHealthHelp, longHealthHelp, func() command { return &healthCommand{} })
+}
+
+type healthPositional struct {
+	Status  string `positional-arg-name:"<status>" required:"yes" description:"a valid health status; required."`
+	Message string `positional-arg-name:"<message>" description:"a short human-readable explanation of the status (when not okay). Must be longer than 7 characters, and will be truncated if over 70. Message cannot be provided if status is okay, but is required otherwise."`
+}
+
+type healthCommand struct {
+	baseCommand
+	healthPositional `positional-args:"yes"`
+	Code             string `long:"code" value-name:"<code>" description:"optional tool-friendly value representing the problem that makes the SDK unhealthy.  Not a number, but a word with 3-30 characters matching [a-z](-?[a-z0-9])+"`
+}
+
+var (
+	validCode = regexp.MustCompile(`^[a-z](?:-?[a-z0-9])+$`).MatchString
+)
+
+func (c *healthCommand) Execute([]string) error {
+	if c.Status == "okay" && (len(c.Message) > 0 || len(c.Code) > 0) {
+		return fmt.Errorf(`when status is "okay", message and code must be empty`)
+	}
+
+	status, err := healthstate.StatusLookup(c.Status)
+	if err != nil {
+		return err
+	}
+	if status == healthstate.UnknownStatus {
+		return fmt.Errorf(`status cannot be manually set to "unknown"`)
+	}
+
+	if len(c.Code) > 0 {
+		if len(c.Code) < 3 || len(c.Code) > 30 {
+			return fmt.Errorf("code must have between 3 and 30 characters, got %d", len(c.Code))
+		}
+		if !validCode(c.Code) {
+			return fmt.Errorf("invalid code %q (code must start with lowercase ASCII letters, and contain only ASCII letters and numbers, optionally separated by single dashes)", c.Code) // technically not dashes but hyphen-minuses
+		}
+	}
+
+	if status != healthstate.OkayStatus {
+		if len(c.Message) == 0 {
+			return fmt.Errorf(`when status is not "okay", message is required`)
+		}
+
+		rmsg := []rune(c.Message)
+		if len(rmsg) < 7 {
+			return fmt.Errorf(`message must be at least 7 characters long (got %d)`, len(rmsg))
+		}
+		if len(rmsg) > 70 {
+			c.Message = string(rmsg[:69]) + "…"
+		}
+	}
+
+	ctx, err := c.ensureContext()
+	if err != nil {
+		return err
+	}
+	ctx.Lock()
+	defer ctx.Unlock()
+
+	health := &healthstate.HealthState{
+		Timestamp: time.Now(),
+		Status:    status,
+		Message:   c.Message,
+		Code:      c.Code,
+	}
+
+	ctx.Set("health", health)
+
+	return nil
+}

--- a/internal/overlord/hookstate/ctlcmd/health.go
+++ b/internal/overlord/hookstate/ctlcmd/health.go
@@ -70,11 +70,11 @@ func (c *healthCommand) Execute([]string) error {
 		return fmt.Errorf(`when status is "okay", message and code must be empty`)
 	}
 
-	status, err := healthstate.SetHealthStatusLookup(c.Status)
+	status, err := healthstate.SetHealthLookup(c.Status)
 	if err != nil {
 		return err
 	}
-	if status == healthstate.UnknownStatus {
+	if status == healthstate.CheckUnknown {
 		return fmt.Errorf(`status cannot be manually set to "unknown"`)
 	}
 
@@ -87,7 +87,7 @@ func (c *healthCommand) Execute([]string) error {
 		}
 	}
 
-	if status != healthstate.ReadyStatus {
+	if status != healthstate.CheckOkay {
 		if len(c.Message) == 0 {
 			return fmt.Errorf(`when status is not "okay", message is required`)
 		}
@@ -112,11 +112,12 @@ func (c *healthCommand) Execute([]string) error {
 		return errors.New(`"set-health" is only allowed from a "check-health" hook`)
 	}
 
-	health := &healthstate.HealthState{
-		Timestamp: time.Now(),
-		Status:    status,
-		Message:   c.Message,
-		Code:      c.Code,
+	health := &healthstate.HealthCheck{
+		Sdk:         ctx.Sdk(),
+		Timestamp:   time.Now(),
+		CheckResult: status,
+		Message:     c.Message,
+		Code:        c.Code,
 	}
 
 	ctx.Set("health", health)

--- a/internal/overlord/hookstate/ctlcmd/health.go
+++ b/internal/overlord/hookstate/ctlcmd/health.go
@@ -18,11 +18,13 @@
 package ctlcmd
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
 
 	"github.com/canonical/workshop/internal/overlord/healthstate"
+	"github.com/canonical/workshop/internal/overlord/hookstate"
 )
 
 var (
@@ -105,6 +107,10 @@ func (c *healthCommand) Execute([]string) error {
 	}
 	ctx.Lock()
 	defer ctx.Unlock()
+
+	if ctx.HookName() != hookstate.CheckHealth.String() {
+		return errors.New(`"set-health" is only allowed from a "check-health" hook`)
+	}
 
 	health := &healthstate.HealthState{
 		Timestamp: time.Now(),

--- a/internal/overlord/hookstate/ctlcmd/health_test.go
+++ b/internal/overlord/hookstate/ctlcmd/health_test.go
@@ -118,7 +118,7 @@ func (s *healthSuite) TestRegularRun(c *check.C) {
 
 	var health healthstate.HealthState
 	c.Assert(s.mockContext.Get("health", &health), check.IsNil)
-	c.Check(health.Status, check.Equals, healthstate.WaitingStatus)
+	c.Check(health.Status, check.Equals, healthstate.PendingStatus)
 	c.Check(health.Message, check.Equals, "message")
 	c.Check(health.Code, check.Equals, "some-code")
 }

--- a/internal/overlord/hookstate/ctlcmd/health_test.go
+++ b/internal/overlord/hookstate/ctlcmd/health_test.go
@@ -136,3 +136,19 @@ func (s *healthSuite) TestMessageTruncation(c *check.C) {
 	c.Check(health.Message, check.Equals, "Sometimes messages will get a little bit too verbose and this can lea…")
 	c.Check(health.Code, check.Equals, "some-code")
 }
+
+func (s *healthSuite) TestRegularRunIncorrectHook(c *check.C) {
+	setup := &hookstate.HookSetup{Workshop: "ws", Sdk: "test-sdk", HookType: hookstate.SetupBase}
+	task, _ := s.mockContext.Task()
+	ctx, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, check.IsNil)
+
+	_, _, err = ctlcmd.Run(ctx, []string{"set-health", "waiting", "message", "--code=some-code"}, 0)
+	c.Assert(err, check.ErrorMatches, `"set-health" is only allowed from a "check-health" hook`)
+
+	s.mockContext.Lock()
+	defer s.mockContext.Unlock()
+
+	var health healthstate.HealthState
+	c.Assert(s.mockContext.Get("health", &health), testutil.ErrorIs, state.ErrNoState)
+}

--- a/internal/overlord/hookstate/ctlcmd/health_test.go
+++ b/internal/overlord/hookstate/ctlcmd/health_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/overlord/healthstate"
+	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/workshop/internal/overlord/hookstate/ctlcmd"
+	"github.com/canonical/workshop/internal/overlord/hookstate/hooktest"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+type healthSuite struct {
+	testutil.BaseTest
+	state       *state.State
+	mockContext *hookstate.Context
+	mockHandler *hooktest.MockHandler
+}
+
+var _ = check.Suite(&healthSuite{})
+
+func (s *healthSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+
+	s.mockHandler = hooktest.NewMockHandler()
+
+	s.state = state.New(nil)
+	s.state.Lock()
+	defer s.state.Unlock()
+	task := s.state.NewTask("test-task", "my test task")
+	setup := &hookstate.HookSetup{Workshop: "ws", Sdk: "test-sdk", HookType: hookstate.CheckHealth}
+
+	ctx, err := hookstate.NewContext(task, s.state, setup, s.mockHandler, "")
+	c.Assert(err, check.IsNil)
+	s.mockContext = ctx
+}
+
+func (s *healthSuite) TestBadArgs(c *check.C) {
+	type tableT struct {
+		args []string
+		err  string
+	}
+	table := []tableT{
+		{
+			[]string{"set-health"},
+			"the required argument `<status>` was not provided",
+		}, {
+			[]string{"set-health", "bananas", "message"},
+			`invalid status "bananas".*`,
+		}, {
+			[]string{"set-health", "unknown", "message"},
+			`status cannot be manually set to "unknown"`,
+		}, {
+			[]string{"set-health", "okay", "message"},
+			`when status is "okay", message and code must be empty`,
+		}, {
+			[]string{"set-health", "okay", "--code=what"},
+			`when status is "okay", message and code must be empty`,
+		}, {
+			[]string{"set-health", "waiting"},
+			`when status is not "okay", message is required`,
+		}, {
+			[]string{"set-health", "waiting", "message", "--code=xx"},
+			`code must have between 3 and 30 characters, got 2`,
+		}, {
+			[]string{"set-health", "waiting", "message", "--code=abcdefghijklmnopqrstuvwxyz12345"},
+			`code must have between 3 and 30 characters, got 31`,
+		}, {
+			[]string{"set-health", "waiting", "message", "--code=☠☢☣💣💢🐍✴👿‼"},
+			`code must have between 3 and 30 characters, got 31`,
+		}, {
+			[]string{"set-health", "waiting", "message", "--code=123"},
+			`invalid code "123".*`,
+		}, {
+			[]string{"set-health", "waiting", "what"},
+			`message must be at least 7 characters long \(got 4\)`,
+		}, {
+			[]string{"set-health", "waiting", "áéíóú"},
+			`message must be at least 7 characters long \(got 5\)`,
+		}, {
+			[]string{"set-health", "waiting", "message"},
+			`cannot invoke workshopctl operation commands \(here "set-health"\) from outside of a workshop`,
+		},
+	}
+
+	for i, t := range table {
+		_, _, err := ctlcmd.Run(nil, t.args, 0)
+		c.Check(err, check.ErrorMatches, t.err, check.Commentf("%d", i))
+	}
+}
+
+func (s *healthSuite) TestRegularRun(c *check.C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"set-health", "waiting", "message", "--code=some-code"}, 0)
+	c.Assert(err, check.IsNil)
+
+	s.mockContext.Lock()
+	defer s.mockContext.Unlock()
+
+	var health healthstate.HealthState
+	c.Assert(s.mockContext.Get("health", &health), check.IsNil)
+	c.Check(health.Status, check.Equals, healthstate.WaitingStatus)
+	c.Check(health.Message, check.Equals, "message")
+	c.Check(health.Code, check.Equals, "some-code")
+}
+
+func (s *healthSuite) TestMessageTruncation(c *check.C) {
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"set-health", "error", "Sometimes messages will get a little bit too verbose and this can lead to some rather nasty UX (as well as potential memory problems in extreme cases) so we kinda have to deal with that", "--code=some-code"}, 0)
+	c.Assert(err, check.IsNil)
+
+	s.mockContext.Lock()
+	defer s.mockContext.Unlock()
+
+	var health healthstate.HealthState
+	c.Assert(s.mockContext.Get("health", &health), check.IsNil)
+	c.Check(health.Status, check.Equals, healthstate.ErrorStatus)
+	c.Check(health.Message, check.Equals, "Sometimes messages will get a little bit too verbose and this can lea…")
+	c.Check(health.Code, check.Equals, "some-code")
+}

--- a/internal/overlord/hookstate/ctlcmd/health_test.go
+++ b/internal/overlord/hookstate/ctlcmd/health_test.go
@@ -116,9 +116,9 @@ func (s *healthSuite) TestRegularRun(c *check.C) {
 	s.mockContext.Lock()
 	defer s.mockContext.Unlock()
 
-	var health healthstate.HealthState
+	var health healthstate.HealthCheck
 	c.Assert(s.mockContext.Get("health", &health), check.IsNil)
-	c.Check(health.Status, check.Equals, healthstate.PendingStatus)
+	c.Check(health.CheckResult, check.Equals, healthstate.CheckWaiting)
 	c.Check(health.Message, check.Equals, "message")
 	c.Check(health.Code, check.Equals, "some-code")
 }
@@ -130,9 +130,9 @@ func (s *healthSuite) TestMessageTruncation(c *check.C) {
 	s.mockContext.Lock()
 	defer s.mockContext.Unlock()
 
-	var health healthstate.HealthState
+	var health healthstate.HealthCheck
 	c.Assert(s.mockContext.Get("health", &health), check.IsNil)
-	c.Check(health.Status, check.Equals, healthstate.ErrorStatus)
+	c.Check(health.CheckResult, check.Equals, healthstate.CheckError)
 	c.Check(health.Message, check.Equals, "Sometimes messages will get a little bit too verbose and this can lea…")
 	c.Check(health.Code, check.Equals, "some-code")
 }

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -139,6 +139,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, worksho
 			},
 			Environment: hook.Environment,
 			WorkDir:     sdk.SdkHooksDir(hook.Sdk),
+			Timeout:     hook.Timeout,
 		},
 		ExecControls: workshopbackend.ExecControls{
 			Stdin:  nil,
@@ -153,7 +154,6 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, worksho
 	if err != nil {
 		return err
 	}
-
 	err = exectx.WaitExecution(ctx)
 
 	st := task.State()

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -134,7 +134,6 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, worksho
 				"-ue",
 				"-o",
 				"pipefail",
-				"-c",
 				hookPath,
 			},
 			Environment: hook.Environment,

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/overlord/state"
-	. "github.com/canonical/workshop/internal/overlord/statecontext"
+	"github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshopbackend"
 
@@ -16,12 +16,12 @@ import (
 )
 
 func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
-	user, prj, workshop, err := UserProjectWorkshop(task)
+	user, prj, workshop, err := statecontext.UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := BackendContext(tomb, user, prj)
+	ctx, cancel := statecontext.BackendContext(tomb, user, prj)
 	defer cancel()
 
 	var hook HookSetup

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -15,13 +15,11 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
-	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 )
 
 type hookSuite struct {
-	fs          afero.Fs
 	backend     *workshopbackend.FakeWorkshopBackend
 	state       *state.State
 	runner      *state.TaskRunner
@@ -48,11 +46,9 @@ func setWorkshopProject(w string, p *workshopbackend.Project, tasks ...*state.Ta
 }
 
 func (s *hookSuite) SetUpTest(c *check.C) {
-	s.fs = afero.NewMemMapFs()
-	ctx := context.WithValue(context.Background(), workshopbackend.ContextUser, "testuser")
-
 	s.backend = workshopbackend.NewFakeWorkshopBackend()
 
+	ctx := context.WithValue(context.Background(), workshopbackend.ContextUser, "testuser")
 	var err error
 	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
@@ -86,7 +82,7 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	t1 := hookstate.SetupHook(s.state, "ws", "new", hookstate.SetupBase)
+	t1 := hookstate.Hook(s.state, "ws", "new", hookstate.SetupBase)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -113,7 +109,7 @@ base: ubuntu@20.04
 func (s *hookSuite) TestExecSaveState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.SaveState)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.SaveState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -150,7 +146,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.RestoreState)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.RestoreState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -183,7 +179,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.SaveState)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.SaveState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -219,7 +215,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 func (s *hookSuite) TestExecEnsureContextHandlerHappyPath(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -243,7 +239,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerHappyPath(c *check.C) {
 func (s *hookSuite) TestExecEnsureContextHandlerUnhappyPath(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -279,7 +275,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerUnhappyPath(c *check.C) {
 func (s *hookSuite) TestExecEnsureContextHandlerErrorFails(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
 	// The context handler will return an error that must be the final error of
 	// the task.
 	s.mockHandler.ErrorError = true
@@ -318,7 +314,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerErrorFails(c *check.C) {
 func (s *hookSuite) TestExecEnsureContextHandlerIgnoresError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
 	s.mockHandler.IgnoreOriginalErr = true
 
 	chg := s.state.NewChange("sample", "...")
@@ -354,7 +350,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerIgnoresError(c *check.C) {
 func (s *hookSuite) TestHookTaskHandlerBeforeError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
 	s.mockHandler.BeforeError = true
 
 	chg := s.state.NewChange("sample", "...")
@@ -382,7 +378,7 @@ func (s *hookSuite) TestHookTaskHandlerBeforeError(c *check.C) {
 func (s *hookSuite) TestHookTaskHandlerDoneError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
 	s.mockHandler.DoneError = true
 
 	chg := s.state.NewChange("sample", "...")
@@ -408,7 +404,7 @@ func (s *hookSuite) TestHookTaskHandlerDoneError(c *check.C) {
 func (s *hookSuite) TestHookWithMultipleHandlersIsError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.SetupHook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
 	s.hookmgr.Register(regexp.MustCompile("^fake-*"), func(context *hookstate.Context) hookstate.Handler {
 		return s.mockHandler
 	})

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
@@ -210,6 +211,46 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
 	c.Assert(t1.Log()[0], check.Matches, ".*hook execution error$")
+}
+
+func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.HookWithTimeout(s.state, "ws", "one", hookstate.FakeHook, 100*time.Millisecond)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.launchWorkshop(c, "one")
+
+	s.backend.DoExec = func(ctx context.Context, name string, args *workshopbackend.Execution) (workshopbackend.ExecContext, error) {
+		return workshopbackend.ExecContext{
+			WaitExecution: func(ctx context.Context) error {
+				child, cancel := context.WithTimeout(ctx, args.Timeout)
+				defer cancel()
+				time.Sleep(200 * time.Millisecond)
+				return child.Err()
+			},
+		}, nil
+	}
+	defer func() {
+		s.backend.DoExec = workshopbackend.DoExecDefault
+	}()
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(s.backend.ExecCalls, check.HasLen, 1)
+	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
+		[]string{"bash", "-ue", "-o", "pipefail", "-c", "/var/lib/workshop/sdk/one/current/sdk/hooks/fake-hook"})
+
+	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Check(t1.Log(), check.HasLen, 1)
+	c.Assert(t1.Log()[0], check.Matches, ".*context deadline exceeded$")
 }
 
 func (s *hookSuite) TestExecEnsureContextHandlerHappyPath(c *check.C) {

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -125,7 +125,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	s.state.Lock()
 	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "-c", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
 
 	// ensure that the save-state handler has created the required state directory
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
@@ -138,7 +138,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "-c", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 2)
@@ -171,7 +171,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "-c", "/var/lib/workshop/sdk/one/current/sdk/hooks/restore-state"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/restore-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 2)
@@ -206,7 +206,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "-c", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
@@ -246,7 +246,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "-c", "/var/lib/workshop/sdk/one/current/sdk/hooks/fake-hook"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/fake-hook"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/internal/overlord/state"
-	. "github.com/canonical/workshop/internal/overlord/statecontext"
+	"github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
@@ -73,7 +73,7 @@ func New(s *state.State, runner *state.TaskRunner, server workshopbackend.Worksh
 		contexts:   make(map[string]*Context),
 	}
 
-	runner.AddHandler("run-hook", OnDo(manager.doRunHook), nil)
+	runner.AddHandler("run-hook", statecontext.OnDo(manager.doRunHook), nil)
 
 	setupHooks(manager)
 

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -43,12 +43,13 @@ const (
 	SetupBase WorkshopHookType = iota
 	SaveState
 	RestoreState
+	CheckHealth
 
 	fakeHook // tests only
 )
 
 func (s WorkshopHookType) String() string {
-	return [...]string{"setup-base", "save-state", "restore-state", "fake-hook"}[s]
+	return [...]string{"setup-base", "save-state", "restore-state", "check-health", "fake-hook"}[s]
 }
 
 func (h *HookSetup) Type() string {

--- a/internal/overlord/hookstate/request.go
+++ b/internal/overlord/hookstate/request.go
@@ -3,18 +3,30 @@ package hookstate
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
-func Hook(st *state.State, workshop, sdk string, hook WorkshopHookType) *state.Task {
-	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
-
+func hookSetup(workshop, sdk string, hook WorkshopHookType) HookSetup {
 	setup := HookSetup{HookType: hook, Workshop: workshop, Sdk: sdk, Environment: map[string]string{}}
 	if hook == SaveState || hook == RestoreState {
 		setup.Environment["SDK_STATE_DIR"] = filepath.Join(workshopbackend.WorkshopStateDir, "sdk", sdk)
 	}
+	return setup
+}
+
+func Hook(st *state.State, workshop, sdk string, hook WorkshopHookType) *state.Task {
+	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
+	setup_hook.Set("hook-setup", hookSetup(workshop, sdk, hook))
+	return setup_hook
+}
+
+func HookWithTimeout(st *state.State, workshop, sdk string, hook WorkshopHookType, timeout time.Duration) *state.Task {
+	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
+	setup := hookSetup(workshop, sdk, hook)
+	setup.Timeout = timeout
 	setup_hook.Set("hook-setup", &setup)
 	return setup_hook
 }

--- a/internal/overlord/hookstate/request.go
+++ b/internal/overlord/hookstate/request.go
@@ -8,7 +8,7 @@ import (
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
-func SetupHook(st *state.State, workshop, sdk string, hook WorkshopHookType) *state.Task {
+func Hook(st *state.State, workshop, sdk string, hook WorkshopHookType) *state.Task {
 	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
 
 	setup := HookSetup{HookType: hook, Workshop: workshop, Sdk: sdk, Environment: map[string]string{}}

--- a/internal/overlord/hookstate/request_test.go
+++ b/internal/overlord/hookstate/request_test.go
@@ -2,6 +2,7 @@ package hookstate_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -47,4 +48,19 @@ func (s *S) TestCreateHook(c *check.C) {
 		c.Assert(hookSetup.Environment, check.DeepEquals, envs[num])
 		c.Check(task.Summary(), check.Equals, fmt.Sprintf("Run hook %q for \"go\" SDK", hookSetup.Type()))
 	}
+}
+
+func (s *S) TestCreateHookWithTimeout(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	task := hookstate.HookWithTimeout(s.state, "test", "go", hookstate.CheckHealth, 5*time.Second)
+	var hookSetup hookstate.HookSetup
+	err := task.Get("hook-setup", &hookSetup)
+	c.Assert(err, check.IsNil)
+	c.Assert(hookSetup.Type(), check.Equals, "check-health")
+	c.Assert(hookSetup.Workshop, check.DeepEquals, "test")
+	c.Assert(hookSetup.Sdk, check.DeepEquals, "go")
+	c.Assert(hookSetup.Environment, check.HasLen, 0)
+	c.Assert(hookSetup.Timeout, check.Equals, 5*time.Second)
+	c.Check(task.Summary(), check.Equals, fmt.Sprintf("Run hook %q for \"go\" SDK", hookSetup.Type()))
 }

--- a/internal/overlord/hookstate/request_test.go
+++ b/internal/overlord/hookstate/request_test.go
@@ -36,7 +36,7 @@ func (s *S) TestCreateHook(c *check.C) {
 		hookstate.SaveState,
 		hookstate.RestoreState,
 	} {
-		task := hookstate.SetupHook(s.state, "test", "go", i)
+		task := hookstate.Hook(s.state, "test", "go", i)
 
 		var hookSetup hookstate.HookSetup
 		err := task.Get("hook-setup", &hookSetup)

--- a/internal/overlord/operation/operation.go
+++ b/internal/overlord/operation/operation.go
@@ -78,7 +78,7 @@ func OperationInProgress(st *state.State, name, projectId string) *Operation {
 
 func StartOperation(st *state.State, name, projectId string, op Operation) error {
 	if cur := OperationInProgress(st, name, projectId); cur != nil {
-		return fmt.Errorf("cannot begin %s: %s operation is in progress", op.Operation, cur.Operation)
+		return fmt.Errorf("cannot %s: %s operation is in progress", op.Operation, cur.Operation)
 	}
 	var refresh Operations = make(Operations)
 	st.Get(OpsInProgressKey, &refresh)

--- a/internal/overlord/operation/operation.go
+++ b/internal/overlord/operation/operation.go
@@ -1,10 +1,9 @@
-package statecontext
+package operation
 
 import (
 	"fmt"
 
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
 const (
@@ -50,6 +49,10 @@ type Operation struct {
 	WaitOnError bool   `json:"wait-on-error"`
 }
 
+func operationKey(workshop, projectId string) string {
+	return fmt.Sprintf("%s-%s", workshop, projectId)
+}
+
 // The family of functions to maintain the state of current operations across
 // the workshops. The reason we track the current operations as part of the
 // state structure and not as a property of a workshop is that, for example, a
@@ -67,7 +70,7 @@ func OperationInProgress(st *state.State, name, projectId string) *Operation {
 		return nil
 	}
 
-	if op, ok := ops[workshopbackend.InstanceName(name, projectId)]; ok {
+	if op, ok := ops[operationKey(name, projectId)]; ok {
 		return &op
 	}
 	return nil
@@ -79,7 +82,7 @@ func StartOperation(st *state.State, name, projectId string, op Operation) error
 	}
 	var refresh Operations = make(Operations)
 	st.Get(OpsInProgressKey, &refresh)
-	refresh[workshopbackend.InstanceName(name, projectId)] = op
+	refresh[operationKey(name, projectId)] = op
 	st.Set(OpsInProgressKey, refresh)
 	return nil
 }
@@ -135,7 +138,7 @@ func StopOperation(st *state.State, name, projectId, opname string) error {
 	if err != nil {
 		return err
 	}
-	opkey := workshopbackend.InstanceName(name, projectId)
+	opkey := operationKey(name, projectId)
 	op, ok := ops[opkey]
 	if !ok || opname != op.Operation {
 		return fmt.Errorf("cannot finish: no %s in progress", opname)

--- a/internal/overlord/operation/operation_test.go
+++ b/internal/overlord/operation/operation_test.go
@@ -1,10 +1,10 @@
-package statecontext_test
+package operation_test
 
 import (
 	"testing"
 
+	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/workshopbackend"
 	"gopkg.in/check.v1"
 )
@@ -27,7 +27,7 @@ func (s *OperationSuite) TestResumeRefreshNothingInProgress(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	_, err := statecontext.ResumeRefresh(s.state, "ws", s.project.ProjectId, statecontext.RefreshContinue)
+	_, err := operation.ResumeRefresh(s.state, "ws", s.project.ProjectId, operation.RefreshContinue)
 	c.Check(err, check.ErrorMatches, ".* no refresh in progress")
 }
 
@@ -35,13 +35,13 @@ func (s *OperationSuite) TestResumeRefreshAnotherOperationInProgress(c *check.C)
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationStart, WaitOnError: true})
+	operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationStart, WaitOnError: true})
 	change := s.state.NewChange("start", "...")
 	task := s.state.NewTask("no-op", "...")
 	task.SetToWait(state.DoingStatus)
 	change.AddTask(task)
 
-	_, err := statecontext.ResumeRefresh(s.state, "ws", s.project.ProjectId, statecontext.RefreshContinue)
+	_, err := operation.ResumeRefresh(s.state, "ws", s.project.ProjectId, operation.RefreshContinue)
 	c.Check(err, check.ErrorMatches, ".*cannot resume, no refresh in progress.*")
 }
 
@@ -49,13 +49,13 @@ func (s *OperationSuite) TestResumeRefreshContinue(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
+	operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationRefresh, WaitOnError: true})
 	change := s.state.NewChange("refresh", "...")
 	task := s.state.NewTask("no-op", "...")
 	task.SetToWait(state.DoingStatus)
 	change.AddTask(task)
 
-	_, err := statecontext.ResumeRefresh(s.state, "ws", s.project.ProjectId, statecontext.RefreshContinue)
+	_, err := operation.ResumeRefresh(s.state, "ws", s.project.ProjectId, operation.RefreshContinue)
 	c.Check(err, check.IsNil)
 	c.Assert(task.Status(), check.Equals, state.DoingStatus)
 }
@@ -64,13 +64,13 @@ func (s *OperationSuite) TestResumeRefreshAbort(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
+	operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationRefresh, WaitOnError: true})
 	change := s.state.NewChange("refresh", "...")
 	task := s.state.NewTask("no-op", "...")
 	change.AddTask(task)
 	task.SetToWait(state.DoingStatus)
 
-	_, err := statecontext.ResumeRefresh(s.state, "ws", s.project.ProjectId, statecontext.RefreshAbort)
+	_, err := operation.ResumeRefresh(s.state, "ws", s.project.ProjectId, operation.RefreshAbort)
 	c.Check(err, check.IsNil)
 	c.Assert(task.Status(), check.Equals, state.ErrorStatus)
 }

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/cmdstate"
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/patch"
@@ -150,6 +151,8 @@ func New(dir string, b workshopbackend.WorkshopBackend, restartHandler restart.H
 
 	o.hookmgr = hookstate.New(s, o.runner, o.workshopBackend)
 	o.addManager(o.hookmgr)
+
+	healthstate.Init(o.hookmgr)
 
 	o.commandmgr = cmdstate.New(o.runner, o.workshopBackend)
 	o.addManager(o.commandmgr)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -3,6 +3,7 @@ package sdkstate
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -80,6 +81,18 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	st.Unlock()
 
 	return nil
+}
+
+func (m *SdkManager) undoRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	st.Lock()
+	var setup sdk.Setup
+	err := task.Get("sdk-setup", &setup)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+	return os.Remove(setup.Filename())
 }
 
 func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -13,7 +13,7 @@ type SdkManager struct {
 func New(runner *state.TaskRunner, server backend.WorkshopBackend) *SdkManager {
 	manager := &SdkManager{backend: server}
 
-	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
+	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), OnUndo(manager.undoRetrieveSdk))
 	runner.AddHandler("install-sdk", OnDo(manager.doInstallSDK), OnUndo(manager.undoInstallSdk))
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), OnUndo(manager.undoLinkSdk))
 

--- a/internal/overlord/statecontext/common_state_context.go
+++ b/internal/overlord/statecontext/common_state_context.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/workshopbackend"
+
 	"gopkg.in/tomb.v2"
 )
 
@@ -35,9 +37,9 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 			// see if the task finishes the chain of tasks representing an
 			// operation launch, refresh, etc.
 			if task.Has("stop-operation") {
-				op := OperationInProgress(st, ws, p.ProjectId)
+				op := operation.OperationInProgress(st, ws, p.ProjectId)
 				if op != nil {
-					if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+					if e := operation.StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
 						return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
 					}
 				}
@@ -48,17 +50,17 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 			// the context cancellation here means the change was aborted and
 			// the undo logic chain started. we don't report the context
 			// cancellation as error here as it is an expected interruption
-			op := OperationInProgress(st, ws, p.ProjectId)
+			op := operation.OperationInProgress(st, ws, p.ProjectId)
 			if op != nil {
-				if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+				if e := operation.StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
 					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
 				}
 			}
 			return nil
 		case err != nil:
-			op := OperationInProgress(st, ws, p.ProjectId)
+			op := operation.OperationInProgress(st, ws, p.ProjectId)
 			if op != nil {
-				if op.Operation == OperationRefresh && op.WaitOnError {
+				if op.Operation == operation.OperationRefresh && op.WaitOnError {
 					task.Logf("Setting the task to wait until the refresh is either aborted or continued...")
 					task.Errorf("%v", err)
 					return &state.Wait{
@@ -67,7 +69,7 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 					}
 				}
 
-				if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+				if e := operation.StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
 					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
 				}
 			}
@@ -96,9 +98,9 @@ func OnUndo(handler state.HandlerFunc) state.HandlerFunc {
 		// task that has just completed its undoing logic, i.e. the
 		// workshop is ready for the new commands again
 		if task.Has("start-operation") {
-			op := OperationInProgress(st, ws, p.ProjectId)
+			op := operation.OperationInProgress(st, ws, p.ProjectId)
 			if op != nil {
-				if e := StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
+				if e := operation.StopOperation(st, ws, p.ProjectId, op.Operation); e != nil {
 					return fmt.Errorf("internal error: cannot stop %s for %q: %v, error: %v", op.Operation, ws, e, err)
 				}
 			}

--- a/internal/overlord/statecontext/common_state_context.go
+++ b/internal/overlord/statecontext/common_state_context.go
@@ -28,6 +28,11 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 		}
 
 		err = handler(task, tomb)
+		switch err.(type) {
+		case *state.Retry:
+			return err
+		}
+
 		st := task.State()
 		st.Lock()
 		defer st.Unlock()

--- a/internal/overlord/statecontext/common_state_context_test.go
+++ b/internal/overlord/statecontext/common_state_context_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/workshopbackend"
@@ -44,7 +45,7 @@ func (s *CommonStateFuncs) TestStopTaskOperation(c *check.C) {
 	s.state.Lock()
 	// mark task to stop the associated operation
 	task.Set("stop-operation", true)
-	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
+	err := operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationRefresh, WaitOnError: true})
 	c.Assert(err, check.IsNil)
 	task.Change().Abort()
 	s.state.Unlock()
@@ -56,7 +57,7 @@ func (s *CommonStateFuncs) TestStopTaskOperation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	s.state.Lock()
-	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	op := operation.OperationInProgress(s.state, "ws", s.project.ProjectId)
 	c.Assert(op, check.IsNil)
 	s.state.Unlock()
 }
@@ -65,7 +66,7 @@ func (s *CommonStateFuncs) TestContextCancelled(c *check.C) {
 	task := s.setupTask()
 
 	s.state.Lock()
-	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
+	err := operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationRefresh, WaitOnError: true})
 	c.Assert(err, check.IsNil)
 	task.Change().Abort()
 	s.state.Unlock()
@@ -77,7 +78,7 @@ func (s *CommonStateFuncs) TestContextCancelled(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	s.state.Lock()
-	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	op := operation.OperationInProgress(s.state, "ws", s.project.ProjectId)
 	c.Assert(op, check.IsNil)
 	s.state.Unlock()
 }
@@ -86,7 +87,7 @@ func (s *CommonStateFuncs) TestExecutionErrorOnDo(c *check.C) {
 	task := s.setupTask()
 
 	s.state.Lock()
-	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: false})
+	err := operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationRefresh, WaitOnError: false})
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 
@@ -99,7 +100,7 @@ func (s *CommonStateFuncs) TestExecutionErrorOnDo(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	op := operation.OperationInProgress(s.state, "ws", s.project.ProjectId)
 	c.Assert(op, check.IsNil)
 }
 
@@ -108,7 +109,7 @@ func (s *CommonStateFuncs) TestStartTaskOnUndo(c *check.C) {
 
 	s.state.Lock()
 	task.Set("start-operation", true)
-	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: false})
+	err := operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationRefresh, WaitOnError: false})
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 
@@ -121,7 +122,7 @@ func (s *CommonStateFuncs) TestStartTaskOnUndo(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	op := operation.OperationInProgress(s.state, "ws", s.project.ProjectId)
 	c.Assert(op, check.IsNil)
 }
 
@@ -130,7 +131,7 @@ func (s *CommonStateFuncs) TestRefreshInProgressError(c *check.C) {
 		return errors.New("task failed")
 	})
 	s.state.Lock()
-	err := statecontext.StartOperation(s.state, "ws", s.project.ProjectId, statecontext.Operation{ChangeId: "1", Operation: statecontext.OperationRefresh, WaitOnError: true})
+	err := operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationRefresh, WaitOnError: true})
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 
@@ -142,7 +143,7 @@ func (s *CommonStateFuncs) TestRefreshInProgressError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	op := statecontext.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	op := operation.OperationInProgress(s.state, "ws", s.project.ProjectId)
 	c.Assert(op, check.NotNil)
 	c.Assert(op.ChangeId, check.Equals, "1")
 	c.Assert(op.Operation, check.Equals, "refresh")

--- a/internal/overlord/statecontext/common_state_context_test.go
+++ b/internal/overlord/statecontext/common_state_context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
 
 	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -19,6 +20,8 @@ type CommonStateFuncs struct {
 }
 
 var _ = check.Suite(&CommonStateFuncs{})
+
+func Test(t *testing.T) { check.TestingT(t) }
 
 func (s *CommonStateFuncs) setupTask() *state.Task {
 	s.state.Lock()
@@ -147,4 +150,27 @@ func (s *CommonStateFuncs) TestRefreshInProgressError(c *check.C) {
 	c.Assert(op, check.NotNil)
 	c.Assert(op.ChangeId, check.Equals, "1")
 	c.Assert(op.Operation, check.Equals, "refresh")
+}
+
+func (s *CommonStateFuncs) TestExecutionOnDoRetry(c *check.C) {
+	task := s.setupTask()
+
+	s.state.Lock()
+	task.Set("stop-operation", true)
+	err := operation.StartOperation(s.state, "ws", s.project.ProjectId, operation.Operation{ChangeId: "1", Operation: operation.OperationRefresh, WaitOnError: false})
+	c.Assert(err, check.IsNil)
+	s.state.Unlock()
+
+	handler := statecontext.OnDo(func(task *state.Task, tomb *tomb.Tomb) error {
+		return &state.Retry{Reason: "not enough time"}
+	})
+
+	err = handler(task, nil)
+	c.Assert(err, check.ErrorMatches, "task should be retried")
+	c.Assert(err.(*state.Retry).Reason, check.Equals, "not enough time")
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	op := operation.OperationInProgress(s.state, "ws", s.project.ProjectId)
+	c.Assert(op, check.NotNil)
 }

--- a/internal/overlord/workshopstate/export_test.go
+++ b/internal/overlord/workshopstate/export_test.go
@@ -9,6 +9,5 @@ var (
 	StopManyImpl      = stopMany
 	RemoveManyImpl    = removeMany
 
-	Launch        = launch
-	WorkshopState = (*WorkshopManager).workshopStatus
+	Launch = launch
 )

--- a/internal/overlord/workshopstate/export_test.go
+++ b/internal/overlord/workshopstate/export_test.go
@@ -1,13 +1,15 @@
 package workshopstate
 
 var (
-	Refresh           = refresh
-	RefreshManyImpl   = refreshMany
-	RestoreStateHooks = restoreStateHooks
-	SaveStateHooks    = saveStateHooks
-	StartManyImpl     = startMany
-	StopManyImpl      = stopMany
-	RemoveManyImpl    = removeMany
-
-	Launch = launch
+	Refresh            = refresh
+	RefreshManyImpl    = refreshMany
+	CheckHealthHooks   = checkHealthHooks
+	SaveStateHooks     = saveStateHooks
+	RestoreStateHooks  = restoreStateHooks
+	StartManyImpl      = startMany
+	StopManyImpl       = stopMany
+	RemoveManyImpl     = removeMany
+	Launch             = launch
+	CheckHealthTimeout = checkHealthTimeout
+	StartOperation     = (*WorkshopManager).startOperationMany
 )

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -2,10 +2,16 @@ package workshopstate
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"golang.org/x/exp/slices"
+
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	. "github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/workshopbackend"
+	"github.com/canonical/x-go/strutil"
 )
 
 type WorkshopManager struct {
@@ -19,7 +25,6 @@ func New(st *state.State, runner *state.TaskRunner, server workshopbackend.Works
 		state:   st,
 	}
 
-	/* Workshop management */
 	runner.AddHandler("create-workshop", OnDo(manager.doCreateWorkshop), OnUndo(manager.undoCreateWorkshop))
 	runner.AddHandler("start-workshop", OnDo(manager.doStart), OnUndo(manager.doStop))
 	runner.AddHandler("stop-workshop", OnDo(manager.doStop), OnUndo(manager.doStart))
@@ -41,23 +46,24 @@ func (w *WorkshopManager) Ensure() error {
 	return nil
 }
 
-// Checks all of the provided list of workshops are in the required status as
-// per the matchStatus predicate. It returns the first workshop that does NOT
-// meet the predicate's condition.
-func (w *WorkshopManager) CheckStatus(ctx context.Context, names []string, pId string,
-	matchStatus func(status workshopbackend.WorkshopStatus) bool) (string, workshopbackend.WorkshopStatus, error) {
+// Checks all of the provided list of workshops are in the required health status.
+func (w *WorkshopManager) CheckStatus(ctx context.Context, names []string, pId string, allowedStatuses []healthstate.HealthStatus) error {
 	for _, name := range names {
-		wrkspc, err := w.Workshop(ctx, name, pId)
+		workshop, err := w.Workshop(ctx, name, pId)
 		if err != nil {
-			return "", workshopbackend.WorkshopOff, err
+			return err
 		}
 
-		status := w.workshopStatus(wrkspc)
-		if !matchStatus(status) {
-			return name, status, nil
+		health := w.WorkshopHealth(workshop)
+		allowed := []string{}
+		for _, s := range allowedStatuses {
+			allowed = append(allowed, s.String())
+		}
+		if slices.Index(allowedStatuses, health.Status) == -1 {
+			return fmt.Errorf("%q status is %q, must be one of: %s", name, health.Status.String(), strutil.Quoted(allowed))
 		}
 	}
-	return "", workshopbackend.WorkshopOff, nil
+	return nil
 }
 
 // Loads a workshop, the state must be locked as it is used to find out the
@@ -66,13 +72,12 @@ func (w *WorkshopManager) Workshop(ctx context.Context, name, pId string) (*work
 	// project-id must be in the context for this query
 	pCtx := context.WithValue(ctx, workshopbackend.ContextProjectId, pId)
 
-	wrkspc, err := w.backend.Workshop(pCtx, name)
+	workshop, err := w.backend.Workshop(pCtx, name)
 	if err != nil {
 		return nil, err
 	}
 
-	wrkspc.SetStatus(w.workshopStatus(wrkspc))
-	return wrkspc, nil
+	return workshop, nil
 }
 
 // Loads all workshops for a project, the state must be locked as it is used to find out the
@@ -86,45 +91,48 @@ func (w *WorkshopManager) Workshops(ctx context.Context, pId string) ([]*worksho
 		return nil, nil, err
 	}
 
-	for _, wrkspc := range workshops {
-		wrkspc.SetStatus(w.workshopStatus(wrkspc))
-	}
-
 	return files, workshops, nil
 }
 
 // Infers the state of a workshop based on the container's state and any of the
 // operations in progress for the workshop. The state must be locked before the
 // call.
-func (w *WorkshopManager) workshopStatus(ws *workshopbackend.Workshop) workshopbackend.WorkshopStatus {
-	op := OperationInProgress(w.state, ws.Name, ws.ProjectId())
-	if op != nil {
-		if ws.IsRunning() {
-			change := w.state.Change(op.ChangeId)
-			if change == nil {
-				return workshopbackend.WorkshopError
-			}
-			if change.Status() == state.WaitStatus {
-				ws.AddError(workshopbackend.WaitOnError)
-				return workshopbackend.WorkshopPending
-			}
-			if len(ws.Errors()) == 0 {
-				return workshopbackend.WorkshopPending
-			}
-			return workshopbackend.WorkshopError
-		} else {
-			if len(ws.Errors()) > 0 {
-				return workshopbackend.WorkshopError
-			}
-			return workshopbackend.WorkshopPending
-		}
-	} else {
-		if ws.IsRunning() && len(ws.Errors()) == 0 {
-			return workshopbackend.WorkshopReady
-		}
-		if len(ws.Errors()) > 0 {
-			return workshopbackend.WorkshopError
-		}
-		return workshopbackend.WorkshopStopped
+func (w *WorkshopManager) WorkshopHealth(ws *workshopbackend.Workshop) healthstate.HealthState {
+	var healthState = healthstate.HealthState{
+		Timestamp: time.Now(),
+		Code:      "-",
 	}
+
+	// check the project directory exists
+	if !ws.Project().Exists() {
+		healthState.Status = healthstate.ErrorStatus
+		healthState.Code = "missing-project"
+		return healthState
+	}
+
+	// check if the workshop file exists
+	if _, err := ws.File(); err != nil {
+		healthState.Status = healthstate.ErrorStatus
+		healthState.Code = "missing-file"
+		return healthState
+	}
+
+	op := OperationInProgress(w.state, ws.Name, ws.Project().ProjectId)
+	if op != nil {
+		change := w.state.Change(op.ChangeId)
+		if change == nil {
+			healthState.Status = healthstate.ErrorStatus
+		}
+		if change.Status() == state.WaitStatus {
+			healthState.Code = "wait-on-error"
+		}
+		healthState.Status = healthstate.PendingStatus
+	} else {
+		if ws.IsRunning() {
+			healthState.Status = healthstate.ReadyStatus
+		} else {
+			healthState.Status = healthstate.StoppedStatus
+		}
+	}
+	return healthState
 }

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/canonical/workshop/internal/overlord/healthstate"
+	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
 	. "github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/workshopbackend"
@@ -47,7 +48,7 @@ func (w *WorkshopManager) Ensure() error {
 }
 
 // Checks all of the provided list of workshops are in the required health status.
-func (w *WorkshopManager) CheckStatus(ctx context.Context, names []string, pId string, allowedStatuses []healthstate.HealthStatus) error {
+func (w *WorkshopManager) CheckStatus(ctx context.Context, names []string, pId string, allowedStatuses []healthstate.Status) error {
 	for _, name := range names {
 		workshop, err := w.Workshop(ctx, name, pId)
 		if err != nil {
@@ -94,13 +95,27 @@ func (w *WorkshopManager) Workshops(ctx context.Context, pId string) ([]*worksho
 	return files, workshops, nil
 }
 
+// Examine the tasks of the change to fetch possible check-health hook results
+// for the workshop's SDKs.
+func sdksHealthCheckSummary(chg *state.Change) map[string]healthstate.HealthCheck {
+	var SdkChecks = map[string]healthstate.HealthCheck{}
+	for _, task := range chg.Tasks() {
+		if task.Kind() == "run-hook" {
+			var healthCheck healthstate.HealthCheck
+			if err := task.Get("health", &healthCheck); err == nil {
+				SdkChecks[healthCheck.Sdk] = healthCheck
+			}
+		}
+	}
+	return SdkChecks
+}
+
 // Infers the state of a workshop based on the container's state and any of the
 // operations in progress for the workshop. The state must be locked before the
 // call.
 func (w *WorkshopManager) WorkshopHealth(ws *workshopbackend.Workshop) healthstate.HealthState {
 	var healthState = healthstate.HealthState{
 		Timestamp: time.Now(),
-		Code:      "-",
 	}
 
 	// check the project directory exists
@@ -117,15 +132,19 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshopbackend.Workshop) healthsta
 		return healthState
 	}
 
-	op := OperationInProgress(w.state, ws.Name, ws.Project().ProjectId)
+	op := operation.OperationInProgress(w.state, ws.Name, ws.Project().ProjectId)
 	if op != nil {
 		change := w.state.Change(op.ChangeId)
+		// a change could have gone as a result of pruning TODO: when prune
+		// changes, abort all the outstanding operations connected with it
 		if change == nil {
 			healthState.Status = healthstate.ErrorStatus
 		}
 		if change.Status() == state.WaitStatus {
 			healthState.Code = "wait-on-error"
 		}
+
+		healthState.SdkHealth = sdksHealthCheckSummary(change)
 		healthState.Status = healthstate.PendingStatus
 	} else {
 		if ws.IsRunning() {

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -139,6 +139,7 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshopbackend.Workshop) healthsta
 		// changes, abort all the outstanding operations connected with it
 		if change == nil {
 			healthState.Status = healthstate.ErrorStatus
+			return healthState
 		}
 		if change.Status() == state.WaitStatus {
 			healthState.Code = "wait-on-error"

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -52,7 +52,7 @@ func (w *WorkshopManager) CheckStatus(ctx context.Context, names []string, pId s
 	for _, name := range names {
 		workshop, err := w.Workshop(ctx, name, pId)
 		if err != nil {
-			return err
+			return fmt.Errorf("status check for %q failed (%v)", name, err)
 		}
 
 		health := w.WorkshopHealth(workshop)

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -1,21 +1,24 @@
 package workshopstate_test
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"html/template"
 	"os"
 	"path/filepath"
 
 	"github.com/canonical/workshop/internal/overlord/healthstate"
-	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
 	"gopkg.in/check.v1"
 )
 
-type ManagerSuite struct {
+type managerSuite struct {
 	state   *state.State
 	backend workshopbackend.WorkshopBackend
 	runner  *state.TaskRunner
@@ -24,9 +27,9 @@ type ManagerSuite struct {
 	project *workshopbackend.Project
 }
 
-var _ = check.Suite(&ManagerSuite{})
+var _ = check.Suite(&managerSuite{})
 
-func (s *ManagerSuite) SetUpTest(c *check.C) {
+func (s *managerSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.backend = workshopbackend.NewFakeWorkshopBackend()
 	s.runner = state.NewTaskRunner(s.state)
@@ -36,7 +39,7 @@ func (s *ManagerSuite) SetUpTest(c *check.C) {
 	s.ctx = context.WithValue(ctx, workshopbackend.ContextProjectId, s.project.ProjectId)
 }
 
-func (s *ManagerSuite) TestAddHandlers(c *check.C) {
+func (s *managerSuite) TestAddHandlers(c *check.C) {
 	workshopstate.New(s.state, s.runner, s.backend)
 
 	c.Assert(s.runner.KnownTaskKinds(), testutil.DeepUnsortedMatches, []string{
@@ -52,26 +55,55 @@ func (s *ManagerSuite) TestAddHandlers(c *check.C) {
 	})
 }
 
-func (s *ManagerSuite) launchWorkshopWithTestSdk(c *check.C) *workshopbackend.Workshop {
-	// Setup
-	os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
-base: ubuntu@20.04
-sdks:
-  test-sdk:
-    channel: latest/stable
-`), 0644)
-	err := s.backend.LaunchWorkshop(s.ctx, "test", "ubuntu@20.04")
+func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []sdk.Setup) *workshopbackend.Workshop {
+	t, err := template.New("workshop").Parse(fmt.Sprintf(workshopTemplate, ws))
 	c.Assert(err, check.IsNil)
-	ws, err := s.backend.Workshop(s.ctx, "test")
+
+	var workshopFile = bytes.NewBuffer([]byte{})
+	t.Execute(workshopFile, sdks)
+
+	err = os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(".workshop.%s.yaml", ws)), workshopFile.Bytes(), 0644)
 	c.Assert(err, check.IsNil)
-	return ws
+
+	err = s.backend.LaunchWorkshop(s.ctx, ws, "ubuntu@20.04")
+	c.Assert(err, check.IsNil)
+
+	workshop, err := s.backend.Workshop(s.ctx, ws)
+	c.Assert(err, check.IsNil)
+	return workshop
 }
 
-func (s *ManagerSuite) TestWorkshopHealthReady(c *check.C) {
+func (s *managerSuite) TestWorkshopManagerStartOperationOK(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	chg := s.state.NewChange("refresh", "test")
+	s.launchWorkshopWithSDKs(c, "test-1", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	s.launchWorkshopWithSDKs(c, "test-2", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+
+	err := workshopstate.StartOperation(s.manager, []string{"test-1", "test-2"}, s.project.ProjectId, operation.Operation{Operation: operation.OperationRefresh, ChangeId: chg.ID()})
+	c.Assert(err, check.IsNil)
+	c.Assert(operation.OperationInProgress(s.state, "test-1", s.project.ProjectId), check.NotNil)
+	c.Assert(operation.OperationInProgress(s.state, "test-2", s.project.ProjectId), check.NotNil)
+}
+
+func (s *managerSuite) TestWorkshopManagerStartOperationFail(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	chg := s.state.NewChange("refresh", "test")
+	s.launchWorkshopWithSDKs(c, "test-2", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	_, err := s.manager.RefreshMany(s.ctx, []string{"test-2"}, s.project.ProjectId, operation.RefreshTransactional, chg.ID())
+	c.Assert(err, check.IsNil)
+
+	err = workshopstate.StartOperation(s.manager, []string{"test-1", "test-2"}, s.project.ProjectId, operation.Operation{Operation: operation.OperationRefresh, ChangeId: chg.ID()})
+	c.Assert(err, check.ErrorMatches, `cannot refresh: refresh operation is in progress`)
+	c.Assert(operation.OperationInProgress(s.state, "test-1", s.project.ProjectId), check.IsNil)
+}
+
+func (s *managerSuite) TestWorkshopHealthReady(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	workshop := s.launchWorkshopWithTestSdk(c)
+	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
 	health := s.manager.WorkshopHealth(workshop)
 
 	c.Assert(health.Status, check.Equals, healthstate.ReadyStatus)
@@ -80,11 +112,11 @@ func (s *ManagerSuite) TestWorkshopHealthReady(c *check.C) {
 	c.Check(health.Code, check.HasLen, 0)
 }
 
-func (s *ManagerSuite) TestWorkshopHealthStopped(c *check.C) {
+func (s *managerSuite) TestWorkshopHealthStopped(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	workshop := s.launchWorkshopWithTestSdk(c)
+	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
 	c.Assert(s.backend.StopWorkshop(s.ctx, "test", true), check.IsNil)
 	health := s.manager.WorkshopHealth(workshop)
 
@@ -94,11 +126,11 @@ func (s *ManagerSuite) TestWorkshopHealthStopped(c *check.C) {
 	c.Check(health.Code, check.HasLen, 0)
 }
 
-func (s *ManagerSuite) TestWorkshopHealthMissingProject(c *check.C) {
+func (s *managerSuite) TestWorkshopHealthMissingProject(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	workshop := s.launchWorkshopWithTestSdk(c)
+	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
 	c.Assert(os.RemoveAll(s.project.Path), check.IsNil)
 	health := s.manager.WorkshopHealth(workshop)
 
@@ -108,11 +140,11 @@ func (s *ManagerSuite) TestWorkshopHealthMissingProject(c *check.C) {
 	c.Check(health.Code, check.Equals, "missing-project")
 }
 
-func (s *ManagerSuite) TestWorkshopHealthMissingFile(c *check.C) {
+func (s *managerSuite) TestWorkshopHealthMissingFile(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	workshop := s.launchWorkshopWithTestSdk(c)
+	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
 	c.Assert(os.RemoveAll(filepath.Join(s.project.Path, ".workshop.test.yaml")), check.IsNil)
 	health := s.manager.WorkshopHealth(workshop)
 
@@ -122,13 +154,13 @@ func (s *ManagerSuite) TestWorkshopHealthMissingFile(c *check.C) {
 	c.Check(health.Code, check.Equals, "missing-file")
 }
 
-func (s *ManagerSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
+func (s *managerSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("launch", "test")
 
-	workshop := s.launchWorkshopWithTestSdk(c)
+	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
 	err := operation.StartOperation(s.state, "test", s.project.ProjectId, operation.Operation{
 		ChangeId:  chg.ID(),
 		Operation: "launch",
@@ -142,14 +174,14 @@ func (s *ManagerSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 	c.Check(health.Code, check.HasLen, 0)
 }
 
-func (s *ManagerSuite) TestWorkshopHealthOperationInProgressWithNotes(c *check.C) {
+func (s *managerSuite) TestWorkshopHealthOperationInProgressWithNotes(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("refresh", "test")
 	chg.SetStatus(state.WaitStatus)
 
-	workshop := s.launchWorkshopWithTestSdk(c)
+	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
 	err := operation.StartOperation(s.state, "test", s.project.ProjectId, operation.Operation{
 		ChangeId:  chg.ID(),
 		Operation: "refresh",
@@ -163,7 +195,7 @@ func (s *ManagerSuite) TestWorkshopHealthOperationInProgressWithNotes(c *check.C
 	c.Check(health.Code, check.Equals, "wait-on-error")
 }
 
-func (s *ManagerSuite) TestWorkshopHealthSdkHealth(c *check.C) {
+func (s *managerSuite) TestWorkshopHealthSdkHealth(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -178,7 +210,7 @@ func (s *ManagerSuite) TestWorkshopHealthSdkHealth(c *check.C) {
 	task.Set("health", healthCheck)
 	chg.AddTask(task)
 
-	workshop := s.launchWorkshopWithTestSdk(c)
+	workshop := s.launchWorkshopWithSDKs(c, "test", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
 	err := operation.StartOperation(s.state, "test", s.project.ProjectId, operation.Operation{
 		ChangeId:  chg.ID(),
 		Operation: "launch",
@@ -193,98 +225,67 @@ func (s *ManagerSuite) TestWorkshopHealthSdkHealth(c *check.C) {
 	c.Check(health.Code, check.HasLen, 0)
 }
 
-func (s *ManagerSuite) TestRefreshSdkWasAdded(c *check.C) {
+func (s *managerSuite) TestRefreshManyOK(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+	chg := s.state.NewChange("refresh", "test")
+	s.launchWorkshopWithSDKs(c, "test-1", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	s.launchWorkshopWithSDKs(c, "test-2", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
 
-	// Setup
-	s.launchWorkshopWithTestSdk(c)
+	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId, operation.RefreshTransactional, chg.ID())
+	c.Assert(err, check.IsNil)
 
-	// a user added an SDK to the workshop file and called refresh
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
-base: ubuntu@20.04
-sdks:
-  test-sdk:
-    channel: latest/stable
-  new:
-    channel: latest/stable
-`), 0644)
-	c.Check(err, check.IsNil)
+	op := operation.OperationInProgress(s.state, "test-1", s.project.ProjectId)
+	c.Check(op, check.NotNil)
+	c.Assert(op.Operation, check.Equals, "refresh")
+	c.Assert(op.ChangeId, check.Equals, chg.ID())
+	c.Assert(op.WaitOnError, check.Equals, false)
 
-	// Execute
-	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, operation.RefreshTransactional, "1")
-	c.Check(err, check.IsNil)
-
-	// Validate
-	s.validateStateHooksTasksSetup(c, ts, []string{"test-sdk"}, []string{"test-sdk"})
+	op = operation.OperationInProgress(s.state, "test-2", s.project.ProjectId)
+	c.Check(op, check.NotNil)
+	c.Assert(op.Operation, check.Equals, "refresh")
+	c.Assert(op.ChangeId, check.Equals, chg.ID())
+	c.Assert(op.WaitOnError, check.Equals, false)
 }
 
-func (s *ManagerSuite) TestRefreshSdkWasRemoved(c *check.C) {
+func (s *managerSuite) TestRefreshManyWorkshopHasOperationPending(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+	chg := s.state.NewChange("refresh", "test")
+	chg2 := s.state.NewChange("refresh", "test")
+	s.launchWorkshopWithSDKs(c, "test-1", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	s.launchWorkshopWithSDKs(c, "test-2", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
 
-	// Setup
-	s.launchWorkshopWithTestSdk(c)
+	operation.StartOperation(s.state, "test-1", s.project.ProjectId, operation.Operation{Operation: operation.OperationRefresh, ChangeId: chg.ID()})
 
-	// a user removed an SDK in the workshop file and called refresh
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
-base: ubuntu@20.04
-`), 0644)
-	c.Check(err, check.IsNil)
-
-	// Execute
-	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, operation.RefreshTransactional, "1")
-	c.Check(err, check.IsNil)
-
-	// Validate
-	s.validateStateHooksTasksSetup(c, ts, []string{}, []string{})
+	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId, operation.RefreshTransactional, chg2.ID())
+	c.Assert(err, check.ErrorMatches, `cannot refresh: "test-1" status is "Pending", must be one of: "Ready"`)
+	c.Assert(operation.OperationInProgress(s.state, "test-2", s.project.ProjectId), check.IsNil)
 }
 
-func (s *ManagerSuite) TestRefreshSdkChannelWasUpdated(c *check.C) {
+func (s *managerSuite) TestRefreshRequireStatusReady(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+	chg := s.state.NewChange("refresh", "test")
+	s.launchWorkshopWithSDKs(c, "test-1", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	workshop2 := s.launchWorkshopWithSDKs(c, "test-2", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	err := s.backend.StopWorkshop(s.ctx, workshop2.Name, true)
+	c.Assert(err, check.IsNil)
 
-	// Setup
-	s.launchWorkshopWithTestSdk(c)
-
-	// a user updated an SDK in the workshop file and called refresh
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
-base: ubuntu@20.04
-sdks:
-  test-sdk:
-    channel: latest/edge
-`), 0644)
-	c.Check(err, check.IsNil)
-
-	// Execute
-	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, operation.RefreshTransactional, "1")
-	c.Check(err, check.IsNil)
-
-	// Validate
-	s.validateStateHooksTasksSetup(c, ts, []string{"test-sdk"}, []string{"test-sdk"})
+	_, err = s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId, operation.RefreshTransactional, chg.ID())
+	c.Assert(err, check.ErrorMatches, `cannot refresh: "test-2" status is "Stopped", must be one of: "Ready"`)
+	c.Assert(operation.OperationInProgress(s.state, "test-1", s.project.ProjectId), check.IsNil)
+	c.Assert(operation.OperationInProgress(s.state, "test-2", s.project.ProjectId), check.IsNil)
 }
 
-// the save state shall be called only for the previously installed SDK
-// the restore state shall be called for both, the old and the new SDK
-func (*ManagerSuite) validateStateHooksTasksSetup(c *check.C, ts []*state.TaskSet, expectedSave, expectedRestore []string) {
-	obtainedSave := []string{}
-	obtainedRestore := []string{}
-	for _, t := range ts[0].Tasks() {
-		if t.Kind() == "run-hook" {
-			var setup hookstate.HookSetup
-			err := t.Get("hook-setup", &setup)
-			c.Assert(err, check.IsNil)
-			switch setup.HookType {
-			case hookstate.SaveState:
-				obtainedSave = append(obtainedSave, setup.Sdk)
-			case hookstate.RestoreState:
-				obtainedRestore = append(obtainedRestore, setup.Sdk)
-			}
-		}
-	}
+func (s *managerSuite) TestRefreshRequireWorkshopExistance(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	chg := s.state.NewChange("refresh", "test")
+	s.launchWorkshopWithSDKs(c, "test-1", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
 
-	// the save state shall be called only for the previously installed SDK
-	c.Assert(obtainedSave, testutil.DeepUnsortedMatches, expectedSave)
-	// the restore state shall be called for the new previously installed SDK
-	c.Assert(obtainedRestore, testutil.DeepUnsortedMatches, expectedRestore)
+	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId, operation.RefreshTransactional, chg.ID())
+	c.Assert(err, check.ErrorMatches, `cannot refresh: status check for "test-2" failed \(workshop not found\)`)
+	c.Assert(operation.OperationInProgress(s.state, "test-1", s.project.ProjectId), check.IsNil)
+	c.Assert(operation.OperationInProgress(s.state, "test-2", s.project.ProjectId), check.IsNil)
 }

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -51,69 +51,69 @@ func (s *ManagerSuite) TestAddHandlers(c *check.C) {
 	})
 }
 
-func (s *ManagerSuite) setupWorkshop(running bool) *workshopbackend.Workshop {
-	wrkspc := workshopbackend.NewWorkshop(s.backend, "ws", "42424242")
-	wrkspc.SetRunning(running)
-	return wrkspc
-}
+// func (s *ManagerSuite) setupWorkshop(running bool) *workshopbackend.Workshop {
+// 	wrkspc := workshopbackend.NewWorkshop(s.backend, s.project, "ws")
+// 	wrkspc.SetRunning(running)
+// 	return wrkspc
+// }
 
-func (s *ManagerSuite) TestWorkshopStateChanges(c *check.C) {
-	type stateSetup struct {
-		status            state.Status
-		running           bool
-		refreshInProgress bool
-		hasErrors         bool
-		expectedState     workshopbackend.WorkshopStatus
-		expectedErrors    []workshopbackend.WorkshopErrorType
-	}
-	cases := []stateSetup{
-		// running, no operation in progress, no errors
-		{state.DefaultStatus, true, false, false, workshopbackend.WorkshopReady, nil},
-		// running, no operation in prorgess, has errors
-		{state.DefaultStatus, true, false, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
-		// not running, no operation in prorgess, no errors
-		{state.DefaultStatus, false, false, false, workshopbackend.WorkshopStopped, nil},
-		// not running, no operation in prorgess, has errors
-		{state.DefaultStatus, false, false, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
-		// running, has operation in prorgess, waits on error
-		{state.WaitStatus, true, true, false, workshopbackend.WorkshopPending, []workshopbackend.WorkshopErrorType{workshopbackend.WaitOnError}},
-		// running, has operation in prorgess, no errors
-		{state.DoingStatus, true, true, false, workshopbackend.WorkshopPending, nil},
-		// running, has operation in prorgess, has errors
-		{state.DoingStatus, true, true, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
-		// not running, has operation in prorgess, no errors
-		{state.DoingStatus, false, true, false, workshopbackend.WorkshopPending, nil},
-		// not running, has operation in prorgess, has errors
-		{state.DoingStatus, false, true, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
-	}
+// func (s *ManagerSuite) TestWorkshopStateChanges(c *check.C) {
+// 	type stateSetup struct {
+// 		status            state.Status
+// 		running           bool
+// 		refreshInProgress bool
+// 		hasErrors         bool
+// 		expectedState     healthstate.HealthStatus
+// 		expectedErrors    []workshopbackend.WorkshopErrorType
+// 	}
+// 	cases := []stateSetup{
+// 		// running, no operation in progress, no errors
+// 		{state.DefaultStatus, true, false, false, healthstate.ReadyStatus, nil},
+// 		// running, no operation in prorgess, has errors
+// 		{state.DefaultStatus, true, false, true, healthstate.ReadyStatus, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
+// 		// not running, no operation in prorgess, no errors
+// 		{state.DefaultStatus, false, false, false, workshopbackend.WorkshopStopped, nil},
+// 		// not running, no operation in prorgess, has errors
+// 		{state.DefaultStatus, false, false, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
+// 		// running, has operation in prorgess, waits on error
+// 		{state.WaitStatus, true, true, false, workshopbackend.WorkshopPending, []workshopbackend.WorkshopErrorType{workshopbackend.WaitOnError}},
+// 		// running, has operation in prorgess, no errors
+// 		{state.DoingStatus, true, true, false, workshopbackend.WorkshopPending, nil},
+// 		// running, has operation in prorgess, has errors
+// 		{state.DoingStatus, true, true, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
+// 		// not running, has operation in prorgess, no errors
+// 		{state.DoingStatus, false, true, false, workshopbackend.WorkshopPending, nil},
+// 		// not running, has operation in prorgess, has errors
+// 		{state.DoingStatus, false, true, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
+// 	}
 
-	s.state.Lock()
-	defer s.state.Unlock()
+// 	s.state.Lock()
+// 	defer s.state.Unlock()
 
-	for i, setup := range cases {
-		// setup
-		wrkspc := s.setupWorkshop(setup.running)
-		if setup.hasErrors {
-			// add any error to emulate error state
-			wrkspc.AddError(workshopbackend.MissingFile)
-		}
-		if setup.refreshInProgress {
-			chg := s.state.NewChange("test", "...")
-			chg.SetStatus(setup.status)
-			err := statecontext.StartOperation(s.state, "ws", "42424242", statecontext.Operation{Operation: statecontext.OperationRefresh, ChangeId: chg.ID(), WaitOnError: true})
-			c.Assert(err, check.IsNil)
-		}
+// 	for i, setup := range cases {
+// 		// setup
+// 		wrkspc := s.setupWorkshop(setup.running)
+// 		if setup.hasErrors {
+// 			// add any error to emulate error state
+// 			wrkspc.AddError(workshopbackend.MissingFile)
+// 		}
+// 		if setup.refreshInProgress {
+// 			chg := s.state.NewChange("test", "...")
+// 			chg.SetStatus(setup.status)
+// 			err := statecontext.StartOperation(s.state, "ws", "42424242", statecontext.Operation{Operation: statecontext.OperationRefresh, ChangeId: chg.ID(), WaitOnError: true})
+// 			c.Assert(err, check.IsNil)
+// 		}
 
-		// validate
-		st := workshopstate.WorkshopState(s.manager, wrkspc)
-		c.Assert(st, check.Equals, setup.expectedState, check.Commentf("case num: %v", i))
-		c.Assert(wrkspc.Errors(), testutil.DeepUnsortedMatches, setup.expectedErrors, check.Commentf("case num: %v", i))
-		if setup.refreshInProgress {
-			err := statecontext.StopOperation(s.state, "ws", "42424242", statecontext.OperationRefresh)
-			c.Assert(err, check.IsNil)
-		}
-	}
-}
+// 		// validate
+// 		st := workshopstate.WorkshopStatus(s.manager, wrkspc)
+// 		c.Assert(st, check.Equals, setup.expectedState, check.Commentf("case num: %v", i))
+// 		c.Assert(wrkspc.Errors(), testutil.DeepUnsortedMatches, setup.expectedErrors, check.Commentf("case num: %v", i))
+// 		if setup.refreshInProgress {
+// 			err := statecontext.StopOperation(s.state, "ws", "42424242", statecontext.OperationRefresh)
+// 			c.Assert(err, check.IsNil)
+// 		}
+// 	}
+// }
 
 func (s *ManagerSuite) TestRefreshSdkWasAdded(c *check.C) {
 	s.state.Lock()

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
@@ -141,7 +141,7 @@ sdks:
 	c.Check(err, check.IsNil)
 
 	// Execute
-	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, statecontext.RefreshTransactional, "1")
+	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, operation.RefreshTransactional, "1")
 	c.Check(err, check.IsNil)
 
 	// Validate
@@ -169,7 +169,7 @@ base: ubuntu@20.04
 	c.Check(err, check.IsNil)
 
 	// Execute
-	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, statecontext.RefreshTransactional, "1")
+	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, operation.RefreshTransactional, "1")
 	c.Check(err, check.IsNil)
 
 	// Validate
@@ -200,7 +200,7 @@ sdks:
 	c.Check(err, check.IsNil)
 
 	// Execute
-	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, statecontext.RefreshTransactional, "1")
+	ts, err := s.manager.RefreshMany(s.ctx, []string{"test"}, s.project.ProjectId, operation.RefreshTransactional, "1")
 	c.Check(err, check.IsNil)
 
 	// Validate

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -51,74 +52,7 @@ func (s *ManagerSuite) TestAddHandlers(c *check.C) {
 	})
 }
 
-// func (s *ManagerSuite) setupWorkshop(running bool) *workshopbackend.Workshop {
-// 	wrkspc := workshopbackend.NewWorkshop(s.backend, s.project, "ws")
-// 	wrkspc.SetRunning(running)
-// 	return wrkspc
-// }
-
-// func (s *ManagerSuite) TestWorkshopStateChanges(c *check.C) {
-// 	type stateSetup struct {
-// 		status            state.Status
-// 		running           bool
-// 		refreshInProgress bool
-// 		hasErrors         bool
-// 		expectedState     healthstate.HealthStatus
-// 		expectedErrors    []workshopbackend.WorkshopErrorType
-// 	}
-// 	cases := []stateSetup{
-// 		// running, no operation in progress, no errors
-// 		{state.DefaultStatus, true, false, false, healthstate.ReadyStatus, nil},
-// 		// running, no operation in prorgess, has errors
-// 		{state.DefaultStatus, true, false, true, healthstate.ReadyStatus, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
-// 		// not running, no operation in prorgess, no errors
-// 		{state.DefaultStatus, false, false, false, workshopbackend.WorkshopStopped, nil},
-// 		// not running, no operation in prorgess, has errors
-// 		{state.DefaultStatus, false, false, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
-// 		// running, has operation in prorgess, waits on error
-// 		{state.WaitStatus, true, true, false, workshopbackend.WorkshopPending, []workshopbackend.WorkshopErrorType{workshopbackend.WaitOnError}},
-// 		// running, has operation in prorgess, no errors
-// 		{state.DoingStatus, true, true, false, workshopbackend.WorkshopPending, nil},
-// 		// running, has operation in prorgess, has errors
-// 		{state.DoingStatus, true, true, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
-// 		// not running, has operation in prorgess, no errors
-// 		{state.DoingStatus, false, true, false, workshopbackend.WorkshopPending, nil},
-// 		// not running, has operation in prorgess, has errors
-// 		{state.DoingStatus, false, true, true, workshopbackend.WorkshopError, []workshopbackend.WorkshopErrorType{workshopbackend.MissingFile}},
-// 	}
-
-// 	s.state.Lock()
-// 	defer s.state.Unlock()
-
-// 	for i, setup := range cases {
-// 		// setup
-// 		wrkspc := s.setupWorkshop(setup.running)
-// 		if setup.hasErrors {
-// 			// add any error to emulate error state
-// 			wrkspc.AddError(workshopbackend.MissingFile)
-// 		}
-// 		if setup.refreshInProgress {
-// 			chg := s.state.NewChange("test", "...")
-// 			chg.SetStatus(setup.status)
-// 			err := statecontext.StartOperation(s.state, "ws", "42424242", statecontext.Operation{Operation: statecontext.OperationRefresh, ChangeId: chg.ID(), WaitOnError: true})
-// 			c.Assert(err, check.IsNil)
-// 		}
-
-// 		// validate
-// 		st := workshopstate.WorkshopStatus(s.manager, wrkspc)
-// 		c.Assert(st, check.Equals, setup.expectedState, check.Commentf("case num: %v", i))
-// 		c.Assert(wrkspc.Errors(), testutil.DeepUnsortedMatches, setup.expectedErrors, check.Commentf("case num: %v", i))
-// 		if setup.refreshInProgress {
-// 			err := statecontext.StopOperation(s.state, "ws", "42424242", statecontext.OperationRefresh)
-// 			c.Assert(err, check.IsNil)
-// 		}
-// 	}
-// }
-
-func (s *ManagerSuite) TestRefreshSdkWasAdded(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
+func (s *ManagerSuite) launchWorkshopWithTestSdk(c *check.C) *workshopbackend.Workshop {
 	// Setup
 	os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
 base: ubuntu@20.04
@@ -128,9 +62,146 @@ sdks:
 `), 0644)
 	err := s.backend.LaunchWorkshop(s.ctx, "test", "ubuntu@20.04")
 	c.Assert(err, check.IsNil)
+	ws, err := s.backend.Workshop(s.ctx, "test")
+	c.Assert(err, check.IsNil)
+	return ws
+}
+
+func (s *ManagerSuite) TestWorkshopHealthReady(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	workshop := s.launchWorkshopWithTestSdk(c)
+	health := s.manager.WorkshopHealth(workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.ReadyStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.HasLen, 0)
+}
+
+func (s *ManagerSuite) TestWorkshopHealthStopped(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	workshop := s.launchWorkshopWithTestSdk(c)
+	c.Assert(s.backend.StopWorkshop(s.ctx, "test", true), check.IsNil)
+	health := s.manager.WorkshopHealth(workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.StoppedStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.HasLen, 0)
+}
+
+func (s *ManagerSuite) TestWorkshopHealthMissingProject(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	workshop := s.launchWorkshopWithTestSdk(c)
+	c.Assert(os.RemoveAll(s.project.Path), check.IsNil)
+	health := s.manager.WorkshopHealth(workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.ErrorStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.Equals, "missing-project")
+}
+
+func (s *ManagerSuite) TestWorkshopHealthMissingFile(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	workshop := s.launchWorkshopWithTestSdk(c)
+	c.Assert(os.RemoveAll(filepath.Join(s.project.Path, ".workshop.test.yaml")), check.IsNil)
+	health := s.manager.WorkshopHealth(workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.ErrorStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.Equals, "missing-file")
+}
+
+func (s *ManagerSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("launch", "test")
+
+	workshop := s.launchWorkshopWithTestSdk(c)
+	err := operation.StartOperation(s.state, "test", s.project.ProjectId, operation.Operation{
+		ChangeId:  chg.ID(),
+		Operation: "launch",
+	})
+	c.Assert(err, check.IsNil)
+	health := s.manager.WorkshopHealth(workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.HasLen, 0)
+}
+
+func (s *ManagerSuite) TestWorkshopHealthOperationInProgressWithNotes(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("refresh", "test")
+	chg.SetStatus(state.WaitStatus)
+
+	workshop := s.launchWorkshopWithTestSdk(c)
+	err := operation.StartOperation(s.state, "test", s.project.ProjectId, operation.Operation{
+		ChangeId:  chg.ID(),
+		Operation: "refresh",
+	})
+	c.Assert(err, check.IsNil)
+	health := s.manager.WorkshopHealth(workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.Equals, "wait-on-error")
+}
+
+func (s *ManagerSuite) TestWorkshopHealthSdkHealth(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("launch", "test")
+	task := s.state.NewTask("run-hook", "test task")
+	healthCheck := healthstate.HealthCheck{
+		Sdk:         "test",
+		CheckResult: healthstate.CheckWaiting,
+		Message:     "still waiting",
+		Code:        "how-much-longer",
+	}
+	task.Set("health", healthCheck)
+	chg.AddTask(task)
+
+	workshop := s.launchWorkshopWithTestSdk(c)
+	err := operation.StartOperation(s.state, "test", s.project.ProjectId, operation.Operation{
+		ChangeId:  chg.ID(),
+		Operation: "launch",
+	})
+	c.Assert(err, check.IsNil)
+	health := s.manager.WorkshopHealth(workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
+	c.Assert(health.SdkHealth, check.HasLen, 1)
+	c.Assert(health.SdkHealth["test"], check.DeepEquals, healthCheck)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.HasLen, 0)
+}
+
+func (s *ManagerSuite) TestRefreshSdkWasAdded(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Setup
+	s.launchWorkshopWithTestSdk(c)
 
 	// a user added an SDK to the workshop file and called refresh
-	err = os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
+	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
 base: ubuntu@20.04
 sdks:
   test-sdk:
@@ -153,17 +224,10 @@ func (s *ManagerSuite) TestRefreshSdkWasRemoved(c *check.C) {
 	defer s.state.Unlock()
 
 	// Setup
-	os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
-base: ubuntu@20.04
-sdks:
-  test-sdk:
-    channel: latest/stable
-`), 0644)
-	err := s.backend.LaunchWorkshop(s.ctx, "test", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
+	s.launchWorkshopWithTestSdk(c)
 
 	// a user removed an SDK in the workshop file and called refresh
-	err = os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
+	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
 base: ubuntu@20.04
 `), 0644)
 	c.Check(err, check.IsNil)
@@ -181,17 +245,10 @@ func (s *ManagerSuite) TestRefreshSdkChannelWasUpdated(c *check.C) {
 	defer s.state.Unlock()
 
 	// Setup
-	os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
-base: ubuntu@20.04
-sdks:
-  test-sdk:
-    channel: latest/stable
-`), 0644)
-	err := s.backend.LaunchWorkshop(s.ctx, "test", "ubuntu@20.04")
-	c.Assert(err, check.IsNil)
+	s.launchWorkshopWithTestSdk(c)
 
 	// a user updated an SDK in the workshop file and called refresh
-	err = os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
+	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.test.yaml"), []byte(`name: test
 base: ubuntu@20.04
 sdks:
   test-sdk:

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
@@ -61,11 +62,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, err
 		}
 
-		tasks, err := launch(w.state, file, project)
-		if err != nil {
-			return nil, fmt.Errorf("cannot launch %q: %w", i, err)
-		}
-
+		tasks := launch(w.state, file, project)
 		for _, tsk := range tasks.Tasks() {
 			if tsk.Kind() == "create-workshop" {
 				tsk.Set("start-operation", true)
@@ -90,32 +87,26 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	return taskset, nil
 }
 
-func launch(st *state.State, file *workshopbackend.WorkshopFile, project *workshopbackend.Project) (*state.TaskSet, error) {
+func retrieveSdks(st *state.State, file *workshopbackend.WorkshopFile) *state.TaskSet {
 	retrieve := state.NewTaskSet([]*state.Task{}...)
-	install := state.NewTaskSet([]*state.Task{}...)
-	setupHook := state.NewTaskSet([]*state.Task{}...)
-	autoConnectSet := state.NewTaskSet([]*state.Task{}...)
-
-	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", file.Name))
-	create.Set("base", file.Base)
-
-	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
-	mountProject.WaitFor(create)
-
-	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", file.Name))
-	start.WaitFor(mountProject)
-
-	prevInstall := (*state.TaskSet)(nil)
-	prevSetup := (*state.Task)(nil)
-	prevAuto := (*state.Task)(nil)
 	for _, sdk := range file.Sdks {
 		r := sdkstate.Retrieve(st, &sdk)
 		retrieve.AddTask(r)
+	}
+	return retrieve
+}
 
+func installSdks(st *state.State, file *workshopbackend.WorkshopFile, retrieveSet *state.TaskSet) *state.TaskSet {
+	var prevInstall *state.TaskSet
+	var prevSetup, prevAuto *state.Task
+	install := state.NewTaskSet([]*state.Task{}...)
+	setupHook := state.NewTaskSet([]*state.Task{}...)
+	autoConnectSet := state.NewTaskSet([]*state.Task{}...)
+	for idx, sdk := range file.Sdks {
 		// The install task sets must not run concurrently as exec ops are not
 		// allowed by LXD to be run concurrently and in general case we cannot
 		// guarantee safety of concurrent installations
-		installTaskSet := sdkstate.Install(st, sdk.Name, r.ID())
+		installTaskSet := sdkstate.Install(st, sdk.Name, retrieveSet.Tasks()[idx].ID())
 		if prevInstall != nil {
 			installTaskSet.WaitAll(prevInstall)
 		}
@@ -138,23 +129,67 @@ func launch(st *state.State, file *workshopbackend.WorkshopFile, project *worksh
 		}
 		prevAuto = autoconnect
 	}
-	create.WaitAll(retrieve)
-	install.WaitFor(start)
 	setupHook.WaitAll(install)
 	autoConnectSet.WaitAll(setupHook)
 
-	set := state.NewTaskSet(create, mountProject, start)
-	set.AddAll(retrieve)
-	set.AddAll(install)
-	set.AddAll(setupHook)
-	set.AddAll(autoConnectSet)
+	all := state.NewTaskSet(install.Tasks()...)
+	all.AddAll(setupHook)
+	all.AddAll(autoConnectSet)
+	return all
+}
 
-	for _, i := range set.Tasks() {
+func checkHealth(st *state.State, file *workshopbackend.WorkshopFile) *state.TaskSet {
+	var prevCheck *state.Task
+	checkHealth := state.NewTaskSet([]*state.Task{}...)
+	for _, sdk := range file.Sdks {
+		checkHealthTask := hookstate.HookWithTimeout(st, file.Name, sdk.Name, hookstate.CheckHealth, 5*time.Second)
+		if prevCheck != nil {
+			checkHealthTask.WaitFor(prevCheck)
+		}
+		prevCheck = checkHealthTask
+		checkHealth.AddTask(checkHealthTask)
+	}
+	return checkHealth
+}
+
+func constructWorkshop(st *state.State, file *workshopbackend.WorkshopFile, project *workshopbackend.Project) *state.TaskSet {
+	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", file.Name))
+	create.Set("base", file.Base)
+
+	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
+	mountProject.WaitFor(create)
+
+	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", file.Name))
+	start.WaitFor(mountProject)
+	return state.NewTaskSet(create, mountProject, start)
+}
+
+func launch(st *state.State, file *workshopbackend.WorkshopFile, project *workshopbackend.Project) *state.TaskSet {
+	// check and download all the required SDKs
+	retrieve := retrieveSdks(st, file)
+
+	// create a basic workshop
+	create := constructWorkshop(st, file, project)
+	create.WaitAll(retrieve)
+
+	// install the downloaded sdks
+	install := installSdks(st, file, retrieve)
+	install.WaitAll(create)
+
+	// run a quick check health script (for every SDK, if present)
+	checkHealth := checkHealth(st, file)
+	checkHealth.WaitAll(install)
+
+	all := state.NewTaskSet(retrieve.Tasks()...)
+	all.AddAll(create)
+	all.AddAll(install)
+	all.AddAll(checkHealth)
+	for _, i := range all.Tasks() {
 		i.Set("workshop", file.Name)
 		i.Set("project", project)
 	}
 
-	return set, nil
+	return all
 }
 
 func (w *WorkshopManager) RefreshMany(ctx context.Context,
@@ -272,7 +307,11 @@ func refresh(st *state.State, file *workshopbackend.WorkshopFile, content []sdk.
 	// 5. Run restore state
 	// 6. Delete the old workshop
 
+	retrieve := retrieveSdks(st, file)
+
 	createStateStorage := st.NewTask("create-state-storage", "Create SDK state storage")
+	createStateStorage.WaitAll(retrieve)
+
 	saveStateHooks := saveStateHooks(st, file.Name, content, file.Sdks)
 	saveStateHooks.WaitFor(createStateStorage)
 
@@ -280,43 +319,48 @@ func refresh(st *state.State, file *workshopbackend.WorkshopFile, content []sdk.
 	disconnect := disconnectSdks(content, st)
 	disconnect.WaitAll(saveStateHooks)
 
+	// put the workshop (old) away and disconnect its interfaces
 	putToStash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
 	putToStash.WaitAll(disconnect)
 	putToStash.WaitAll(saveStateHooks)
 	putToStash.WaitFor(createStateStorage)
 
-	launch, err := launch(st, file, p)
-	if err != nil {
-		return nil, err
-	}
+	// create a fresh workshop (new)
+	create := constructWorkshop(st, file, p)
+	create.WaitFor(putToStash)
 
+	// install SDKs and run restore-state scripts
+	install := installSdks(st, file, retrieve)
+	install.WaitAll(create)
 	restoreStateHooks := restoreStateHooks(st, file.Name, content, file.Sdks)
+	restoreStateHooks.WaitAll(install)
 
+	// remove the state storage after running restore-state scripts
 	removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
-	removeFromStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", file.Name))
 
-	// save-state -> stop-workshop -> launch -> restore state
+	// remove the workshop from stash after the state storage was detached
+	removeFromStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", file.Name))
 	removeFromStash.WaitFor(removeStateStorage)
-	if len(restoreStateHooks.Tasks()) > 0 {
-		removeStateStorage.WaitAll(restoreStateHooks)
-		restoreStateHooks.WaitAll(launch)
-	} else {
-		lastLaunchTask := launch.Tasks()[len(launch.Tasks())-1]
-		removeStateStorage.WaitFor(lastLaunchTask)
+
+	if len(restoreStateHooks.Tasks()) == 0 {
 		// we are dealing with a workshop that does not have
 		// SDKs, i.e. it will not be running any hooks. Thus,
 		// the point of no return is the last launch task (i.e.
 		// before the moment when we delete the copy of the workshop
 		// after the refresh operation).
-		launch.MarkEdge(lastLaunchTask, EdgeLastBeforeRefreshIrreversible)
+		lastLaunchTask := create.Tasks()[len(create.Tasks())-1]
+		removeStateStorage.WaitFor(lastLaunchTask)
+		create.MarkEdge(lastLaunchTask, EdgeLastBeforeRefreshIrreversible)
+	} else {
+		removeStateStorage.WaitAll(restoreStateHooks)
 	}
 
-	launch.WaitFor(putToStash)
-
 	refresh := state.NewTaskSet([]*state.Task{}...)
+	refresh.AddAll(retrieve)
 	refresh.AddTask(createStateStorage)
 	refresh.AddAll(saveStateHooks)
-	refresh.AddAllWithEdges(launch)
+	refresh.AddAllWithEdges(create)
+	refresh.AddAll(install)
 	refresh.AddAllWithEdges(restoreStateHooks)
 	refresh.AddTask(putToStash)
 	refresh.AddAll(disconnect)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/workshop/internal/overlord/operation"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/overlord/statecontext"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshopbackend"
@@ -84,7 +84,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		taskset = append(taskset, tasks)
 	}
 
-	if err = w.startOperation(names, projectId, statecontext.Operation{ChangeId: opChangeId, Operation: statecontext.OperationLaunch}); err != nil {
+	if err = w.startOperation(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationLaunch}); err != nil {
 		return nil, err
 	}
 	return taskset, nil
@@ -158,7 +158,7 @@ func launch(st *state.State, file *workshopbackend.WorkshopFile, project *worksh
 }
 
 func (w *WorkshopManager) RefreshMany(ctx context.Context,
-	names []string, projectId string, refreshMode statecontext.RefreshMode, opChangeId string) ([]*state.TaskSet, error) {
+	names []string, projectId string, refreshMode operation.RefreshMode, opChangeId string) ([]*state.TaskSet, error) {
 	project, err := w.loadProject(ctx, projectId)
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		ctx,
 		names,
 		projectId,
-		[]healthstate.HealthStatus{healthstate.ReadyStatus})
+		[]healthstate.Status{healthstate.ReadyStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot refresh: %w", err)
 	}
@@ -198,10 +198,10 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		return nil, err
 	}
 
-	if err = w.startOperation(names, projectId, statecontext.Operation{
+	if err = w.startOperation(names, projectId, operation.Operation{
 		ChangeId:    opChangeId,
-		Operation:   statecontext.OperationRefresh,
-		WaitOnError: refreshMode == statecontext.RefreshWaitOnError,
+		Operation:   operation.OperationRefresh,
+		WaitOnError: refreshMode == operation.RefreshWaitOnError,
 	}); err != nil {
 		return nil, err
 	}
@@ -403,7 +403,7 @@ func (w *WorkshopManager) StartMany(ctx context.Context, names []string, project
 		ctx,
 		names,
 		projectId,
-		[]healthstate.HealthStatus{healthstate.StoppedStatus})
+		[]healthstate.Status{healthstate.StoppedStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot start: %w", err)
 	}
@@ -417,7 +417,7 @@ func (w *WorkshopManager) StartMany(ctx context.Context, names []string, project
 		return nil, err
 	}
 
-	if err = w.startOperation(names, projectId, statecontext.Operation{ChangeId: opChangeId, Operation: statecontext.OperationStart}); err != nil {
+	if err = w.startOperation(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationStart}); err != nil {
 		return nil, err
 	}
 	return taskset, nil
@@ -445,7 +445,7 @@ func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectI
 		ctx,
 		names,
 		projectId,
-		[]healthstate.HealthStatus{healthstate.ReadyStatus, healthstate.StoppedStatus})
+		[]healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot stop: %w", err)
 	}
@@ -459,7 +459,7 @@ func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectI
 		return nil, err
 	}
 
-	if err = w.startOperation(names, projectId, statecontext.Operation{ChangeId: opChangeId, Operation: statecontext.OperationStop}); err != nil {
+	if err = w.startOperation(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationStop}); err != nil {
 		return nil, err
 	}
 	return taskset, nil
@@ -493,7 +493,7 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 		ctx,
 		[]string{name},
 		projectId,
-		[]healthstate.HealthStatus{healthstate.ReadyStatus, healthstate.PendingStatus})
+		[]healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot exec: %w", err)
 	}
@@ -532,7 +532,7 @@ func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projec
 		ctx,
 		names,
 		projectId,
-		[]healthstate.HealthStatus{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus})
+		[]healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot remove: %w", err)
 	}
@@ -558,23 +558,23 @@ func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projec
 		return nil, err
 	}
 
-	if err := w.startOperation(names, projectId, statecontext.Operation{ChangeId: opChangeId, Operation: statecontext.OperationRemove}); err != nil {
+	if err := w.startOperation(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationRemove}); err != nil {
 		return nil, err
 	}
 
 	return taskset, nil
 }
 
-func (w *WorkshopManager) startOperation(names []string, projectId string, op statecontext.Operation) error {
+func (w *WorkshopManager) startOperation(names []string, projectId string, op operation.Operation) error {
 	rev := revert.New()
 	for _, name := range names {
-		err := statecontext.StartOperation(w.state, name, projectId, op)
+		err := operation.StartOperation(w.state, name, projectId, op)
 		if err != nil {
 			return err
 		}
 		name := name // go loop var capturing issue
 		rev.Add(func() {
-			statecontext.StopOperation(w.state, name, projectId, op.Operation)
+			operation.StopOperation(w.state, name, projectId, op.Operation)
 		})
 	}
 	rev.Success()

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -164,19 +164,13 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		return nil, err
 	}
 
-	invalid, status, err := w.CheckStatus(
+	err = w.CheckStatus(
 		ctx,
 		names,
 		projectId,
-		func(status workshopbackend.WorkshopStatus) bool {
-			return status == workshopbackend.WorkshopReady
-		})
+		[]healthstate.HealthStatus{healthstate.ReadyStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot refresh: %w", err)
-	}
-
-	if len(invalid) > 0 {
-		return nil, fmt.Errorf("cannot refresh: %q is in %s; must be ready", invalid, strings.ToLower(status.String()))
 	}
 
 	_, workshops, err := w.Workshops(ctx, projectId)
@@ -191,7 +185,11 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		if idx == -1 {
 			return nil, fmt.Errorf("%q workshop not found", i)
 		}
-		files = append(files, workshops[idx].File())
+		file, err := project.WorkshopFile(workshops[idx].Name)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, file)
 		content = append(content, workshops[idx].Content())
 	}
 
@@ -401,19 +399,13 @@ func createStateHooks(st *state.State, workshop string, content []sdk.Setup, new
 
 func (w *WorkshopManager) StartMany(ctx context.Context, names []string, projectId string, opChangeId string) (*state.TaskSet, error) {
 	// check if all the workshops are stopped
-	invalid, status, err := w.CheckStatus(
+	err := w.CheckStatus(
 		ctx,
 		names,
 		projectId,
-		func(status workshopbackend.WorkshopStatus) bool {
-			return status == workshopbackend.WorkshopStopped
-		})
+		[]healthstate.HealthStatus{healthstate.StoppedStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot start: %w", err)
-	}
-
-	if len(invalid) > 0 {
-		return nil, fmt.Errorf("cannot start: %q is in %s; must be stopped", invalid, strings.ToLower(status.String()))
 	}
 
 	project, err := w.loadProject(ctx, projectId)
@@ -449,19 +441,13 @@ func startMany(st *state.State, names []string, project *workshopbackend.Project
 }
 
 func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectId string, opChangeId string) (*state.TaskSet, error) {
-	invalid, status, err := w.CheckStatus(
+	err := w.CheckStatus(
 		ctx,
 		names,
 		projectId,
-		func(status workshopbackend.WorkshopStatus) bool {
-			return status == workshopbackend.WorkshopStopped || status == workshopbackend.WorkshopReady
-		})
+		[]healthstate.HealthStatus{healthstate.ReadyStatus, healthstate.StoppedStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot stop: %w", err)
-	}
-
-	if len(invalid) > 0 {
-		return nil, fmt.Errorf("cannot stop: %q is in %s; must be stopped or ready", invalid, strings.ToLower(status.String()))
 	}
 
 	project, err := w.loadProject(ctx, projectId)
@@ -503,19 +489,13 @@ type ExecMeta struct {
 }
 
 func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args *workshopbackend.ExecArgs) (*state.Task, error) {
-	invalid, status, err := w.CheckStatus(
+	err := w.CheckStatus(
 		ctx,
 		[]string{name},
 		projectId,
-		func(status workshopbackend.WorkshopStatus) bool {
-			return status == workshopbackend.WorkshopReady || status == workshopbackend.WorkshopPending
-		})
+		[]healthstate.HealthStatus{healthstate.ReadyStatus, healthstate.PendingStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot exec: %w", err)
-	}
-
-	if len(invalid) > 0 {
-		return nil, fmt.Errorf("cannot exec: %q is in %s; must be ready or pending", invalid, strings.ToLower(status.String()))
 	}
 
 	project, err := w.loadProject(ctx, projectId)
@@ -548,19 +528,13 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 }
 
 func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projectId string, opChangeId string) (*state.TaskSet, error) {
-	invalid, status, err := w.CheckStatus(
+	err := w.CheckStatus(
 		ctx,
 		names,
 		projectId,
-		func(status workshopbackend.WorkshopStatus) bool {
-			return status != workshopbackend.WorkshopPending && status != workshopbackend.WorkshopOff
-		})
+		[]healthstate.HealthStatus{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus})
 	if err != nil {
 		return nil, fmt.Errorf("cannot remove: %w", err)
-	}
-
-	if len(invalid) > 0 {
-		return nil, fmt.Errorf("cannot remove: %q is in %s; must be ready, stopped or error", invalid, strings.ToLower(status.String()))
 	}
 
 	project, err := w.loadProject(ctx, projectId)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -123,7 +123,7 @@ func launch(st *state.State, file *workshopbackend.WorkshopFile, project *worksh
 		install.AddAll(installTaskSet)
 
 		// Make sure that the hook tasks are not concurrent
-		setupHookTask := hookstate.SetupHook(st, file.Name, sdk.Name, hookstate.SetupBase)
+		setupHookTask := hookstate.Hook(st, file.Name, sdk.Name, hookstate.SetupBase)
 		if prevSetup != nil {
 			setupHookTask.WaitFor(prevSetup)
 		}
@@ -389,7 +389,7 @@ func createStateHooks(st *state.State, workshop string, content []sdk.Setup, new
 			continue
 		}
 
-		stateHook := hookstate.SetupHook(st, workshop, newsdk.Name, hooktype)
+		stateHook := hookstate.Hook(st, workshop, newsdk.Name, hooktype)
 		stateHooks.AddTask(stateHook)
 		if prevRestore != nil {
 			stateHook.WaitFor(prevRestore)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -163,36 +163,28 @@ func launch(st *state.State, file *workshopbackend.WorkshopFile, project *worksh
 	create := constructWorkshop(st, file, project)
 	create.WaitAll(retrieve)
 
-	// install the downloaded sdks
-	install := installSdks(st, file, retrieve)
-	install.WaitAll(create)
+	// launch the downloaded sdks
+	launch := installSdks(st, file, retrieve)
+	launch.WaitAll(create)
 
 	// run a quick check health script (for every SDK, if present)
 	checkHealth := checkHealthHooks(st, file)
-	checkHealth.WaitAll(install)
+	checkHealth.WaitAll(launch)
+	launch.AddAll(checkHealth)
 
 	all := state.NewTaskSet(retrieve.Tasks()...)
 	all.AddAll(create)
-	all.AddAll(install)
-	all.AddAll(checkHealth)
+	all.AddAll(launch)
 
-	checkTasksLen := len(checkHealth.Tasks())
+	tasksLen := len(all.Tasks())
+	all.Tasks()[0].Set("start-operation", true)
+	all.Tasks()[tasksLen-1].Set("stop-operation", true)
+
 	for _, task := range all.Tasks() {
 		task.Set("workshop", file.Name)
 		task.Set("project", project)
-
-		if task.Kind() == "create-workshop" {
-			task.Set("start-operation", true)
-		}
-		if checkTasksLen == 0 && task.Kind() == "start-workshop" {
-			task.Set("stop-operation", true)
-		}
 	}
 
-	if checkTasksLen > 0 {
-		lastCheck := checkHealth.Tasks()[checkTasksLen-1]
-		lastCheck.Set("stop-operation", true)
-	}
 	return all
 }
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -18,10 +18,16 @@ import (
 )
 
 const (
-	LaneCleanupRefresh                = 1
-	EdgeLastBeforeRefreshIrreversible = state.TaskSetEdge("last-before-irreversible")
-	EdgeCleanupRefresh                = state.TaskSetEdge("refresh-cleanup")
+	// mark the last task in a taskset after which refresh becomes irreversible (i.e. the following tasks
+	// will not be possible to undo, e.g. removing an old workshop copy)
+	EdgeLastTaskBeforeRefreshIrreversible = state.TaskSetEdge("last-before-irreversible")
+
+	// mark the tasks that denote irreversible clean up logic for refresh (e.g.
+	// removing state storage and the old workshop copy)
+	EdgeRefreshCleanup = state.TaskSetEdge("refresh-cleanup")
 )
+
+var checkHealthTimeout = 5 * time.Second
 
 func (w *WorkshopManager) loadProject(ctx context.Context, id string) (*workshopbackend.Project, error) {
 	username, ok := ctx.Value(workshopbackend.ContextUser).(string)
@@ -54,8 +60,8 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, fmt.Errorf("cannot read %q file: %w", i, err)
 		}
 
-		wrkspace, err := w.Workshop(ctx, i, projectId)
-		if wrkspace != nil {
+		workshop, err := w.Workshop(ctx, i, projectId)
+		if workshop != nil {
 			return nil, fmt.Errorf("cannot launch: %q already exists", i)
 		}
 		if !errors.Is(err, workshopbackend.ErrWorkshopNotFound) {
@@ -63,25 +69,10 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		}
 
 		tasks := launch(w.state, file, project)
-		for _, tsk := range tasks.Tasks() {
-			if tsk.Kind() == "create-workshop" {
-				tsk.Set("start-operation", true)
-			}
-
-			if len(file.Sdks) == 0 {
-				if tsk.Kind() == "start-workshop" {
-					tsk.Set("stop-operation", true)
-				}
-			} else {
-				if tsk.Kind() == "auto-connect" && len(tsk.HaltTasks()) == 0 {
-					tsk.Set("stop-operation", true)
-				}
-			}
-		}
 		taskset = append(taskset, tasks)
 	}
 
-	if err = w.startOperation(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationLaunch}); err != nil {
+	if err = w.startOperationMany(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationLaunch}); err != nil {
 		return nil, err
 	}
 	return taskset, nil
@@ -138,11 +129,11 @@ func installSdks(st *state.State, file *workshopbackend.WorkshopFile, retrieveSe
 	return all
 }
 
-func checkHealth(st *state.State, file *workshopbackend.WorkshopFile) *state.TaskSet {
+func checkHealthHooks(st *state.State, file *workshopbackend.WorkshopFile) *state.TaskSet {
 	var prevCheck *state.Task
 	checkHealth := state.NewTaskSet([]*state.Task{}...)
 	for _, sdk := range file.Sdks {
-		checkHealthTask := hookstate.HookWithTimeout(st, file.Name, sdk.Name, hookstate.CheckHealth, 5*time.Second)
+		checkHealthTask := hookstate.HookWithTimeout(st, file.Name, sdk.Name, hookstate.CheckHealth, checkHealthTimeout)
 		if prevCheck != nil {
 			checkHealthTask.WaitFor(prevCheck)
 		}
@@ -177,18 +168,31 @@ func launch(st *state.State, file *workshopbackend.WorkshopFile, project *worksh
 	install.WaitAll(create)
 
 	// run a quick check health script (for every SDK, if present)
-	checkHealth := checkHealth(st, file)
+	checkHealth := checkHealthHooks(st, file)
 	checkHealth.WaitAll(install)
 
 	all := state.NewTaskSet(retrieve.Tasks()...)
 	all.AddAll(create)
 	all.AddAll(install)
 	all.AddAll(checkHealth)
-	for _, i := range all.Tasks() {
-		i.Set("workshop", file.Name)
-		i.Set("project", project)
+
+	checkTasksLen := len(checkHealth.Tasks())
+	for _, task := range all.Tasks() {
+		task.Set("workshop", file.Name)
+		task.Set("project", project)
+
+		if task.Kind() == "create-workshop" {
+			task.Set("start-operation", true)
+		}
+		if checkTasksLen == 0 && task.Kind() == "start-workshop" {
+			task.Set("stop-operation", true)
+		}
 	}
 
+	if checkTasksLen > 0 {
+		lastCheck := checkHealth.Tasks()[checkTasksLen-1]
+		lastCheck.Set("stop-operation", true)
+	}
 	return all
 }
 
@@ -205,7 +209,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		projectId,
 		[]healthstate.Status{healthstate.ReadyStatus})
 	if err != nil {
-		return nil, fmt.Errorf("cannot refresh: %w", err)
+		return nil, fmt.Errorf("cannot refresh: %v", err)
 	}
 
 	_, workshops, err := w.Workshops(ctx, projectId)
@@ -215,10 +219,10 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 
 	files := make([]*workshopbackend.WorkshopFile, 0)
 	content := make([][]sdk.Setup, 0)
-	for _, i := range names {
-		idx := slices.IndexFunc(workshops, func(w *workshopbackend.Workshop) bool { return w.Name == i })
+	for _, workshop := range names {
+		idx := slices.IndexFunc(workshops, func(w *workshopbackend.Workshop) bool { return w.Name == workshop })
 		if idx == -1 {
-			return nil, fmt.Errorf("%q workshop not found", i)
+			return nil, fmt.Errorf("cannot refresh: workshop %q not found", workshop)
 		}
 		file, err := project.WorkshopFile(workshops[idx].Name)
 		if err != nil {
@@ -233,7 +237,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		return nil, err
 	}
 
-	if err = w.startOperation(names, projectId, operation.Operation{
+	if err = w.startOperationMany(names, projectId, operation.Operation{
 		ChangeId:    opChangeId,
 		Operation:   operation.OperationRefresh,
 		WaitOnError: refreshMode == operation.RefreshWaitOnError,
@@ -257,7 +261,7 @@ func refreshMany(st *state.State, w []*workshopbackend.WorkshopFile, content [][
 	}
 
 	for _, ts := range taskset {
-		cleanup, err := ts.Edge(EdgeCleanupRefresh)
+		cleanup, err := ts.Edge(EdgeRefreshCleanup)
 		if err != nil {
 			return nil, err
 		}
@@ -272,26 +276,11 @@ func refreshMany(st *state.State, w []*workshopbackend.WorkshopFile, content [][
 		// other changes before execution.
 		for _, otherts := range taskset {
 			if ts != otherts {
-				last, err := otherts.Edge(EdgeLastBeforeRefreshIrreversible)
+				last, err := otherts.Edge(EdgeLastTaskBeforeRefreshIrreversible)
 				if err != nil {
 					return nil, err
 				}
 				cleanup.WaitFor(last)
-				// if the change was aborted during the cleanup stage execution,
-				// there is a chance that some of the workshop copies that had
-				// been created during the refresh were already deleted. If we
-				// start to Undo those workshops' refresh progress we will
-				// endup deleting the workshops that finished their refresh.
-				// Given that they have no copy already, the undo logic
-				// (stash-workshop) will delete the existing workshop
-				// and fail to restore from the copy. We don't want that. Hence,
-				// all the cleanup tasks are extracted into a separate lane. If
-				// any problem happens, the workshops which had finished their
-				// refresh will not suffer.
-				cleanup.JoinLane(LaneCleanupRefresh)
-				for _, t := range cleanup.HaltTasks() {
-					t.JoinLane(LaneCleanupRefresh)
-				}
 			}
 		}
 	}
@@ -306,18 +295,20 @@ func refresh(st *state.State, file *workshopbackend.WorkshopFile, content []sdk.
 	// 4. Launch the new workshop
 	// 5. Run restore state
 	// 6. Delete the old workshop
-
 	retrieve := retrieveSdks(st, file)
 
 	createStateStorage := st.NewTask("create-state-storage", "Create SDK state storage")
 	createStateStorage.WaitAll(retrieve)
 
+	// the saveStateHooks can be empty if the old SDKs were all removed in
+	// the new version of the workshop
 	saveStateHooks := saveStateHooks(st, file.Name, content, file.Sdks)
 	saveStateHooks.WaitFor(createStateStorage)
 
 	// disconnect and remove SDKs plugs and slots
 	disconnect := disconnectSdks(content, st)
 	disconnect.WaitAll(saveStateHooks)
+	disconnect.WaitFor(createStateStorage)
 
 	// put the workshop (old) away and disconnect its interfaces
 	putToStash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
@@ -325,58 +316,72 @@ func refresh(st *state.State, file *workshopbackend.WorkshopFile, content []sdk.
 	putToStash.WaitAll(saveStateHooks)
 	putToStash.WaitFor(createStateStorage)
 
-	// create a fresh workshop (new)
-	create := constructWorkshop(st, file, p)
-	create.WaitFor(putToStash)
+	// launch a workshop (new)
+	launch := constructWorkshop(st, file, p)
+	launch.WaitFor(putToStash)
 
-	// install SDKs and run restore-state scripts
+	// install SDKs and run restore-state scripts. The restoreStateHooks can be
+	// empty if the old SDKs were all removed in the new version of the workshop
 	install := installSdks(st, file, retrieve)
-	install.WaitAll(create)
-	restoreStateHooks := restoreStateHooks(st, file.Name, content, file.Sdks)
-	restoreStateHooks.WaitAll(install)
+	install.WaitAll(launch)
+	launch.AddAll(install)
+
+	// note: restore-state list may be empty if there are no SDKs or
+	// old SDKs are all gone
+	restoreState := restoreStateHooks(st, file.Name, content, file.Sdks)
+	restoreState.WaitAll(install)
+	launch.AddAll(restoreState)
+
+	checkHealth := checkHealthHooks(st, file)
+	checkHealth.WaitAll(install)
+	checkHealth.WaitAll(restoreState)
+	launch.AddAll(checkHealth)
 
 	// remove the state storage after running restore-state scripts
 	removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
+	createLen := len(launch.Tasks())
+	lastLaunchTask := launch.Tasks()[createLen-1]
+	removeStateStorage.WaitFor(lastLaunchTask)
+	launch.MarkEdge(lastLaunchTask, EdgeLastTaskBeforeRefreshIrreversible)
 
 	// remove the workshop from stash after the state storage was detached
 	removeFromStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", file.Name))
 	removeFromStash.WaitFor(removeStateStorage)
 
-	if len(restoreStateHooks.Tasks()) == 0 {
-		// we are dealing with a workshop that does not have
-		// SDKs, i.e. it will not be running any hooks. Thus,
-		// the point of no return is the last launch task (i.e.
-		// before the moment when we delete the copy of the workshop
-		// after the refresh operation).
-		lastLaunchTask := create.Tasks()[len(create.Tasks())-1]
-		removeStateStorage.WaitFor(lastLaunchTask)
-		create.MarkEdge(lastLaunchTask, EdgeLastBeforeRefreshIrreversible)
-	} else {
-		removeStateStorage.WaitAll(restoreStateHooks)
-	}
+	// if the change was aborted during the cleanup stage execution,
+	// there is a chance that some of the workshop copies that had
+	// been created during the refresh were already deleted. If we
+	// start to Undo those workshops' refresh progress we will
+	// endup deleting the workshops that finished their refresh.
+	// Given that they have no copy already, the undo logic
+	// (stash-workshop) will delete the existing workshop
+	// and fail to restore from the copy. We don't want that. Hence,
+	// all the cleanup tasks are extracted into a separate lane. If
+	// any problem happens, the workshops that had finished their
+	// refresh will not be affected.
+	cleanupLane := st.NewLane()
+	removeStateStorage.JoinLane(cleanupLane)
+	removeFromStash.JoinLane(cleanupLane)
 
 	refresh := state.NewTaskSet([]*state.Task{}...)
 	refresh.AddAll(retrieve)
 	refresh.AddTask(createStateStorage)
 	refresh.AddAll(saveStateHooks)
-	refresh.AddAllWithEdges(create)
-	refresh.AddAll(install)
-	refresh.AddAllWithEdges(restoreStateHooks)
-	refresh.AddTask(putToStash)
 	refresh.AddAll(disconnect)
+	refresh.AddTask(putToStash)
+	refresh.AddAllWithEdges(launch)
 	refresh.AddTask(removeStateStorage)
 	refresh.AddTask(removeFromStash)
 
+	refresh.MarkEdge(removeStateStorage, EdgeRefreshCleanup)
+
 	// mark the first task to start the operation so if cancelled or failed the
 	// operation will be removed from the list of the active ones
-	createStateStorage.Set("start-operation", true)
+	refresh.Tasks()[0].Set("start-operation", true)
 
 	// mark the last task to stop the operation
 	// and make the workshop available for other commands
 	removeFromStash.Set("stop-operation", true)
-
-	refresh.MarkEdge(removeStateStorage, EdgeCleanupRefresh)
-
 	for _, i := range refresh.Tasks() {
 		i.Set("workshop", file.Name)
 		i.Set("project", *p)
@@ -406,19 +411,7 @@ func saveStateHooks(st *state.State, workshop string, content []sdk.Setup, newCo
 }
 
 func restoreStateHooks(st *state.State, workshop string, content []sdk.Setup, newContent workshopbackend.SdkList) *state.TaskSet {
-	stateHooks := createStateHooks(st, workshop, content, newContent, hookstate.RestoreState)
-
-	// if the restore hooks are not present (i.e. workshop has no SDKs after
-	// the refresh), we should mark the last launch task as last before the
-	// irreversible change happens. This will be done in the refreshMany
-	// call.
-	if len(stateHooks.Tasks()) > 0 {
-		last := stateHooks.Tasks()[len(stateHooks.Tasks())-1]
-		// last restore state hook for the refresh call is the last task before the
-		// previous refresh copy removal, ie. before making something irreversible
-		stateHooks.MarkEdge(last, EdgeLastBeforeRefreshIrreversible)
-	}
-	return stateHooks
+	return createStateHooks(st, workshop, content, newContent, hookstate.RestoreState)
 }
 
 func createStateHooks(st *state.State, workshop string, content []sdk.Setup, newContent workshopbackend.SdkList, hooktype hookstate.WorkshopHookType) *state.TaskSet {
@@ -430,7 +423,6 @@ func createStateHooks(st *state.State, workshop string, content []sdk.Setup, new
 		if slices.IndexFunc(content, func(s sdk.Setup) bool { return s.Name == newsdk.Name }) == -1 {
 			continue
 		}
-
 		stateHook := hookstate.Hook(st, workshop, newsdk.Name, hooktype)
 		stateHooks.AddTask(stateHook)
 		if prevRestore != nil {
@@ -461,7 +453,7 @@ func (w *WorkshopManager) StartMany(ctx context.Context, names []string, project
 		return nil, err
 	}
 
-	if err = w.startOperation(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationStart}); err != nil {
+	if err = w.startOperationMany(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationStart}); err != nil {
 		return nil, err
 	}
 	return taskset, nil
@@ -503,7 +495,7 @@ func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectI
 		return nil, err
 	}
 
-	if err = w.startOperation(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationStop}); err != nil {
+	if err = w.startOperationMany(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationStop}); err != nil {
 		return nil, err
 	}
 	return taskset, nil
@@ -602,15 +594,16 @@ func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projec
 		return nil, err
 	}
 
-	if err := w.startOperation(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationRemove}); err != nil {
+	if err := w.startOperationMany(names, projectId, operation.Operation{ChangeId: opChangeId, Operation: operation.OperationRemove}); err != nil {
 		return nil, err
 	}
 
 	return taskset, nil
 }
 
-func (w *WorkshopManager) startOperation(names []string, projectId string, op operation.Operation) error {
+func (w *WorkshopManager) startOperationMany(names []string, projectId string, op operation.Operation) error {
 	rev := revert.New()
+	defer rev.Fail()
 	for _, name := range names {
 		err := operation.StartOperation(w.state, name, projectId, op)
 		if err != nil {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
@@ -18,7 +19,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-type S struct {
+type requestSuite struct {
 	state   *state.State
 	project *workshopbackend.Project
 	backend workshopbackend.WorkshopBackend
@@ -26,11 +27,11 @@ type S struct {
 	ctx     context.Context
 }
 
-var _ = check.Suite(&S{})
+var _ = check.Suite(&requestSuite{})
 
 func Test(t *testing.T) { check.TestingT(t) }
 
-func (s *S) SetUpTest(c *check.C) {
+func (s *requestSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.ctx = context.WithValue(context.Background(), workshopbackend.ContextUser, "testuser")
 
@@ -49,7 +50,7 @@ sdks:
   {{ end }} 
 `
 
-func (s *S) launchWorkshopWithSDKs(c *check.C, ws string, sdks []sdk.Setup) {
+func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []sdk.Setup) {
 	t, err := template.New("workshop").Parse(fmt.Sprintf(workshopTemplate, ws))
 	c.Assert(err, check.IsNil)
 
@@ -63,7 +64,7 @@ func (s *S) launchWorkshopWithSDKs(c *check.C, ws string, sdks []sdk.Setup) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *S) ensureTaskHasWorkshopAndProjectKeys(c *check.C, w string, ts []*state.Task) {
+func (s *requestSuite) ensureTaskHasWorkshopAndProjectKeys(c *check.C, w string, ts []*state.Task) {
 	for _, i := range ts {
 		var prj workshopbackend.Project
 		err := i.Get("project", &prj)
@@ -97,7 +98,30 @@ func verifyDisconnectDependencies(c *check.C, ts *state.TaskSet) {
 	}
 }
 
-func (s *S) TestLaunchWorkshopNoSdk(c *check.C) {
+func validateStateHooksTasksSetup(c *check.C, ts []*state.TaskSet, expectedSave, expectedRestore []string) {
+	obtainedSave := []string{}
+	obtainedRestore := []string{}
+	for _, t := range ts[0].Tasks() {
+		if t.Kind() == "run-hook" {
+			var setup hookstate.HookSetup
+			err := t.Get("hook-setup", &setup)
+			c.Assert(err, check.IsNil)
+			switch setup.HookType {
+			case hookstate.SaveState:
+				obtainedSave = append(obtainedSave, setup.Sdk)
+			case hookstate.RestoreState:
+				obtainedRestore = append(obtainedRestore, setup.Sdk)
+			}
+		}
+	}
+
+	// the save state shall be called only for the previously installed SDK
+	c.Assert(obtainedSave, testutil.DeepUnsortedMatches, expectedSave)
+	// the restore state shall be called for the new previously installed SDK
+	c.Assert(obtainedRestore, testutil.DeepUnsortedMatches, expectedRestore)
+}
+
+func (s *requestSuite) TestLaunchWorkshopNoSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	file := &workshopbackend.WorkshopFile{Name: "test", Base: "ubuntu@22.04"}
@@ -117,7 +141,7 @@ func (s *S) TestLaunchWorkshopNoSdk(c *check.C) {
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "test", ts.Tasks())
 }
 
-func (s *S) TestLaunchWorkshopWithSdks(c *check.C) {
+func (s *requestSuite) TestLaunchWorkshopWithSdks(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	sdk := workshopbackend.SdkRecord{Name: "sdk", Channel: "latest/stable"}
@@ -185,7 +209,7 @@ func (s *S) TestLaunchWorkshopWithSdks(c *check.C) {
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "test", tasks)
 }
 
-func (s *S) TestRefreshEmptyWorkshop(c *check.C) {
+func (s *requestSuite) TestRefreshEmptyWorkshop(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -215,7 +239,158 @@ func (s *S) TestRefreshEmptyWorkshop(c *check.C) {
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "ws", tasks)
 }
 
-func (s *S) TestRefreshManyEmptyWorkshopMany(c *check.C) {
+func (s *requestSuite) TestRefreshWorkshopWithSdks(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	file := &workshopbackend.WorkshopFile{
+		Name: "ws",
+		Base: "ubuntu@22.04",
+		Sdks: workshopbackend.SdkList{{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"}}}
+
+	ts, err := workshopstate.Refresh(s.state, file, []sdk.Setup{
+		{Name: "sdk-1", Channel: "latest/stable"},
+		{Name: "sdk-2", Channel: "latest/stable"},
+	}, s.project)
+	c.Assert(err, check.IsNil)
+
+	expected := []string{
+		"retrieve-sdk",
+		"retrieve-sdk",
+		"create-state-storage",
+		"run-hook", // save-state sdk-1
+		"run-hook", // save-state sdk-2
+		"disconnect",
+		"disconnect",
+		"stash-workshop",
+		"create-workshop",
+		"mount-project",
+		"start-workshop",
+		"install-sdk",
+		"link-sdk",
+		"install-sdk",
+		"link-sdk",
+		"auto-connect",
+		"auto-connect",
+		"run-hook", // setup-base sdk-1
+		"run-hook", // setup-base sdk-2
+		"run-hook", // restore-state sdk-1
+		"run-hook", // restore-state sdl-2
+		"run-hook", // check-health sdk-1
+		"run-hook", // check-health sdk-2
+		"remove-workshop-stash",
+		"remove-state-storage",
+	}
+
+	tasks := ts.Tasks()
+
+	c.Assert(err, check.Equals, nil)
+	verifyExpectedTasks(c, tasks, expected)
+	verifyDisconnectDependencies(c, ts)
+
+	s.ensureTaskHasWorkshopAndProjectKeys(c, "ws", tasks)
+}
+
+func (s *requestSuite) TestRefreshSdkRemoved(c *check.C) {
+	// Setup
+	s.state.Lock()
+	defer s.state.Unlock()
+	existingSdks := []sdk.Setup{
+		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
+	}
+
+	file := &workshopbackend.WorkshopFile{
+		Name: "ws",
+		Base: "ubuntu@22.04",
+		Sdks: workshopbackend.SdkList{{Name: "sdk-1", Channel: "latest/stable"}}}
+
+	s.launchWorkshopWithSDKs(c, "ws", existingSdks)
+
+	// Execute
+	ts, err := workshopstate.Refresh(s.state, file, existingSdks, s.project)
+	c.Assert(err, check.IsNil)
+
+	// Validate
+	// save-state and restore-state will only exist for sdk-1
+	validateStateHooksTasksSetup(c, []*state.TaskSet{ts}, []string{"sdk-1"}, []string{"sdk-1"})
+	verifyDisconnectDependencies(c, ts)
+}
+
+func (s *requestSuite) TestRefreshSdkRemovedMakingWorkshopEmpty(c *check.C) {
+	// Setup
+	s.state.Lock()
+	defer s.state.Unlock()
+	existingSdks := []sdk.Setup{
+		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
+	}
+
+	file := &workshopbackend.WorkshopFile{
+		Name: "ws",
+		Base: "ubuntu@22.04"}
+
+	s.launchWorkshopWithSDKs(c, "ws", existingSdks)
+
+	// Execute
+	ts, err := workshopstate.Refresh(s.state, file, existingSdks, s.project)
+	c.Assert(err, check.IsNil)
+
+	// Validate
+	// save-state and restore-state will only exist for sdk-1
+	validateStateHooksTasksSetup(c, []*state.TaskSet{ts}, []string{}, []string{})
+	verifyDisconnectDependencies(c, ts)
+}
+
+func (s *requestSuite) TestRefreshSdkReplaced(c *check.C) {
+	// Setup
+	s.state.Lock()
+	defer s.state.Unlock()
+	existingSdks := []sdk.Setup{
+		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
+	}
+
+	file := &workshopbackend.WorkshopFile{
+		Name: "ws",
+		Base: "ubuntu@22.04",
+		Sdks: workshopbackend.SdkList{{Name: "test-1", Channel: "latest/stable"}, {Name: "test-2", Channel: "latest/stable"}}}
+
+	s.launchWorkshopWithSDKs(c, "ws", existingSdks)
+
+	// Execute
+	ts, err := workshopstate.Refresh(s.state, file, existingSdks, s.project)
+	c.Assert(err, check.IsNil)
+
+	// Validate
+	// save-state and restore-state will only exist for sdk-1
+	validateStateHooksTasksSetup(c, []*state.TaskSet{ts}, nil, nil)
+	verifyDisconnectDependencies(c, ts)
+}
+
+func (s *requestSuite) TestRefreshSdkChannelUpdated(c *check.C) {
+	// Setup
+	s.state.Lock()
+	defer s.state.Unlock()
+	existingSdks := []sdk.Setup{
+		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
+	}
+
+	file := &workshopbackend.WorkshopFile{
+		Name: "ws",
+		Base: "ubuntu@22.04",
+		Sdks: workshopbackend.SdkList{{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/edge"}}}
+
+	s.launchWorkshopWithSDKs(c, "ws", existingSdks)
+
+	// Execute
+	ts, err := workshopstate.Refresh(s.state, file, existingSdks, s.project)
+	c.Assert(err, check.IsNil)
+
+	// Validate
+	// save-state and restore-state will only exist for sdk-1
+	validateStateHooksTasksSetup(c, []*state.TaskSet{ts}, []string{"sdk-1", "sdk-2"}, []string{"sdk-1", "sdk-2"})
+	verifyDisconnectDependencies(c, ts)
+}
+
+func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -248,45 +423,46 @@ func (s *S) TestRefreshManyEmptyWorkshopMany(c *check.C) {
 		"create-state-storage",
 		"remove-state-storage",
 		"create-workshop",
-		"remove-workshop-stash",
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
+		"remove-workshop-stash",
 	}
 
 	expected_ws_1 := []string{
+		"retrieve-sdk",
 		"create-state-storage",
-		"remove-state-storage",
-		"create-workshop",
-		"remove-workshop-stash",
-		"run-hook",
-		"stash-workshop",
+		"run-hook", // save-state hook
 		"disconnect",
+		"stash-workshop",
+		"create-workshop",
 		"mount-project",
 		"start-workshop",
-		"retrieve-sdk",
 		"install-sdk",
 		"link-sdk",
 		"auto-connect",
-		"run-hook",
-		"run-hook", // restore state hook
+		"run-hook", // setup-base hook
+		"run-hook", // restore-state hook
+		"run-hook", // check-health hook
+		"remove-workshop-stash",
+		"remove-state-storage",
 	}
 
 	verifyExpectedTasks(c, ts[0].Tasks(), expected_ws)
 	verifyExpectedTasks(c, ts[1].Tasks(), expected_ws_1)
 
-	c.Assert(ts[0].MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible).Kind(), check.Equals, "start-workshop")
-	waitFor := ts[0].MaybeEdge(workshopstate.EdgeCleanupRefresh).WaitTasks()
+	c.Assert(ts[0].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible).Kind(), check.Equals, "start-workshop")
+	waitFor := ts[0].MaybeEdge(workshopstate.EdgeRefreshCleanup).WaitTasks()
 	c.Assert(waitFor, testutil.DeepUnsortedMatches, []*state.Task{
-		ts[0].MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible),
-		ts[1].MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible),
+		ts[0].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible),
+		ts[1].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible),
 	})
 
-	c.Assert(ts[1].MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible).Kind(), check.Equals, "run-hook")
-	waitFor = ts[1].MaybeEdge(workshopstate.EdgeCleanupRefresh).WaitTasks()
+	c.Assert(ts[1].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible).Kind(), check.Equals, "run-hook")
+	waitFor = ts[1].MaybeEdge(workshopstate.EdgeRefreshCleanup).WaitTasks()
 	c.Assert(waitFor, testutil.DeepUnsortedMatches, []*state.Task{
-		ts[0].MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible),
-		ts[1].MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible),
+		ts[0].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible),
+		ts[1].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible),
 	})
 
 	for i, t := range ts {
@@ -294,60 +470,7 @@ func (s *S) TestRefreshManyEmptyWorkshopMany(c *check.C) {
 	}
 }
 
-func (s *S) TestRefreshWithAnSDK(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	testSdk := workshopbackend.SdkRecord{Name: "sdk-1", Channel: "latest/stable"}
-	testSdk2 := workshopbackend.SdkRecord{Name: "sdk-2", Channel: "latest/stable"}
-
-	file := &workshopbackend.WorkshopFile{
-		Name: "ws",
-		Base: "ubuntu@22.04",
-		Sdks: workshopbackend.SdkList{testSdk, testSdk2}}
-
-	ts, err := workshopstate.Refresh(s.state, file, []sdk.Setup{
-		{Name: "sdk-1", Channel: "latest/stable"},
-		{Name: "sdk-2", Channel: "latest/stable"},
-	}, s.project)
-	c.Assert(err, check.IsNil)
-
-	expected := []string{
-		"create-state-storage",
-		"remove-state-storage",
-		"create-workshop",
-		"remove-workshop-stash",
-		"run-hook",
-		"run-hook",
-		"stash-workshop",
-		"disconnect",
-		"disconnect",
-		"mount-project",
-		"start-workshop",
-		"retrieve-sdk",
-		"install-sdk",
-		"link-sdk",
-		"retrieve-sdk",
-		"install-sdk",
-		"link-sdk",
-		"auto-connect",
-		"auto-connect",
-		"run-hook",
-		"run-hook", // restore state hook
-		"run-hook",
-		"run-hook",
-	}
-
-	tasks := ts.Tasks()
-
-	c.Assert(err, check.Equals, nil)
-	verifyExpectedTasks(c, tasks, expected)
-	verifyDisconnectDependencies(c, ts)
-
-	s.ensureTaskHasWorkshopAndProjectKeys(c, "ws", tasks)
-}
-
-func (s *S) TestRefreshManyTasktest(c *check.C) {
+func (s *requestSuite) TestRefreshManyAllWorkshopsHaveSdks(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -383,21 +506,22 @@ func (s *S) TestRefreshManyTasktest(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	expected := []string{
+		"retrieve-sdk",
 		"create-state-storage",
-		"remove-state-storage",
 		"run-hook",
-		"stash-workshop",
 		"disconnect",
+		"stash-workshop",
 		"create-workshop",
 		"mount-project",
 		"start-workshop",
-		"retrieve-sdk",
 		"install-sdk",
 		"link-sdk",
 		"auto-connect",
-		"run-hook",
+		"run-hook", // setup-base hook
 		"run-hook", // restore state hook
+		"run-hook", // check-health hook
 		"remove-workshop-stash",
+		"remove-state-storage",
 	}
 
 	for i, t := range ts {
@@ -405,10 +529,9 @@ func (s *S) TestRefreshManyTasktest(c *check.C) {
 		verifyExpectedTasks(c, t.Tasks(), expected)
 		s.ensureTaskHasWorkshopAndProjectKeys(c, files[i].Name, t.Tasks())
 	}
-
 }
 
-func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
+func (s *requestSuite) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -443,18 +566,18 @@ func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 	ts, err := workshopstate.RefreshManyImpl(s.state, files, content, s.project)
 	c.Assert(err, check.IsNil)
 
-	lastChanceWs := ts[0].MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible)
+	lastChanceWs := ts[0].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible)
 	c.Assert(lastChanceWs, check.NotNil)
 	c.Assert(lastChanceWs.Kind(), check.Equals, "run-hook")
 
-	lastChanceWs1 := ts[1].MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible)
+	lastChanceWs1 := ts[1].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible)
 	c.Assert(lastChanceWs1, check.NotNil)
 	c.Assert(lastChanceWs1.Kind(), check.Equals, "run-hook")
 
 	// Ensure that the remove-stash for ws will wait on the own
 	// remove-state-storage and ws1's (i.e. all the other workshops') restore
 	// state hooks
-	removeWsStStorage := ts[0].MaybeEdge(workshopstate.EdgeCleanupRefresh)
+	removeWsStStorage := ts[0].MaybeEdge(workshopstate.EdgeRefreshCleanup)
 	removeStash := removeWsStStorage.HaltTasks()[0]
 	c.Assert(removeWsStStorage.WaitTasks(), testutil.DeepUnsortedMatches, []*state.Task{lastChanceWs, lastChanceWs1})
 
@@ -469,7 +592,7 @@ func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 	// Ensure that the delete-copy for ws1 will wait on the own
 	// remove-state-storage and ws's (i.e. all the other workshops') restore
 	// state hooks
-	removeWsStStorage = ts[1].MaybeEdge(workshopstate.EdgeCleanupRefresh)
+	removeWsStStorage = ts[1].MaybeEdge(workshopstate.EdgeRefreshCleanup)
 	removeStash = removeWsStStorage.HaltTasks()[0]
 	c.Assert(removeWsStStorage.WaitTasks(), testutil.DeepUnsortedMatches, []*state.Task{lastChanceWs1, lastChanceWs})
 
@@ -482,7 +605,7 @@ func (s *S) TestRefreshManyWaitsOnAllSuccessfulBeforeRemovingStash(c *check.C) {
 	c.Assert(removeWsStStorage.Lanes(), check.HasLen, 1)
 }
 
-func (s *S) TestRefreshManyRestoreStateHooksExecutedSequentially(c *check.C) {
+func (s *requestSuite) TestRestoreStateHooks(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -503,11 +626,42 @@ func (s *S) TestRefreshManyRestoreStateHooksExecutedSequentially(c *check.C) {
 			c.Assert(t.WaitTasks(), check.DeepEquals, []*state.Task{prev})
 		}
 		prev = t
+		var setup hookstate.HookSetup
+		err := t.Get("hook-setup", &setup)
+		c.Assert(err, check.IsNil)
+		c.Assert(setup.HookType, check.Equals, hookstate.RestoreState)
 	}
-	c.Assert(ts.MaybeEdge(workshopstate.EdgeLastBeforeRefreshIrreversible), check.Equals, prev)
 }
 
-func (s *S) TestRefreshManySaveStateHooksExecutedSequentially(c *check.C) {
+func (s *requestSuite) TestCheckHealthHooks(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	file := &workshopbackend.WorkshopFile{
+		Name: "ws",
+		Base: "ubuntu@22.04",
+		Sdks: workshopbackend.SdkList{{Name: "one", Channel: "latest/stable"}, {Name: "two", Channel: "latest/stable"}},
+	}
+
+	ts := workshopstate.CheckHealthHooks(s.state, file)
+	c.Assert(ts.Tasks(), check.HasLen, 2)
+
+	prev := (*state.Task)(nil)
+	for _, t := range ts.Tasks() {
+		if prev != nil {
+			c.Assert(t.WaitTasks(), check.DeepEquals, []*state.Task{prev})
+		}
+		prev = t
+
+		var setup hookstate.HookSetup
+		err := t.Get("hook-setup", &setup)
+		c.Assert(err, check.IsNil)
+		c.Assert(setup.HookType, check.Equals, hookstate.CheckHealth)
+		c.Assert(setup.Timeout, check.Equals, workshopstate.CheckHealthTimeout)
+	}
+}
+
+func (s *requestSuite) TestSaveStateHooks(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -528,24 +682,14 @@ func (s *S) TestRefreshManySaveStateHooksExecutedSequentially(c *check.C) {
 			c.Assert(t.WaitTasks(), check.DeepEquals, []*state.Task{prev})
 		}
 		prev = t
+		var setup hookstate.HookSetup
+		err := t.Get("hook-setup", &setup)
+		c.Assert(err, check.IsNil)
+		c.Assert(setup.HookType, check.Equals, hookstate.SaveState)
 	}
 }
 
-func (s *S) TestRefreshManyNoRestoreStateHooks(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	file := &workshopbackend.WorkshopFile{
-		Name: "ws1",
-		Base: "ubuntu@22.04",
-		Sdks: workshopbackend.SdkList{},
-	}
-
-	ts := workshopstate.RestoreStateHooks(s.state, "ws", []sdk.Setup{}, file.Sdks)
-	c.Assert(ts.Tasks(), check.HasLen, 0)
-}
-
-func (s *S) TestStartMany(c *check.C) {
+func (s *requestSuite) TestStartMany(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -562,7 +706,7 @@ func (s *S) TestStartMany(c *check.C) {
 	c.Assert(ts.Tasks()[1].Has("start-operation"), check.Equals, true)
 }
 
-func (s *S) TestStopMany(c *check.C) {
+func (s *requestSuite) TestStopMany(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -584,7 +728,7 @@ func (s *S) TestStopMany(c *check.C) {
 	c.Assert(force, check.Equals, false)
 }
 
-func (s *S) TestRemoveMany(c *check.C) {
+func (s *requestSuite) TestRemoveMany(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	content := []sdk.Setup{

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -101,18 +101,17 @@ func (s *S) TestLaunchWorkshopNoSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	file := &workshopbackend.WorkshopFile{Name: "test", Base: "ubuntu@22.04"}
-	ts, err := workshopstate.Launch(s.state, file, s.project)
+	ts := workshopstate.Launch(s.state, file, s.project)
 
 	expected := []string{"create-workshop",
 		"mount-project",
 		"start-workshop"}
 	tasks := ts.Tasks()
 
-	c.Assert(err, check.Equals, nil)
 	verifyExpectedTasks(c, tasks, expected)
 
 	var base string
-	err = tasks[0].Get("base", &base)
+	err := tasks[0].Get("base", &base)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(base, check.Equals, "ubuntu@22.04")
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "test", ts.Tasks())
@@ -129,7 +128,7 @@ func (s *S) TestLaunchWorkshopWithSdks(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workshopbackend.SdkList{sdk, sdk_2}}
 
-	ts, err := workshopstate.Launch(s.state, file, s.project)
+	ts := workshopstate.Launch(s.state, file, s.project)
 
 	expected := []string{
 		"create-workshop",
@@ -144,19 +143,21 @@ func (s *S) TestLaunchWorkshopWithSdks(c *check.C) {
 		"auto-connect",
 		"auto-connect",
 		"run-hook",
+		"run-hook",
+		"run-hook",
 		"run-hook"}
 
 	tasks := ts.Tasks()
 
-	c.Assert(err, check.Equals, nil)
 	verifyExpectedTasks(c, tasks, expected)
+	var err error
 
 	var s1, s2 workshopbackend.SdkRecord
-	err = tasks[3].Get("sdk-record", &s1)
+	err = tasks[0].Get("sdk-record", &s1)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(s1, check.Equals, sdk)
 
-	err = tasks[4].Get("sdk-record", &s2)
+	err = tasks[1].Get("sdk-record", &s2)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(s2, check.Equals, sdk_2)
 
@@ -164,22 +165,22 @@ func (s *S) TestLaunchWorkshopWithSdks(c *check.C) {
 	var id1, id2 string
 	err = tasks[5].Get("sdk-retrieve-task", &id1)
 	c.Assert(err, check.Equals, nil)
-	c.Assert(id1, check.Equals, tasks[3].ID())
+	c.Assert(id1, check.Equals, tasks[0].ID())
 
 	// link-sdk task for sdk
 	err = tasks[6].Get("sdk-retrieve-task", &id2)
 	c.Assert(err, check.Equals, nil)
-	c.Assert(id2, check.Equals, tasks[3].ID())
+	c.Assert(id2, check.Equals, tasks[0].ID())
 
 	// install-sdk task for sdk_2
 	err = tasks[8].Get("sdk-retrieve-task", &id1)
 	c.Assert(err, check.Equals, nil)
-	c.Assert(id1, check.Equals, tasks[4].ID())
+	c.Assert(id1, check.Equals, tasks[1].ID())
 
 	// link-sdk task for sdk_2
 	err = tasks[8].Get("sdk-retrieve-task", &id2)
 	c.Assert(err, check.Equals, nil)
-	c.Assert(id2, check.Equals, tasks[4].ID())
+	c.Assert(id2, check.Equals, tasks[1].ID())
 
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "test", tasks)
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -18,7 +18,7 @@ type Setup struct {
 	Name        string    `json:"name"`
 	Channel     string    `json:"channel"`
 	Revision    int64     `json:"revision"`
-	InstallTime time.Time `json:"install-time"`
+	InstallTime time.Time `json:"install-time,omitzero"`
 }
 
 type sdkYaml struct {

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -300,7 +300,8 @@ func (s *LxdBackend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx 
 // removed already)
 func (s *LxdBackend) checkAndRecoverProjectPaths(client lxd.InstanceServer, ctx context.Context, projects []*Project) ([]*Project, error) {
 	for idx, prj := range projects {
-		if ok, _, err := osutil.ExistsIsDir(prj.Path); !ok {
+		if !prj.Exists() {
+			var err error
 			// If got here then there is no project directory for the projectId
 			// anymore. It can mean moving or deletion happened in the past. Try
 			// to recover the new project path
@@ -888,14 +889,9 @@ func (s *LxdBackend) Workshop(ctx context.Context, name string) (*Workshop, erro
 
 func (s *LxdBackend) loadWorkshop(inst *api.Instance, p *Project) (*Workshop, error) {
 	var err error
-	var running, ok bool
-	var pId string
+	var running bool
 
 	name := WorkshopName(inst.Name)
-
-	if pId, ok = inst.Config["user.workshop.project-id"]; !ok {
-		return nil, fmt.Errorf("no project assossiated with the workshop %q", name)
-	}
 
 	if inst.StatusCode == api.Running || inst.StatusCode == api.Ready {
 		running = true
@@ -907,22 +903,12 @@ func (s *LxdBackend) loadWorkshop(inst *api.Instance, p *Project) (*Workshop, er
 	}
 
 	var workshop = &Workshop{
-		backend:   s,
-		projectId: pId,
-		Name:      name,
-		running:   running,
-		base:      base,
-		devices:   inst.Devices,
-	}
-
-	file, err := p.WorkshopFile(name)
-	if err != nil {
-		workshop.AddError(MissingFile)
-	}
-	workshop.SetFile(file)
-
-	if exists, isDir, _ := osutil.ExistsIsDir(p.Path); !exists || !isDir {
-		workshop.AddError(MissingProject)
+		backend: s,
+		project: p,
+		Name:    name,
+		running: running,
+		base:    base,
+		devices: inst.Devices,
 	}
 
 	// Fetch information about the installed SDKs

--- a/internal/workshopbackend/lxd_backend_mock.go
+++ b/internal/workshopbackend/lxd_backend_mock.go
@@ -295,7 +295,9 @@ func (f *FakeWorkshopBackend) Exec(ctx context.Context, name string, args *Execu
 
 func DoExecDefault(ctx context.Context, name string, args *Execution) (ExecContext, error) {
 	return ExecContext{
-		WaitExecution: func(ctx context.Context) error { return nil },
+		WaitExecution: func(ctx context.Context) error {
+			return nil
+		},
 	}, nil
 }
 

--- a/internal/workshopbackend/lxd_backend_mock.go
+++ b/internal/workshopbackend/lxd_backend_mock.go
@@ -107,26 +107,25 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, name, base str
 	}
 
 	ws := &FakeWorkshop{}
-	file, err := prj.WorkshopFile(name)
-	if err != nil {
-		return err
-	}
-
 	ws.Config = make(map[string]string)
 	ws.WorkshopFilesystem = NewFakeWorkshopFs()
 
 	ws.Workshop = &Workshop{backend: f,
-		Name:      name,
-		devices:   defaultDevices(),
-		running:   true,
-		projectId: projectId,
-		content:   make(map[string]sdk.Setup),
-		file:      file,
+		Name:    name,
+		devices: defaultDevices(),
+		running: true,
+		project: prj,
+		content: make(map[string]sdk.Setup),
+		base:    base,
 	}
 
 	f.Workshops[projectId][name] = ws
 
-	for _, s := range ws.File().Sdks {
+	file, err := prj.WorkshopFile(name)
+	if err != nil {
+		return err
+	}
+	for _, s := range file.Sdks {
 		ws.LinkSdk(ctx, sdk.Setup{
 			Name:    s.Name,
 			Channel: s.Channel,
@@ -246,10 +245,6 @@ func (f *FakeWorkshopBackend) Workshop(ctx context.Context, name string) (*Works
 	workshop := f.Workshops[projectId][name]
 	if workshop == nil {
 		return nil, ErrWorkshopNotFound
-	}
-	workshop.file, err = project.WorkshopFile(workshop.Name)
-	if err != nil {
-		return nil, err
 	}
 
 	workshop.content, err = InstalledContent(f.Workshops[projectId][name].Config)

--- a/internal/workshopbackend/lxd_backend_stash.go
+++ b/internal/workshopbackend/lxd_backend_stash.go
@@ -96,7 +96,6 @@ func (s *LxdBackend) moveInstanceAndProfiles(conn lxd.InstanceServer, ctx contex
 	// Stash the workshop
 	// the new name must not be the same, otherwise the LXD's DNS will fail
 	// the new instance creation; hence, the prefix.
-	conn = conn.UseProject(source)
 	if op, err := conn.MigrateInstance(instanceFrom, api.InstancePost{
 		Name:      instanceTo,
 		Project:   target,

--- a/internal/workshopbackend/lxd_backend_test.go
+++ b/internal/workshopbackend/lxd_backend_test.go
@@ -55,52 +55,13 @@ sdks:
 	c.Assert(err, check.IsNil)
 	c.Assert(ws.Name, check.Equals, "ws")
 	c.Assert(ws.IsRunning(), check.Equals, true)
-	c.Assert(ws.Errors(), check.HasLen, 0)
-	c.Assert(ws.ProjectId(), check.Equals, f.project.ProjectId)
+	c.Assert(ws.Project().ProjectId, check.Equals, f.project.ProjectId)
 	c.Assert(ws.Content(), testutil.DeepUnsortedMatches, []sdk.Setup{{
 		Name:     "go",
 		Channel:  "latest/stable",
 		Revision: 277,
 	},
 	})
-}
-
-func (f *LxdBeTests) TestLoadWorkshopMissingErrors(c *check.C) {
-	// Setup
-	project := workshopbackend.Project{ProjectId: f.project.ProjectId, Path: f.project.Path}
-
-	b := &workshopbackend.LxdBackend{}
-
-	// Execute
-	ws, err := workshopbackend.LoadWorkshop(b, &api.Instance{
-		Name: workshopbackend.InstanceName("ws", f.project.ProjectId),
-		InstancePut: api.InstancePut{Config: map[string]string{
-			"user.workshop.project-id": f.project.ProjectId,
-		},
-		}}, &project)
-
-	// Validate
-	c.Assert(err, check.IsNil)
-	c.Assert(ws.Name, check.Equals, "ws")
-	c.Assert(ws.Errors(), testutil.Contains, workshopbackend.MissingFile)
-	c.Assert(ws.Errors(), check.HasLen, 1)
-
-	// Setup
-	os.RemoveAll(f.project.Path)
-
-	// Execute
-	ws, err = workshopbackend.LoadWorkshop(b, &api.Instance{
-		Name: workshopbackend.InstanceName("ws", f.project.ProjectId),
-		InstancePut: api.InstancePut{Config: map[string]string{
-			"user.workshop.project-id": f.project.ProjectId,
-		},
-		}}, &project)
-
-	// Validate
-	c.Assert(err, check.IsNil)
-	c.Assert(ws.Errors(), testutil.Contains, workshopbackend.MissingFile)
-	c.Assert(ws.Errors(), testutil.Contains, workshopbackend.MissingProject)
-	c.Assert(ws.Errors(), check.HasLen, 2)
 }
 
 func (f *LxdBeTests) TestLxdBackendMergeFilesAndInstances(c *check.C) {
@@ -131,8 +92,6 @@ base: ubuntu@20.04`), 0644)
 	c.Assert(merged, check.HasLen, 2)
 	c.Assert(merged[0].IsRunning(), check.Equals, true)
 	c.Assert(merged[1].IsRunning(), check.Equals, true)
-	c.Assert(merged[0].Errors(), check.HasLen, 0)
-	c.Assert(merged[1].Errors(), check.HasLen, 0)
 }
 
 func (f *LxdBeTests) TestLxdBackendMergeFilesAndInstancesWorkshopOff(c *check.C) {
@@ -162,7 +121,6 @@ base: ubuntu@20.04`), 0644)
 	c.Assert(wsFiles, check.HasLen, 1)
 
 	c.Assert(merged[0].IsRunning(), check.Equals, true)
-	c.Assert(merged[0].Errors(), check.HasLen, 0)
 }
 
 func (f *LxdBeTests) TestProjectSubDirectoryProvideAsPath(c *check.C) {

--- a/internal/workshopbackend/project.go
+++ b/internal/workshopbackend/project.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/canonical/workshop/internal/osutil"
 )
 
 var (
@@ -28,6 +30,11 @@ var validWorkshopFilename = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z
 type Project struct {
 	Path      string `json:"path"`
 	ProjectId string `json:"id"`
+}
+
+func (p *Project) Exists() bool {
+	exists, dir, _ := osutil.ExistsIsDir(p.Path)
+	return exists && dir
 }
 
 func ReadProjects(jsonData []byte) ([]*Project, error) {

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -28,50 +28,22 @@ const (
 
 var InstallTimeNow = time.Now
 
-type WorkshopStatus int
-
-const (
-	WorkshopOff WorkshopStatus = iota
-	WorkshopReady
-	WorkshopStopped
-	WorkshopPending
-	WorkshopError
-)
-
-func (s WorkshopStatus) String() string {
-	return [...]string{"Off", "Ready", "Stopped", "Pending", "Error"}[s]
-}
-
-func ParseWorkshopStatus(s string) WorkshopStatus {
-	refreshMap := map[string]WorkshopStatus{
-		WorkshopOff.String():     WorkshopOff,
-		WorkshopReady.String():   WorkshopReady,
-		WorkshopStopped.String(): WorkshopStopped,
-		WorkshopPending.String(): WorkshopPending,
-		WorkshopError.String():   WorkshopError,
-	}
-	return refreshMap[s]
-}
-
-func NewWorkshop(backend WorkshopBackend, name, projectId string) *Workshop {
+func NewWorkshop(backend WorkshopBackend, project *Project, name string) *Workshop {
 	return &Workshop{
-		Name:      name,
-		projectId: projectId,
-		backend:   backend,
+		Name:    name,
+		project: project,
+		backend: backend,
 	}
 }
 
 type Workshop struct {
-	backend   WorkshopBackend
-	file      *WorkshopFile
-	projectId string
-	base      string
-	Name      string
-	devices   map[string]map[string]string
-	content   map[string]sdk.Setup
-	errs      []WorkshopErrorType
-	running   bool
-	status    WorkshopStatus
+	backend WorkshopBackend
+	project *Project
+	base    string
+	Name    string
+	devices map[string]map[string]string
+	content map[string]sdk.Setup
+	running bool
 }
 
 func (w *Workshop) Base() string {
@@ -86,38 +58,18 @@ func (w *Workshop) SetRunning(run bool) {
 	w.running = run
 }
 
-func (w *Workshop) ProjectId() string {
-	return w.projectId
+func (w *Workshop) Project() *Project {
+	return w.project
 }
 
-func (w *Workshop) Errors() []WorkshopErrorType {
-	return w.errs
-}
-
-func (w *Workshop) AddError(err WorkshopErrorType) {
-	w.errs = append(w.errs, err)
+func (w *Workshop) File() (*WorkshopFile, error) {
+	return w.project.WorkshopFile(w.Name)
 }
 
 func (w *Workshop) Content() []sdk.Setup {
 	content := maps.Values(w.content)
 	slices.SortFunc(content, func(a, b sdk.Setup) bool { return a.Name < b.Name })
 	return content
-}
-
-func (w *Workshop) File() *WorkshopFile {
-	return w.file
-}
-
-func (w *Workshop) SetFile(f *WorkshopFile) {
-	w.file = f
-}
-
-func (w *Workshop) Status() WorkshopStatus {
-	return w.status
-}
-
-func (w *Workshop) SetStatus(st WorkshopStatus) {
-	w.status = st
 }
 
 // Associate an SDK with the workshop by creating a 'current' symlink and adding
@@ -190,29 +142,6 @@ func (w *Workshop) UnlinkSdk(ctx context.Context, name string) error {
 	defer fs.Close()
 
 	return fs.Remove(sdk.SdkCurrentPath(name))
-}
-
-const (
-	None WorkshopErrorType = iota
-	MissingProject
-	MissingFile
-	BrokenSdkRecord
-	WaitOnError
-)
-
-func (s WorkshopErrorType) String() string {
-	return [...]string{"", "missing-project", "missing-file", "invalid-sdk", "wait-on-error"}[s]
-}
-
-func ParseWorkshopError(s string) WorkshopErrorType {
-	wserrs := map[string]WorkshopErrorType{
-		None.String():            None,
-		MissingProject.String():  MissingProject,
-		MissingFile.String():     MissingFile,
-		BrokenSdkRecord.String(): BrokenSdkRecord,
-		WaitOnError.String():     WaitOnError,
-	}
-	return wserrs[s]
 }
 
 func WorkshopFilePath(dir, name string) string {

--- a/tests/lib/sdk/test-sdk-basic/sdk/hooks/restore-state
+++ b/tests/lib/sdk/test-sdk-basic/sdk/hooks/restore-state
@@ -1,5 +1,0 @@
-#!/usr/bin/bash
-
-state=$(cat $SDK_STATE_DIR/state)
-echo "latest/stable restore-state to ~/state: $state"
-cp -f $SDK_STATE_DIR/state ~/ || true

--- a/tests/lib/sdk/test-sdk-basic/sdk/hooks/save-state
+++ b/tests/lib/sdk/test-sdk-basic/sdk/hooks/save-state
@@ -1,5 +1,0 @@
-#!/usr/bin/bash
-
-state=$(cat ~/state)
-echo "latest/stable save-state from ~/state: $state"
-cp ~/state $SDK_STATE_DIR 2>/dev/null || true

--- a/tests/lib/sdk/test-sdk-basic/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-basic/sdk/hooks/setup-base
@@ -1,2 +1,2 @@
 #!/usr/bin/bash
-echo "Set up base ran successfully!"
+echo "setup-base ran successfully!"

--- a/tests/lib/sdk/test-sdk-content/sdk/hooks/restore-state
+++ b/tests/lib/sdk/test-sdk-content/sdk/hooks/restore-state
@@ -1,5 +1,0 @@
-#!/usr/bin/bash
-
-state=$(cat $SDK_STATE_DIR/state)
-echo "latest/stable restore-state to ~/state: $state"
-cp -f $SDK_STATE_DIR/state ~/ || true

--- a/tests/lib/sdk/test-sdk-content/sdk/hooks/save-state
+++ b/tests/lib/sdk/test-sdk-content/sdk/hooks/save-state
@@ -1,5 +1,0 @@
-#!/usr/bin/bash
-
-state=$(cat ~/state)
-echo "latest/stable save-state from ~/state: $state"
-cp ~/state $SDK_STATE_DIR 2>/dev/null || true

--- a/tests/lib/sdk/test-sdk-health-error/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-error/meta/sdk.yaml
@@ -1,0 +1,7 @@
+name: test-sdk-health-error
+title: test-sdk-health-error
+base: ubuntu@22.04
+
+summary: test-sdk-health-error SDK
+description: |
+  test-sdk-health-error SDK

--- a/tests/lib/sdk/test-sdk-health-error/sdk/hooks/check-health
+++ b/tests/lib/sdk/test-sdk-health-error/sdk/hooks/check-health
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+workshopctl set-health error --code unknown-problem "Health check failed"

--- a/tests/lib/sdk/test-sdk-health-error/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-health-error/sdk/hooks/setup-base
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+echo "Set up base ran successfully!"

--- a/tests/lib/sdk/test-sdk-health-ok/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-ok/meta/sdk.yaml
@@ -1,0 +1,7 @@
+name: test-sdk-health-ok
+title: test-sdk-health-ok
+base: ubuntu@22.04
+
+summary: test-sdk-health-ok SDK
+description: |
+  test-sdk-health-ok SDK

--- a/tests/lib/sdk/test-sdk-health-ok/sdk/hooks/check-health
+++ b/tests/lib/sdk/test-sdk-health-ok/sdk/hooks/check-health
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+workshopctl set-health okay
+echo -n "Health check finished successfully"

--- a/tests/lib/sdk/test-sdk-health-ok/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-health-ok/sdk/hooks/setup-base
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+echo "Set up base ran successfully!"

--- a/tests/lib/sdk/test-sdk-health-waiting/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-waiting/meta/sdk.yaml
@@ -1,0 +1,7 @@
+name: test-sdk-health-waiting
+title: test-sdk-health-waiting
+base: ubuntu@22.04
+
+summary: test-sdk-health-waiting SDK
+description: |
+  test-sdk-health-waiting SDK

--- a/tests/lib/sdk/test-sdk-health-waiting/sdk/hooks/check-health
+++ b/tests/lib/sdk/test-sdk-health-waiting/sdk/hooks/check-health
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+counter_file="/root/counter"
+if [ ! -f "$counter_file" ]; then
+    echo "0" > "$counter_file"
+fi
+
+counter=$(<"$counter_file")
+counter=$((counter + 1))
+
+if [ "$counter" -gt 3 ]; then
+    workshopctl set-health okay
+else 
+    workshopctl set-health waiting --code try-later "Cannot finish health check"
+fi
+
+echo "$counter" > "$counter_file"

--- a/tests/lib/sdk/test-sdk-health-waiting/sdk/hooks/check-health
+++ b/tests/lib/sdk/test-sdk-health-waiting/sdk/hooks/check-health
@@ -10,6 +10,7 @@ counter=$((counter + 1))
 if [ "$counter" -gt 3 ]; then
     workshopctl set-health okay
 else 
+    sleep 2
     workshopctl set-health waiting --code try-later "Cannot finish health check"
 fi
 

--- a/tests/lib/sdk/test-sdk-health-waiting/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-health-waiting/sdk/hooks/setup-base
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+echo "Set up base ran successfully!"

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -6,7 +6,7 @@ function prepare_environment() {
   snap install go --classic
 
   snap install lxd --classic
-  lxd init --auto
+  lxd init --auto --storage-backend zfs
   
   snap install --dangerous --classic /workshop/tests/*.snap
   snap set workshop store.url=http://localhost:8080/storage/v1/
@@ -29,7 +29,7 @@ function start_sdk_store() {
 
   echo "Waiting for the fake SDK store to start on port 8080..."
   while ! nc -z localhost 8080; do
-    sleep 0.1 # wait for 1/10 of the second before check again
+    sleep 0.1
   done
 }
 

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -6,7 +6,7 @@ function prepare_environment() {
   snap install go --classic
 
   snap install lxd --classic
-  lxd init --auto --storage-backend zfs
+  lxd init --auto
   
   snap install --dangerous --classic /workshop/tests/*.snap
   snap set workshop store.url=http://localhost:8080/storage/v1/

--- a/tests/main/check-health/.workshop.ws-error.yaml
+++ b/tests/main/check-health/.workshop.ws-error.yaml
@@ -1,0 +1,5 @@
+name: ws-error
+base: ubuntu@22.04
+sdks:
+  test-sdk-health-error:
+    channel: latest/stable

--- a/tests/main/check-health/.workshop.ws-waiting.yaml
+++ b/tests/main/check-health/.workshop.ws-waiting.yaml
@@ -1,0 +1,5 @@
+name: ws-waiting
+base: ubuntu@22.04
+sdks:
+  test-sdk-health-waiting:
+    channel: latest/stable

--- a/tests/main/check-health/.workshop.ws.yaml
+++ b/tests/main/check-health/.workshop.ws.yaml
@@ -1,0 +1,5 @@
+name: ws
+base: ubuntu@22.04
+sdks:
+  test-sdk-health-ok:
+    channel: latest/stable

--- a/tests/main/check-health/task.yaml
+++ b/tests/main/check-health/task.yaml
@@ -1,0 +1,28 @@
+summary: Check check-health hook and set-health reporting
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup ./
+
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  project=$(pwd)
+  workshop_exec --project "$project" launch ws
+
+  echo "Check launch change is Done"
+  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
+
+  workshop_exec refresh --project "$project" ws
+
+  echo "Check refresh change is Done"
+  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws\" workshop$"
+
+  echo "Check the workshop is in Ready state"
+  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$" 
+
+  workshop_exec --project "$project" launch ws-waiting
+  
+  echo "Check launch change is Done"
+  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-waiting\" workshop$"
+
+  workshop_exec refresh --project "$project" ws-waiting

--- a/tests/main/check-health/task.yaml
+++ b/tests/main/check-health/task.yaml
@@ -9,20 +9,18 @@ execute: |
   project=$(pwd)
   workshop_exec --project "$project" launch ws
 
-  echo "Check launch change is Done"
+  echo "Check health reported okay"
   workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
-
-  workshop_exec refresh --project "$project" ws
-
-  echo "Check refresh change is Done"
+  workshop_exec refresh --project "$project" ws  
   workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws\" workshop$"
-
-  echo "Check the workshop is in Ready state"
   workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$" 
 
-  workshop_exec --project "$project" launch ws-waiting
-  
-  echo "Check launch change is Done"
+  echo "Check health reported waiting"  
+  workshop_exec --project "$project" launch ws-waiting    
   workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-waiting\" workshop$"
-
   workshop_exec refresh --project "$project" ws-waiting
+  
+  echo "Check health reported error"
+  workshop_exec --project "$project" launch ws-error || true
+  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Error[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-error\" workshop$"
+  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws-error[[:space:]]+Off[[:space:]]+-$" 

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -42,4 +42,4 @@ execute: |
 
   echo "Check stopped workshop"
   workshop_exec stop --project "$project" ws
-  workshop_exec exec --project "$project" ws pwd | MATCH '.*"ws" is in stopped; must be ready or pending$'
+  workshop_exec exec --project "$project" ws pwd | MATCH '.*"ws" status is "Stopped", must be one of: "Ready", "Pending"$'

--- a/tests/main/info/.workshop.ws.yaml
+++ b/tests/main/info/.workshop.ws.yaml
@@ -1,0 +1,5 @@
+name: ws
+base: ubuntu@22.04
+sdks:
+  test-sdk-health-waiting:
+    channel: latest/stable

--- a/tests/main/info/health.exp
+++ b/tests/main/info/health.exp
@@ -4,7 +4,7 @@ set timeout 120
 spawn watch -n 0.5 workshop info ws
 
 expect {
-    -re "message:\[ \]*Cannot finish health check" {
+    -re "message:\[ \]*Cannot finish health check" {        
         exit 0
     }    
     timeout { 

--- a/tests/main/info/health.exp
+++ b/tests/main/info/health.exp
@@ -1,0 +1,14 @@
+#!/usr/bin/expect -f
+
+set timeout 120
+spawn watch -n 0.5 workshop info ws
+
+expect {
+    -re "message:\[ \]*Cannot finish health check" {
+        exit 0
+    }    
+    timeout { 
+        puts "Timed out while waiting for the SDK health message"
+        exit 1
+    }
+}

--- a/tests/main/info/task.yaml
+++ b/tests/main/info/task.yaml
@@ -13,5 +13,8 @@ execute: |
   . "$TESTSLIB"/utils.sh
   PROJECT=$(pwd)
   
-  workshop_exec --project "$PROJECT" launch ws --no-wait
+  change_id=$(workshop_exec --project "$PROJECT" launch ws --no-wait | tr -d '\n')
   expect -f ./health.exp
+  while workshop_exec changes | grep -q "$change_id  Doing.*Launch \"ws\" workshop$"; do
+    sleep 0.1
+  done

--- a/tests/main/info/task.yaml
+++ b/tests/main/info/task.yaml
@@ -1,0 +1,23 @@
+summary: |
+  Test workshop info output
+  
+prepare: |
+  apt install expect jq -y --no-install-recommends
+  snap install yq
+
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup ./
+
+execute: |
+  . "$TESTSLIB"/utils.sh
+  PROJECT=$(pwd)
+  
+  change_id=$(workshop_exec --project "$PROJECT" launch ws --no-wait | tr -d '\n')  
+  
+  while workshop_exec tasks $change_id | grep  -q ".*Do .*check-health"; do
+    sleep 0.1
+  done
+  sleep 2
+  workshop_exec --project "$PROJECT" info ws
+  workshop_exec --project "$PROJECT" info ws | grep -v notes | yq '.content["test-sdk-health-waiting"].message' | MATCH "Cannot finish health check"

--- a/tests/main/info/task.yaml
+++ b/tests/main/info/task.yaml
@@ -13,11 +13,5 @@ execute: |
   . "$TESTSLIB"/utils.sh
   PROJECT=$(pwd)
   
-  change_id=$(workshop_exec --project "$PROJECT" launch ws --no-wait | tr -d '\n')  
-  
-  while workshop_exec tasks $change_id | grep  -q ".*Do .*check-health"; do
-    sleep 0.1
-  done
-  sleep 2
-  workshop_exec --project "$PROJECT" info ws
-  workshop_exec --project "$PROJECT" info ws | grep -v notes | yq '.content["test-sdk-health-waiting"].message' | MATCH "Cannot finish health check"
+  workshop_exec --project "$PROJECT" launch ws --no-wait
+  expect -f ./health.exp

--- a/tests/main/list-global/task.yaml
+++ b/tests/main/list-global/task.yaml
@@ -28,5 +28,5 @@ execute: |
   cp -R project-2 project-2-copy
   workshop_exec --project $projects/project-2-copy launch ws
   rm -rf project-2-copy
-  workshop_exec list --global | MATCH "^$projects/project-2-copy[[:space:]]+ws[[:space:]]+Error[[:space:]]+missing-file,missing-project$"
+  workshop_exec list --global | MATCH "^$projects/project-2-copy[[:space:]]+ws[[:space:]]+Error[[:space:]]+missing-project$"
   

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -14,7 +14,7 @@ execute: |
   sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' $project/.workshop.ws.yaml
 
   echo "Check the workshop is in Pending state"
-   workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Pending[[:space:]]+wait-on-error$"
+  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Pending[[:space:]]+wait-on-error$"
 
   echo "Check the workshop refresh --abort reverts to the previous state"
   workshop_exec refresh --project "$project" --abort ws | MATCH "\"ws\" refresh aborted"


### PR DESCRIPTION
# Description

## Workshopd
The SDK check-health hook is a way for the SDK authors to provide a light-weight readiness assessment during the launch or refresh operations.

A new `set-health` command added to `workshopctl` for health reporting from the check-health hook:

```
workshopctl set-health [--code=<error-code>] <status> [<message>]

status     One of okay, waiting, error. Required. 
error-code A note, e.g. missing-cuda, up to 20 symbols. Not allowed if okay. Optional.
message    A user-friendly message expanding the note, 7-70 lines long. Not allowed if okay. Required.
```

`set-health` allows to ask workshop for retry if the readiness check cannot be completed quickly. An error reported by `set-health` will lead to abortion of the current change (be it refresh or launch).

## Workshop CLI

`workshop info` has been changed to display the results of the SDK health check as follows:

```
project:  /home/dmitry/work/workshop
status:   pending
notes:    try-again
content:
    go:
        channel:  latest/beta  2024-02-20  703
        message:  Cannot resolve the health status...
```

## See also
There is a corresponding PR for sdkcraft that introduces support for check-health hooks: https://github.com/canonical/sdkcraft/pull/39

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
