### PR TITLE
Chore: remount messaging

### DIFF
--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -68,13 +68,23 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 		}
 	}()
 
-	conn, err := o.InterfaceManager().Repository().Connected(reqData.Plug.ProjectId, reqData.Plug.Workshop, reqData.Plug.Sdk, reqData.Plug.Name)
+	repo := o.InterfaceManager().Repository()
+	connRef, err := repo.Connected(reqData.Plug.ProjectId, reqData.Plug.Workshop, reqData.Plug.Sdk, reqData.Plug.Name)
 	if err != nil {
 		return statusBadRequest(err.Error())
 	}
 
-	if len(conn) == 0 {
+	if len(connRef) == 0 {
 		return statusBadRequest(`"%s/%s:%s" must be connected for remount`, reqData.Plug.Workshop, reqData.Plug.Sdk, reqData.Plug.Name)
+	}
+
+	conn, err := repo.Connection(connRef[0])
+	if err != nil {
+		return statusBadRequest(err.Error())
+	}
+
+	if conn.Plug.Interface() != "content" {
+		return statusBadRequest("remount requires a content interface plug (provided plug is of %q interface)", conn.Plug.Interface())
 	}
 
 	taskset, err := o.WorkshopManager().Remount(r.Context(), st, reqData.Plug, reqData.Source, projectId)

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-func (s *apiSuite) launchWorkshopWithPlug(ctx context.Context, name string, c *check.C) *workshopbackend.Workshop {
+func (s *apiSuite) launchWorkshopWithPlug(c *check.C, ctx context.Context, name string) *workshopbackend.Workshop {
 	b := s.d.overlord.WorkshopBackend()
 	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
 base: ubuntu@20.04
@@ -91,7 +91,7 @@ func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []
 
 func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 	s.daemon(c)
-	s.launchWorkshopWithPlug(s.ctx, "ws", c)
+	s.launchWorkshopWithPlug(c, s.ctx, "ws")
 
 	// Setup
 	requests := []*bytes.Buffer{
@@ -115,7 +115,7 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
 	// Setup
 	s.daemon(c)
-	s.launchWorkshopWithPlug(s.ctx, "ws", c)
+	s.launchWorkshopWithPlug(c, s.ctx, "ws")
 	_, err := s.d.overlord.InterfaceManager().Repository().DisconnectSdk(s.project.ProjectId, "ws", "test-sdk")
 	c.Check(err, check.IsNil)
 
@@ -158,4 +158,44 @@ func (s *apiSuite) TestWorkshopRemountInvalidSetup(c *check.C) {
 	}
 
 	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) {})
+}
+
+func (s *apiSuite) TestWorkshopRemountInvalidInterface(c *check.C) {
+	s.daemon(c)
+	s.launchWorkshop(s.ctx, "ws", c)
+
+	sdkInfo := &sdk.Info{ProjectId: s.project.ProjectId, Workshop: "ws", Name: "test-sdk"}
+	plug := &sdk.PlugInfo{
+		Sdk:       sdkInfo,
+		Name:      "test-plug",
+		Interface: "gpu",
+	}
+	slot := &sdk.SlotInfo{
+		Sdk:       sdkInfo,
+		Name:      "test-slot",
+		Interface: "gpu",
+	}
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.AddPlug(plug), check.IsNil)
+	c.Assert(repo.AddSlot(slot), check.IsNil)
+	_, err := repo.Connect(interfaces.NewConnRef(plug, slot), nil, nil, nil, nil, nil)
+	c.Assert(err, check.IsNil)
+
+	// Setup
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":"/srv/data"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `remount requires a content interface plug (provided plug is of "gpu" interface)`,
+		},
+	}
+
+	soon := 0
+	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) { soon++ })
+	c.Assert(soon, check.Equals, 0)
 }

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -662,10 +662,10 @@ func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	return m.remount(ctx, &plug, source, inst.IsRunning())
+	return m.remount(ctx, task, &plug, source, inst.IsRunning())
 }
 
-func (m *InterfaceManager) remount(ctx context.Context, plug *interfaces.PlugRef, source string, workshopRunning bool) error {
+func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *interfaces.PlugRef, source string, workshopRunning bool) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -713,36 +713,36 @@ func (m *InterfaceManager) remount(ctx context.Context, plug *interfaces.PlugRef
 
 	_, err = os.Stat(oldSource)
 	if osutil.IsDirNotExist(err) {
-		return fmt.Errorf("plug's current 'source' %q does not exist", oldSource)
+		task.State().Warnf("%s/%s:%s's source at %q did not exist, the mount was re-created", plug.Workshop, plug.Sdk, plug.Name, oldSource)
 	} else if err != nil {
 		return err
-	}
-
-	if err := osutil.Rename(oldSource, source); err != nil {
-		if errno, ok := err.(syscall.Errno); ok {
-			if workshopRunning {
-				if errno == syscall.ENOTEMPTY {
-					return fmt.Errorf("new source is not empty; workshop must be stopped to remount safely")
-				}
-				if errno == syscall.EXDEV {
-					return fmt.Errorf("current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely")
+	} else {
+		if err := osutil.Rename(oldSource, source); err != nil {
+			if errno, ok := err.(syscall.Errno); ok {
+				if workshopRunning {
+					if errno == syscall.ENOTEMPTY {
+						return fmt.Errorf("new source is not empty; workshop must be stopped to remount safely")
+					}
+					if errno == syscall.EXDEV {
+						return fmt.Errorf("current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely")
+					}
+				} else {
+					// if the workshop is stopped, we can perform a remount safely
+					// (other fs or non-empty dir), otherwise, return the error
+					if errno != syscall.ENOTEMPTY && errno != syscall.EXDEV {
+						return err
+					}
 				}
 			} else {
-				// if the workshop is stopped, we can perform a remount safely
-				// (other fs or non-empty dir), otherwise, return the error
-				if errno != syscall.ENOTEMPTY && errno != syscall.EXDEV {
-					return err
-				}
+				return err
 			}
 		} else {
-			return err
+			revert.Add(func() {
+				if err := os.Rename(source, oldSource); err != nil {
+					logger.Debugf("cannot rename %s to %s on a failed remount", source, oldSource)
+				}
+			})
 		}
-	} else {
-		revert.Add(func() {
-			if err := os.Rename(source, oldSource); err != nil {
-				logger.Debugf("cannot rename %s to %s on a failed remount", source, oldSource)
-			}
-		})
 	}
 
 	for _, backend := range m.repo.Backends() {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -914,6 +914,49 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
 }
 
+func (s *interfaceHandlersSuite) TestRemountRenameOldSourceDoesNotExist(c *check.C) {
+	// Setup
+	oldSource := "/does/not/exist"
+	newSource := c.MkDir()
+	s.launchRemountWorkshop(c)
+	change := s.newRemountChange(newSource)
+
+	var setup sync.Once
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+		// Set the plug's source attribute to emulate an existing connection as
+		// the remount handler expects that a plug IS connected and HAS a
+		// "source" attribute
+		setup.Do(func() {
+			s.setupPlugConnectionAttribute(c, repo, oldSource)
+		})
+		return nil
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
+
+	// Execute
+	s.o.Settle(5 * time.Second)
+
+	// Validate
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(change.Status(), check.Equals, state.DoneStatus)
+
+	repo := s.mgr.Repository()
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	connection, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	var src string
+	c.Assert(connection.Plug.Attr("source", &src), check.IsNil)
+	c.Assert(src, check.Equals, newSource)
+
+	c.Assert(osutil.FileExists(newSource), check.Equals, true)
+	// 2 calls for the autoconnect, 1 call for the remount
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
+}
+
 func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a connected content plug


### PR DESCRIPTION
# Description

Make error messages for `workshop remount` clearer for the end user:

* Check for the plug's interface type.
* Report a missing old source via workshop warnings.