### PR TITLE
Add label for jammy to github workflows

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04-64]
         suite: [main, documentation, integration]
-    runs-on: [self-hosted, Linux, X64, xlarge]
+    runs-on: [self-hosted, linux, jammy, x64, xlarge]
     steps:
       - name: Cleanup job workspace
         run: |


### PR DESCRIPTION
This is in preparation for the availability of noble runners, and will ensure this repo remains on jammy until explicitly requesting to switch to noble.