### PR TITLE
Link workshopctl statically

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,9 +39,13 @@ parts:
     plugin: go
     source: .
     source-type: local
+    override-build: |
+      go install ./cmd/workshop
+      go install ./cmd/workshopd
+      CGO_ENABLED=0 go install ./cmd/workshopctl
     build-snaps:
       - go/latest/stable
-
+      
   wrappers:
     plugin: dump
     source: snap/local/


### PR DESCRIPTION
`workshopctl` is installed in a workshop, therefore, it must be statically linked.