### PR TITLE
ssh-agent interface

### DIFF
--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -36,6 +36,8 @@ var (
 	SdkDir string
 	// Path to the daemon's unix socket
 	SocketPath string
+	// Base for the XDG runtime directory of a host user
+	XdgRuntimeDirBase string
 )
 
 func getEnvPaths() (workshopdDir string, socketPath string) {
@@ -59,6 +61,7 @@ func init() {
 	}
 
 	ExecDir = filepath.Dir(execPath)
+	XdgRuntimeDirBase = "/run/user"
 	BaseDir, SocketPath = getEnvPaths()
 	SetRootDir(BaseDir)
 

--- a/internal/interfaces/backend.go
+++ b/internal/interfaces/backend.go
@@ -49,7 +49,7 @@ type SecurityBackend interface {
 	Remove(context context.Context, workshop, sdkName string) error
 
 	// NewSpecification returns a new specification associated with this backend.
-	NewSpecification(user, pid string) Specification
+	NewSpecification(user, project_id string) Specification
 }
 
 // SecurityBackendSetupMany interface may be implemented by backends that can optimize their operations

--- a/internal/interfaces/builtin/gpu.go
+++ b/internal/interfaces/builtin/gpu.go
@@ -35,7 +35,7 @@ const gpuBaseDeclarationSlots = `
         - agent
       allow-connection: true
       allow-auto-connection: true
- `
+`
 
 type gpuInterface struct{}
 

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/device"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshopbackend"
+)
+
+const sshAgentSummary = `allows sharing host's ssh-agent socket with SDKs`
+
+const sshAgentBaseDeclarationSlots = `
+  ssh-agent:
+    allow-installation:
+      slot-sdk-type:
+        - agent
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+type sshAgentInterface struct{}
+
+func (iface *sshAgentInterface) Name() string {
+	return "ssh-agent"
+}
+
+func (iface *sshAgentInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              sshAgentSummary,
+		BaseDeclarationSlots: sshAgentBaseDeclarationSlots,
+		AffectsPlugOnRefresh: true,
+	}
+}
+
+func (iface *sshAgentInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
+	return nil
+}
+
+func (iface *sshAgentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	return false
+}
+
+func (iface *sshAgentInterface) MountConnectedSlot(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	return nil
+}
+
+func (iface *sshAgentInterface) MountConnectedPlug(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	user, err := workshopbackend.LookupUsername(spec.User())
+	if err != nil {
+		return err
+	}
+
+	uid, _, err := osutil.UidGid(user)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("sudo", "-E", "-u", spec.User(), "systemctl", "--user", "show-environment")
+	// XDG_RUNTIME_DIR may not be set if a command invoked by sudo or
+	// systemd-run; set it here to the default location. It is required for the
+	// systemctl to work with --user. See:
+	// https://unix.stackexchange.com/questions/346841/why-does-sudo-i-not-set-xdg-runtime-dir-for-the-target-user
+	defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, strconv.FormatUint(uint64(uid), 10))
+	cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+defaultXdg)
+	out, errOut, err := osutil.RunCmd(cmd)
+	if err != nil {
+		return fmt.Errorf(string(errOut))
+	}
+
+	rawEnv := strings.FieldsFunc(string(out), func(r rune) bool { return r == '\n' })
+	env, err := osutil.ParseEnvironment(rawEnv)
+	if err != nil {
+		return err
+	}
+
+	sock, ok := env["SSH_AUTH_SOCK"]
+	if !ok {
+		return fmt.Errorf("user %q does not have SSH_AUTH_SOCK set. ssh-agent is not running?", user.Username)
+	}
+
+	fromSocket := "unix:" + sock
+	toSocket := "unix:" + filepath.Join(dirs.WorkshopBaseDir, plug.Name()+".ssh")
+
+	spec.AddDeviceEntry(workshopbackend.NetworkProxy(plug.Name(), fromSocket, toSocket, "instance"))
+
+	return nil
+}
+
+func init() {
+	registerIface(&sshAgentInterface{})
+}

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -59,16 +59,8 @@ func (iface *sshAgentInterface) StaticInfo() interfaces.StaticInfo {
 	}
 }
 
-func (iface *sshAgentInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
-	return nil
-}
-
 func (iface *sshAgentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
-	return false
-}
-
-func (iface *sshAgentInterface) MountConnectedSlot(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	return nil
+	return true
 }
 
 func (iface *sshAgentInterface) MountConnectedPlug(spec *device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
@@ -105,10 +97,12 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *device.Specification, p
 		return fmt.Errorf("user %q does not have SSH_AUTH_SOCK set. ssh-agent is not running?", user.Username)
 	}
 
-	fromSocket := "unix:" + sock
-	toSocket := "unix:" + filepath.Join(dirs.WorkshopBaseDir, plug.Name()+".ssh")
+	name := plug.Sdk().Name + "-" + plug.Name()
 
-	spec.AddDeviceEntry(workshopbackend.NetworkProxy(plug.Name(), fromSocket, toSocket, "instance"))
+	fromSocket := sock
+	toSocket := filepath.Join(dirs.WorkshopBaseDir, name+".ssh")
+
+	spec.AddDeviceEntry(workshopbackend.SshAgent(name, fromSocket, toSocket))
 
 	return nil
 }

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -73,7 +73,7 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedProxy := workshopbackend.NetworkProxy(plug.Name, "unix:/tmp/dir/ssh", "unix:/var/lib/workshop/ssh-agent.ssh", "instance")
+	expectedProxy := workshopbackend.SshAgent("consumer-"+plug.Name, "/tmp/dir/ssh", "/var/lib/workshop/consumer-ssh-agent.ssh")
 	c.Assert(deviceSpec.DeviceEntries(), check.DeepEquals, []workshopbackend.Device{expectedProxy})
 }
 

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -1,0 +1,103 @@
+package builtin_test
+
+import (
+	"os/user"
+
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/interfaces/device"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshopbackend"
+	"gopkg.in/check.v1"
+)
+
+type sshAgentSuite struct {
+	iface     interfaces.Interface
+	projectId string
+	restore   func()
+}
+
+var _ = check.Suite(&sshAgentSuite{
+	iface: builtin.MustInterface("ssh-agent"),
+})
+
+func (s *sshAgentSuite) SetUpTest(c *check.C) {
+	s.projectId = "42424242"
+	usr, err := user.Current()
+	c.Assert(err, check.IsNil)
+	homeDir := c.MkDir()
+	s.restore = testutil.FakeFunc(func(name string) (*user.User, error) {
+		u := &user.User{
+			Name:     usr.Name,
+			Username: usr.Name,
+			Uid:      usr.Uid,
+			Gid:      usr.Gid,
+			HomeDir:  homeDir,
+		}
+		return u, nil
+	}, &workshopbackend.LookupUsername)
+}
+
+func (s *sshAgentSuite) TearDown(c *check.C) {
+	s.restore()
+}
+
+func (s *sshAgentSuite) TestName(c *check.C) {
+	c.Assert(s.iface.Name(), check.Equals, "ssh-agent")
+}
+
+func (s *sshAgentSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *sshAgentSuite) TestSshAgentInterface(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+  ssh-agent:
+    interface: ssh-agent
+`, s.projectId, "ws", "consumer", "ssh-agent")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  ssh-agent:
+`, s.projectId, "ws", "producer", "ssh-agent")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := &device.Specification{}
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo "SSH_AUTH_SOCK=/tmp/dir/ssh"
+exit 0`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+	expectedProxy := workshopbackend.NetworkProxy(plug.Name, "unix:/tmp/dir/ssh", "unix:/var/lib/workshop/ssh-agent.ssh", "instance")
+	c.Assert(deviceSpec.DeviceEntries(), check.DeepEquals, []workshopbackend.Device{expectedProxy})
+}
+
+func (s *sshAgentSuite) TestSshAgentInterfaceSystemctlFails(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+  ssh-agent:
+    interface: ssh-agent
+`, s.projectId, "ws", "consumer", "ssh-agent")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  ssh-agent:
+`, s.projectId, "ws", "producer", "ssh-agent")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := &device.Specification{}
+
+	fake := testutil.FakeCommand(c, "sudo", `
+>&2 echo -n "No medium found"
+exit 1`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, `No medium found`)
+}

--- a/internal/interfaces/device/backend.go
+++ b/internal/interfaces/device/backend.go
@@ -25,7 +25,7 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 
 // Setup creates mount profile specific to a given sdk.
 func (b *Backend) Setup(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-	s, err := repo.SdkSpecification(context, b.Name(), sdkInfo)
+	s, err := repo.SdkSpecification(context, b.Name(), sdkInfo) 
 	if err != nil {
 		return fmt.Errorf("cannot obtain device snippets for workshop %q: %s", sdkInfo.Workshop, err)
 	}

--- a/internal/osutil/env.go
+++ b/internal/osutil/env.go
@@ -107,6 +107,10 @@ func parseRawEnvironment(raw []string) (Environment, error) {
 	return env, nil
 }
 
+func ParseEnvironment(raw []string) (Environment, error) {
+	return parseRawEnvironment(raw)
+}
+
 // OSEnvironment returns the environment of the calling process.
 func OSEnvironment() (Environment, error) {
 	return parseRawEnvironment(os.Environ())

--- a/internal/osutil/exec.go
+++ b/internal/osutil/exec.go
@@ -15,6 +15,8 @@
 package osutil
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -166,4 +168,20 @@ func StreamCommand(name string, args ...string) (io.ReadCloser, error) {
 	}
 
 	return &waitingReader{reader: pipe, cmd: cmd}, nil
+}
+
+// RunCmd runs a command and returns separately stdout and stderr
+// output, and an error.
+func RunCmd(c *exec.Cmd) ([]byte, []byte, error) {
+	if c.Stdout != nil {
+		return nil, nil, errors.New("osutil.Run: Stdout already set")
+	}
+	if c.Stderr != nil {
+		return nil, nil, errors.New("osutil.Run: Stderr already set")
+	}
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
 }

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"slices"
 	"syscall"
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/policy"
 	"github.com/canonical/workshop/internal/logger"
@@ -354,7 +352,9 @@ func (m *InterfaceManager) disconnectSdk(ctx context.Context, task *state.Task, 
 	}
 
 	for _, backend := range m.repo.Backends() {
-		if err := backend.Remove(ctx, workshop, sdkName); err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
+		// if there are not plugs or slots declared by the SDK the profile does
+		// not neccessarily exist for the SDK.
+		if err := backend.Remove(ctx, workshop, sdkName); err != nil && !errors.Is(err, workshopbackend.ErrSdkProfileNotFound) {
 			return err
 		}
 	}

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -1047,6 +1047,44 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
+func (s *interfaceHandlersSuite) TestAutoDisconnectNoSdkProfile(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a content plug
+	repo := s.mgr.Repository()
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	s.secBackend.RemoveCallback = func(sdkName string) error { return workshopbackend.ErrSdkProfileNotFound }
+
+	// Execute
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("auto-disconnect", "...")
+	t1.Set("sdk", "consumer")
+	setWorkshopProject("ws", s.prj, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	s.state.Unlock()
+
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
+}
+
 func (s *interfaceHandlersSuite) disconnectChange(c *check.C, workshop string, forget bool) *state.Change {
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")

--- a/internal/sdk/agent.go
+++ b/internal/sdk/agent.go
@@ -10,6 +10,8 @@ slots:
     interface: content
   gpu:
     interface: gpu
+  ssh-agent:
+    interface: ssh-agent
 `
 
 func AgentSdkMeta(base string) string {

--- a/internal/workshopbackend/backend.go
+++ b/internal/workshopbackend/backend.go
@@ -2,7 +2,9 @@ package workshopbackend
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 )
 
 type ContextKeyProjectId string
@@ -20,6 +22,11 @@ func NewWorkshopConfigFilter(key string, value string) WorkshopConfigFilter {
 		return config[key] == value
 	}
 }
+
+var (
+	ErrWorkshopNotFound   = errors.New("workshop not found")
+	ErrSdkProfileNotFound = errors.New("sdk profile not found")
+)
 
 type ErrExec struct {
 	Status int
@@ -60,6 +67,57 @@ type StateStorage interface {
 	// Delete a temporary state storage volume for the workshop. It does
 	// not unmount the volume from the workshop if mounted.
 	DeleteStateStorage(ctx context.Context, name string) error
+}
+
+type DeviceType int
+
+const (
+	BindMount DeviceType = iota
+	DiskVolume
+	GPU
+	SshAgentProxy
+)
+
+type Device struct {
+	name       string
+	properties map[string]string
+	deviceType DeviceType
+}
+
+func (d Device) Name() string {
+	return d.name
+}
+
+func (d Device) Type() DeviceType {
+	return d.deviceType
+}
+
+type SdkProfile struct {
+	sdk     string
+	devices map[string]Device
+}
+
+func NewSdkProfile(sdkName string) SdkProfile {
+	return SdkProfile{
+		sdk:     sdkName,
+		devices: make(map[string]Device),
+	}
+}
+
+func (s SdkProfile) Name() string {
+	return s.sdk
+}
+
+func (s SdkProfile) AddDevice(dev Device) error {
+	if _, ok := s.devices[dev.Name()]; ok {
+		return fmt.Errorf("device %s already exists in the %s SDK profile", dev.Name(), s.Name())
+	}
+	s.devices[dev.Name()] = dev
+	return nil
+}
+
+func profileName(pid, workshop, sdk string) string {
+	return strings.Join([]string{InstanceName(workshop, pid), sdk}, "-")
 }
 
 type Profile interface {

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -3,7 +3,6 @@ package workshopbackend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -69,8 +68,7 @@ var (
 	NewProjectId         = allocateProjectId
 	defaultDevices       = createDefaultDevices
 
-	ErrWorkshopNotFound = errors.New("workshop not found")
-	imageServer         = "https://cloud-images.ubuntu.com/releases/"
+	imageServer = "https://cloud-images.ubuntu.com/releases/"
 )
 
 func New() (WorkshopBackend, error) {

--- a/internal/workshopbackend/lxd_backend_device.go
+++ b/internal/workshopbackend/lxd_backend_device.go
@@ -1,0 +1,59 @@
+package workshopbackend
+
+
+func Mount(name, source, target string) Device {
+	return Device{name: name,
+		deviceType: BindMount,
+		properties: map[string]string{"type": "disk", "source": source,
+			"path": target},
+	}
+}
+
+func Volume(name, mountTo, volume string) Device {
+	return Device{
+		name:       name,
+		deviceType: DiskVolume,
+		properties: map[string]string{"type": "disk",
+			"pool":   "default",
+			"path":   mountTo,
+			"source": volume},
+	}
+}
+
+func Gpu(name string) Device {
+	return Device{
+		name:       name,
+		deviceType: GPU,
+
+		// The default workshop user must be able to acces the GPU device.
+		// Workshop assigns the GPU devices to workshop.workshop. A more
+		// traditional way here would be to add dri devices to the video/render
+		// groups, but it requires an additional workshop exec to find out the
+		// groups' ids at the LXD profile generation time. Given that we are
+		// solving the problem of access in a confined environment and workshop
+		// is a passwordless sudo user anyway, it was decided that it is OK if
+		// the workshop user owns GPU devices.
+
+		// On another note, the render and video groups are not assigned to the
+		// card*/render* dri devices by LXD properly. Both will be assigned to
+		// the group provided in "gid"; there is no way to assign video to card*
+		// and render to render* devices.
+		properties: map[string]string{"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"},
+	}
+}
+
+// A network protocol proxy device, opens a port on the host or in a workhop.
+// from, to are the source and destination addresses (paths in the case of unix sockets),
+// see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
+// bind denotes where the port is open (can be: instance, host)
+func SshAgent(name string, from, to string) Device {
+	return Device{
+		name:       name,
+		deviceType: SshAgentProxy,
+		properties: map[string]string{"type": "proxy", "connect": "unix:" + from, "listen": "unix:" + to, "uid": "1000", "gid": "1000", "bind": "instance"},
+	}
+}
+
+func (w Device) lxdProperties() map[string]string {
+	return w.properties
+}

--- a/internal/workshopbackend/lxd_backend_profile.go
+++ b/internal/workshopbackend/lxd_backend_profile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/exp/slices"
@@ -53,6 +54,7 @@ const (
 	BindMount DeviceType = iota
 	DiskVolume
 	GPU
+	Proxy
 )
 
 type Device struct {
@@ -110,6 +112,18 @@ func Gpu(name string) Device {
 	}
 }
 
+// A network protocol proxy device, opens a port on the host or in a workhop.
+// from, to are the source and destination addresses (paths in the case of unix sockets),
+// see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
+// bind denotes where the port is open (can be: instance, host)
+func NetworkProxy(name string, from, to string, bind string) Device {
+	return Device{
+		name:       name,
+		deviceType: Proxy,
+		properties: map[string]string{"type": "proxy", "connect": from, "listen": to, "uid": "1000", "gid": "1000", "bind": bind},
+	}
+}
+
 func profileName(pid, workshop, sdk string) string {
 	return strings.Join([]string{InstanceName(workshop, pid), sdk}, "-")
 }
@@ -151,6 +165,20 @@ func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile
 			} else if !info.IsDir() {
 				return fmt.Errorf("cannot create a workshop mount with target %q: the target is not a directory", target)
 			}
+		}
+
+		if dev.Type() == Proxy {
+			// add SSH_AUTH_SOCK setup
+			env, err := fs.Create(filepath.Join("/etc/profile.d", dev.name+".sh"))
+			if err != nil {
+				return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
+			}
+
+			_, err = env.Write([]byte("export SSH_AUTH_SOCK=" + strings.TrimPrefix(dev.properties["listen"], "unix:")))
+			if err != nil {
+				return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
+			}
+			_ = env.Close()
 		}
 	}
 

--- a/internal/workshopbackend/lxd_backend_profile.go
+++ b/internal/workshopbackend/lxd_backend_profile.go
@@ -10,35 +10,9 @@ import (
 
 	"golang.org/x/exp/slices"
 
-	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/workshop/internal/osutil"
-	"github.com/canonical/workshop/internal/revert"
 )
-
-type SdkProfile struct {
-	sdk     string
-	devices map[string]Device
-}
-
-func NewSdkProfile(sdkName string) SdkProfile {
-	return SdkProfile{
-		sdk:     sdkName,
-		devices: make(map[string]Device),
-	}
-}
-
-func (s SdkProfile) Name() string {
-	return s.sdk
-}
-
-func (s SdkProfile) AddDevice(dev Device) error {
-	if _, ok := s.devices[dev.Name()]; ok {
-		return fmt.Errorf("device %s already exists in the %s SDK profile", dev.Name(), s.Name())
-	}
-	s.devices[dev.Name()] = dev
-	return nil
-}
 
 func (p SdkProfile) lxdDevices() map[string]map[string]string {
 	lxdDevs := make(map[string]map[string]string, len(p.devices))
@@ -46,90 +20,6 @@ func (p SdkProfile) lxdDevices() map[string]map[string]string {
 		lxdDevs[d.Name()] = d.properties
 	}
 	return lxdDevs
-}
-
-type DeviceType int
-
-const (
-	BindMount DeviceType = iota
-	DiskVolume
-	GPU
-	Proxy
-)
-
-type Device struct {
-	name       string
-	properties map[string]string
-	deviceType DeviceType
-}
-
-func (d Device) Name() string {
-	return d.name
-}
-
-func (d Device) Type() DeviceType {
-	return d.deviceType
-}
-
-func Mount(name, source, target string) Device {
-	return Device{name: name,
-		deviceType: BindMount,
-		properties: map[string]string{"type": "disk", "source": source,
-			"path": target},
-	}
-}
-
-func Volume(name, mountTo, volume string) Device {
-	return Device{
-		name:       name,
-		deviceType: DiskVolume,
-		properties: map[string]string{"type": "disk",
-			"pool":   "default",
-			"path":   mountTo,
-			"source": volume},
-	}
-}
-
-func Gpu(name string) Device {
-	return Device{
-		name:       name,
-		deviceType: GPU,
-
-		// The default workshop user must be able to acces the GPU device.
-		// Workshop assigns the GPU devices to workshop.workshop. A more
-		// traditional way here would be to add dri devices to the video/render
-		// groups, but it requires an additional workshop exec to find out the
-		// groups' ids at the LXD profile generation time. Given that we are
-		// solving the problem of access in a confined environment and workshop
-		// is a passwordless sudo user anyway, it was decided that it is OK if
-		// the workshop user owns GPU devices.
-
-		// On another note, the render and video groups are not assigned to the
-		// card*/render* dri devices by LXD properly. Both will be assigned to
-		// the group provided in "gid"; there is no way to assign video to card*
-		// and render to render* devices.
-		properties: map[string]string{"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"},
-	}
-}
-
-// A network protocol proxy device, opens a port on the host or in a workhop.
-// from, to are the source and destination addresses (paths in the case of unix sockets),
-// see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
-// bind denotes where the port is open (can be: instance, host)
-func NetworkProxy(name string, from, to string, bind string) Device {
-	return Device{
-		name:       name,
-		deviceType: Proxy,
-		properties: map[string]string{"type": "proxy", "connect": from, "listen": to, "uid": "1000", "gid": "1000", "bind": bind},
-	}
-}
-
-func profileName(pid, workshop, sdk string) string {
-	return strings.Join([]string{InstanceName(workshop, pid), sdk}, "-")
-}
-
-func (w Device) lxdProperties() map[string]string {
-	return w.properties
 }
 
 func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile SdkProfile) error {
@@ -167,18 +57,11 @@ func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile
 			}
 		}
 
-		if dev.Type() == Proxy {
-			// add SSH_AUTH_SOCK setup
-			env, err := fs.Create(filepath.Join("/etc/profile.d", dev.name+".sh"))
-			if err != nil {
-				return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
+		if dev.Type() == SshAgentProxy {
+			// add SSH_AUTH_SOCK variable to the workshop's environment
+			if err = setSshAuthSock(fs, dev, workshop); err != nil {
+				return err
 			}
-
-			_, err = env.Write([]byte("export SSH_AUTH_SOCK=" + strings.TrimPrefix(dev.properties["listen"], "unix:")))
-			if err != nil {
-				return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
-			}
-			_ = env.Close()
 		}
 	}
 
@@ -190,14 +73,23 @@ func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile
 
 	// Either create or update an existing LXD profile for the SDK so that later
 	// it can be assigned to the required workshop
-	_, etag, err := conn.GetProfile(lxdname)
+	oldProfile, etag, err := conn.GetProfile(lxdname)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return err
 	} else if api.StatusErrorCheck(err, http.StatusNotFound) {
-		if err := conn.CreateProfile(api.ProfilesPost{ProfilePut: newProfile, Name: lxdname}); err != nil {
+		if err = conn.CreateProfile(api.ProfilesPost{ProfilePut: newProfile, Name: lxdname}); err != nil {
 			return err
 		}
 	} else {
+		// Find the difference between a set of old and new devices to detect if any
+		// clean up is required when a new profile will be assigned (updated).
+		for key, dev := range oldProfile.Devices {
+			if _, ok := newProfile.Devices[key]; !ok {
+				if dev["type"] == "proxy" {
+					unsetSshAuthSock(fs, key)
+				}
+			}
+		}
 		if err := conn.UpdateProfile(lxdname, newProfile, etag); err != nil {
 			return err
 		}
@@ -223,41 +115,22 @@ func (s *LxdBackend) AssignProfile(ctx context.Context, workshop string, profile
 	return nil
 }
 
-func (s *LxdBackend) lxdEmptyUnmountWorkaround(conn lxd.InstanceServer, ctx context.Context, projectId, workshop string, profile string) (*revert.Reverter, error) {
-	// We have to workaround the LXD issue here as it would remove
-	// the target directory on unmount if it was empty. It should
-	// not touch the directories that it has not created.
-	// https://github.com/canonical/lxd/issues/12648
-	fs, err := s.WorkshopFs(ctx, workshop)
+func setSshAuthSock(fs WorkshopFs, dev Device, workshop string) error {
+	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.name+".sh"))
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
 	}
 
-	lxdProfile, _, err := conn.GetProfile(profileName(projectId, workshop, profile))
+	_, err = env.Write([]byte("export SSH_AUTH_SOCK=" + strings.TrimPrefix(dev.properties["listen"], "unix:")))
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
 	}
+	_ = env.Close()
+	return nil
+}
 
-	var revertWorkaround revert.Reverter
-	revertWorkaround.Add(func() { fs.Close() })
-	for _, mount := range lxdProfile.Devices {
-		// only for the bind mounts
-		if mount["type"] == "disk" && mount["pool"] == "" {
-			target := mount["path"]
-			info, err := fs.Stat(target)
-			if err != nil {
-				continue
-			}
-			revertWorkaround.Add(func() {
-				// Making a new directory unconditionally can be done, because
-				// the target must have existed for this profile to be created
-				// in the first place.
-				_ = fs.Mkdir(target, info.Mode())
-			})
-		}
-	}
-
-	return &revertWorkaround, nil
+func unsetSshAuthSock(fs WorkshopFs, name string) {
+	_ = fs.Remove(filepath.Join("/etc/profile.d", name+".sh"))
 }
 
 func (s *LxdBackend) RemoveProfile(ctx context.Context, workshop string, profile string) error {
@@ -277,14 +150,7 @@ func (s *LxdBackend) RemoveProfile(ctx context.Context, workshop string, profile
 		return err
 	}
 
-	// TEMPORARY: Workaround LXD bug with empty dir unmounts
-	revertWorkaround, err := s.lxdEmptyUnmountWorkaround(conn, ctx, projectId, workshop, profile)
-	if err != nil {
-		return err
-	}
-	defer revertWorkaround.Fail()
-
-	// 1. Untie the profile from the workshop
+	// 1. Unassign the profile from the workshop
 	lxdname := profileName(projectId, workshop, profile)
 	if idx := slices.Index(inst.Profiles, lxdname); idx != -1 {
 		inst.Profiles = slices.Delete(inst.Profiles, idx, idx+1)
@@ -292,7 +158,7 @@ func (s *LxdBackend) RemoveProfile(ctx context.Context, workshop string, profile
 		if err != nil {
 			return err
 		}
-		if err := op.Wait(); err != nil {
+		if err = op.Wait(); err != nil {
 			return err
 		}
 	}
@@ -300,7 +166,7 @@ func (s *LxdBackend) RemoveProfile(ctx context.Context, workshop string, profile
 	// 2. Delete the profile
 	err = conn.DeleteProfile(profileName(projectId, workshop, profile))
 	if api.StatusErrorCheck(err, http.StatusNotFound) {
-		return fmt.Errorf("workshop %q has no %q SDK profile", workshop, profile)
+		return ErrSdkProfileNotFound
 	}
 	return err
 }

--- a/internal/workshopbackend/tests/integration/profile_test.go
+++ b/internal/workshopbackend/tests/integration/profile_test.go
@@ -5,6 +5,9 @@ package workshopbackend_test
 
 import (
 	"context"
+	"net"
+	"os"
+	"path/filepath"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -68,7 +71,8 @@ func (f *profileTest) TestSdkProfileCreatedAndUpdatedSuccessfully(c *check.C) {
 	// Setup
 	var backend workshopbackend.Profile = &workshopbackend.LxdBackend{}
 	profile := workshopbackend.NewSdkProfile("sdk")
-	device := workshopbackend.Mount("sdk-device", c.MkDir(), "/root")
+	// ensure the target directory is created as a workaround for the LXD bind-mount issue
+	device := workshopbackend.Mount("sdk-device", c.MkDir(), "/new-dir")
 	err := profile.AddDevice(device)
 	c.Assert(err, check.IsNil)
 
@@ -109,8 +113,6 @@ func (f *profileTest) TestSdkProfileCreatedAndUpdatedSuccessfully(c *check.C) {
 func (f *profileTest) TestSdkProfileBindMountFailsIfTargetIsAFile(c *check.C) {
 	// Setup
 	var backend workshopbackend.Profile = &workshopbackend.LxdBackend{}
-
-	// Setup
 	profile := workshopbackend.NewSdkProfile("sdk")
 	device := workshopbackend.Mount("sdk-device", c.MkDir(), "/root/.profile")
 	err := profile.AddDevice(device)
@@ -121,29 +123,51 @@ func (f *profileTest) TestSdkProfileBindMountFailsIfTargetIsAFile(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `.*cannot create a workshop mount with target "/root/.profile": the target is not a directory`)
 }
 
-func (f *profileTest) TestSdkProfileBindMountPreventsLxdFromRemovingTarget(c *check.C) {
+func (f *profileTest) TestSdkProfileSshAgentProxy(c *check.C) {
 	// Setup
 	var backend workshopbackend.Profile = &workshopbackend.LxdBackend{}
 	profile := workshopbackend.NewSdkProfile("sdk")
-	device := workshopbackend.Mount("sdk-device", c.MkDir(), "/opt")
-	deviceNonEmpty := workshopbackend.Mount("sdk-device-2", c.MkDir(), "/home/workshop")
-	err := profile.AddDevice(device)
+	sshAgentDir := c.MkDir()
+	sockPath := filepath.Join(sshAgentDir, "ssh")
+	sock, err := net.Listen("unix", sockPath)
 	c.Assert(err, check.IsNil)
-	err = profile.AddDevice(deviceNonEmpty)
+	defer func() {
+		sock.Close()
+		os.Remove(sockPath)
+	}()
+
+	device := workshopbackend.SshAgent("agent", sockPath, "/home/workshop/ssh-agent.ssh")
+	err = profile.AddDevice(device)
 	c.Assert(err, check.IsNil)
 
 	// Execute
 	err = backend.AssignProfile(f.ctx, "test", profile)
-	c.Assert(err, check.IsNil)
-	err = backend.RemoveProfile(f.ctx, "test", profile.Name())
 	c.Assert(err, check.IsNil)
 
 	// Validate
 	fs, err := f.client.GetInstanceFileSFTP(workshopbackend.InstanceName("test", "42424242"))
 	c.Assert(err, check.IsNil)
 	defer fs.Close()
-	_, err = fs.Stat("/opt")
+	var buf = make([]byte, 100)
+	agentScript, err := fs.Open("/etc/profile.d/agent.sh")
 	c.Assert(err, check.IsNil)
-	_, err = fs.Stat("/home/workshop")
+	n, _ := agentScript.Read(buf)
 	c.Assert(err, check.IsNil)
+	c.Assert(string(buf[:n]), check.Equals, "export SSH_AUTH_SOCK=/home/workshop/ssh-agent.ssh")
+
+	// Execute
+	// Simulate a scenario when a profile is updated not created
+	err = backend.AssignProfile(f.ctx, "test", workshopbackend.NewSdkProfile("sdk"))
+	c.Assert(err, check.IsNil)
+
+	// Validate
+	_, err = fs.Stat("/etc/profile.d/agent.sh")
+	c.Assert(os.IsNotExist(err), check.Equals, true)
+}
+
+func (f *profileTest) TestSdkProfileRemove(c *check.C) {
+	// Setup
+	var backend workshopbackend.Profile = &workshopbackend.LxdBackend{}
+	err := backend.RemoveProfile(f.ctx, "test", "sdk")
+	c.Assert(err, testutil.ErrorIs, workshopbackend.ErrSdkProfileNotFound)
 }


### PR DESCRIPTION
# Description

An SDK can declare an ssh-agent interface plug to get access to host's ssh-agent in the workshop (if running):
```
plug:
  ssh-agent:
    interface: ssh-agent
```

The interface's slot provided by the agent SDK denies auto-connections. When connected, a proxy Unix socket is created for the workshop and SSH_AUTH_SOCK is set for the workshop users.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
