### PR TITLE
Workshop connect

### DIFF
--- a/client/connections.go
+++ b/client/connections.go
@@ -102,3 +102,12 @@ func (client *Client) Disconnect(plugProjectId, plugWorkshop, plugSdkName, plugN
 		Slots:  []Slot{{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName, Name: slotName}},
 	})
 }
+
+// Connects a plug and a slot.
+func (client *Client) Connect(plugProjectId, plugWorkshop, plugSdkName, plugName, slotProjectId, slotWorkshop, slotSdkName, slotName string, opts *DisconnectOptions) (changeID string, err error) {
+	return client.performInterfaceAction(&InterfaceAction{
+		Action: "connect",
+		Plugs:  []Plug{{ProjectId: plugProjectId, Workshop: plugWorkshop, Sdk: plugSdkName, Name: plugName}},
+		Slots:  []Slot{{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName, Name: slotName}},
+	})
+}

--- a/client/connections_test.go
+++ b/client/connections_test.go
@@ -297,6 +297,42 @@ func (cs *clientSuite) TestClientConnectionsFilter(c *check.C) {
 	})
 }
 
+func (cs *clientSuite) TestClientConnect(c *check.C) {
+	cs.status = 202
+	cs.rsp = `{
+		"type": "async",
+                "status-code": 202,
+		"result": { },
+                "change": "42"
+	}`
+	id, err := cs.cli.Connect("b8639dea", "consumer-ws", "consumer", "plug", "b8639dea", "producer-ws", "producer", "slot", nil)
+	c.Assert(err, check.IsNil)
+	c.Check(id, check.Equals, "42")
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"action": "connect",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"project-id": "b8639dea",
+				"workshop":   "consumer-ws",
+				"sdk":        "consumer",
+				"plug":       "plug",
+			},
+		},
+		"slots": []interface{}{
+			map[string]interface{}{
+				"project-id": "b8639dea",
+				"workshop":   "producer-ws",
+				"sdk":        "producer",
+				"slot":       "slot",
+			},
+		},
+	})
+}
+
 func (cs *clientSuite) TestClientDisconnect(c *check.C) {
 	cs.status = 202
 	cs.rsp = `{

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -127,3 +127,14 @@ func ParseSlotRef(slot string) (*SlotRef, error) {
 	}
 	return (*SlotRef)(plugRef), nil
 }
+
+func ParseSlotSdkRef(slot string) (*SlotRef, error) {
+	var slotRef SlotRef
+	parts := strings.Split(slot, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("unknown plug or slot reference %q", slot)
+	}
+	slotRef.Workshop = parts[0]
+	slotRef.Sdk = parts[1]
+	return &slotRef, nil
+}

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/canonical/workshop/client"
+	"github.com/spf13/cobra"
+)
+
+type CmdConnect struct {
+	waitMixin
+}
+
+func (c *CmdConnect) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "connect <workshop>/<sdk>:<plug> [<workshop>/<sdk>:<slot>]",
+		Args:  cobra.RangeArgs(1, 2),
+		Short: "The connect command connects a plug and a slot.",
+		RunE:  c.Run,
+	}
+
+	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
+		false,
+		"Do not wait for the operation to finish but just print the change id")
+
+	return cmd
+}
+
+func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
+	var err error
+
+	cli, err := client.New(&ClientConfig)
+	if err != nil {
+		return fmt.Errorf("cannot create client: %v", err)
+	}
+
+	c.setClient(cli)
+
+	project, err := c.client.Project(Project)
+	if err != nil {
+		return err
+	}
+
+	plugRef, err := client.ParsePlugRef(av[0])
+	if err != nil {
+		return err
+	}
+	plugRef.ProjectId = project.Id
+
+	slotRef := &client.SlotRef{}
+	if len(av) > 1 {
+		// check if the second arg is a short version of the agent-provided slot reference
+		if strings.HasPrefix(av[1], ":") {
+			slotRef.Workshop = plugRef.Workshop
+			slotRef.Sdk = "agent"
+			slotRef.Name = av[1][1:]
+		} else {
+			slotRef, err = client.ParseSlotRef(av[1])
+			if err != nil {
+				// see if an SDK (empty slot) reference provided
+				slotRef, err = client.ParseSlotSdkRef(av[1])
+				if err != nil {
+					return err
+				}
+			}
+		}
+		slotRef.ProjectId = plugRef.ProjectId
+	} else {
+		// workshop connect <workshop>/<sdk>:plug which means that the plug will
+		// be attempted to connect to the same name slot in the agent SDK (if
+		// exists)
+		slotRef.ProjectId = plugRef.ProjectId
+		slotRef.Workshop = plugRef.Workshop
+		slotRef.Sdk = "agent"
+		slotRef.Name = plugRef.Name
+	}
+
+	if plugRef.ProjectId != slotRef.ProjectId {
+		return fmt.Errorf("cannot connect plugs and slots across different workshops")
+	}
+
+	if plugRef.Workshop != slotRef.Workshop {
+		return fmt.Errorf("cannot connect plugs and slots across different workshops")
+	}
+
+	changeId, err := c.client.Connect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
+		slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name, nil)
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.wait(changeId, false); err != nil {
+		if err == errNoWait {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/cmd/workshop/connect_test.go
+++ b/cmd/workshop/connect_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+)
+
+type connectSuite struct {
+	BaseWorkshopSuite
+	prjDir string
+	prjId  string
+}
+
+var _ = check.Suite(&connectSuite{})
+
+func (m *connectSuite) SetUpTest(c *check.C) {
+	m.prjDir = c.MkDir()
+	m.prjId = "42424242"
+	m.BaseWorkshopSuite.SetUpTest(c)
+}
+
+func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
+	cmd := &CmdConnect{}
+	body := map[string]interface{}{
+		"action": "connect",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"project-id": "42424242",
+				"workshop":   "ws",
+				"sdk":        "sdk",
+				"plug":       "plug",
+			},
+		},
+		"slots": []interface{}{
+			map[string]interface{}{
+				"project-id": "42424242",
+				"workshop":   "ws",
+				"sdk":        "agent",
+				"slot":       "content",
+			},
+		},
+	}
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, body)
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
+			fmt.Fprintln(w, mockReadyChangeJSON)
+		default:
+			c.Errorf("expected 3 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"ws/sdk:plug", ":content"})
+	c.Assert(err, check.IsNil)
+
+	n = 0
+	body = map[string]interface{}{
+		"action": "connect",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"project-id": "42424242",
+				"workshop":   "ws",
+				"sdk":        "sdk",
+				"plug":       "plug2",
+			},
+		},
+		"slots": []interface{}{
+			map[string]interface{}{
+				"project-id": "42424242",
+				"workshop":   "ws",
+				"sdk":        "sdk-2",
+				"slot":       "producer",
+			},
+		},
+	}
+
+	err = cmd.Run(cmd.Command(), []string{"ws/sdk:plug2", "ws/sdk-2:producer"})
+	c.Assert(err, check.IsNil)
+
+	n = 0
+	body = map[string]interface{}{
+		"action": "connect",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"project-id": "42424242",
+				"workshop":   "ws",
+				"sdk":        "sdk",
+				"plug":       "plug2",
+			},
+		},
+		"slots": []interface{}{
+			map[string]interface{}{
+				"project-id": "42424242",
+				"workshop":   "ws",
+				"sdk":        "sdk-2",
+				"slot":       "",
+			},
+		},
+	}
+
+	err = cmd.Run(cmd.Command(), []string{"ws/sdk:plug2", "ws/sdk-2"})
+	c.Assert(err, check.IsNil)
+}
+
+func (m *connectSuite) TestDisconnectSlotNotProvided(c *check.C) {
+	cmd := &CmdConnect{}
+	body := map[string]interface{}{
+		"action": "connect",
+		"plugs": []interface{}{
+			map[string]interface{}{
+				"project-id": "42424242",
+				"workshop":   "ws",
+				"sdk":        "sdk",
+				"plug":       "plug",
+			},
+		},
+		"slots": []interface{}{
+			map[string]interface{}{
+				"project-id": "42424242",
+				"workshop":   "ws",
+				"sdk":        "agent",
+				"slot":       "plug",
+			},
+		},
+	}
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, body)
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
+			fmt.Fprintln(w, mockReadyChangeJSON)
+		default:
+			c.Errorf("expected 3 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"ws/sdk:plug"})
+	c.Assert(err, check.IsNil)
+}

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -69,6 +69,7 @@ func main() {
 	rootCmd.AddCommand((&CmdRemove{}).Command())
 	rootCmd.AddCommand((&CmdRemount{}).Command())
 	rootCmd.AddCommand((&CmdConnections{}).Command())
+	rootCmd.AddCommand((&CmdConnect{}).Command())
 	rootCmd.AddCommand((&CmdDisconnect{}).Command())
 
 	rootCmd.SilenceErrors = true

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -338,6 +338,20 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	switch a.Action {
+	case "connect":
+		var connRef *interfaces.ConnRef
+		repo := c.d.overlord.InterfaceManager().Repository()
+		connRef, err = repo.ResolveConnect(a.Plugs[0].ProjectId, a.Plugs[0].Workshop, a.Plugs[0].Sdk, a.Plugs[0].Name,
+			a.Slots[0].ProjectId, a.Slots[0].Workshop, a.Slots[0].Sdk, a.Slots[0].Name)
+		if err == nil {
+			ts, connErr := ifacestate.Connect(st, connRef)
+			if connErr != nil {
+				if _, ok := connErr.(*ifacestate.ErrAlreadyConnected); !ok {
+					return statusBadRequest(connErr.Error())
+				}
+			}
+			tasksets = append(tasksets, ts)
+		}
 	case "disconnect":
 		var conns []*interfaces.ConnRef
 		conns, err = c.d.overlord.InterfaceManager().ResolveDisconnect(a.Plugs[0].ProjectId, a.Plugs[0].Workshop, a.Plugs[0].Sdk, a.Plugs[0].Name,

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -913,6 +913,287 @@ slots:
 
 // Tests for POST /v1/connections
 
+func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	d.Overlord().Loop()
+	defer d.Overlord().Stop()
+
+	action := &client.InterfaceAction{
+		Action: "connect",
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"}},
+	}
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	cmd := apiCmd("/v1/connections")
+	req, err := http.NewRequest("POST", cmd.Path, buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 202)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	id := body["change"].(string)
+
+	st := d.Overlord().State()
+	st.Lock()
+	chg := st.Change(id)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+
+	<-chg.Ready()
+
+	st.Lock()
+	err = chg.Err()
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+
+	repo := d.Overlord().InterfaceManager().Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, check.HasLen, 1)
+	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+	}})
+}
+
+func mockIface(c *check.C, d *Daemon, iface interfaces.Interface) {
+	err := d.Overlord().InterfaceManager().Repository().AddInterface(iface)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *apiSuite) TestConnectPlugFailureInterfaceMismatch(c *check.C) {
+	d := s.daemon(c)
+
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "different"})
+
+	var differentProducerYaml = `
+name: producer
+base: ubuntu@22.04
+slots:
+  slot:
+    interface: different
+    key: value 
+    label: label
+`
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, differentProducerYaml, "producer-ws")
+
+	action := &client.InterfaceAction{
+		Action: "connect",
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"}},
+	}
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	cmd := apiCmd("/v1/connections")
+	req, err := http.NewRequest("POST", cmd.Path, buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 400)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"result": map[string]interface{}{
+			"message": "cannot connect consumer-ws/consumer:plug (\"test\" interface) to producer-ws/producer:slot (\"different\" interface)",
+		},
+		"status":      "Bad Request",
+		"status-code": 400.0,
+		"type":        "error",
+	})
+	repo := d.Overlord().InterfaceManager().Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, check.HasLen, 0)
+}
+
+func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
+	d := s.daemon(c)
+
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "different"})
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	action := &client.InterfaceAction{
+		Action: "connect",
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "missingplug"}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"}},
+	}
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	cmd := apiCmd("/v1/connections")
+	req, err := http.NewRequest("POST", cmd.Path, buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 400)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"result": map[string]interface{}{
+			"message": "SDK \"consumer-ws/consumer\" has no plug named \"missingplug\"",
+		},
+		"status":      "Bad Request",
+		"status-code": 400.0,
+		"type":        "error",
+	})
+	repo := d.Overlord().InterfaceManager().Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, check.HasLen, 0)
+}
+
+func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
+	d := s.daemon(c)
+
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "different"})
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	action := &client.InterfaceAction{
+		Action: "connect",
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "missingslot"}},
+	}
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	cmd := apiCmd("/v1/connections")
+	req, err := http.NewRequest("POST", cmd.Path, buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 400)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"result": map[string]interface{}{
+			"message": "SDK producer-ws/producer has no slot named \"missingslot\"",
+		},
+		"status":      "Bad Request",
+		"status-code": 400.0,
+		"type":        "error",
+	})
+	repo := d.Overlord().InterfaceManager().Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, check.HasLen, 0)
+}
+
+func (s *apiSuite) TestConnectAlreadyConnected(c *check.C) {
+	d := s.daemon(c)
+
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "different"})
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+	connRef := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+	}
+	d.Overlord().Loop()
+	defer d.Overlord().Stop()
+
+	_, err := d.overlord.InterfaceManager().Repository().Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, check.IsNil)
+
+	action := &client.InterfaceAction{
+		Action: "connect",
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"}},
+	}
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	cmd := apiCmd("/v1/connections")
+	req, err := http.NewRequest("POST", cmd.Path, buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 202)
+	var body map[string]interface{}
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	id := body["change"].(string)
+
+	st := d.Overlord().State()
+	st.Lock()
+	chg := st.Change(id)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+
+	<-chg.Ready()
+
+	st.Lock()
+	err = chg.Err()
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *apiSuite) TestConnectFailureOnConflict(c *check.C) {
+	d := s.daemon(c)
+
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
+
+	cmd := apiCmd("/v1/connections")
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	action := &client.InterfaceAction{
+		Action: "connect",
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"}},
+	}
+
+	st := s.d.state
+	st.Lock()
+	chg := st.NewChange("conflict", "...")
+	tsk := st.NewTask("stop-workshop", "...")
+	chg.AddTask(tsk)
+	tsk.Set("workshop", "producer-ws")
+	chg.Set("project-id", "b8639dea")
+	st.Unlock()
+
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	req, err := http.NewRequest("POST", cmd.Path, buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 400)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"result": map[string]interface{}{
+			"message": `workshop "producer-ws" has "conflict" change in progress`,
+		},
+		"status":      "Bad Request",
+		"status-code": 400.0,
+		"type":        "error",
+	})
+}
+
 func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, slotWorkshop, slotSdk, slotName string) {
 	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer restore()

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -1033,3 +1033,77 @@ func (r *Repository) AutoConnectCandidatePlugs(projectId, workshop, slotSdkName,
 	}
 	return candidates
 }
+
+// ResolveConnect resolves potentially missing plug or slot names and returns a
+// fully populated connection reference.
+func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, plugName, slotProjectId, slotWorkshop, slotSdkName, slotName string) (*ConnRef, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if plugProjectId == "" {
+		return nil, fmt.Errorf("cannot resolve connection, plug project-id name is empty")
+	}
+	if plugWorkshop == "" {
+		return nil, fmt.Errorf("cannot resolve connection, plug Workshop name is empty")
+	}
+	if plugSdkName == "" {
+		return nil, fmt.Errorf("cannot resolve connection, plug SDK name is empty")
+	}
+	if plugName == "" {
+		return nil, fmt.Errorf("cannot resolve connection, plug name is empty")
+	}
+
+	plugKey := plugOrSlotKey(plugProjectId, plugWorkshop, plugSdkName)
+
+	// Ensure that such plug exists
+	plug := r.plugs[plugKey][plugName]
+	if plug == nil {
+		return nil, &NoPlugOrSlotError{
+			message: fmt.Sprintf(`SDK "%s/%s" has no plug named %q`,
+				plugWorkshop, plugSdkName, plugName),
+		}
+	}
+
+	if slotSdkName == "" {
+		// Use the agent SDK if the slot-side snap name is empty
+		slotProjectId = plugProjectId
+		slotWorkshop = plugWorkshop
+		slotSdkName = sdk.Agent.String()
+	}
+
+	slotKey := plugOrSlotKey(slotProjectId, slotWorkshop, slotSdkName)
+
+	if slotName == "" {
+		// Find the unambiguous slot that satisfies plug requirements
+		var candidates []string
+		for candidateSlotName, candidateSlot := range r.slots[slotKey] {
+			// TODO: use some smarter matching (e.g. against $attrs)
+			if candidateSlot.Interface == plug.Interface {
+				candidates = append(candidates, candidateSlotName)
+			}
+		}
+		switch len(candidates) {
+		case 0:
+			return nil, fmt.Errorf(`SDK %s/%s has no %q interface slots`, slotWorkshop, slotSdkName, plug.Interface)
+		case 1:
+			slotName = candidates[0]
+		default:
+			sort.Strings(candidates)
+			return nil, fmt.Errorf("SDK %s/%s has multiple %q interface slots: %s", slotWorkshop, slotSdkName, plug.Interface, strings.Join(candidates, ", "))
+		}
+	}
+
+	// Ensure that such slot exists
+	slot := r.slots[slotKey][slotName]
+	if slot == nil {
+		return nil, &NoPlugOrSlotError{
+			message: fmt.Sprintf("SDK %s/%s has no slot named %q", slotWorkshop, slotSdkName, slotName),
+		}
+	}
+	// Ensure that plug and slot are compatible
+	if slot.Interface != plug.Interface {
+		return nil, fmt.Errorf("cannot connect %s/%s:%s (%q interface) to %s/%s:%s (%q interface)",
+			plugWorkshop, plugSdkName, plugName, plug.Interface, slotWorkshop, slotSdkName, slotName, slot.Interface)
+	}
+	return NewConnRef(plug, slot), nil
+}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -246,8 +246,6 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 				}
 			}
 
-			// no policy check passed in here as it has been checked when looked
-			// up the candidates.
 			conn, err := m.repo.Connect(connRef, plug.Attrs, plugDynamicAttrs, slot.Attrs, nil, connectCheck)
 			if err != nil || conn == nil {
 				return err
@@ -435,6 +433,70 @@ func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRe
 		return plugRef, slotRef, err
 	}
 	return plugRef, slotRef, nil
+}
+
+func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var user string
+	err := task.Change().Get("user", &user)
+	if err != nil {
+		return err
+	}
+
+	plugRef, slotRef, err := getPlugAndSlotRefs(task)
+	if err != nil {
+		return err
+	}
+
+	cref := &interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
+
+	conns, err := getConns(st)
+	if err != nil {
+		return err
+	}
+
+	plug := m.repo.Plug(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name)
+	if plug == nil {
+		return fmt.Errorf("SDK %q has no %q plug", plugRef.Sdk, plugRef.Name)
+	}
+
+	slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
+	if slot == nil {
+		return fmt.Errorf("snap %q has no %q slot", slotRef.Sdk, slotRef.Name)
+	}
+
+	conn, err := m.repo.Connect(cref, plug.Attrs, nil, slot.Attrs, nil, connectCheck)
+	if err != nil || conn == nil {
+		return err
+	}
+
+	plugSdkRef := sdk.Ref{ProjectId: plugRef.ProjectId, Workshop: plugRef.Workshop, Sdk: plugRef.Sdk}
+	slotSdkRef := sdk.Ref{ProjectId: slotRef.ProjectId, Workshop: slotRef.Workshop, Sdk: slotRef.Sdk}
+
+	for _, ref := range []sdk.Ref{plugSdkRef, slotSdkRef} {
+		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
+		defer cancel()
+		for _, backend := range m.repo.Backends() {
+			if err = backend.Setup(ctx, ref, m.repo); err != nil {
+				return err
+			}
+		}
+	}
+
+	conns[cref.ID()] = &schema.ConnState{
+		Interface:        conn.Interface(),
+		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
+		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
+		StaticSlotAttrs:  conn.Slot.StaticAttrs(),
+		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
+		Auto:             false,
+	}
+	setConns(st, conns)
+
+	return nil
 }
 
 func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -33,13 +33,16 @@ func New(s *state.State, r *state.TaskRunner, be workshopbackend.WorkshopBackend
 
 	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), m.undoAutoConnect)
 	r.AddHandler("auto-disconnect", OnDo(m.doAutoDisconnect), m.undoAutoDisconnect)
+
+	r.AddHandler("connect", m.doConnect, nil)
+	r.AddHandler("disconnect", m.doDisconnect, nil)
+	r.AddHandler("discard-conns", m.doDiscard, m.undoDiscard)
+
 	// TODO: there is no use for the undo logic as remount is a single task
 	// change that will either finish successfully or fail (in which case it
 	// would revert all the partial progress). Shall remount be used as part of
 	// a larger change the undo logic must be implemented.
 	r.AddHandler("remount", m.doRemount, nil)
-	r.AddHandler("disconnect", m.doDisconnect, nil)
-	r.AddHandler("discard-conns", m.doDiscard, m.undoDiscard)
 
 	return m
 }

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -8,6 +8,52 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 )
 
+// ErrAlreadyConnected describes the error that occurs when attempting to connect already connected interface.
+type ErrAlreadyConnected struct {
+	Connection interfaces.ConnRef
+}
+
+const (
+	ConnectTaskEdge       = state.TaskSetEdge("connect-task")
+	AfterConnectHooksEdge = state.TaskSetEdge("after-connect-hooks")
+)
+
+func (e ErrAlreadyConnected) Error() string {
+	return fmt.Sprintf("already connected: %q", e.Connection.ID())
+}
+
+// Connect returns a set of tasks for connecting an interface.
+func Connect(st *state.State, connRef *interfaces.ConnRef) (*state.TaskSet, error) {
+	plugProject, plugWorkshop := connRef.PlugRef.ProjectId, connRef.PlugRef.Workshop
+	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
+	if err != nil {
+		return nil, err
+	}
+
+	slotProject, slotWorkshop := connRef.SlotRef.ProjectId, connRef.SlotRef.Workshop
+	err = conflict.CheckChangeConflict(st, slotProject, slotWorkshop, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// check if the connection already exists
+	conns, err := getConns(st)
+	if err != nil {
+		return nil, err
+	}
+	if conn, ok := conns[connRef.ID()]; ok && !conn.Undesired {
+		return nil, &ErrAlreadyConnected{Connection: *connRef}
+	}
+
+	connectInterface := st.NewTask("connect", fmt.Sprintf("Connect %s/%s:%s to %s/%s:%s", plugWorkshop, connRef.PlugRef.Sdk, connRef.PlugRef.Name,
+		slotWorkshop, connRef.SlotRef.Sdk, connRef.SlotRef.Name))
+
+	connectInterface.Set("slot", connRef.SlotRef)
+	connectInterface.Set("plug", connRef.PlugRef)
+
+	return state.NewTaskSet(connectInterface), nil
+}
+
 func Forget(st *state.State, conn *interfaces.ConnRef, forget bool) (*state.TaskSet, error) {
 	plugProject, plugWorkshop := conn.PlugRef.ProjectId, conn.PlugRef.Workshop
 	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -13,11 +13,6 @@ type ErrAlreadyConnected struct {
 	Connection interfaces.ConnRef
 }
 
-const (
-	ConnectTaskEdge       = state.TaskSetEdge("connect-task")
-	AfterConnectHooksEdge = state.TaskSetEdge("after-connect-hooks")
-)
-
 func (e ErrAlreadyConnected) Error() string {
 	return fmt.Sprintf("already connected: %q", e.Connection.ID())
 }

--- a/internal/workshopbackend/lxd_backend_profile.go
+++ b/internal/workshopbackend/lxd_backend_profile.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"golang.org/x/exp/slices"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
 )
 
@@ -115,7 +117,14 @@ func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile
 			// confirm the target path exists
 			target := dev.properties["path"]
 			if info, err := fs.Stat(target); err != nil {
-				return fmt.Errorf("cannot create a workshop mount with target %q: %v", target, err)
+				if !osutil.IsDirNotExist(err) {
+					return err
+				}
+				// FIXME: workaround LXD empty directory issue (which, if the
+				// connection was disconnected earlier, was removed by LXD).
+				if err = fs.Mkdir(target, os.ModePerm); err != nil {
+					return err
+				}
 			} else if !info.IsDir() {
 				return fmt.Errorf("cannot create a workshop mount with target %q: the target is not a directory", target)
 			}

--- a/internal/workshopbackend/tests/integration/profile_test.go
+++ b/internal/workshopbackend/tests/integration/profile_test.go
@@ -106,22 +106,14 @@ func (f *profileTest) TestSdkProfileCreatedAndUpdatedSuccessfully(c *check.C) {
 	c.Assert(inst.Profiles, testutil.DeepUnsortedMatches, []string{"default", "test-42424242-sdk"})
 }
 
-func (f *profileTest) TestSdkProfileBindMountFailsIfTargetDoesNotExist(c *check.C) {
+func (f *profileTest) TestSdkProfileBindMountFailsIfTargetIsAFile(c *check.C) {
 	// Setup
 	var backend workshopbackend.Profile = &workshopbackend.LxdBackend{}
-	profile := workshopbackend.NewSdkProfile("sdk")
-	device := workshopbackend.Mount("sdk-device", c.MkDir(), "/not-exist")
-	err := profile.AddDevice(device)
-	c.Assert(err, check.IsNil)
-
-	// Execute
-	err = backend.AssignProfile(f.ctx, "test", profile)
-	c.Assert(err, check.ErrorMatches, `.*cannot create a workshop mount with target "/not-exist": file does not exist`)
 
 	// Setup
-	profile = workshopbackend.NewSdkProfile("sdk")
-	device = workshopbackend.Mount("sdk-device", c.MkDir(), "/root/.profile")
-	err = profile.AddDevice(device)
+	profile := workshopbackend.NewSdkProfile("sdk")
+	device := workshopbackend.Mount("sdk-device", c.MkDir(), "/root/.profile")
+	err := profile.AddDevice(device)
 	c.Assert(err, check.IsNil)
 
 	// Execute


### PR DESCRIPTION
# Description

The connect command connects a plug and a slot. It has several forms:

```
# connect a plug and a slot
workshop connect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot> 

# connects the specific plug to the only slot in the provided <sdk-slot> that matches
# the connected interface.
workshop connect <workshop>/<sdk>:<plug or slot> <workshop>/<sdk-slot>

# connects the provided plug to the slot in the agent SDK with a name matching
# the plug name.
workshop connect <workshop>/<sdk>:<plug>
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
