### PR TITLE
Chore: remove unnecessary WorkshopFilePath & WorkshopFileName funcs

### DIFF
--- a/internal/workshopbackend/project.go
+++ b/internal/workshopbackend/project.go
@@ -26,6 +26,9 @@ const (
 	ProjectIdConfig     = "user.workshop.project-id"
 )
 
+// *.yaml is the only supported extension for workshop files as the only
+// recommended "official" extension: https://yaml.org/faq.html. Also, having a
+// single way of naming workshop files avoids unneccesary inconsistencies.
 var validWorkshopFilename = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
 
 func LockPath(path string) string {
@@ -43,7 +46,7 @@ func (p *Project) Exists() bool {
 }
 
 func (w *Project) WorkshopFile(workshop string) (*WorkshopFile, error) {
-	file, err := readWorkshop(filepath.Join(w.Path, WorkshopFileName(workshop)))
+	file, err := readWorkshop(filepath.Join(w.Path, fmt.Sprintf(".workshop.%s.yaml", workshop)))
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +66,7 @@ func (w *Project) EnumWorkshopFiles() ([]*WorkshopFile, error) {
 			continue
 		}
 
-		/* The first element in names will contain the workshop name if matched */
+		// The first element in names will contain the workshop name if matched
 		if names := validWorkshopFilename.FindStringSubmatch(info.Name()); names != nil {
 			file, err := readWorkshop(filepath.Join(w.Path, info.Name()))
 			if err != nil {

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -138,14 +138,6 @@ func (w *Workshop) UnlinkSdk(ctx context.Context, name string) error {
 	return fs.Remove(sdk.SdkCurrentPath(name))
 }
 
-func WorkshopFilePath(dir, name string) string {
-	return filepath.Join(dir, WorkshopFileName(name))
-}
-
-func WorkshopFileName(name string) string {
-	return fmt.Sprintf(".workshop.%s.yaml", name)
-}
-
 func InstanceName(name string, project_id string) string {
 	return fmt.Sprintf("%s-%s", name, project_id)
 }

--- a/internal/workshopbackend/workshop_file.go
+++ b/internal/workshopbackend/workshop_file.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
@@ -55,30 +54,24 @@ func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
 
 func readWorkshop(pathname string) (*WorkshopFile, error) {
 	var err error
-
-	var file = &WorkshopFile{}
+	var file WorkshopFile
 
 	buf, err := os.ReadFile(pathname)
-
 	if err != nil {
 		return nil, err
 	}
 
-	if err = yaml.Unmarshal(buf, file); err != nil {
+	if err = yaml.Unmarshal(buf, &file); err != nil {
 		return nil, err
 	}
 
-	/* Validate workshop properties */
+	// Validate workshop properties
 	if !sdk.ValidName.MatchString(file.Name) {
 		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) include only lower case alpha-numeric or an underscore symbol(s)")
 	}
 
 	if !slices.Contains(sdk.ValidBases, file.Base) {
 		return nil, fmt.Errorf("unsupported base: %s", file.Base)
-	}
-
-	if WorkshopFileName(file.Name) != filepath.Base(pathname) {
-		return nil, fmt.Errorf("%s's file must be named as .workshop.%s.yaml (now: %s)", file.Name, file.Name, filepath.Base(pathname))
 	}
 
 	for _, k := range file.Sdks {
@@ -92,5 +85,5 @@ func readWorkshop(pathname string) (*WorkshopFile, error) {
 		}
 	}
 
-	return file, nil
+	return &file, nil
 }

--- a/internal/workshopbackend/workshop_file_test.go
+++ b/internal/workshopbackend/workshop_file_test.go
@@ -2,6 +2,7 @@ package workshopbackend_test
 
 import (
 	"cmp"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -22,6 +23,10 @@ func (f *F) SetUpTest(c *check.C) {
 	f.fs = afero.NewMemMapFs()
 }
 
+func workshopFilePath(dir, name string) string {
+	return filepath.Join(dir, fmt.Sprintf(".workshop.%s.yaml", name))
+}
+
 func (f *F) TestWorkshopFileParse(c *check.C) {
 	buf := []byte(`name: xbert-gpu
 base: ubuntu@20.04
@@ -36,8 +41,8 @@ sdks:
     channel: latest/beta
 `)
 	dir := c.MkDir()
-	os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644)
-	file, err := workshopbackend.ReadWorkshop(workshopbackend.WorkshopFilePath(dir, "xbert-gpu"))
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	file, err := workshopbackend.ReadWorkshop(workshopFilePath(dir, "xbert-gpu"))
 	c.Assert(err, check.Equals, nil)
 	c.Assert(file.Name, check.Equals, "xbert-gpu")
 	c.Assert(file.Base, check.Equals, "ubuntu@20.04")
@@ -64,8 +69,8 @@ sdks:
     channel: latest/edge
 `)
 	dir := c.MkDir()
-	os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644)
-	file, err := workshopbackend.ReadWorkshop(workshopbackend.WorkshopFilePath(dir, "xbert-gpu"))
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	file, err := workshopbackend.ReadWorkshop(workshopFilePath(dir, "xbert-gpu"))
 	c.Assert(file, check.IsNil)
 	c.Assert(err, check.NotNil)
 }
@@ -78,8 +83,8 @@ sdks:
     channel: latest/stable
 `)
 	dir := c.MkDir()
-	os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644)
-	file, err := workshopbackend.ReadWorkshop(workshopbackend.WorkshopFilePath(dir, "xbert-gpu"))
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	file, err := workshopbackend.ReadWorkshop(workshopFilePath(dir, "xbert-gpu"))
 	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
 	c.Assert(file, check.IsNil)
 }


### PR DESCRIPTION
# Description
Removes the public functions that should not be public and, also, comments on the decision to stick
with .yaml as the only possible extension for the workshop files.

# Self-review quick check

 * [x] Delete dead code and redundant comments.
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Put a blank line between two logically different chunks of code.
