### PR TITLE
Remove infomational logging from the client output

### DIFF
--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -156,7 +156,6 @@ func (wmx waitMixin) wait(id string, abortExpected bool) (*client.Change, error)
 				continue
 			case t.Progress.Total == 1:
 				pb.Spin(t.Summary)
-				maybeShowLog(t)
 			case t.ID == lastID:
 				pb.Set(float64(t.Progress.Done))
 			default:

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -148,9 +148,8 @@ func (h *healthHandler) Done() (err error) {
 			// this is used by external parties to read and report the health
 			// check statuses e.g. workshop info command.
 			task.Set("health", health)
-			if retry, ok := err.(*state.Retry); ok {
+			if _, ok := err.(*state.Retry); ok {
 				h.context.Set("retry-counter", retryCounter+1)
-				task.Logf("Retrying check-health in %v, reason: %s", retry.After, health.Message)
 			}
 			h.context.Unlock()
 		}

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -299,8 +299,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 	s.state.Lock()
 
 	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
-	c.Assert(t1.Log()[0], check.Matches, `.*not ready yet`)
-	c.Assert(t1.Log(), check.HasLen, 1)
+	c.Assert(t1.Log(), check.HasLen, 0)
 	ensureTaskHealthIsSet(t1, &resultOkay, c)
 }
 
@@ -357,8 +356,8 @@ func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 	s.state.Lock()
 
 	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
-	c.Assert(t1.Log()[2], check.Matches, `.*SDK \"one\" is not healthy after multiple checks`)
-	c.Assert(t1.Log(), check.HasLen, 3)
+	c.Assert(t1.Log()[0], check.Matches, `.*SDK \"one\" is not healthy after multiple checks`)
+	c.Assert(t1.Log(), check.HasLen, 1)
 
 	s.state.Unlock()
 	hookContext.Lock()


### PR DESCRIPTION
# Description

* Do not log retry attempts of the check-health hook. The SDKs may choose to do so themselves if required.

* No INFO type messages in the client's output during the operation, e.g. if a check-health hook logged info during multiple retries, these shall not be shown in the client output, only attached to a corresponding task.
