### PR TITLE
GPU interface

### DIFF
--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -142,7 +142,12 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 
 	dopts.HTTPAddress = rcmd.HTTP
 
-	d, err := daemon.New(&dopts, workshopbackend.New())
+	wbe, err := workshopbackend.New()
+	if err != nil {
+		return err
+	}
+
+	d, err := daemon.New(&dopts, wbe)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	cloud.google.com/go/storage v1.36.0
+	github.com/adrg/xdg v0.4.0
 	github.com/canonical/lxd v0.0.0-20240226153229-0ff71ae3cb84
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b
 	github.com/gorilla/websocket v1.5.1
@@ -19,7 +20,6 @@ require (
 )
 
 require (
-	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -66,7 +66,7 @@ require (
 	golang.org/x/crypto v0.19.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
-	golang.org/x/term v0.17.0 // indirect
+	golang.org/x/term v0.17.0
 	golang.org/x/text v0.14.0
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240205150955-31a09d347014 // indirect

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -135,9 +135,11 @@ func (iface *contentInterface) MountConnectedPlug(spec *device.Specification, pl
 	}
 
 	if err = osutil.MkdirAllChown(source, 0744, uid, gid); err != nil {
-		return nil
+		return err
 	}
-	return spec.AddDeviceEntry(workshopbackend.Mount(plug.Name(), source, iface.target(plug)))
+
+	spec.AddDeviceEntry(workshopbackend.Mount(plug.Name(), source, iface.target(plug)))
+	return nil
 }
 
 func init() {

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -34,7 +34,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-type ContentSuite struct {
+type contentSuite struct {
 	iface     interfaces.Interface
 	projectId string
 }
@@ -43,19 +43,19 @@ func Test(t *testing.T) {
 	check.TestingT(t)
 }
 
-var _ = check.Suite(&ContentSuite{
+var _ = check.Suite(&contentSuite{
 	iface: builtin.MustInterface("content"),
 })
 
-func (s *ContentSuite) SetUpTest(c *check.C) {
+func (s *contentSuite) SetUpTest(c *check.C) {
 	s.projectId = "42424242"
 }
 
-func (s *ContentSuite) TestName(c *check.C) {
+func (s *contentSuite) TestName(c *check.C) {
 	c.Assert(s.iface.Name(), check.Equals, "content")
 }
 
-func (s *ContentSuite) TestSanitizeSlotSimple(c *check.C) {
+func (s *contentSuite) TestSanitizeSlotSimple(c *check.C) {
 	const mockSdkYaml = `name: content-slot-sdk
 base: ubuntu@22.04
 slots:
@@ -67,7 +67,7 @@ slots:
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
 }
 
-func (s *ContentSuite) TestSanitizePlugSimple(c *check.C) {
+func (s *contentSuite) TestSanitizePlugSimple(c *check.C) {
 	const mockSdkYaml = `name: content-slot-sdk
 base: ubuntu@22.04
 plugs:
@@ -80,7 +80,7 @@ plugs:
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
 }
 
-func (s *ContentSuite) TestSanitizePlugSimpleNoTarget(c *check.C) {
+func (s *contentSuite) TestSanitizePlugSimpleNoTarget(c *check.C) {
 	const mockSdkYaml = `name: content-slot-sdk
 base: ubuntu@22.04
 plugs:
@@ -93,7 +93,7 @@ plugs:
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content plug must contain target path")
 }
 
-func (s *ContentSuite) TestSanitizePlugSimpleTargetRelative(c *check.C) {
+func (s *contentSuite) TestSanitizePlugSimpleTargetRelative(c *check.C) {
 	const mockSdkYaml = `name: content-slot-sdk
 base: ubuntu@22.04
 plugs:
@@ -107,11 +107,11 @@ plugs:
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content interface path is not clean:.*")
 }
 
-func (s *ContentSuite) TestInterfaces(c *check.C) {
+func (s *contentSuite) TestInterfaces(c *check.C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
 
-func (s *ContentSuite) TestContentInterface(c *check.C) {
+func (s *contentSuite) TestContentInterface(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
 base: ubuntu@22.04
 plugs:

--- a/internal/interfaces/builtin/gpu.go
+++ b/internal/interfaces/builtin/gpu.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/device"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshopbackend"
+)
+
+const gpuSummary = `allows sharing host GPUs with SDKs`
+
+const gpuBaseDeclarationSlots = `
+  gpu:
+    allow-installation:
+      slot-sdk-type:
+        - agent
+      allow-connection: true
+      allow-auto-connection: true
+ `
+
+type gpuInterface struct{}
+
+func (iface *gpuInterface) Name() string {
+	return "gpu"
+}
+
+func (iface *gpuInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              gpuSummary,
+		BaseDeclarationSlots: gpuBaseDeclarationSlots,
+		AffectsPlugOnRefresh: true,
+	}
+}
+
+func (iface *gpuInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
+	return nil
+}
+
+func (iface *gpuInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+func (iface *gpuInterface) MountConnectedSlot(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	return nil
+}
+
+func (iface *gpuInterface) MountConnectedPlug(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Add the GPU entry here. In case of a nvidia card, the device caps and
+	// runtime will be passed through by the initial workshop configuration (see
+	// defaultConfig). This is required as adding nvidia.* entries does not take
+	// effect unless the workshop is restarted.
+	spec.AddDeviceEntry(workshopbackend.Gpu(plug.Name()))
+	return nil
+}
+
+func init() {
+	registerIface(&gpuInterface{})
+}

--- a/internal/interfaces/builtin/gpu_test.go
+++ b/internal/interfaces/builtin/gpu_test.go
@@ -1,0 +1,55 @@
+package builtin_test
+
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/interfaces/device"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshopbackend"
+	"gopkg.in/check.v1"
+)
+
+type gpuSuite struct {
+	iface     interfaces.Interface
+	projectId string
+}
+
+var _ = check.Suite(&gpuSuite{
+	iface: builtin.MustInterface("gpu"),
+})
+
+func (s *gpuSuite) SetUpTest(c *check.C) {
+	s.projectId = "42424242"
+}
+
+func (s *gpuSuite) TestName(c *check.C) {
+	c.Assert(s.iface.Name(), check.Equals, "gpu")
+}
+
+func (s *gpuSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *gpuSuite) TestGpuInterface(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ gpu:
+  interface: gpu
+`, s.projectId, "ws", "consumer", "gpu")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+ gpu:
+`, s.projectId, "ws", "producer", "gpu")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := &device.Specification{}
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the mount specification.
+	expectedDevice := workshopbackend.Gpu(plug.Name)
+	c.Assert(deviceSpec.DeviceEntries(), check.DeepEquals, []workshopbackend.Device{expectedDevice})
+}

--- a/internal/interfaces/device/spec.go
+++ b/internal/interfaces/device/spec.go
@@ -58,10 +58,9 @@ func (s *Specification) DeviceEntries() []workshopbackend.Device {
 	return maps.Values(s.devices)
 }
 
-func (s *Specification) AddDeviceEntry(dev workshopbackend.Device) error {
+func (s *Specification) AddDeviceEntry(dev workshopbackend.Device) {
 	if s.devices == nil {
 		s.devices = make(map[string]workshopbackend.Device)
 	}
 	s.devices[dev.Name()] = dev
-	return nil
 }

--- a/internal/sdk/agent.go
+++ b/internal/sdk/agent.go
@@ -8,6 +8,8 @@ type: agent
 slots:
   content:
     interface: content
+  gpu:
+    interface: gpu
 `
 
 func AgentSdkMeta(base string) string {

--- a/internal/workshopbackend/export_test.go
+++ b/internal/workshopbackend/export_test.go
@@ -7,4 +7,9 @@ var (
 	ReadWorkshop           = readWorkshop
 	ReadProjects           = readProjects
 	SaveProjects           = saveProjects
+	DefaultConfig          = (*LxdBackend).defaultConfig
 )
+
+func (s *LxdBackend) SetNvidia(runtime bool) {
+	s.nvidiaRuntime = runtime
+}

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -56,6 +56,7 @@ type ExecContext struct {
 }
 
 type LxdBackend struct {
+	nvidiaRuntime bool
 }
 
 const (
@@ -72,9 +73,29 @@ var (
 	imageServer         = "https://cloud-images.ubuntu.com/releases/"
 )
 
-func New() WorkshopBackend {
+func New() (WorkshopBackend, error) {
 	server := LxdBackend{}
-	return &server
+
+	srv, err := lxd.ConnectLXDUnixWithContext(context.Background(), LxdSock, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resources, err := srv.GetServerResources()
+	if err != nil {
+		return nil, err
+	}
+
+	// check if nvidia card(s) are present as this requires additional
+	// configuration for the GPU interfaces runtime passthrough
+	for _, card := range resources.GPU.Cards {
+		if card.Nvidia != nil {
+			server.nvidiaRuntime = true
+			break
+		}
+	}
+
+	return &server, nil
 }
 
 func (s *LxdBackend) LaunchWorkshop(ctx context.Context, name, base string) error {
@@ -124,7 +145,7 @@ func (s *LxdBackend) LaunchWorkshop(ctx context.Context, name, base string) erro
 	req := api.InstancesPost{
 		InstancePut: api.InstancePut{
 			Devices: defaultDevices(),
-			Config:  defaultConfig(projectId, usr.Uid, usr.Gid),
+			Config:  s.defaultConfig(projectId, usr.Uid, usr.Gid),
 		},
 		Name: InstanceName(name, projectId),
 		Type: api.InstanceType("container"),
@@ -698,7 +719,7 @@ func createDefaultDevices() map[string]map[string]string {
 	}
 }
 
-func defaultConfig(projectId string, userid, groupid string) map[string]string {
+func (s *LxdBackend) defaultConfig(projectId string, userid, groupid string) map[string]string {
 	cloudInitConfig := `#cloud-config
 users:
   - default
@@ -708,16 +729,20 @@ users:
     groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video,render
     shell: /bin/bash
 `
-	return map[string]string{
+	cfg := map[string]string{
 		"raw.idmap":                fmt.Sprint("uid ", userid, " 1000\ngid ", groupid, " 1000"),
 		"security.nesting":         "true",
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,
+	}
+
+	if s.nvidiaRuntime {
 		// nvidia.* properties must be set at launch as otherwise it requires a
 		// container restart to take effect.
-		"nvidia.driver.capabilities": "all",
-		"nvidia.runtime":             "true",
+		cfg["nvidia.driver.capabilities"] = "all"
+		cfg["nvidia.runtime"] = "true"
 	}
+	return cfg
 }
 
 func (s *LxdBackend) fetchRemoteImage(base string) (lxd.ImageServer, *api.Image, error) {

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -705,7 +705,7 @@ users:
   - name: workshop
     primary_group: workshop
     sudo: ALL=(ALL) NOPASSWD:ALL
-    groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video
+    groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video,render
     shell: /bin/bash
 `
 	return map[string]string{
@@ -713,6 +713,10 @@ users:
 		"security.nesting":         "true",
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,
+		// nvidia.* properties must be set at launch as otherwise it requires a
+		// container restart to take effect.
+		"nvidia.driver.capabilities": "all",
+		"nvidia.runtime":             "true",
 	}
 }
 

--- a/internal/workshopbackend/lxd_backend_profile.go
+++ b/internal/workshopbackend/lxd_backend_profile.go
@@ -52,6 +52,7 @@ type DeviceType int
 const (
 	BindMount DeviceType = iota
 	DiskVolume
+	GPU
 )
 
 type Device struct {
@@ -84,6 +85,17 @@ func Volume(name, mountTo, volume string) Device {
 			"pool":   "default",
 			"path":   mountTo,
 			"source": volume},
+	}
+}
+
+func Gpu(name string) Device {
+	return Device{
+		name:       name,
+		deviceType: GPU,
+		// The default workshop user must be able to acces the GPU device this
+		// is an alternative to adding the render devices to the video/render
+		// group.
+		properties: map[string]string{"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"},
 	}
 }
 

--- a/internal/workshopbackend/lxd_backend_profile.go
+++ b/internal/workshopbackend/lxd_backend_profile.go
@@ -92,9 +92,20 @@ func Gpu(name string) Device {
 	return Device{
 		name:       name,
 		deviceType: GPU,
-		// The default workshop user must be able to acces the GPU device this
-		// is an alternative to adding the render devices to the video/render
-		// group.
+
+		// The default workshop user must be able to acces the GPU device.
+		// Workshop assigns the GPU devices to workshop.workshop. A more
+		// traditional way here would be to add dri devices to the video/render
+		// groups, but it requires an additional workshop exec to find out the
+		// groups' ids at the LXD profile generation time. Given that we are
+		// solving the problem of access in a confined environment and workshop
+		// is a passwordless sudo user anyway, it was decided that it is OK if
+		// the workshop user owns GPU devices.
+
+		// On another note, the render and video groups are not assigned to the
+		// card*/render* dri devices by LXD properly. Both will be assigned to
+		// the group provided in "gid"; there is no way to assign video to card*
+		// and render to render* devices.
 		properties: map[string]string{"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"},
 	}
 }

--- a/internal/workshopbackend/lxd_backend_test.go
+++ b/internal/workshopbackend/lxd_backend_test.go
@@ -26,9 +26,6 @@ func (s *LxdBeTests) SetUpTest(c *check.C) {
 	s.project = &workshopbackend.Project{ProjectId: "42ws42ws", Path: dir}
 }
 
-func (s *LxdBeTests) TearDownTest(c *check.C) {
-}
-
 func (f *LxdBeTests) TestLoadWorkshopSuccess(c *check.C) {
 	// Setup
 	os.WriteFile(filepath.Join(f.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
@@ -212,4 +209,31 @@ func (f *LxdBeTests) TestReadProjectsSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(projects, check.NotNil)
 	c.Assert(projects, check.HasLen, 0)
+}
+
+func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
+	// Setup
+	b := &workshopbackend.LxdBackend{}
+	b.SetNvidia(true)
+
+	// Execute
+	cfg := workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001")
+
+	// Validate
+	c.Assert(cfg["raw.idmap"], check.Equals, "uid 1001 1000\ngid 1001 1000")
+	c.Assert(cfg["security.nesting"], check.Equals, "true")
+	c.Assert(cfg["user.workshop.project-id"], check.Equals, f.project.ProjectId)
+
+	c.Assert(cfg["nvidia.runtime"], check.Equals, "true")
+	c.Assert(cfg["nvidia.driver.capabilities"], check.Equals, "all")
+
+	// Setup
+	b.SetNvidia(false)
+
+	// Execute
+	cfg = workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001")
+
+	// Validate
+	c.Assert(cfg["nvidia.runtime"], check.Equals, "")
+	c.Assert(cfg["nvidia.driver.capabilities"], check.Equals, "")
 }

--- a/internal/workshopbackend/tests/integration/workshop_exec_test.go
+++ b/internal/workshopbackend/tests/integration/workshop_exec_test.go
@@ -43,7 +43,9 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 	f.restoreImageServer = workshopbackend.FakeImageServer(minimalImageServer)
 
 	socketPath := c.MkDir() + ".workshop.socket"
-	f.be = workshopbackend.New()
+	var err error
+	f.be, err = workshopbackend.New()
+	c.Assert(err, check.IsNil)
 
 	d, err := daemon.New(&daemon.Options{
 		Dir:        c.MkDir(),

--- a/internal/workshopbackend/tests/integration/workshop_test.go
+++ b/internal/workshopbackend/tests/integration/workshop_test.go
@@ -40,7 +40,9 @@ var _ = check.Suite(&wsOps{})
 
 func (f *wsOps) SetUpTest(c *check.C) {
 	socketPath := c.MkDir() + ".workshop.socket"
-	f.be = workshopbackend.New()
+	var err error
+	f.be, err = workshopbackend.New()
+	c.Assert(err, check.IsNil)
 
 	d, err := daemon.New(&daemon.Options{
 		Dir:        c.MkDir(),

--- a/tests/lib/sdk/test-sdk-gpu/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-gpu/meta/sdk.yaml
@@ -1,0 +1,10 @@
+name: test-sdk-gpu
+title: test-sdk-gpu
+base: ubuntu@20.04
+
+summary: test-sdk-gpu SDK
+description: |
+  test-sdk-gpu SDK
+plugs:
+  gpu:
+    interface: gpu

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -8,6 +8,9 @@ function prepare_environment() {
   snap install lxd --classic
   lxd init --auto --storage-backend zfs
   
+  snap install yq
+  apt install jq -y --no-install-recommends
+  
   snap install --dangerous --classic /workshop/tests/*.snap
   snap set workshop store.url=http://localhost:8080/storage/v1/
   snap restart workshop

--- a/tests/main/connect/.workshop.ws-1.yaml
+++ b/tests/main/connect/.workshop.ws-1.yaml
@@ -1,0 +1,7 @@
+name: ws-1
+base: ubuntu@22.04
+sdks:
+    test-sdk-content:
+        channel: latest/stable
+    test-sdk-gpu:
+        channel: latest/stable

--- a/tests/main/connect/task.yaml
+++ b/tests/main/connect/task.yaml
@@ -1,0 +1,34 @@
+summary: Check that "workshop connect" works as expected
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup ./
+
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  project=$(pwd)
+  workshop_exec --project "$project" launch ws-1
+  
+  echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot> form"
+  workshop_exec --project "$project" disconnect ws-1/test-sdk-content:content-plug-one ws-1/agent:content  
+  workshop_exec --project "$project" connect ws-1/test-sdk-content:content-plug-one ws-1/agent:content
+  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+manual$"
+  
+  echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk> form"
+  workshop_exec --project "$project" disconnect ws-1/test-sdk-content:content-plug-two :content
+  workshop_exec --project "$project" connect ws-1/test-sdk-content:content-plug-two ws-1/agent
+  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+manual$"
+  
+  echo "Check connect <workshop>/<sdk>:<plug> form"
+  workshop_exec --project "$project" disconnect ws-1/test-sdk-gpu:gpu
+  workshop_exec --project "$project" connect ws-1/test-sdk-gpu:gpu
+  workshop_exec --project "$project" connections ws-1 | MATCH "^gpu.+ws-1/test-sdk-gpu:gpu.+:gpu.+manual$"
+  
+  echo "Check workshop refresh reconnects manually connected connections"
+  workshop_exec --project "$project" refresh ws-1
+  workshop_exec --project "$project" connections ws-1 > output.log
+  MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+manual$" < output.log
+  MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+manual$" < output.log
+  MATCH "^gpu.+ws-1/test-sdk-gpu:gpu.+:gpu.+manual$" < output.log
+
+  

--- a/tests/main/interface-gpu/.workshop.ws.yaml
+++ b/tests/main/interface-gpu/.workshop.ws.yaml
@@ -1,0 +1,5 @@
+name: ws
+base: ubuntu@22.04
+sdks:
+    test-sdk-gpu:
+        channel: latest/stable

--- a/tests/main/interface-gpu/task.yaml
+++ b/tests/main/interface-gpu/task.yaml
@@ -1,0 +1,33 @@
+summary: Check GPU interface scenarios
+restore: |
+  . "$TESTSLIB"/utils.sh
+  cleanup ./
+execute: |
+  . "$TESTSLIB"/utils.sh
+  
+  echo "Check the GPU interface plug can be auto-connected"
+  project=$(pwd)
+  workshop_exec launch --project "$project" ws
+  workshop_exec --project "$project" connections ws | MATCH "^gpu.+ws/test-sdk-gpu:gpu.+:gpu.+\-$"
+  
+  echo "Check the GPU interface plug can be connected and disconnected manually"
+  workshop_exec --project "$project" disconnect ws/test-sdk-gpu:gpu  
+  workshop_exec --project "$project" connect ws/test-sdk-gpu:gpu
+  workshop_exec --project "$project" connections ws | MATCH "^gpu.+ws/test-sdk-gpu:gpu.+:gpu.+manual$"
+  
+  echo "Ensure a GPU device is created when connected"
+  
+  # Ideally, check that a GPU device exists in the workshop (as a side effect of
+  # the interface being connected). However, given the VM env without a card0,
+  # ensure that the LXD profile contains a gpu device with a proper
+  # configuration.  
+  project_id=$(cat "$project"/.workshop.lock)
+  lxc profile show --project workshop.ubuntu ws-"$project_id"-test-sdk-gpu | yq '.devices.gpu' > output.log
+  MATCH "type: gpu" < output.log
+  MATCH "gputype: physical" < output.log
+  MATCH 'uid: "1000"' < output.log
+  MATCH 'gid: "1000"' < output.log
+
+
+  
+  

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -1,7 +1,6 @@
 summary: Ensure that 'workshop launch' creates a core LXD config correctly
 prepare: |
   apt install jq -y --no-install-recommends
-  snap install yq
 restore: |
   . "$TESTSLIB"/utils.sh
   cleanup ./

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -1,7 +1,4 @@
 summary: Check workshop remount scenarios
-prepare: |
-  apt install jq -y --no-install-recommends
-  snap install yq
 restore: |
   . "$TESTSLIB"/utils.sh
   cleanup ./


### PR DESCRIPTION
# Description

An SDK can declare an auto-connectable GPU plug to get access to all the hosts GPUs:

```
plug:
  gpu:
    interface: gpu
```

The GPU slot can only be installed by the agent SDK.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
