### PR TITLE
Agent SDK

### DIFF
--- a/client/connections.go
+++ b/client/connections.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"net/url"
+)
+
+// Connection describes a connection between a plug and a slot.
+type Connection struct {
+	Slot      SlotRef `json:"slot"`
+	Plug      PlugRef `json:"plug"`
+	Interface string  `json:"interface"`
+	// Manual is set for connections that were established manually.
+	Manual bool `json:"manual"`
+	// SlotAttrs is the list of attributes of the slot side of the connection.
+	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`
+	// PlugAttrs is the list of attributes of the plug side of the connection.
+	PlugAttrs map[string]interface{} `json:"plug-attrs,omitempty"`
+}
+
+// Connections contains information about connections, as well as related plugs
+// and slots.
+type Connections struct {
+	// Established is the list of connections that are currently present.
+	Established []Connection `json:"established"`
+	// Undersired is a list of connections that are manually denied.
+	Undesired []Connection `json:"undesired"`
+	Plugs     []Plug       `json:"plugs"`
+	Slots     []Slot       `json:"slots"`
+}
+
+// ConnectionOptions contains criteria for selecting matching connections, plugs
+// and slots.
+type ConnectionOptions struct {
+	ProjectId string
+	// Workshop selects connections with the workshop on one of the sides, as well
+	// as plugs and slots of a given workshop.
+	Workshop string
+	// Interface selects connections, plugs or slots using given interface.
+	Interface string
+	// All when true, selects established and undesired connections as well
+	// as all disconnected plugs and slots.
+	All bool
+}
+
+// Connections returns matching plugs, slots and their connections. Unless
+// specified by matching options, returns established connections.
+func (client *Client) Connections(opts *ConnectionOptions) (Connections, error) {
+	var conns Connections
+	query := url.Values{}
+	if opts != nil && opts.ProjectId != "" {
+		query.Set("project-id", opts.ProjectId)
+	}
+	if opts != nil && opts.Workshop != "" {
+		query.Set("workshop", opts.Workshop)
+	}
+	if opts != nil && opts.Interface != "" {
+		query.Set("interface", opts.Interface)
+	}
+	if opts != nil && opts.All {
+		query.Set("select", "all")
+	}
+	_, err := client.doSync("GET", "/v1/connections", query, nil, nil, &conns)
+	return conns, err
+}

--- a/client/connections_test.go
+++ b/client/connections_test.go
@@ -1,0 +1,297 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"net/url"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
+)
+
+func (cs *clientSuite) TestClientConnectionsCallsEndpoint(c *check.C) {
+	_, _ = cs.cli.Connections(nil)
+	c.Check(cs.req.Method, check.Equals, "GET")
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/connections")
+}
+
+func (cs *clientSuite) TestClientConnectionsDefault(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": {
+			"established": [
+				{
+					"slot": {"project-id":"b8639dea", "workshop": "keyboard-lights", "sdk": "lights",  "slot": "capslock-led"},
+					"plug": {"project-id":"b8639dea", "workshop": "canonical-pi2", "sdk": "pi", "plug": "pin-13"},
+					"interface": "bool-file"
+                }
+			],
+			"plugs": [
+				{
+					"project-id": "b8639dea",
+					"workshop": "canonical-pi2",
+					"sdk": "pi",
+					"plug": "pin-13",
+					"interface": "bool-file",
+					"label": "Pin 13",
+					"connections": [
+						{"project-id":"b8639dea","workshop": "keyboard-lights", "sdk":"lights", "slot": "capslock-led"}
+					]
+				}
+			],
+			"slots": [
+				{
+					"project-id":"b8639dea",
+					"workshop": "keyboard-lights",
+					"sdk": "lights",
+					"slot": "capslock-led",
+					"interface": "bool-file",
+					"label": "Capslock indicator LED",
+					"connections": [
+						{"project-id":"b8639dea","workshop": "canonical-pi2", "sdk":"pi", "plug": "pin-13"}
+					]
+				}
+			]
+		}
+	}`
+	conns, err := cs.cli.Connections(&client.ConnectionOptions{ProjectId: "b8639dea"})
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/connections")
+	c.Check(conns, check.DeepEquals, client.Connections{
+		Established: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "b8639dea", Workshop: "canonical-pi2", Sdk: "pi", Name: "pin-13"},
+				Slot:      client.SlotRef{ProjectId: "b8639dea", Workshop: "keyboard-lights", Sdk: "lights", Name: "capslock-led"},
+				Interface: "bool-file",
+			},
+		},
+		Plugs: []client.Plug{
+			{
+				ProjectId: "b8639dea",
+				Workshop:  "canonical-pi2",
+				Sdk:       "pi",
+				Name:      "pin-13",
+				Interface: "bool-file",
+				Label:     "Pin 13",
+				Connections: []client.SlotRef{
+					{
+						ProjectId: "b8639dea",
+						Workshop:  "keyboard-lights",
+						Sdk:       "lights",
+						Name:      "capslock-led",
+					},
+				},
+			},
+		},
+		Slots: []client.Slot{
+			{
+				ProjectId: "b8639dea",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "capslock-led",
+				Interface: "bool-file",
+				Label:     "Capslock indicator LED",
+				Connections: []client.PlugRef{
+					{
+						ProjectId: "b8639dea",
+						Workshop:  "canonical-pi2",
+						Sdk:       "pi",
+						Name:      "pin-13",
+					},
+				},
+			},
+		},
+	})
+}
+
+func (cs *clientSuite) TestClientConnectionsAll(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": {
+			"established": [
+				{
+					"slot": {"project-id":"b8639dea", "workshop": "keyboard-lights", "sdk": "lights",  "slot": "capslock-led"},
+					"plug": {"project-id":"b8639dea", "workshop": "canonical-pi2", "sdk": "pi", "plug": "pin-13"},
+					"interface": "bool-file"
+                }
+			],
+			"undesired": [
+				{
+					"slot": {"project-id":"b8639dea", "workshop": "keyboard-lights", "sdk": "lights",  "slot": "numlock-led"},
+					"plug": {"project-id":"b8639dea", "workshop": "canonical-pi2", "sdk": "pi", "plug": "pin-14"},
+					"interface": "bool-file",
+					"manual": true
+                }
+			],
+			"plugs": [
+				{
+					"project-id": "b8639dea",
+					"workshop": "canonical-pi2",
+					"sdk": "pi",
+					"plug": "pin-13",
+					"interface": "bool-file",
+					"label": "Pin 13",
+					"connections": [
+						{"project-id":"b8639dea","workshop": "keyboard-lights", "sdk":"lights", "slot": "capslock-led"}
+					]
+				},
+				{
+					"project-id": "b8639dea",
+					"workshop": "canonical-pi2",
+					"sdk": "pi",
+					"plug": "pin-14",
+					"interface": "bool-file",
+					"label": "Pin 14"
+				}
+			],
+			"slots": [
+				{
+					"project-id":"b8639dea",
+					"workshop": "keyboard-lights",
+					"sdk": "lights",
+					"slot": "capslock-led",
+					"interface": "bool-file",
+					"label": "Capslock indicator LED",
+					"connections": [
+						{"project-id":"b8639dea","workshop": "canonical-pi2", "sdk":"pi", "plug": "pin-13"}
+					]
+				},
+				{
+					"project-id":"b8639dea",
+					"workshop": "keyboard-lights",
+					"sdk": "lights",
+					"slot": "numlock-led",
+					"interface": "bool-file",
+					"label": "Numlock LED"
+				}
+			]
+		}
+	}`
+	conns, err := cs.cli.Connections(&client.ConnectionOptions{ProjectId: "b8639dea", All: true})
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/connections")
+	c.Check(cs.req.URL.RawQuery, check.Equals, "project-id=b8639dea&select=all")
+	c.Check(conns, check.DeepEquals, client.Connections{
+		Established: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "b8639dea", Workshop: "canonical-pi2", Sdk: "pi", Name: "pin-13"},
+				Slot:      client.SlotRef{ProjectId: "b8639dea", Workshop: "keyboard-lights", Sdk: "lights", Name: "capslock-led"},
+				Interface: "bool-file",
+			},
+		},
+		Undesired: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "b8639dea", Workshop: "canonical-pi2", Sdk: "pi", Name: "pin-14"},
+				Slot:      client.SlotRef{ProjectId: "b8639dea", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock-led"},
+				Interface: "bool-file",
+				Manual:    true,
+			},
+		},
+		Plugs: []client.Plug{
+			{
+				ProjectId: "b8639dea",
+				Workshop:  "canonical-pi2",
+				Sdk:       "pi",
+				Name:      "pin-13",
+				Interface: "bool-file",
+				Label:     "Pin 13",
+				Connections: []client.SlotRef{
+					{
+						ProjectId: "b8639dea",
+						Workshop:  "keyboard-lights",
+						Sdk:       "lights",
+						Name:      "capslock-led",
+					},
+				},
+			},
+			{
+				ProjectId: "b8639dea",
+				Workshop:  "canonical-pi2",
+				Sdk:       "pi",
+				Name:      "pin-14",
+				Interface: "bool-file",
+				Label:     "Pin 14",
+			},
+		},
+		Slots: []client.Slot{
+			{
+				ProjectId: "b8639dea",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "capslock-led",
+				Interface: "bool-file",
+				Label:     "Capslock indicator LED",
+				Connections: []client.PlugRef{
+					{
+						ProjectId: "b8639dea",
+						Workshop:  "canonical-pi2",
+						Sdk:       "pi",
+						Name:      "pin-13",
+					},
+				},
+			},
+			{
+				ProjectId: "b8639dea",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "numlock-led",
+				Interface: "bool-file",
+				Label:     "Numlock LED",
+			},
+		},
+	})
+}
+
+func (cs *clientSuite) TestClientConnectionsFilter(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": {
+			"established": [],
+			"plugs": [],
+			"slots": []
+		}
+	}`
+
+	_, err := cs.cli.Connections(&client.ConnectionOptions{All: true})
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/connections")
+	c.Check(cs.req.URL.RawQuery, check.Equals, "select=all")
+
+	_, err = cs.cli.Connections(&client.ConnectionOptions{Workshop: "foo"})
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/connections")
+	c.Check(cs.req.URL.RawQuery, check.Equals, "workshop=foo")
+
+	_, err = cs.cli.Connections(&client.ConnectionOptions{Interface: "test"})
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/connections")
+	c.Check(cs.req.URL.RawQuery, check.Equals, "interface=test")
+
+	_, err = cs.cli.Connections(&client.ConnectionOptions{ProjectId: "b8639dea", All: true, Workshop: "foo", Interface: "test"})
+	c.Assert(err, check.IsNil)
+	query := cs.req.URL.Query()
+	c.Check(query, check.DeepEquals, url.Values{
+		"project-id": []string{"b8639dea"},
+		"select":     []string{"all"},
+		"interface":  []string{"test"},
+		"workshop":   []string{"foo"},
+	})
+}

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+// Plug represents the potential of a given snap to connect to a slot.
+type Plug struct {
+	ProjectId   string                 `json:"project-id"`
+	Workshop    string                 `json:"workshop"`
+	Sdk         string                 `json:"sdk"`
+	Name        string                 `json:"plug"`
+	Interface   string                 `json:"interface,omitempty"`
+	Attrs       map[string]interface{} `json:"attrs,omitempty"`
+	Label       string                 `json:"label,omitempty"`
+	Connections []SlotRef              `json:"connections,omitempty"`
+}
+
+// PlugRef is a reference to a plug.
+type PlugRef struct {
+	ProjectId string `json:"project-id"`
+	Workshop  string `json:"workshop"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"plug"`
+}
+
+// Slot represents a capacity offered by a snap.
+type Slot struct {
+	ProjectId   string                 `json:"project-id"`
+	Workshop    string                 `json:"workshop"`
+	Sdk         string                 `json:"sdk"`
+	Name        string                 `json:"slot"`
+	Interface   string                 `json:"interface,omitempty"`
+	Attrs       map[string]interface{} `json:"attrs,omitempty"`
+	Label       string                 `json:"label,omitempty"`
+	Connections []PlugRef              `json:"connections,omitempty"`
+}
+
+// SlotRef is a reference to a slot.
+type SlotRef struct {
+	ProjectId string `json:"project-id"`
+	Workshop  string `json:"workshop"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"slot"`
+}
+
+// Interface holds information about a given interface and its instances.
+type Interface struct {
+	Name    string `json:"name,omitempty"`
+	Summary string `json:"summary,omitempty"`
+	DocURL  string `json:"doc-url,omitempty"`
+	Plugs   []Plug `json:"plugs,omitempty"`
+	Slots   []Slot `json:"slots,omitempty"`
+}
+
+// InterfaceAction represents an action performed on the interface system.
+type InterfaceAction struct {
+	Action string `json:"action"`
+	Forget bool   `json:"forget,omitempty"`
+	Plugs  []Plug `json:"plugs,omitempty"`
+	Slots  []Slot `json:"slots,omitempty"`
+}
+
+// InterfaceOptions represents opt-in elements include in responses.
+type InterfaceOptions struct {
+	Names     []string
+	Doc       bool
+	Plugs     bool
+	Slots     bool
+	Connected bool
+}
+
+// DisconnectOptions represents extra options for disconnect op
+type DisconnectOptions struct {
+	Forget bool
+}

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -40,13 +40,6 @@ type ListOptions struct {
 	ProjectId string
 }
 
-type PlugRef struct {
-	ProjectId string `json:"project-id"`
-	Workshop  string `json:"workshop"`
-	Sdk       string `json:"sdk"`
-	Name      string `json:"plug"`
-}
-
 type Remount struct {
 	Action string   `json:"action"`
 	Plug   *PlugRef `json:"plug"`

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/canonical/workshop/client"
+	"github.com/canonical/x-go/i18n"
+	"github.com/spf13/cobra"
+)
+
+type CmdConnections struct {
+	clientMixin
+	all bool
+}
+
+func (c *CmdConnections) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "connections [<WORKSHOP>] [--all]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "List interface connections.",
+		RunE:  c.Run,
+	}
+
+	cmd.Flags().BoolVar(&c.all, "all", false, "Lists connected and unconnected plugs and slots.")
+
+	return cmd
+}
+
+func isAgentSdk(sdkName string) bool {
+	return sdkName == "agent"
+}
+
+func endpoint(workshop, sdkName, name string) string {
+	if isAgentSdk(sdkName) {
+		return ":" + name
+	}
+	return workshop + "/" + sdkName + ":" + name
+}
+
+type connection struct {
+	slot          string
+	plug          string
+	interfaceName string
+	manual        bool
+}
+
+func (cn connection) String() string {
+	opts := []string{}
+	if cn.manual {
+		opts = append(opts, "manual")
+	}
+	if len(opts) == 0 {
+		return "-"
+	}
+	return strings.Join(opts, ",")
+}
+
+type byConnectionData []connection
+
+func (b byConnectionData) Len() int      { return len(b) }
+func (b byConnectionData) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b byConnectionData) Less(i, j int) bool {
+	iCon, jCon := b[i], b[j]
+	if iCon.interfaceName != jCon.interfaceName {
+		return iCon.interfaceName < jCon.interfaceName
+	}
+	if iCon.plug != jCon.plug {
+		return iCon.plug < jCon.plug
+	}
+	return iCon.slot < jCon.slot
+}
+
+func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
+	var err error
+
+	cli, err := client.New(&ClientConfig)
+	if err != nil {
+		return fmt.Errorf("cannot create client: %v", err)
+	}
+
+	c.setClient(cli)
+
+	project, err := c.client.Project(Project)
+	if err != nil {
+		return err
+	}
+
+	workshop := ""
+	if len(av) > 0 {
+		workshop = av[0]
+		if c.all {
+			// passing a workshop name already implies --all, error out
+			// when it was passed explicitly
+			return fmt.Errorf("cannot use --all with workshop name")
+		}
+		c.all = true
+	}
+
+	connections, err := c.client.Connections(&client.ConnectionOptions{ProjectId: project.Id, Workshop: workshop, All: c.all})
+	if err != nil {
+		return err
+	}
+
+	if len(connections.Plugs) == 0 && len(connections.Slots) == 0 {
+		return nil
+	}
+
+	annotatedConns := make([]connection, 0, len(connections.Established)+len(connections.Undesired))
+	for _, conn := range connections.Established {
+		annotatedConns = append(annotatedConns, connection{
+			plug:          endpoint(conn.Plug.Workshop, conn.Plug.Sdk, conn.Plug.Name),
+			slot:          endpoint(conn.Slot.Workshop, conn.Slot.Sdk, conn.Slot.Name),
+			manual:        conn.Manual,
+			interfaceName: conn.Interface,
+		})
+	}
+
+	w := tabWriter()
+	fmt.Fprintln(w, i18n.G("Interface\tPlug\tSlot\tNotes"))
+
+	for _, plug := range connections.Plugs {
+		if len(plug.Connections) == 0 && c.all {
+			annotatedConns = append(annotatedConns, connection{
+				plug:          endpoint(plug.Workshop, plug.Sdk, plug.Name),
+				slot:          "-",
+				interfaceName: plug.Interface,
+			})
+		}
+	}
+	for _, slot := range connections.Slots {
+		if isAgentSdk(slot.Sdk) {
+			// displaying unconnected system snap slots is boring,
+			// unless explicitly asked to show them
+			continue
+		}
+		if len(slot.Connections) == 0 && c.all {
+			annotatedConns = append(annotatedConns, connection{
+				plug:          "-",
+				slot:          endpoint(slot.Workshop, slot.Sdk, slot.Name),
+				interfaceName: slot.Interface,
+			})
+		}
+	}
+
+	sort.Sort(byConnectionData(annotatedConns))
+
+	for _, note := range annotatedConns {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", note.interfaceName, note.plug, note.slot, note)
+	}
+
+	if len(annotatedConns) > 0 {
+		w.Flush()
+	}
+
+	return nil
+}

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -1,0 +1,869 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"gopkg.in/check.v1"
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
+)
+
+type connectionsSuite struct {
+	BaseWorkshopSuite
+	prjDir string
+	prjId  string
+}
+
+var _ = check.Suite(&connectionsSuite{})
+
+func (m *connectionsSuite) SetUpTest(c *check.C) {
+	m.prjDir = c.MkDir()
+	m.prjId = "42424242"
+	m.BaseWorkshopSuite.SetUpTest(c)
+}
+
+func (s *connectionsSuite) TestConnectionsNoneConnected(c *check.C) {
+	n := 0
+	query := url.Values{"project-id": []string{"42424242"}}
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 4:
+			result := client.Connections{}
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+
+	cmd := &CmdConnections{}
+	err := cmd.Run(cmd.Command(), []string{})
+
+	c.Check(err, check.IsNil)
+	c.Assert(s.Stdout(), check.Equals, "")
+	c.Assert(s.Stderr(), check.Equals, "")
+
+	s.ResetStdStreams()
+
+	query = url.Values{
+		"project-id": []string{"42424242"},
+		"select":     []string{"all"},
+	}
+
+	allCmd := cmd.Command()
+	cmd.all = true
+	err = cmd.Run(allCmd, []string{})
+	c.Check(err, IsNil)
+	c.Assert(s.Stdout(), check.Equals, "")
+	c.Assert(s.Stderr(), check.Equals, "")
+}
+
+func (s *connectionsSuite) TestConnectionsNotInstalled(c *C) {
+	query := url.Values{
+		"project-id": []string{"42424242"},
+		"workshop":   []string{"foo"},
+		"select":     []string{"all"},
+	}
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/v1/connections")
+			c.Check(r.URL.Query(), DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, IsNil)
+			c.Check(body, DeepEquals, []byte{})
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "not found"}, "status-code": 404}`)
+		}
+	})
+	cmd := &CmdConnections{}
+	err := cmd.Run(cmd.Command(), []string{"foo"})
+	c.Check(err, ErrorMatches, `not found`)
+	c.Assert(s.Stdout(), Equals, "")
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *C) {
+	query := url.Values{
+		"project-id": []string{"42424242"},
+		"select":     []string{"all"},
+	}
+	result := client.Connections{
+		Plugs: []client.Plug{
+			{
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "capslock-led",
+				Interface: "leds",
+			},
+		},
+	}
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 4:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+
+	cmd := &CmdConnections{}
+	command := cmd.Command()
+	cmd.all = true
+	err := cmd.Run(command, []string{})
+	c.Assert(err, IsNil)
+	expectedStdout := "" +
+		"Interface  Plug                                 Slot  Notes\n" +
+		"leds       keyboard-lights/lights:capslock-led  -     -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+
+	s.ResetStdStreams()
+
+	query = url.Values{
+		"project-id": []string{"42424242"},
+		"select":     []string{"all"},
+		"workshop":   []string{"keyboard-lights"},
+	}
+
+	err = cmd.Run(cmd.Command(), []string{"keyboard-lights"})
+	c.Assert(err, IsNil)
+	expectedStdout = "" +
+		"Interface  Plug                                 Slot  Notes\n" +
+		"leds       keyboard-lights/lights:capslock-led  -     -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *C) {
+	result := client.Connections{}
+	query := url.Values{"project-id": []string{"42424242"}, "select": []string{"all"}, "workshop": []string{"foo"}}
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 4:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+	cmd := &CmdConnections{}
+	err := cmd.Run(cmd.Command(), []string{"foo"})
+	c.Check(err, IsNil)
+	c.Assert(s.Stdout(), check.Equals, "")
+	c.Assert(s.Stderr(), check.Equals, "")
+
+	s.ResetStdStreams()
+
+	result = client.Connections{
+		Slots: []client.Slot{
+			{
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "provider",
+				Name:      "capslock-led",
+				Interface: "leds",
+			},
+		},
+	}
+	err = cmd.Run(cmd.Command(), []string{"foo"})
+	c.Assert(err, check.IsNil)
+	expectedStdout := "" +
+		"Interface  Plug  Slot                                 Notes\n" +
+		"leds       -     leds-provider/provider:capslock-led  -\n"
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
+}
+
+func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
+	result := client.Connections{
+		Established: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "capslock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "leds-provider", Sdk: "provider", Name: "capslock-led"},
+				Interface: "leds",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "numlock-led"},
+				Interface: "leds",
+				Manual:    true,
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "scrollock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "scrollock-led"},
+				Interface: "leds",
+			},
+		},
+		Plugs: []client.Plug{
+			{
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "capslock",
+				Interface: "leds",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "leds-provider",
+					Sdk:       "provider",
+					Name:      "capslock-led",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "numlock",
+				Interface: "leds",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "agent",
+					Name:      "numlock-led",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "scrollock",
+				Interface: "leds",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "agent",
+					Name:      "scrollock-led",
+				}},
+			},
+		},
+		Slots: []client.Slot{
+			{
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "agent",
+				Name:      "numlock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "numlock",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "agent",
+				Name:      "scrollock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "scrollock",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "provider",
+				Name:      "capslock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "capslock",
+				}},
+			},
+		},
+	}
+	n := 0
+	query := url.Values{"project-id": []string{"42424242"}}
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+	cmd := &CmdConnections{}
+	err := cmd.Run(cmd.Command(), []string{})
+	c.Assert(err, IsNil)
+	expectedStdout := "" +
+		"Interface  Plug                              Slot                                 Notes\n" +
+		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led  -\n" +
+		"leds       keyboard-lights/lights:numlock    :numlock-led                         manual\n" +
+		"leds       keyboard-lights/lights:scrollock  :scrollock-led                       -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
+	result := client.Connections{
+		Established: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "scrollock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "scrollock-led"},
+				Interface: "leds",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "capslock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "leds-provider", Sdk: "provider", Name: "capslock-led"},
+				Interface: "leds",
+			},
+		},
+		Undesired: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "numlock-led"},
+				Interface: "leds",
+				Manual:    true,
+			},
+		},
+		Plugs: []client.Plug{
+			{
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "capslock",
+				Interface: "leds",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "leds-provider",
+					Sdk:       "provider",
+					Name:      "capslock-led",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "numlock",
+				Interface: "leds",
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "scrollock",
+				Interface: "leds",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "agent",
+					Name:      "scrollock-led",
+				}},
+			},
+		},
+		Slots: []client.Slot{
+			{
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "agent",
+				Name:      "capslock-led",
+				Interface: "leds",
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "agent",
+				Name:      "numlock-led",
+				Interface: "leds",
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "agent",
+				Name:      "scrollock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "scrollock",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "provider",
+				Name:      "capslock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "capslock",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "numlock-provider",
+				Name:      "numlock-led",
+				Interface: "leds",
+			},
+		},
+	}
+	n := 0
+	query := url.Values{"project-id": []string{"42424242"}, "select": []string{"all"}}
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+
+	cmd := &CmdConnections{}
+	cmdAll := cmd.Command()
+	cmd.all = true
+	err := cmd.Run(cmdAll, []string{})
+	c.Assert(err, IsNil)
+	expectedStdout := "" +
+		"Interface  Plug                              Slot                                          Notes\n" +
+		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
+		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
+		"leds       keyboard-lights/lights:numlock    -                                             -\n" +
+		"leds       keyboard-lights/lights:scrollock  :scrollock-led                                -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *connectionsSuite) TestConnectionsOnlyDisconnected(c *C) {
+	result := client.Connections{
+		Undesired: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "leds-provider", Sdk: "numlock-provider", Name: "numlock-led"},
+				Interface: "leds",
+				Manual:    true,
+			},
+		},
+		Slots: []client.Slot{
+			{
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "provider",
+				Name:      "capslock-led",
+				Interface: "leds",
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "numlock-provider",
+				Name:      "numlock-led",
+				Interface: "leds",
+			},
+		},
+	}
+	query := url.Values{
+		"project-id": []string{"42424242"},
+		"workshop":   []string{"leds-provider"},
+		"select":     []string{"all"},
+	}
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+
+	cmd := &CmdConnections{}
+	err := cmd.Run(cmd.Command(), []string{"leds-provider"})
+	c.Assert(err, IsNil)
+	expectedStdout := "" +
+		"Interface  Plug  Slot                                        Notes\n" +
+		"leds       -     leds-provider/numlock-provider:numlock-led  -\n" +
+		"leds       -     leds-provider/provider:capslock-led         -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *connectionsSuite) TestConnectionsFiltering(c *C) {
+	result := client.Connections{}
+	query := url.Values{
+		"project-id": []string{"42424242"},
+		"select":     []string{"all"},
+	}
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 4:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+
+	query = url.Values{
+		"project-id": []string{"42424242"},
+		"select":     []string{"all"},
+		"workshop":   []string{"mouse-buttons"},
+	}
+	cmd := &CmdConnections{}
+
+	err := cmd.Run(cmd.Command(), []string{"mouse-buttons"})
+	c.Assert(err, IsNil)
+
+	cmdAll := cmd.Command()
+	cmd.all = true
+	err = cmd.Run(cmdAll, []string{"mouse-buttons"})
+	c.Assert(err, ErrorMatches, "cannot use --all with workshop name")
+}
+
+func (s *connectionsSuite) TestConnectionsSorting(c *C) {
+	result := client.Connections{
+		Established: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "foo", Name: "plug"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "a-content-provider", Name: "data"},
+				Interface: "content",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "foo", Name: "plug"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "b-content-provider", Name: "data"},
+				Interface: "content",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "foo", Name: "desktop-plug"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "agent", Name: "desktop"},
+				Interface: "desktop",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "foo", Name: "x11-plug"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "agent", Name: "x11"},
+				Interface: "x11",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "def", Sdk: "foo", Name: "a-x11-plug"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "def", Sdk: "agent", Name: "x11"},
+				Interface: "x11",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "a-foo", Name: "plug"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "a-content-provider", Name: "data"},
+				Interface: "content",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "def", Sdk: "keyboard-app", Name: "x11"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "def", Sdk: "agent", Name: "x11"},
+				Interface: "x11",
+				Manual:    true,
+			},
+		},
+		Undesired: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "foo", Name: "plug"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "c-content-provider", Name: "data"},
+				Interface: "content",
+				Manual:    true,
+			},
+		},
+		Plugs: []client.Plug{
+			{
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "foo",
+				Name:      "plug",
+				Interface: "content",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "a-content-provider",
+					Name:      "data",
+				}, {
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "b-content-provider",
+					Name:      "data",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "foo",
+				Name:      "desktop-plug",
+				Interface: "desktop",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "agent",
+					Name:      "desktop",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "foo",
+				Name:      "x11-plug",
+				Interface: "x11",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "agent",
+					Name:      "x11",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "foo",
+				Name:      "a-x11-plug",
+				Interface: "x11",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "agent",
+					Name:      "x11",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "a-foo",
+				Name:      "plug",
+				Interface: "content",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "a-content-provider",
+					Name:      "data",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "def",
+				Sdk:       "keyboard-app",
+				Name:      "x11",
+				Interface: "x11",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "agent",
+					Name:      "x11",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "keyboard-lights",
+				Name:      "numlock",
+				Interface: "leds",
+			},
+		},
+		Slots: []client.Slot{
+			{
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "c-content-provider",
+				Name:      "data",
+				Interface: "content",
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "a-content-provider",
+				Name:      "data",
+				Interface: "content",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "foo",
+					Name:      "plug",
+				}, {
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "a-foo",
+					Name:      "plug",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "b-content-provider",
+				Name:      "data",
+				Interface: "content",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "foo",
+					Name:      "plug",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "def",
+				Sdk:       "agent",
+				Name:      "x11",
+				Interface: "x11",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "foo",
+					Name:      "a-x11-plug",
+				}, {
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "foo",
+					Name:      "x11-plug",
+				}, {
+					ProjectId: "42424242",
+					Workshop:  "abc",
+					Sdk:       "keyboard-app",
+					Name:      "x11",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "abc",
+				Sdk:       "leds-provider",
+				Name:      "numlock-led",
+				Interface: "leds",
+			},
+		},
+	}
+	query := url.Values{
+		"project-id": []string{"42424242"},
+		"select":     []string{"all"},
+	}
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 4:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := ioutil.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+	cmd := &CmdConnections{}
+	cmdAll := cmd.Command()
+	cmd.all = true
+	err := cmd.Run(cmdAll, []string{})
+	c.Assert(err, IsNil)
+	expectedStdout := "" +
+		"Interface  Plug                         Slot                           Notes\n" +
+		"content    -                            abc/c-content-provider:data    -\n" +
+		"content    abc/a-foo:plug               abc/a-content-provider:data    -\n" +
+		"content    abc/foo:plug                 abc/a-content-provider:data    -\n" +
+		"content    abc/foo:plug                 abc/b-content-provider:data    -\n" +
+		"desktop    abc/foo:desktop-plug         :desktop                       -\n" +
+		"leds       -                            abc/leds-provider:numlock-led  -\n" +
+		"leds       abc/keyboard-lights:numlock  -                              -\n" +
+		"x11        abc/foo:x11-plug             :x11                           -\n" +
+		"x11        def/foo:a-x11-plug           :x11                           -\n" +
+		"x11        def/keyboard-app:x11         :x11                           manual\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -68,6 +68,7 @@ func main() {
 	rootCmd.AddCommand((&CmdShellAlias{}).Command())
 	rootCmd.AddCommand((&CmdRemove{}).Command())
 	rootCmd.AddCommand((&CmdRemount{}).Command())
+	rootCmd.AddCommand((&CmdConnections{}).Command())
 
 	rootCmd.SilenceErrors = true
 

--- a/cmd/workshop/main_test.go
+++ b/cmd/workshop/main_test.go
@@ -49,6 +49,27 @@ func (s *BaseWorkshopSuite) RedirectClientToTestServer(handler func(http.Respons
 	s.BaseTest.AddCleanup(func() { ClientConfig.BaseURL = "" })
 }
 
+func (s *BaseWorkshopSuite) ResetStdStreams() {
+	s.stdin.Reset()
+	s.stdout.Reset()
+	s.stderr.Reset()
+}
+
+func (s *BaseWorkshopSuite) Stdout() string {
+	return s.stdout.String()
+}
+
+func (s *BaseWorkshopSuite) Stderr() string {
+	return s.stderr.String()
+}
+
+// EncodeResponseBody writes JSON-serialized body to the response writer.
+func EncodeResponseBody(c *check.C, w http.ResponseWriter, body interface{}) {
+	encoder := json.NewEncoder(w)
+	err := encoder.Encode(body)
+	c.Assert(err, check.IsNil)
+}
+
 // DecodedRequestBody returns the JSON-decoded body of the request.
 func DecodedRequestBody(c *check.C, r *http.Request) map[string]interface{} {
 	var body map[string]interface{}

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -24,16 +24,16 @@ var (
 
 	ruleSubrules = []string{"allow-installation", "deny-installation", "allow-connection", "deny-connection", "allow-auto-connection", "deny-auto-connection"}
 
-	validWorkshopType = regexp.MustCompile(`^(?:agent|regular)$`)
+	validSdkType = regexp.MustCompile(`^(?:agent|regular)$`)
 
 	validIDConstraints = map[string]*regexp.Regexp{
-		"slot-type": validWorkshopType,
-		"plug-type": validWorkshopType,
+		"slot-sdk-type": validSdkType,
+		"plug-sdk-type": validSdkType,
 	}
 
 	attributeConstraints = []string{"plug-attributes", "slot-attributes"}
 
-	slotIDConstraints = []string{"plug-type"}
+	slotIDConstraints = []string{"plug-sdk-type"}
 
 	sideArityConstraints        = []string{"slots-per-plug", "plugs-per-slot"}
 	sideArityConstraintsSetters = map[string]func(sideArityConstraintsHolder, SideArityConstraint){
@@ -51,7 +51,7 @@ type SlotInstallationConstraints struct {
 
 func (c *SlotInstallationConstraints) setIDConstraints(field string, cstrs []string) {
 	switch field {
-	case "slot-type":
+	case "slot-sdk-type":
 		c.SlotTypes = cstrs
 	default:
 		panic("unknown SlotInstallationConstraints field " + field)
@@ -105,7 +105,7 @@ type SlotConnectionConstraints struct {
 
 func (c *SlotConnectionConstraints) setIDConstraints(field string, cstrs []string) {
 	switch field {
-	case "plug-type":
+	case "plug-sdk-type":
 		c.PlugSdkTypes = cstrs
 	default:
 		panic("unknown SlotConnectionConstraints field " + field)
@@ -232,7 +232,7 @@ func castSlotInstallationConstraints(cstrs []constraintsHolder) (res []*SlotInst
 
 func compileSlotInstallationConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
 	slotInstCstrs := &SlotInstallationConstraints{}
-	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-attributes"}, []string{"slot-type"})
+	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-attributes"}, []string{"slot-sdk-type"})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -24,7 +24,7 @@ var (
 
 	ruleSubrules = []string{"allow-installation", "deny-installation", "allow-connection", "deny-connection", "allow-auto-connection", "deny-auto-connection"}
 
-	validWorkshopType = regexp.MustCompile(`^(?:core|sdk)$`)
+	validWorkshopType = regexp.MustCompile(`^(?:agent|regular)$`)
 
 	validIDConstraints = map[string]*regexp.Regexp{
 		"slot-type": validWorkshopType,

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -21,14 +21,14 @@ type plugSlotRulesSuite struct{}
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstraints(c *check.C) {
 	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
 		"allow-installation": map[string]interface{}{
-			"slot-type": []interface{}{"core", "sdk"},
+			"slot-type": []interface{}{"agent", "regular"},
 		},
 	})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(rule.AllowInstallation, check.HasLen, 1)
 	cstrs := rule.AllowInstallation[0]
-	c.Check(cstrs.SlotTypes, check.DeepEquals, []string{"core", "sdk"})
+	c.Check(cstrs.SlotTypes, check.DeepEquals, []string{"agent", "regular"})
 }
 
 func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.SlotConnectionConstraints, always bool) {

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -21,7 +21,7 @@ type plugSlotRulesSuite struct{}
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstraints(c *check.C) {
 	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
 		"allow-installation": map[string]interface{}{
-			"slot-type": []interface{}{"agent", "regular"},
+			"slot-sdk-type": []interface{}{"agent", "regular"},
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -169,12 +169,12 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
     - true`, `alternative 1 of allow-connection in slot rule for interface "iface" must be a map`},
 		{`iface:
   allow-connection:
-    plug-type:
-      - foo`, `plug-type in allow-connection in slot rule for interface "iface" contains an invalid element: "foo"`},
+    plug-sdk-type:
+      - foo`, `plug-sdk-type in allow-connection in slot rule for interface "iface" contains an invalid element: "foo"`},
 		{`iface:
   allow-connection:
-    plug-type:
-      - xapp`, `plug-type in allow-connection in slot rule for interface "iface" contains an invalid element: "xapp"`},
+    plug-sdk-type:
+      - xapp`, `plug-sdk-type in allow-connection in slot rule for interface "iface" contains an invalid element: "xapp"`},
 		{`iface:
   allow-connect: true`, `slot rule for interface "iface" must specify at least one of allow-installation, deny-installation, allow-connection, deny-connection, allow-auto-connection, deny-auto-connection`},
 		{`iface:

--- a/internal/asserts/sdk_asserts_test.go
+++ b/internal/asserts/sdk_asserts_test.go
@@ -20,13 +20,13 @@ slots:
   interface3:
     deny-installation: true
     allow-auto-connection:
-      plug-type:
+      plug-sdk-type:
         - agent
   interface4:
     allow-connection: true
     deny-connection: false
     allow-installation:
-      slot-type:
+      slot-sdk-type:
         - agent
         - regular
 timestamp: 2016-09-29T19:50:49Z
@@ -106,7 +106,7 @@ revision: 0
 slots:
   network:
     allow-installation:
-      slot-type:
+      slot-sdk-type:
         - agent
 `
 

--- a/internal/asserts/sdk_asserts_test.go
+++ b/internal/asserts/sdk_asserts_test.go
@@ -21,14 +21,14 @@ slots:
     deny-installation: true
     allow-auto-connection:
       plug-type:
-        - core
+        - agent
   interface4:
     allow-connection: true
     deny-connection: false
     allow-installation:
       slot-type:
-        - core
-        - sdk
+        - agent
+        - regular
 timestamp: 2016-09-29T19:50:49Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
@@ -48,11 +48,11 @@ AXNpZw==`
 	c.Assert(slotRule3, check.NotNil)
 	c.Assert(slotRule3.DenyInstallation, check.HasLen, 1)
 	c.Assert(slotRule3.AllowAutoConnection, check.HasLen, 1)
-	c.Check(slotRule3.AllowAutoConnection[0].PlugSdkTypes, check.DeepEquals, []string{"core"})
+	c.Check(slotRule3.AllowAutoConnection[0].PlugSdkTypes, check.DeepEquals, []string{"agent"})
 
 	slotRule4 := baseDecl.SlotRule("interface4")
 	c.Assert(slotRule4, check.NotNil)
-	c.Check(slotRule4.AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"core", "sdk"})
+	c.Check(slotRule4.AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"agent", "regular"})
 	c.Assert(slotRule4.DenyInstallation, check.HasLen, 1)
 	c.Assert(slotRule3.AllowConnection, check.HasLen, 1)
 	c.Assert(slotRule3.DenyConnection, check.HasLen, 1)
@@ -107,7 +107,7 @@ slots:
   network:
     allow-installation:
       slot-type:
-        - core
+        - agent
 `
 
 	err := asserts.InitBuiltinBaseDeclaration([]byte(headers))
@@ -121,7 +121,7 @@ slots:
 
 	c.Check(baseDecl.AuthorityID(), check.Equals, "canonical")
 	c.Check(baseDecl.Series(), check.Equals, "1")
-	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"core"})
+	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"agent"})
 
 	enc := asserts.Encode(baseDecl)
 	// it's expected that it cannot be decoded

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -49,6 +49,11 @@ var api = []*Command{{
 	UserOK:  true,
 	POST:    v1PostWorkshopMount,
 }, {
+	Path:    "/v1/connections",
+	GuestOK: false,
+	UserOK:  true,
+	GET:     v1GetConnections,
+}, {
 	Path:   "/v1/changes",
 	UserOK: true,
 	GET:    v1GetChanges,

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -1,0 +1,264 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"sort"
+
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/overlord/ifacestate"
+	"github.com/canonical/workshop/internal/overlord/workshopstate"
+)
+
+type collectFilter struct {
+	projectId string
+	workshop  string
+	ifaceName string
+	connected bool
+}
+
+func (c *collectFilter) plugOrConnectedSlotMatches(plug *interfaces.PlugRef, connectedSlots []interfaces.SlotRef) bool {
+	for _, slot := range connectedSlots {
+		if c.slotOrConnectedPlugMatches(&slot, nil) {
+			return true
+		}
+	}
+	if (c.projectId != plug.ProjectId) || (c.workshop != "" && plug.Workshop != c.workshop) {
+		return false
+	}
+	return true
+}
+
+func (c *collectFilter) slotOrConnectedPlugMatches(slot *interfaces.SlotRef, connectedPlugs []interfaces.PlugRef) bool {
+	for _, plug := range connectedPlugs {
+		if c.plugOrConnectedSlotMatches(&plug, nil) {
+			return true
+		}
+	}
+	if (c.projectId != slot.ProjectId) || (c.workshop != "" && slot.Workshop != c.workshop) {
+		return false
+	}
+	return true
+}
+
+func (c *collectFilter) ifaceMatches(ifaceName string) bool {
+	if c.ifaceName != "" && c.ifaceName != ifaceName {
+		return false
+	}
+	return true
+}
+
+type bySlotRef []interfaces.SlotRef
+
+func (b bySlotRef) Len() int      { return len(b) }
+func (b bySlotRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b bySlotRef) Less(i, j int) bool {
+	return b[i].SortsBefore(b[j])
+}
+
+type byPlugRef []interfaces.PlugRef
+
+func (b byPlugRef) Len() int      { return len(b) }
+func (b byPlugRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b byPlugRef) Less(i, j int) bool {
+	return b[i].SortsBefore(b[j])
+}
+
+// mergeAttrs merges attributes from 2 disjoint sets of static and dynamic slot or
+// plug attributes into a single map.
+func mergeAttrs(one map[string]interface{}, other map[string]interface{}) map[string]interface{} {
+	merged := make(map[string]interface{}, len(one)+len(other))
+	for k, v := range one {
+		merged[k] = v
+	}
+	for k, v := range other {
+		merged[k] = v
+	}
+	return merged
+}
+
+func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFilter) (*connectionsJSON, error) {
+	repo := ifaceMgr.Repository()
+	ifaces := repo.Interfaces()
+
+	var connsjson connectionsJSON
+	var connStates map[string]ifacestate.ConnectionState
+	plugConns := map[string][]interfaces.SlotRef{}
+	slotConns := map[string][]interfaces.PlugRef{}
+
+	var err error
+	connStates, err = ifaceMgr.ConnectionStates()
+	if err != nil {
+		return nil, err
+	}
+
+	connsjson.Established = make([]connectionJSON, 0, len(connStates))
+	connsjson.Plugs = make([]*plugJSON, 0, len(ifaces.Plugs))
+	connsjson.Slots = make([]*slotJSON, 0, len(ifaces.Slots))
+
+	for crefStr, cstate := range connStates {
+		if cstate.Undesired && filter.connected {
+			continue
+		}
+
+		cref, err := interfaces.ParseConnRef(crefStr)
+		if err != nil {
+			return nil, err
+		}
+
+		if repo.Plug(cref.PlugRef.ProjectId, cref.PlugRef.Workshop, cref.PlugRef.Sdk, cref.PlugRef.Name) == nil ||
+			repo.Slot(cref.SlotRef.ProjectId, cref.SlotRef.Workshop, cref.SlotRef.Sdk, cref.SlotRef.Name) == nil {
+			continue
+		}
+
+		if !filter.plugOrConnectedSlotMatches(&cref.PlugRef, nil) && !filter.slotOrConnectedPlugMatches(&cref.SlotRef, nil) {
+			continue
+		}
+		if !filter.ifaceMatches(cstate.Interface) {
+			continue
+		}
+		plugRef := interfaces.PlugRef{ProjectId: cref.PlugRef.ProjectId, Workshop: cref.PlugRef.Workshop, Sdk: cref.PlugRef.Sdk, Name: cref.PlugRef.Name}
+		slotRef := interfaces.SlotRef{ProjectId: cref.SlotRef.ProjectId, Workshop: cref.SlotRef.Workshop, Sdk: cref.SlotRef.Sdk, Name: cref.SlotRef.Name}
+		plugID := plugRef.String()
+		slotID := slotRef.String()
+
+		cj := connectionJSON{
+			Slot:      slotRef,
+			Plug:      plugRef,
+			Manual:    !cstate.Auto,
+			Interface: cstate.Interface,
+			PlugAttrs: mergeAttrs(cstate.StaticPlugAttrs, cstate.DynamicPlugAttrs),
+			SlotAttrs: mergeAttrs(cstate.StaticSlotAttrs, cstate.DynamicSlotAttrs),
+		}
+		if cstate.Undesired {
+			// explicitly disconnected are always manual
+			cj.Manual = true
+			connsjson.Undesired = append(connsjson.Undesired, cj)
+		} else {
+			plugConns[plugID] = append(plugConns[plugID], slotRef)
+			slotConns[slotID] = append(slotConns[slotID], plugRef)
+
+			connsjson.Established = append(connsjson.Established, cj)
+		}
+	}
+
+	for _, plug := range ifaces.Plugs {
+		plugRef := interfaces.PlugRef{ProjectId: plug.Sdk.ProjectId, Workshop: plug.Sdk.Workshop, Sdk: plug.Sdk.Name, Name: plug.Name}
+		connectedSlots, connected := plugConns[plugRef.String()]
+		if !connected && filter.connected {
+			continue
+		}
+		if !filter.ifaceMatches(plug.Interface) || !filter.plugOrConnectedSlotMatches(&plugRef, connectedSlots) {
+			continue
+		}
+		sort.Sort(bySlotRef(connectedSlots))
+		pj := &plugJSON{
+			ProjectId:   plugRef.ProjectId,
+			Workshop:    plugRef.Workshop,
+			Sdk:         plugRef.Sdk,
+			Name:        plugRef.Name,
+			Interface:   plug.Interface,
+			Attrs:       plug.Attrs,
+			Label:       plug.Label,
+			Connections: connectedSlots,
+		}
+		connsjson.Plugs = append(connsjson.Plugs, pj)
+	}
+	for _, slot := range ifaces.Slots {
+		slotRef := interfaces.SlotRef{ProjectId: slot.Sdk.ProjectId, Workshop: slot.Sdk.Workshop, Sdk: slot.Sdk.Name, Name: slot.Name}
+		connectedPlugs, connected := slotConns[slotRef.String()]
+		if !connected && filter.connected {
+			continue
+		}
+		if !filter.ifaceMatches(slot.Interface) || !filter.slotOrConnectedPlugMatches(&slotRef, connectedPlugs) {
+			continue
+		}
+		sort.Sort(byPlugRef(connectedPlugs))
+		sj := &slotJSON{
+			ProjectId:   slotRef.ProjectId,
+			Workshop:    slotRef.Workshop,
+			Sdk:         slotRef.Sdk,
+			Name:        slotRef.Name,
+			Interface:   slot.Interface,
+			Attrs:       slot.Attrs,
+			Label:       slot.Label,
+			Connections: connectedPlugs,
+		}
+		connsjson.Slots = append(connsjson.Slots, sj)
+	}
+	return &connsjson, nil
+}
+
+type byCrefConnJSON []connectionJSON
+
+func (b byCrefConnJSON) Len() int      { return len(b) }
+func (b byCrefConnJSON) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b byCrefConnJSON) Less(i, j int) bool {
+	icj := b[i]
+	jcj := b[j]
+	iCref := interfaces.ConnRef{PlugRef: icj.Plug, SlotRef: icj.Slot}
+	jCref := interfaces.ConnRef{PlugRef: jcj.Plug, SlotRef: jcj.Slot}
+	sortsBefore := iCref.SortsBefore(&jCref)
+	return sortsBefore
+}
+
+func checkWorkshopExists(ctx context.Context, manager *workshopstate.WorkshopManager, projectId, name string) error {
+	_, err := manager.Workshop(ctx, name, projectId)
+	return err
+}
+
+func v1GetConnections(c *Command, r *http.Request, _ *userState) Response {
+	query := r.URL.Query()
+	projectId := query.Get("project-id")
+	workshop := query.Get("workshop")
+	ifaceName := query.Get("interface")
+	qselect := query.Get("select")
+
+	if projectId == "" {
+		return statusBadRequest("project-id must not be empty")
+	}
+
+	if qselect != "all" && qselect != "" {
+		return statusBadRequest("unsupported select qualifier")
+	}
+	onlyConnected := qselect == ""
+
+	if workshop != "" {
+		if err := checkWorkshopExists(r.Context(), c.d.overlord.WorkshopManager(), projectId, workshop); err != nil {
+			return statusNotFound("cannot access workshop: %v", err)
+		}
+	}
+
+	connsjson, err := collectConnections(c.d.overlord.InterfaceManager(), collectFilter{
+		projectId: projectId,
+		workshop:  workshop,
+		ifaceName: ifaceName,
+		connected: onlyConnected,
+	})
+	if err != nil {
+		return statusInternalError("collecting connection information failed: %v", err)
+	}
+	sort.Sort(byCrefConnJSON(connsjson.Established))
+	sort.Sort(byCrefConnJSON(connsjson.Undesired))
+
+	return SyncResponse(connsjson, http.StatusOK)
+}

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1,0 +1,909 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/interfaces/ifacetest"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/x-go/strutil"
+)
+
+// Tests for GET /v1/connections
+
+const (
+	consumerYaml = `
+name: consumer
+base: ubuntu@22.04
+plugs:
+ plug:
+  interface: test
+  key: value
+  label: label
+`
+	producerYaml = `
+name: producer
+base: ubuntu@22.04
+slots:
+ slot:
+  interface: test
+  key: value
+  label: label
+`
+)
+
+func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, workshop string) {
+	info := sdk.MockInfo(c, yaml, s.project.ProjectId, workshop)
+	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, workshop)), []byte(fmt.Sprintf(`name: %s
+base: ubuntu@20.04
+sdks:
+  %s:
+    channel: latest/stable
+`, workshop, info.Name)), 0644)
+	c.Assert(err, check.IsNil)
+	c.Assert(s.b.LaunchWorkshop(s.ctx, workshop, "ubuntu@20.04"), check.IsNil)
+}
+
+func (s *apiSuite) testConnectionsConnected(c *check.C, d *Daemon, query string, connsState map[string]interface{}, repoConnected []string, expected map[string]interface{}) {
+	repo := d.Overlord().InterfaceManager().Repository()
+	for crefStr, cstate := range connsState {
+		// if repoConnected is defined, then given connection must be on
+		// list, otherwise it's not going to be connected in the repository
+		// to simulate missing plugs/slots.
+		if repoConnected != nil && !strutil.ListContains(repoConnected, crefStr) {
+			continue
+		}
+		cref, err := interfaces.ParseConnRef(crefStr)
+		c.Assert(err, check.IsNil)
+		conn := cstate.(map[string]interface{})
+		if undesiredRaw, ok := conn["undesired"]; ok {
+			undesired, ok := undesiredRaw.(bool)
+			c.Assert(ok, check.Equals, true, check.Commentf("unexpected value for key 'undesired': %v", cstate))
+			if undesired {
+				// do not add connections that are undesired
+				continue
+			}
+		}
+		staticPlugAttrs, _ := conn["plug-static"].(map[string]interface{})
+		dynamicPlugAttrs, _ := conn["plug-dynamic"].(map[string]interface{})
+		staticSlotAttrs, _ := conn["slot-static"].(map[string]interface{})
+		dynamicSlotAttrs, _ := conn["slot-dynamic"].(map[string]interface{})
+		_, err = repo.Connect(cref, staticPlugAttrs, dynamicPlugAttrs, staticSlotAttrs, dynamicSlotAttrs, nil)
+		c.Assert(err, check.IsNil)
+	}
+
+	st := d.Overlord().State()
+	st.Lock()
+	st.Set("conns", connsState)
+	st.Unlock()
+
+	s.testConnections(c, query, expected)
+}
+
+func (s *apiSuite) testConnections(c *check.C, query string, expected map[string]interface{}) {
+	cmd := apiCmd("/v1/connections")
+	req, err := s.createProjectsRequest("GET", query, nil)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1GetConnections(cmd, req, nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 200)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, expected)
+}
+
+func (s *apiSuite) TestConnectionsUnhappy(c *check.C) {
+	s.daemon(c)
+	cmd := apiCmd("/v1/connections")
+	req, err := s.createProjectsRequest("GET", "/v2/connections?project-id=b8639dea&select=not-found", nil)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1GetConnections(cmd, req, nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 400)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"result": map[string]interface{}{
+			"message": "unsupported select qualifier"},
+		"status":      "Bad Request",
+		"status-code": 400.0,
+		"type":        "error",
+	})
+}
+
+func (s *apiSuite) TestConnectionsEmpty(c *check.C) {
+	s.daemon(c)
+	s.testConnections(c, "/v2/connections?project-id=b8639dea", map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs":       []interface{}{},
+			"slots":       []interface{}{},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs":       []interface{}{},
+			"slots":       []interface{}{},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
+func (s *apiSuite) TestConnectionsNotFound(c *check.C) {
+	s.daemon(c)
+	cmd := apiCmd("/v1/connections")
+	req, err := s.createProjectsRequest("GET", "/v2/connections?project-id=b8639dea&workshop=not-found", nil)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1GetConnections(cmd, req, nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 404)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"result": map[string]interface{}{
+			"message": `cannot access workshop: workshop not found`,
+		},
+		"status":      "Not Found",
+		"status-code": 404.0,
+		"type":        "error",
+	})
+}
+
+func (s *apiSuite) TestConnectionsUnconnected(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "ws-consumer")
+	s.mockInstalledSDK(c, producerYaml, "ws-producer")
+
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": s.project.ProjectId,
+					"workshop":   "ws-consumer",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": s.project.ProjectId,
+					"workshop":   "ws-producer",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
+func (s *apiSuite) TestConnectionsByWorkshopName(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&workshop=producer-ws", map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": s.project.ProjectId,
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+			"plugs": []interface{}{},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&workshop=consumer-ws", map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": s.project.ProjectId,
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+			"slots": []interface{}{},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&workshop=producer-ws", map[string]interface{}{
+		"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+		},
+	}, nil, map[string]interface{}{
+		"result": map[string]interface{}{
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					},
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					},
+				},
+			},
+			"established": []interface{}{
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"manual":    true,
+					"interface": "test",
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
+func (s *apiSuite) TestConnectionsMissingPlugSlotFilteredOut(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	for _, missingPlugOrSlot := range []string{"b8639dea:consumer-ws:consumer:plug2 b8639dea:producer-ws:producer:slot", "b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot2"} {
+		s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&workshop=producer-ws", map[string]interface{}{
+			"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+				"interface": "test",
+			},
+			missingPlugOrSlot: map[string]interface{}{
+				"interface": "test",
+			},
+		},
+			[]string{"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot"},
+			map[string]interface{}{
+				"result": map[string]interface{}{
+					"plugs": []interface{}{
+						map[string]interface{}{
+							"project-id": "b8639dea",
+							"workshop":   "consumer-ws",
+							"sdk":        "consumer",
+							"plug":       "plug",
+							"interface":  "test",
+							"attrs":      map[string]interface{}{"key": "value"},
+							"label":      "label",
+							"connections": []interface{}{
+								map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+							},
+						},
+					},
+					"slots": []interface{}{
+						map[string]interface{}{
+							"project-id": "b8639dea",
+							"workshop":   "producer-ws",
+							"sdk":        "producer",
+							"slot":       "slot",
+							"interface":  "test",
+							"attrs":      map[string]interface{}{"key": "value"},
+							"label":      "label",
+							"connections": []interface{}{
+								map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+							},
+						},
+					},
+					"established": []interface{}{
+						map[string]interface{}{
+							"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+							"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+							"manual":    true,
+							"interface": "test",
+						},
+					},
+				},
+				"status":      "OK",
+				"status-code": 200.0,
+				"type":        "sync",
+			})
+	}
+}
+
+func (s *apiSuite) TestConnectionsByIfaceName(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+	restore = builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "different"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+	var differentProducerYaml = `
+name: different-producer
+base: ubuntu@22.04
+slots:
+ slot:
+  interface: different
+  key: value
+  label: label
+`
+	var differentConsumerYaml = `
+name: different-consumer
+base: ubuntu@22.04
+plugs:
+ plug:
+  interface: different
+  key: value
+  label: label
+`
+	s.mockInstalledSDK(c, differentConsumerYaml, "consumer-diff-ws")
+	s.mockInstalledSDK(c, differentProducerYaml, "producer-diff-ws")
+
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&interface=test", map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&interface=different", map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-diff-ws",
+					"sdk":        "different-consumer",
+					"plug":       "plug",
+					"interface":  "different",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-diff-ws",
+					"sdk":        "different-producer",
+					"slot":       "slot",
+					"interface":  "different",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+
+	// modifies state internally
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&interfaces=test", map[string]interface{}{
+		"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+		},
+	}, nil, map[string]interface{}{
+		"result": map[string]interface{}{
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					},
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					},
+				},
+			},
+			"established": []interface{}{
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"manual":    true,
+					"interface": "test",
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+	// use state modified by previous call
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&interface=different", map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"slots":       []interface{}{},
+			"plugs":       []interface{}{},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
+func (s *apiSuite) TestConnectionsDefaultManual(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]interface{}{
+		"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+		},
+	}, nil, map[string]interface{}{
+		"result": map[string]interface{}{
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					},
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					},
+				},
+			},
+			"established": []interface{}{
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"manual":    true,
+					"interface": "test",
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
+func (s *apiSuite) TestConnectionsDefaultAuto(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]interface{}{
+		"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+			"plug-static": map[string]interface{}{
+				"key": "value",
+			},
+			"plug-dynamic": map[string]interface{}{
+				"foo-plug-dynamic": "bar-dynamic",
+			},
+			"slot-static": map[string]interface{}{
+				"key": "value",
+			},
+			"slot-dynamic": map[string]interface{}{
+				"foo-slot-dynamic": "bar-dynamic",
+			},
+		},
+	}, nil, map[string]interface{}{
+		"result": map[string]interface{}{
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					},
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					},
+				},
+			},
+			"established": []interface{}{
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"interface": "test",
+					"plug-attrs": map[string]interface{}{
+						"key":              "value",
+						"foo-plug-dynamic": "bar-dynamic",
+					},
+					"slot-attrs": map[string]interface{}{
+						"key":              "value",
+						"foo-slot-dynamic": "bar-dynamic",
+					},
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
+func (s *apiSuite) TestConnectionsAll(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
+		"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+			"undesired": true,
+		},
+	}, nil, map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+				},
+			},
+			"undesired": []interface{}{
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"manual":    true,
+					"interface": "test",
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
+func (s *apiSuite) TestConnectionsOnlyConnected(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]interface{}{
+		"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+			"undesired": true,
+		},
+	}, nil, map[string]interface{}{
+		"result": map[string]interface{}{
+			"established": []interface{}{},
+			"plugs":       []interface{}{},
+			"slots":       []interface{}{},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
+func (s *apiSuite) TestConnectionsSorted(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	var anotherConsumerYaml = `
+name: another-consumer-%s
+base: ubuntu@22.04
+plugs:
+ plug:
+  interface: test
+  key: value
+  label: label
+`
+	var anotherProducerYaml = `
+name: another-producer
+base: ubuntu@22.04
+slots:
+ slot:
+  interface: test
+  key: value
+  label: label
+`
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, fmt.Sprintf(anotherConsumerYaml, "def"), "consumer-ws-def")
+	s.mockInstalledSDK(c, fmt.Sprintf(anotherConsumerYaml, "abc"), "consumer-ws-abc")
+
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+	s.mockInstalledSDK(c, anotherProducerYaml, "another-producer-ws")
+
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]interface{}{
+		"b8639dea:consumer-ws:consumer:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+		},
+		"b8639dea:consumer-ws-def:another-consumer-def:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+		},
+		"b8639dea:consumer-ws-abc:another-consumer-abc:plug b8639dea:producer-ws:producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+		},
+		"b8639dea:consumer-ws-def:another-consumer-def:plug b8639dea:another-producer-ws:another-producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+		},
+	}, nil, map[string]interface{}{
+		"result": map[string]interface{}{
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					},
+				},
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws-abc",
+					"sdk":        "another-consumer-abc",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					},
+				},
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws-def",
+					"sdk":        "another-consumer-def",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "another-producer-ws", "sdk": "another-producer", "slot": "slot"},
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					},
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "another-producer-ws",
+					"sdk":        "another-producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
+					},
+				},
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-abc", "sdk": "another-consumer-abc", "plug": "plug"},
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
+					},
+				},
+			},
+			"established": []interface{}{
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"interface": "test",
+				},
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-abc", "sdk": "another-consumer-abc", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"interface": "test",
+				},
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "another-producer-ws", "sdk": "another-producer", "slot": "slot"},
+					"interface": "test",
+				},
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"interface": "test",
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}

--- a/internal/daemon/api_json.go
+++ b/internal/daemon/api_json.go
@@ -1,0 +1,86 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+)
+
+// plugJSON aids in marshaling snap.PlugInfo into JSON.
+type plugJSON struct {
+	ProjectId string                 `json:"project-id"`
+	Workshop  string                 `json:"workshop"`
+	Sdk       string                 `json:"sdk"`
+	Name      string                 `json:"plug"`
+	Interface string                 `json:"interface,omitempty"`
+	Attrs     map[string]interface{} `json:"attrs,omitempty"`
+	Label     string                 `json:"label,omitempty"`
+	// Connections are synthesized, they are not on the original type.
+	Connections []interfaces.SlotRef `json:"connections,omitempty"`
+}
+
+// slotJSON aids in marshaling snap.SlotInfo into JSON.
+type slotJSON struct {
+	ProjectId string                 `json:"project-id"`
+	Workshop  string                 `json:"workshop"`
+	Sdk       string                 `json:"sdk"`
+	Name      string                 `json:"slot"`
+	Interface string                 `json:"interface,omitempty"`
+	Attrs     map[string]interface{} `json:"attrs,omitempty"`
+	Label     string                 `json:"label,omitempty"`
+	// Connections are synthesized, they are not on the original type.
+	Connections []interfaces.PlugRef `json:"connections,omitempty"`
+}
+
+// interfaceJSON aids in marshaling interfaces.Info into JSON.
+type interfaceJSON struct {
+	Name    string      `json:"name,omitempty"`
+	Summary string      `json:"summary,omitempty"`
+	DocURL  string      `json:"doc-url,omitempty"`
+	Plugs   []*plugJSON `json:"plugs,omitempty"`
+	Slots   []*slotJSON `json:"slots,omitempty"`
+}
+
+// interfaceAction is an action performed on the interface system.
+type interfaceAction struct {
+	Action string     `json:"action"`
+	Forget bool       `json:"forget,omitempty"`
+	Plugs  []plugJSON `json:"plugs,omitempty"`
+	Slots  []slotJSON `json:"slots,omitempty"`
+}
+
+// connectionsJSON aids in marshalling information about a single connection
+// into JSON
+type connectionJSON struct {
+	Slot      interfaces.SlotRef     `json:"slot"`
+	Plug      interfaces.PlugRef     `json:"plug"`
+	Interface string                 `json:"interface"`
+	Manual    bool                   `json:"manual,omitempty"`
+	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`
+	PlugAttrs map[string]interface{} `json:"plug-attrs,omitempty"`
+}
+
+// connectionsJSON aids in marshaling connections into JSON.
+type connectionsJSON struct {
+	Established []connectionJSON `json:"established"`
+	Undesired   []connectionJSON `json:"undesired,omitempty"`
+	Plugs       []*plugJSON      `json:"plugs"`
+	Slots       []*slotJSON      `json:"slots"`
+}

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -87,6 +87,7 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	}
 	d, err := New(&Options{Dir: s.workshopDir}, s.b)
 	c.Assert(err, check.IsNil)
+	c.Assert(d.overlord.StartUp(), check.IsNil)
 	d.addRoutes()
 	s.d = d
 	return d

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/interfaces/ifacetest"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
@@ -97,7 +96,6 @@ func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []
 
 func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 	s.daemon(c)
-	mockIface(c, s.d, &ifacetest.TestInterface{InterfaceName: "content"})
 	s.launchWorkshopWithPlug(s.ctx, "ws", c)
 
 	// Setup
@@ -122,7 +120,6 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
 	// Setup
 	s.daemon(c)
-	mockIface(c, s.d, &ifacetest.TestInterface{InterfaceName: "content"})
 	s.launchWorkshopWithPlug(s.ctx, "ws", c)
 	_, err := s.d.overlord.InterfaceManager().Repository().DisconnectSdk(s.project.ProjectId, "ws", "test-sdk")
 	c.Check(err, check.IsNil)

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -21,6 +21,9 @@ var (
 
 	// SDKs directory to install an SDK in a workshop
 	WorkshopSdksDir = filepath.Join(WorkshopBaseDir, "sdk")
+
+	// Base directory for the workshop state storage
+	WorkshopStateDir = "/var/lib/workshop/state"
 )
 
 // Variables for workshopd (host paths)

--- a/internal/interfaces/builtin/all_test.go
+++ b/internal/interfaces/builtin/all_test.go
@@ -112,7 +112,7 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotNames(c *C) {
 	})
 	defer restore()
 
-	sdkInfo := sdk.MockInvalidInfo(c, testConsumerInvalidSlotNameYaml, sdk.Setup{})
+	sdkInfo := sdk.MockInvalidInfo(c, testConsumerInvalidSlotNameYaml)
 	sdk.SanitizePlugsSlots(sdkInfo)
 	c.Assert(sdkInfo.BadInterfaces, HasLen, 1)
 	c.Check(sdk.BadInterfacesSummary(sdkInfo), Matches, `sdk "consumer" has bad plugs or slots: ttyS5 \(invalid slot name: "ttyS5"\)`)
@@ -124,7 +124,7 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
 	})
 	defer restore()
 
-	sdkInfo := sdk.MockInvalidInfo(c, testConsumerInvalidPlugNameYaml, sdk.Setup{})
+	sdkInfo := sdk.MockInvalidInfo(c, testConsumerInvalidPlugNameYaml)
 	sdk.SanitizePlugsSlots(sdkInfo)
 	c.Assert(sdkInfo.BadInterfaces, HasLen, 1)
 	c.Check(sdk.BadInterfacesSummary(sdkInfo), Matches, `sdk "consumer" has bad plugs or slots: ttyS3 \(invalid plug name: "ttyS3"\)`)

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -38,7 +38,7 @@ const contentBaseDeclarationSlots = `
   content:
     allow-installation:
       slot-type:
-        - core
+        - agent
     allow-connection: true
     allow-auto-connection: true
 `

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -54,7 +54,6 @@ func (iface *contentInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              contentSummary,
 		BaseDeclarationSlots: contentBaseDeclarationSlots,
-		ImplicitOnCore:       true,
 		AffectsPlugOnRefresh: true,
 	}
 }

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -123,6 +123,7 @@ func (iface *contentInterface) MountConnectedPlug(spec *device.Specification, pl
 	if err != nil {
 		return err
 	}
+
 	source, err := iface.source(user, plug)
 	if err != nil {
 		return err

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -37,7 +37,7 @@ const contentSummary = `allows sharing host code and data with SDKs`
 const contentBaseDeclarationSlots = `
   content:
     allow-installation:
-      slot-type:
+      slot-sdk-type:
         - agent
     allow-connection: true
     allow-auto-connection: true

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -62,7 +62,7 @@ slots:
  content-slot:
   interface: content
 `
-	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws", sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	slot := info.Slots["content-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
 }
@@ -75,7 +75,7 @@ plugs:
   interface: content
   target: import
 `
-	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws", sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
 }
@@ -88,7 +88,7 @@ plugs:
   interface: content
   content: mycont
 `
-	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws", sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content plug must contain target path")
 }
@@ -102,7 +102,7 @@ plugs:
   content: mycont
   target: ../foo
 `
-	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws", sdk.Setup{})
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content interface path is not clean:.*")
 }
@@ -117,14 +117,14 @@ base: ubuntu@22.04
 plugs:
  content:
   target: /project/training
-`, s.projectId, "ws", sdk.Setup{}, "content")
+`, s.projectId, "ws", "consumer", "content")
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 
 	slot := builtin.MockSlot(c, `name: producer
 base: ubuntu@22.04
 slots:
  content:
-`, s.projectId, "ws", sdk.Setup{}, "content")
+`, s.projectId, "ws", "producer", "content")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 	deviceSpec := &device.Specification{}
 

--- a/internal/interfaces/builtin/export_test.go
+++ b/internal/interfaces/builtin/export_test.go
@@ -52,18 +52,18 @@ func MustInterface(name string) interfaces.Interface {
 	panic(fmt.Errorf("cannot find interface with name %q", name))
 }
 
-func MockPlug(c *check.C, yaml string, projectId, workshop string, si sdk.Setup, plugName string) *sdk.PlugInfo {
-	info := sdk.MockInfo(c, yaml, projectId, workshop, si)
+func MockPlug(c *check.C, yaml string, projectId, workshop, sdkName string, plugName string) *sdk.PlugInfo {
+	info := sdk.MockInfo(c, yaml, projectId, workshop)
 	if plugInfo, ok := info.Plugs[plugName]; ok {
 		return plugInfo
 	}
-	panic(fmt.Sprintf("cannot find plug %q in sdk %q", plugName, si.Name))
+	panic(fmt.Sprintf("cannot find plug %q in sdk %q", plugName, sdkName))
 }
 
-func MockSlot(c *check.C, yaml string, projectId, workshop string, si sdk.Setup, slotName string) *sdk.SlotInfo {
-	info := sdk.MockInfo(c, yaml, projectId, workshop, si)
+func MockSlot(c *check.C, yaml string, projectId, workshop, sdkName string, slotName string) *sdk.SlotInfo {
+	info := sdk.MockInfo(c, yaml, projectId, workshop)
 	if slotInfo, ok := info.Slots[slotName]; ok {
 		return slotInfo
 	}
-	panic(fmt.Sprintf("cannot find slot %q in sdk %q", slotName, si.Name))
+	panic(fmt.Sprintf("cannot find slot %q in sdk %q", slotName, sdkName))
 }

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -51,7 +51,7 @@ plugs:
         attr: value
         complex:
             c: d
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	s.plug = consumer.Plugs["plug"]
 	producer := sdk.MockInfo(c, `
 name: producer
@@ -63,7 +63,7 @@ slots:
         number: 100
         complex:
             a: b
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	s.slot = producer.Slots["slot"]
 }
 

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -222,9 +222,6 @@ type StaticInfo struct {
 	Summary string `json:"summary,omitempty"`
 	DocURL  string `json:"doc-url,omitempty"`
 
-	// ImplicitOnCore controls if a slot is automatically added to core (non-classic) systems.
-	ImplicitOnCore bool `json:"implicit-on-core,omitempty"`
-
 	// AffectsPlugOnRefresh tells if refreshing of a sdk with a slot of this interface
 	// is disruptive for the sdk on the plug side (when the interface is connected),
 	// meaning that a refresh of the slot-side affects sdk(s) on the plug side

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -73,6 +73,9 @@ func (ref PlugRef) String() string {
 
 // SortsBefore returns true when plug should be sorted before the other
 func (ref PlugRef) SortsBefore(other PlugRef) bool {
+	if ref.Workshop != other.Workshop {
+		return ref.Workshop < other.Workshop
+	}
 	if ref.Sdk != other.Sdk {
 		return ref.Sdk < other.Sdk
 	}
@@ -107,6 +110,9 @@ func (ref SlotRef) String() string {
 
 // SortsBefore returns true when slot should be sorted before the other
 func (ref SlotRef) SortsBefore(other SlotRef) bool {
+	if ref.Workshop != other.Workshop {
+		return ref.Workshop < other.Workshop
+	}
 	if ref.Sdk != other.Sdk {
 		return ref.Sdk < other.Sdk
 	}

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -151,7 +151,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: mock-service-snippets
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	plug := info.Plugs["plug"]
 
 	snips, err := interfaces.PermanentPlugServiceSnippets(iface, plug)
@@ -175,7 +175,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: unclean-service-snippets
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	plug := info.Plugs["plug"]
 
 	iface, err := interfaces.ByName("unclean-service-snippets")
@@ -193,7 +193,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: iface
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	plug := info.Plugs["plug"]
 	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
 		InterfaceName: "iface",
@@ -214,7 +214,7 @@ base: ubuntu@22.04
 slots:
   slot:
     interface: iface
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	slot := info.Slots["slot"]
 	c.Assert(interfaces.BeforePrepareSlot(&ifacetest.TestInterface{
 		InterfaceName: "iface",

--- a/internal/interfaces/policy/basedeclaration.go
+++ b/internal/interfaces/policy/basedeclaration.go
@@ -50,26 +50,26 @@ import (
 //   slots:
 //     manual-connected-implicit-slot:
 //       allow-installation:
-//         slot-type:
-//           - core                     # implicit slot
+//         slot-sdk-type:
+//           - agent                     # implicit slot
 //       deny-auto-connection: true     # force manual connect
 //
 //     auto-connected-implicit-slot:
 //       allow-installation:
-//         slot-type:
-//           - core                     # implicit slot
+//         slot-sdk-type:
+//           - agent                     # implicit slot
 //       allow-auto-connection: true    # allow auto-connect
 //
 //     manual-connected-provided-slot:
 //       allow-installation:
-//         slot-type:
+//         slot-sdk-type:
 //           - sdk                      # sdk provided slot
 //       deny-connection: true          # require allow-connection in sdk decl
 //       deny-auto-connection: true     # force manual connect
 //
 //     auto-connected-provided-slot:
 //       allow-installation:
-//         slot-type:
+//         slot-sdk-type:
 //           - sdk                      # sdk provided slot
 //       deny-connection: true          # require allow-connection in sdk decl
 

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -133,12 +133,12 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *C) {
 
 func (s *baseDeclSuite) TestContentSlotInstallation(c *C) {
 	// test content specially
-	ic := s.installSlotCand(c, "content", sdk.Sdk, ``)
+	ic := s.installSlotCand(c, "content", sdk.Regular, ``)
 	err := ic.Check()
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "installation not allowed by \"content\" slot rule of interface \"content\"")
 
-	ic = s.installSlotCand(c, "content", sdk.Core, ``)
+	ic = s.installSlotCand(c, "content", sdk.Agent, ``)
 	err = ic.Check()
 	c.Assert(err, IsNil)
 }

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -69,8 +69,8 @@ plugs:
   %s:
 `, iface)
 	}
-	slotSdk := sdk.MockInfo(c, slotYaml, "mock424242", "ws", sdk.Setup{})
-	plugSdk := sdk.MockInfo(c, plugYaml, "mock424242", "ws", sdk.Setup{})
+	slotSdk := sdk.MockInfo(c, slotYaml, "mock424242", "ws")
+	plugSdk := sdk.MockInfo(c, plugYaml, "mock424242", "ws")
 	return &policy.ConnectCandidate{
 		Plug:            interfaces.NewConnectedPlug(plugSdk.Plugs[iface], nil, nil),
 		Slot:            interfaces.NewConnectedSlot(slotSdk.Slots[iface], nil, nil),
@@ -87,7 +87,7 @@ slots:
   %s:
 `, sdkType, iface)
 	}
-	sdk := sdk.MockInfo(c, yaml, "mock424242", "ws", sdk.Setup{})
+	sdk := sdk.MockInfo(c, yaml, "mock424242", "ws")
 	return &policy.InstallCandidate{
 		Sdk:             sdk,
 		BaseDeclaration: s.baseDecl,
@@ -103,7 +103,7 @@ plugs:
   %s:
 `, sdkType, iface)
 	}
-	sdk := sdk.MockInfo(c, yaml, "mock424242", "ws", sdk.Setup{})
+	sdk := sdk.MockInfo(c, yaml, "mock424242", "ws")
 	return &policy.InstallCandidate{
 		Sdk:             sdk,
 		BaseDeclaration: s.baseDecl,

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -54,7 +54,7 @@ func (s *baseDeclSuite) TearDownSuite(c *C) {
 	s.restoreSanitize()
 }
 
-func (s *baseDeclSuite) connectCand(c *C, iface, slotYaml, plugYaml string) *policy.ConnectCandidate {
+func (s *baseDeclSuite) connectCand(c *C, iface, slotYaml, plugYaml string, slotprj, plugprj string, slotws, plugws string) *policy.ConnectCandidate {
 	if slotYaml == "" {
 		slotYaml = fmt.Sprintf(`name: slot-sdk
 base: ubuntu@22.04
@@ -69,8 +69,8 @@ plugs:
   %s:
 `, iface)
 	}
-	slotSdk := sdk.MockInfo(c, slotYaml, "mock424242", "ws")
-	plugSdk := sdk.MockInfo(c, plugYaml, "mock424242", "ws")
+	slotSdk := sdk.MockInfo(c, slotYaml, slotprj, slotws)
+	plugSdk := sdk.MockInfo(c, plugYaml, plugprj, plugws)
 	return &policy.ConnectCandidate{
 		Plug:            interfaces.NewConnectedPlug(plugSdk.Plugs[iface], nil, nil),
 		Slot:            interfaces.NewConnectedSlot(slotSdk.Slots[iface], nil, nil),
@@ -117,7 +117,7 @@ slots:
     %s:
 `, "content")
 
-	cand := s.connectCand(c, "content", slotYaml, "")
+	cand := s.connectCand(c, "content", slotYaml, "", "mock424242", "mock424242", "ws", "ws")
 	arity, err := cand.CheckAutoConnect()
 	c.Check(err, check.IsNil)
 	c.Check(arity.SlotsPerPlugAny(), check.Equals, false)
@@ -159,4 +159,46 @@ func (s *baseDeclSuite) TestDoesNotPanic(c *C) {
 	// on startup. This test prevents this from happing unnoticed.
 	_, err := policy.ComposeBaseDeclaration(builtin.Interfaces())
 	c.Assert(err, IsNil)
+}
+
+func (s *baseDeclSuite) TestAgentSlotConnectionPlugFromDifferentWorkshop(c *C) {
+	slotYaml := `name: slot-sdk
+base: ubuntu@22.04
+type: agent
+slots:
+    content:
+`
+	cand := s.connectCand(c, "content", slotYaml, "", "mock424242", "mock424242", "slot-ws", "plug-ws")
+	_, err := cand.Check()
+	c.Check(err, check.ErrorMatches, `connection not allowed by slot rule of interface "content"`)
+	_, err = cand.CheckAutoConnect()
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by slot rule of interface "content"`)
+}
+
+func (s *baseDeclSuite) TestAgentSlotConnectionPlugFromSameWorkshop(c *C) {
+	slotYaml := `name: slot-sdk
+base: ubuntu@22.04
+type: agent
+slots:
+    content:
+`
+	cand := s.connectCand(c, "content", slotYaml, "", "mock424242", "mock424242", "ws", "ws")
+	_, err := cand.Check()
+	c.Check(err, check.IsNil)
+	_, err = cand.CheckAutoConnect()
+	c.Check(err, check.IsNil)
+}
+
+func (s *baseDeclSuite) TestAgentSlotConnectionPlugFromSameWorkshopDifferentProject(c *C) {
+	slotYaml := `name: slot-sdk
+base: ubuntu@22.04
+type: agent
+slots:
+    content:
+`
+	cand := s.connectCand(c, "content", slotYaml, "", "slot-project", "mock424242", "ws", "ws")
+	_, err := cand.Check()
+	c.Check(err, check.ErrorMatches, `connection not allowed by slot rule of interface "content"`)
+	_, err = cand.CheckAutoConnect()
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by slot rule of interface "content"`)
 }

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -28,7 +28,6 @@ import (
 )
 
 // check helpers
-
 func checkSlotType(sdkInfo *sdk.Info, types []string) error {
 	if !slices.Contains(types, string(sdkInfo.Type)) {
 		return fmt.Errorf("invalid sdk type %q", sdkInfo.Type)
@@ -83,6 +82,12 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	}
 	if err := constraints.SlotAttributes.Check(connc.Slot, connc); err != nil {
 		return err
+	}
+	if connc.Slot.Sdk().Type == sdk.Agent {
+		plugSdk, slotSdk := connc.Plug.Sdk(), connc.Slot.Sdk()
+		if plugSdk.ProjectId != slotSdk.ProjectId || plugSdk.Workshop != slotSdk.Workshop {
+			return fmt.Errorf("%q cannot be connected to the agent SDK from a different workshop", connc.Plug.Ref())
+		}
 	}
 	return nil
 }

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -78,9 +78,9 @@ func (s *RepositorySuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 
-	consumer := sdk.MockInfo(c, consumerYaml, s.projectId, "ws", sdk.Setup{Name: "plug-sdk"})
+	consumer := sdk.MockInfo(c, consumerYaml, s.projectId, "ws")
 	s.plug = consumer.Plugs["plug"]
-	producer := sdk.MockInfo(c, producerYaml, s.projectId, "ws", sdk.Setup{Name: "slot-sdk"})
+	producer := sdk.MockInfo(c, producerYaml, s.projectId, "ws")
 	s.slot = producer.Slots["slot"]
 	s.plugSelf = producer.Plugs["self"]
 
@@ -104,7 +104,7 @@ type instanceNameAndYaml struct {
 func addPlugsSlotsFromInstances(c *C, repo *Repository, projectId string, iys []instanceNameAndYaml) []*sdk.Info {
 	result := make([]*sdk.Info, 0, len(iys))
 	for _, iy := range iys {
-		info := sdk.MockInfo(c, iy.Yaml, projectId, "ws-"+iy.Name, sdk.Setup{})
+		info := sdk.MockInfo(c, iy.Yaml, projectId, "ws-"+iy.Name)
 		if iy.Name != "" {
 			c.Assert(sdk.Validate(info), IsNil)
 		}
@@ -276,7 +276,7 @@ func (s *RepositorySuite) TestAddPlugParallelInstance(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
 
-	consumer := sdk.MockInfo(c, consumerYaml, s.projectId, "ws-instance", sdk.Setup{})
+	consumer := sdk.MockInfo(c, consumerYaml, s.projectId, "ws-instance")
 	err = s.testRepo.AddPlug(consumer.Plugs["plug"])
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 2)
@@ -630,7 +630,7 @@ func (s *RepositorySuite) TestAddSlotParallelInstance(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 1)
 
-	producer := sdk.MockInfo(c, producerYaml, s.projectId, "ws-instance", sdk.Setup{})
+	producer := sdk.MockInfo(c, producerYaml, s.projectId, "ws-instance")
 	err = s.testRepo.AddSlot(producer.Slots["slot"])
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 2)
@@ -1081,14 +1081,14 @@ base: ubuntu@22.04
 plugs:
     auto:
     manual:
-`, s.projectId, "ws", sdk.Setup{Name: "consumer"})
+`, s.projectId, "ws")
 	producer := sdk.MockInfo(c, `
 name: producer
 base: ubuntu@22.04
 slots:
     auto:
     manual:
-`, s.projectId, "ws", sdk.Setup{Name: "producer"})
+`, s.projectId, "ws")
 	err = repo.AddSdk(producer)
 	c.Assert(err, IsNil)
 	err = repo.AddSdk(consumer)
@@ -1123,7 +1123,7 @@ name: producer
 base: ubuntu@22.04
 slots:
     auto:
-`, s.projectId, "ws", sdk.Setup{Name: "producer"})
+`, s.projectId, "ws")
 	err = repo.AddSdk(producer)
 	c.Assert(err, IsNil)
 
@@ -1133,7 +1133,7 @@ name: consumer1
 base: ubuntu@22.04
 plugs:
     auto:
-`, s.projectId, "ws", sdk.Setup{Name: "consumer1"})
+`, s.projectId, "ws")
 
 	err = repo.AddSdk(consumer1)
 	c.Assert(err, IsNil)
@@ -1144,7 +1144,7 @@ name: consumer2
 base: ubuntu@22.04
 plugs:
     auto:
-`, s.projectId, "ws", sdk.Setup{Name: "consumer2"})
+`, s.projectId, "ws")
 
 	err = repo.AddSdk(consumer2)
 	c.Assert(err, IsNil)
@@ -1199,7 +1199,7 @@ func (s *AddRemoveSuite) TearDownTest(c *C) {
 }
 
 func (s *AddRemoveSuite) addSdk(c *C, yaml string, projectId string) (*sdk.Info, error) {
-	sdkInfo := sdk.MockInfo(c, yaml, projectId, "ws", sdk.Setup{})
+	sdkInfo := sdk.MockInfo(c, yaml, projectId, "ws")
 	return sdkInfo, s.repo.AddSdk(sdkInfo)
 }
 
@@ -1240,8 +1240,6 @@ func (s *DisconnectSdkSuite) SetUpTest(c *C) {
 	err = s.repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface-b"})
 	c.Assert(err, IsNil)
 
-	setup := sdk.Setup{}
-
 	s.s1 = sdk.MockInfo(c, `
 name: s1
 base: ubuntu@22.04
@@ -1249,7 +1247,7 @@ plugs:
     iface-a:
 slots:
     iface-b:
-`, "42424242", "ws", setup)
+`, "42424242", "ws")
 	err = s.repo.AddSdk(s.s1)
 	c.Assert(err, IsNil)
 
@@ -1260,7 +1258,7 @@ plugs:
     iface-b:
 slots:
     iface-a:
-`, "42424242", "ws", setup)
+`, "42424242", "ws")
 	c.Assert(err, IsNil)
 	err = s.repo.AddSdk(s.s2)
 	c.Assert(err, IsNil)
@@ -1271,7 +1269,7 @@ plugs:
     iface-b:
 slots:
     iface-a:
-`, "42424242", "ws", setup)
+`, "42424242", "ws")
 	c.Assert(err, IsNil)
 	err = s.repo.AddSdk(s.s2Instance)
 	c.Assert(err, IsNil)
@@ -1375,7 +1373,7 @@ plugs:
   imported-content:
     interface: content
     content: %s
-`, plugContentToken), projectId, "ws-importer", sdk.Setup{})
+`, plugContentToken), projectId, "ws-importer")
 	slotSnap := sdk.MockInfo(c, fmt.Sprintf(`
 name: content-slot-sdk
 base: ubuntu@22.04
@@ -1383,7 +1381,7 @@ slots:
   exported-content:
     interface: content
     content: %s
-`, slotContentToken), projectId, "ws-exporter", sdk.Setup{})
+`, slotContentToken), projectId, "ws-exporter")
 
 	err = repo.AddSdk(plugSnap)
 	c.Assert(err, IsNil)
@@ -1458,9 +1456,9 @@ func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1", sdk.Setup{})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1")
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2", sdk.Setup{})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2")
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
@@ -1494,9 +1492,9 @@ func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1", sdk.Setup{})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1")
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2", sdk.Setup{})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2")
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
@@ -1520,9 +1518,9 @@ func (s *RepositorySuite) TestBeforeConnectValidationPolicyCheckFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1", sdk.Setup{})
+	s1 := sdk.MockInfo(c, ifacehooksSnap1, s.projectId, "ws-s1")
 	c.Assert(s.emptyRepo.AddSdk(s1), IsNil)
-	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2", sdk.Setup{})
+	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2")
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
 	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
@@ -1609,7 +1607,7 @@ base: ubuntu@22.04
 plugs:
   i1:
   i2:
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	c.Assert(r.AddSdk(s1), IsNil)
 
 	s2 := sdk.MockInfo(c, `
@@ -1618,7 +1616,7 @@ base: ubuntu@22.04
 slots: 
   i1:
   i3:
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	c.Assert(r.AddSdk(s2), IsNil)
 
 	s3 := sdk.MockInfo(c, `
@@ -1627,14 +1625,14 @@ base: ubuntu@22.04
 type: core
 slots:
   i2:
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	c.Assert(r.AddSdk(s3), IsNil)
 	s4 := sdk.MockInfo(c, `
 name: s4
 base: ubuntu@22.04
 plugs:
   i2:
-`, s.projectId, "ws", sdk.Setup{})
+`, s.projectId, "ws")
 	c.Assert(r.AddSdk(s4), IsNil)
 
 	// Connect a few things for the tests below.

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1622,7 +1622,7 @@ slots:
 	s3 := sdk.MockInfo(c, `
 name: s3
 base: ubuntu@22.04
-type: core
+type: agent
 slots:
   i2:
 `, s.projectId, "ws")

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1366,7 +1366,7 @@ func makeContentConnectionTestSdks(c *C, projectId, plugContentToken, slotConten
 	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "content", AutoConnectCallback: contentAutoConnect})
 	c.Assert(err, IsNil)
 
-	plugSnap := sdk.MockInfo(c, fmt.Sprintf(`
+	plugSdk := sdk.MockInfo(c, fmt.Sprintf(`
 name: content-plug-sdk
 base: ubuntu@22.04
 plugs:
@@ -1374,7 +1374,7 @@ plugs:
     interface: content
     content: %s
 `, plugContentToken), projectId, "ws-importer")
-	slotSnap := sdk.MockInfo(c, fmt.Sprintf(`
+	slotSdk := sdk.MockInfo(c, fmt.Sprintf(`
 name: content-slot-sdk
 base: ubuntu@22.04
 slots:
@@ -1383,12 +1383,12 @@ slots:
     content: %s
 `, slotContentToken), projectId, "ws-exporter")
 
-	err = repo.AddSdk(plugSnap)
+	err = repo.AddSdk(plugSdk)
 	c.Assert(err, IsNil)
-	err = repo.AddSdk(slotSnap)
+	err = repo.AddSdk(slotSdk)
 	c.Assert(err, IsNil)
 
-	return repo, plugSnap, slotSnap
+	return repo, plugSdk, slotSdk
 }
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceSimple(c *C) {

--- a/internal/interfaces/sorting_test.go
+++ b/internal/interfaces/sorting_test.go
@@ -32,8 +32,10 @@ type SortingSuite struct{}
 
 var _ = Suite(&SortingSuite{})
 
-func newConnRef(plugSdk, plug, slotSdk, slot string) *interfaces.ConnRef {
-	return &interfaces.ConnRef{PlugRef: interfaces.PlugRef{Sdk: plugSdk, Name: plug}, SlotRef: interfaces.SlotRef{Sdk: slotSdk, Name: slot}}
+func newConnRef(plugWs, plugSdk, plug, slotWs, slotSdk, slot string) *interfaces.ConnRef {
+	return &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Workshop: plugWs, Sdk: plugSdk, Name: plug},
+		SlotRef: interfaces.SlotRef{Workshop: slotWs, Sdk: slotSdk, Name: slot}}
 }
 
 func (s *SortingSuite) TestByInterfaceName(c *C) {
@@ -50,29 +52,29 @@ func (s *SortingSuite) TestByInterfaceName(c *C) {
 
 func (s *SortingSuite) TestByConnRef(c *C) {
 	list := []*interfaces.ConnRef{
-		newConnRef("name-1", "plug-3", "name-2", "slot-1"),
-		newConnRef("name-1", "plug-1", "name-2", "slot-3"),
-		newConnRef("name-1", "plug-2", "name-2", "slot-2"),
-		newConnRef("name-1", "plug-1", "name-2", "slot-4"),
-		newConnRef("name-1", "plug-1", "name-2", "slot-1"),
-		newConnRef("name-1", "plug-1", "name-2_instance", "slot-1"),
-		newConnRef("name-1_instance", "plug-1", "name-2", "slot-1"),
+		newConnRef("abc", "name-1", "plug-3", "abc", "name-2", "slot-1"),
+		newConnRef("abc", "name-1", "plug-1", "abc", "name-2", "slot-3"),
+		newConnRef("def", "name-1", "plug-2", "abc", "name-2", "slot-2"),
+		newConnRef("abc", "name-1", "plug-1", "abc", "name-2", "slot-4"),
+		newConnRef("abc", "name-1", "plug-1", "abc", "name-2", "slot-1"),
+		newConnRef("abc", "name-1", "plug-1", "def", "name-2_instance", "slot-1"),
+		newConnRef("abc", "name-1_instance", "plug-1", "abc", "name-2", "slot-1"),
 	}
 	sort.Sort(interfaces.ByConnRef(list))
 
 	c.Assert(list, DeepEquals, []*interfaces.ConnRef{
-		newConnRef("name-1", "plug-1", "name-2", "slot-1"),
-		newConnRef("name-1", "plug-1", "name-2", "slot-3"),
-		newConnRef("name-1", "plug-1", "name-2", "slot-4"),
-		newConnRef("name-1", "plug-1", "name-2_instance", "slot-1"),
-		newConnRef("name-1", "plug-2", "name-2", "slot-2"),
-		newConnRef("name-1", "plug-3", "name-2", "slot-1"),
-		newConnRef("name-1_instance", "plug-1", "name-2", "slot-1"),
+		newConnRef("abc", "name-1", "plug-1", "abc", "name-2", "slot-1"),
+		newConnRef("abc", "name-1", "plug-1", "abc", "name-2", "slot-3"),
+		newConnRef("abc", "name-1", "plug-1", "abc", "name-2", "slot-4"),
+		newConnRef("abc", "name-1", "plug-1", "def", "name-2_instance", "slot-1"),
+		newConnRef("abc", "name-1", "plug-3", "abc", "name-2", "slot-1"),
+		newConnRef("abc", "name-1_instance", "plug-1", "abc", "name-2", "slot-1"),
+		newConnRef("def", "name-1", "plug-2", "abc", "name-2", "slot-2"),
 	})
 }
 
-func newSlotRef(sdk, name string) *interfaces.SlotRef {
-	return &interfaces.SlotRef{Sdk: sdk, Name: name}
+func newSlotRef(workshop, sdk, name string) *interfaces.SlotRef {
+	return &interfaces.SlotRef{Workshop: workshop, Sdk: sdk, Name: name}
 }
 
 type bySlotRef []*interfaces.SlotRef
@@ -85,20 +87,20 @@ func (b bySlotRef) Less(i, j int) bool {
 
 func (s *SortingSuite) TestSortSlotRef(c *C) {
 	list := []*interfaces.SlotRef{
-		newSlotRef("name-2", "slot-3"),
-		newSlotRef("name-2_instance", "slot-1"),
-		newSlotRef("name-2", "slot-2"),
-		newSlotRef("name-2", "slot-4"),
-		newSlotRef("name-2", "slot-1"),
+		newSlotRef("abc", "name-2", "slot-3"),
+		newSlotRef("def", "name-2_instance", "slot-1"),
+		newSlotRef("def", "name-2", "slot-2"),
+		newSlotRef("abc", "name-2", "slot-4"),
+		newSlotRef("def", "name-2", "slot-1"),
 	}
 	sort.Sort(bySlotRef(list))
 
 	c.Assert(list, DeepEquals, []*interfaces.SlotRef{
-		newSlotRef("name-2", "slot-1"),
-		newSlotRef("name-2", "slot-2"),
-		newSlotRef("name-2", "slot-3"),
-		newSlotRef("name-2", "slot-4"),
-		newSlotRef("name-2_instance", "slot-1"),
+		newSlotRef("abc", "name-2", "slot-3"),
+		newSlotRef("abc", "name-2", "slot-4"),
+		newSlotRef("def", "name-2", "slot-1"),
+		newSlotRef("def", "name-2", "slot-2"),
+		newSlotRef("def", "name-2_instance", "slot-1"),
 	})
 }
 
@@ -110,25 +112,25 @@ func (b byPlugRef) Less(i, j int) bool {
 	return b[i].SortsBefore(*b[j])
 }
 
-func newPlugRef(sdk, name string) *interfaces.PlugRef {
-	return &interfaces.PlugRef{Sdk: sdk, Name: name}
+func newPlugRef(workshop, sdk, name string) *interfaces.PlugRef {
+	return &interfaces.PlugRef{Workshop: workshop, Sdk: sdk, Name: name}
 }
 
 func (s *SortingSuite) TestSortPlugRef(c *C) {
 	list := []*interfaces.PlugRef{
-		newPlugRef("name-2", "plug-3"),
-		newPlugRef("name-2_instance", "plug-1"),
-		newPlugRef("name-2", "plug-4"),
-		newPlugRef("name-2", "plug-2"),
-		newPlugRef("name-2", "plug-1"),
+		newPlugRef("abc", "name-2", "plug-3"),
+		newPlugRef("def", "name-2_instance", "plug-1"),
+		newPlugRef("abc", "name-2", "plug-4"),
+		newPlugRef("def", "name-2", "plug-2"),
+		newPlugRef("def", "name-2", "plug-1"),
 	}
 	sort.Sort(byPlugRef(list))
 
 	c.Assert(list, DeepEquals, []*interfaces.PlugRef{
-		newPlugRef("name-2", "plug-1"),
-		newPlugRef("name-2", "plug-2"),
-		newPlugRef("name-2", "plug-3"),
-		newPlugRef("name-2", "plug-4"),
-		newPlugRef("name-2_instance", "plug-1"),
+		newPlugRef("abc", "name-2", "plug-3"),
+		newPlugRef("abc", "name-2", "plug-4"),
+		newPlugRef("def", "name-2", "plug-1"),
+		newPlugRef("def", "name-2", "plug-2"),
+		newPlugRef("def", "name-2_instance", "plug-1"),
 	})
 }

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -35,7 +36,7 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 
 	if hook.HookType == SaveState || hook.HookType == RestoreState {
 		volume := workshopbackend.WorkshopStateVolumeName(workshop, prj.ProjectId)
-		if err := h.backend.AddWorkshopDevice(ctx, workshop, workshopbackend.Volume(volume, workshopbackend.WorkshopStateDir, volume)); err != nil {
+		if err := h.backend.AddWorkshopDevice(ctx, workshop, workshopbackend.Volume(volume, dirs.WorkshopStateDir, volume)); err != nil {
 			return fmt.Errorf("cannot run hook %q for SDK %q: %w", hook.Type(), hook.Sdk, err)
 		}
 

--- a/internal/overlord/hookstate/request.go
+++ b/internal/overlord/hookstate/request.go
@@ -5,14 +5,14 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
 func hookSetup(workshop, sdk string, hook WorkshopHookType) HookSetup {
 	setup := HookSetup{HookType: hook, Workshop: workshop, Sdk: sdk, Environment: map[string]string{}}
 	if hook == SaveState || hook == RestoreState {
-		setup.Environment["SDK_STATE_DIR"] = filepath.Join(workshopbackend.WorkshopStateDir, "sdk", sdk)
+		setup.Environment["SDK_STATE_DIR"] = filepath.Join(dirs.WorkshopStateDir, "sdk", sdk)
 	}
 	return setup
 }

--- a/internal/overlord/ifacestate/export_test.go
+++ b/internal/overlord/ifacestate/export_test.go
@@ -1,7 +1,29 @@
 package ifacestate
 
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/overlord/ifacestate/schema"
+)
+
 var (
 	GetConns          = getConns
 	SetConns          = setConns
 	ReloadConnections = (*InterfaceManager).reloadConnections
 )
+
+func UpdateConnectionInConnState(conns map[string]*schema.ConnState, conn *interfaces.Connection, autoConnect, undesired bool) {
+	connRef := &interfaces.ConnRef{
+		PlugRef: *conn.Plug.Ref(),
+		SlotRef: *conn.Slot.Ref(),
+	}
+
+	conns[connRef.ID()] = &schema.ConnState{
+		Interface:        conn.Interface(),
+		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
+		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
+		StaticSlotAttrs:  conn.Slot.StaticAttrs(),
+		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
+		Auto:             autoConnect,
+		Undesired:        undesired,
+	}
+}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -176,10 +176,6 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
 
 		for _, slot := range candidates {
-			// if slot.Sdk.ProjectId != plug.Sdk.ProjectId || slot.Sdk.Workshop != plug.Sdk.Workshop {
-			// 	continue
-			// }
-
 			connRef := interfaces.NewConnRef(plug, slot)
 
 			if _, ok := conns[connRef.ID()]; ok {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"syscall"
 
 	"gopkg.in/tomb.v2"
@@ -30,6 +31,36 @@ func sdkName(task *state.Task) (string, error) {
 		return "", err
 	}
 	return sdkName, nil
+}
+
+func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
+	allPlugs := m.repo.AllPlugs("content")
+
+	for _, plug := range sdkInfo.Plugs {
+		if plug.Interface != "content" {
+			continue
+		}
+		candidateTarget, _ := plug.Lookup("target")
+
+		idx := slices.IndexFunc(allPlugs, func(pi *sdk.PlugInfo) bool {
+			// only plugs from the same workshop will be considered
+			if pi.Sdk.ProjectId != plug.Sdk.ProjectId || pi.Sdk.Workshop != plug.Sdk.Workshop {
+				return false
+			}
+			// exclude oneself
+			if pi.Sdk.Ref() == plug.Sdk.Ref() && pi.Name == plug.Name {
+				return false
+			}
+			target, _ := pi.Lookup("target")
+			return target == candidateTarget
+
+		})
+		if idx != -1 {
+			return fmt.Errorf(`cannot connect "%s/%s:%s": target %s is also mounted by %s/%s:%s`, plug.Sdk.Workshop, plug.Sdk.Name, plug.Name, candidateTarget,
+				allPlugs[idx].Sdk.Workshop, allPlugs[idx].Sdk.Name, allPlugs[idx].Name)
+		}
+	}
+	return nil
 }
 
 func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err error) {
@@ -69,35 +100,40 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	// old workshop/SDK is removed (see the 'disconnect' task handler) and see
 	// if any of those are still relevant for the new workshop.
 	st := task.State()
-	var sdkRef = sdk.Ref{ProjectId: project.ProjectId, Workshop: workshop, Sdk: s}
-	var plugsToRemount = map[string]map[string]interface{}{}
+
 	st.Lock()
 	var alltasks = task.Change().Tasks()
+	var kind = task.Change().Kind()
 	st.Unlock()
-	for _, task := range alltasks {
-		// The disconnect tasks of the refresh change store pre-refresh
-		// content interface connections.
-		if task.Kind() == "disconnect" {
-			_, project, workshop, err := handlersetup.UserProjectWorkshop(task)
-			if err != nil {
-				continue
-			}
 
-			taskSdk, err := sdkName(task)
-			if err != nil {
-				continue
-			}
-			taskSdkRef := sdk.Ref{ProjectId: project.ProjectId, Workshop: workshop, Sdk: taskSdk}
-			if sdkRef.ID() == taskSdkRef.ID() {
-				st.Lock()
-				_ = task.Get("plugs-to-remount", &plugsToRemount)
-				st.Unlock()
-				break
+	if kind == "refresh" {
+		var sdkRef = sdk.Ref{ProjectId: project.ProjectId, Workshop: workshop, Sdk: s}
+		var plugsToRemount = map[string]map[string]interface{}{}
+		for _, task := range alltasks {
+			// The disconnect tasks of the refresh change store pre-refresh
+			// content interface connections.
+			if task.Kind() == "disconnect" {
+				_, project, workshop, err := handlersetup.UserProjectWorkshop(task)
+				if err != nil {
+					continue
+				}
+
+				taskSdk, err := sdkName(task)
+				if err != nil {
+					continue
+				}
+				taskSdkRef := sdk.Ref{ProjectId: project.ProjectId, Workshop: workshop, Sdk: taskSdk}
+				if sdkRef.ID() == taskSdkRef.ID() {
+					st.Lock()
+					_ = task.Get("plugs-to-remount", &plugsToRemount)
+					st.Unlock()
+					break
+				}
 			}
 		}
+		return m.setupSdkConnections(task, ctx, sdkInfo, plugsToRemount)
 	}
-
-	return m.setupSdkConnections(task, ctx, sdkInfo, plugsToRemount)
+	return m.setupSdkConnections(task, ctx, sdkInfo, nil)
 }
 
 // Returns content interface connection IDs of the SDK and their corresponding
@@ -152,6 +188,16 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 		return err
 	}
 
+	// Ensure that if the SDK is connected there will be no conflicting bind
+	// mount targets in the workshop, i.e. the situation when a two or more
+	// sources are bind mount at the same target in the workshop. Do it after
+	// the SDK was added to the repository to also validate that it does not
+	// contain conflicting targets itself (though, this kind of validation must
+	// be caught by the craft tool).
+	if err = m.checkConflictingTargets(sdkInfo); err != nil {
+		return err
+	}
+
 	if len(sdkInfo.BadInterfaces) > 0 {
 		task.Logf("%s", sdk.BadInterfacesSummary(sdkInfo))
 	}
@@ -174,7 +220,6 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 	defer revertConnections.Fail()
 	for _, plug := range sdkInfo.Plugs {
 		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
-
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
 
@@ -200,7 +245,7 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 
 			// no policy check passed in here as it has been checked when looked
 			// up the candidates.
-			conn, err := m.repo.Connect(connRef, plug.Attrs, plugDynamicAttrs, slot.Attrs, nil, nil)
+			conn, err := m.repo.Connect(connRef, plug.Attrs, plugDynamicAttrs, slot.Attrs, nil, connectCheck)
 			if err != nil || conn == nil {
 				return err
 			}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -176,6 +176,10 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
 
 		for _, slot := range candidates {
+			// if slot.Sdk.ProjectId != plug.Sdk.ProjectId || slot.Sdk.Workshop != plug.Sdk.Workshop {
+			// 	continue
+			// }
+
 			connRef := interfaces.NewConnRef(plug, slot)
 
 			if _, ok := conns[connRef.ID()]; ok {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -586,8 +586,17 @@ plugs:
         interface: content
         target: /home/workshop
 `
+	var agentYaml = `
+name: agent
+base: ubuntu@22.04
+type: agent
+slots:
+    slot:
+        interface: content        
+`
 	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, agentYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 }
 
 func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C) {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -63,6 +63,22 @@ plugs:
     attribute: three
 `
 
+var conflictingTarget1 = `name: conflict-1
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: content
+    target: /home/workshop  
+`
+
+var conflictingTarget2 = `name: conflict-2
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: content
+    target: /home/workshop  
+`
+
 var csetup = sdk.Setup{Name: "consumer", Channel: "latest/stable"}
 
 var consumerNoPlugs = `name: consumer
@@ -255,9 +271,38 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoAllBackendSetupsIfEitherFail
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
+func (s *interfaceHandlersSuite) TestAutoconnectFailsIfWorkshopHasConflictingContentTargets(c *check.C) {
+	// Setup
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+		{Name: "conflict-1", Channel: "latest/stable"}: conflictingTarget1,
+		{Name: "conflict-2", Channel: "latest/stable"}: conflictingTarget2,
+	})
+
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("auto-connect", "...")
+	t1.Set("sdk", "conflict-1")
+	t2 := s.state.NewTask("auto-connect", "...")
+	t2.Set("sdk", "conflict-2")
+	t2.WaitFor(t1)
+	setWorkshopProject("ws", s.prj, t1, t2)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	s.state.Unlock()
+
+	// Execute
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Validate
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target /home/workshop is also mounted by ws/conflict-1:plug.*`)
+}
+
 func (s *interfaceHandlersSuite) TestAutoconnectNoConnections(c *check.C) {
 	// Setup
-
 	repo := s.mgr.Repository()
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
@@ -500,7 +545,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugs(c *check.C) {
 
 	// Execute
 	s.state.Lock()
-	chg := s.state.NewChange("sample", "...")
+	chg := s.state.NewChange("refresh", "...")
 	t := s.state.NewTask("disconnect", "...")
 	// see doAutoConnect and doDisconnect handlers for details
 	t.Set("plugs-to-remount", map[string]map[string]interface{}{

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -115,7 +115,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
@@ -177,7 +177,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendEnsureDisconnectsIfBacken
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerManyPlugs})
 
@@ -231,7 +231,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoAllBackendSetupsIfEitherFail
 	defer func() { s.secBackend.SetupCallback = nil }()
 
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerManyPlugs})
 
@@ -298,7 +298,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
@@ -341,7 +341,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemovesNonExistingConnections(c 
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer", psetup)), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
@@ -400,7 +400,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectReconnectsExistingConnections(c 
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
@@ -493,7 +493,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugs(c *check.C) {
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer", psetup)), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
@@ -587,7 +587,7 @@ plugs:
         target: /home/workshop
 `
 	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
-	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer", csetup)), check.IsNil)
+	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 }
 
 func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C) {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -875,7 +875,7 @@ func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 	repo := s.mgr.Repository()
 	s.launchRemountWorkshop(c)
 
-	connRefKey := "42424242:ws-consumer:consumer:plug core:core:core:content"
+	connRefKey := "42424242:ws-consumer:consumer:plug 42424242:ws-consumer:agent:slot"
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
 		connRefKey: map[string]interface{}{

--- a/internal/overlord/ifacestate/helpers.go
+++ b/internal/overlord/ifacestate/helpers.go
@@ -30,6 +30,21 @@ func autoConnectCheck(plug *interfaces.ConnectedPlug, slot *interfaces.Connected
 	return true, err
 }
 
+func connectCheck(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (bool, error) {
+	baseDecl := asserts.BuiltinBaseDeclaration()
+	if baseDecl == nil {
+		return false, fmt.Errorf("internal error: cannot find base declaration")
+	}
+
+	ic := policy.ConnectCandidate{
+		Plug:            plug,
+		Slot:            slot,
+		BaseDeclaration: baseDecl,
+	}
+	_, err := ic.Check()
+	return true, err
+}
+
 // getConns returns information about connections from the state.
 func getConns(st *state.State) (conns map[string]*schema.ConnState, err error) {
 	var raw *json.RawMessage

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -45,6 +45,62 @@ func (m *InterfaceManager) Repository() *interfaces.Repository {
 	return m.repo
 }
 
+type ConnectionState struct {
+	// Auto indicates whether the connection was established automatically
+	Auto bool
+	// ByGadget indicates whether the connection was trigged by the gadget
+	ByGadget bool
+	// Interface name of the connection
+	Interface string
+	// Undesired indicates whether the connection, otherwise established
+	// automatically, was explicitly disconnected
+	Undesired        bool
+	StaticPlugAttrs  map[string]interface{}
+	DynamicPlugAttrs map[string]interface{}
+	StaticSlotAttrs  map[string]interface{}
+	DynamicSlotAttrs map[string]interface{}
+}
+
+// Active returns true if connection is not undesired and not removed by
+// hotplug.
+func (c ConnectionState) Active() bool {
+	return !c.Undesired
+}
+
+// ConnectionStates return the state of connections stored in the state.
+// Note that this includes inactive connections (i.e. referring to non-
+// existing plug/slots), so this map must be cross-referenced with current
+// snap info if needed.
+// The state must be locked by the caller.
+func ConnectionStates(st *state.State) (connStateByRef map[string]ConnectionState, err error) {
+	states, err := getConns(st)
+	if err != nil {
+		return nil, err
+	}
+
+	connStateByRef = make(map[string]ConnectionState, len(states))
+	for cref, cstate := range states {
+		connStateByRef[cref] = ConnectionState{
+			Auto:             cstate.Auto,
+			Interface:        cstate.Interface,
+			Undesired:        cstate.Undesired,
+			StaticPlugAttrs:  cstate.StaticPlugAttrs,
+			DynamicPlugAttrs: cstate.DynamicPlugAttrs,
+			StaticSlotAttrs:  cstate.StaticSlotAttrs,
+			DynamicSlotAttrs: cstate.DynamicSlotAttrs,
+		}
+	}
+	return connStateByRef, nil
+}
+
+// ConnectionStates return the state of connections tracked by the manager
+func (m *InterfaceManager) ConnectionStates() (connStateByRef map[string]ConnectionState, err error) {
+	m.state.Lock()
+	defer m.state.Unlock()
+
+	return ConnectionStates(m.state)
+}
+
 func (m *InterfaceManager) StartUp() error {
 	m.state.Lock()
 	defer m.state.Unlock()

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -85,6 +85,14 @@ func (m *InterfaceManager) StartUp() error {
 					logger.Noticef("Cannot create internal mounts for %q workshop: %v", workshop.Name, err)
 				}
 
+				agent, err := workshop.SdkInfo(pctx, sdk.Agent.String())
+				if err != nil {
+					continue
+				}
+				if err = m.repo.AddSdk(agent); err != nil {
+					continue
+				}
+
 				infos, err := workshop.ContentInfo(pctx)
 				if err != nil {
 					logger.Noticef("Cannot obtain the list of installed SDKs for %q workshop: %v", workshop.Name, err)
@@ -99,25 +107,6 @@ func (m *InterfaceManager) StartUp() error {
 				}
 			}
 		}
-	}
-
-	coreSdk := &sdk.Info{
-		ProjectId:     "core",
-		Workshop:      "core",
-		Name:          "core",
-		Base:          "ubuntu@22.04",
-		Type:          sdk.Agent,
-		Plugs:         make(map[string]*sdk.PlugInfo),
-		Slots:         make(map[string]*sdk.SlotInfo),
-		BadInterfaces: make(map[string]string),
-	}
-
-	if err := m.addImplicitSlots(coreSdk); err != nil {
-		return err
-	}
-
-	if err := m.repo.AddSdk(coreSdk); err != nil {
-		return err
 	}
 
 	if _, err := m.reloadConnections("", "", ""); err != nil {
@@ -231,33 +220,6 @@ func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string
 		setConns(m.state, conns)
 	}
 	return affected, nil
-}
-
-func (m *InterfaceManager) addImplicitSlots(sdkInfo *sdk.Info) error {
-	if sdkInfo.Type != sdk.Agent {
-		return nil
-	}
-
-	// Ask each interface if it wants to be implicitly added.
-	for _, iface := range builtin.Interfaces() {
-		si := interfaces.StaticInfoOf(iface)
-		if si.ImplicitOnCore {
-			ifaceName := iface.Name()
-			if _, ok := sdkInfo.Slots[ifaceName]; !ok {
-				sdkInfo.Slots[ifaceName] = makeImplicitSlot(sdkInfo, ifaceName)
-			}
-		}
-	}
-
-	return nil
-}
-
-func makeImplicitSlot(sdkInfo *sdk.Info, ifaceName string) *sdk.SlotInfo {
-	return &sdk.SlotInfo{
-		Sdk:       sdkInfo,
-		Name:      ifaceName,
-		Interface: ifaceName,
-	}
 }
 
 var securityBackendsOverride []interfaces.SecurityBackend

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -106,7 +106,7 @@ func (m *InterfaceManager) StartUp() error {
 		Workshop:      "core",
 		Name:          "core",
 		Base:          "ubuntu@22.04",
-		Type:          sdk.Core,
+		Type:          sdk.Agent,
 		Plugs:         make(map[string]*sdk.PlugInfo),
 		Slots:         make(map[string]*sdk.SlotInfo),
 		BadInterfaces: make(map[string]string),
@@ -234,7 +234,7 @@ func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string
 }
 
 func (m *InterfaceManager) addImplicitSlots(sdkInfo *sdk.Info) error {
-	if sdkInfo.Type != sdk.Core {
+	if sdkInfo.Type != sdk.Agent {
 		return nil
 	}
 

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
@@ -96,23 +95,6 @@ func (s *interfaceManagerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sd
 	}
 }
 
-func (s *interfaceManagerSuite) TestManagerAddImplicitSlots(c *check.C) {
-	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
-	err := mgr.StartUp()
-	c.Assert(err, check.IsNil)
-
-	repo := mgr.Repository()
-
-	for _, iface := range builtin.Interfaces() {
-		si := interfaces.StaticInfoOf(iface)
-		if si.ImplicitOnCore {
-			slots := repo.AllSlots(iface.Name())
-			c.Assert(slots, check.HasLen, 1)
-			c.Assert(slots[0].Sdk.Type, check.Equals, sdk.Agent)
-		}
-	}
-}
-
 func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *check.C) {
 	var consumerYaml = `
 name: consumer
@@ -123,9 +105,9 @@ plugs:
   attr: plug-value
 `
 	var producerYaml = `
-name: producer
+name: agent
 base: ubuntu@22.04
-type: core
+type: agent
 slots:
  slot:
   interface: content
@@ -134,11 +116,11 @@ slots:
 
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
 		{Name: "consumer", Channel: "latest/stable"}: consumerYaml,
-		{Name: "producer", Channel: "latest/stable"}: producerYaml,
+		{Name: "agent", Channel: "latest/stable"}:    producerYaml,
 	})
 
 	s.state.Lock()
-	key := fmt.Sprintf("%s:ws:consumer:plug %s:ws:producer:slot", s.prj.ProjectId, s.prj.ProjectId)
+	key := fmt.Sprintf("%s:ws:consumer:plug %s:ws:agent:slot", s.prj.ProjectId, s.prj.ProjectId)
 	s.state.Set("conns", map[string]interface{}{
 		key: map[string]interface{}{
 			"interface": "content",
@@ -164,7 +146,7 @@ slots:
 	c.Assert(ifaces.Connections, check.HasLen, 1)
 	cref := &interfaces.ConnRef{
 		PlugRef: interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"}}
+		SlotRef: interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "agent", Name: "slot"}}
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{cref})
 
 	conn, err := repo.Connection(cref)

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -248,3 +248,98 @@ slots:
 
 	c.Assert(mgr.Repository().Interfaces().Connections, check.HasLen, 0)
 }
+
+func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *check.C) {
+	var isAuto, isUndesired bool = true, false
+	s.testConnectionStates(c, isAuto, isUndesired, map[string]ifacestate.ConnectionState{
+		"pid:ws:consumer:plug pid:ws:producer:slot": {
+			Interface: "test",
+			Auto:      true,
+			StaticPlugAttrs: map[string]interface{}{
+				"attr1": "value1",
+			},
+			DynamicPlugAttrs: map[string]interface{}{
+				"dynamic-number": int64(7),
+			},
+			StaticSlotAttrs: map[string]interface{}{
+				"attr2": "value2",
+			},
+			DynamicSlotAttrs: map[string]interface{}{
+				"other-number": int64(9),
+			},
+		}})
+}
+
+func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *check.C) {
+	var isAuto, isUndesired bool = true, true
+	s.testConnectionStates(c, isAuto, isUndesired, map[string]ifacestate.ConnectionState{
+		"pid:ws:consumer:plug pid:ws:producer:slot": {
+			Interface: "test",
+			Auto:      true,
+			Undesired: true,
+			StaticPlugAttrs: map[string]interface{}{
+				"attr1": "value1",
+			},
+			DynamicPlugAttrs: map[string]interface{}{
+				"dynamic-number": int64(7),
+			},
+			StaticSlotAttrs: map[string]interface{}{
+				"attr2": "value2",
+			},
+			DynamicSlotAttrs: map[string]interface{}{
+				"other-number": int64(9),
+			},
+		}})
+}
+
+func (s *interfaceManagerSuite) testConnectionStates(c *check.C, auto, undesired bool, expected map[string]ifacestate.ConnectionState) {
+	consumer := sdk.MockInfo(c, `
+name: consumer
+base: ubuntu@22.04
+plugs:
+    plug:
+        interface: test
+        attr1: value1
+`, "pid", "ws")
+
+	producer := sdk.MockInfo(c, `
+name: producer
+base: ubuntu@22.04
+slots:
+    slot:
+        interface: test
+        attr2: value2
+`, "pid", "ws")
+	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
+	err := mgr.StartUp()
+	c.Assert(err, check.IsNil)
+
+	conns, err := mgr.ConnectionStates()
+	c.Assert(err, check.IsNil)
+	c.Check(conns, check.HasLen, 0)
+
+	st := s.state
+	st.Lock()
+	sc, err := ifacestate.GetConns(st)
+	c.Assert(err, check.IsNil)
+
+	slot := producer.Slots["slot"]
+	c.Assert(slot, check.NotNil)
+	plug := consumer.Plugs["plug"]
+	c.Assert(plug, check.NotNil)
+	dynamicPlugAttrs := map[string]interface{}{"dynamic-number": 7}
+	dynamicSlotAttrs := map[string]interface{}{"other-number": 9}
+	// create connection in conns state
+	conn := &interfaces.Connection{
+		Plug: interfaces.NewConnectedPlug(plug, nil, dynamicPlugAttrs),
+		Slot: interfaces.NewConnectedSlot(slot, nil, dynamicSlotAttrs),
+	}
+	ifacestate.UpdateConnectionInConnState(sc, conn, auto, undesired)
+	ifacestate.SetConns(st, sc)
+	st.Unlock()
+
+	conns, err = mgr.ConnectionStates()
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Check(conns, check.DeepEquals, expected)
+}

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -67,8 +67,7 @@ func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
 
 func (s *interfaceManagerSuite) writeSDKMetaFile(c *check.C, fs workshopbackend.WorkshopFs, name, yaml string) {
 	sdkPath := filepath.Join(dirs.WorkshopSdksDir, name, "current", "meta", "sdk.yaml")
-	err := afero.WriteFile(fs, sdkPath, []byte(yaml), 0644)
-	c.Assert(err, check.IsNil)
+	c.Assert(afero.WriteFile(fs, sdkPath, []byte(yaml), 0644), check.IsNil)
 }
 
 func (s *interfaceManagerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdkYamls map[sdk.Setup]string) {
@@ -90,9 +89,20 @@ func (s *interfaceManagerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sd
 	c.Assert(err, check.IsNil)
 	defer wsfs.Close()
 
+	var agentYaml = `name: agent
+base: ubuntu@22.04
+type: agent
+slots:
+  slot:
+    interface: content
+    attr: slot-value
+`
+	c.Assert(wsfs.MkdirAll(filepath.Join(dirs.WorkshopSdksDir, "agent", "current", "meta", "sdk.yaml"), 0655), check.IsNil)
+	s.writeSDKMetaFile(c, wsfs, "agent", agentYaml)
 	for sdk, yaml := range sdkYamls {
 		s.writeSDKMetaFile(c, wsfs, sdk.Name, yaml)
 	}
+
 }
 
 func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *check.C) {
@@ -104,19 +114,9 @@ plugs:
   interface: content
   attr: plug-value
 `
-	var producerYaml = `
-name: agent
-base: ubuntu@22.04
-type: agent
-slots:
- slot:
-  interface: content
-  attr: slot-value
-`
 
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
 		{Name: "consumer", Channel: "latest/stable"}: consumerYaml,
-		{Name: "agent", Channel: "latest/stable"}:    producerYaml,
 	})
 
 	s.state.Lock()

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -108,7 +108,7 @@ func (s *interfaceManagerSuite) TestManagerAddImplicitSlots(c *check.C) {
 		if si.ImplicitOnCore {
 			slots := repo.AllSlots(iface.Name())
 			c.Assert(slots, check.HasLen, 1)
-			c.Assert(slots[0].Sdk.Type, check.Equals, sdk.Core)
+			c.Assert(slots[0].Sdk.Type, check.Equals, sdk.Agent)
 		}
 	}
 }

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -222,6 +222,17 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	// validate that the SDK is of the acceptable type, no non-regular SDKs are
+	// allowed from outside
+	info, err := inst.SdkInfo(ctx, setup.Name)
+	if err != nil {
+		return err
+	}
+
+	if info.Type != sdk.Regular {
+		return fmt.Errorf("unknown SDK type %q", info.Type.String())
+	}
+
 	return nil
 }
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -159,7 +159,7 @@ func (s *H) TestDoInstallSdkExecFail(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Info{Name: "test", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Name: "test"}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -263,7 +263,7 @@ func (s *H) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Info{Workshop: "ws", Name: "test", Channel: "latest/stable", Revision: 2}
+	newSdk := sdk.Info{Workshop: "ws", Name: "test"}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	link := s.state.NewTask("link-sdk", "test")

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -42,7 +42,7 @@ func (m *WorkshopManager) installAgentSdk(wfs workshopbackend.WorkshopFs, base s
 	}
 
 	// /var/lib/workshop/sdk/agent/current/meta
-	file, err := wfs.Create(filepath.Join(agentMetaDir, "sdk.yaml"))
+	file, err := wfs.OpenFile(filepath.Join(agentMetaDir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
 		return err
 	}
@@ -79,8 +79,11 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 		return err
 	}
 
+	// clean up must not be cancelled if the parent was cancelled and the change
+	// is winding down
+	revertCtx := context.WithoutCancel(ctx)
 	rev.Add(func() {
-		_ = m.backend.RemoveWorkshop(context.Background(), workshop)
+		_ = m.backend.RemoveWorkshop(revertCtx, workshop)
 	})
 
 	wfs, err := m.backend.WorkshopFs(ctx, workshop)

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
+	"github.com/canonical/workshop/internal/revert"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshopbackend"
 
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -33,6 +35,24 @@ func (m *WorkshopManager) undoCreateWorkshop(task *state.Task, tomb *tomb.Tomb) 
 	return m.backend.RemoveWorkshop(ctx, workshop)
 }
 
+func (m *WorkshopManager) installAgentSdk(wfs workshopbackend.WorkshopFs, base string) error {
+	agentMetaDir := filepath.Join(sdk.SdkCurrentPath("agent"), "meta")
+	if err := wfs.MkdirAll(agentMetaDir, 0655); err != nil {
+		return err
+	}
+
+	// /var/lib/workshop/sdk/agent/current/meta
+	file, err := wfs.Create(filepath.Join(agentMetaDir, "sdk.yaml"))
+	if err != nil {
+		return err
+	}
+
+	if _, err = file.Write([]byte(sdk.AgentSdkMeta(base))); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, workshop, err := UserProjectWorkshop(task)
 	if err != nil {
@@ -53,9 +73,27 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 		return fmt.Errorf("cannot get workshop base for task %q: %v", task.ID(), err)
 	}
 
-	/* Launch a workshop with the required base */
-	return m.backend.LaunchWorkshop(ctx, workshop,
-		base)
+	var rev revert.Reverter
+	defer rev.Fail()
+	if err = m.backend.LaunchWorkshop(ctx, workshop, base); err != nil {
+		return err
+	}
+
+	rev.Add(func() {
+		_ = m.backend.RemoveWorkshop(context.Background(), workshop)
+	})
+
+	wfs, err := m.backend.WorkshopFs(ctx, workshop)
+	if err != nil {
+		return err
+	}
+	defer wfs.Close()
+
+	if err = m.installAgentSdk(wfs, base); err != nil {
+		return err
+	}
+	rev.Success()
+	return nil
 }
 
 func (m *WorkshopManager) doMountProject(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -3,6 +3,7 @@ package workshopstate_test
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -229,4 +230,66 @@ sdks:
 	exist, _, _ = osutil.ExistsIsDir(filepath.Join(projectContent, "ws_test_plug4.sdk"))
 	c.Assert(exist, check.Equals, true)
 
+}
+
+func (s *workshopHandlers) TestCreateWorkshopWithAgentSdk(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
+base: ubuntu@22.04
+`), 0644)
+	c.Check(err, check.IsNil)
+
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("create-workshop", "...")
+	t1.Set("base", "ubuntu@22.04")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	info, err := wfs.Stat("/var/lib/workshop/sdk/agent/current/meta/sdk.yaml")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, fs.FileMode(0666))
+}
+
+func (s *workshopHandlers) TestCreateWorkshopAgentSdkFails(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
+base: ubuntu@22.04
+`), 0644)
+	c.Check(err, check.IsNil)
+	s.backend.WorkshopFsCallback = func(ctx context.Context, name string) (workshopbackend.WorkshopFs, error) {
+		return nil, errors.New("cannot get WorkshopFs")
+	}
+
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("create-workshop", "...")
+	t1.Set("base", "ubuntu@22.04")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+	s.backend.WorkshopFsCallback = nil
+
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	ws, err := s.backend.Workshop(s.ctx, "ws")
+	c.Assert(ws, check.IsNil)
+	c.Assert(err, testutil.ErrorIs, workshopbackend.ErrWorkshopNotFound)
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -87,10 +87,14 @@ func retrieveSdks(st *state.State, file *workshopbackend.WorkshopFile) *state.Ta
 
 func installSdks(st *state.State, file *workshopbackend.WorkshopFile, retrieveSet *state.TaskSet) *state.TaskSet {
 	var prevInstall *state.TaskSet
-	var prevSetup, prevAuto *state.Task
+	var prevSetup *state.Task
+
 	install := state.NewTaskSet()
 	setupHook := state.NewTaskSet()
-	autoConnectSet := state.NewTaskSet()
+
+	prevAuto := st.NewTask("auto-connect", `Auto-connect interfaces of "agent" SDK`)
+	prevAuto.Set("sdk", "agent")
+	autoConnectSet := state.NewTaskSet(prevAuto)
 	for idx, sdk := range file.Sdks {
 		// The install task sets must not run concurrently as exec ops are not
 		// allowed by LXD to be run concurrently and in general case we cannot

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -77,7 +77,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 }
 
 func retrieveSdks(st *state.State, file *workshopbackend.WorkshopFile) *state.TaskSet {
-	retrieve := state.NewTaskSet([]*state.Task{}...)
+	retrieve := state.NewTaskSet()
 	for _, sdk := range file.Sdks {
 		r := sdkstate.Retrieve(st, &sdk)
 		retrieve.AddTask(r)
@@ -88,9 +88,9 @@ func retrieveSdks(st *state.State, file *workshopbackend.WorkshopFile) *state.Ta
 func installSdks(st *state.State, file *workshopbackend.WorkshopFile, retrieveSet *state.TaskSet) *state.TaskSet {
 	var prevInstall *state.TaskSet
 	var prevSetup, prevAuto *state.Task
-	install := state.NewTaskSet([]*state.Task{}...)
-	setupHook := state.NewTaskSet([]*state.Task{}...)
-	autoConnectSet := state.NewTaskSet([]*state.Task{}...)
+	install := state.NewTaskSet()
+	setupHook := state.NewTaskSet()
+	autoConnectSet := state.NewTaskSet()
 	for idx, sdk := range file.Sdks {
 		// The install task sets must not run concurrently as exec ops are not
 		// allowed by LXD to be run concurrently and in general case we cannot
@@ -129,7 +129,7 @@ func installSdks(st *state.State, file *workshopbackend.WorkshopFile, retrieveSe
 
 func checkHealthHooks(st *state.State, file *workshopbackend.WorkshopFile) *state.TaskSet {
 	var prevCheck *state.Task
-	checkHealth := state.NewTaskSet([]*state.Task{}...)
+	checkHealth := state.NewTaskSet()
 	for _, sdk := range file.Sdks {
 		checkHealthTask := hookstate.HookWithTimeout(st, file.Name, sdk.Name, hookstate.CheckHealth, checkHealthTimeout)
 		if prevCheck != nil {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -131,7 +131,7 @@ func (s *requestSuite) TestLaunchWorkshopNoSdk(c *check.C) {
 
 	expected := []string{"create-workshop",
 		"mount-project",
-		"start-workshop"}
+		"start-workshop", "auto-connect"}
 	tasks := ts.Tasks()
 
 	verifyExpectedTasks(c, tasks, expected)
@@ -166,6 +166,7 @@ func (s *requestSuite) TestLaunchWorkshopWithSdks(c *check.C) {
 		"install-sdk",
 		"link-sdk",
 		"link-sdk",
+		"auto-connect", // agent SDK
 		"auto-connect",
 		"auto-connect",
 		"run-hook",
@@ -231,6 +232,7 @@ func (s *requestSuite) TestRefreshEmptyWorkshop(c *check.C) {
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
+		"auto-connect", // "agent" SDK
 	}
 
 	tasks := ts.Tasks()
@@ -272,6 +274,7 @@ func (s *requestSuite) TestRefreshWorkshopWithSdks(c *check.C) {
 		"link-sdk",
 		"install-sdk",
 		"link-sdk",
+		"auto-connect", // "agent" SDK
 		"auto-connect",
 		"auto-connect",
 		"run-hook", // setup-base sdk-1
@@ -428,6 +431,7 @@ func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
+		"auto-connect", // agent SDK
 		"remove-workshop-stash",
 	}
 
@@ -442,6 +446,7 @@ func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 		"start-workshop",
 		"install-sdk",
 		"link-sdk",
+		"auto-connect", // agent SDK
 		"auto-connect",
 		"run-hook", // setup-base hook
 		"run-hook", // restore-state hook
@@ -453,7 +458,7 @@ func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 	verifyExpectedTasks(c, ts[0].Tasks(), expected_ws)
 	verifyExpectedTasks(c, ts[1].Tasks(), expected_ws_1)
 
-	c.Assert(ts[0].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible).Kind(), check.Equals, "start-workshop")
+	c.Assert(ts[0].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible).Kind(), check.Equals, "auto-connect")
 	waitFor := ts[0].MaybeEdge(workshopstate.EdgeRefreshCleanup).WaitTasks()
 	c.Assert(waitFor, testutil.DeepUnsortedMatches, []*state.Task{
 		ts[0].MaybeEdge(workshopstate.EdgeLastTaskBeforeRefreshIrreversible),
@@ -518,6 +523,7 @@ func (s *requestSuite) TestRefreshManyAllWorkshopsHaveSdks(c *check.C) {
 		"start-workshop",
 		"install-sdk",
 		"link-sdk",
+		"auto-connect", // agent SDK
 		"auto-connect",
 		"run-hook", // setup-base hook
 		"run-hook", // restore state hook

--- a/internal/sdk/agent.go
+++ b/internal/sdk/agent.go
@@ -1,0 +1,15 @@
+package sdk
+
+import "fmt"
+
+var agentSdkYamlTemplate = `name: agent
+base: %s
+type: agent
+slots:
+  content:
+    interface: content
+`
+
+func AgentSdkMeta(base string) string {
+	return fmt.Sprintf(agentSdkYamlTemplate, base)
+}

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -46,8 +46,6 @@ type Info struct {
 	Name      string
 	Base      string
 	Type      Type
-	Channel   string
-	Revision  int64
 
 	Plugs map[string]*PlugInfo
 	Slots map[string]*SlotInfo
@@ -77,7 +75,7 @@ var SanitizePlugsSlots = func(snapInfo *Info) {
 	panic("SanitizePlugsSlots function not set")
 }
 
-func ReadSdkInfo(yamlData []byte, projectId, workshop string, setup Setup) (*Info, error) {
+func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 	var sdkYaml sdkYaml
 	err := yaml.Unmarshal(yamlData, &sdkYaml)
 	if err != nil {
@@ -97,8 +95,6 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string, setup Setup) (*Inf
 		Plugs:         make(map[string]*PlugInfo),
 		Slots:         make(map[string]*SlotInfo),
 		BadInterfaces: make(map[string]string),
-		Revision:      setup.Revision,
-		Channel:       setup.Channel,
 	}
 
 	if err := setPlugsFromSdkYaml(&sdkYaml, sdkInfo); err != nil {
@@ -310,10 +306,10 @@ func MockSanitizePlugsSlots(f func(sdkInfo *Info)) (restore func()) {
 	return func() { SanitizePlugsSlots = old }
 }
 
-func MockInfo(c *check.C, yamlText string, projectId, workshop string, setup Setup) *Info {
+func MockInfo(c *check.C, yamlText string, projectId, workshop string) *Info {
 	restoreSanitize := MockSanitizePlugsSlots(func(sdkInfo *Info) {})
 	defer restoreSanitize()
-	info, err := ReadSdkInfo([]byte(yamlText), projectId, workshop, setup)
+	info, err := ReadSdkInfo([]byte(yamlText), projectId, workshop)
 	c.Assert(err, check.IsNil)
 
 	err = Validate(info)
@@ -321,11 +317,11 @@ func MockInfo(c *check.C, yamlText string, projectId, workshop string, setup Set
 	return info
 }
 
-func MockInvalidInfo(c *check.C, yamlText string, setup Setup) *Info {
+func MockInvalidInfo(c *check.C, yamlText string) *Info {
 	restoreSanitize := MockSanitizePlugsSlots(func(sdkInfo *Info) {})
 	defer restoreSanitize()
 
-	sdkInfo, err := ReadSdkInfo([]byte(yamlText), "invalid", "ws", setup)
+	sdkInfo, err := ReadSdkInfo([]byte(yamlText), "invalid", "ws")
 	c.Assert(err, check.IsNil)
 	err = Validate(sdkInfo)
 	c.Assert(err, check.NotNil)

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -32,8 +32,8 @@ type sdkYaml struct {
 type Type string
 
 const (
-	Sdk  Type = "sdk"
-	Core Type = "core"
+	Regular Type = "regular"
+	Agent   Type = "agent"
 )
 
 func (t Type) String() string {
@@ -83,7 +83,7 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 	}
 
 	if sdkYaml.Type == "" {
-		sdkYaml.Type = Sdk.String()
+		sdkYaml.Type = Regular.String()
 	}
 
 	sdkInfo := &Info{

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -43,13 +43,11 @@ func (s *SdkSuite) TestSimple(c *check.C) {
 base: ubuntu@20.04
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws", s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Assert(info.ProjectId, check.Equals, s.projectId)
 	c.Assert(info.Base, check.Equals, "ubuntu@20.04")
 	c.Assert(info.Name, check.Equals, "sdk")
-	c.Assert(info.Channel, check.Equals, "latest/stable")
-	c.Assert(info.Revision, check.Equals, int64(1))
 	c.Assert(info.Workshop, check.Equals, "ws")
 	c.Assert(info.Plugs, check.HasLen, 0)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -64,7 +62,7 @@ plugs:
     target: /project
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws", s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -85,7 +83,7 @@ slots:
     source: /project
 `)
 
-	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws", s.setup)
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Slots, check.HasLen, 1)
 	c.Assert(info.Plugs, check.HasLen, 0)
@@ -109,7 +107,7 @@ plugs:
         m:
           a: A
           b: B
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -136,7 +134,7 @@ plugs:
     net:
         interface: content
         attr: 2
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Plugs, check.HasLen, 1)
 	c.Assert(info.Slots, check.HasLen, 0)
@@ -155,7 +153,7 @@ name: sdk
 plugs:
     content:
         ipv6-aware: true
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 1)
 	c.Check(info.Slots, check.HasLen, 0)
@@ -174,7 +172,7 @@ name: sdk
 plugs:
     bool-file:
         label: Disk I/O indicator
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 
 	c.Check(info.Plugs, check.HasLen, 1)
@@ -196,7 +194,7 @@ plugs:
     net:
         interface: 1.0
         ipv6-aware: true
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `interface name on plug "net" is not a string \(found float64\)`)
 }
 
@@ -207,7 +205,7 @@ name: sdk
 plugs:
     bool-file:
         label: 1.0
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `label of plug "bool-file" is not a string \(found float64\)`)
 }
 
@@ -218,7 +216,7 @@ name: sdk
 plugs:
     net:
         1: ok
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `plug "net" has attribute key that is not a string \(found int\)`)
 }
 
@@ -229,7 +227,7 @@ name: sdk
 plugs:
     net:
         "": ok
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `plug "net" has an empty attribute key`)
 }
 
@@ -239,7 +237,7 @@ func (s *SdkSuite) TestUnmarshalCorruptedPlugWithUnexpectedType(c *check.C) {
 name: sdk
 plugs:
     net: 5
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `plug "net" has malformed definition \(found int\)`)
 }
 
@@ -251,7 +249,7 @@ plugs:
     serial:
         interface: serial-port
         $baud-rate: [9600]
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `plug "serial" uses reserved attribute "\$baud-rate"`)
 }
 
@@ -263,7 +261,7 @@ plugs:
     serial:
         interface: serial-port
         foo: null
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `attribute "foo" of plug \"serial\": invalid scalar:.*`)
 }
 
@@ -277,7 +275,7 @@ plugs:
         bar:
           baz:
           - 1: A
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `attribute "bar" of plug \"serial\": non-string key: 1`)
 }
 
@@ -289,7 +287,7 @@ func (s *SdkSuite) TestUnmarshalStandaloneImplicitSlot(c *check.C) {
 name: sdk
 slots:
     content:
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -306,7 +304,7 @@ func (s *SdkSuite) TestUnmarshalStandaloneAbbreviatedSlot(c *check.C) {
 name: sdk
 slots:
     net: content
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -325,7 +323,7 @@ slots:
     net:
         interface: content
         ipv6-aware: true
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -348,7 +346,7 @@ slots:
         l: [1,2]
         m:
           a: "A"
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -375,7 +373,7 @@ slots:
     net:
         interface: content
         attr: 2
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -394,7 +392,7 @@ name: sdk
 slots:
     content:
         ipv6-aware: true
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -414,7 +412,7 @@ slots:
     led0:
         interface: bool-file
         label: Front panel LED (red)
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Plugs, check.HasLen, 0)
 	c.Check(info.Slots, check.HasLen, 1)
@@ -434,7 +432,7 @@ slots:
     net:
         interface: 1.0
         ipv6-aware: true
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `interface name on slot "net" is not a string \(found float64\)`)
 }
 
@@ -445,7 +443,7 @@ name: sdk
 slots:
     bool-file:
         label: 1.0
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `label of slot "bool-file" is not a string \(found float64\)`)
 }
 
@@ -456,7 +454,7 @@ name: sdk
 slots:
     net:
         1: ok
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `slot "net" has attribute key that is not a string \(found int\)`)
 }
 
@@ -467,7 +465,7 @@ name: sdk
 slots:
     net:
         "": ok
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `slot "net" has an empty attribute key`)
 }
 
@@ -477,7 +475,7 @@ func (s *SdkSuite) TestUnmarshalCorruptedSlotWithUnexpectedType(c *check.C) {
 name: sdk
 slots:
     net: 5
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `slot "net" has malformed definition \(found int\)`)
 }
 
@@ -489,7 +487,7 @@ slots:
     serial:
         interface: serial-port
         $baud-rate: [9600]
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `slot "serial" uses reserved attribute "\$baud-rate"`)
 }
 
@@ -501,6 +499,6 @@ slots:
     serial:
         interface: serial-port
         foo: null
-`), s.projectId, "ws", s.setup)
+`), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `attribute "foo" of slot \"serial\": invalid scalar:.*`)
 }

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -65,7 +65,7 @@ func (s *ValidateSuite) TestValidateSlotPlugInterfaceName(c *check.C) {
 
 func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo.something
-`), s.projectId, "ws", sdk.Setup{})
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)
@@ -75,7 +75,7 @@ func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
 func (s *ValidateSuite) TestIllegalSdkBase(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo.something
 base: ubuntu@20.04
-`), s.projectId, "ws", sdk.Setup{})
+`), s.projectId, "ws")
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -689,11 +689,7 @@ func createDefaultDevices() map[string]map[string]string {
 }
 
 func defaultConfig(projectId string, userid, groupid string) map[string]string {
-	return map[string]string{
-		"raw.idmap":                fmt.Sprint("uid ", userid, " 1000\ngid ", groupid, " 1000"),
-		"security.nesting":         "true",
-		"user.workshop.project-id": projectId,
-		"user.user-data": `#cloud-config
+	cloudInitConfig := fmt.Sprintf(`#cloud-config
 users:
   - default
   - name: workshop
@@ -701,7 +697,12 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
     groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video
     shell: /bin/bash
-`,
+`)
+	return map[string]string{
+		"raw.idmap":                fmt.Sprint("uid ", userid, " 1000\ngid ", groupid, " 1000"),
+		"security.nesting":         "true",
+		"user.workshop.project-id": projectId,
+		"user.user-data":           cloudInitConfig,
 	}
 }
 

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -436,7 +436,7 @@ func (s *LxdBackend) Workshop(ctx context.Context, name string) (*Workshop, erro
 	return workshop, nil
 }
 
-func InstalledContent(lxdConfig map[string]string) (map[string]sdk.Setup, error) {
+func installedContent(lxdConfig map[string]string) (map[string]sdk.Setup, error) {
 	content := make(map[string]sdk.Setup)
 	if sdks, ok := lxdConfig["user.workshop.content"]; ok {
 		err := json.Unmarshal([]byte(sdks), &content)
@@ -472,7 +472,7 @@ func (s *LxdBackend) loadWorkshop(inst *api.Instance, p *Project) (*Workshop, er
 	}
 
 	// Fetch information about the installed SDKs
-	workshop.content, err = InstalledContent(inst.Config)
+	workshop.content, err = installedContent(inst.Config)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load workshop: installed SDK content is not readable: %v", err)
 	}

--- a/internal/workshopbackend/lxd_backend_mock.go
+++ b/internal/workshopbackend/lxd_backend_mock.go
@@ -27,6 +27,10 @@ type ExecCall struct {
 	Args *Execution
 }
 
+type WorkshopExecCall struct {
+	Name string
+}
+
 type FakeWorkshopBackend struct {
 	// the key is a project-id - workshop name
 	Workshops map[string]map[string]*FakeWorkshop
@@ -37,6 +41,9 @@ type FakeWorkshopBackend struct {
 
 	DoExec    ExecFunc
 	ExecCalls []*ExecCall
+
+	WorkshopFsCallback func(ctx context.Context, name string) (WorkshopFs, error)
+	WorkshopFsCalls    []*WorkshopExecCall
 }
 
 func NewFakeWorkshopBackend() *FakeWorkshopBackend {
@@ -281,6 +288,11 @@ func (f *FakeWorkshopBackend) GetWorkshopsByConfig(ctx context.Context, filter W
 }
 
 func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (WorkshopFs, error) {
+	s.WorkshopFsCalls = append(s.WorkshopFsCalls, &WorkshopExecCall{Name: name})
+	if s.WorkshopFsCallback != nil {
+		return s.WorkshopFsCallback(ctx, name)
+	}
+
 	_, projectId, err := s.userProject(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/workshopbackend/lxd_backend_mock.go
+++ b/internal/workshopbackend/lxd_backend_mock.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/workshop/internal/sdk"
 	"golang.org/x/exp/slices"
 )
 
@@ -247,7 +247,7 @@ func (f *FakeWorkshopBackend) Workshop(ctx context.Context, name string) (*Works
 		return nil, ErrWorkshopNotFound
 	}
 
-	workshop.content, err = InstalledContent(f.Workshops[projectId][name].Config)
+	workshop.content, err = installedContent(f.Workshops[projectId][name].Config)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -21,12 +21,6 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-type WorkshopErrorType int
-
-const (
-	WorkshopStateDir = "/var/lib/workshop/state"
-)
-
 var InstallTimeNow = time.Now
 
 func NewWorkshop(backend WorkshopBackend, project *Project, name string) *Workshop {
@@ -189,15 +183,10 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	}
 	defer wsfs.Close()
 
-	sdkSetup, ok := w.content[sdkName]
-	if !ok {
-		return nil, fmt.Errorf("%q SDK not installed in %q workshop", sdkName, w.Name)
-	}
-
-	sdkPath := sdk.SdkCurrentPath(sdkSetup.Name)
+	sdkPath := sdk.SdkCurrentPath(sdkName)
 	sdkYamlFile, err := wsfs.Open(filepath.Join(sdkPath, "meta/sdk.yaml"))
 	if err != nil {
-		return nil, fmt.Errorf("cannot read %q SDK metadata (%v)", sdkSetup.Name, err)
+		return nil, fmt.Errorf("cannot read %q SDK metadata (%v)", sdkName, err)
 	}
 	defer sdkYamlFile.Close()
 
@@ -206,7 +195,7 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 		return nil, err
 	}
 
-	info, err := sdk.ReadSdkInfo(yamlData, projectId, w.Name, sdkSetup)
+	info, err := sdk.ReadSdkInfo(yamlData, projectId, w.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workshopbackend/workshop_file.go
+++ b/internal/workshopbackend/workshop_file.go
@@ -82,6 +82,9 @@ func readWorkshop(pathname string) (*WorkshopFile, error) {
 	}
 
 	for _, k := range file.Sdks {
+		if k.Name == sdk.Agent.String() {
+			return nil, fmt.Errorf(`"agent" is a reserved SDK name`)
+		}
 		if matches := sdk.ValidChannel.FindStringSubmatch(k.Channel); matches != nil {
 			continue
 		} else {

--- a/internal/workshopbackend/workshop_file_test.go
+++ b/internal/workshopbackend/workshop_file_test.go
@@ -68,3 +68,17 @@ sdks:
 	c.Assert(file, check.IsNil)
 	c.Assert(err, check.NotNil)
 }
+
+func (f *F) TestWorkshopFileReservedNames(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  agent:
+    channel: latest/stable
+`)
+	dir := c.MkDir()
+	os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644)
+	file, err := workshopbackend.ReadWorkshop(workshopbackend.WorkshopFilePath(dir, "xbert-gpu"))
+	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
+	c.Assert(file, check.IsNil)
+}

--- a/tests/main/connections/.workshop.ws-1.yaml
+++ b/tests/main/connections/.workshop.ws-1.yaml
@@ -1,0 +1,5 @@
+name: ws-1
+base: ubuntu@22.04
+sdks:
+    test-sdk-content:
+        channel: latest/stable

--- a/tests/main/connections/.workshop.ws-2.yaml
+++ b/tests/main/connections/.workshop.ws-2.yaml
@@ -1,0 +1,5 @@
+name: ws-2
+base: ubuntu@22.04
+sdks:
+    test-sdk-content:
+        channel: latest/stable

--- a/tests/main/connections/task.yaml
+++ b/tests/main/connections/task.yaml
@@ -1,0 +1,21 @@
+summary: Check that "workshop connections" works as expected
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup ./
+
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  project=$(pwd)
+  workshop_exec --project "$project" launch ws-1
+  workshop_exec --project "$project" launch ws-2
+  
+  echo "Check connections for a workshop name provided"
+  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+\-$"  
+  
+  echo "Check connections for all workshops of the project"
+  workshop_exec --project "$project" connections  | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec --project "$project" connections  | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+\-$"  
+  workshop_exec --project "$project" connections  | MATCH "^content.+ws-2/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec --project "$project" connections  | MATCH "^content.+ws-2/test-sdk-content:content-plug-two.+:content.+\-$"  


### PR DESCRIPTION
# Description

## Agent SDK

Every workshop contains a special type SDK called "agent" that exposes system resources via interface slots. This change ensures that every newly spawned workshop has the agent installed. Some slots can only be installed by the agent SDK (e.g. content interface).

The "agent SDK" is a reserved name. The SDK is:
* Not provided by the SDK Store and constructed for every workshop implicitly.
* Installed first and removed last.
* Not providing hooks or any additional content. 
* Not removable by the user.
* Not listed in the content of the workshop info output.
* Only the plugs that come from the same workshop can be connected to this workshop's agent SDK's slots.

## New `workshop connections` CLI

The command shows a workshop's or a project's existing interface connections. Its implementation was mainly cross-ported from `snap connections`:

```
$ workshop connections albert
Project          Interface  Plug              Slot      Notes
~/work/workshop  content    albert/go:cache   :content  -
~/work/workshop  content    albert/go:vendor  :content  -
```



# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
