### PR TITLE
Re-track a project if LXD was removed and installed again

### DIFF
--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -145,6 +145,7 @@ func (m *InterfaceManager) StartUp() error {
 				// socket will render /deleted)
 				if err := m.recreateInternalMounts(pctx, workshop.Name); err != nil {
 					logger.Noticef("Cannot create internal mounts for %q workshop: %v", workshop.Name, err)
+					continue
 				}
 
 				agent, err := workshop.SdkInfo(pctx, sdk.Agent.String())

--- a/internal/workshopbackend/lxd_backend_project.go
+++ b/internal/workshopbackend/lxd_backend_project.go
@@ -121,6 +121,11 @@ func (s *LxdBackend) loadProjectFromPath(client lxd.InstanceServer, ctx context.
 		idx := slices.IndexFunc(projects, func(p *Project) bool { return p.ProjectId == pId })
 		if idx != -1 {
 			return projects[idx], nil
+		} else {
+			// The lock is found, but the project is not tracked. This could happen
+			// if LXD was removed and reinstalled. Track the project again.
+			var prj = &Project{Path: path, ProjectId: pId}
+			return prj, s.trackProject(client, ctx, prj)
 		}
 	}
 	return nil, ErrProjectNotFound

--- a/internal/workshopbackend/tests/integration/project_test.go
+++ b/internal/workshopbackend/tests/integration/project_test.go
@@ -25,7 +25,7 @@ type wsProject struct {
 	username string
 }
 
-var workshopMock = `name: test
+var workshopYaml = `name: test
 base: ubuntu@22.04
 `
 
@@ -73,8 +73,8 @@ func (f *wsProject) TestLxdBackendCreateProject(c *check.C) {
 	defer restore()
 	projectDir, projectDir2 := c.MkDir(), c.MkDir()
 
-	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
-	os.WriteFile(filepath.Join(projectDir2, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
+	os.WriteFile(filepath.Join(projectDir2, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 
 	// Execute
 	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
@@ -108,7 +108,7 @@ func (f *wsProject) TestLxdBackendReconcileProjectIfNotRecovered(c *check.C) {
 	defer restore()
 	projectDir := c.MkDir()
 
-	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 
 	// Execute
 	_, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
@@ -131,7 +131,7 @@ func (f *wsProject) TestLxdBackendLoadProject(c *check.C) {
 	restore := testutil.FakeFunc(func() (string, error) { return "b8639dea", nil }, &workshopbackend.NewProjectId)
 	projectDir := c.MkDir()
 
-	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
 	c.Assert(prj, check.NotNil)
 	c.Assert(prj.Path, check.Equals, projectDir)
@@ -168,7 +168,7 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryMoved(c *check.C) {
 			},
 		}, "")
 
-	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 	os.WriteFile(filepath.Join(projectDir, ".workshop.lock"), []byte("b8639dea"), 0644)
 	err := os.Rename(projectDir, newDir)
 	c.Assert(err, check.IsNil)
@@ -199,8 +199,8 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryCopied(c *check.C) {
 			},
 		}, "")
 
-	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
-	os.WriteFile(filepath.Join(newDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
+	os.WriteFile(filepath.Join(newDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 	os.WriteFile(filepath.Join(projectDir, ".workshop.lock"), []byte("b8639dea"), 0644)
 	os.WriteFile(filepath.Join(newDir, ".workshop.lock"), []byte("b8639dea"), 0644)
 
@@ -223,8 +223,8 @@ func (f *wsProject) TestLxdBackendListAvailableProjects(c *check.C) {
 	defer restore()
 	projectDir, projectDir2 := c.MkDir(), c.MkDir()
 
-	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
-	os.WriteFile(filepath.Join(projectDir2, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
+	os.WriteFile(filepath.Join(projectDir2, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 
 	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
 	c.Assert(prj, check.NotNil)
@@ -255,7 +255,7 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryRemoved(c *check.C) {
 	be := workshopbackend.LxdBackend{}
 	projectDir := c.MkDir()
 
-	err := os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	err := os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 	c.Assert(err, check.IsNil)
 	_, _, err = be.CreateOrLoadProject(f.ctx, projectDir)
 	c.Assert(err, check.IsNil)
@@ -287,7 +287,7 @@ func (f *wsProject) TestLxdBackendLoadProjectsAllUsers(c *check.C) {
 
 	projectDir := c.MkDir()
 
-	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
 	c.Assert(prj, check.NotNil)
 	c.Assert(err, check.IsNil)
@@ -308,7 +308,7 @@ func (f *wsProject) TestLxdBackendLoadProjectAsDifferentUser(c *check.C) {
 	restore := testutil.FakeFunc(func() (string, error) { return "b8639dea", nil }, &workshopbackend.NewProjectId)
 	projectDir := c.MkDir()
 
-	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopMock), 0644)
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
 	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
 	c.Assert(prj, check.NotNil)
 	c.Assert(prj.Path, check.Equals, projectDir)
@@ -325,4 +325,21 @@ func (f *wsProject) TestLxdBackendLoadProjectAsDifferentUser(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "project already exists")
 	c.Assert(prj, check.IsNil)
 	c.Assert(created, check.Equals, false)
+}
+
+func (f *wsProject) TestLxdBackendLoadUntrackedProject(c *check.C) {
+	// Setup
+	be := workshopbackend.LxdBackend{}
+	projectDir := c.MkDir()
+	c.Assert(os.WriteFile(filepath.Join(projectDir, ".workshop.lock"), []byte("ab639dea"), os.ModePerm), check.IsNil)
+
+	os.WriteFile(filepath.Join(projectDir, ".workshop.test.yaml"), []byte(workshopYaml), 0644)
+	prj, _, err := be.CreateOrLoadProject(f.ctx, projectDir)
+	c.Assert(prj, check.NotNil)
+	c.Assert(prj.Path, check.Equals, projectDir)
+	c.Assert(prj.ProjectId, check.Equals, "ab639dea")
+	c.Assert(err, check.IsNil)
+
+	lxdProject, _, _ := f.client.GetProject(workshopbackend.LxdProjectName("testuser"))
+	c.Assert(lxdProject.Config["user.workshop.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"ab639dea"}]`, projectDir))
 }


### PR DESCRIPTION
# Description

LXD project metadata is used to track workshop projects. Not the ideal solution, needs relocating to the state (it was there before workshop cross-ported the state package). Hence, if LXD was removed and installed back, the projects track
will be lost. This fix restart tracking for the already existing project locks.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
