### PR TITLE
Workshop warnings & okay

### DIFF
--- a/client/warnings.go
+++ b/client/warnings.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+	"time"
+)
+
+// A Warning is a short messages that's meant to alert about system events.
+// There'll only ever be one Warning with the same message, and it can be
+// silenced for a while before repeating. After a (supposedly longer) while
+// it'll go away on its own (unless it recurrs).
+type Warning struct {
+	Message     string        `json:"message"`
+	FirstAdded  time.Time     `json:"first-added"`
+	LastAdded   time.Time     `json:"last-added"`
+	LastShown   time.Time     `json:"last-shown,omitempty"`
+	ExpireAfter time.Duration `json:"expire-after,omitempty"`
+	RepeatAfter time.Duration `json:"repeat-after,omitempty"`
+}
+
+type jsonWarning struct {
+	Warning
+	ExpireAfter string `json:"expire-after,omitempty"`
+	RepeatAfter string `json:"repeat-after,omitempty"`
+}
+
+// WarningsOptions contains options for querying workshopd for warnings
+// supported options:
+// - All: return all warnings, instead of only the un-okayed ones.
+type WarningsOptions struct {
+	All bool
+}
+
+// Warnings returns the list of un-okayed warnings.
+func (client *Client) Warnings(opts WarningsOptions) ([]*Warning, error) {
+	var jws []*jsonWarning
+	q := make(url.Values)
+	if opts.All {
+		q.Add("select", "all")
+	}
+	_, err := client.doSync("GET", "/v1/warnings", q, nil, nil, &jws)
+
+	ws := make([]*Warning, len(jws))
+	for i, jw := range jws {
+		ws[i] = &jw.Warning
+		ws[i].ExpireAfter, _ = time.ParseDuration(jw.ExpireAfter)
+		ws[i].RepeatAfter, _ = time.ParseDuration(jw.RepeatAfter)
+	}
+
+	return ws, err
+}
+
+type warningsAction struct {
+	Action    string    `json:"action"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// Okay asks workshopd to chill about the warnings that would have been returned by
+// Warnings at the given time.
+func (client *Client) Okay(t time.Time) error {
+	var body bytes.Buffer
+	var op = warningsAction{Action: "okay", Timestamp: t}
+	if err := json.NewEncoder(&body).Encode(op); err != nil {
+		return err
+	}
+	_, err := client.doSync("POST", "/v1/warnings", nil, nil, &body, nil)
+	return err
+}

--- a/client/warnings_test.go
+++ b/client/warnings_test.go
@@ -1,0 +1,121 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"encoding/json"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
+)
+
+func (cs *clientSuite) testWarnings(c *check.C, all bool) {
+	t1 := time.Date(2018, 9, 19, 12, 41, 18, 505007495, time.UTC)
+	t2 := time.Date(2018, 9, 19, 12, 44, 19, 680362867, time.UTC)
+	cs.rsp = `{
+		"result": [
+		    {
+			"expire-after": "672h0m0s",
+			"first-added": "2018-09-19T12:41:18.505007495Z",
+			"last-added": "2018-09-19T12:41:18.505007495Z",
+			"message": "hello world number one",
+			"repeat-after": "24h0m0s"
+		    },
+		    {
+			"expire-after": "672h0m0s",
+			"first-added": "2018-09-19T12:44:19.680362867Z",
+			"last-added": "2018-09-19T12:44:19.680362867Z",
+			"message": "hello world number two",
+			"repeat-after": "24h0m0s"
+		    }
+		],
+		"status": "OK",
+		"status-code": 200,
+		"type": "sync",
+		"warning-count": 2,
+		"warning-timestamp": "2018-09-19T12:44:19.680362867Z"
+	}`
+
+	ws, err := cs.cli.Warnings(client.WarningsOptions{All: all})
+	c.Assert(err, check.IsNil)
+	c.Check(ws, check.DeepEquals, []*client.Warning{
+		{
+			Message:     "hello world number one",
+			FirstAdded:  t1,
+			LastAdded:   t1,
+			ExpireAfter: time.Hour * 24 * 28,
+			RepeatAfter: time.Hour * 24,
+		},
+		{
+			Message:     "hello world number two",
+			FirstAdded:  t2,
+			LastAdded:   t2,
+			ExpireAfter: time.Hour * 24 * 28,
+			RepeatAfter: time.Hour * 24,
+		},
+	})
+	c.Check(cs.req.Method, check.Equals, "GET")
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/warnings")
+	query := cs.req.URL.Query()
+	if all {
+		c.Check(query, check.HasLen, 1)
+		c.Check(query.Get("select"), check.Equals, "all")
+	} else {
+		c.Check(query, check.HasLen, 0)
+	}
+
+	// this could be done at the end of any sync method
+	count, stamp := cs.cli.WarningsSummary()
+	c.Check(count, check.Equals, 2)
+	c.Check(stamp, check.Equals, t2)
+}
+
+func (cs *clientSuite) TestWarningsAll(c *check.C) {
+	cs.testWarnings(c, true)
+}
+
+func (cs *clientSuite) TestWarnings(c *check.C) {
+	cs.testWarnings(c, false)
+}
+
+func (cs *clientSuite) TestOkay(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200,
+		"result": { }
+	}`
+	t0 := time.Now()
+	err := cs.cli.Okay(t0)
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Query(), check.HasLen, 0)
+	var body map[string]interface{}
+	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
+	c.Check(body, check.HasLen, 2)
+	c.Check(body["action"], check.Equals, "okay")
+	c.Check(body["timestamp"], check.Equals, t0.Format(time.RFC3339Nano))
+
+	// note there's no warnings summary in the response
+	count, stamp := cs.cli.WarningsSummary()
+	c.Check(count, check.Equals, 0)
+	c.Check(stamp, check.Equals, time.Time{})
+}

--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -49,6 +49,11 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 		return fmt.Errorf("cannot create client: %v", err)
 	}
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	if cmd.Parent().Flag("project").Changed {
 		clientOpts.ProjectPath = cmd.Parent().Flag("project").Value.String()

--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -34,7 +34,8 @@ Notes:
 - To investigate the details of a specific change, use 'workshop tasks' instead
 `,
 
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	return cmd
@@ -49,11 +50,6 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 		return fmt.Errorf("cannot create client: %v", err)
 	}
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
 	if cmd.Parent().Flag("project").Changed {
 		clientOpts.ProjectPath = cmd.Parent().Flag("project").Value.String()
@@ -61,7 +57,7 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 
 	clientOpts.Selector = client.ChangesAll
 
-	chngs, err := c.client.Changes(&clientOpts)
+	chngs, err := c.cli.Changes(&clientOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/color.go
+++ b/cmd/workshop/color.go
@@ -1,0 +1,173 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/canonical/x-go/i18n"
+	"golang.org/x/term"
+)
+
+var isStdinTTY = term.IsTerminal(0)
+
+type mixinDescs map[string]string
+
+func (mxd mixinDescs) also(m map[string]string) mixinDescs {
+	n := make(map[string]string, len(mxd)+len(m))
+	for k, v := range mxd {
+		n[k] = v
+	}
+	for k, v := range m {
+		n[k] = v
+	}
+	return n
+}
+
+type unicodeMixin struct {
+	Unicode string `long:"unicode" default:"auto" choice:"auto" choice:"never" choice:"always"`
+}
+
+func (ux unicodeMixin) addUnicodeChars(esc *escapes) {
+	if canUnicode(ux.Unicode) {
+		esc.dash = "–" // that's an en dash (so yaml is happy)
+		esc.uparrow = "↑"
+		esc.tick = "✓"
+		esc.star = "✪"
+	} else {
+		esc.dash = "--" // two dashes keeps yaml happy also
+		esc.uparrow = "^"
+		esc.tick = "**"
+		esc.star = "*"
+	}
+}
+
+func (ux unicodeMixin) getEscapes() *escapes {
+	esc := &escapes{}
+	ux.addUnicodeChars(esc)
+	return esc
+}
+
+type colorMixin struct {
+	Color string `long:"color" default:"auto" choice:"auto" choice:"never" choice:"always"`
+	unicodeMixin
+}
+
+func (mx colorMixin) getEscapes() *escapes {
+	esc := colorTable(mx.Color)
+	mx.addUnicodeChars(&esc)
+	return &esc
+}
+
+func canUnicode(mode string) bool {
+	switch mode {
+	case "always":
+		return true
+	case "never":
+		return false
+	}
+	if !isStdoutTTY {
+		return false
+	}
+	var lang string
+	for _, k := range []string{"LC_MESSAGES", "LC_ALL", "LANG"} {
+		lang = os.Getenv(k)
+		if lang != "" {
+			break
+		}
+	}
+	if lang == "" {
+		return false
+	}
+	lang = strings.ToUpper(lang)
+	return strings.Contains(lang, "UTF-8") || strings.Contains(lang, "UTF8")
+}
+
+var isStdoutTTY = term.IsTerminal(1)
+
+func colorTable(mode string) escapes {
+	switch mode {
+	case "always":
+		return color
+	case "never":
+		return noesc
+	}
+	if !isStdoutTTY {
+		return noesc
+	}
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		// from http://no-color.org/:
+		//   command-line software which outputs text with ANSI color added should
+		//   check for the presence of a NO_COLOR environment variable that, when
+		//   present (regardless of its value), prevents the addition of ANSI color.
+		return mono // bold & dim is still ok
+	}
+	if term := os.Getenv("TERM"); term == "xterm-mono" || term == "linux-m" {
+		// these are often used to flag "I don't want to see color" more than "I can't do color"
+		// (if you can't *do* color, `color` and `mono` should produce the same results)
+		return mono
+	}
+	return color
+}
+
+var colorDescs = mixinDescs{
+	// TRANSLATORS: This should not start with a lowercase letter.
+	"color":   i18n.G("Use a little bit of color to highlight some things."),
+	"unicode": unicodeDescs["unicode"],
+}
+
+var unicodeDescs = mixinDescs{
+	// TRANSLATORS: This should not start with a lowercase letter.
+	"unicode": i18n.G("Use a little bit of Unicode to improve legibility."),
+}
+
+type escapes struct {
+	green        string
+	brightYellow string
+	bold         string
+	end          string
+
+	tick, dash, uparrow, star string
+}
+
+var (
+	color = escapes{
+		green:        "\033[32m",
+		brightYellow: "\033[93m",
+		bold:         "\033[1m",
+		end:          "\033[0m",
+	}
+
+	mono = escapes{
+		green:        "\033[1m", // bold
+		brightYellow: "\033[2m", // dim
+		bold:         "\033[1m",
+		end:          "\033[0m",
+	}
+
+	noesc = escapes{}
+)
+
+// fillerPublisher is used to add an no-op escape sequence to a header in a
+// tabwriter table, so that things line up.
+func fillerPublisher(esc *escapes) string {
+	return esc.green + esc.end
+}

--- a/cmd/workshop/color_test.go
+++ b/cmd/workshop/color_test.go
@@ -1,0 +1,122 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"os"
+	"runtime"
+
+	"gopkg.in/check.v1"
+)
+
+type colorSuite struct {
+	BaseWorkshopSuite
+}
+
+func setEnviron(env map[string]string) func() {
+	old := make(map[string]string, len(env))
+	ok := make(map[string]bool, len(env))
+
+	for k, v := range env {
+		old[k], ok[k] = os.LookupEnv(k)
+		if v != "" {
+			os.Setenv(k, v)
+		} else {
+			os.Unsetenv(k)
+		}
+	}
+
+	return func() {
+		for k := range ok {
+			if ok[k] {
+				os.Setenv(k, old[k])
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}
+}
+
+func (s *colorSuite) TestCanUnicode(c *check.C) {
+	// setenv is per thread
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	type T struct {
+		lang, lcAll, lcMsg string
+		expected           bool
+	}
+
+	for _, t := range []T{
+		{expected: false}, // all locale unset
+		{lang: "C", expected: false},
+		{lang: "C", lcAll: "C", expected: false},
+		{lang: "C", lcAll: "C", lcMsg: "C", expected: false},
+		{lang: "C.UTF-8", lcAll: "C", lcMsg: "C", expected: false}, // LC_MESSAGES wins
+		{lang: "C.UTF-8", lcAll: "C.UTF-8", lcMsg: "C", expected: false},
+		{lang: "C.UTF-8", lcAll: "C.UTF-8", lcMsg: "C.UTF-8", expected: true},
+		{lang: "C.UTF-8", lcAll: "C", lcMsg: "C.UTF-8", expected: true},
+		{lang: "C", lcAll: "C", lcMsg: "C.UTF-8", expected: true},
+		{lang: "C", lcAll: "C.UTF-8", expected: true},
+		{lang: "C.UTF-8", expected: true},
+		{lang: "C.utf8", expected: true}, // deals with a bit of rando weirdness
+	} {
+		restore := setEnviron(map[string]string{"LANG": t.lang, "LC_ALL": t.lcAll, "LC_MESSAGES": t.lcMsg})
+		c.Check(CanUnicode("never"), check.Equals, false)
+		c.Check(CanUnicode("always"), check.Equals, true)
+		restoreIsTTY := MockIsStdoutTTY(true)
+		c.Check(CanUnicode("auto"), check.Equals, t.expected)
+		MockIsStdoutTTY(false)
+		c.Check(CanUnicode("auto"), check.Equals, false)
+		restoreIsTTY()
+		restore()
+	}
+}
+
+func (s *colorSuite) TestColorTable(c *check.C) {
+	// setenv is per thread
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	type T struct {
+		isTTY         bool
+		noColor, term string
+		expected      interface{}
+		desc          string
+	}
+
+	for _, t := range []T{
+		{isTTY: false, expected: NoEscColorTable, desc: "not a tty"},
+		{isTTY: false, noColor: "1", expected: NoEscColorTable, desc: "no tty *and* NO_COLOR set"},
+		{isTTY: false, term: "linux-m", expected: NoEscColorTable, desc: "no tty *and* mono term set"},
+		{isTTY: true, expected: ColorColorTable, desc: "is a tty"},
+		{isTTY: true, noColor: "1", expected: MonoColorTable, desc: "is a tty, but NO_COLOR set"},
+		{isTTY: true, term: "linux-m", expected: MonoColorTable, desc: "is a tty, but TERM=linux-m"},
+		{isTTY: true, term: "xterm-mono", expected: MonoColorTable, desc: "is a tty, but TERM=xterm-mono"},
+	} {
+		restoreIsTTY := MockIsStdoutTTY(t.isTTY)
+		restoreEnv := setEnviron(map[string]string{"NO_COLOR": t.noColor, "TERM": t.term})
+		c.Check(ColorTable("never"), check.DeepEquals, NoEscColorTable, check.Commentf(t.desc))
+		c.Check(ColorTable("always"), check.DeepEquals, ColorColorTable, check.Commentf(t.desc))
+		c.Check(ColorTable("auto"), check.DeepEquals, t.expected, check.Commentf(t.desc))
+		restoreEnv()
+		restoreIsTTY()
+	}
+}

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -14,10 +14,11 @@ type CmdConnect struct {
 
 func (c *CmdConnect) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "connect <workshop>/<sdk>:<plug> [<workshop>/<sdk>:<slot>]",
-		Args:  cobra.RangeArgs(1, 2),
-		Short: "The connect command connects a plug and a slot.",
-		RunE:  c.Run,
+		Use:     "connect <workshop>/<sdk>:<plug> [<workshop>/<sdk>:<slot>]",
+		Args:    cobra.RangeArgs(1, 2),
+		Short:   "The connect command connects a plug and a slot.",
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -37,7 +38,7 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 
 	c.setClient(cli)
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
@@ -84,7 +85,7 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 		return fmt.Errorf("cannot connect plugs and slots across different workshops")
 	}
 
-	changeId, err := c.client.Connect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
+	changeId, err := c.cli.Connect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
 		slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name, nil)
 	if err != nil {
 		return err

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -81,6 +81,11 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	project, err := c.client.Project(Project)
 	if err != nil {

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -17,10 +17,11 @@ type CmdConnections struct {
 
 func (c *CmdConnections) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "connections [<WORKSHOP>] [--all]",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "List interface connections.",
-		RunE:  c.Run,
+		Use:     "connections [<WORKSHOP>] [--all]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "List interface connections.",
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	cmd.Flags().BoolVar(&c.all, "all", false, "Lists connected and unconnected plugs and slots.")
@@ -81,13 +82,8 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
@@ -103,7 +99,7 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 		c.all = true
 	}
 
-	connections, err := c.client.Connections(&client.ConnectionOptions{ProjectId: project.Id, Workshop: workshop, All: c.all})
+	connections, err := c.cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, Workshop: workshop, All: c.all})
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -41,6 +41,11 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	project, err := c.client.Project(Project)
 	if err != nil {

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -15,10 +15,11 @@ type CmdDisconnect struct {
 
 func (c *CmdDisconnect) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "disconnect [OPTIONS] <workshop>/<sdk>:<plug> [<workshop>/<sdk>]:<slot>",
-		Args:  cobra.RangeArgs(1, 2),
-		Short: "The disconnect command disconnects a plug from a slot.",
-		RunE:  c.Run,
+		Use:     "disconnect [OPTIONS] <workshop>/<sdk>:<plug> [<workshop>/<sdk>]:<slot>",
+		Args:    cobra.RangeArgs(1, 2),
+		Short:   "The disconnect command disconnects a plug from a slot.",
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.forget, "forget",
@@ -41,13 +42,8 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
@@ -75,7 +71,7 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	var opts = client.DisconnectOptions{Forget: c.forget}
-	changeId, err := c.client.Disconnect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
+	changeId, err := c.cli.Disconnect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
 		slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name, &opts)
 	if err != nil {
 		return err

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -89,11 +89,12 @@ Notes:
 
 func (c *CmdExec) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "exec <WORKSHOP>",
-		Args:  cobra.MinimumNArgs(1),
-		Short: shortExecHelp,
-		Long:  longExecHelp,
-		RunE:  c.Run,
+		Use:     "exec <WORKSHOP>",
+		Args:    cobra.MinimumNArgs(1),
+		Short:   shortExecHelp,
+		Long:    longExecHelp,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	cmd.Flags().SortFlags = false
@@ -139,7 +140,7 @@ func (cmd *CmdExec) Run(c *cobra.Command, av []string) error {
 
 	cmd.setClient(cli)
 
-	project, err := cmd.client.Project(Project)
+	project, err := cmd.cli.Project(Project)
 	if err != nil {
 		return err
 	}
@@ -218,7 +219,7 @@ func (cmd *CmdExec) Run(c *cobra.Command, av []string) error {
 	}
 
 	// Start the command.
-	process, err := cmd.client.Exec(opts, av[0], project.Id)
+	process, err := cmd.cli.Exec(opts, av[0], project.Id)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/export_test.go
+++ b/cmd/workshop/export_test.go
@@ -1,0 +1,36 @@
+package main
+
+var (
+	CanUnicode           = canUnicode
+	ColorTable           = colorTable
+	MonoColorTable       = mono
+	ColorColorTable      = color
+	NoEscColorTable      = noesc
+	ColorMixinGetEscapes = (colorMixin).getEscapes
+
+	MaybePresentWarnings  = maybePresentWarnings
+	WriteWarningTimestamp = writeWarningTimestamp
+)
+
+func MockIsStdoutTTY(t bool) (restore func()) {
+	oldIsStdoutTTY := isStdoutTTY
+	isStdoutTTY = t
+	return func() {
+		isStdoutTTY = oldIsStdoutTTY
+	}
+}
+
+func MockIsStdinTTY(t bool) (restore func()) {
+	oldIsStdinTTY := isStdinTTY
+	isStdinTTY = t
+	return func() {
+		isStdinTTY = oldIsStdinTTY
+	}
+}
+
+func ColorMixin(cmode, umode string) colorMixin {
+	return colorMixin{
+		Color:        cmode,
+		unicodeMixin: unicodeMixin{Unicode: umode},
+	}
+}

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -68,9 +68,10 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
-
 	defer func() {
-		maybePresentWarnings(cli.WarningsSummary())
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
 	}()
 
 	project, err := c.client.Project(Project)

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -35,7 +35,8 @@ Notes:
 - Avoid assumptions based on SDK channels: 'latest/stable' may be neither
 `,
 
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	return cmd
@@ -68,18 +69,13 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
 
-	workshop, err := c.client.Workshop(project.Id, av[0])
+	workshop, err := c.cli.Workshop(project.Id, av[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -69,6 +69,10 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 
 	c.setClient(cli)
 
+	defer func() {
+		maybePresentWarnings(cli.WarningsSummary())
+	}()
+
 	project, err := c.client.Project(Project)
 	if err != nil {
 		return err

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -56,6 +56,11 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	project, err := c.client.Project(Project)
 	if err != nil {

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -35,7 +35,8 @@ Notes:
 - SDKs are installed in alphabetical order
 `,
 
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -56,18 +57,13 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
 
-	changeId, err := c.client.Launch(project.Id, av)
+	changeId, err := c.cli.Launch(project.Id, av)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -46,7 +46,7 @@ Notes:
 	return cmd
 }
 
-func (c *CmdList) Run(cmd *cobra.Command, av []string) error {
+func (c *CmdList) Run(cmd *cobra.Command, _ []string) error {
 	// check if both --project and --global were provided
 	if cmd.Parent().Flag("project").Changed && cmd.Flag("global").Changed {
 		return fmt.Errorf("cannot list: '--project' incompatible with '--global'")

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -63,6 +63,11 @@ func (c *CmdList) runList() error {
 	}
 
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	if !c.global {
 		project, err := c.client.Project(Project)

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -38,7 +38,8 @@ however, it doesn't include any that are *Off*.
 Notes:
 - For details of a single workshop, use 'workshop info' instead
 `,
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	cmd.Flags().BoolVar(&c.global, "global", false, "List workshops from all projects in the system")
@@ -63,19 +64,14 @@ func (c *CmdList) runList() error {
 	}
 
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
 	if !c.global {
-		project, err := c.client.Project(Project)
+		project, err := c.cli.Project(Project)
 		if err != nil {
 			return err
 		}
 
-		workshops, err := c.client.ListWorkshops(&client.ListOptions{ProjectId: project.Id})
+		workshops, err := c.cli.ListWorkshops(&client.ListOptions{ProjectId: project.Id})
 		if err != nil {
 			return err
 		}
@@ -91,7 +87,7 @@ func (c *CmdList) runList() error {
 		w := tabWriter()
 		fmt.Fprintf(w, "Project\tWorkshop\tStatus\tNotes\n")
 
-		projects, err := c.client.Projects()
+		projects, err := c.cli.Projects()
 		slices.SortFunc(projects, func(a, b *client.Project) int { return cmp.Compare(a.Path, b.Path) })
 
 		if err != nil {
@@ -99,7 +95,7 @@ func (c *CmdList) runList() error {
 		}
 
 		for _, i := range projects {
-			workshops, err := c.client.ListWorkshops(&client.ListOptions{ProjectId: i.Id})
+			workshops, err := c.cli.ListWorkshops(&client.ListOptions{ProjectId: i.Id})
 			slices.SortFunc(workshops, func(a, b *client.Workshop) int { return cmp.Compare(a.Name, b.Name) })
 
 			if err != nil {

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -13,11 +13,15 @@ import (
 )
 
 type clientMixin struct {
-	client *client.Client
+	cli *client.Client
 }
 
 func (ch *clientMixin) setClient(cli *client.Client) {
-	ch.client = cli
+	ch.cli = cli
+}
+
+func (ch *clientMixin) client() *client.Client {
+	return ch.cli
 }
 
 var rootCmd = &cobra.Command{
@@ -39,6 +43,14 @@ var Project string
 var ClientConfig = client.Config{
 	// we need the powerful socket
 	Socket: dirs.SocketPath,
+}
+
+func postRunWarnings(c *clientMixin) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if c.client() != nil {
+			maybePresentWarnings(c.client().WarningsSummary())
+		}
+	}
 }
 
 func main() {

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -71,6 +71,8 @@ func main() {
 	rootCmd.AddCommand((&CmdConnections{}).Command())
 	rootCmd.AddCommand((&CmdConnect{}).Command())
 	rootCmd.AddCommand((&CmdDisconnect{}).Command())
+	rootCmd.AddCommand((&CmdWarnings{}).Command())
+	rootCmd.AddCommand((&CmdOkay{}).Command())
 
 	rootCmd.SilenceErrors = true
 

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -90,6 +90,11 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	project, err := c.client.Project(Project)
 	if err != nil {

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -47,7 +47,8 @@ Notes:
   set by 'workshop remount', if any
 `,
 
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",
@@ -90,13 +91,8 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
@@ -112,7 +108,7 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		mode = "abort"
 	}
 
-	changeId, err := c.client.Refresh(project.Id, av, mode)
+	changeId, err := c.cli.Refresh(project.Id, av, mode)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -36,7 +36,8 @@ Notes:
   aren't removed
 `,
 
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -65,20 +66,15 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
 
 	plugRef.ProjectId = project.Id
 
-	changeId, err := c.client.Remount(plugRef, source)
+	changeId, err := c.cli.Remount(plugRef, source)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -65,6 +65,11 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	project, err := c.client.Project(Project)
 	if err != nil {

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -31,7 +31,8 @@ Notes:
   aren't removed
 `,
 
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	return cmd
@@ -49,18 +50,13 @@ func (c *CmdRemove) Run(cmd *cobra.Command, av []string) error {
 
 	c.setClient(cli)
 	c.skipAbort = true
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
 
-	changeId, err := c.client.Remove(project.Id, av)
+	changeId, err := c.cli.Remove(project.Id, av)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -49,6 +49,11 @@ func (c *CmdRemove) Run(cmd *cobra.Command, av []string) error {
 
 	c.setClient(cli)
 	c.skipAbort = true
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	project, err := c.client.Project(Project)
 	if err != nil {

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -31,7 +31,8 @@ Notes:
 - When interrupted, the command attempts to gracefully revert its actions
 - To stop a started workshop, use 'workshop stop'
 `,
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	return cmd
@@ -49,18 +50,13 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 
 	c.setClient(cli)
 	c.skipAbort = true
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
 
-	changeId, err := c.client.Start(project.Id, av)
+	changeId, err := c.cli.Start(project.Id, av)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -49,6 +49,11 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 
 	c.setClient(cli)
 	c.skipAbort = true
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	project, err := c.client.Project(Project)
 	if err != nil {

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -48,6 +48,11 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 	c.skipAbort = true
 
 	project, err := c.client.Project(Project)

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -31,7 +31,8 @@ Notes:
 - When interrupted, the command attempts to gracefully revert its actions
 - To start a stopped workshop, use 'workshop start'
 `,
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	return cmd
@@ -48,19 +49,14 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 	c.skipAbort = true
 
-	project, err := c.client.Project(Project)
+	project, err := c.cli.Project(Project)
 	if err != nil {
 		return err
 	}
 
-	changeId, err := c.client.Stop(project.Id, av)
+	changeId, err := c.cli.Stop(project.Id, av)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -35,7 +35,8 @@ Notes:
 - The command may print additional log details for tasks that store them
 - To investigate recent changes in a project, use 'workshop changes' instead
 `,
-		RunE: c.Run,
+		RunE:    c.Run,
+		PostRun: postRunWarnings(&c.clientMixin),
 	}
 
 	return cmd
@@ -52,11 +53,6 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 		return fmt.Errorf("cannot create client: %v", err)
 	}
 	c.setClient(cli)
-	defer func() {
-		if cli != nil {
-			maybePresentWarnings(cli.WarningsSummary())
-		}
-	}()
 
 	if cmd.Parent().Flag("project").Changed {
 		clientOpts.ProjectPath = cmd.Parent().Flag("project").Value.String()
@@ -64,7 +60,7 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 
 	clientOpts.Selector = client.ChangesAll
 
-	change, err := c.client.Change(av[0])
+	change, err := c.cli.Change(av[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -52,6 +52,11 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 		return fmt.Errorf("cannot create client: %v", err)
 	}
 	c.setClient(cli)
+	defer func() {
+		if cli != nil {
+			maybePresentWarnings(cli.WarningsSummary())
+		}
+	}()
 
 	if cmd.Parent().Flag("project").Changed {
 		clientOpts.ProjectPath = cmd.Parent().Flag("project").Value.String()

--- a/cmd/workshop/times.go
+++ b/cmd/workshop/times.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"time"
+
+	"github.com/canonical/workshop/internal/timeutil"
+)
+
+var timeutilHuman = timeutil.Human
+
+type timeMixin struct {
+	AbsTime bool `long:"abs-time"`
+}
+
+func (mx timeMixin) fmtTime(t time.Time) string {
+	if mx.AbsTime {
+		return t.Format(time.RFC3339)
+	}
+	return timeutilHuman(t)
+}

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -62,7 +62,7 @@ func (wmx waitMixin) wait(id string, abortExpected bool) (*client.Change, error)
 		fmt.Fprintf(Stdout, "%s\n", id)
 		return nil, errNoWait
 	}
-	cli := wmx.client
+	cli := wmx.cli
 	// Intercept sigint
 	c := make(chan os.Signal, 2)
 
@@ -76,7 +76,7 @@ func (wmx waitMixin) wait(id string, abortExpected bool) (*client.Change, error)
 		if sig == nil || wmx.skipAbort {
 			return
 		}
-		_, err := wmx.client.Abort(id)
+		_, err := wmx.cli.Abort(id)
 		if err != nil {
 			fmt.Fprintf(Stderr, err.Error()+"\n")
 		}

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -156,7 +156,7 @@ func (c *CmdWarnings) Run(cmd *cobra.Command, av []string) error {
 	}
 	c.setClient(cli)
 
-	warnings, err := c.client.Warnings(client.WarningsOptions{All: c.All})
+	warnings, err := c.cli.Warnings(client.WarningsOptions{All: c.All})
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func (cmd *CmdOkay) Run(c *cobra.Command, av []string) error {
 	}
 	cmd.setClient(cli)
 
-	return cmd.client.Okay(last)
+	return cmd.cli.Okay(last)
 }
 
 const warnFileEnvKey = "WORKSHOPD_LAST_WARNING_TIMESTAMP_FILENAME"

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -1,0 +1,308 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/x-go/i18n"
+	"github.com/canonical/x-go/strutil"
+	"github.com/canonical/x-go/strutil/quantity"
+
+	"github.com/adrg/xdg"
+)
+
+type CmdWarnings struct {
+	clientMixin
+	timeMixin
+	unicodeMixin
+	All     bool `long:"all"`
+	Verbose bool `long:"verbose"`
+}
+
+type CmdOkay struct{ clientMixin }
+
+func (c *CmdWarnings) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "warnings [OPTIONS]",
+		Args:  cobra.NoArgs,
+		Short: "List warnings.",
+		Long: `
+The warnings command lists the warnings that have been reported to the system.
+
+Once warnings have been listed with 'workshop warnings', 'workshop okay' may be used to
+silence them. A warning that's been silenced in this way will not be listed
+again unless it happens again, _and_ a cooldown time has passed.
+
+Warnings expire automatically, and once expired they are forgotten.
+`,
+		RunE: c.Run,
+	}
+
+	cmd.PersistentFlags().BoolVar(&c.All, "all",
+		false,
+		"Show all warnings.")
+
+	cmd.PersistentFlags().BoolVar(&c.All, "verbose",
+		false,
+		"Show more information.")
+
+	cmd.PersistentFlags().BoolVar(&c.AbsTime, "abs-time",
+		false,
+		"Display absolute times (in RFC 3339 format). Otherwise, display relative times up to 60 days, then YYYY-MM-DD.")
+
+	cmd.PersistentFlags().StringVar(&c.Unicode, "unicode",
+		"auto",
+		"Use a little bit of Unicode to improve legibility (auto|never|always). (default: auto)")
+
+	return cmd
+}
+
+func (c *CmdOkay) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "warnings [OPTIONS]",
+		Args:  cobra.NoArgs,
+		Short: "Acknowledge warnings.",
+		Long: `
+The okay command acknowledges the warnings listed with 'workshop warnings'.
+
+Once acknowledged a warning won't appear again unless it re-occurrs and
+sufficient time has passed.
+`,
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func termSize() (width, height int) {
+	if f, ok := Stdout.(*os.File); ok {
+		width, height, _ = terminal.GetSize(int(f.Fd()))
+	}
+
+	if width <= 0 {
+		width = int(osutil.GetenvInt64("COLUMNS"))
+	}
+
+	if height <= 0 {
+		height = int(osutil.GetenvInt64("LINES"))
+	}
+
+	if width < 40 {
+		width = 80
+	}
+
+	if height < 15 {
+		height = 25
+	}
+
+	return width, height
+}
+
+// printDescr formats a given string (typically a workshop description)
+// in a user friendly way.
+//
+// The rules are (intentionally) very simple:
+// - trim trailing whitespace
+// - word wrap at "max" chars preserving line indent
+// - keep \n intact and break there
+func printDescr(w io.Writer, descr string, termWidth int) error {
+	var err error
+	descr = strings.TrimRightFunc(descr, unicode.IsSpace)
+	for _, line := range strings.Split(descr, "\n") {
+		err = strutil.WordWrapPadded(w, []rune(line), "  ", termWidth)
+		if err != nil {
+			break
+		}
+	}
+	return err
+}
+
+func (c *CmdWarnings) Run(cmd *cobra.Command, av []string) error {
+	now := time.Now()
+
+	cli, err := client.New(&ClientConfig)
+	if err != nil {
+		return fmt.Errorf("cannot create client: %v", err)
+	}
+	c.setClient(cli)
+
+	warnings, err := c.client.Warnings(client.WarningsOptions{All: c.All})
+	if err != nil {
+		return err
+	}
+	if len(warnings) == 0 {
+		if t, _ := lastWarningTimestamp(); t.IsZero() {
+			fmt.Fprintln(Stdout, "No warnings.")
+		} else {
+			fmt.Fprintln(Stdout, "No further warnings.")
+		}
+		return nil
+	}
+
+	if err := writeWarningTimestamp(now); err != nil {
+		return err
+	}
+
+	termWidth, _ := termSize()
+	if termWidth > 100 {
+		// any wider than this and it gets hard to read
+		termWidth = 100
+	}
+
+	esc := c.getEscapes()
+	w := tabWriter()
+	for i, warning := range warnings {
+		if i > 0 {
+			fmt.Fprintln(w, "---")
+		}
+		if c.Verbose {
+			fmt.Fprintf(w, "first-occurrence:\t%s\n", c.fmtTime(warning.FirstAdded))
+		}
+		fmt.Fprintf(w, "last-occurrence:\t%s\n", c.fmtTime(warning.LastAdded))
+		if c.Verbose {
+			lastShown := esc.dash
+			if !warning.LastShown.IsZero() {
+				lastShown = c.fmtTime(warning.LastShown)
+			}
+			fmt.Fprintf(w, "acknowledged:\t%s\n", lastShown)
+			// TODO: cmd.fmtDuration() using timeutil.HumanDuration
+			fmt.Fprintf(w, "repeats-after:\t%s\n", quantity.FormatDuration(warning.RepeatAfter.Seconds()))
+			fmt.Fprintf(w, "expires-after:\t%s\n", quantity.FormatDuration(warning.ExpireAfter.Seconds()))
+		}
+		fmt.Fprintln(w, "warning: |")
+		printDescr(w, warning.Message, termWidth)
+		w.Flush()
+	}
+
+	return nil
+}
+
+func (cmd *CmdOkay) Run(c *cobra.Command, av []string) error {
+	last, err := lastWarningTimestamp()
+	if err != nil {
+		return err
+	}
+
+	cli, err := client.New(&ClientConfig)
+	if err != nil {
+		return fmt.Errorf("cannot create client: %v", err)
+	}
+	cmd.setClient(cli)
+
+	return cmd.client.Okay(last)
+}
+
+const warnFileEnvKey = "WORKSHOPD_LAST_WARNING_TIMESTAMP_FILENAME"
+
+func warnFilename() string {
+	if fn := os.Getenv(warnFileEnvKey); fn != "" {
+		return fn
+	}
+
+	return filepath.Join(xdg.CacheHome, "workshop", "warnings.json")
+}
+
+type clientWarningData struct {
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func writeWarningTimestamp(t time.Time) error {
+	user, err := osutil.UserMaybeSudoUser()
+	if err != nil {
+		return err
+	}
+	uid, gid, err := osutil.UidGid(user)
+	if err != nil {
+		return err
+	}
+
+	filename := warnFilename()
+	if err := osutil.MkdirAllChown(filepath.Dir(filename), 0700, uid, gid); err != nil {
+		return err
+	}
+
+	aw, err := osutil.NewAtomicFile(filename, 0600, 0, uid, gid)
+	if err != nil {
+		return err
+	}
+	// Cancel once Committed is a NOP :-)
+	defer aw.Cancel()
+
+	enc := json.NewEncoder(aw)
+	if err := enc.Encode(clientWarningData{Timestamp: t}); err != nil {
+		return err
+	}
+
+	return aw.Commit()
+}
+
+func lastWarningTimestamp() (time.Time, error) {
+	_, err := osutil.UserMaybeSudoUser()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cannot determine real user: %v", err)
+	}
+
+	f, err := os.Open(warnFilename())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return time.Time{}, fmt.Errorf("you must have looked at the warnings before acknowledging them. Try 'workshop warnings'.")
+		}
+		return time.Time{}, fmt.Errorf("cannot open timestamp file: %v", err)
+
+	}
+	dec := json.NewDecoder(f)
+	var d clientWarningData
+	if err := dec.Decode(&d); err != nil {
+		return time.Time{}, fmt.Errorf("cannot decode timestamp file: %v", err)
+	}
+	if dec.More() {
+		return time.Time{}, fmt.Errorf("spurious extra data in timestamp file")
+	}
+	return d.Timestamp, nil
+}
+
+func maybePresentWarnings(count int, timestamp time.Time) {
+	if count == 0 {
+		return
+	}
+
+	if last, _ := lastWarningTimestamp(); !timestamp.After(last) {
+		return
+	}
+
+	fmt.Fprintf(Stderr,
+		i18n.NG("WARNING: There is %d new warning. See 'workshop warnings'.\n",
+			"WARNING: There are %d new warnings. See 'workshop warnings'.\n",
+			count),
+		count)
+}

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -89,7 +89,7 @@ Warnings expire automatically, and once expired they are forgotten.
 
 func (c *CmdOkay) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "warnings [OPTIONS]",
+		Use:   "okay",
 		Args:  cobra.NoArgs,
 		Short: "Acknowledge warnings.",
 		Long: `

--- a/cmd/workshop/warnings_test.go
+++ b/cmd/workshop/warnings_test.go
@@ -231,9 +231,10 @@ func (s *warningSuite) TestListWithWarnings(c *check.C) {
 		// call it from tests and not have to do this (whole
 		// block) by hand
 
-		count, stamp := cmdList.client.WarningsSummary()
+		count, stamp := cmdList.cli.WarningsSummary()
 		c.Check(count, check.Equals, 2)
 		c.Check(stamp, check.Equals, time.Date(2018, 9, 19, 12, 44, 19, 680362867, time.UTC))
+		maybePresentWarnings(count, stamp)
 
 	}
 

--- a/cmd/workshop/warnings_test.go
+++ b/cmd/workshop/warnings_test.go
@@ -1,0 +1,247 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/check.v1"
+)
+
+type warningSuite struct {
+	BaseWorkshopSuite
+	cmdW *CmdWarnings
+	cmdO *CmdOkay
+}
+
+var _ = check.Suite(&warningSuite{})
+
+func (m *warningSuite) SetUpTest(c *check.C) {
+	m.BaseWorkshopSuite.SetUpTest(c)
+	m.cmdW = &CmdWarnings{}
+	m.cmdO = &CmdOkay{}
+
+	os.Setenv("WORKSHOPD_LAST_WARNING_TIMESTAMP_FILENAME", filepath.Join(c.MkDir(), "warnings.json"))
+}
+
+const twoWarnings = `{
+			"result": [
+			    {
+				"expire-after": "672h0m0s",
+				"first-added": "2018-09-19T12:41:18.505007495Z",
+				"last-added": "2018-09-19T12:41:18.505007495Z",
+				"message": "hello world number one",
+				"repeat-after": "24h0m0s"
+			    },
+			    {
+				"expire-after": "672h0m0s",
+				"first-added": "2018-09-19T12:44:19.680362867Z",
+				"last-added": "2018-09-19T12:44:19.680362867Z",
+				"message": "hello world number two",
+				"repeat-after": "24h0m0s"
+			    }
+			],
+			"status": "OK",
+			"status-code": 200,
+			"type": "sync"
+		}`
+
+func mkWarningsFakeHandler(c *check.C, body string) func(w http.ResponseWriter, r *http.Request) {
+	var called bool
+	return func(w http.ResponseWriter, r *http.Request) {
+		if called {
+			c.Fatalf("expected a single request")
+		}
+		called = true
+		c.Check(r.URL.Path, check.Equals, "/v1/warnings")
+		c.Check(r.URL.Query(), check.HasLen, 0)
+
+		buf, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+		c.Check(string(buf), check.Equals, "")
+		c.Check(r.Method, check.Equals, "GET")
+		w.WriteHeader(200)
+		fmt.Fprintln(w, body)
+	}
+}
+
+func (s *warningSuite) TestNoWarningsEver(c *check.C) {
+	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, `{"type": "sync", "status-code": 200, "result": []}`))
+
+	s.cmdW.AbsTime = true
+	err := s.cmdW.Run(s.cmdW.Command(), nil)
+	c.Assert(err, check.IsNil)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "No warnings.\n")
+}
+
+func (s *warningSuite) TestNoFurtherWarnings(c *check.C) {
+	WriteWarningTimestamp(time.Now())
+
+	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, `{"type": "sync", "status-code": 200, "result": []}`))
+
+	s.cmdW.AbsTime = true
+	err := s.cmdW.Run(s.cmdW.Command(), nil)
+	c.Assert(err, check.IsNil)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "No further warnings.\n")
+}
+
+func (s *warningSuite) TestWarnings(c *check.C) {
+	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, twoWarnings))
+	cmd := s.cmdW.Command()
+	s.cmdW.AbsTime = true
+	s.cmdW.Unicode = "never"
+	err := s.cmdW.Run(cmd, nil)
+	c.Assert(err, check.IsNil)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, `
+last-occurrence:  2018-09-19T12:41:18Z
+warning: |
+  hello world number one
+---
+last-occurrence:  2018-09-19T12:44:19Z
+warning: |
+  hello world number two
+`[1:])
+}
+
+func (s *warningSuite) TestVerboseWarnings(c *check.C) {
+	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, twoWarnings))
+	cmd := s.cmdW.Command()
+	s.cmdW.AbsTime = true
+	s.cmdW.Verbose = true
+	s.cmdW.Unicode = "never"
+	err := s.cmdW.Run(cmd, nil)
+	c.Assert(err, check.IsNil)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, `
+first-occurrence:  2018-09-19T12:41:18Z
+last-occurrence:   2018-09-19T12:41:18Z
+acknowledged:      --
+repeats-after:     1d00h
+expires-after:     28d0h
+warning: |
+  hello world number one
+---
+first-occurrence:  2018-09-19T12:44:19Z
+last-occurrence:   2018-09-19T12:44:19Z
+acknowledged:      --
+repeats-after:     1d00h
+expires-after:     28d0h
+warning: |
+  hello world number two
+`[1:])
+}
+
+func (s *warningSuite) TestOkay(c *check.C) {
+	t0 := time.Now()
+	WriteWarningTimestamp(t0)
+
+	var n int
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		if n != 1 {
+			c.Fatalf("expected 1 request, now on %d", n)
+		}
+		c.Check(r.URL.Path, check.Equals, "/v1/warnings")
+		c.Check(r.URL.Query(), check.HasLen, 0)
+		c.Assert(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "okay", "timestamp": t0.Format(time.RFC3339Nano)})
+		c.Check(r.Method, check.Equals, "POST")
+		w.WriteHeader(200)
+		fmt.Fprintln(w, `{
+			"status": "OK",
+			"status-code": 200,
+			"type": "sync"
+		}`)
+	})
+
+	err := s.cmdO.Run(s.cmdO.Command(), nil)
+	c.Assert(err, check.IsNil)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "")
+}
+
+func (s *warningSuite) TestOkayBeforeWarnings(c *check.C) {
+	err := s.cmdO.Run(s.cmdO.Command(), nil)
+	c.Assert(err, check.ErrorMatches, "you must have looked at the warnings before acknowledging them. Try 'workshop warnings'.")
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "")
+}
+
+func (s *warningSuite) TestListWithWarnings(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, "42424242", "/home/project")
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects/42424242/workshops")
+			buf, err := ioutil.ReadAll(r.Body)
+			c.Assert(err, check.IsNil)
+			c.Check(string(buf), check.Equals, "")
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{
+					"result": [{}],
+					"status": "OK",
+					"status-code": 200,
+					"type": "sync",
+					"warning-count": 2,
+					"warning-timestamp": "2018-09-19T12:44:19.680362867Z"
+				}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+
+	})
+	cmdList := &CmdList{}
+	err := cmdList.runList()
+	c.Assert(err, check.IsNil)
+
+	{
+		// TODO: I hope to get to refactor run() so we can
+		// call it from tests and not have to do this (whole
+		// block) by hand
+
+		count, stamp := cmdList.client.WarningsSummary()
+		c.Check(count, check.Equals, 2)
+		c.Check(stamp, check.Equals, time.Date(2018, 9, 19, 12, 44, 19, 680362867, time.UTC))
+
+		MaybePresentWarnings(count, stamp)
+	}
+
+	c.Check(s.Stdout(), check.Equals, `
+Project        Workshop  Status  Notes
+/home/project                    -
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "WARNING: There are 2 new warnings. See 'workshop warnings'.\n")
+
+}

--- a/cmd/workshop/warnings_test.go
+++ b/cmd/workshop/warnings_test.go
@@ -235,7 +235,6 @@ func (s *warningSuite) TestListWithWarnings(c *check.C) {
 		c.Check(count, check.Equals, 2)
 		c.Check(stamp, check.Equals, time.Date(2018, 9, 19, 12, 44, 19, 680362867, time.UTC))
 
-		MaybePresentWarnings(count, stamp)
 	}
 
 	c.Check(s.Stdout(), check.Equals, `

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ cloud.google.com/go/iam v1.1.6/go.mod h1:O0zxdPeGBoFdWW3HWmBxJsk0pfvNM/p/qa82rWO
 cloud.google.com/go/storage v1.36.0 h1:P0mOkAcaJxhCTvAkMhxMfrTKiNcub4YmmPBtlhAyTr8=
 cloud.google.com/go/storage v1.36.0/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/canonical/lxd v0.0.0-20240226153229-0ff71ae3cb84 h1:tEwXoEYYlZKs8WiPPqMBu3yUHlpuIxVZquWCiVUmuiM=
 github.com/canonical/lxd v0.0.0-20240226153229-0ff71ae3cb84/go.mod h1:v91XagUQhKjCyNdVy4M2RSEKqj/6Yprbv01AkoRz4ao=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
@@ -202,6 +204,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -59,6 +59,11 @@ var api = []*Command{{
 	UserOK: true,
 	GET:    v1GetChanges,
 }, {
+	Path:   "/v1/warnings",
+	UserOK: true,
+	GET:    v1GetWarnings,
+	POST:   v1PostWarnings,
+}, {
 	Path:   "/v1/changes/{id}",
 	UserOK: true,
 	GET:    v1GetChange,

--- a/internal/daemon/api_warnings.go
+++ b/internal/daemon/api_warnings.go
@@ -1,0 +1,67 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/canonical/workshop/internal/overlord/state"
+)
+
+var (
+	stateOkayWarnings    = (*state.State).OkayWarnings
+	stateAllWarnings     = (*state.State).AllWarnings
+	statePendingWarnings = (*state.State).PendingWarnings
+)
+
+func v1GetWarnings(c *Command, r *http.Request, _ *userState) Response {
+	query := r.URL.Query()
+	var all bool
+	sel := query.Get("select")
+	switch sel {
+	case "all":
+		all = true
+	case "pending", "":
+		all = false
+	default:
+		return statusBadRequest("invalid select parameter: %q", sel)
+	}
+
+	st := c.d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var ws []*state.Warning
+	if all {
+		ws = stateAllWarnings(st)
+	} else {
+		ws, _ = statePendingWarnings(st)
+	}
+	if len(ws) == 0 {
+		// no need to confuse the issue
+		return SyncResponse([]state.Warning{}, http.StatusOK)
+	}
+
+	return SyncResponse(ws, http.StatusOK)
+}
+
+func v1PostWarnings(c *Command, r *http.Request, _ *userState) Response {
+	defer r.Body.Close()
+	var op struct {
+		Action    string    `json:"action"`
+		Timestamp time.Time `json:"timestamp"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&op); err != nil {
+		return statusBadRequest("cannot decode request body into warnings operation: %v", err)
+	}
+	if op.Action != "okay" {
+		return statusBadRequest("unknown warning action %q", op.Action)
+	}
+	st := c.d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+	n := stateOkayWarnings(st, op.Timestamp)
+
+	return SyncResponse(n, http.StatusOK)
+}

--- a/internal/daemon/api_warnings_test.go
+++ b/internal/daemon/api_warnings_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/canonical/workshop/internal/overlord/state"
+	"gopkg.in/check.v1"
+)
+
+func (s *apiSuite) testWarnings(c *check.C, all bool, body io.Reader) (calls string, result interface{}) {
+	s.daemon(c)
+
+	okayWarns := func(*state.State, time.Time) int { calls += "ok"; return 0 }
+	allWarns := func(*state.State) []*state.Warning { calls += "all"; return nil }
+	pendingWarns := func(*state.State) ([]*state.Warning, time.Time) { calls += "show"; return nil, time.Time{} }
+	restore := MockWarningsAccessors(okayWarns, allWarns, pendingWarns)
+	defer restore()
+
+	method := "GET"
+	handler := v1GetWarnings
+	if body != nil {
+		method = "POST"
+		handler = v1PostWarnings
+	}
+	q := url.Values{}
+	if all {
+		q.Set("select", "all")
+	}
+	cmd := apiCmd("/v1/warnings")
+
+	req, err := http.NewRequest(method, "/v1/warnings?"+q.Encode(), body)
+	c.Assert(err, check.IsNil)
+
+	rsp := handler(cmd, req.WithContext(s.ctx), nil)
+
+	c.Check(rsp.(*resp).Status, check.Equals, 200)
+	c.Assert(rsp.(*resp).Result, check.NotNil)
+	return calls, rsp.(*resp).Result
+}
+
+func (s *apiSuite) TestAllWarnings(c *check.C) {
+	calls, result := s.testWarnings(c, true, nil)
+	c.Check(calls, check.Equals, "all")
+	c.Check(result, check.DeepEquals, []state.Warning{})
+}
+
+func (s *apiSuite) TestSomeWarnings(c *check.C) {
+	calls, result := s.testWarnings(c, false, nil)
+	c.Check(calls, check.Equals, "show")
+	c.Check(result, check.DeepEquals, []state.Warning{})
+}
+
+func (s *apiSuite) TestAckWarnings(c *check.C) {
+	calls, result := s.testWarnings(c, false, bytes.NewReader([]byte(`{"action": "okay", "timestamp": "2006-01-02T15:04:05Z"}`)))
+	c.Check(calls, check.Equals, "ok")
+	c.Check(result, check.DeepEquals, 0)
+}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -115,7 +117,7 @@ func workshopToInfo(workshop *workshopbackend.Workshop, health healthstate.Healt
 	return &info
 }
 
-func sdkConnsToMounts(repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount {
+func sdkConnsToMounts(st *state.State, repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount {
 	connections, err := repo.Connections(projectId, workshop, sdk)
 	if err != nil {
 		return nil
@@ -133,6 +135,11 @@ func sdkConnsToMounts(repo *interfaces.Repository, projectId, workshop, sdk stri
 			if err != nil {
 				continue
 			}
+			// check if the source exists as otherwise the mount is broken
+			if _, err = os.Stat(source); osutil.IsDirNotExist(err) {
+				st.Warnf("%s/%s:%s mount is broken: %s does not exist", workshop, sdk, connection.Plug.Name(), source)
+			}
+
 			err = connection.Plug.Attr("target", &target)
 			if err != nil {
 				continue
@@ -310,7 +317,7 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	repo := c.d.overlord.InterfaceManager().Repository()
 	mounts := map[string][]*Mount{}
 	for _, sdk := range workshop.Content() {
-		mounts[sdk.Name] = sdkMounts(repo, projectId, name, sdk.Name)
+		mounts[sdk.Name] = sdkMounts(state, repo, projectId, name, sdk.Name)
 	}
 
 	return SyncResponse(workshopToInfo(workshop, health, mounts), http.StatusOK)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -94,7 +94,7 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 			"go": {Sdk: "go", Message: "test health check message", Code: "check-waiting", CheckResult: healthstate.CheckWaiting},
 		}}
 	})
-	restoreMounts := FakeSdkMounts(func(repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount {
+	restoreMounts := FakeSdkMounts(func(st *state.State, repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount {
 		return []*Mount{
 			{Source: "/home/user/" + sdk, Target: "/home/workshop/" + sdk, Plug: interfaces.PlugRef{ProjectId: projectId, Workshop: workshop, Sdk: sdk, Name: "content-plug"}},
 		}

--- a/internal/daemon/export_test.go
+++ b/internal/daemon/export_test.go
@@ -49,7 +49,7 @@ func FakeWorkshopHealth(f func(mgr *workshopstate.WorkshopManager, w *workshopba
 	}
 }
 
-func FakeSdkMounts(f func(repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount) (restore func()) {
+func FakeSdkMounts(f func(state *state.State, repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount) (restore func()) {
 	old := sdkMounts
 	sdkMounts = f
 	return func() {

--- a/internal/daemon/export_test.go
+++ b/internal/daemon/export_test.go
@@ -56,3 +56,17 @@ func FakeSdkMounts(f func(repo *interfaces.Repository, projectId, workshop, sdk 
 		sdkMounts = old
 	}
 }
+
+func MockWarningsAccessors(okay func(*state.State, time.Time) int, all func(*state.State) []*state.Warning, pending func(*state.State) ([]*state.Warning, time.Time)) (restore func()) {
+	oldOK := stateOkayWarnings
+	oldAll := stateAllWarnings
+	oldPending := statePendingWarnings
+	stateOkayWarnings = okay
+	stateAllWarnings = all
+	statePendingWarnings = pending
+	return func() {
+		stateOkayWarnings = oldOK
+		stateAllWarnings = oldAll
+		statePendingWarnings = oldPending
+	}
+}

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"strings"
+	"syscall"
 
 	"github.com/canonical/workshop/internal/osutil/sys"
 )
@@ -123,4 +125,62 @@ func NormalizeUidGid(uid, gid *int, username, group string) (*int, *int, error) 
 		return nil, nil, fmt.Errorf("must specify group, not just UID")
 	}
 	return uid, gid, nil
+}
+
+// UserMaybeSudoUser finds the user behind a sudo invocation when root, if
+// applicable and possible. Otherwise the current user is returned.
+//
+// Don't check SUDO_USER when not root and simply return the current uid
+// to properly support sudo'ing from root to a non-root user
+func UserMaybeSudoUser() (*user.User, error) {
+	cur, err := userCurrent()
+	if err != nil {
+		return nil, err
+	}
+
+	// not root, so no sudo invocation we care about
+	if cur.Uid != "0" {
+		return cur, nil
+	}
+
+	realName := os.Getenv("SUDO_USER")
+	if realName == "" {
+		// not sudo; current is correct
+		return cur, nil
+	}
+
+	real, err := user.Lookup(realName)
+	// This is a best effort, see the comment in findGidNoGetentFallback in
+	// group.go.
+	//
+	// But here the effect is not worrisome, because if we fail to
+	// identify the error as unknown user, we will just fail here and won't
+	// inadvertently raise or lower permissions, as the current user is already
+	// root in this codepath
+	if isUnknownUserOrEnoent(err) {
+		return cur, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return real, nil
+}
+
+// Note: this is best effort, comparing err here with UnknownUserError
+// is inherently flawed and may end up missing some legitimate unknown
+// user errors, see the comment on findGidNoGetentFallback in group.go
+// for more details. It seems the most common return value is ENOENT so
+// check for that too (e.g. when the sssd package is installed).
+func isUnknownUserOrEnoent(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := err.(user.UnknownUserError); ok {
+		return true
+	}
+	// Check for ENOENT, ideally go itself would handle this, see
+	// https://github.com/golang/go/issues/40334 for the upstream
+	// bug
+	return strings.HasSuffix(err.Error(), syscall.ENOENT.Error())
 }


### PR DESCRIPTION
# Description

Cross-port /v1/warnings API and corresponding CLI from snapd.

The warnings command lists the warnings that have been reported to the system:

```
workshop warnings [OPTIONS] [flags]
```

The okay command acknowledges the warnings listed with 'workshop warnings':

```
workshop okay [flags]
```

Currently, Workshop can issue a warning if a workshop's mount source directory was deleted (detectable by `workshop info <ws>`). 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
