### PR TITLE
Add workshop shell command alias for interactive sessions

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -41,6 +41,10 @@ type CmdExec struct {
 	NonInteractive bool          `short:"I"`
 }
 
+type CmdShellAlias struct {
+	execCommand *CmdExec
+}
+
 var shortExecHelp = "Run a command and wait for it to complete."
 var longExecHelp = `
 The 'exec' subcommand runs an arbitrary command in the specified workshop,
@@ -69,6 +73,8 @@ Notes:
   for running the command in the workshop; reasonable defaults are provided
 `
 
+var shortShellHelp = "Start an interactive terminal session for the workshop."
+
 func (c *CmdExec) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "exec <WORKSHOP>",
@@ -88,6 +94,24 @@ func (c *CmdExec) Command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.NonInteractive, "non-interactive", "I", false, "Force non-interactive mode")
 
 	return cmd
+}
+
+func (c *CmdShellAlias) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "shell <WORKSHOP>",
+		Args:  cobra.ExactArgs(1),
+		Short: shortShellHelp,
+		RunE:  c.Run,
+	}
+
+	c.execCommand = &CmdExec{}
+	c.execCommand.UserId = 0
+	c.execCommand.GroupId = 0
+	return cmd
+}
+
+func (cmd *CmdShellAlias) Run(c *cobra.Command, av []string) error {
+	return cmd.execCommand.Run(c, []string{av[0], "su", "-l", "workshop"})
 }
 
 func (cmd *CmdExec) Run(c *cobra.Command, av []string) error {

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -65,6 +65,7 @@ func main() {
 	rootCmd.AddCommand((&CmdStop{}).Command())
 	rootCmd.AddCommand((&CmdInfo{}).Command())
 	rootCmd.AddCommand((&CmdExec{}).Command())
+	rootCmd.AddCommand((&CmdShellAlias{}).Command())
 	rootCmd.AddCommand((&CmdRemove{}).Command())
 
 	rootCmd.SilenceErrors = true

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -54,15 +54,15 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	}
 
 	taskset := make([]*state.TaskSet, 0, len(names))
-	for _, i := range names {
-		file, err := workshopbackend.ReadWorkshop(workshopbackend.WorkshopFilePath(project.Path, i))
+	for _, name := range names {
+		file, err := project.WorkshopFile(name)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read %q file: %w", i, err)
+			return nil, fmt.Errorf("cannot read %q file: %w", name, err)
 		}
 
-		workshop, err := w.Workshop(ctx, i, projectId)
+		workshop, err := w.Workshop(ctx, name, projectId)
 		if workshop != nil {
-			return nil, fmt.Errorf("cannot launch: %q already exists", i)
+			return nil, fmt.Errorf("cannot launch: %q already exists", name)
 		}
 		if !errors.Is(err, workshopbackend.ErrWorkshopNotFound) {
 			return nil, err

--- a/internal/workshopbackend/export_test.go
+++ b/internal/workshopbackend/export_test.go
@@ -4,4 +4,7 @@ var (
 	MergeInstancesAndFiles = mergeInstancesAndFiles
 	LoadWorkshop           = (*LxdBackend).loadWorkshop
 	LxdDevices             = (*Device).lxdProperties
+	ReadWorkshop           = readWorkshop
+	ReadProjects           = readProjects
+	SaveProjects           = saveProjects
 )

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -111,7 +111,7 @@ func (s *LxdBackend) loadProject(client lxd.InstanceServer, ctx context.Context,
 		return nil, fmt.Errorf("context key %s not found", ContextUser)
 	}
 
-	pId, err := projectId(LockPath(path))
+	pId, err := projectId(path)
 	lockNotFound := false
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, err
@@ -124,7 +124,7 @@ func (s *LxdBackend) loadProject(client lxd.InstanceServer, ctx context.Context,
 		return nil, err
 	}
 
-	projects, err := ReadProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
+	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,9 @@ func (s *LxdBackend) loadProject(client lxd.InstanceServer, ctx context.Context,
 		for _, i := range projects {
 			if i.Path == path {
 				// save the lock file in the project's location
-				i.UpdateLockFile()
+				if err = i.createProjectLock(); err != nil {
+					return nil, err
+				}
 				return i, nil
 			}
 		}
@@ -160,7 +162,7 @@ func (s *LxdBackend) untrackProject(client lxd.InstanceServer, ctx context.Conte
 		return err
 	}
 
-	projects, err := ReadProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
+	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
 	if err != nil {
 		return err
 	}
@@ -171,7 +173,7 @@ func (s *LxdBackend) untrackProject(client lxd.InstanceServer, ctx context.Conte
 	}
 
 	projects = slices.Delete(projects, idx, idx+1)
-	projectsJson, err := SaveProjects(projects)
+	projectsJson, err := saveProjects(projects)
 	if err != nil {
 		return err
 	}
@@ -191,7 +193,7 @@ func (s *LxdBackend) trackProject(client lxd.InstanceServer, ctx context.Context
 		return err
 	}
 
-	projects, err := ReadProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
+	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
 	if err != nil {
 		return err
 	}
@@ -203,7 +205,7 @@ func (s *LxdBackend) trackProject(client lxd.InstanceServer, ctx context.Context
 		projects[idx] = prj
 	}
 
-	projectsJson, err := SaveProjects(projects)
+	projectsJson, err := saveProjects(projects)
 	if err != nil {
 		return err
 	}
@@ -345,7 +347,7 @@ func ProjectPath(cwd string) (string, error) {
 		var err error
 		var ok, isDir bool
 		if ok, isDir, err = osutil.ExistsIsDir(path); err == nil && ok && isDir {
-			if ok = osutil.FileExists(LockPath(path)); ok {
+			if _, err := projectId(path); err == nil {
 				return filepath.Clean(path), nil
 			}
 		}
@@ -420,10 +422,13 @@ func (s *LxdBackend) CreateOrLoadProject(ctx context.Context, path string) (*Pro
 				}
 				var newPrj = Project{Path: projectDir, ProjectId: id}
 
-				if err = newPrj.UpdateLockFile(); err != nil {
+				// rewrite the existing lock file with the new project id.
+				if err = newPrj.updateProjectLock(); err != nil {
 					return nil, false, err
 				}
-				s.trackProject(client, ctx, &newPrj)
+				if err := s.trackProject(client, ctx, &newPrj); err != nil {
+					return nil, false, err
+				}
 				return &newPrj, true, nil
 			}
 		}
@@ -455,7 +460,11 @@ func (s *LxdBackend) CreateOrLoadProject(ctx context.Context, path string) (*Pro
 	} else {
 		// if we allocated a new project ID successfully,
 		// we store it in the lock file immediately
-		if err = project.UpdateLockFile(); err != nil {
+		if err = project.createProjectLock(); err != nil {
+			// a possible reason to fail here is to try to create
+			// a project in a directory where a different user has
+			// a project already. That project will not be visible to
+			// anyone but the owner.
 			return nil, false, err
 		}
 	}
@@ -480,7 +489,7 @@ func (s *LxdBackend) Projects(ctx context.Context) (map[string][]*Project, error
 			return nil, err
 		}
 
-		projects, err := ReadProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
+		projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
 		if err != nil {
 			return nil, err
 		}
@@ -511,7 +520,7 @@ func (s *LxdBackend) Projects(ctx context.Context) (map[string][]*Project, error
 			// if the project is created by workshop, the key must be present
 			if _, ok := prj.Config["user.workshop.projects"]; ok && err == nil {
 				prjctx := context.WithValue(ctx, ContextUser, username)
-				projects, err := ReadProjects([]byte(prj.Config["user.workshop.projects"]))
+				projects, err := readProjects([]byte(prj.Config["user.workshop.projects"]))
 				if err != nil {
 					return nil, err
 				}

--- a/internal/workshopbackend/project.go
+++ b/internal/workshopbackend/project.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -27,6 +28,10 @@ const (
 
 var validWorkshopFilename = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
 
+func LockPath(path string) string {
+	return filepath.Join(path, ProjectLock)
+}
+
 type Project struct {
 	Path      string `json:"path"`
 	ProjectId string `json:"id"`
@@ -37,43 +42,8 @@ func (p *Project) Exists() bool {
 	return exists && dir
 }
 
-func ReadProjects(jsonData []byte) ([]*Project, error) {
-	var projects = make([]*Project, 0)
-	if len(jsonData) == 0 {
-		return projects, nil
-	}
-	if err := json.Unmarshal([]byte(jsonData), &projects); err != nil {
-		return nil, fmt.Errorf("invalid projects record: %w", err)
-	}
-	return projects, nil
-}
-
-func SaveProjects(projects []*Project) (string, error) {
-	buf, err := json.Marshal(projects)
-	if err != nil {
-		return "", err
-	}
-	return string(buf), nil
-}
-
-func LockPath(path string) string {
-	return filepath.Join(path, ProjectLock)
-}
-
-func projectId(lockFile string) (string, error) {
-	if buf, err := os.ReadFile(lockFile); err == nil {
-		return string(buf), nil
-	} else {
-		return "", err
-	}
-}
-
-func (w *Project) UpdateLockFile() error {
-	return os.WriteFile(LockPath(w.Path), []byte(w.ProjectId), 0644)
-}
-
 func (w *Project) WorkshopFile(workshop string) (*WorkshopFile, error) {
-	file, err := ReadWorkshop(filepath.Join(w.Path, WorkshopFileName(workshop)))
+	file, err := readWorkshop(filepath.Join(w.Path, WorkshopFileName(workshop)))
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +65,7 @@ func (w *Project) EnumWorkshopFiles() ([]*WorkshopFile, error) {
 
 		/* The first element in names will contain the workshop name if matched */
 		if names := validWorkshopFilename.FindStringSubmatch(info.Name()); names != nil {
-			file, err := ReadWorkshop(filepath.Join(w.Path, info.Name()))
+			file, err := readWorkshop(filepath.Join(w.Path, info.Name()))
 			if err != nil {
 				return nil, err
 			}
@@ -104,4 +74,87 @@ func (w *Project) EnumWorkshopFiles() ([]*WorkshopFile, error) {
 		}
 	}
 	return workshops, nil
+}
+
+func (w *Project) updateProjectLock() error {
+	lock, err := osutil.NewFileLockWithMode(LockPath(w.Path), 0644)
+	if err != nil {
+		return err
+	}
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+	defer lock.Close()
+
+	_, err = lock.File().Write([]byte(w.ProjectId))
+	if err != nil {
+		return err
+	}
+
+	return lock.File().Sync()
+}
+
+func (w *Project) createProjectLock() error {
+	lock, err := osutil.NewFileLockWithMode(LockPath(w.Path), 0644)
+	if err != nil {
+		return err
+	}
+	if err := lock.Lock(); err != nil {
+		return err
+	}
+	defer lock.Close()
+
+	id, err := io.ReadAll(lock.File())
+	if err != nil {
+		return err
+	}
+
+	if len(id) > 0 {
+		return fmt.Errorf("project already exists")
+	}
+
+	_, err = lock.File().Write([]byte(w.ProjectId))
+	if err != nil {
+		return err
+	}
+
+	return lock.File().Sync()
+}
+
+func readProjects(jsonData []byte) ([]*Project, error) {
+	var projects = make([]*Project, 0)
+	if len(jsonData) == 0 {
+		return projects, nil
+	}
+	if err := json.Unmarshal([]byte(jsonData), &projects); err != nil {
+		return nil, fmt.Errorf("invalid projects record: %w", err)
+	}
+	return projects, nil
+}
+
+func saveProjects(projects []*Project) (string, error) {
+	buf, err := json.Marshal(projects)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// Read a project id from projectDir (.workshop.lock)
+func projectId(projectDir string) (string, error) {
+	lock, err := osutil.OpenExistingLockForReading(LockPath(projectDir))
+	if err != nil {
+		return "", err
+	}
+
+	if err := lock.ReadLock(); err != nil {
+		return "", err
+	}
+
+	defer lock.Close()
+	buf, err := io.ReadAll(lock.File())
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
 }

--- a/internal/workshopbackend/tests/integration/project_test.go
+++ b/internal/workshopbackend/tests/integration/project_test.go
@@ -179,9 +179,9 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryCopied(c *check.C) {
 	os.WriteFile(filepath.Join(newDir, ".workshop.lock"), []byte("b8639dea"), 0644)
 
 	prj, created, err := be.CreateOrLoadProject(f.ctx, newDir)
+	c.Assert(err, check.IsNil)
 	c.Assert(prj, check.NotNil)
 	c.Assert(prj.Path, check.Equals, newDir)
-	c.Assert(err, check.IsNil)
 	c.Assert(created, check.Equals, true)
 	c.Assert(filepath.Join(newDir, ".workshop.lock"), testutil.FileEquals, "abcdefgi")
 	lxdProject, _, _ := f.client.GetProject(workshopbackend.LxdProjectName(f.username))
@@ -274,5 +274,29 @@ func (f *wsProject) TestLxdBackendLoadProjectsAllUsers(c *check.C) {
 	c.Assert(projects, testutil.DeepUnsortedMatches, map[string][]*workshopbackend.Project{
 		f.username: {{ProjectId: "b8639dea", Path: projectDir}},
 	})
+}
 
+func (f *wsProject) TestLxdBackendLoadProjectAsDifferentUser(c *check.C) {
+	// Setup
+	be := workshopbackend.LxdBackend{}
+	restore := testutil.FakeFunc(func() (string, error) { return "b8639dea", nil }, &workshopbackend.NewProjectId)
+	projectDir := c.MkDir()
+
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
+	c.Assert(prj, check.NotNil)
+	c.Assert(prj.Path, check.Equals, projectDir)
+	c.Assert(err, check.IsNil)
+	// restore the new project id generator, we won't need it anymore
+	// as we will be loading the project
+	restore()
+
+	// Execute (this time the project must be loaded)
+	ctx := context.WithValue(f.ctx, workshopbackend.ContextUser, "anotheruser")
+	prj, created, err := be.CreateOrLoadProject(ctx, projectDir)
+
+	// Validate
+	c.Assert(err, check.ErrorMatches, "project already exists")
+	c.Assert(prj, check.IsNil)
+	c.Assert(created, check.Equals, false)
 }

--- a/internal/workshopbackend/workshop_file.go
+++ b/internal/workshopbackend/workshop_file.go
@@ -53,7 +53,7 @@ func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-func ReadWorkshop(pathname string) (*WorkshopFile, error) {
+func readWorkshop(pathname string) (*WorkshopFile, error) {
 	var err error
 
 	var file = &WorkshopFile{}

--- a/tests/main/info/health.exp
+++ b/tests/main/info/health.exp
@@ -1,24 +1,27 @@
 #!/usr/bin/expect -f
 
-set timeout 360
-spawn -noecho watch -n 0.5 workshop info ws
+set timeout 180
 set success 0 
 
-expect {
-    -re "message:\[ \]*SDK is not ready yet..." {
-        puts "Seen the expected SDK health messages"
-        set success 1
-        exp_continue
-    }
-    -re "ready" {
-        if { $success == 1 } {
-            exit 0
+while {1} {
+    spawn workshop info ws
+    expect {
+        -re "message:\[ \]*Cannot finish health check" {
+            puts "Seen the expected SDK health messages"
+            set success 1
+            exp_continue
         }
-        puts "Could not find the expected SDK health message"
-        exit 1
+        -re "ready" {
+            if { $success == 1 } {
+                exit 0
+            }
+            puts "Could not find the expected SDK health message"
+            exit 1
+        }
+        timeout { 
+            puts "Timed out while waiting for the SDK health message"
+            exit 1
+        }
     }
-    timeout { 
-        puts "Timed out while waiting for the SDK health message"
-        exit 1
-    }
+    after 500
 }

--- a/tests/main/info/task.yaml
+++ b/tests/main/info/task.yaml
@@ -13,4 +13,4 @@ execute: |
   . "$TESTSLIB"/utils.sh
   PROJECT=$(pwd)  
   workshop_exec --project "$PROJECT" launch ws --no-wait
-  expect -f ./health.exp
+  sudo -u ubuntu 2>&1 -- expect -f ./health.exp


### PR DESCRIPTION
# Description

Add workshop shell command alias for interactive sessions. Some additional changes:

* Rework error messages for the scenario when multiple users try to create a project in the same directory as it has been demonstrated by the failing workshop info spread test. It failed correctly, but the reason wasn't obvious for the
end user.

* Make a few functions of the Workshop and Project to be unexported.


# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
