### PR TITLE
Workshop remount

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -1,6 +1,10 @@
 package client
 
-import "time"
+import (
+	"bytes"
+	"encoding/json"
+	"time"
+)
 
 type HealthCheck struct {
 	Timestamp time.Time `json:"timestamp"`
@@ -29,6 +33,19 @@ type ListOptions struct {
 	ProjectId string
 }
 
+type PlugRef struct {
+	ProjectId string `json:"project-id"`
+	Workshop  string `json:"workshop"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"plug"`
+}
+
+type Remount struct {
+	Action string   `json:"action"`
+	Plug   *PlugRef `json:"plug"`
+	Source string   `json:"source"`
+}
+
 func (client *Client) ListWorkshops(opts *ListOptions) ([]*Workshop, error) {
 	var workshops []*Workshop
 	_, err := client.doSync("GET", "/v1/projects/"+opts.ProjectId+"/workshops", nil, nil, nil, &workshops)
@@ -45,4 +62,18 @@ func (client *Client) Workshop(projectId, name string) (*Workshop, error) {
 		return nil, err
 	}
 	return &workshop, nil
+}
+
+func (client *Client) Remount(plug *PlugRef, source string) (changeId string, err error) {
+	var body bytes.Buffer
+	var remoutReq = Remount{
+		Action: "remount",
+		Plug:   plug,
+		Source: source,
+	}
+	if err := json.NewEncoder(&body).Encode(remoutReq); err != nil {
+		return "", err
+	}
+
+	return client.doAsync("POST", "/v1/projects/"+plug.ProjectId+"/workshops/"+plug.Workshop+"/mounts", nil, nil, &body)
 }

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -12,12 +12,19 @@ type HealthCheck struct {
 	Code      string    `json:"code,omitempty"`
 }
 
+type Mount struct {
+	Plug   PlugRef `json:"plug"`
+	Source string  `json:"source"`
+	Target string  `json:"target"`
+}
+
 type Sdk struct {
 	Name        string       `json:"name"`
 	Channel     string       `json:"channel"`
 	Revision    string       `json:"revision"`
 	InstallTime time.Time    `json:"install-time"`
 	Health      *HealthCheck `json:"health-check,omitempty"`
+	Mounts      []*Mount     `json:"mounts,omitempty"`
 }
 
 type Workshop struct {

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -1,6 +1,8 @@
 package client_test
 
 import (
+	"fmt"
+	"io"
 	"time"
 
 	"github.com/canonical/workshop/client"
@@ -37,4 +39,20 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 		},
 	})
 	c.Check(cs.req.Method, check.Equals, "GET")
+}
+
+func (cs *clientSuite) TestRemountRequest(c *check.C) {
+	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
+
+	source := c.MkDir()
+	id, err := cs.cli.Remount(&client.PlugRef{ProjectId: "4242", Workshop: "ws", Sdk: "sdk", Name: "plug"}, source)
+
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Assert(id, check.Equals, "24")
+	c.Assert(err, check.IsNil)
+
+	body, err := io.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(string(body), check.Matches, fmt.Sprintf(`{"action":"remount","plug":{"project-id":"4242","workshop":"ws","sdk":"sdk","plug":"plug"},"source":%q}\n`, source))
 }

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
-	cs.rsp = `{"type": "sync", "result": [{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready",
-	"notes":["missing-project"],
-	"content":[{"name":"go","channel":"latest/stable","revision":"453","install-time":"2023-04-25T01:02:03Z", "health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"}}]
+	cs.rsp = `{"type": "sync", "result": [{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":["missing-project"],
+	"content":[
+		{"name":"go","channel":"latest/stable","revision":"453","install-time":"2023-04-25T01:02:03Z", 
+		"health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"}}]
 	}]}`
 	prj, err := cs.cli.ListWorkshops(&client.ListOptions{ProjectId: "42ws42ws"})
 	c.Assert(err, check.IsNil)
@@ -34,6 +35,42 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 						Message:   "hello from health-check",
 						Code:      "check-waiting",
 					},
+				},
+			},
+		},
+	})
+	c.Check(cs.req.Method, check.Equals, "GET")
+}
+func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
+	cs.rsp = `{"type": "sync", "result": {"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready",
+	"content":[
+		{"name":"go",
+		"channel":"latest/stable",
+		"revision":"453",
+		"install-time":"2023-04-25T01:02:03Z", 
+		"health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"},
+		"mounts":[{"source":"/home/user/src","target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}}]
+	}]}}`
+	prj, err := cs.cli.Workshop("42ws42ws", "workshop")
+	c.Assert(err, check.IsNil)
+	c.Assert(prj, check.DeepEquals, &client.Workshop{
+		ProjectId: "42ws42ws",
+		Name:      "workshop",
+		Base:      "ubuntu@20.04",
+		Status:    "Ready",
+		Content: []*client.Sdk{
+			{
+				Name:        "go",
+				Channel:     "latest/stable",
+				Revision:    "453",
+				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+				Health: &client.HealthCheck{
+					Timestamp: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+					Message:   "hello from health-check",
+					Code:      "check-waiting",
+				},
+				Mounts: []*client.Mount{
+					{Source: "/home/user/src", Target: "/home/workshop/target", Plug: client.PlugRef{ProjectId: "42ws42ws", Workshop: "workshop", Sdk: "go", Name: "plug-name"}},
 				},
 			},
 		},

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"cmp"
 	"fmt"
+	"os/user"
+	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/canonical/workshop/client"
@@ -33,6 +37,24 @@ Notes:
 	}
 
 	return cmd
+}
+
+// The default paths created by workshop are not human friendly. Thus, the
+// client checks if that path is a lengthy default and substitutes its common
+// prefix with .../. Hence something like:
+//
+//	/home/dmitry/.local/share/workshop/project/17942561/content/albert_go_mod-cache.sdk
+//
+// becomes:
+//
+//	.../17942561/content/albert_go_mod-cache.sdk
+func shortenDefaulPath(source string) string {
+	user, _ := user.Current()
+	defaultPathPrefix := filepath.Join(user.HomeDir, ".local", "share", "workshop", "project")
+	if after, ok := strings.CutPrefix(source, defaultPathPrefix); ok {
+		return "..." + after
+	}
+	return source
 }
 
 func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
@@ -96,9 +118,10 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 
 			if len(sdk.Mounts) > 0 {
 				fmt.Fprintf(w, "    mounts:\n")
+				slices.SortFunc(sdk.Mounts, func(a, b *client.Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
 				for _, mount := range sdk.Mounts {
 					fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
-					fmt.Fprintf(w, "        host:\t%s\n", mount.Source)
+					fmt.Fprintf(w, "        host:\t%s\n", shortenDefaulPath(mount.Source))
 					fmt.Fprintf(w, "        workshop:\t%s\n", mount.Target)
 				}
 			}

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -84,14 +84,23 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	if len(workshop.Content) > 0 {
 		fmt.Fprintf(w, "content:\n")
 		for _, sdk := range workshop.Content {
-			fmt.Fprintf(w, "\t%s:\n", sdk.Name)
+			fmt.Fprintf(w, "  %s:\n", sdk.Name)
 			installTime := sdk.InstallTime.Format("2006-01-02")
 			if sdk.InstallTime.IsZero() {
 				installTime = ""
 			}
-			fmt.Fprintf(w, "\t\tchannel:\t%s\t%s\t%s\n", sdk.Channel, installTime, sdk.Revision)
+			fmt.Fprintf(w, "    channel:\t%s\t%s\t%s\n", sdk.Channel, installTime, sdk.Revision)
 			if sdk.Health != nil {
-				fmt.Fprintf(w, "\t\tmessage:\t%s\n", sdk.Health.Message)
+				fmt.Fprintf(w, "    message:\t%s\n", sdk.Health.Message)
+			}
+
+			if len(sdk.Mounts) > 0 {
+				fmt.Fprintf(w, "    mounts:\n")
+				for _, mount := range sdk.Mounts {
+					fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
+					fmt.Fprintf(w, "        host:\t%s\n", mount.Source)
+					fmt.Fprintf(w, "        workshop:\t%s\n", mount.Target)
+				}
 			}
 		}
 	}

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -99,7 +99,8 @@ content:
 var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready",
 "content":[
 	{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z",
-	"mounts":[{"source":"/home/user/src","target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}}]
+	"mounts":[{"source":"/home/user/src","target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}},
+	{"source":"/home/dmitry/.local/share/workshop/project/17942561/content/ws_go_mod-cache.sdk","target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-default"}}]
 }]}}`
 
 func (m *WorkshopInfo) TestWorkshopInfoWithSdkMounts(c *check.C) {
@@ -135,6 +136,9 @@ content:
   go:
     channel:  latest/edge  2017-03-22  1
     mounts:
+      plug-default:
+        host:      .../17942561/content/ws_go_mod-cache.sdk
+        workshop:  /home/workshop/target
       plug-name:
         host:      /home/user/src
         workshop:  /home/workshop/target

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os/user"
 
 	"gopkg.in/check.v1"
 )
@@ -100,13 +101,15 @@ var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","re
 "content":[
 	{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z",
 	"mounts":[{"source":"/home/user/src","target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}},
-	{"source":"/home/dmitry/.local/share/workshop/project/17942561/content/ws_go_mod-cache.sdk","target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-default"}}]
+	{"source":"%s/.local/share/workshop/project/17942561/content/ws_go_mod-cache.sdk","target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-default"}}]
 }]}}`
 
 func (m *WorkshopInfo) TestWorkshopInfoWithSdkMounts(c *check.C) {
 	cmd := &CmdInfo{}
 	workshop := "ws"
 	n := 0
+	user, err := user.Current()
+	c.Assert(err, check.IsNil)
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
@@ -119,13 +122,13 @@ func (m *WorkshopInfo) TestWorkshopInfoWithSdkMounts(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockWorkshopWithMounts)
+			fmt.Fprintln(w, fmt.Sprintf(mockWorkshopWithMounts, user.HomeDir))
 		default:
 			c.Errorf("expected 2 calls, now on %d", n)
 		}
 	})
 
-	err := cmd.Run(cmd.Command(), []string{workshop})
+	err = cmd.Run(cmd.Command(), []string{workshop})
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`name:     ws
 base:     ubuntu@22.04

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -53,8 +53,8 @@ project:  %s
 status:   error
 notes:    missing-file
 content:
-    go:
-        channel:  latest/edge  2017-03-22  1
+  go:
+    channel:  latest/edge  2017-03-22  1
 `, m.prjDir))
 }
 
@@ -90,8 +90,53 @@ project:  %s
 status:   pending
 notes:    workshop-note,try-later
 content:
-    go:
-        channel:  latest/edge  2017-03-22  1
-        message:  Waiting for all required modules to be installed
+  go:
+    channel:  latest/edge  2017-03-22  1
+    message:  Waiting for all required modules to be installed
+`, m.prjDir))
+}
+
+var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready",
+"content":[
+	{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z",
+	"mounts":[{"source":"/home/user/src","target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}}]
+}]}}`
+
+func (m *WorkshopInfo) TestWorkshopInfoWithSdkMounts(c *check.C) {
+	cmd := &CmdInfo{}
+	workshop := "ws"
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithMounts)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{workshop})
+	c.Assert(err, check.IsNil)
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`name:     ws
+base:     ubuntu@22.04
+project:  %s
+status:   ready
+notes:    -
+content:
+  go:
+    channel:  latest/edge  2017-03-22  1
+    mounts:
+      plug-name:
+        host:      /home/user/src
+        workshop:  /home/workshop/target
 `, m.prjDir))
 }

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -67,6 +67,7 @@ func main() {
 	rootCmd.AddCommand((&CmdExec{}).Command())
 	rootCmd.AddCommand((&CmdShellAlias{}).Command())
 	rootCmd.AddCommand((&CmdRemove{}).Command())
+	rootCmd.AddCommand((&CmdRemount{}).Command())
 
 	rootCmd.SilenceErrors = true
 

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -123,7 +123,7 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		return fmt.Errorf("%v\n%s refresh aborted", err, strutil.Quoted(av))
 	}
 
-	if c.Abort && err == nil {
+	if c.Abort {
 		fmt.Fprintf(Stdout, "%q refresh aborted\n", av[0])
 		return nil
 	}

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/canonical/workshop/client"
+	"github.com/spf13/cobra"
+)
+
+type CmdRemount struct {
+	waitMixin
+}
+
+func (c *CmdRemount) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "remount <workshop>[/<sdk>]:<plug> <SOURCE>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Mount the content interface plug's source directory to the new location.",
+		RunE:  c.Run,
+	}
+
+	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
+		false,
+		"Do not wait for the operation to finish but just print the change id")
+
+	return cmd
+}
+
+func parsePlugRef(plug string) (*client.PlugRef, error) {
+	// the expected format of the plug ref is <workshop>[/<sdk>]:<plug>
+	var plugRef client.PlugRef
+	parts := strings.Split(plug, ":")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("cannot remount: unknown plug reference %q", plug)
+	}
+
+	wssdk := strings.Split(parts[0], "/")
+	if len(wssdk) != 2 {
+		return nil, fmt.Errorf("cannot remount: unknown plug reference %q", plug)
+	}
+
+	plugRef.Workshop = wssdk[0]
+	plugRef.Sdk = wssdk[1]
+	plugRef.Name = parts[1]
+	return &plugRef, nil
+}
+
+func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
+	var err error
+
+	plugRef, err := parsePlugRef(av[0])
+	if err != nil {
+		return err
+	}
+
+	cli, err := client.New(&ClientConfig)
+	if err != nil {
+		return fmt.Errorf("cannot create client: %v", err)
+	}
+
+	c.setClient(cli)
+
+	project, err := c.client.Project(Project)
+	if err != nil {
+		return err
+	}
+
+	plugRef.ProjectId = project.Id
+
+	changeId, err := c.client.Remount(plugRef, av[1])
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.wait(changeId, false); err != nil {
+		if err == errNoWait {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/canonical/workshop/client"
@@ -54,6 +55,11 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
+	source, err := filepath.Abs(av[1])
+	if err != nil {
+		return err
+	}
+
 	cli, err := client.New(&ClientConfig)
 	if err != nil {
 		return fmt.Errorf("cannot create client: %v", err)
@@ -68,7 +74,7 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 
 	plugRef.ProjectId = project.Id
 
-	changeId, err := c.client.Remount(plugRef, av[1])
+	changeId, err := c.client.Remount(plugRef, source)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/remount_test.go
+++ b/cmd/workshop/remount_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+)
+
+type remountSuite struct {
+	BaseWorkshopSuite
+	prjDir string
+	prjId  string
+}
+
+var _ = check.Suite(&remountSuite{})
+
+func (m *remountSuite) SetUpTest(c *check.C) {
+	m.prjDir = c.MkDir()
+	m.prjId = "42424242"
+	m.BaseWorkshopSuite.SetUpTest(c)
+}
+
+func (m *remountSuite) TestRemountSuccess(c *check.C) {
+	cmd := &CmdRemount{}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws/mounts", m.prjId))
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
+			fmt.Fprintln(w, mockReadyChangeJSON)
+		default:
+			c.Errorf("expected 3 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"ws/sdk:plug", "/new/source"})
+	c.Assert(err, check.IsNil)
+}
+
+func (m *remountSuite) TestRemountBrokenReference(c *check.C) {
+	cmd := &CmdRemount{}
+	err := cmd.Run(cmd.Command(), []string{"ws:sdk:plug", "/new/source"})
+	c.Assert(err, check.ErrorMatches, `cannot remount: unknown plug reference "ws:sdk:plug"`)
+}

--- a/cmd/workshopd/workshopctl
+++ b/cmd/workshopd/workshopctl
@@ -1,1 +1,0 @@
-/home/dmitry/go/bin/workshopctl

--- a/cmd/workshopd/workshopctl
+++ b/cmd/workshopd/workshopctl
@@ -1,0 +1,1 @@
+/home/dmitry/go/bin/workshopctl

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -4,84 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
-	"time"
 
-	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
-
-type HealthCheckInfo struct {
-	Timestamp time.Time `json:"timestamp"`
-	Message   string    `json:"message,omitempty"`
-	Code      string    `json:"code,omitempty"`
-}
-
-type SdkInfo struct {
-	Name        string           `json:"name"`
-	Channel     string           `json:"channel"`
-	Revision    string           `json:"revision"`
-	InstallTime time.Time        `json:"install-time"`
-	Health      *HealthCheckInfo `json:"health-check,omitempty"`
-}
-
-type WorkshopInfo struct {
-	Name      string     `json:"name"`
-	Base      string     `json:"base"`
-	ProjectId string     `json:"project-id"`
-	Status    string     `json:"status"`
-	Content   []*SdkInfo `json:"content,omitempty"`
-	Notes     []string   `json:"notes,omitempty"`
-}
-
-var ensureStateSoon = stateEnsureBefore
-
-func workshopFileToInfo(file *workshopbackend.WorkshopFile, pid string) *WorkshopInfo {
-	var ws WorkshopInfo
-	ws.Name = file.Name
-	ws.Base = file.Base
-	ws.ProjectId = pid
-	ws.Status = healthstate.OffStatus.String()
-	for _, i := range file.Sdks {
-		ws.Content = append(ws.Content, &SdkInfo{
-			Name:    i.Name,
-			Channel: i.Channel,
-		})
-	}
-	return &ws
-}
-
-func workshopPropsToInfo(props *workshopbackend.Workshop, health healthstate.HealthState) *WorkshopInfo {
-	var info WorkshopInfo
-	info.Name = props.Name
-	info.ProjectId = props.Project().ProjectId
-	info.Base = props.Base()
-
-	for _, val := range props.Content() {
-		var healthInfo *HealthCheckInfo
-		if sdkHealth, ok := health.SdkHealth[val.Name]; ok {
-			healthInfo = &HealthCheckInfo{
-				Timestamp: sdkHealth.Timestamp,
-				Message:   sdkHealth.Message,
-				Code:      sdkHealth.Code,
-			}
-		}
-
-		info.Content = append(info.Content, &SdkInfo{
-			Name:        val.Name,
-			Channel:     val.Channel,
-			Revision:    strconv.FormatInt(val.Revision, 10),
-			InstallTime: val.InstallTime,
-			Health:      healthInfo,
-		})
-	}
-
-	if len(health.Code) > 0 {
-		info.Notes = append(info.Notes, health.Code)
-	}
-	info.Status = health.Status.String()
-	return &info
-}
 
 func v1GetProjects(c *Command, r *http.Request, _ *userState) Response {
 	st := c.d.overlord.State()

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -27,7 +27,10 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
-		return statusBadRequest("cannot %s: failed to decode data from request body: %v", err)
+		return statusBadRequest("cannot decode data from request body: %v", err)
+	}
+	if reqData.Action != "remount" {
+		return statusBadRequest("unknown action %q", reqData.Action)
 	}
 
 	return AsyncResponse(nil, "")

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -84,5 +84,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 
 	change.AddAll(taskset)
 
+	ensureStateSoon(st, 0)
+
 	return AsyncResponse(nil, change.ID())
 }

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -2,10 +2,30 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/workshopbackend"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
+
+type mountRequest struct {
+	Action string             `json:"action"`
+	Plug   interfaces.PlugRef `json:"plug"`
+	Source string             `json:"source"`
+}
+
+func newMountChange(st *state.State, user string, reqData *mountRequest) *state.Change {
+	summary := fmt.Sprintf("%s %q", cases.Title(language.BritishEnglish).String(reqData.Action), fmt.Sprintf("%s/%s:%s", reqData.Plug.Workshop, reqData.Plug.Sdk, reqData.Plug.Name))
+
+	change := st.NewChange(reqData.Action, summary)
+	change.Set("user", user)
+	change.Set("project-id", reqData.Plug.ProjectId)
+	return change
+}
 
 func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	projectId := muxVars(r)["id"]
@@ -19,12 +39,18 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("workshop name must be provided")
 	}
 
-	var reqData struct {
-		Action string             `json:"action"`
-		Plug   interfaces.PlugRef `json:"plug"`
-		Source string             `json:"source"`
+	user, ok := r.Context().Value(workshopbackend.ContextUser).(string)
+	if !ok {
+		return statusBadRequest("internal error: no user associated with the request")
 	}
 
+	st := c.d.state
+	st.Lock()
+	defer st.Unlock()
+
+	o := c.d.overlord
+
+	var reqData mountRequest
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
 		return statusBadRequest("cannot decode data from request body: %v", err)
@@ -32,6 +58,31 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	if reqData.Action != "remount" {
 		return statusBadRequest("unknown action %q", reqData.Action)
 	}
+	reqData.Plug.Workshop = workshop
+	reqData.Plug.ProjectId = projectId
 
-	return AsyncResponse(nil, "")
+	change := newMountChange(st, user, &reqData)
+	defer func() {
+		if len(change.Tasks()) == 0 {
+			change.SetStatus(state.DoneStatus)
+		}
+	}()
+
+	conn, err := o.InterfaceManager().Repository().Connected(reqData.Plug.ProjectId, reqData.Plug.Workshop, reqData.Plug.Sdk, reqData.Plug.Name)
+	if err != nil {
+		return statusBadRequest(err.Error())
+	}
+
+	if len(conn) == 0 {
+		return statusBadRequest(`"%s/%s:%s" must be connected for remount`, reqData.Plug.Workshop, reqData.Plug.Sdk, reqData.Plug.Name)
+	}
+
+	taskset, err := o.WorkshopManager().Remount(r.Context(), st, reqData.Plug, reqData.Source, projectId)
+	if err != nil {
+		return statusBadRequest(err.Error())
+	}
+
+	change.AddAll(taskset)
+
+	return AsyncResponse(nil, change.ID())
 }

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -114,7 +114,9 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 		},
 	}
 
-	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) {})
+	soon := 0
+	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) { soon++ })
+	c.Assert(soon, check.Equals, 1)
 }
 
 func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -2,24 +2,166 @@ package daemon
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
 
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/ifacetest"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshopbackend"
 	"gopkg.in/check.v1"
 )
 
-func (s *apiSuite) TestWorkshopRemount(c *check.C) {
-	// Setup
-	s.daemon(c)
-	command := apiCmd("/v1/projects/{id}/workshops/{name}/mounts")
+func mockIface(c *check.C, d *Daemon, iface interfaces.Interface) {
+	err := d.Overlord().InterfaceManager().Repository().AddInterface(iface)
+	c.Assert(err, check.IsNil)
+}
 
-	buf := bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"go","name":"cache"},"source":"/srv/data"}`)
-
-	req, err := s.createProjectsRequest("POST", fmt.Sprintf("/v1/projects/%s/workshops/%s/mounts", s.project.ProjectId, "ws"), buf)
+func (s *apiSuite) launchWorkshopWithPlug(ctx context.Context, name string, c *check.C) *workshopbackend.Workshop {
+	b := s.d.overlord.WorkshopBackend()
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
+base: ubuntu@20.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+`, name)), 0644)
+	c.Assert(err, check.IsNil)
+	err = b.LaunchWorkshop(ctx, name, "ubuntu@20.04")
+	c.Assert(err, check.IsNil)
+	ws, err := b.Workshop(ctx, name)
 	c.Assert(err, check.IsNil)
 
-	// Execute
-	rsp := v1PostWorkshopMount(command, req, nil).(*resp)
+	sdkInfo := &sdk.Info{ProjectId: s.project.ProjectId, Workshop: name, Name: "test-sdk"}
+	plug := &sdk.PlugInfo{
+		Sdk:       sdkInfo,
+		Name:      "test-plug",
+		Interface: "content",
+	}
+	slot := &sdk.SlotInfo{
+		Sdk:       sdkInfo,
+		Name:      "test-slot",
+		Interface: "content",
+	}
 
-	// Verify
-	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.AddPlug(plug), check.IsNil)
+	c.Assert(repo.AddSlot(slot), check.IsNil)
+	_, err = repo.Connect(interfaces.NewConnRef(plug, slot), nil, nil, nil, nil, nil)
+	c.Assert(err, check.IsNil)
+
+	return ws
+}
+
+func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp, ens func(st *state.State, d time.Duration)) {
+	s.vars = map[string]string{"id": s.project.ProjectId, "name": "ws"}
+	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}/mounts")
+	requests := []*http.Request{}
+
+	for _, i := range buffers {
+		req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workshops/ws/mounts", i)
+		c.Assert(err, check.IsNil)
+		requests = append(requests, req)
+	}
+
+	restoreEnsure := testutil.FakeFunc(ens, &ensureStateSoon)
+	defer restoreEnsure()
+
+	for num, req := range requests {
+		// Execute
+		rsp := v1PostWorkshopMount(projectsCmd, req, nil).(*resp)
+
+		// Verify
+		c.Check(rsp.Type, check.Equals, expected[num].Type)
+		c.Assert(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v", num))
+		if rsp.Type == ResponseTypeError {
+			c.Assert(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
+		}
+
+		if rsp.Type == ResponseTypeAsync {
+			st := s.d.state
+			st.Lock()
+			change := s.d.state.Change(rsp.Change)
+			st.Unlock()
+			c.Assert(change, check.NotNil)
+			c.Assert(change.Kind(), check.Equals, expected[num].Kind)
+			c.Assert(change.Summary(), check.Equals, expected[num].Summary)
+		}
+	}
+}
+
+func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
+	s.daemon(c)
+	mockIface(c, s.d, &ifacetest.TestInterface{InterfaceName: "content"})
+	s.launchWorkshopWithPlug(s.ctx, "ws", c)
+
+	// Setup
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":"/srv/data"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "remount",
+			Summary: `Remount "ws/test-sdk:test-plug"`,
+		},
+	}
+
+	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) {})
+}
+
+func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
+	// Setup
+	s.daemon(c)
+	mockIface(c, s.d, &ifacetest.TestInterface{InterfaceName: "content"})
+	s.launchWorkshopWithPlug(s.ctx, "ws", c)
+	_, err := s.d.overlord.InterfaceManager().Repository().DisconnectSdk(s.project.ProjectId, "ws", "test-sdk")
+	c.Check(err, check.IsNil)
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":"/srv/data"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `"ws/test-sdk:test-plug" must be connected for remount`,
+		},
+	}
+
+	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) {})
+}
+
+func (s *apiSuite) TestWorkshopRemountInvalidSetup(c *check.C) {
+	s.daemon(c)
+	s.launchWorkshop(s.ctx, "ws", c)
+
+	// Setup
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"action":"mount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":"/srv/data"}`),
+		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug","source":"/srv/data"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `unknown action "mount"`,
+		},
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot decode data from request body: unexpected EOF`,
+		},
+	}
+
+	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) {})
 }

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -25,7 +25,7 @@ type reqData struct {
 	Options actionOpts `json:"options"`
 }
 
-func newChange(st *state.State, kind string, user, projectId string, reqData *reqData) *state.Change {
+func newWorkshopChange(st *state.State, kind string, user, projectId string, reqData *reqData) *state.Change {
 	var summary string
 	switch len(reqData.Names) {
 	case 1:
@@ -111,7 +111,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 
 	switch reqData.Action {
 	case "launch":
-		change = newChange(st, "launch", user, projectId, &reqData)
+		change = newWorkshopChange(st, "launch", user, projectId, &reqData)
 		taskset, err = wsmgr.LaunchMany(r.Context(), reqData.Names, projectId, change.ID())
 	case "refresh":
 		var refreshMode conflict.RefreshMode
@@ -125,7 +125,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		}
 
 		if refreshMode == conflict.RefreshTransactional || refreshMode == conflict.RefreshWaitOnError {
-			change = newChange(st, "refresh", user, projectId, &reqData)
+			change = newWorkshopChange(st, "refresh", user, projectId, &reqData)
 			taskset, err = wsmgr.RefreshMany(r.Context(), reqData.Names, projectId, refreshMode, change.ID())
 		}
 
@@ -136,13 +136,13 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 			}
 		}
 	case "start":
-		change = newChange(st, "start", user, projectId, &reqData)
+		change = newWorkshopChange(st, "start", user, projectId, &reqData)
 		taskset, err = wsmgr.StartMany(r.Context(), reqData.Names, projectId, change.ID())
 	case "stop":
-		change = newChange(st, "stop", user, projectId, &reqData)
+		change = newWorkshopChange(st, "stop", user, projectId, &reqData)
 		taskset, err = wsmgr.StopMany(r.Context(), reqData.Names, projectId, change.ID())
 	case "remove":
-		change = newChange(st, "remove", user, projectId, &reqData)
+		change = newWorkshopChange(st, "remove", user, projectId, &reqData)
 		taskset, err = wsmgr.RemoveMany(r.Context(), reqData.Names, projectId, change.ID())
 	default:
 		return statusBadRequest("unknown action")

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -91,7 +91,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	var reqData reqData
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
-		return statusBadRequest("cannot %s: failed to decode data from request body: %v", err)
+		return statusBadRequest("cannot decode data from request body: %v", err)
 	}
 
 	if len(reqData.Names) == 0 {

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -4,9 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/conflict"
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/workshopbackend"
@@ -19,13 +23,127 @@ type actionOpts struct {
 	Mode string `json:"refresh-mode"`
 }
 
-type reqData struct {
+type workshopReq struct {
 	Names   []string   `json:"names"`
 	Action  string     `json:"action"`
 	Options actionOpts `json:"options"`
 }
 
-func newWorkshopChange(st *state.State, kind string, user, projectId string, reqData *reqData) *state.Change {
+type HealthCheckInfo struct {
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message,omitempty"`
+	Code      string    `json:"code,omitempty"`
+}
+
+type SdkInfo struct {
+	Name        string           `json:"name"`
+	Channel     string           `json:"channel"`
+	Revision    string           `json:"revision"`
+	InstallTime time.Time        `json:"install-time"`
+	Health      *HealthCheckInfo `json:"health-check,omitempty"`
+	Mounts      []*Mount         `json:"mounts,omitempty"`
+}
+
+type Mount struct {
+	Plug   interfaces.PlugRef `json:"plug"`
+	Source string             `json:"source"`
+	Target string             `json:"target"`
+}
+
+type WorkshopInfo struct {
+	Name      string     `json:"name"`
+	Base      string     `json:"base"`
+	ProjectId string     `json:"project-id"`
+	Status    string     `json:"status"`
+	Content   []*SdkInfo `json:"content,omitempty"`
+	Notes     []string   `json:"notes,omitempty"`
+}
+
+var ensureStateSoon = stateEnsureBefore
+var sdkMounts = sdkConnsToMounts
+
+func workshopFileToInfo(file *workshopbackend.WorkshopFile, pid string) *WorkshopInfo {
+	var ws WorkshopInfo
+	ws.Name = file.Name
+	ws.Base = file.Base
+	ws.ProjectId = pid
+	ws.Status = healthstate.OffStatus.String()
+	for _, i := range file.Sdks {
+		ws.Content = append(ws.Content, &SdkInfo{
+			Name:    i.Name,
+			Channel: i.Channel,
+		})
+	}
+	return &ws
+}
+
+func workshopToInfo(workshop *workshopbackend.Workshop, health healthstate.HealthState, mounts map[string][]*Mount) *WorkshopInfo {
+	var info WorkshopInfo
+	info.Name = workshop.Name
+	info.ProjectId = workshop.Project().ProjectId
+	info.Base = workshop.Base()
+
+	for _, sdk := range workshop.Content() {
+		var healthInfo *HealthCheckInfo
+		if sdkHealth, ok := health.SdkHealth[sdk.Name]; ok {
+			healthInfo = &HealthCheckInfo{
+				Timestamp: sdkHealth.Timestamp,
+				Message:   sdkHealth.Message,
+				Code:      sdkHealth.Code,
+			}
+		}
+
+		var sdkMounts []*Mount
+		if mounts != nil {
+			sdkMounts = mounts[sdk.Name]
+		}
+
+		info.Content = append(info.Content, &SdkInfo{
+			Name:        sdk.Name,
+			Channel:     sdk.Channel,
+			Revision:    strconv.FormatInt(sdk.Revision, 10),
+			InstallTime: sdk.InstallTime,
+			Health:      healthInfo,
+			Mounts:      sdkMounts,
+		})
+	}
+
+	if len(health.Code) > 0 {
+		info.Notes = append(info.Notes, health.Code)
+	}
+	info.Status = health.Status.String()
+	return &info
+}
+
+func sdkConnsToMounts(repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount {
+	connections, err := repo.Connections(projectId, workshop, sdk)
+	if err != nil {
+		return nil
+	}
+	var mounts []*Mount
+	for _, conn := range connections {
+		connection, err := repo.Connection(conn)
+		if err != nil {
+			continue
+		}
+
+		if connection.Interface() == "content" {
+			var source, target string
+			err = connection.Plug.Attr("source", &source)
+			if err != nil {
+				continue
+			}
+			err = connection.Plug.Attr("target", &target)
+			if err != nil {
+				continue
+			}
+			mounts = append(mounts, &Mount{Source: source, Target: target, Plug: conn.PlugRef})
+		}
+	}
+	return mounts
+}
+
+func newWorkshopChange(st *state.State, kind string, user, projectId string, reqData *workshopReq) *state.Change {
 	var summary string
 	switch len(reqData.Names) {
 	case 1:
@@ -64,7 +182,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 		if wstate != "all" && strings.ToLower(health.Status.String()) != wstate {
 			continue
 		}
-		info := workshopPropsToInfo(w, health)
+		info := workshopToInfo(w, health, nil)
 		infoLst = append(infoLst, info)
 	}
 
@@ -88,7 +206,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	defer st.Unlock()
 	wsmgr := c.d.overlord.WorkshopManager()
 
-	var reqData reqData
+	var reqData workshopReq
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
 		return statusBadRequest("cannot decode data from request body: %v", err)
@@ -188,5 +306,12 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return statusNotFound("%v", err)
 	}
 	health := workshopHealth(wrkmgr, workshop)
-	return SyncResponse(workshopPropsToInfo(workshop, health), http.StatusOK)
+
+	repo := c.d.overlord.InterfaceManager().Repository()
+	mounts := map[string][]*Mount{}
+	for _, sdk := range workshop.Content() {
+		mounts[sdk.Name] = sdkMounts(repo, projectId, name, sdk.Name)
+	}
+
+	return SyncResponse(workshopToInfo(workshop, health, mounts), http.StatusOK)
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
@@ -82,19 +83,27 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	workshop := s.launchWorkshop(s.ctx, "ws-test", c)
-	restore := testutil.FakeFunc(func() time.Time { return time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC) }, &workshopbackend.InstallTimeNow)
+	restoreTime := testutil.FakeFunc(func() time.Time { return time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC) }, &workshopbackend.InstallTimeNow)
 	workshop.LinkSdk(s.ctx, sdk.Setup{Name: "go", Channel: "latest/stable", Revision: 234})
 	workshop.LinkSdk(s.ctx, sdk.Setup{Name: "java", Channel: "latest/stable", Revision: 324})
-	restore()
+	restoreTime()
 
 	// Execute
-	restore = FakeWorkshopHealth(func(mgr *workshopstate.WorkshopManager, w *workshopbackend.Workshop) healthstate.HealthState {
+	restoreHealth := FakeWorkshopHealth(func(mgr *workshopstate.WorkshopManager, w *workshopbackend.Workshop) healthstate.HealthState {
 		return healthstate.HealthState{Status: healthstate.ReadyStatus, SdkHealth: map[string]healthstate.HealthCheck{
 			"go": {Sdk: "go", Message: "test health check message", Code: "check-waiting", CheckResult: healthstate.CheckWaiting},
 		}}
 	})
+	restoreMounts := FakeSdkMounts(func(repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount {
+		return []*Mount{
+			{Source: "/home/user/" + sdk, Target: "/home/workshop/" + sdk, Plug: interfaces.PlugRef{ProjectId: projectId, Workshop: workshop, Sdk: sdk, Name: "content-plug"}},
+		}
+	})
+
 	rsp := v1GetProjectWorkshop(projectsCmd, req, nil).(*resp)
-	restore()
+
+	restoreHealth()
+	restoreMounts()
 
 	// Verify
 	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
@@ -118,12 +127,16 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 					Message: "test health check message",
 					Code:    "check-waiting",
 				},
+				Mounts: []*Mount{
+					{Source: "/home/user/go", Target: "/home/workshop/go", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "go", Name: "content-plug"}}},
 			},
 			{
 				Name:        "java",
 				Channel:     "latest/stable",
 				Revision:    "324",
 				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+				Mounts: []*Mount{
+					{Source: "/home/user/java", Target: "/home/workshop/java", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "java", Name: "content-plug"}}},
 			},
 		},
 	})

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -38,7 +38,6 @@ import (
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
-	"github.com/canonical/workshop/internal/osutil/sys"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/restart"
 	"github.com/canonical/workshop/internal/overlord/standby"
@@ -51,7 +50,6 @@ var (
 	ErrRestartSocket = fmt.Errorf("daemon stop requested to wait for socket activation")
 
 	systemdSdNotify = systemd.SdNotify
-	sysGetuid       = sys.Getuid
 	LookupUserId    = user.LookupId
 )
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -47,14 +47,13 @@ import (
 // Hook up check.v1 into the "go test" runner
 
 type daemonSuite struct {
-	workshopDir     string
-	socketPath      string
-	httpAddress     string
-	statePath       string
-	authorized      bool
-	err             error
-	notified        []string
-	restoreBackends func()
+	workshopDir string
+	socketPath  string
+	httpAddress string
+	statePath   string
+	authorized  bool
+	err         error
+	notified    []string
 }
 
 var _ = check.Suite(&daemonSuite{})

--- a/internal/daemon/export_test.go
+++ b/internal/daemon/export_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
@@ -45,5 +46,13 @@ func FakeWorkshopHealth(f func(mgr *workshopstate.WorkshopManager, w *workshopba
 	workshopHealth = f
 	return func() {
 		workshopHealth = old
+	}
+}
+
+func FakeSdkMounts(f func(repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount) (restore func()) {
+	old := sdkMounts
+	sdkMounts = f
+	return func() {
+		sdkMounts = old
 	}
 }

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -70,10 +70,6 @@ func validatePath(path string) error {
 	return nil
 }
 
-func (iface *contentInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
-	return nil
-}
-
 func (iface *contentInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 	target, ok := plug.Attrs["target"].(string)
 	if !ok || len(target) == 0 {

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -96,9 +96,16 @@ func (iface *contentInterface) target(attrs interfaces.Attrer) string {
 }
 
 func (iface *contentInterface) source(user *user.User, plug *interfaces.ConnectedPlug) string {
+	var source string
+	// see if the plug's mount has been remounted to a new location
+	if err := plug.Attr("remount-source", &source); err == nil {
+		return source
+	}
+
 	// <workshop>_<sdk>_plug.sdk
 	dir := strings.Join([]string{plug.Sdk().Workshop, plug.Sdk().Name, plug.Name()}, "_") + ".sdk"
-	source := filepath.Join(user.HomeDir, ".local", "share", "workshop", "project", plug.Ref().ProjectId, "content", dir)
+	source = filepath.Join(user.HomeDir, ".local", "share", "workshop", "project", plug.Ref().ProjectId, "content", dir)
+
 	return source
 }
 
@@ -118,6 +125,10 @@ func (iface *contentInterface) MountConnectedPlug(spec *device.Specification, pl
 		return err
 	}
 	source := iface.source(user, plug)
+
+	if err = plug.SetAttr("source", source); err != nil {
+		return err
+	}
 
 	uid, gid, err := osutil.UidGid(user)
 	if err != nil {

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -95,18 +95,22 @@ func (iface *contentInterface) target(attrs interfaces.Attrer) string {
 	return ""
 }
 
-func (iface *contentInterface) source(user *user.User, plug *interfaces.ConnectedPlug) string {
+func (iface *contentInterface) source(user *user.User, plug *interfaces.ConnectedPlug) (string, error) {
 	var source string
 	// see if the plug's mount has been remounted to a new location
-	if err := plug.Attr("remount-source", &source); err == nil {
-		return source
+	if err := plug.Attr("source", &source); err == nil {
+		return source, nil
 	}
 
 	// <workshop>_<sdk>_plug.sdk
 	dir := strings.Join([]string{plug.Sdk().Workshop, plug.Sdk().Name, plug.Name()}, "_") + ".sdk"
 	source = filepath.Join(user.HomeDir, ".local", "share", "workshop", "project", plug.Ref().ProjectId, "content", dir)
 
-	return source
+	if err := plug.SetAttr("source", source); err != nil {
+		return "", err
+	}
+
+	return source, nil
 }
 
 func (iface *contentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
@@ -124,9 +128,8 @@ func (iface *contentInterface) MountConnectedPlug(spec *device.Specification, pl
 	if err != nil {
 		return err
 	}
-	source := iface.source(user, plug)
-
-	if err = plug.SetAttr("source", source); err != nil {
+	source, err := iface.source(user, plug)
+	if err != nil {
 		return err
 	}
 

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -151,6 +151,11 @@ slots:
 	expectedMnt := workshopbackend.Mount(plug.Name, sourceDir, "/project/training")
 	c.Assert(deviceSpec.DeviceEntries(), check.DeepEquals, []workshopbackend.Device{expectedMnt})
 
+	// Vaildate plug attribute
+	var src string
+	c.Assert(connectedPlug.Attr("source", &src), check.IsNil)
+	c.Assert(src, check.Equals, sourceDir)
+
 	// Validate the source directory was created correctly
 	exists, isDir, err := osutil.ExistsIsDir(sourceDir)
 	c.Assert(exists, check.Equals, true)

--- a/internal/osutil/rename.go
+++ b/internal/osutil/rename.go
@@ -1,0 +1,9 @@
+package osutil
+
+import (
+	"syscall"
+)
+
+func Rename(olddir, newdir string) error {
+	return syscall.Rename(olddir, newdir)
+}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -46,12 +46,12 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
-	sdkName, err := sdkName(task)
+	s, err := sdkName(task)
 	if err != nil {
 		return err
 	}
 
-	sdkInfo, err := inst.SdkInfo(ctx, sdkName)
+	sdkInfo, err := inst.SdkInfo(ctx, s)
 	if err != nil {
 		return err
 	}
@@ -59,13 +59,75 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	if err = policy.CheckInterfaces(sdkInfo); err != nil {
 		return err
 	}
-	return m.setupSdkConnections(task, ctx, project.ProjectId, workshop, sdkInfo)
+
+	// If auto-connect is executed during refresh, chances are, that there are
+	// SDKs that are going to be reinstalled without any changes to their
+	// content interface plugs. In this case, their 'source' directories must be
+	// set to how it was in the previous workshop instance as some of those
+	// plugs may have been remounted with `workshop remount`. To preserve that,
+	// we store the content interface connection's 'source' directories when the
+	// old workshop/SDK is removed (see the 'disconnect' task handler) and see
+	// if any of those are still relevant for the new workshop.
+	st := task.State()
+	var sdkRef = sdk.Ref{ProjectId: project.ProjectId, Workshop: workshop, Sdk: s}
+	var plugsToRemount = map[string]map[string]interface{}{}
+	st.Lock()
+	var alltasks = task.Change().Tasks()
+	st.Unlock()
+	for _, task := range alltasks {
+		// The disconnect tasks of the refresh change store pre-refresh
+		// content interface connections.
+		if task.Kind() == "disconnect" {
+			_, project, workshop, err := handlersetup.UserProjectWorkshop(task)
+			if err != nil {
+				continue
+			}
+
+			taskSdk, err := sdkName(task)
+			if err != nil {
+				continue
+			}
+			taskSdkRef := sdk.Ref{ProjectId: project.ProjectId, Workshop: workshop, Sdk: taskSdk}
+			if sdkRef.ID() == taskSdkRef.ID() {
+				st.Lock()
+				_ = task.Get("plugs-to-remount", &plugsToRemount)
+				st.Unlock()
+				break
+			}
+		}
+	}
+
+	return m.setupSdkConnections(task, ctx, sdkInfo, plugsToRemount)
 }
 
-func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Context, projectId string, workshop string, sdkInfo *sdk.Info) (err error) {
+// Returns content interface connection IDs of the SDK and their corresponding
+// plug's dynamic attributes.
+func (m *InterfaceManager) findContentPlugsAttrs(projectId, workshop, sdkname string) map[string]map[string]interface{} {
+	// [ref.ID]source
+	var candidates = map[string]map[string]interface{}{}
+
+	connRefs, err := m.repo.Connections(projectId, workshop, sdkname)
+	if err != nil {
+		return nil
+	}
+
+	for _, conRef := range connRefs {
+		connection, err := m.repo.Connection(conRef)
+		if err != nil {
+			continue
+		}
+		if connection.Interface() == "content" {
+			candidates[conRef.ID()] = connection.Plug.DynamicAttrs()
+		}
+	}
+	return candidates
+}
+
+func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Context, sdkInfo *sdk.Info, plugsToRemount map[string]map[string]interface{}) (err error) {
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
+
 	// this can be a refresh for an existing SDK, hence, reconnect the SDK's
 	// connections from scratch. Consider the following scenarios for an
 	// SDK:
@@ -77,12 +139,12 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 	// - remove the SDK from the repository (e.g. remove all its plugs and slots)
 	// - find and connect candidates for the SDK plug and slot
 	// - rebuild SDK profiles for the affected SDKs and assign them to the corresponding workshops
-	disconnected, err := m.repo.DisconnectSdk(projectId, workshop, sdkInfo.Name)
+	disconnected, err := m.repo.DisconnectSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name)
 	if err != nil {
 		return err
 	}
 
-	if err := m.repo.RemoveSdk(projectId, workshop, sdkInfo.Name); err != nil {
+	if err := m.repo.RemoveSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name); err != nil {
 		return err
 	}
 
@@ -109,7 +171,7 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 	var connected = map[sdk.Ref]*sdk.Info{}
 	var connectRefs = []*interfaces.ConnRef{}
 	for _, plug := range sdkInfo.Plugs {
-		candidates := m.repo.AutoConnectCandidateSlots(plug.Sdk.ProjectId, workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
+		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
 
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
@@ -121,9 +183,22 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 				// a normal and common condition.
 				continue
 			}
-			// no policy check passed in here as it has beeb checked when looked
+
+			// plugsToRemount can be passed in when a previously existing
+			// content interface connection (e.g. pre-refresh) needs to be
+			// recreated without changes to its 'source' attribute in the new
+			// workshop (given the new workshop also has an SDK with exactly the
+			// same plug; the target directory may change in the new workshop).
+			var plugDynamicAttrs map[string]interface{}
+			if plugsToRemount != nil {
+				if attrs, ok := plugsToRemount[connRef.ID()]; ok {
+					plugDynamicAttrs = attrs
+				}
+			}
+
+			// no policy check passed in here as it has been checked when looked
 			// up the candidates.
-			conn, err := m.repo.Connect(connRef, plug.Attrs, nil, slot.Attrs, nil, nil)
+			conn, err := m.repo.Connect(connRef, plug.Attrs, plugDynamicAttrs, slot.Attrs, nil, nil)
 			if err != nil || conn == nil {
 				return err
 			}
@@ -131,7 +206,7 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 			connected[conn.Slot.Sdk().Ref()] = conn.Slot.Sdk()
 			defer func() {
 				if err != nil {
-					if err := m.repo.Disconnect(plug.Sdk.ProjectId, workshop, plug.Sdk.Name, plug.Name, slot.Sdk.ProjectId,
+					if err := m.repo.Disconnect(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, slot.Sdk.ProjectId,
 						slot.Sdk.Workshop, slot.Sdk.Name, slot.Name); err != nil {
 						logger.Noticef("cannot disconnect failed connection: %v", err)
 					}
@@ -203,6 +278,7 @@ func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) er
 }
 
 func (m *InterfaceManager) disconnectSdk(ctx context.Context, task *state.Task, project *workshopbackend.Project, workshop string, sdkName string) error {
+	st := task.State()
 	sdkRef := sdk.Ref{ProjectId: project.ProjectId, Workshop: workshop, Sdk: sdkName}
 
 	disconnected, err := m.repo.DisconnectSdk(project.ProjectId, workshop, sdkName)
@@ -214,7 +290,6 @@ func (m *InterfaceManager) disconnectSdk(ctx context.Context, task *state.Task, 
 		return err
 	}
 
-	st := task.State()
 	st.Lock()
 	defer st.Unlock()
 
@@ -254,6 +329,15 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		return err
 	}
 
+	// Store plugs attributes for the existing content interface connections, so
+	// refresh can recover 'source' attributes for the plugs that were remount
+	// in the previous workshop instance.
+	st := task.State()
+	preRefreshPlugs := m.findContentPlugsAttrs(project.ProjectId, workshop, sdkName)
+	st.Lock()
+	task.Set("plugs-to-remount", preRefreshPlugs)
+	st.Unlock()
+
 	return m.disconnectSdk(ctx, task, project, workshop, sdkName)
 }
 
@@ -281,7 +365,7 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 		return err
 	}
 
-	return m.setupSdkConnections(task, ctx, project.ProjectId, workshop, sdkInfo)
+	return m.setupSdkConnections(task, ctx, sdkInfo, nil)
 }
 
 func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -328,6 +328,9 @@ func (m *InterfaceManager) remount(ctx context.Context, plug *interfaces.PlugRef
 	if err := connection.Plug.SetAttr("source", source); err != nil {
 		return err
 	}
+
+	// the connection exists already; this connect is required to update the
+	// plug's source attribute
 	newConnection, err := m.repo.Connect(connRef, connection.Plug.StaticAttrs(), connection.Plug.DynamicAttrs(), connection.Slot.StaticAttrs(), connection.Slot.DynamicAttrs(), nil)
 	if err != nil {
 		return err

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -379,7 +379,7 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 }
 
 func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
-	user, project, _, err := handlersetup.UserProjectWorkshop(task)
+	user, project, workshop, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
@@ -401,10 +401,15 @@ func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	return m.remount(ctx, &plug, source)
+	inst, err := m.backend.Workshop(ctx, workshop)
+	if err != nil {
+		return err
+	}
+
+	return m.remount(ctx, &plug, source, inst.IsRunning())
 }
 
-func (m *InterfaceManager) remount(ctx context.Context, plug *interfaces.PlugRef, source string) error {
+func (m *InterfaceManager) remount(ctx context.Context, plug *interfaces.PlugRef, source string, workshopRunning bool) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -450,20 +455,39 @@ func (m *InterfaceManager) remount(ctx context.Context, plug *interfaces.PlugRef
 		}
 	})
 
-	if err := osutil.Rename(oldSource, source); err != nil {
-		if errno, ok := err.(syscall.Errno); ok {
-			if errno == syscall.EXDEV {
-				return fmt.Errorf("old and new sources of the %q plug's are not on the same mounted filesystem", plug.String())
-			}
-		}
+	_, err = os.Stat(oldSource)
+	if osutil.IsDirNotExist(err) {
+		return fmt.Errorf("plug's current 'source' %q does not exist", oldSource)
+	} else if err != nil {
 		return err
 	}
 
-	revert.Add(func() {
-		if err := os.Rename(source, oldSource); err != nil {
-			logger.Debugf("cannot rename %s to %s on a failed remount", source, oldSource)
+	if err := osutil.Rename(oldSource, source); err != nil {
+		if errno, ok := err.(syscall.Errno); ok {
+			if workshopRunning {
+				if errno == syscall.ENOTEMPTY {
+					return fmt.Errorf("new source is not empty; workshop must be stopped to remount safely")
+				}
+				if errno == syscall.EXDEV {
+					return fmt.Errorf("current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely")
+				}
+			} else {
+				// if the workshop is stopped, we can perform a remount safely
+				// (other fs or non-empty dir), otherwise, return the error
+				if errno != syscall.ENOTEMPTY && errno != syscall.EXDEV {
+					return err
+				}
+			}
+		} else {
+			return err
 		}
-	})
+	} else {
+		revert.Add(func() {
+			if err := os.Rename(source, oldSource); err != nil {
+				logger.Debugf("cannot rename %s to %s on a failed remount", source, oldSource)
+			}
+		})
+	}
 
 	for _, backend := range m.repo.Backends() {
 		if err := backend.Setup(ctx, connection.Plug.Sdk(), m.repo); err != nil {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -123,7 +123,7 @@ func (m *InterfaceManager) findContentPlugsAttrs(projectId, workshop, sdkname st
 	return candidates
 }
 
-func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Context, sdkInfo *sdk.Info, plugsToRemount map[string]map[string]interface{}) (err error) {
+func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Context, sdkInfo *sdk.Info, plugsToRemount map[string]map[string]interface{}) error {
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
@@ -170,6 +170,8 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 	// At the moment, only searching for auto-connect-able slots
 	var connected = map[sdk.Ref]*sdk.Info{}
 	var connectRefs = []*interfaces.ConnRef{}
+	var revertConnections revert.Reverter
+	defer revertConnections.Fail()
 	for _, plug := range sdkInfo.Plugs {
 		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
 
@@ -204,14 +206,12 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 			}
 			connected[conn.Plug.Sdk().Ref()] = conn.Plug.Sdk()
 			connected[conn.Slot.Sdk().Ref()] = conn.Slot.Sdk()
-			defer func() {
-				if err != nil {
-					if err := m.repo.Disconnect(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, slot.Sdk.ProjectId,
-						slot.Sdk.Workshop, slot.Sdk.Name, slot.Name); err != nil {
-						logger.Noticef("cannot disconnect failed connection: %v", err)
-					}
+			revertConnections.Add(func() {
+				if err := m.repo.Disconnect(conn.Plug.Ref().ProjectId, conn.Plug.Ref().Workshop, conn.Plug.Ref().Sdk, conn.Plug.Name(),
+					conn.Slot.Ref().ProjectId, conn.Slot.Ref().Workshop, conn.Slot.Ref().Sdk, conn.Slot.Name()); err != nil {
+					logger.Noticef("cannot disconnect failed connection: %v", err)
 				}
-			}()
+			})
 
 			connectRefs = append(connectRefs, connRef)
 		}
@@ -229,11 +229,19 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 		affectedSet[s.Ref()] = s
 	}
 
+	var revertBackendSetup revert.Reverter
+	defer revertBackendSetup.Fail()
 	for _, s := range affectedSet {
 		for _, backend := range m.repo.Backends() {
 			if err = backend.Setup(ctx, s, m.repo); err != nil {
 				return err
 			}
+			// fix for the Go loop variable capture (<1.22)
+			be := backend
+			workshop, sdkName := s.Workshop, s.Name
+			revertBackendSetup.Add(func() {
+				_ = be.Remove(ctx, workshop, sdkName)
+			})
 		}
 	}
 
@@ -255,6 +263,8 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 	}
 
 	setConns(st, conns)
+	revertConnections.Success()
+	revertBackendSetup.Success()
 
 	return nil
 }

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -272,39 +272,37 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 }
 
 func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
+	user, project, _, err := handlersetup.UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := handlersetup.BackendContext(tomb, user, project)
+	defer cancel()
+
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
 
 	var plug interfaces.PlugRef
-	if err := task.Get("remount-plug", &plug); err != nil {
+	if err := task.Get("plug", &plug); err != nil {
 		return err
 	}
 
 	var source string
-	if err := task.Get("remount-source", &source); err != nil {
+	if err := task.Get("source", &source); err != nil {
 		return err
 	}
 
-	return m.remount(&plug, source)
+	return m.remount(ctx, &plug, source)
 }
 
-func (m *InterfaceManager) remount(plug *interfaces.PlugRef, source string) error {
+func (m *InterfaceManager) remount(ctx context.Context, plug *interfaces.PlugRef, source string) error {
 	revert := revert.New()
 	defer revert.Fail()
 
 	conns, err := getConns(m.state)
 	if err != nil {
-		return err
-	}
-
-	plugInfo := m.repo.Plug(plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name)
-	if plugInfo == nil {
-		return fmt.Errorf("plug %q does not exist", plug.String())
-	}
-
-	var oldSource string
-	if err := plugInfo.Attr("source", &oldSource); err != nil {
 		return err
 	}
 
@@ -315,20 +313,29 @@ func (m *InterfaceManager) remount(plug *interfaces.PlugRef, source string) erro
 	if len(plugConns) != 1 {
 		return fmt.Errorf("plug %q must have exactly one connection to be remounted", plug.String())
 	}
-	connection := plugConns[0]
-
-	slotInfo := m.repo.Slot(connection.SlotRef.ProjectId, connection.SlotRef.Workshop, connection.SlotRef.Sdk, connection.SlotRef.Name)
-	if slotInfo == nil {
-		return fmt.Errorf("slot %q does not exist", connection.SlotRef.String())
+	connRef := plugConns[0]
+	// get the connected plug-slot pair to get its existing attributes (source)
+	connection, err := m.repo.Connection(connRef)
+	if err != nil {
+		return err
 	}
 
-	conn, err := m.repo.Connect(connection, plugInfo.Attrs, map[string]interface{}{"remount-source": source}, slotInfo.Attrs, nil, nil)
+	var oldSource string
+	if err := connection.Plug.Attr("source", &oldSource); err != nil {
+		return err
+	}
+
+	if err := connection.Plug.SetAttr("source", source); err != nil {
+		return err
+	}
+	newConnection, err := m.repo.Connect(connRef, connection.Plug.StaticAttrs(), connection.Plug.DynamicAttrs(), connection.Slot.StaticAttrs(), connection.Slot.DynamicAttrs(), nil)
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() {
-		if _, err := m.repo.Connect(connection, plugInfo.Attrs, nil, slotInfo.Attrs, nil, nil); err != nil {
+		_ = connection.Plug.SetAttr("source", oldSource)
+		if _, err := m.repo.Connect(connRef, connection.Plug.StaticAttrs(), connection.Plug.DynamicAttrs(), connection.Slot.StaticAttrs(), connection.Slot.DynamicAttrs(), nil); err != nil {
 			logger.Debugf("cannot reconnect %q plug on a failed remount", plug.String())
 		}
 	})
@@ -349,17 +356,17 @@ func (m *InterfaceManager) remount(plug *interfaces.PlugRef, source string) erro
 	})
 
 	for _, backend := range m.repo.Backends() {
-		if err := backend.Setup(context.Background(), plugInfo.Sdk, m.repo); err != nil {
+		if err := backend.Setup(ctx, connection.Plug.Sdk(), m.repo); err != nil {
 			return err
 		}
 	}
 
-	conns[connection.ID()] = &schema.ConnState{
-		Interface:        conn.Interface(),
-		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
-		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
-		StaticSlotAttrs:  conn.Slot.StaticAttrs(),
-		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
+	conns[connRef.ID()] = &schema.ConnState{
+		Interface:        newConnection.Interface(),
+		StaticPlugAttrs:  newConnection.Plug.StaticAttrs(),
+		DynamicPlugAttrs: newConnection.Plug.DynamicAttrs(),
+		StaticSlotAttrs:  newConnection.Slot.StaticAttrs(),
+		DynamicSlotAttrs: newConnection.Slot.DynamicAttrs(),
 		Auto:             true,
 	}
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -106,15 +106,15 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 	}
 
 	// At the moment, only searching for auto-connect-able slots
-	var connected = make(map[sdk.Ref]*sdk.Info, 0)
+	var connected = map[sdk.Ref]*sdk.Info{}
+	var connectRefs = []*interfaces.ConnRef{}
 	for _, plug := range sdkInfo.Plugs {
 		candidates := m.repo.AutoConnectCandidateSlots(plug.Sdk.ProjectId, workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
 
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
 
-			key := connRef.ID()
-			if _, ok := conns[key]; ok {
+			if _, ok := conns[connRef.ID()]; ok {
 				// Suggested connection already exist (or has
 				// Undesired flag set) so don't clobber it.
 				// NOTE: we don't log anything here as this is
@@ -138,19 +138,12 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 				}
 			}()
 
-			conns[key] = &schema.ConnState{
-				Interface:        conn.Interface(),
-				StaticPlugAttrs:  conn.Plug.StaticAttrs(),
-				DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
-				StaticSlotAttrs:  conn.Slot.StaticAttrs(),
-				DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
-				Auto:             true,
-			}
+			connectRefs = append(connectRefs, connRef)
 		}
 	}
 
-	setConns(st, conns)
-
+	// Onces the new connections are made, reinstate those in the interface
+	// backend (e.g. regenerate a LXD profile)
 	affectedSet := make(map[sdk.Ref]*sdk.Info, len(connected)+len(disconnected))
 
 	for ref, s := range connected {
@@ -168,6 +161,26 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 			}
 		}
 	}
+
+	// setConns must be called after all the backend calls were made as those
+	// can add/set dynamic attributes
+	for _, ref := range connectRefs {
+		conn, err := m.repo.Connection(ref)
+		if err != nil {
+			return err
+		}
+		conns[ref.ID()] = &schema.ConnState{
+			Interface:        conn.Interface(),
+			StaticPlugAttrs:  conn.Plug.StaticAttrs(),
+			DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
+			StaticSlotAttrs:  conn.Slot.StaticAttrs(),
+			DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
+			Auto:             true,
+		}
+	}
+
+	setConns(st, conns)
+
 	return nil
 }
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -3,15 +3,19 @@ package ifacestate
 import (
 	"context"
 	"fmt"
+	"os"
+	"syscall"
 
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/policy"
 	"github.com/canonical/workshop/internal/logger"
-	. "github.com/canonical/workshop/internal/overlord/handlersetup"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/ifacestate/schema"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
@@ -29,12 +33,12 @@ func sdkName(task *state.Task) (string, error) {
 }
 
 func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err error) {
-	user, project, workshop, err := UserProjectWorkshop(task)
+	user, project, workshop, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := BackendContext(tomb, user, project)
+	ctx, cancel := handlersetup.BackendContext(tomb, user, project)
 	defer cancel()
 
 	inst, err := m.backend.Workshop(ctx, workshop)
@@ -129,7 +133,7 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 				if err != nil {
 					if err := m.repo.Disconnect(plug.Sdk.ProjectId, workshop, plug.Sdk.Name, plug.Name, slot.Sdk.ProjectId,
 						slot.Sdk.Workshop, slot.Sdk.Name, slot.Name); err != nil {
-						logger.Noticef("cannot undo failed connection: %v", err)
+						logger.Noticef("cannot disconnect failed connection: %v", err)
 					}
 				}
 			}()
@@ -168,12 +172,12 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 }
 
 func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) error {
-	user, project, workshop, err := UserProjectWorkshop(task)
+	user, project, workshop, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := BackendContext(tomb, user, project)
+	ctx, cancel := handlersetup.BackendContext(tomb, user, project)
 	defer cancel()
 
 	sdkName, err := sdkName(task)
@@ -224,12 +228,12 @@ func (m *InterfaceManager) disconnectSdk(ctx context.Context, task *state.Task, 
 }
 
 func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {
-	user, project, workshop, err := UserProjectWorkshop(task)
+	user, project, workshop, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := BackendContext(tomb, user, project)
+	ctx, cancel := handlersetup.BackendContext(tomb, user, project)
 	defer cancel()
 
 	sdkName, err := sdkName(task)
@@ -241,12 +245,12 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 }
 
 func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {
-	user, project, workshop, err := UserProjectWorkshop(task)
+	user, project, workshop, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := BackendContext(tomb, user, project)
+	ctx, cancel := handlersetup.BackendContext(tomb, user, project)
 	defer cancel()
 
 	sdkName, err := sdkName(task)
@@ -267,10 +271,41 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 	return m.setupSdkConnections(task, ctx, project.ProjectId, workshop, sdkInfo)
 }
 
-func (m *InterfaceManager) doRemount(plug interfaces.PlugRef, source string) error {
+func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var plug interfaces.PlugRef
+	if err := task.Get("remount-plug", &plug); err != nil {
+		return err
+	}
+
+	var source string
+	if err := task.Get("remount-source", &source); err != nil {
+		return err
+	}
+
+	return m.remount(&plug, source)
+}
+
+func (m *InterfaceManager) remount(plug *interfaces.PlugRef, source string) error {
+	revert := revert.New()
+	defer revert.Fail()
+
+	conns, err := getConns(m.state)
+	if err != nil {
+		return err
+	}
+
 	plugInfo := m.repo.Plug(plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name)
 	if plugInfo == nil {
 		return fmt.Errorf("plug %q does not exist", plug.String())
+	}
+
+	var oldSource string
+	if err := plugInfo.Attr("source", &oldSource); err != nil {
+		return err
 	}
 
 	plugConns, err := m.repo.Connected(plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name)
@@ -287,12 +322,49 @@ func (m *InterfaceManager) doRemount(plug interfaces.PlugRef, source string) err
 		return fmt.Errorf("slot %q does not exist", connection.SlotRef.String())
 	}
 
-	if err = m.repo.Disconnect(plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name, connection.SlotRef.ProjectId, connection.SlotRef.Workshop, connection.SlotRef.Sdk, connection.SlotRef.Name); err != nil {
+	conn, err := m.repo.Connect(connection, plugInfo.Attrs, map[string]interface{}{"remount-source": source}, slotInfo.Attrs, nil, nil)
+	if err != nil {
 		return err
 	}
 
-	if _, err := m.repo.Connect(connection, plugInfo.Attrs, map[string]interface{}{"source": source}, slotInfo.Attrs, nil, nil); err != nil {
+	revert.Add(func() {
+		if _, err := m.repo.Connect(connection, plugInfo.Attrs, nil, slotInfo.Attrs, nil, nil); err != nil {
+			logger.Debugf("cannot reconnect %q plug on a failed remount", plug.String())
+		}
+	})
+
+	if err := osutil.Rename(oldSource, source); err != nil {
+		if errno, ok := err.(syscall.Errno); ok {
+			if errno == syscall.EXDEV {
+				return fmt.Errorf("old and new sources of the %q plug's are not on the same mounted filesystem", plug.String())
+			}
+		}
 		return err
 	}
+
+	revert.Add(func() {
+		if err := os.Rename(source, oldSource); err != nil {
+			logger.Debugf("cannot rename %s to %s on a failed remount", source, oldSource)
+		}
+	})
+
+	for _, backend := range m.repo.Backends() {
+		if err := backend.Setup(context.Background(), plugInfo.Sdk, m.repo); err != nil {
+			return err
+		}
+	}
+
+	conns[connection.ID()] = &schema.ConnState{
+		Interface:        conn.Interface(),
+		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
+		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
+		StaticSlotAttrs:  conn.Slot.StaticAttrs(),
+		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
+		Auto:             true,
+	}
+
+	setConns(m.state, conns)
+
+	revert.Success()
 	return nil
 }

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -710,7 +710,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	c.Assert(conns, check.HasLen, 1)
 }
 
-func (s *interfaceHandlersSuite) TestRemountRenameFails(c *check.C) {
+func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *check.C) {
 	// Setup
 	oldSource := c.MkDir()
 	newSource := c.MkDir()
@@ -737,7 +737,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameFails(c *check.C) {
 	// Validate
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Check(change.Err(), check.ErrorMatches, "(?s).*\\(directory not empty\\)")
+	c.Check(change.Err(), check.ErrorMatches, "(?s).*\\(new source is not empty; workshop must be stopped to remount safely\\)")
 	c.Assert(change.Status(), check.Equals, state.ErrorStatus)
 
 	repo := s.mgr.Repository()
@@ -755,6 +755,58 @@ func (s *interfaceHandlersSuite) TestRemountRenameFails(c *check.C) {
 	c.Assert(osutil.FileExists(newSource), check.Equals, true)
 	// 2 calls for the autoconnect, no calls for the remount
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+}
+
+func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *check.C) {
+	// Setup
+	oldSource := c.MkDir()
+	newSource := c.MkDir()
+	_, err := os.Create(filepath.Join(newSource, "tempfile"))
+	c.Check(err, check.IsNil)
+	s.launchRemountWorkshop(c)
+
+	// the remount will be performed if the workshop is not running
+	err = s.wsbackend.StopWorkshop(s.ctx, "ws-consumer", true)
+	c.Check(err, check.IsNil)
+
+	change := s.newRemountChange(newSource)
+
+	var setup sync.Once
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		// Set the plug's source attribute to emulate an existing connection as
+		// the remount handler expects that a plug IS connected and HAS a
+		// "source" attribute
+		setup.Do(func() {
+			s.setupPlugConnectionAttribute(c, repo, oldSource)
+		})
+		return nil
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
+
+	// Execute
+	s.o.Settle(5 * time.Second)
+
+	// Validate
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(change.Err(), check.IsNil)
+	c.Assert(change.Status(), check.Equals, state.DoneStatus)
+
+	repo := s.mgr.Repository()
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	connection, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	var src string
+	c.Assert(connection.Plug.Attr("source", &src), check.IsNil)
+	c.Assert(src, check.Equals, newSource)
+
+	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
+	c.Assert(osutil.FileExists(newSource), check.Equals, true)
+	// 2 calls for the autoconnect, 1 call for the remount
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
 }
 
 func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.C) {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -48,6 +48,21 @@ plugs:
     interface: mock-network
     attribute: one
 `
+
+var consumerManyPlugs = `name: consumer
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: mock-network
+    attribute: one
+  plug2:
+    interface: mock-network
+    attribute: two
+  plug3:
+    interface: mock-network
+    attribute: three
+`
+
 var csetup = sdk.Setup{Name: "consumer", Channel: "latest/stable"}
 
 var consumerNoPlugs = `name: consumer
@@ -155,6 +170,89 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	// ensure that backend profiles were set for both SDKs
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectBackendEnsureDisconnectsIfBackendSetupFails(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a candidate SDK/slot
+	repo := s.mgr.Repository()
+	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+
+	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerManyPlugs})
+
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		return errors.New("cannot finish backend setup")
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
+
+	// Execute
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("auto-connect", "...")
+	t1.Set("sdk", "consumer")
+	setWorkshopProject("ws-consumer", s.prj, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	s.state.Unlock()
+
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.NotNil)
+
+	// Validate
+	for _, plug := range []string{"plug", "plug2", "plug3"} {
+		ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", plug)
+		c.Assert(ref, check.HasLen, 0)
+		c.Assert(err, check.IsNil)
+	}
+
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Assert(ref, check.HasLen, 0)
+	c.Assert(err, check.IsNil)
+
+	var conns map[string]interface{}
+	s.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectUndoAllBackendSetupsIfEitherFailed(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a candidate SDK/slot
+	repo := s.mgr.Repository()
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		if len(s.secBackend.SetupCalls) <= 1 {
+			return nil
+		}
+		return errors.New("cannot finish backend setup")
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
+
+	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+
+	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerManyPlugs})
+
+	// Execute
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("auto-connect", "...")
+	t1.Set("sdk", "consumer")
+	setWorkshopProject("ws-consumer", s.prj, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	s.state.Unlock()
+
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.NotNil)
+
+	// Validate
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectNoConnections(c *check.C) {
@@ -360,7 +458,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectReconnectsExistingConnections(c 
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestDoAutoconnectFailInstallPolicyCheck(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoconnectFailInstallPolicyCheck(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -489,6 +587,7 @@ plugs:
         target: /home/workshop
 `
 	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
+	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer", csetup)), check.IsNil)
 }
 
 func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C) {
@@ -553,7 +652,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	c.Assert(conns, check.HasLen, 1)
 }
 
-func (s *interfaceHandlersSuite) TestRemountSuccessDestDoesNotExist(c *check.C) {
+func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *check.C) {
 	// Setup
 	oldSource := c.MkDir()
 	newSource := filepath.Join(c.MkDir(), "new")
@@ -707,4 +806,58 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(osutil.FileExists(newSource), check.Equals, false)
 	// 2 calls for the autoconnect, no calls for the remount
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
+}
+
+func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a connected content plug
+	repo := s.mgr.Repository()
+	s.launchRemountWorkshop(c)
+
+	connRefKey := "42424242:ws-consumer:consumer:plug core:core:core:content"
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		connRefKey: map[string]interface{}{
+			"interface":    "content",
+			"auto":         true,
+			"plug-static":  map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
+		},
+	})
+	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
+	c.Assert(err, check.IsNil)
+	s.state.Unlock()
+
+	// Execute
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("disconnect", "...")
+	t1.Set("sdk", "consumer")
+	setWorkshopProject("ws-consumer", s.prj, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	s.state.Unlock()
+
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+
+	var stateConns map[string]interface{}
+	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
+	c.Assert(stateConns, check.HasLen, 0)
+
+	var attrs map[string]interface{}
+	c.Assert(t1.Get("plugs-to-remount", &attrs), check.IsNil)
+	c.Assert(attrs, check.HasLen, 1)
+	c.Assert(attrs[connRefKey], check.DeepEquals, map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"})
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -1,14 +1,20 @@
 package ifacestate_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
@@ -372,4 +378,188 @@ slots:
 
 	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Assert(t1.Log()[0], check.Matches, ".*installation not allowed.*")
+}
+
+func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Change {
+	s.state.Lock()
+	t1 := s.state.NewTask("auto-connect", "test")
+	t1.Set("sdk", "consumer")
+	t2 := s.state.NewTask("remount", "remount")
+	t2.Set("remount-source", newSource)
+	t2.Set("remount-plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
+	t2.WaitFor(t1)
+	setWorkshopProject("ws-consumer", s.prj, t1, t2)
+
+	// Prevent undoing if the remount fails, so we don't have plugs disconnected
+	// as we want to test remount in isolation, as if it was a single change.
+	connLane := s.state.NewLane()
+	t1.JoinLane(connLane)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	s.state.Unlock()
+	return chg
+}
+
+func (s *interfaceHandlersSuite) launchRemountWorkshop(c *check.C, oldSource string) {
+	// Note: we set the source attribute for the plug in these tests, however,
+	// it is a dynamic attribute that will be defined when we install an SDK
+	// into a workshop as the default path depends on the username
+	var sdkYaml = fmt.Sprintf(`
+name: consumer
+base: ubuntu@22.04
+plugs:
+    plug:
+        interface: content
+        target: /home/workshop
+        source: %s
+`, oldSource)
+	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
+}
+
+func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C) {
+	// Setup
+	oldSource := c.MkDir()
+	newSource := c.MkDir()
+	_, err := os.Create(filepath.Join(oldSource, "tempfile"))
+	c.Check(err, check.IsNil)
+
+	s.launchRemountWorkshop(c, oldSource)
+	change := s.newRemountChange(newSource)
+
+	// Execute
+	s.o.Settle(5 * time.Second)
+
+	// Validate
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(change.Err(), check.IsNil)
+	c.Assert(change.Status(), check.Equals, state.DoneStatus)
+
+	repo := s.mgr.Repository()
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	connection, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	var remountSource string
+	c.Assert(connection.Plug.Attr("remount-source", &remountSource), check.IsNil)
+	c.Assert(remountSource, check.Equals, remountSource)
+
+	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
+	// 2 calls for the autoconnect, one call for the remount
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+1)
+	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Name, check.Equals, "consumer")
+	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Workshop, check.Equals, "ws-consumer")
+}
+
+func (s *interfaceHandlersSuite) TestRemountSuccessDestDoesNotExist(c *check.C) {
+	// Setup
+	oldSource := c.MkDir()
+	newSource := filepath.Join(c.MkDir(), "new")
+	s.launchRemountWorkshop(c, oldSource)
+	change := s.newRemountChange(newSource)
+
+	// Execute
+	s.o.Settle(5 * time.Second)
+
+	// Validate
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(change.Err(), check.IsNil)
+	c.Assert(change.Status(), check.Equals, state.DoneStatus)
+
+	repo := s.mgr.Repository()
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	connection, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	var remountSource string
+	c.Assert(connection.Plug.Attr("remount-source", &remountSource), check.IsNil)
+	c.Assert(remountSource, check.Equals, remountSource)
+
+	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
+	// 2 calls for the autoconnect, one call for the remount
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+1)
+	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Name, check.Equals, "consumer")
+	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Workshop, check.Equals, "ws-consumer")
+}
+
+func (s *interfaceHandlersSuite) TestRemountRenameFails(c *check.C) {
+	// Setup
+	oldSource := c.MkDir()
+	newSource := c.MkDir()
+	_, err := os.Create(filepath.Join(newSource, "tempfile"))
+	c.Check(err, check.IsNil)
+	s.launchRemountWorkshop(c, oldSource)
+	change := s.newRemountChange(newSource)
+
+	// Execute
+	s.o.Settle(5 * time.Second)
+
+	// Validate
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(change.Err(), check.ErrorMatches, "(?s).*\\(directory not empty\\)")
+	c.Assert(change.Status(), check.Equals, state.ErrorStatus)
+
+	repo := s.mgr.Repository()
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	connection, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	c.Assert(connection.Plug.Attr("remount-source", string("")), testutil.ErrorIs, sdk.AttributeNotFoundError{})
+
+	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
+	c.Assert(osutil.FileExists(newSource), check.Equals, true)
+	// 2 calls for the autoconnect, no calls for the remount
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+}
+
+func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.C) {
+	// Setup
+	oldSource := c.MkDir()
+	newSource := c.MkDir()
+	s.launchRemountWorkshop(c, oldSource)
+	change := s.newRemountChange(newSource)
+
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		// Emulate the case when remount could not update the LXD profile for
+		// the SDK (the first two calls come from the auto-connect task)
+		if len(s.secBackend.SetupCalls) == 3 {
+			return errors.New("cannot setup LXD profile")
+		}
+		return nil
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
+
+	// Execute
+	s.o.Settle(5 * time.Second)
+
+	// Validate
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(change.Err(), check.ErrorMatches, "(?s).*\\(cannot setup LXD profile\\)")
+	c.Assert(change.Status(), check.Equals, state.ErrorStatus)
+
+	repo := s.mgr.Repository()
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	connection, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	c.Assert(connection.Plug.Attr("remount-source", string("")), testutil.ErrorIs, sdk.AttributeNotFoundError{})
+
+	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
+	c.Assert(osutil.FileExists(newSource), check.Equals, false)
+	// 2 calls for the autoconnect, no calls for the remount
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
 }

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -210,7 +210,6 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
 	t1 := s.state.NewTask("auto-connect", "...")
 	t1.Set("sdk", "consumer")
 	t2 := s.state.NewTask("error-trigger", "...")
-
 	setWorkshopProject("ws", s.prj, t1)
 	setWorkshopProject("ws", s.prj, t2)
 	chg.Set("user", "testuser")
@@ -372,7 +371,6 @@ slots:
   slot:
     interface: content
 `
-
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: sdkYaml})
 
 	t1 := s.state.NewTask("auto-connect", "test")
@@ -390,6 +388,58 @@ slots:
 
 	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Assert(t1.Log()[0], check.Matches, ".*installation not allowed.*")
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugs(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a candidate SDK/slot
+	repo := s.mgr.Repository()
+	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+
+	// Launch another workshop with a candidate plug
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
+
+	// Execute
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t := s.state.NewTask("disconnect", "...")
+	// see doAutoConnect and doDisconnect handlers for details
+	t.Set("plugs-to-remount", map[string]map[string]interface{}{
+		"42424242:ws:consumer:plug 42424242:ws-producer:producer:slot": {"source": "/old/source"},
+	})
+	t.Set("sdk", "consumer")
+	t.SetStatus(state.DoneStatus)
+	t1 := s.state.NewTask("auto-connect", "...")
+	t1.Set("sdk", "consumer")
+	setWorkshopProject("ws", s.prj, t, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t)
+	chg.AddTask(t1)
+	s.state.Unlock()
+
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	var conns map[string]interface{}
+	s.state.Get("conns", &conns)
+	c.Assert(conns, check.DeepEquals, map[string]interface{}{
+		"42424242:ws:consumer:plug 42424242:ws-producer:producer:slot": map[string]interface{}{
+			"interface":    "mock-network",
+			"auto":         true,
+			"plug-static":  map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"source": "/old/source"},
+		},
+	})
+
+	// ensure that backend profiles were set for both SDKs
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
 func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Change {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
+	"github.com/canonical/workshop/internal/overlord/ifacestate/schema"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshopbackend"
@@ -476,6 +477,19 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+1)
 	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Name, check.Equals, "consumer")
 	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Workshop, check.Equals, "ws-consumer")
+
+	// ensure the global conns state was updated correctly
+	conns, err := ifacestate.GetConns(s.state)
+	c.Assert(err, check.IsNil)
+	c.Assert(conns[ref[0].ID()], check.DeepEquals, &schema.ConnState{
+		Auto:             true,
+		Interface:        "content",
+		Undesired:        false,
+		StaticPlugAttrs:  map[string]interface{}{"target": "/home/workshop"},
+		DynamicPlugAttrs: map[string]interface{}{"source": newSource},
+		StaticSlotAttrs:  map[string]interface{}{},
+		DynamicSlotAttrs: map[string]interface{}{}})
+	c.Assert(conns, check.HasLen, 1)
 }
 
 func (s *interfaceHandlersSuite) TestRemountSuccessDestDoesNotExist(c *check.C) {
@@ -521,6 +535,19 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestDoesNotExist(c *check.C) 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+1)
 	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Name, check.Equals, "consumer")
 	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Workshop, check.Equals, "ws-consumer")
+
+	// ensure the global conns state was updated correctly
+	conns, err := ifacestate.GetConns(s.state)
+	c.Assert(err, check.IsNil)
+	c.Assert(conns[ref[0].ID()], check.DeepEquals, &schema.ConnState{
+		Auto:             true,
+		Interface:        "content",
+		Undesired:        false,
+		StaticPlugAttrs:  map[string]interface{}{"target": "/home/workshop"},
+		DynamicPlugAttrs: map[string]interface{}{"source": newSource},
+		StaticSlotAttrs:  map[string]interface{}{},
+		DynamicSlotAttrs: map[string]interface{}{}})
+	c.Assert(conns, check.HasLen, 1)
 }
 
 func (s *interfaceHandlersSuite) TestRemountRenameFails(c *check.C) {
@@ -558,8 +585,11 @@ func (s *interfaceHandlersSuite) TestRemountRenameFails(c *check.C) {
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
-	_, err = repo.Connection(ref[0])
+	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
+	var src string
+	c.Assert(connection.Plug.Attr("source", &src), check.IsNil)
+	c.Assert(src, check.Equals, oldSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
 	c.Assert(osutil.FileExists(newSource), check.Equals, true)
@@ -605,8 +635,12 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
-	_, err = repo.Connection(ref[0])
+	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
+	c.Assert(err, check.IsNil)
+	var src string
+	c.Assert(connection.Plug.Attr("source", &src), check.IsNil)
+	c.Assert(src, check.Equals, oldSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
 	c.Assert(osutil.FileExists(newSource), check.Equals, false)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -105,6 +105,16 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
 
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		connections, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+		c.Assert(err, check.IsNil)
+		connection, err := repo.Connection(connections[0])
+		c.Assert(err, check.IsNil)
+		c.Assert(connection.Plug.SetAttr("test-dynamic-attr", "new-dynamic-value"), check.IsNil)
+		return nil
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
+
 	// Execute
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
@@ -135,9 +145,10 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.DeepEquals, map[string]interface{}{
 		"42424242:ws:consumer:plug 42424242:ws-producer:producer:slot": map[string]interface{}{
-			"interface":   "mock-network",
-			"auto":        true,
-			"plug-static": map[string]interface{}{"attribute": "one"},
+			"interface":    "mock-network",
+			"auto":         true,
+			"plug-static":  map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
 		},
 	})
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -3,9 +3,9 @@ package ifacestate_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
@@ -25,6 +24,7 @@ type interfaceHandlersSuite struct {
 	mgr                      *ifacestate.InterfaceManager
 	restoreInterface         func()
 	restoreSecurtityBackends func()
+	setup                    sync.Once
 }
 
 var _ = check.Suite(&interfaceHandlersSuite{})
@@ -385,8 +385,8 @@ func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Chang
 	t1 := s.state.NewTask("auto-connect", "test")
 	t1.Set("sdk", "consumer")
 	t2 := s.state.NewTask("remount", "remount")
-	t2.Set("remount-source", newSource)
-	t2.Set("remount-plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
+	t2.Set("source", newSource)
+	t2.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
 	t2.WaitFor(t1)
 	setWorkshopProject("ws-consumer", s.prj, t1, t2)
 
@@ -403,19 +403,29 @@ func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Chang
 	return chg
 }
 
-func (s *interfaceHandlersSuite) launchRemountWorkshop(c *check.C, oldSource string) {
+func (s *interfaceHandlersSuite) setupPlugConnectionAttribute(c *check.C, repo *interfaces.Repository, oldSource string) {
+	connections, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(err, check.IsNil)
+	c.Assert(connections, check.HasLen, 1)
+
+	connRef := connections[0]
+	connection, err := repo.Connection(connRef)
+	c.Assert(err, check.IsNil)
+	c.Assert(connection.Plug.SetAttr("source", oldSource), check.IsNil)
+}
+
+func (s *interfaceHandlersSuite) launchRemountWorkshop(c *check.C) {
 	// Note: we set the source attribute for the plug in these tests, however,
 	// it is a dynamic attribute that will be defined when we install an SDK
 	// into a workshop as the default path depends on the username
-	var sdkYaml = fmt.Sprintf(`
+	var sdkYaml = `
 name: consumer
 base: ubuntu@22.04
 plugs:
     plug:
         interface: content
         target: /home/workshop
-        source: %s
-`, oldSource)
+`
 	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
 }
 
@@ -426,8 +436,20 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	_, err := os.Create(filepath.Join(oldSource, "tempfile"))
 	c.Check(err, check.IsNil)
 
-	s.launchRemountWorkshop(c, oldSource)
+	s.launchRemountWorkshop(c)
 	change := s.newRemountChange(newSource)
+
+	var setup sync.Once
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		// Set the plug's source attribute to emulate an existing connection as
+		// the remount handler expects that a plug IS connected and HAS a
+		// "source" attribute
+		setup.Do(func() {
+			s.setupPlugConnectionAttribute(c, repo, oldSource)
+		})
+		return nil
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
 	s.o.Settle(5 * time.Second)
@@ -446,8 +468,8 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
 	var remountSource string
-	c.Assert(connection.Plug.Attr("remount-source", &remountSource), check.IsNil)
-	c.Assert(remountSource, check.Equals, remountSource)
+	c.Assert(connection.Plug.Attr("source", &remountSource), check.IsNil)
+	c.Assert(remountSource, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
 	// 2 calls for the autoconnect, one call for the remount
@@ -460,8 +482,19 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestDoesNotExist(c *check.C) 
 	// Setup
 	oldSource := c.MkDir()
 	newSource := filepath.Join(c.MkDir(), "new")
-	s.launchRemountWorkshop(c, oldSource)
+	s.launchRemountWorkshop(c)
 	change := s.newRemountChange(newSource)
+
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		// Set the plug's source attribute to emulate an existing connection as
+		// the remount handler expects that a plug IS connected and HAS a
+		// "source" attribute
+		s.setup.Do(func() {
+			s.setupPlugConnectionAttribute(c, repo, oldSource)
+		})
+		return nil
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
 	s.o.Settle(5 * time.Second)
@@ -480,8 +513,8 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestDoesNotExist(c *check.C) 
 	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
 	var remountSource string
-	c.Assert(connection.Plug.Attr("remount-source", &remountSource), check.IsNil)
-	c.Assert(remountSource, check.Equals, remountSource)
+	c.Assert(connection.Plug.Attr("source", &remountSource), check.IsNil)
+	c.Assert(remountSource, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
 	// 2 calls for the autoconnect, one call for the remount
@@ -496,8 +529,20 @@ func (s *interfaceHandlersSuite) TestRemountRenameFails(c *check.C) {
 	newSource := c.MkDir()
 	_, err := os.Create(filepath.Join(newSource, "tempfile"))
 	c.Check(err, check.IsNil)
-	s.launchRemountWorkshop(c, oldSource)
+	s.launchRemountWorkshop(c)
 	change := s.newRemountChange(newSource)
+
+	var setup sync.Once
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		// Set the plug's source attribute to emulate an existing connection as
+		// the remount handler expects that a plug IS connected and HAS a
+		// "source" attribute
+		setup.Do(func() {
+			s.setupPlugConnectionAttribute(c, repo, oldSource)
+		})
+		return nil
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
 	s.o.Settle(5 * time.Second)
@@ -513,9 +558,8 @@ func (s *interfaceHandlersSuite) TestRemountRenameFails(c *check.C) {
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
-	connection, err := repo.Connection(ref[0])
+	_, err = repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
-	c.Assert(connection.Plug.Attr("remount-source", string("")), testutil.ErrorIs, sdk.AttributeNotFoundError{})
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
 	c.Assert(osutil.FileExists(newSource), check.Equals, true)
@@ -527,10 +571,17 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	// Setup
 	oldSource := c.MkDir()
 	newSource := c.MkDir()
-	s.launchRemountWorkshop(c, oldSource)
+	s.launchRemountWorkshop(c)
 	change := s.newRemountChange(newSource)
 
+	var setup sync.Once
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo *sdk.Info, repo *interfaces.Repository) error {
+		// Set the plug's source attribute to emulate an existing connection as
+		// the remount handler expects that a plug IS connected and HAS a
+		// "source" attribute
+		setup.Do(func() {
+			s.setupPlugConnectionAttribute(c, repo, oldSource)
+		})
 		// Emulate the case when remount could not update the LXD profile for
 		// the SDK (the first two calls come from the auto-connect task)
 		if len(s.secBackend.SetupCalls) == 3 {
@@ -554,9 +605,8 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
-	connection, err := repo.Connection(ref[0])
+	_, err = repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
-	c.Assert(connection.Plug.Attr("remount-source", string("")), testutil.ErrorIs, sdk.AttributeNotFoundError{})
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
 	c.Assert(osutil.FileExists(newSource), check.Equals, false)

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -32,6 +32,11 @@ func New(s *state.State, r *state.TaskRunner, be workshopbackend.WorkshopBackend
 
 	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), m.undoAutoConnect)
 	r.AddHandler("disconnect", OnDo(m.doDisconnect), m.undoDisconnect)
+	// TODO: there is no use for the undo logic as remount is a single task
+	// change that will either finish successfully or fail (in which case it
+	// would revert all the partial progress). Shall remount be used as part of
+	// a larger change the undo logic must be implemented.
+	r.AddHandler("remount", m.doRemount, nil)
 
 	return m
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -598,9 +598,11 @@ func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug int
 		return nil, err
 	}
 
-	remount := st.NewTask("remount", fmt.Sprintf("Remount %q:%q to %q", plug.Sdk, plug.Name, source))
+	remount := st.NewTask("remount", fmt.Sprintf(`Remount "%s/%s:%s" to %q`, plug.Workshop, plug.Sdk, plug.Name, source))
 	remount.Set("workshop", plug.Workshop)
 	remount.Set("project", project)
+	remount.Set("plug", plug)
+	remount.Set("source", source)
 
 	return state.NewTaskSet(remount), nil
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
@@ -575,9 +576,31 @@ func remove(st *state.State, workshop *workshopbackend.Workshop, project *worksh
 	removeSet.AddAll(disconnectSet)
 	removeSet.AddTask(remove)
 
-	for _, i := range removeSet.Tasks() {
-		i.Set("workshop", workshop.Name)
-		i.Set("project", project)
+	for _, task := range removeSet.Tasks() {
+		task.Set("workshop", workshop.Name)
+		task.Set("project", project)
 	}
 	return removeSet, nil
+}
+
+func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug interfaces.PlugRef, source string, projectId string) (*state.TaskSet, error) {
+	err := w.CheckStatus(
+		ctx,
+		[]string{plug.Workshop},
+		projectId,
+		[]healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus})
+	if err != nil {
+		return nil, fmt.Errorf("cannot remount: %w", err)
+	}
+
+	project, err := w.loadProject(ctx, projectId)
+	if err != nil {
+		return nil, err
+	}
+
+	remount := st.NewTask("remount", fmt.Sprintf("Remount %q:%q to %q", plug.Sdk, plug.Name, source))
+	remount.Set("workshop", plug.Workshop)
+	remount.Set("project", project)
+
+	return state.NewTaskSet(remount), nil
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -584,6 +585,12 @@ func remove(st *state.State, workshop *workshopbackend.Workshop, project *worksh
 }
 
 func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug interfaces.PlugRef, source string, projectId string) (*state.TaskSet, error) {
+	if !filepath.IsAbs(source) {
+		return nil, fmt.Errorf("cannot remount: the `source` path must be absolute")
+	}
+
+	source = filepath.Clean(source)
+
 	err := w.CheckStatus(
 		ctx,
 		[]string{plug.Workshop},

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -229,14 +229,14 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 	return taskset, nil
 }
 
-func refreshMany(st *state.State, w []*workshopbackend.WorkshopFile, content [][]sdk.Setup,
+func refreshMany(st *state.State, files []*workshopbackend.WorkshopFile, content [][]sdk.Setup,
 	project *workshopbackend.Project) ([]*state.TaskSet, error) {
-	taskset := make([]*state.TaskSet, 0, len(w))
+	taskset := make([]*state.TaskSet, 0, len(files))
 
-	for i, w := range w {
-		tasks, err := refresh(st, w, content[i], project)
+	for i, file := range files {
+		tasks, err := refresh(st, file, content[i], project)
 		if err != nil {
-			return nil, fmt.Errorf("cannot refresh \"%s\" workshop: %w", w, err)
+			return nil, fmt.Errorf("cannot refresh \"%s\" workshop: %w", file, err)
 		}
 		taskset = append(taskset, tasks)
 	}

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
@@ -745,4 +746,58 @@ func (s *requestSuite) TestRemoveMany(c *check.C) {
 	}
 	c.Assert(ts[0].Tasks()[3].Kind(), check.Equals, "remove-workshop")
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "ws-1", ts[0].Tasks())
+}
+
+func (s *requestSuite) TestRemountSuccess(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	plug := interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-1", Sdk: "sdk-1", Name: "plug"}
+	content := []sdk.Setup{
+		{Name: "sdk-1", Channel: "latest/stable"},
+	}
+	source := c.MkDir()
+
+	s.launchWorkshopWithSDKs(c, "ws-1", content)
+
+	ts, err := s.mgr.Remount(s.ctx, s.state, plug, source, s.project.ProjectId)
+	c.Assert(err, check.IsNil)
+	c.Assert(ts.Tasks(), check.HasLen, 1)
+
+	var workshop string
+	var project workshopbackend.Project
+	task := ts.Tasks()[0]
+	c.Assert(task.Get("workshop", &workshop), check.IsNil)
+	c.Assert(task.Get("project", &project), check.IsNil)
+	c.Assert(workshop, check.Equals, "ws-1")
+	c.Assert(project, check.DeepEquals, *s.project)
+
+	var plugRef interfaces.PlugRef
+	var src string
+	c.Assert(task.Get("plug", &plugRef), check.IsNil)
+	c.Assert(plugRef, check.DeepEquals, plug)
+	c.Assert(task.Get("source", &src), check.IsNil)
+	c.Assert(src, check.Equals, source)
+}
+
+func (s *requestSuite) TestRemountWorkshopNotReady(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	plug := interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-1", Sdk: "sdk-1", Name: "plug"}
+	content := []sdk.Setup{
+		{Name: "sdk-1", Channel: "latest/stable"},
+	}
+
+	s.launchWorkshopWithSDKs(c, "ws-1", content)
+
+	// pretend there is another change running that would conflict with this one.
+	change := s.state.NewChange("refresh", "test")
+	task := s.state.NewTask("task", "test")
+	task.Set("workshop", "ws-1")
+	change.AddTask(task)
+	change.Set("project-id", s.project.ProjectId)
+
+	_, err := s.mgr.Remount(s.ctx, s.state, plug, c.MkDir(), s.project.ProjectId)
+	c.Assert(err, check.ErrorMatches, `cannot remount: "ws-1" status is "Pending", must be one of: "Ready", "Stopped"`)
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -97,11 +97,11 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string, setup Setup) (*Inf
 		Channel:       setup.Channel,
 	}
 
-	if err := setPlugsFromSnapYaml(&sdkYaml, sdkInfo); err != nil {
+	if err := setPlugsFromSdkYaml(&sdkYaml, sdkInfo); err != nil {
 		return nil, err
 	}
 
-	if err := setSlotsFromSnapYaml(&sdkYaml, sdkInfo); err != nil {
+	if err := setSlotsFromSdkYaml(&sdkYaml, sdkInfo); err != nil {
 		return nil, err
 	}
 
@@ -109,12 +109,13 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string, setup Setup) (*Inf
 	return sdkInfo, nil
 }
 
-func setPlugsFromSnapYaml(y *sdkYaml, sdk *Info) error {
+func setPlugsFromSdkYaml(y *sdkYaml, sdk *Info) error {
 	for name, data := range y.Plugs {
 		iface, label, attrs, err := convertToSlotOrPlugData("plug", name, data)
 		if err != nil {
 			return err
 		}
+
 		sdk.Plugs[name] = &PlugInfo{
 			Sdk:       sdk,
 			Name:      name,
@@ -127,7 +128,7 @@ func setPlugsFromSnapYaml(y *sdkYaml, sdk *Info) error {
 	return nil
 }
 
-func setSlotsFromSnapYaml(y *sdkYaml, sdk *Info) error {
+func setSlotsFromSdkYaml(y *sdkYaml, sdk *Info) error {
 	for name, data := range y.Slots {
 		iface, label, attrs, err := convertToSlotOrPlugData("slot", name, data)
 		if err != nil {
@@ -243,13 +244,13 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 	return v, true
 }
 
-func getAttribute(snapName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
+func getAttribute(sdkName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := lookupAttr(attrs, key)
 	if !ok {
-		return AttributeNotFoundError{fmt.Errorf("sdk %q does not have attribute %q for interface %q", snapName, key, ifaceName)}
+		return AttributeNotFoundError{fmt.Errorf("sdk %q does not have attribute %q for interface %q", sdkName, key, ifaceName)}
 	}
 
-	return metautil.SetValueFromAttribute(snapName, ifaceName, key, v, val)
+	return metautil.SetValueFromAttribute(sdkName, ifaceName, key, v, val)
 }
 
 func (slot *SlotInfo) Attr(key string, val interface{}) error {
@@ -299,14 +300,14 @@ func (s *Setup) Filename() string {
 	return filepath.Join(dirs.SdkDir, fmt.Sprintf("%s_%d.sdk", s.Name, s.Revision))
 }
 
-func MockSanitizePlugsSlots(f func(snapInfo *Info)) (restore func()) {
+func MockSanitizePlugsSlots(f func(sdkInfo *Info)) (restore func()) {
 	old := SanitizePlugsSlots
 	SanitizePlugsSlots = f
 	return func() { SanitizePlugsSlots = old }
 }
 
 func MockInfo(c *check.C, yamlText string, projectId, workshop string, setup Setup) *Info {
-	restoreSanitize := MockSanitizePlugsSlots(func(snapInfo *Info) {})
+	restoreSanitize := MockSanitizePlugsSlots(func(sdkInfo *Info) {})
 	defer restoreSanitize()
 	info, err := ReadSdkInfo([]byte(yamlText), projectId, workshop, setup)
 	c.Assert(err, check.IsNil)
@@ -317,7 +318,7 @@ func MockInfo(c *check.C, yamlText string, projectId, workshop string, setup Set
 }
 
 func MockInvalidInfo(c *check.C, yamlText string, setup Setup) *Info {
-	restoreSanitize := MockSanitizePlugsSlots(func(snapInfo *Info) {})
+	restoreSanitize := MockSanitizePlugsSlots(func(sdkInfo *Info) {})
 	defer restoreSanitize()
 
 	sdkInfo, err := ReadSdkInfo([]byte(yamlText), "invalid", "ws", setup)

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -69,6 +69,10 @@ type Ref struct {
 	Sdk       string
 }
 
+func (r *Ref) ID() string {
+	return fmt.Sprintf("%s/%s:%s", r.ProjectId, r.Workshop, r.Sdk)
+}
+
 var SanitizePlugsSlots = func(snapInfo *Info) {
 	panic("SanitizePlugsSlots function not set")
 }

--- a/internal/workshopbackend/lxd_backend_profile.go
+++ b/internal/workshopbackend/lxd_backend_profile.go
@@ -2,17 +2,15 @@ package workshopbackend
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/exp/slices"
 
+	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/revert"
 )
 
 type SdkProfile struct {
@@ -37,6 +35,14 @@ func (s SdkProfile) AddDevice(dev Device) error {
 	}
 	s.devices[dev.Name()] = dev
 	return nil
+}
+
+func (p SdkProfile) lxdDevices() map[string]map[string]string {
+	lxdDevs := make(map[string]map[string]string, len(p.devices))
+	for _, d := range p.devices {
+		lxdDevs[d.Name()] = d.properties
+	}
+	return lxdDevs
 }
 
 type DeviceType int
@@ -87,14 +93,6 @@ func (w Device) lxdProperties() map[string]string {
 	return w.properties
 }
 
-func (p SdkProfile) lxdDevices() map[string]map[string]string {
-	lxdDevs := make(map[string]map[string]string, len(p.devices))
-	for _, d := range p.devices {
-		lxdDevs[d.Name()] = d.properties
-	}
-	return lxdDevs
-}
-
 func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile SdkProfile) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
@@ -119,14 +117,6 @@ func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile
 				return fmt.Errorf("cannot create a workshop mount with target %q: %v", target, err)
 			} else if !info.IsDir() {
 				return fmt.Errorf("cannot create a workshop mount with target %q: the target is not a directory", target)
-			}
-			// We have to workaround the LXD issue here as it would remove
-			// the target directory on unmount if it was empty. It should
-			// not touch the directories that it has not created.
-			// https://github.com/canonical/lxd/issues/12648
-			_, err := fs.Create(filepath.Join(target, fmt.Sprintf(".workshop.%s.%s", projectId, workshop)))
-			if err != nil && !errors.Is(err, os.ErrExist) {
-				logger.Noticef(`Cannot not prevent "target" in %q workshop from removing: %v`, workshop, err)
 			}
 		}
 	}
@@ -172,6 +162,43 @@ func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile
 	return nil
 }
 
+func (s *LxdBackend) lxdEmptyUnmountWorkaround(conn lxd.InstanceServer, ctx context.Context, projectId, workshop string, profile string) (*revert.Reverter, error) {
+	// We have to workaround the LXD issue here as it would remove
+	// the target directory on unmount if it was empty. It should
+	// not touch the directories that it has not created.
+	// https://github.com/canonical/lxd/issues/12648
+	fs, err := s.WorkshopFs(ctx, workshop)
+	if err != nil {
+		return nil, err
+	}
+
+	lxdProfile, _, err := conn.GetProfile(profileName(projectId, workshop, profile))
+	if err != nil {
+		return nil, err
+	}
+
+	var revertWorkaround revert.Reverter
+	revertWorkaround.Add(func() { fs.Close() })
+	for _, mount := range lxdProfile.Devices {
+		// only for the bind mounts
+		if mount["type"] == "disk" && mount["pool"] == "" {
+			target := mount["path"]
+			info, err := fs.Stat(target)
+			if err != nil {
+				continue
+			}
+			revertWorkaround.Add(func() {
+				// Making a new directory unconditionally can be done, because
+				// the target must have existed for this profile to be created
+				// in the first place.
+				_ = fs.Mkdir(target, info.Mode())
+			})
+		}
+	}
+
+	return &revertWorkaround, nil
+}
+
 func (s *LxdBackend) RemoveProfile(ctx context.Context, workshop string, profile string) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
@@ -187,6 +214,13 @@ func (s *LxdBackend) RemoveProfile(ctx context.Context, workshop string, profile
 	if err != nil {
 		return err
 	}
+
+	// TEMPORARY: Workaround LXD bug with empty dir unmounts
+	revertWorkaround, err := s.lxdEmptyUnmountWorkaround(conn, ctx, projectId, workshop, profile)
+	if err != nil {
+		return err
+	}
+	defer revertWorkaround.Fail()
 
 	// 1. Untie the profile from the workshop
 	lxdname := profileName(projectId, workshop, profile)

--- a/internal/workshopbackend/tests/integration/profile_test.go
+++ b/internal/workshopbackend/tests/integration/profile_test.go
@@ -134,7 +134,10 @@ func (f *profileTest) TestSdkProfileBindMountPreventsLxdFromRemovingTarget(c *ch
 	var backend workshopbackend.Profile = &workshopbackend.LxdBackend{}
 	profile := workshopbackend.NewSdkProfile("sdk")
 	device := workshopbackend.Mount("sdk-device", c.MkDir(), "/opt")
+	deviceNonEmpty := workshopbackend.Mount("sdk-device-2", c.MkDir(), "/home/workshop")
 	err := profile.AddDevice(device)
+	c.Assert(err, check.IsNil)
+	err = profile.AddDevice(deviceNonEmpty)
 	c.Assert(err, check.IsNil)
 
 	// Execute
@@ -148,5 +151,7 @@ func (f *profileTest) TestSdkProfileBindMountPreventsLxdFromRemovingTarget(c *ch
 	c.Assert(err, check.IsNil)
 	defer fs.Close()
 	_, err = fs.Stat("/opt")
+	c.Assert(err, check.IsNil)
+	_, err = fs.Stat("/home/workshop")
 	c.Assert(err, check.IsNil)
 }

--- a/tests/main/info/task.yaml
+++ b/tests/main/info/task.yaml
@@ -1,5 +1,8 @@
 summary: |
   Check workshop info output
+  
+prepare: |
+  apt install expect -y --no-install-recommends
 
 restore: |
   . "$TESTSLIB"/utils.sh

--- a/tests/main/info/task.yaml
+++ b/tests/main/info/task.yaml
@@ -1,9 +1,5 @@
 summary: |
-  Test workshop info output
-  
-prepare: |
-  apt install expect jq -y --no-install-recommends
-  snap install yq
+  Check workshop info output
 
 restore: |
   . "$TESTSLIB"/utils.sh

--- a/tests/main/remount/.workshop.ws.yaml
+++ b/tests/main/remount/.workshop.ws.yaml
@@ -1,0 +1,5 @@
+name: ws
+base: ubuntu@22.04
+sdks:
+    test-sdk-content:
+        channel: latest/stable

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -24,7 +24,7 @@ execute: |
   workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-one"]' | MATCH "^host:.*$new_source"
   
   echo "Remount: the new source is not empty"  
-  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-one /home/ubuntu  | MATCH ".*(directory not empty)"
+  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-one /home/ubuntu  | MATCH ".*(new source is not empty; workshop must be stopped to remount safely)"
   
   echo "Remount: workshop stopped"
   new_source="/home/ubuntu/content-plug-two"
@@ -34,6 +34,18 @@ execute: |
   workshop_exec start --project "$project" ws
   workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$new_source"
   test -d "$new_source"
+  
+  echo "Remount: new source is on a different filesystem"
+  otherfs_path=/home/ubuntu/other-fs/new
+  otherfs=$(mktemp -d)
+  mkdir -p /home/ubuntu/other-fs
+  mount --bind "$otherfs" /home/ubuntu/other-fs
+  mkdir "$otherfs_path"
+  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-two "$otherfs_path" | MATCH ".*(current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely)"
+  workshop_exec stop --project "$project" ws
+  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-two "$otherfs_path"
+  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$otherfs_path"
+  
   
   echo "Remount: workshop remove does not delete remounted dirs"
   workshop_exec remove --project "$project" ws

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -31,4 +31,13 @@ execute: |
   workshop_exec stop --project "$project" ws
   workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-two "$new_source"
   workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$new_source"
+  workshop_exec start --project "$project" ws
+  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$new_source"
   test -d "$new_source"
+  
+  echo "Remount: workshop remove does not delete remounted dirs"
+  workshop_exec remove --project "$project" ws
+  test -d "/home/ubuntu/content-plug-one"
+  test -d "/home/ubuntu/content-plug-two"
+
+  

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -1,4 +1,7 @@
 summary: Check workshop remount scenarios
+prepare: |
+  apt install jq -y --no-install-recommends
+  snap install yq
 restore: |
   . "$TESTSLIB"/utils.sh
   cleanup ./
@@ -6,18 +9,23 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   project=$(pwd)
-  workshop_exec launch --project $project ws  
+  workshop_exec launch --project "$project" ws  
   
   echo "Remount: the new source is empty or does not exist"
   new_source="/home/ubuntu/content-plug-one"
-  workshop_exec remount --project $project ws/test-sdk-content:content-plug-one "$new_source"
+  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-one "$new_source"
   test -d "$new_source"
   
+  echo "Remount: check workshop info output"
+  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-one"]' | MATCH "^host:.*$new_source"
+  
   echo "Remount: the new source is not empty"  
-  workshop_exec remount --project $project ws/test-sdk-content:content-plug-one /home/ubuntu  | MATCH ".*(directory not empty)"
+  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-one /home/ubuntu  | MATCH ".*(directory not empty)"
   
   echo "Remount: workshop stopped"
   new_source="/home/ubuntu/content-plug-two"
-  workshop_exec stop --project $project ws
-  workshop_exec remount --project $project ws/test-sdk-content:content-plug-two "$new_source"
-  test -d "$new_source"
+  workshop_exec stop --project "$project" ws
+  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-two "$new_source"
+  test -d "$new_source"  
+  
+  

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -19,6 +19,10 @@ execute: |
   echo "Remount: check workshop info output"
   workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-one"]' | MATCH "^host:.*$new_source"
   
+  echo "Remount: plugs remount sources are preserved after refresh"
+  workshop_exec refresh --project "$project" ws
+  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-one"]' | MATCH "^host:.*$new_source"
+  
   echo "Remount: the new source is not empty"  
   workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-one /home/ubuntu  | MATCH ".*(directory not empty)"
   
@@ -26,6 +30,5 @@ execute: |
   new_source="/home/ubuntu/content-plug-two"
   workshop_exec stop --project "$project" ws
   workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-two "$new_source"
-  test -d "$new_source"  
-  
-  
+  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$new_source"
+  test -d "$new_source"

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -1,0 +1,23 @@
+summary: Check workshop remount scenarios
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup ./
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  project=$(pwd)
+  workshop_exec launch --project $project ws  
+  
+  echo "Remount: the new source is empty or does not exist"
+  new_source="/home/ubuntu/content-plug-one"
+  workshop_exec remount --project $project ws/test-sdk-content:content-plug-one "$new_source"
+  test -d "$new_source"
+  
+  echo "Remount: the new source is not empty"  
+  workshop_exec remount --project $project ws/test-sdk-content:content-plug-one /home/ubuntu  | MATCH ".*(directory not empty)"
+  
+  echo "Remount: workshop stopped"
+  new_source="/home/ubuntu/content-plug-two"
+  workshop_exec stop --project $project ws
+  workshop_exec remount --project $project ws/test-sdk-content:content-plug-two "$new_source"
+  test -d "$new_source"


### PR DESCRIPTION
# Description
```
workshop remount <workshop>[/<sdk>]:<plug> <source>
```

The `remount` command mounts the <source> directory in the host at the SDK plug's target directory inside the workshop, so that the content currently inside <source> becomes visible at the target. The operation is done atomically if the <source> is a non-existing or an empty directory in the same filesystem as the current plug’s source. Otherwise, the workshop must be stopped for remount, as it would be unreliable to replace the underlying data while processes are running.

This change affects other workshop commands:
- `workshop refresh` preserves the plug's 'source' attribute across refreshes; if a plug was remounted and it still exists in the new workshop, the source provided by the user will be used for connection (instead of the default one).
- `workshop info` lists all the SDKs mounts.
- `workshop remove` does not remove content plug's source directory if it was remounted.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
