### PR TITLE
Preserve workshop file that was used to launch a workshop

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -34,12 +34,14 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - name: Setup
-        uses: actions/setup-go@v3
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
         with:
-          go-version: '1.20'
-      - name: Install multipass
-        run: sudo snap install multipass
+          detached: true
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
       - name: Checkout Workshop
         uses: actions/checkout@v4
         with:
@@ -49,6 +51,12 @@ jobs:
           name: snap
           path: ${{ github.workspace }}/tests/
       - name: Install spread
-        run: go install github.com/snapcore/spread/cmd/spread@latest
+        run: |
+          # go install is not supported for forks...
+          git clone https://github.com/dmitry-lyfar/spread
+          cd spread
+          go install ./...
       - name: Run spread
-        run: spread tests/${{matrix.suite}}/
+        run: | 
+          lxd init --auto
+          spread tests/${{matrix.suite}}/

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -34,14 +34,12 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - name: Setup tmate session
-        uses: canonical/action-tmate@main
-        with:
-          detached: true
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
+      - name: Install multipass
+        run: sudo snap install multipass
       - name: Checkout Workshop
         uses: actions/checkout@v4
         with:

--- a/.spread.yaml
+++ b/.spread.yaml
@@ -10,10 +10,64 @@ repack: |
     test -f tests/*.snap || snapcraft -o tests/
     cat <&3 >&4
 backends:
-  lxd:
+  # Only for local usage, GitHub self-hosted runners
+  # fail on IP allocation for a VM (it is allocated but much later 
+  # than expected by spread).
+  # lxd:
+  #   systems:
+  #     - ubuntu-22.04:
+  #         workers: 3
+  #     - ubuntu-24.04:
+  #         workers: 3
+  multipass:
+    type: adhoc
+    allocate: |
+      if [ "$SPREAD_SYSTEM" = "ubuntu-24.04-64" ]; then
+          image="daily:devel"
+          instance_name=spread-devel
+      else
+          # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
+          # translated to an image XX.YY.
+          image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
+          instance_name="spread-${image/./}"
+      fi
+      if [ -z "${image}" ]; then
+        FATAL "$SPREAD_SYSTEM is not supported!"
+      fi
+      multipass launch --disk 20G --memory 4G --cpus 8 --name "$instance_name" "$image"
+      # Get the IP from the instance
+      ip=$(multipass info --format csv "$instance_name" | tail -1 | cut -d\, -f3)
+      # Enable PasswordAuthertication for root over SSH.
+      multipass exec "$instance_name" -- \
+        sudo sh -c "echo root:ubuntu | sudo chpasswd"
+      multipass exec "$instance_name" -- \
+        sudo sh -c \
+        "sed -i /etc/ssh/sshd_config -e 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' -e 's/^KbdInteractiveAuthentication.*/KbdInteractiveAuthentication yes/'"
+      multipass exec "$instance_name" -- \
+        sudo sh -c \
+        "sed -i /etc/ssh/sshd_config.d/60-cloudimg-settings.conf -e 's/^PasswordAuthentication.*/PasswordAuthentication yes/'"
+      multipass exec "$instance_name" -- \
+        sudo systemctl restart ssh
+      ADDRESS "$ip:22"
+    discard: |
+      if [ "$SPREAD_SYSTEM" = "ubuntu-24.04-64" ]; then
+          image="daily:devel"
+          instance_name=spread-devel
+      else
+          # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
+          # translated to an image XX.YY.
+          image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
+          instance_name="spread-${image/./}"
+      fi
+      if [ -z "${image}" ]; then
+        FATAL "$SPREAD_SYSTEM is not supported!"
+      fi
+      multipass delete --purge "$instance_name"
     systems:
-      - ubuntu-22.04:
+      - ubuntu-22.04-64:
           workers: 1
+          username: root
+          password: ubuntu
 suites:
   tests/main/:
     summary: Core workshop scenarios
@@ -25,15 +79,16 @@ suites:
       . "$TESTSLIB"/utils.sh
       stop_sdk_store
       cleanup_environment
+    debug: |
+      lxc list --project workshop.ubuntu
+      sudo -u ubuntu 2>&1 -- workshop list --global
     kill-timeout: 30m
   tests/integration/:
     summary: LXD integration tests
     prepare: |
       . "$TESTSLIB"/utils.sh
-      prepare_environment
-    restore: |
-      . "$TESTSLIB"/utils.sh
-      cleanup_environment
+      init_lxd
+      snap install go --classic --channel=1.21/stable
     kill-timeout: 30m
   tests/documentation/:
     summary: Documentation tests

--- a/.spread.yaml
+++ b/.spread.yaml
@@ -10,55 +10,10 @@ repack: |
     test -f tests/*.snap || snapcraft -o tests/
     cat <&3 >&4
 backends:
-  multipass:
-    type: adhoc
-    allocate: |
-      if [ "$SPREAD_SYSTEM" = "ubuntu-24.04-64" ]; then
-          image="daily:devel"
-          instance_name=spread-devel
-      else
-          # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
-          # translated to an image XX.YY.
-          image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image/./}"
-      fi
-      if [ -z "${image}" ]; then
-        FATAL "$SPREAD_SYSTEM is not supported!"
-      fi
-      multipass launch --disk 20G --memory 4G --cpus 8 --name "$instance_name" "$image"
-      # Get the IP from the instance
-      ip=$(multipass info --format csv "$instance_name" | tail -1 | cut -d\, -f3)
-      # Enable PasswordAuthertication for root over SSH.
-      multipass exec "$instance_name" -- \
-        sudo sh -c "echo root:ubuntu | sudo chpasswd"
-      multipass exec "$instance_name" -- \
-        sudo sh -c \
-        "sed -i /etc/ssh/sshd_config -e 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' -e 's/^KbdInteractiveAuthentication.*/KbdInteractiveAuthentication yes/'"
-      multipass exec "$instance_name" -- \
-        sudo sh -c \
-        "sed -i /etc/ssh/sshd_config.d/60-cloudimg-settings.conf -e 's/^PasswordAuthentication.*/PasswordAuthentication yes/'"
-      multipass exec "$instance_name" -- \
-        sudo systemctl restart ssh
-      ADDRESS "$ip:22"
-    discard: |
-      if [ "$SPREAD_SYSTEM" = "ubuntu-24.04-64" ]; then
-          image="daily:devel"
-          instance_name=spread-devel
-      else
-          # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
-          # translated to an image XX.YY.
-          image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image/./}"
-      fi
-      if [ -z "${image}" ]; then
-        FATAL "$SPREAD_SYSTEM is not supported!"
-      fi
-      multipass delete --purge "$instance_name"
+  lxd:
     systems:
-      - ubuntu-22.04-64:
+      - ubuntu-22.04:
           workers: 1
-          username: root
-          password: ubuntu
 suites:
   tests/main/:
     summary: Core workshop scenarios
@@ -70,6 +25,7 @@ suites:
       . "$TESTSLIB"/utils.sh
       stop_sdk_store
       cleanup_environment
+    kill-timeout: 30m
   tests/integration/:
     summary: LXD integration tests
     prepare: |
@@ -78,6 +34,7 @@ suites:
     restore: |
       . "$TESTSLIB"/utils.sh
       cleanup_environment
+    kill-timeout: 30m
   tests/documentation/:
     summary: Documentation tests
     prepare: |

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -25,8 +25,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 
 	"github.com/canonical/x-go/strutil"
 	"gopkg.in/check.v1"
@@ -36,6 +34,7 @@ import (
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
 // Tests for GET /v1/connections
@@ -64,14 +63,8 @@ slots:
 func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, workshop string) {
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, workshop)
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, workshop)), []byte(fmt.Sprintf(`name: %s
-base: ubuntu@20.04
-sdks:
-  %s:
-    channel: latest/stable
-`, workshop, info.Name)), 0644)
-	c.Assert(err, check.IsNil)
-	c.Assert(s.b.LaunchWorkshop(s.ctx, workshop, "ubuntu@20.04"), check.IsNil)
+	wf := &workshopbackend.WorkshopFile{Name: workshop, Base: "ubuntu@20.04", Sdks: []workshopbackend.SdkRecord{{Name: info.Name, Channel: "latest/stable"}}}
+	c.Assert(s.b.LaunchWorkshop(s.ctx, wf), check.IsNil)
 }
 
 func (s *apiSuite) testConnectionsConnected(c *check.C, d *Daemon, query string, connsState map[string]interface{}, repoConnected []string, expected map[string]interface{}) {

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
 func (s *apiSuite) setupExec(c *check.C) *Command {
@@ -20,8 +21,9 @@ func (s *apiSuite) setupExec(c *check.C) *Command {
 	s.vars = map[string]string{"id": s.project.ProjectId, "name": "ws"}
 	os.WriteFile(filepath.Join(s.workshopDir, ".workshop.ws.yaml"), []byte(`name: ws
 base: ubuntu@20.04`), 0644)
+	wf := &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@20.04"}
 
-	err := s.b.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	err := s.b.LaunchWorkshop(s.ctx, wf)
 	c.Assert(err, check.IsNil)
 	return projectsCmd
 }

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -26,8 +26,8 @@ sdks:
   test-sdk:
     channel: latest/stable
 `, name)), 0644)
-	c.Assert(err, check.IsNil)
-	err = b.LaunchWorkshop(ctx, name, "ubuntu@20.04")
+	wf := &workshopbackend.WorkshopFile{Name: name, Base: "ubuntu@20.04", Sdks: []workshopbackend.SdkRecord{{Name: "test-sdk", Channel: "latest/stable"}}}
+	err = b.LaunchWorkshop(ctx, wf)
 	c.Assert(err, check.IsNil)
 	ws, err := b.Workshop(ctx, name)
 	c.Assert(err, check.IsNil)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -42,7 +42,7 @@ type SdkInfo struct {
 	Name        string           `json:"name"`
 	Channel     string           `json:"channel"`
 	Revision    string           `json:"revision"`
-	InstallTime time.Time        `json:"install-time"`
+	InstallTime *time.Time       `json:"install-time,omitempty"`
 	Health      *HealthCheckInfo `json:"health-check,omitempty"`
 	Mounts      []*Mount         `json:"mounts,omitempty"`
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -26,7 +26,8 @@ func (s *apiSuite) launchWorkshop(ctx context.Context, name string, c *check.C) 
 base: ubuntu@20.04
 `, name)), 0644)
 	c.Assert(err, check.IsNil)
-	err = b.LaunchWorkshop(ctx, name, "ubuntu@20.04")
+	wf := &workshopbackend.WorkshopFile{Name: name, Base: "ubuntu@20.04"}
+	err = b.LaunchWorkshop(ctx, wf)
 	c.Assert(err, check.IsNil)
 	ws, err := b.Workshop(ctx, name)
 	c.Assert(err, check.IsNil)
@@ -56,6 +57,7 @@ func (s *apiSuite) TestProjectsGetWorkshops(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
+	t := time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
 	c.Check(rsp.Result, check.DeepEquals, []*WorkshopInfo{
 		{
 			Name:      "ws-test",
@@ -67,7 +69,7 @@ func (s *apiSuite) TestProjectsGetWorkshops(c *check.C) {
 					Name:        "go",
 					Channel:     "latest/stable",
 					Revision:    "234",
-					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+					InstallTime: &t,
 				},
 			},
 			Notes: nil,
@@ -112,6 +114,7 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
+	t := time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
 	c.Check(rsp.Result, check.DeepEquals, &WorkshopInfo{
 		Name:      "ws-test",
 		Base:      "ubuntu@20.04",
@@ -123,7 +126,7 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 				Name:        "go",
 				Channel:     "latest/stable",
 				Revision:    "234",
-				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+				InstallTime: &t,
 				Health: &HealthCheckInfo{
 					Message: "test health check message",
 					Code:    "check-waiting",
@@ -135,7 +138,7 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 				Name:        "java",
 				Channel:     "latest/stable",
 				Revision:    "324",
-				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+				InstallTime: &t,
 				Mounts: []*Mount{
 					{Source: "/home/user/java", Target: "/home/workshop/java", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "java", Name: "content-plug"}}},
 			},

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -19,8 +19,6 @@ package healthstate_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -99,14 +97,8 @@ func ensureTaskHealthIsSet(t *state.Task, expected *healthstate.HealthCheck, c *
 }
 
 func (s *healthSuite) launchWorkshop(c *check.C, newsdk string, createHealthCheck bool) {
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04
-sdks:
-  one:
-    channel: latest/stable
-`), 0644)
-	c.Check(err, check.IsNil)
-	err = s.backend.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	wf := &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshopbackend.SdkRecord{{Name: "one", Channel: "latest/stable"}}}
+	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -3,8 +3,6 @@ package hookstate_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
@@ -92,11 +90,7 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 	chg.AddTask(t1)
 
 	// Launch a workshop provinding no hooks
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04
-`), 0644)
-	c.Check(err, check.IsNil)
-	err = s.backend.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	err := s.backend.LaunchWorkshop(s.ctx, &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@20.04"})
 	c.Check(err, check.IsNil)
 
 	s.state.Unlock()
@@ -472,14 +466,8 @@ func (s *hookSuite) TestHookWithMultipleHandlersIsError(c *check.C) {
 }
 
 func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04
-sdks:
-  one:
-    channel: latest/stable
-`), 0644)
-	c.Check(err, check.IsNil)
-	err = s.backend.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	wf := &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshopbackend.SdkRecord{{Name: "one", Channel: "latest/stable"}}}
+	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"os"
 	"path/filepath"
 
 	"github.com/spf13/afero"
 	"golang.org/x/exp/maps"
 	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
@@ -80,10 +80,11 @@ func (s *interfaceManagerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sd
 	var workshopFile = bytes.NewBuffer([]byte{})
 	t.Execute(workshopFile, maps.Keys(sdkYamls))
 
-	err = os.WriteFile(filepath.Join(s.prj.Path, fmt.Sprintf(".workshop.%s.yaml", ws)), workshopFile.Bytes(), 0644)
+	var wf workshopbackend.WorkshopFile
+	err = yaml.Unmarshal(workshopFile.Bytes(), &wf)
 	c.Assert(err, check.IsNil)
 
-	err = s.wsbackend.LaunchWorkshop(ctx, ws, "ubuntu@22.04")
+	err = s.wsbackend.LaunchWorkshop(ctx, &wf)
 	c.Assert(err, check.IsNil)
 
 	wsfs, err := s.wsbackend.WorkshopFs(ctx, ws)

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -88,14 +88,8 @@ func (s *H) SetUpTest(c *check.C) {
 	s.installTime = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
 	s.restoreInstallTime = testutil.FakeFunc(func() time.Time { return s.installTime }, &workshopbackend.InstallTimeNow)
 
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04
-sdks:
-  test:
-    channel: latest/stable
-`), 0644)
-	c.Assert(err, check.IsNil)
-	err = s.backend.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	wf := &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshopbackend.SdkRecord{{Name: "test", Channel: "latest/stable"}}}
+	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Assert(err, check.IsNil)
 
 	var sdkYaml = `
@@ -125,7 +119,7 @@ func (s *H) TearDownTest(c *check.C) {
 func (s *H) TestDoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: 2, InstallTime: &s.installTime}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -188,7 +182,7 @@ func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: 2, InstallTime: &s.installTime}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -228,7 +222,7 @@ func (s *H) TestDoLinkSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	testSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: s.installTime}
+	testSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: &s.installTime}
 
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", testSdk)

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -63,9 +63,9 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	var base string
+	var wf workshopbackend.WorkshopFile
 	st.Lock()
-	err = task.Get("base", &base)
+	err = task.Get("workshop-file", &wf)
 	st.Unlock()
 
 	if err != nil {
@@ -74,7 +74,7 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 
 	var rev revert.Reverter
 	defer rev.Fail()
-	if err = m.backend.LaunchWorkshop(ctx, workshop, base); err != nil {
+	if err = m.backend.LaunchWorkshop(ctx, &wf); err != nil {
 		return err
 	}
 
@@ -91,7 +91,7 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	}
 	defer wfs.Close()
 
-	if err = m.installAgentSdk(wfs, base); err != nil {
+	if err = m.installAgentSdk(wfs, wf.Base); err != nil {
 		return err
 	}
 	rev.Success()

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -69,7 +69,7 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	st.Unlock()
 
 	if err != nil {
-		return fmt.Errorf("cannot get workshop base for task %q: %v", task.ID(), err)
+		return fmt.Errorf("internal error: %q workshop configuration is not found (task ID: %s)", workshop, task.ID())
 	}
 
 	var rev revert.Reverter

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
@@ -98,12 +99,12 @@ func (s *workshopHandlers) TearDownTest(c *check.C) {
 func (s *workshopHandlers) TestStopPeriodicProgressUpdate(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04
-`), 0644)
+	wf := &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@20.04"}
+	wfbuf, err := yaml.Marshal(wf)
 	c.Check(err, check.IsNil)
-
-	err = s.backend.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	err = os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), wfbuf, 0644)
+	c.Check(err, check.IsNil)
+	err = s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 
 	t1, err := s.wrkmgr.StopMany(s.ctx, []string{"ws"}, s.project.ProjectId, "1")
@@ -139,17 +140,13 @@ base: ubuntu@20.04
 func (s *workshopHandlers) TestUndoStash(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04
-sdks:
-  test:
-    channel: latest/stable
-  test2:
-    channel: latest/edge
-`), 0644)
-	c.Check(err, check.IsNil)
 
-	err = s.backend.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	wf := &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshopbackend.SdkRecord{
+		{Name: "test", Channel: "latest/stable"},
+		{Name: "test2", Channel: "latest/stable"},
+	}}
+
+	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 
 	chg := s.state.NewChange("sample", "...")
@@ -177,17 +174,12 @@ sdks:
 func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@20.04
-sdks:
-  test:
-    channel: latest/stable
-  test2:
-    channel: latest/edge
-`), 0644)
-	c.Check(err, check.IsNil)
+	wf := &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshopbackend.SdkRecord{
+		{Name: "test", Channel: "latest/stable"},
+		{Name: "test2", Channel: "latest/stable"},
+	}}
 
-	err = s.backend.LaunchWorkshop(s.ctx, "ws", "ubuntu@20.04")
+	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 
 	// create content plugs directories
@@ -240,10 +232,11 @@ func (s *workshopHandlers) TestCreateWorkshopWithAgentSdk(c *check.C) {
 base: ubuntu@22.04
 `), 0644)
 	c.Check(err, check.IsNil)
+	wf := &workshopbackend.WorkshopFile{Name: "ws", Base: "ubuntu@22.04"}
 
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("create-workshop", "...")
-	t1.Set("base", "ubuntu@22.04")
+	t1.Set("workshop-file", wf)
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -225,6 +225,27 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 
 }
 
+func (s *workshopHandlers) TestCreateWorkshopNoWorkshopConfigurationFound(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("create-workshop", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*internal error: "ws" workshop configuration is not found.*`)
+}
+
 func (s *workshopHandlers) TestCreateWorkshopWithAgentSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -256,7 +277,7 @@ base: ubuntu@22.04
 	c.Assert(info.Mode().Perm(), check.Equals, fs.FileMode(0666))
 }
 
-func (s *workshopHandlers) TestCreateWorkshopAgentSdkFails(c *check.C) {
+func (s *workshopHandlers) TestCreateWorkshopAgentSdkFailedGetsUndone(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -125,7 +125,7 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshopbackend.Workshop) healthsta
 	}
 
 	// check if the workshop file exists
-	if _, err := ws.File(); err != nil {
+	if _, err := ws.Project().WorkshopFile(ws.Name); err != nil {
 		healthState.Status = healthstate.ErrorStatus
 		healthState.Code = "missing-file"
 		return healthState

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
-	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
@@ -56,7 +55,7 @@ func (s *managerSuite) TestAddHandlers(c *check.C) {
 	})
 }
 
-func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []sdk.Setup) *workshopbackend.Workshop {
+func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []workshopbackend.SdkRecord) *workshopbackend.Workshop {
 	t, err := template.New("workshop").Parse(fmt.Sprintf(workshopTemplate, ws))
 	c.Assert(err, check.IsNil)
 
@@ -66,7 +65,8 @@ func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []sdk.
 	err = os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(".workshop.%s.yaml", ws)), workshopFile.Bytes(), 0644)
 	c.Assert(err, check.IsNil)
 
-	err = s.backend.LaunchWorkshop(s.ctx, ws, "ubuntu@20.04")
+	wf := workshopbackend.WorkshopFile{Name: ws, Base: "ubuntu@22.04"}
+	err = s.backend.LaunchWorkshop(s.ctx, &wf)
 	c.Assert(err, check.IsNil)
 
 	workshop, err := s.backend.Workshop(s.ctx, ws)
@@ -185,7 +185,7 @@ func (s *managerSuite) TestWorkshopHealthSdkHealth(c *check.C) {
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
-	workshop := s.launchWorkshopWithSDKs(c, "test", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	workshop := s.launchWorkshopWithSDKs(c, "test", []workshopbackend.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 	health := s.manager.WorkshopHealth(workshop)
 
 	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
@@ -199,8 +199,8 @@ func (s *managerSuite) TestRefreshManyOK(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	chg := s.state.NewChange("refresh", "test")
-	s.launchWorkshopWithSDKs(c, "test-1", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
-	s.launchWorkshopWithSDKs(c, "test-2", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	s.launchWorkshopWithSDKs(c, "test-1", []workshopbackend.SdkRecord{{Name: "test", Channel: "latest/stable"}})
+	s.launchWorkshopWithSDKs(c, "test-2", []workshopbackend.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 
 	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId, conflict.RefreshTransactional, chg.ID())
 	c.Assert(err, check.IsNil)
@@ -217,8 +217,8 @@ func (s *managerSuite) TestRefreshRequireStatusReady(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	chg := s.state.NewChange("refresh", "test")
-	s.launchWorkshopWithSDKs(c, "test-1", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
-	workshop2 := s.launchWorkshopWithSDKs(c, "test-2", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	s.launchWorkshopWithSDKs(c, "test-1", []workshopbackend.SdkRecord{{Name: "test", Channel: "latest/stable"}})
+	workshop2 := s.launchWorkshopWithSDKs(c, "test-2", []workshopbackend.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 	err := s.backend.StopWorkshop(s.ctx, workshop2.Name, true)
 	c.Assert(err, check.IsNil)
 
@@ -230,7 +230,7 @@ func (s *managerSuite) TestRefreshRequireWorkshopExistance(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	chg := s.state.NewChange("refresh", "test")
-	s.launchWorkshopWithSDKs(c, "test-1", []sdk.Setup{{Name: "test", Channel: "latest/stable"}})
+	s.launchWorkshopWithSDKs(c, "test-1", []workshopbackend.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 
 	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId, conflict.RefreshTransactional, chg.ID())
 	c.Assert(err, check.ErrorMatches, `cannot refresh: status check for "test-2" failed \(workshop not found\)`)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -57,11 +57,6 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 
 	taskset := make([]*state.TaskSet, 0, len(names))
 	for _, name := range names {
-		file, err := project.WorkshopFile(name)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read %q file: %w", name, err)
-		}
-
 		workshop, err := w.Workshop(ctx, name, projectId)
 		if workshop != nil {
 			return nil, fmt.Errorf("cannot launch: %q already exists", name)
@@ -70,6 +65,10 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, err
 		}
 
+		file, err := project.WorkshopFile(name)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read %q file: %w", name, err)
+		}
 		tasks := launch(w.state, file, project)
 		taskset = append(taskset, tasks)
 	}
@@ -147,7 +146,7 @@ func checkHealthHooks(st *state.State, file *workshopbackend.WorkshopFile) *stat
 
 func constructWorkshop(st *state.State, file *workshopbackend.WorkshopFile, project *workshopbackend.Project) *state.TaskSet {
 	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", file.Name))
-	create.Set("base", file.Base)
+	create.Set("workshop-file", file)
 
 	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
 	mountProject.WaitFor(create)

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -51,7 +51,7 @@ sdks:
   {{ end }} 
 `
 
-func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []sdk.Setup) {
+func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks workshopbackend.SdkList) *workshopbackend.Workshop {
 	t, err := template.New("workshop").Parse(fmt.Sprintf(workshopTemplate, ws))
 	c.Assert(err, check.IsNil)
 
@@ -61,8 +61,14 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []sdk.
 	err = os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(".workshop.%s.yaml", ws)), workshopFile.Bytes(), 0644)
 	c.Assert(err, check.IsNil)
 
-	err = s.backend.LaunchWorkshop(s.ctx, ws, "ubuntu@20.04")
+	wf := workshopbackend.WorkshopFile{Name: ws, Base: "ubuntu@20.04", Sdks: sdks}
+	err = s.backend.LaunchWorkshop(s.ctx, &wf)
 	c.Assert(err, check.IsNil)
+
+	w, err := s.backend.Workshop(s.ctx, ws)
+	c.Assert(err, check.IsNil)
+
+	return w
 }
 
 func (s *requestSuite) ensureTaskHasWorkshopAndProjectKeys(c *check.C, w string, ts []*state.Task) {
@@ -136,10 +142,10 @@ func (s *requestSuite) TestLaunchWorkshopNoSdk(c *check.C) {
 
 	verifyExpectedTasks(c, tasks, expected)
 
-	var base string
-	err := tasks[0].Get("base", &base)
+	var wf workshopbackend.WorkshopFile
+	err := tasks[0].Get("workshop-file", &wf)
 	c.Assert(err, check.Equals, nil)
-	c.Assert(base, check.Equals, "ubuntu@22.04")
+	c.Assert(&wf, check.DeepEquals, file)
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "test", ts.Tasks())
 }
 
@@ -182,11 +188,11 @@ func (s *requestSuite) TestLaunchWorkshopWithSdks(c *check.C) {
 	var s1, s2 workshopbackend.SdkRecord
 	err = tasks[0].Get("sdk-record", &s1)
 	c.Assert(err, check.Equals, nil)
-	c.Assert(s1, check.Equals, sdk)
+	c.Assert(s1, check.DeepEquals, sdk)
 
 	err = tasks[1].Get("sdk-record", &s2)
 	c.Assert(err, check.Equals, nil)
-	c.Assert(s2, check.Equals, sdk_2)
+	c.Assert(s2, check.DeepEquals, sdk_2)
 
 	// install-sdk task for sdk
 	var id1, id2 string
@@ -304,15 +310,17 @@ func (s *requestSuite) TestRefreshSdkRemoved(c *check.C) {
 		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
 	}
 
-	file := &workshopbackend.WorkshopFile{
+	newFile := &workshopbackend.WorkshopFile{
 		Name: "ws",
 		Base: "ubuntu@22.04",
 		Sdks: workshopbackend.SdkList{{Name: "sdk-1", Channel: "latest/stable"}}}
 
-	s.launchWorkshopWithSDKs(c, "ws", existingSdks)
+	s.launchWorkshopWithSDKs(c, "ws", []workshopbackend.SdkRecord{
+		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
+	})
 
 	// Execute
-	ts, err := workshopstate.Refresh(s.state, file, existingSdks, s.project)
+	ts, err := workshopstate.Refresh(s.state, newFile, existingSdks, s.project)
 	c.Assert(err, check.IsNil)
 
 	// Validate
@@ -325,18 +333,19 @@ func (s *requestSuite) TestRefreshSdkRemovedMakingWorkshopEmpty(c *check.C) {
 	// Setup
 	s.state.Lock()
 	defer s.state.Unlock()
-	existingSdks := []sdk.Setup{
-		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
+	existingSdks := workshopbackend.SdkList{
+		{Name: "sdk-1", Channel: "latest/stable"},
+		{Name: "sdk-2", Channel: "latest/stable"},
 	}
 
 	file := &workshopbackend.WorkshopFile{
 		Name: "ws",
 		Base: "ubuntu@22.04"}
 
-	s.launchWorkshopWithSDKs(c, "ws", existingSdks)
+	w := s.launchWorkshopWithSDKs(c, "ws", existingSdks)
 
 	// Execute
-	ts, err := workshopstate.Refresh(s.state, file, existingSdks, s.project)
+	ts, err := workshopstate.Refresh(s.state, file, w.Content(), s.project)
 	c.Assert(err, check.IsNil)
 
 	// Validate
@@ -349,8 +358,9 @@ func (s *requestSuite) TestRefreshSdkReplaced(c *check.C) {
 	// Setup
 	s.state.Lock()
 	defer s.state.Unlock()
-	existingSdks := []sdk.Setup{
-		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
+	existingSdks := workshopbackend.SdkList{
+		{Name: "sdk-1", Channel: "latest/stable"},
+		{Name: "sdk-2", Channel: "latest/stable"},
 	}
 
 	file := &workshopbackend.WorkshopFile{
@@ -358,10 +368,10 @@ func (s *requestSuite) TestRefreshSdkReplaced(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workshopbackend.SdkList{{Name: "test-1", Channel: "latest/stable"}, {Name: "test-2", Channel: "latest/stable"}}}
 
-	s.launchWorkshopWithSDKs(c, "ws", existingSdks)
+	w := s.launchWorkshopWithSDKs(c, "ws", existingSdks)
 
 	// Execute
-	ts, err := workshopstate.Refresh(s.state, file, existingSdks, s.project)
+	ts, err := workshopstate.Refresh(s.state, file, w.Content(), s.project)
 	c.Assert(err, check.IsNil)
 
 	// Validate
@@ -374,7 +384,7 @@ func (s *requestSuite) TestRefreshSdkChannelUpdated(c *check.C) {
 	// Setup
 	s.state.Lock()
 	defer s.state.Unlock()
-	existingSdks := []sdk.Setup{
+	existingSdks := workshopbackend.SdkList{
 		{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/stable"},
 	}
 
@@ -383,10 +393,10 @@ func (s *requestSuite) TestRefreshSdkChannelUpdated(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workshopbackend.SdkList{{Name: "sdk-1", Channel: "latest/stable"}, {Name: "sdk-2", Channel: "latest/edge"}}}
 
-	s.launchWorkshopWithSDKs(c, "ws", existingSdks)
+	w := s.launchWorkshopWithSDKs(c, "ws", existingSdks)
 
 	// Execute
-	ts, err := workshopstate.Refresh(s.state, file, existingSdks, s.project)
+	ts, err := workshopstate.Refresh(s.state, file, w.Content(), s.project)
 	c.Assert(err, check.IsNil)
 
 	// Validate
@@ -729,7 +739,7 @@ func (s *requestSuite) TestStopMany(c *check.C) {
 func (s *requestSuite) TestRemoveMany(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	content := []sdk.Setup{
+	content := workshopbackend.SdkList{
 		{Name: "sdk-1", Channel: "latest/stable"},
 		{Name: "sdk-2", Channel: "latest/stable"},
 		{Name: "sdk-3", Channel: "latest/stable"},
@@ -760,7 +770,7 @@ func (s *requestSuite) TestRemountSuccess(c *check.C) {
 	defer s.state.Unlock()
 
 	plug := interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-1", Sdk: "sdk-1", Name: "plug"}
-	content := []sdk.Setup{
+	content := workshopbackend.SdkList{
 		{Name: "sdk-1", Channel: "latest/stable"},
 	}
 	source := c.MkDir()
@@ -793,7 +803,7 @@ func (s *requestSuite) TestRemountWorkshopNotReady(c *check.C) {
 	defer s.state.Unlock()
 
 	plug := interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-1", Sdk: "sdk-1", Name: "plug"}
-	content := []sdk.Setup{
+	content := workshopbackend.SdkList{
 		{Name: "sdk-1", Channel: "latest/stable"},
 	}
 

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -16,10 +16,10 @@ import (
 )
 
 type Setup struct {
-	Name        string    `json:"name"`
-	Channel     string    `json:"channel"`
-	Revision    int64     `json:"revision"`
-	InstallTime time.Time `json:"install-time,omitzero"`
+	Name        string     `json:"name"`
+	Channel     string     `json:"channel"`
+	Revision    int64      `json:"revision"`
+	InstallTime *time.Time `json:"install-time"`
 }
 
 type sdkYaml struct {

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -22,12 +22,12 @@ func TestSdkSuite(t *testing.T) { check.TestingT(t) }
 
 func (s *SdkSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
-
+	t := time.Now()
 	s.setup = sdk.Setup{
 		Name:        "sdk",
 		Channel:     "latest/stable",
 		Revision:    1,
-		InstallTime: time.Now(),
+		InstallTime: &t,
 	}
 
 	s.projectId = "prj42prj42"

--- a/internal/workshopbackend/backend.go
+++ b/internal/workshopbackend/backend.go
@@ -149,9 +149,8 @@ type WorkshopBackend interface {
 	// Returns a list of workshops for the project in context.
 	ProjectWorkshops(ctx context.Context) ([]*WorkshopFile, []*Workshop, error)
 
-	// Launch a barebone workshop instance using the base provided. The
-	// supported bases are ubuntu@20.04 and ubuntu@22.04.
-	LaunchWorkshop(ctx context.Context, name, base string) error
+	// Launch a barebone workshop instance using the base provided.
+	LaunchWorkshop(ctx context.Context, file *WorkshopFile) error
 
 	// Delete workshop. Stop the workshop forcefully if not in Stopped before deleting
 	RemoveWorkshop(ctx context.Context, name string) error

--- a/internal/workshopbackend/export_test.go
+++ b/internal/workshopbackend/export_test.go
@@ -7,7 +7,7 @@ var (
 	ReadWorkshop           = readWorkshop
 	ReadProjects           = readProjects
 	SaveProjects           = saveProjects
-	DefaultConfig          = (*LxdBackend).defaultConfig
+	DefaultConfig          = (*LxdBackend).workshopConfig
 )
 
 func (s *LxdBackend) SetNvidia(runtime bool) {

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/gorilla/websocket"
 	"golang.org/x/exp/slices"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
@@ -95,7 +96,7 @@ func New() (WorkshopBackend, error) {
 	return &server, nil
 }
 
-func (s *LxdBackend) LaunchWorkshop(ctx context.Context, name, base string) error {
+func (s *LxdBackend) LaunchWorkshop(ctx context.Context, file *WorkshopFile) error {
 	var err error
 	var imageSrv lxd.ImageServer
 	var image *api.Image
@@ -117,18 +118,18 @@ func (s *LxdBackend) LaunchWorkshop(ctx context.Context, name, base string) erro
 	}
 
 	/* Skip if the instance exists already */
-	if _, _, err := conn.GetInstance(InstanceName(name, projectId)); err == nil {
-		return fmt.Errorf("workshop \"%s\" already exists", name)
+	if _, _, err := conn.GetInstance(InstanceName(file.Name, projectId)); err == nil {
+		return fmt.Errorf("workshop \"%s\" already exists", file.Name)
 	}
 
 	/* Check if we have the base image stored locally */
-	if alias, _, err := conn.GetImageAlias(base); err == nil {
+	if alias, _, err := conn.GetImageAlias(file.Base); err == nil {
 		if image, _, err = conn.GetImage(alias.Target); err != nil {
 			return err
 		}
 		imageSrv = conn
 	} else {
-		imageSrv, image, err = s.fetchRemoteImage(base)
+		imageSrv, image, err = s.fetchRemoteImage(file.Base)
 		if err != nil {
 			return err
 		}
@@ -139,12 +140,16 @@ func (s *LxdBackend) LaunchWorkshop(ctx context.Context, name, base string) erro
 		return err
 	}
 
+	config, err := s.workshopConfig(projectId, usr.Uid, usr.Gid, file)
+	if err != nil {
+		return err
+	}
 	req := api.InstancesPost{
 		InstancePut: api.InstancePut{
 			Devices: defaultDevices(),
-			Config:  s.defaultConfig(projectId, usr.Uid, usr.Gid),
+			Config:  config,
 		},
-		Name: InstanceName(name, projectId),
+		Name: InstanceName(file.Name, projectId),
 		Type: api.InstanceType("container"),
 		Source: api.InstanceSource{
 			Type:        "image",
@@ -161,12 +166,12 @@ func (s *LxdBackend) LaunchWorkshop(ctx context.Context, name, base string) erro
 		return err
 	}
 
-	_, _, err = conn.GetImageAlias(base)
+	_, _, err = conn.GetImageAlias(file.Base)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return err
 	} else if api.StatusErrorCheck(err, http.StatusNotFound) {
 		if err = conn.CreateImageAlias(api.ImageAliasesPost{ImageAliasesEntry: api.ImageAliasesEntry{
-			Name: base,
+			Name: file.Base,
 			ImageAliasesEntryPut: api.ImageAliasesEntryPut{
 				Target: image.Fingerprint,
 			},
@@ -478,35 +483,23 @@ func installedContent(lxdConfig map[string]string) (map[string]sdk.Setup, error)
 }
 
 func (s *LxdBackend) loadWorkshop(inst *api.Instance, p *Project) (*Workshop, error) {
-	var err error
-	var running bool
-
-	name := WorkshopName(inst.Name)
-
-	if inst.StatusCode == api.Running || inst.StatusCode == api.Ready {
-		running = true
-	}
-
 	base := inst.Config["image.os"] + "@" + inst.Config["image.version"]
-	if base == "" {
-		base = "unknown"
-	}
-
-	var workshop = &Workshop{
-		backend: s,
-		project: p,
-		Name:    name,
-		running: running,
-		base:    base,
-		devices: inst.Devices,
-	}
 
 	// Fetch information about the installed SDKs
-	workshop.content, err = installedContent(inst.Config)
+	content, err := installedContent(inst.Config)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load workshop: installed SDK content is not readable: %v", err)
 	}
-	return workshop, nil
+
+	return &Workshop{
+		Name:    WorkshopName(inst.Name),
+		backend: s,
+		project: p,
+		running: inst.StatusCode == api.Running || inst.StatusCode == api.Ready,
+		base:    base,
+		devices: inst.Devices,
+		content: content,
+	}, nil
 }
 
 func (s *LxdBackend) filterLxdInstancesByConfig(conn lxd.InstanceServer, filter WorkshopConfigFilter) ([]api.Instance, error) {
@@ -716,7 +709,7 @@ func createDefaultDevices() map[string]map[string]string {
 	}
 }
 
-func (s *LxdBackend) defaultConfig(projectId string, userid, groupid string) map[string]string {
+func (s *LxdBackend) workshopConfig(projectId string, userid, groupid string, file *WorkshopFile) (map[string]string, error) {
 	cloudInitConfig := `#cloud-config
 users:
   - default
@@ -726,11 +719,18 @@ users:
     groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video,render
     shell: /bin/bash
 `
+
+	workshopFile, err := yaml.Marshal(file)
+	if err != nil {
+		return map[string]string{}, nil
+	}
+
 	cfg := map[string]string{
 		"raw.idmap":                fmt.Sprint("uid ", userid, " 1000\ngid ", groupid, " 1000"),
 		"security.nesting":         "true",
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,
+		"user.workshop.file":       string(workshopFile),
 	}
 
 	if s.nvidiaRuntime {
@@ -739,7 +739,7 @@ users:
 		cfg["nvidia.driver.capabilities"] = "all"
 		cfg["nvidia.runtime"] = "true"
 	}
-	return cfg
+	return cfg, nil
 }
 
 func (s *LxdBackend) fetchRemoteImage(base string) (lxd.ImageServer, *api.Image, error) {

--- a/internal/workshopbackend/lxd_backend_mock.go
+++ b/internal/workshopbackend/lxd_backend_mock.go
@@ -99,7 +99,7 @@ func (f *FakeWorkshopBackend) project(user, id string) *Project {
 	return nil
 }
 
-func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, name, base string) error {
+func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *WorkshopFile) error {
 	user, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, name, base str
 	if f.Workshops[projectId] == nil {
 		f.Workshops[projectId] = make(map[string]*FakeWorkshop)
 	}
-	if _, ok := f.Workshops[projectId][name]; ok {
+	if _, ok := f.Workshops[projectId][file.Name]; ok {
 		return api.StatusErrorf(http.StatusNotFound, "workshop exists already")
 	}
 
@@ -119,20 +119,15 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, name, base str
 	ws.WorkshopFilesystem = NewFakeWorkshopFs()
 
 	ws.Workshop = &Workshop{backend: f,
-		Name:    name,
+		Name:    file.Name,
 		devices: defaultDevices(),
 		running: true,
 		project: prj,
 		content: make(map[string]sdk.Setup),
-		base:    base,
+		base:    file.Base,
 	}
 
-	f.Workshops[projectId][name] = ws
-
-	file, err := prj.WorkshopFile(name)
-	if err != nil {
-		return err
-	}
+	f.Workshops[projectId][file.Name] = ws
 	for _, s := range file.Sdks {
 		ws.LinkSdk(ctx, sdk.Setup{
 			Name:    s.Name,

--- a/internal/workshopbackend/lxd_backend_test.go
+++ b/internal/workshopbackend/lxd_backend_test.go
@@ -215,10 +215,11 @@ func (f *LxdBeTests) TestReadProjectsSuccess(c *check.C) {
 func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 	// Setup
 	b := &workshopbackend.LxdBackend{}
+	file := &workshopbackend.WorkshopFile{Name: "test", Base: "ubuntu@22.04"}
 	b.SetNvidia(true)
 
 	// Execute
-	cfg := workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001")
+	cfg, _ := workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file)
 
 	// Validate
 	c.Assert(cfg["raw.idmap"], check.Equals, "uid 1001 1000\ngid 1001 1000")
@@ -227,12 +228,15 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 
 	c.Assert(cfg["nvidia.runtime"], check.Equals, "true")
 	c.Assert(cfg["nvidia.driver.capabilities"], check.Equals, "all")
+	c.Assert(cfg["user.workshop.file"], check.Equals, `name: test
+base: ubuntu@22.04
+`)
 
 	// Setup
 	b.SetNvidia(false)
 
 	// Execute
-	cfg = workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001")
+	cfg, _ = workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file)
 
 	// Validate
 	c.Assert(cfg["nvidia.runtime"], check.Equals, "")

--- a/internal/workshopbackend/tests/integration/helper_test.go
+++ b/internal/workshopbackend/tests/integration/helper_test.go
@@ -20,7 +20,7 @@ var minimalImageServer = "https://cloud-images.ubuntu.com/minimal/releases/"
 
 func defaultTestDevices() map[string]map[string]string {
 	return map[string]map[string]string{
-		"root":             {"type": "disk", "pool": "testZfsProfile", "path": "/"},
+		"root":             {"type": "disk", "pool": "default", "path": "/"},
 		"workshop.network": {"type": "nic", "network": "lxdbr0", "name": "eth0"},
 	}
 }
@@ -94,13 +94,13 @@ func launchTestWorkshop(c *check.C, ctx context.Context, be workshopbackend.Work
 
 	var err error
 
-	os.WriteFile(filepath.Join(dir, ".workshop.test.yaml"), []byte(`name: test
-base: ubuntu@22.04
-`), 0644)
+	wf := &workshopbackend.WorkshopFile{Name: "test", Base: "ubuntu@22.04"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.test.yaml"), []byte(`name: test
+base: ubuntu@22.04`), 0644), check.IsNil)
 
 	_, _, err = be.CreateOrLoadProject(ctx, dir)
 	c.Assert(err, check.IsNil)
-	err = be.LaunchWorkshop(ctx, "test", "ubuntu@22.04")
+	err = be.LaunchWorkshop(ctx, wf)
 	c.Assert(err, check.IsNil)
 	err = be.StartWorkshop(ctx, "test")
 	c.Assert(err, check.IsNil)

--- a/internal/workshopbackend/tests/integration/profile_test.go
+++ b/internal/workshopbackend/tests/integration/profile_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 
 	lxd "github.com/canonical/lxd/client"
-	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
 	"gopkg.in/check.v1"
@@ -38,14 +37,10 @@ func (f *profileTest) SetUpSuite(c *check.C) {
 
 	f.be = &workshopbackend.LxdBackend{}
 	f.client, _ = f.be.(*workshopbackend.LxdBackend).LxdClient(f.ctx)
-	err := f.client.CreateStoragePool(api.StoragePoolsPost{StoragePoolPut: api.StoragePoolPut{Config: map[string]string{"volume.size": "1GiB"}}, Name: "testZfsProfile", Driver: "zfs"})
-	c.Assert(err, check.IsNil)
 }
 
 func (f *profileTest) TearDownSuite(c *check.C) {
 	f.client, _ = f.be.(*workshopbackend.LxdBackend).LxdClient(f.ctx)
-	err := f.client.DeleteStoragePool("testZfsProfile")
-	c.Check(err, check.IsNil)
 }
 
 func (f *profileTest) SetUpTest(c *check.C) {

--- a/internal/workshopbackend/tests/integration/workshop_exec_test.go
+++ b/internal/workshopbackend/tests/integration/workshop_exec_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	lxd "github.com/canonical/lxd/client"
-	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/daemon"
 	"github.com/canonical/workshop/internal/testutil"
@@ -96,9 +95,6 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 
 	f.restoreDevices = workshopbackend.FakeDefaultDevices(defaultTestDevices)
 
-	err = f.lxdClient.CreateStoragePool(api.StoragePoolsPost{StoragePoolPut: api.StoragePoolPut{Config: map[string]string{"volume.size": "1GiB"}}, Name: "testZfsProfile", Driver: "zfs"})
-	c.Assert(err, check.IsNil)
-
 	f.newProjectidRestore = testutil.FakeFunc(func() (string, error) {
 		return f.project.ProjectId, nil
 	}, &workshopbackend.NewProjectId)
@@ -110,8 +106,6 @@ func (f *wsExec) TearDownSuite(c *check.C) {
 	err := f.be.RemoveWorkshop(f.ctx, "test")
 	c.Check(err, check.IsNil)
 	err = f.daemon.Stop(nil)
-	c.Check(err, check.IsNil)
-	err = f.lxdClient.DeleteStoragePool("testZfsProfile")
 	c.Check(err, check.IsNil)
 	f.lookupUserRestore()
 	f.lookupUserIdRestore()

--- a/internal/workshopbackend/tests/integration/workshop_test.go
+++ b/internal/workshopbackend/tests/integration/workshop_test.go
@@ -9,7 +9,6 @@ import (
 	"os/user"
 
 	lxd "github.com/canonical/lxd/client"
-	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/daemon"
 	"github.com/canonical/workshop/internal/testutil"
@@ -111,17 +110,9 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 	f.username = "testuser"
 	f.restoreDevices = workshopbackend.FakeDefaultDevices(defaultTestDevices)
 	f.restoreImageServer = workshopbackend.FakeImageServer(minimalImageServer)
-	ctx := createTestContext(f.username, "42424242")
-	be := &workshopbackend.LxdBackend{}
-	client, err := be.LxdClient(ctx)
-	c.Assert(err, check.IsNil)
-	err = client.CreateStoragePool(api.StoragePoolsPost{StoragePoolPut: api.StoragePoolPut{Config: map[string]string{"volume.size": "1GiB"}}, Name: "testZfsProfile", Driver: "zfs"})
-	c.Assert(err, check.IsNil)
 }
 
 func (f *wsOps) TearDownSuite(c *check.C) {
-	err := f.lxdClient.DeleteStoragePool("testZfsProfile")
-	c.Check(err, check.IsNil)
 	cleanUpLxdProject(c, f.lxdClient, workshopbackend.LxdProjectName(f.username))
 	cleanUpLxdProject(c, f.lxdClient, workshopbackend.LxdSystemProjectName(f.username))
 	f.restoreDevices()
@@ -203,7 +194,8 @@ func (f *wsOps) TestLxdBackendStateStorageVolumeAddRemove(c *check.C) {
 
 func (f *wsOps) TestLxdBackendRemoveWorkshopStash(c *check.C) {
 	// Setup
-	err := f.be.LaunchWorkshop(f.ctx, "test-1", "ubuntu@22.04")
+	wf := &workshopbackend.WorkshopFile{Name: "test-1", Base: "ubuntu@20.04"}
+	err := f.be.LaunchWorkshop(f.ctx, wf)
 	defer f.be.RemoveWorkshop(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
 
@@ -225,7 +217,8 @@ func (f *wsOps) TestLxdBackendRemoveWorkshopStash(c *check.C) {
 
 func (f *wsOps) TestLxdBackendStartWorkshop(c *check.C) {
 	// Setup
-	err := f.be.LaunchWorkshop(f.ctx, "test-1", "ubuntu@22.04")
+	wf := &workshopbackend.WorkshopFile{Name: "test-1", Base: "ubuntu@20.04"}
+	err := f.be.LaunchWorkshop(f.ctx, wf)
 	c.Assert(err, check.IsNil)
 	defer f.be.RemoveWorkshop(f.ctx, "test-1")
 
@@ -270,7 +263,8 @@ func (f *wsOps) TestLxdBackendStartWorkshop(c *check.C) {
 
 func (f *wsOps) TestLxdBackendDeleteWorkshop(c *check.C) {
 	// Execute
-	err := f.be.LaunchWorkshop(f.ctx, "test-1", "ubuntu@22.04")
+	wf := &workshopbackend.WorkshopFile{Name: "test-1", Base: "ubuntu@22.04"}
+	err := f.be.LaunchWorkshop(f.ctx, wf)
 	c.Assert(err, check.IsNil)
 	err = f.be.StartWorkshop(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)

--- a/internal/workshopbackend/tests/integration/workshop_test.go
+++ b/internal/workshopbackend/tests/integration/workshop_test.go
@@ -212,7 +212,7 @@ func (f *wsOps) TestLxdBackendRemoveWorkshopStash(c *check.C) {
 	c.Assert(err, check.IsNil)
 	cli := f.lxdClient.UseProject(workshopbackend.LxdSystemProjectName(f.username))
 	_, _, err = cli.GetInstance(workshopbackend.InstanceName("test-1", f.project.ProjectId))
-	c.Assert(err, check.ErrorMatches, "Instance not found")
+	c.Assert(err, check.ErrorMatches, ".*Instance not found")
 }
 
 func (f *wsOps) TestLxdBackendStartWorkshop(c *check.C) {

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -13,10 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/canonical/workshop/internal/dirs"
-	"github.com/canonical/workshop/internal/sdk"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 var InstallTimeNow = time.Now

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -13,28 +13,20 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
-
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/sdk"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 var InstallTimeNow = time.Now
 
-func NewWorkshop(backend WorkshopBackend, project *Project, name string) *Workshop {
-	return &Workshop{
-		Name:    name,
-		project: project,
-		backend: backend,
-	}
-}
-
 type Workshop struct {
+	Name string
+
 	backend WorkshopBackend
 	project *Project
 	base    string
-	Name    string
 	devices map[string]map[string]string
 	content map[string]sdk.Setup
 	running bool
@@ -56,21 +48,12 @@ func (w *Workshop) Project() *Project {
 	return w.project
 }
 
-func (w *Workshop) File() (*WorkshopFile, error) {
-	return w.project.WorkshopFile(w.Name)
-}
-
-func (w *Workshop) Content() []sdk.Setup {
-	content := maps.Values(w.content)
-	slices.SortFunc(content, func(a, b sdk.Setup) int { return cmp.Compare(a.Name, b.Name) })
-	return content
-}
-
 // Associate an SDK with the workshop by creating a 'current' symlink and adding
 // the SDK to the workshop content. This method is idempotent, so if an SDK
 // existed, the result will be a no-op
 func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
-	s.InstallTime = InstallTimeNow()
+	now := InstallTimeNow()
+	s.InstallTime = &now
 	w.content[s.Name] = s
 
 	sequenceValue, err := json.Marshal(w.content)
@@ -156,12 +139,7 @@ func WorkshopStateVolumeName(ws, pid string) string {
 	return fmt.Sprintf("%s-state-volume", InstanceName(ws, pid))
 }
 
-// Reads information about the installed SDK from its meta file
-
-// NOTE: we have to accept the filesystem as an argument to ensure it is the
-// callers responsibility to get and close the filesystem due to the LXD's bug:
-// if the filesystem of the container is not closed, it maintains the underlying
-// SFTP connection which stops the container from stoppping.
+// Reads information about the installed SDK from its meta file.
 func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, error) {
 	projectId, ok := ctx.Value(ContextProjectId).(string)
 	if !ok {
@@ -194,6 +172,15 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	return info, nil
 }
 
+// Returns a list of installed SDKs.
+func (w *Workshop) Content() []sdk.Setup {
+	content := maps.Values(w.content)
+	slices.SortFunc(content, func(a, b sdk.Setup) int { return cmp.Compare(a.Name, b.Name) })
+	return content
+}
+
+// Returns a list of SDK info for installed SDKs. The info includes SDK details
+// parsed from its sdk.yaml, such as base, plugs, slots, etc.
 func (w *Workshop) ContentInfo(ctx context.Context) ([]*sdk.Info, error) {
 	var infos = make([]*sdk.Info, 0, len(w.content))
 	for _, sdk := range w.content {

--- a/internal/workshopbackend/workshop_file.go
+++ b/internal/workshopbackend/workshop_file.go
@@ -12,16 +12,16 @@ import (
 )
 
 type SdkRecord struct {
-	Name    string `json:"name"`
-	Channel string `json:"channel"`
+	Name    string `yaml:"name"`
+	Channel string `yaml:"channel"`
 }
 
 type SdkList []SdkRecord
 
 type WorkshopFile struct {
-	Name string `yaml:"name" json:"name"`
-	Base string `yaml:"base" json:"base"`
-	Sdks SdkList
+	Name string  `yaml:"name"`
+	Base string  `yaml:"base"`
+	Sdks SdkList `yaml:"sdks,omitempty"`
 }
 
 func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
@@ -46,9 +46,6 @@ func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
 			return err
 		}
 	}
-	slices.SortFunc(*p, func(a, b SdkRecord) int {
-		return cmp.Compare(a.Name, b.Name)
-	})
 	return nil
 }
 
@@ -64,6 +61,10 @@ func readWorkshop(pathname string) (*WorkshopFile, error) {
 	if err = yaml.Unmarshal(buf, &file); err != nil {
 		return nil, err
 	}
+
+	slices.SortFunc(file.Sdks, func(a, b SdkRecord) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 
 	// Validate workshop properties
 	if !sdk.ValidName.MatchString(file.Name) {

--- a/internal/workshopbackend/workshop_file_test.go
+++ b/internal/workshopbackend/workshop_file_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
-type F struct {
+type workshopFile struct {
 	fs afero.Fs
 }
 
-var _ = check.Suite(&F{})
+var _ = check.Suite(&workshopFile{})
 
-func (f *F) SetUpTest(c *check.C) {
+func (f *workshopFile) SetUpTest(c *check.C) {
 	f.fs = afero.NewMemMapFs()
 }
 
@@ -27,7 +27,7 @@ func workshopFilePath(dir, name string) string {
 	return filepath.Join(dir, fmt.Sprintf(".workshop.%s.yaml", name))
 }
 
-func (f *F) TestWorkshopFileParse(c *check.C) {
+func (f *workshopFile) TestWorkshopFileParse(c *check.C) {
 	buf := []byte(`name: xbert-gpu
 base: ubuntu@20.04
 sdks:
@@ -59,7 +59,7 @@ sdks:
 	c.Assert(file.Sdks[3].Channel, check.Equals, "latest/candidate")
 }
 
-func (f *F) TestWorkshopFileDuplicateSdks(c *check.C) {
+func (f *workshopFile) TestWorkshopFileDuplicateSdks(c *check.C) {
 	buf := []byte(`name: xbert-gpu
 base: ubuntu@20.04
 sdks:
@@ -75,7 +75,7 @@ sdks:
 	c.Assert(err, check.NotNil)
 }
 
-func (f *F) TestWorkshopFileReservedNames(c *check.C) {
+func (f *workshopFile) TestWorkshopFileReservedNames(c *check.C) {
 	buf := []byte(`name: xbert-gpu
 base: ubuntu@20.04
 sdks:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,7 +45,7 @@ parts:
       - CGO_LDFLAGS: "-Wl,-rpath=/snap/core22/current/lib/x86_64-linux-gnu -Wl,--disable-new-dtags -Wl,-dynamic-linker=/snap/core22/current/lib64/ld-linux-x86-64.so.2"
       - CGO_LDFLAGS_ALLOW: ".*"
     override-build: |
-      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/workshop" ./cmd/workshop
+      CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/workshop" ./cmd/workshop
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/workshopd" ./cmd/workshopd
       CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/workshopctl" ./cmd/workshopctl
     prime:

--- a/tests/documentation/how-to-debug-issues/task.yaml
+++ b/tests/documentation/how-to-debug-issues/task.yaml
@@ -1,9 +1,4 @@
 summary: Test 'How to debug issues in workshops' to ensure it's operational
-
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
-
 execute: |
   . "$TESTSLIB"/utils.sh
   

--- a/tests/documentation/how-to-git-worktree/task.yaml
+++ b/tests/documentation/how-to-git-worktree/task.yaml
@@ -1,9 +1,4 @@
 summary: Test 'How to use workshops with Git' to ensure it's operational
-
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
-
 execute: |
   . "$TESTSLIB"/utils.sh
   PROJECT=$(pwd)

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -1,9 +1,4 @@
 summary: Run tutorial commands to ensure it's operational
-
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
-
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/integration/profile/task.yaml
+++ b/tests/integration/profile/task.yaml
@@ -1,4 +1,4 @@
 summary: Run LXD integration tests for SDK profiles
 
 execute: |
-  go test $SPREAD_PATH/internal/workshopbackend/tests/integration -timeout=30m -tags=integration -check.f profileTest
+  go test $SPREAD_PATH/internal/workshopbackend/tests/integration -timeout=30m -tags=integration -check.v -check.f profileTest

--- a/tests/integration/project-tracking/task.yaml
+++ b/tests/integration/project-tracking/task.yaml
@@ -1,4 +1,4 @@
 summary: Run LXD integration tests for project tracking
 
 execute: |
-  go test $SPREAD_PATH/internal/workshopbackend/tests/integration -timeout=30m -tags=integration -check.f wsProject
+  go test $SPREAD_PATH/internal/workshopbackend/tests/integration -timeout=30m -tags=integration -check.v -check.f wsProject

--- a/tests/integration/workshop-exec/task.yaml
+++ b/tests/integration/workshop-exec/task.yaml
@@ -1,4 +1,4 @@
 summary: Run LXD integration tests for workshop exec 
 
 execute: |
-  go test $SPREAD_PATH/internal/workshopbackend/tests/integration -timeout=30m -tags=integration -check.f wsExec
+  go test $SPREAD_PATH/internal/workshopbackend/tests/integration -timeout=30m -tags=integration -check.v -check.f wsExec

--- a/tests/integration/workshop-ops/task.yaml
+++ b/tests/integration/workshop-ops/task.yaml
@@ -1,4 +1,4 @@
 summary: Run LXD integration tests for workshop operations (launch, delete, attach storage, etc.)
 
 execute: |
-  go test $SPREAD_PATH/internal/workshopbackend/tests/integration -timeout=30m -tags=integration -check.f wsOps
+  go test $SPREAD_PATH/internal/workshopbackend/tests/integration -timeout=30m -tags=integration -check.v -check.f wsOps

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -2,17 +2,23 @@
 
 # Install and uninstall workshopd
 
+function init_lxd() {
+  snap install lxd --classic
+  snap refresh lxd --channel=latest/stable
+  
+  # can already be initialised if reused
+  # https://discuss.linuxcontainers.org/t/how-do-i-know-if-lxd-is-initialized/15473/3
+  if [ $(lxc storage list -f compact | grep -c default) -eq 0  ]; then   
+      lxd init --auto --storage-backend=zfs
+  fi
+}
+
 function prepare_environment() {
   systemctl unmask snapd.service
   systemctl start snapd.service
   
-  snap install go --classic
-  
-  snap install lxd --classic
-  snap refresh lxd --channel=latest/stable
-  
-  lxd init --auto
-  
+  init_lxd  
+  snap install go --classic --channel=1.21/stable
   snap install yq
   apt install jq -y --no-install-recommends
   
@@ -23,7 +29,9 @@ function prepare_environment() {
 
 function cleanup_environment() {
   snap remove workshop --purge
-  snap remove lxd
+  lxc delete $(lxc list -c n -f csv --project workshop.ubuntu) --force --project workshop.ubuntu
+  lxc project set workshop.ubuntu user.workshop.projects ""
+  find /workshop -name .workshop.lock -delete
 }
 
 function start_sdk_store() {
@@ -59,15 +67,6 @@ function publish_test_sdk_content() {
       mkdir -p "$STORE_PATH"
       mv "$SDK_FILE" "$STORE_PATH"
     done
-}
-
-# General functions
-function cleanup() {
-  lxc delete $(lxc list -c n -f csv --project workshop.ubuntu) --force --project workshop.ubuntu
-  lxc project set workshop.ubuntu user.workshop.projects ""
-  for i in "$1"/*/; do
-    rm -f "$i"/.workshop.lock
-  done
 }
 
 # Workshop sub-command wrappers

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -3,10 +3,15 @@
 # Install and uninstall workshopd
 
 function prepare_environment() {
+  systemctl unmask snapd.service
+  systemctl start snapd.service
+  
   snap install go --classic
-
+  
   snap install lxd --classic
-  lxd init --auto --storage-backend zfs
+  snap refresh lxd --channel=latest/stable
+  
+  lxd init --auto
   
   snap install yq
   apt install jq -y --no-install-recommends
@@ -32,7 +37,7 @@ function start_sdk_store() {
 
   echo "Waiting for the fake SDK store to start on port 8080..."
   while ! nc -z localhost 8080; do
-    sleep 0.1
+    sleep 2
   done
 }
 

--- a/tests/main/changes/task.yaml
+++ b/tests/main/changes/task.yaml
@@ -1,17 +1,10 @@
 summary: Ensure the changes command output correctness
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
-
 execute: |
   . "$TESTSLIB"/utils.sh
-  
-  project=$(pwd)
-  
-  echo "workshop changes will not produce any output if there are no changes"
-  workshop_exec --project "$project" changes | MATCH "^$"
-
-  workshop_exec --project "$project" launch ws
+    
+  workshop_exec launch ws
 
   echo "The launch change must present in the list"
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
+  
+  workshop_exec remove ws

--- a/tests/main/check-health/task.yaml
+++ b/tests/main/check-health/task.yaml
@@ -1,26 +1,23 @@
 summary: Check check-health hook and set-health reporting
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
-
 execute: |
   . "$TESTSLIB"/utils.sh
-
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws
+  
+  workshop_exec launch ws
 
   echo "Check health reported okay"
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
-  workshop_exec refresh --project "$project" ws  
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws\" workshop$"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$" 
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
+  workshop_exec refresh ws  
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws\" workshop$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$" 
+  workshop_exec remove ws
 
   echo "Check health reported waiting"  
-  workshop_exec --project "$project" launch ws-waiting    
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-waiting\" workshop$"
-  workshop_exec refresh --project "$project" ws-waiting
+  workshop_exec launch ws-waiting    
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-waiting\" workshop$"
+  workshop_exec refresh ws-waiting
+  workshop_exec remove ws-waiting
   
   echo "Check health reported error"
-  workshop_exec --project "$project" launch ws-error || true
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Error[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-error\" workshop$"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws-error[[:space:]]+Off[[:space:]]+-$" 
+  workshop_exec launch ws-error || true
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Error[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-error\" workshop$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws-error[[:space:]]+Off[[:space:]]+-$" 

--- a/tests/main/connect/task.yaml
+++ b/tests/main/connect/task.yaml
@@ -1,32 +1,31 @@
 summary: Check that "workshop connect" works as expected
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-1
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
-
+  workshop_exec remove ws-1
 execute: |
   . "$TESTSLIB"/utils.sh
-
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws-1
   
   echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot> form"
-  workshop_exec --project "$project" disconnect ws-1/test-sdk-content:content-plug-one ws-1/agent:content  
-  workshop_exec --project "$project" connect ws-1/test-sdk-content:content-plug-one ws-1/agent:content
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+manual$"
+  workshop_exec disconnect ws-1/test-sdk-content:content-plug-one ws-1/agent:content  
+  workshop_exec connect ws-1/test-sdk-content:content-plug-one ws-1/agent:content
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+manual$"
   
   echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk> form"
-  workshop_exec --project "$project" disconnect ws-1/test-sdk-content:content-plug-two :content
-  workshop_exec --project "$project" connect ws-1/test-sdk-content:content-plug-two ws-1/agent
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+manual$"
+  workshop_exec disconnect ws-1/test-sdk-content:content-plug-two :content
+  workshop_exec connect ws-1/test-sdk-content:content-plug-two ws-1/agent
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+manual$"
   
   echo "Check connect <workshop>/<sdk>:<plug> form"
-  workshop_exec --project "$project" disconnect ws-1/test-sdk-gpu:gpu
-  workshop_exec --project "$project" connect ws-1/test-sdk-gpu:gpu
-  workshop_exec --project "$project" connections ws-1 | MATCH "^gpu.+ws-1/test-sdk-gpu:gpu.+:gpu.+manual$"
+  workshop_exec disconnect ws-1/test-sdk-gpu:gpu
+  workshop_exec connect ws-1/test-sdk-gpu:gpu
+  workshop_exec connections ws-1 | MATCH "^gpu.+ws-1/test-sdk-gpu:gpu.+:gpu.+manual$"
   
   echo "Check workshop refresh reconnects manually connected connections"
-  workshop_exec --project "$project" refresh ws-1
-  workshop_exec --project "$project" connections ws-1 > output.log
+  workshop_exec refresh ws-1
+  workshop_exec connections ws-1 > output.log
   MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+manual$" < output.log
   MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+manual$" < output.log
   MATCH "^gpu.+ws-1/test-sdk-gpu:gpu.+:gpu.+manual$" < output.log

--- a/tests/main/connections/task.yaml
+++ b/tests/main/connections/task.yaml
@@ -1,21 +1,19 @@
 summary: Check that "workshop connections" works as expected
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-1 ws-2  
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
-
+  workshop_exec remove ws-1 ws-2
 execute: |
   . "$TESTSLIB"/utils.sh
-
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws-1
-  workshop_exec --project "$project" launch ws-2
   
   echo "Check connections for a workshop name provided"
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+\-$"  
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+\-$"  
   
   echo "Check connections for all workshops of the project"
-  workshop_exec --project "$project" connections  | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
-  workshop_exec --project "$project" connections  | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+\-$"  
-  workshop_exec --project "$project" connections  | MATCH "^content.+ws-2/test-sdk-content:content-plug-one.+:content.+\-$"
-  workshop_exec --project "$project" connections  | MATCH "^content.+ws-2/test-sdk-content:content-plug-two.+:content.+\-$"  
+  workshop_exec connections | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec connections | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+\-$"  
+  workshop_exec connections | MATCH "^content.+ws-2/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec connections | MATCH "^content.+ws-2/test-sdk-content:content-plug-two.+:content.+\-$"  

--- a/tests/main/disconnect/task.yaml
+++ b/tests/main/disconnect/task.yaml
@@ -1,34 +1,33 @@
 summary: Check that "workshop disconnect" works as expected
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-1  
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
-
+  workshop_exec remove ws-1
 execute: |
   . "$TESTSLIB"/utils.sh
-
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws-1
   
   echo "Check disconnect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot> form"
-  workshop_exec --project "$project" disconnect ws-1/test-sdk-content:content-plug-one ws-1/agent:content  
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+-.+\-$"
+  workshop_exec disconnect ws-1/test-sdk-content:content-plug-one ws-1/agent:content  
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+-.+\-$"
   
   echo "Check disconnect <workshop>/<sdk>:<plug> :<slot> form (agent SDK)"
-  workshop_exec --project "$project" disconnect ws-1/test-sdk-content:content-plug-two :content  
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+-.+\-$"
+  workshop_exec disconnect ws-1/test-sdk-content:content-plug-two :content  
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+-.+\-$"
   
   echo "Check 'workshop remove' does not leave the undesired connections for the workshop (the automatic connections will exist after remove-launch)"
-  workshop_exec --project "$project" remove ws-1
-  workshop_exec --project "$project" launch ws-1
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+\-$"  
+  workshop_exec remove ws-1
+  workshop_exec launch ws-1
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-two.+:content.+\-$"  
 
   echo "Check disconnect <workshop>/<sdk>:<plug or slot> form (must disconnect all slots auto connections)"
-  workshop_exec --project "$project" disconnect ws-1/agent:content
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+-.+\-$"
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+-.+\-$"  
+  workshop_exec disconnect ws-1/agent:content
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+-.+\-$"
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+-.+\-$"  
   
   echo "Check disconnect --forget (reconnects after refresh)"
-  workshop_exec --project "$project" disconnect ws-1/test-sdk-content:content-plug-one --forget
-  workshop_exec --project "$project" refresh ws-1
-  workshop_exec --project "$project" connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec disconnect ws-1/test-sdk-content:content-plug-one --forget
+  workshop_exec refresh ws-1
+  workshop_exec connections ws-1 | MATCH "^content.+ws-1/test-sdk-content:content-plug-one.+:content.+\-$"

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -1,28 +1,26 @@
 summary: Check major workshop exec scenarios
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
-
+  workshop_exec remove ws
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  echo "Launch a workshop"
-  project=$(pwd)
-  workshop_exec --project ""$project"" launch ws
-
   echo "Check an environment variable can be set"
-  workshop_exec exec --project "$project" --env 'Foo=bar'  ws -- bash -c 'echo -n $Foo' | MATCH bar
+  workshop_exec exec --env 'Foo=bar'  ws -- bash -c 'echo -n $Foo' | MATCH bar
 
   echo "Check default user and group"
-  workshop_exec exec --project "$project" ws -- bash -c 'id -u -n' | MATCH workshop
-  workshop_exec exec --project "$project" ws -- bash -c 'id -g -n' | MATCH workshop
+  workshop_exec exec ws -- bash -c 'id -u -n' | MATCH workshop
+  workshop_exec exec ws -- bash -c 'id -g -n' | MATCH workshop
 
   echo "Check working directory setup"
-  workshop_exec exec --project "$project" ws -- pwd | MATCH '/project'
-  workshop_exec exec --project "$project" -w /home/workshop ws -- pwd | MATCH '/home/workshop'
+  workshop_exec exec ws -- pwd | MATCH '/project'
+  workshop_exec exec -w /home/workshop ws -- pwd | MATCH '/home/workshop'
 
   echo "Check enforce non-interactive mode"
-  workshop_exec exec --project "$project" -I ws -- bash -c '[[ -t 1 ]] || echo -n nonterminal' | MATCH nonterminal
+  workshop_exec exec -I ws -- bash -c '[[ -t 1 ]] || echo -n nonterminal' | MATCH nonterminal
 
   #FIXME: this works in a terminal but not under spread This is due to the
   #websocket client implementation that closes the connection when a reader from
@@ -32,14 +30,14 @@ execute: |
   #by the time already (note: it is only relevant for the interactive sessions
   #where one websocket used for in/out)
   #echo "Check enforce interactive mode"
-  #workshop_exec exec --project "$project" --interactive ws -- bash -c 'echo -n terminal' | MATCH terminal
+  #workshop_exec exec --interactive ws -- bash -c 'echo -n terminal' | MATCH terminal
 
   echo "Check timeout"
-  workshop_exec exec --project "$project" --timeout 1s ws -- bash -c 'sleep 5' | MATCH ".*timed out after 1s.*"
+  workshop_exec exec --timeout 1s ws -- bash -c 'sleep 5' | MATCH ".*timed out after 1s.*"
 
   echo "Check stderr (workshop exec redirects stderr to stdout for MATCH to work)"
-  workshop_exec exec --project "$project" -I ws -- bash -c '>&2 echo -n stderr' | MATCH stderr
+  workshop_exec exec -I ws -- bash -c '>&2 echo -n stderr' | MATCH stderr
 
   echo "Check stopped workshop"
-  workshop_exec stop --project "$project" ws
-  workshop_exec exec --project "$project" ws pwd | MATCH '.*"ws" status is "Stopped", must be one of: "Ready", "Pending"$'
+  workshop_exec stop ws
+  workshop_exec exec ws pwd | MATCH '.*"ws" status is "Stopped", must be one of: "Ready", "Pending"$'

--- a/tests/main/info-sdk-health/task.yaml
+++ b/tests/main/info-sdk-health/task.yaml
@@ -1,16 +1,13 @@
 summary: |
   Check 'workshop info' SDK health reporting
-  
 prepare: |
-  sudo apt-add-repository universe
+  apt-add-repository -y universe
   apt install expect -y --no-install-recommends
-
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
-
+  apt remove -y expect
 execute: |
   . "$TESTSLIB"/utils.sh
-  PROJECT=$(pwd)  
-  workshop_exec --project "$PROJECT" launch ws --no-wait
+  workshop_exec launch ws --no-wait
   sudo -u ubuntu 2>&1 -- expect -f ./health.exp
+  workshop_exec remove ws

--- a/tests/main/info-sdk-health/task.yaml
+++ b/tests/main/info-sdk-health/task.yaml
@@ -2,6 +2,7 @@ summary: |
   Check 'workshop info' SDK health reporting
   
 prepare: |
+  sudo apt-add-repository universe
   apt install expect -y --no-install-recommends
 
 restore: |

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -1,7 +1,6 @@
 summary: Error states tracking and recovery for the .workshop.lock
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
   rm -rf ./new-project
 execute: |
   . "$TESTSLIB"/utils.sh

--- a/tests/main/interface-content/task.yaml
+++ b/tests/main/interface-content/task.yaml
@@ -1,62 +1,56 @@
 summary: Check content interface scenarios
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
 execute: |
   . "$TESTSLIB"/utils.sh
     
-  function validate_plugs() {
+  function validate_plug_mounts() {
     test -d "$source_one"
     test -d "$source_two"
-    workshop_exec exec --project $project ws -- bash -c "test -d /home/workshop"
-    workshop_exec exec --project $project ws -- bash -c "test -d /opt"
-    workshop_exec exec --project $project ws -- bash -c "touch /home/workshop/output"
+    workshop_exec exec ws -- bash -c "test -d /home/workshop"
+    workshop_exec exec ws -- bash -c "test -d /opt"
+    workshop_exec exec ws -- bash -c "touch /home/workshop/output"
     test -f "$source_one"/output
   }
   
   echo "Check the content interface plug can be installed and auto-connected"
-  project=$(pwd)
-  workshop_exec launch --project $project ws
+  workshop_exec launch ws
   
-  project_id=$(cat "$project"/.workshop.lock)
-  workshop_exec --project $project changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
+  project_id=$(cat .workshop.lock)
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
   
   source_one="/home/ubuntu/.local/share/workshop/project/"$project_id"/content/ws_test-sdk-content_content-plug-one.sdk"
   source_two="/home/ubuntu/.local/share/workshop/project/"$project_id"/content/ws_test-sdk-content_content-plug-two.sdk"
-  validate_plugs
+  validate_plug_mounts
 
   echo "Check the content interface plugs auto-reconnected after refresh"
-  workshop_exec refresh --project $project ws
-  validate_plugs
+  workshop_exec refresh ws
+  validate_plug_mounts
   
   echo "Check the content interface plugs auto-reconnected if refresh fails"
-  sed -i 's/test-sdk-content/test-sdk-fail/g' $project/.workshop.ws.yaml
-  workshop_exec refresh --project $project ws || true
-  sed -i 's/test-sdk-fail/test-sdk-content/g' $project/.workshop.ws.yaml
-  validate_plugs
+  sed -i 's/test-sdk-content/test-sdk-fail/g' .workshop.ws.yaml
+  workshop_exec refresh ws || true
+  sed -i 's/test-sdk-fail/test-sdk-content/g' .workshop.ws.yaml
+  validate_plug_mounts
   
   echo "Check the content interface slots cannot be installed by a workshop"
-  sed -i 's/test-sdk-content/test-sdk-content-broken/g' $project/.workshop.ws.yaml
-  workshop_exec refresh --project $project ws 2>&1 | MATCH ".*installation not allowed by \"one\" slot rule of interface \"content\".*"
-  sed -i 's/test-sdk-content-broken/test-sdk-content/g' $project/.workshop.ws.yaml
-  validate_plugs
+  sed -i 's/test-sdk-content/test-sdk-content-broken/g' .workshop.ws.yaml
+  workshop_exec refresh ws 2>&1 | MATCH ".*installation not allowed by \"one\" slot rule of interface \"content\".*"
+  sed -i 's/test-sdk-content-broken/test-sdk-content/g' .workshop.ws.yaml
+  validate_plug_mounts
   
   echo "Check the content interface plugs removed after refresh if they don't exist anymore"
-  sed -i 's/test-sdk-content/test-sdk-basic/g' $project/.workshop.ws.yaml
-  workshop_exec refresh --project $project ws
-  sed -i 's/test-sdk-basic/test-sdk-content/g' $project/.workshop.ws.yaml
+  sed -i 's/test-sdk-content/test-sdk-basic/g' .workshop.ws.yaml
+  workshop_exec refresh ws
+  sed -i 's/test-sdk-basic/test-sdk-content/g' .workshop.ws.yaml
   # no bind mounts in the workshop after refresh
-  workshop_exec exec --project $project ws -- bash -c "test ! -d /home/workshop/one"
-  workshop_exec exec --project $project ws -- bash -c "test ! -d /two"
+  workshop_exec exec ws -- bash -c "test ! -d /home/workshop/one"
+  workshop_exec exec ws -- bash -c "test ! -d /two"
   # the source directory shall still exist after refresh
   test -d "$source_one"
   test -d "$source_two"
   
   echo "Check remove will also clean up the default content interface host locations"
-  workshop_exec remove --project $project ws
+  workshop_exec remove ws
   test ! -d "$source_one"
   test ! -d "$source_two"
-  
-
   
   

--- a/tests/main/interface-gpu/task.yaml
+++ b/tests/main/interface-gpu/task.yaml
@@ -1,19 +1,20 @@
 summary: Check GPU interface scenarios
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
+  workshop_exec remove ws
 execute: |
   . "$TESTSLIB"/utils.sh
   
   echo "Check the GPU interface plug can be auto-connected"
-  project=$(pwd)
-  workshop_exec launch --project "$project" ws
-  workshop_exec --project "$project" connections ws | MATCH "^gpu.+ws/test-sdk-gpu:gpu.+:gpu.+\-$"
+  workshop_exec connections ws | MATCH "^gpu.+ws/test-sdk-gpu:gpu.+:gpu.+\-$"
   
   echo "Check the GPU interface plug can be connected and disconnected manually"
-  workshop_exec --project "$project" disconnect ws/test-sdk-gpu:gpu  
-  workshop_exec --project "$project" connect ws/test-sdk-gpu:gpu
-  workshop_exec --project "$project" connections ws | MATCH "^gpu.+ws/test-sdk-gpu:gpu.+:gpu.+manual$"
+  workshop_exec disconnect ws/test-sdk-gpu:gpu  
+  workshop_exec connect ws/test-sdk-gpu:gpu
+  workshop_exec connections ws | MATCH "^gpu.+ws/test-sdk-gpu:gpu.+:gpu.+manual$"
   
   echo "Ensure a GPU device is created when connected"
   
@@ -21,7 +22,7 @@ execute: |
   # the interface being connected). However, given the VM env without a card0,
   # ensure that the LXD profile contains a gpu device with a proper
   # configuration.  
-  project_id=$(cat "$project"/.workshop.lock)
+  project_id=$(cat .workshop.lock)
   lxc profile show --project workshop.ubuntu ws-"$project_id"-test-sdk-gpu | yq '.devices.gpu' > output.log
   MATCH "type: gpu" < output.log
   MATCH "gputype: physical" < output.log

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -1,18 +1,13 @@
-summary: Ensure that 'workshop launch' creates a core LXD config correctly
-prepare: |
-  apt install jq -y --no-install-recommends
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
-  snap remove ya --purge
+summary: Ensure that launch creates a core LXD config correctly
 execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Check workshop can be launched with a basic SDK"
-  path=$(pwd)
-  workshop_exec --project "$path" launch ws
-  workshop_exec --project "$path" list | MATCH "$path[[:space:]]*ws[[:space:]]*Ready[[:space:]]*-"
+  workshop_exec launch ws
+  workshop_exec list | MATCH "$(pwd)[[:space:]]*ws[[:space:]]*Ready[[:space:]]*-"
   
   # Ensure there is one installed SDK that was provided in the workshop definition
-  workshop_exec --project "$path" info ws | grep -v notes | yq ".content | length == 1"
-  workshop_exec --project "$path" info ws | grep -v notes | yq '.content["test-sdk-basic"].channel' | MATCH "latest/stable"
+  workshop_exec info ws | grep -v notes | yq ".content | length == 1"
+  workshop_exec info ws | grep -v notes | yq '.content["test-sdk-basic"].channel' | MATCH "latest/stable"
+
+  workshop_exec remove ws

--- a/tests/main/launch/task.yaml
+++ b/tests/main/launch/task.yaml
@@ -1,7 +1,4 @@
-summary: Test 'workshop launch' for the supported workshop bases
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
+summary: Test launch for the supported workshop bases
 execute: |
   . "$TESTSLIB"/utils.sh
 
@@ -12,6 +9,7 @@ execute: |
     workshop_exec list | MATCH "$(pwd)[[:space:]]*$1[[:space:]]*Ready[[:space:]]*-"
     # ensure the workshop has a socket for workshopctl
     workshop_exec exec "$1" -- test -S /var/lib/workshop/.workshop.socket.untrusted
+    workshop_exec remove "$1"
   }
   
   launch_and_validate ws-20

--- a/tests/main/list-global/task.yaml
+++ b/tests/main/list-global/task.yaml
@@ -1,7 +1,6 @@
 summary: Test workshop list with a --global flag on
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
   for path in ./{*-copy,*-new}; do
     rm -rf "$path"
   done
@@ -29,4 +28,6 @@ execute: |
   workshop_exec --project $projects/project-2-copy launch ws
   rm -rf project-2-copy
   workshop_exec list --global | MATCH "^$projects/project-2-copy[[:space:]]+ws[[:space:]]+Error[[:space:]]+missing-project$"
-  
+
+  workshop_exec --project "$projects"/project-1 remove ws
+  workshop_exec --project "$projects"/project-2 remove ws

--- a/tests/main/list/task.yaml
+++ b/tests/main/list/task.yaml
@@ -8,7 +8,6 @@ summary: |
 
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
   for path in ./{*-copy,*-new}; do
     rm -rf "$path"
   done
@@ -44,6 +43,7 @@ execute: |
   # launch from a new directory successfully
   workshop_exec --project "$PROJECT"-copy launch ws
   workshop_exec --project "$PROJECT"-copy list | MATCH "^${PROJECT}-copy[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec --project "$PROJECT" remove ws
 
   # TODO:
   # mv dir dir-1

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -1,21 +1,21 @@
 summary: Check a failed non-transactional refresh can be aborted successfully
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
+  workshop_exec remove ws
 execute: |
   . "$TESTSLIB"/utils.sh
- 
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws
 
   echo "Update the workshop file to include a failing SDK"
-  sed -i 's/test-sdk-basic/test-sdk-setup-fail/g' $project/.workshop.ws.yaml
-  workshop_exec refresh --project "$project" --wait-on-error ws || true
-  sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' $project/.workshop.ws.yaml
+  sed -i 's/test-sdk-basic/test-sdk-setup-fail/g' .workshop.ws.yaml
+  workshop_exec refresh --wait-on-error ws || true
+  sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' .workshop.ws.yaml
 
   echo "Check the workshop is in Pending state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Pending[[:space:]]+wait-on-error$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Pending[[:space:]]+wait-on-error$"
 
   echo "Check the workshop refresh --abort reverts to the previous state"
-  workshop_exec refresh --project "$project" --abort ws | MATCH "\"ws\" refresh aborted"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec refresh --abort ws | MATCH "\"ws\" refresh aborted"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -1,27 +1,26 @@
 summary: Check a failed refresh can be fixed and continued successfully
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
-  
+  workshop_exec remove ws
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws
-
   echo "Update the workshop file to include a failing SDK"
-  sed -i 's/test-sdk-basic/test-sdk-setup-fail/g' "$project"/.workshop.ws.yaml
-  workshop_exec --project "$project" refresh --wait-on-error ws || true
-  sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' "$project"/.workshop.ws.yaml
+  sed -i 's/test-sdk-basic/test-sdk-setup-fail/g' .workshop.ws.yaml
+  workshop_exec refresh --wait-on-error ws || true
+  sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' .workshop.ws.yaml
 
   echo "Check the workshop is in Pending state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Pending[[:space:]]+wait-on-error$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Pending[[:space:]]+wait-on-error$"
 
   echo "\"Fix\" the SDK error by replacing the setup-base hook"
-  workshop_exec exec --project "$project" --uid 0 --gid 0 ws -- sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
+  workshop_exec exec --uid 0 --gid 0 ws -- sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
 
   echo "Check the workshop refresh --continue reverts to the previous state"
-  workshop_exec refresh --project "$project" --continue ws | MATCH "\"ws\" refreshed"
+  workshop_exec refresh --continue ws | MATCH "\"ws\" refreshed"
 
   echo "Check the workshop is in Ready state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -1,35 +1,28 @@
 summary: Check that basic refresh scenarios work correctly for the transactional mode
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws ws-sdk
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
-
+  workshop_exec remove ws ws-sdk
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  echo "Test refresh with an empty workshop"
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws
-
   echo "Check launch change is Done"
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws\" workshop$"
 
-  workshop_exec refresh --project "$project" ws
+  workshop_exec refresh ws
 
   echo "Check refresh change is Done"
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws\" workshop$"
 
   echo "Check the workshop is in Ready state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
 
-  echo "Test refresh with a basic SDK in the workshop"
-  workshop_exec --project "$project" launch ws-sdk
-  echo "Check launch change is Done"
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-sdk\" workshop$"
-
-  workshop_exec refresh --project "$project" ws-sdk
+  workshop_exec refresh ws-sdk
 
   echo "Check refresh change is Done"
-  workshop_exec --project "$project" changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws-sdk\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws-sdk\" workshop$"
 
   echo "Check the workshop is in Ready state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws-sdk[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws-sdk[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -1,35 +1,30 @@
 summary: Check workshop remount scenarios
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
 execute: |
   . "$TESTSLIB"/utils.sh
-
-  project=$(pwd)
-  workshop_exec launch --project "$project" ws  
   
+  workshop_exec launch ws  
   echo "Remount: the new source is empty or does not exist"
   new_source="/home/ubuntu/content-plug-one"
-  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-one "$new_source"
+  workshop_exec remount ws/test-sdk-content:content-plug-one "$new_source"
   test -d "$new_source"
   
   echo "Remount: check workshop info output"
-  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-one"]' | MATCH "^host:.*$new_source"
+  workshop_exec info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-one"]' | MATCH "^host:.*$new_source"
   
   echo "Remount: plugs remount sources are preserved after refresh"
-  workshop_exec refresh --project "$project" ws
-  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-one"]' | MATCH "^host:.*$new_source"
+  workshop_exec refresh ws
+  workshop_exec info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-one"]' | MATCH "^host:.*$new_source"
   
   echo "Remount: the new source is not empty"  
-  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-one /home/ubuntu  | MATCH ".*(new source is not empty; workshop must be stopped to remount safely)"
+  workshop_exec remount ws/test-sdk-content:content-plug-one /home/ubuntu  | MATCH ".*(new source is not empty; workshop must be stopped to remount safely)"
   
   echo "Remount: workshop stopped"
   new_source="/home/ubuntu/content-plug-two"
-  workshop_exec stop --project "$project" ws
-  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-two "$new_source"
-  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$new_source"
-  workshop_exec start --project "$project" ws
-  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$new_source"
+  workshop_exec stop ws
+  workshop_exec remount ws/test-sdk-content:content-plug-two "$new_source"
+  workshop_exec info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$new_source"
+  workshop_exec start ws
+  workshop_exec info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$new_source"
   test -d "$new_source"
   
   echo "Remount: new source is on a different filesystem"
@@ -38,14 +33,13 @@ execute: |
   mkdir -p /home/ubuntu/other-fs
   mount --bind "$otherfs" /home/ubuntu/other-fs
   mkdir "$otherfs_path"
-  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-two "$otherfs_path" | MATCH ".*(current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely)"
-  workshop_exec stop --project "$project" ws
-  workshop_exec remount --project "$project" ws/test-sdk-content:content-plug-two "$otherfs_path"
-  workshop_exec --project "$project" info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$otherfs_path"
-  
+  workshop_exec remount ws/test-sdk-content:content-plug-two "$otherfs_path" | MATCH ".*(current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely)"
+  workshop_exec stop ws
+  workshop_exec remount ws/test-sdk-content:content-plug-two "$otherfs_path"
+  workshop_exec info ws | grep -v notes | yq '.content["test-sdk-content"].mounts["content-plug-two"]' | MATCH "^host:.*$otherfs_path"
   
   echo "Remount: workshop remove does not delete remounted dirs"
-  workshop_exec remove --project "$project" ws
+  workshop_exec remove ws
   test -d "/home/ubuntu/content-plug-one"
   test -d "/home/ubuntu/content-plug-two"
 

--- a/tests/main/remove/task.yaml
+++ b/tests/main/remove/task.yaml
@@ -1,31 +1,26 @@
 summary: Check workshop remove
-restore: |
-  . "$TESTSLIB"/utils.sh
-  cleanup ./
-
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  project=$(pwd)
   echo "Launch a workshop"
-  workshop_exec --project "$project" launch  ws
+  workshop_exec launch  ws
 
   echo "Check the workshop can be removed if in Ready"
-  workshop_exec --project "$project" remove ws
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec remove ws
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Off[[:space:]]+-$"
 
   echo "Check the workshop can be removed if in Stopped"
-  workshop_exec --project "$project" launch ws
-  workshop_exec --project "$project" stop  ws
-  workshop_exec --project "$project" remove ws
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec launch ws
+  workshop_exec stop  ws
+  workshop_exec remove ws
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Off[[:space:]]+-$"
   
   echo "Check the workshop can be removed and SDKs disconnected"
-  workshop_exec --project "$project" launch  ws-content
-  workshop_exec --project "$project" remove ws-content
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws-content[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec launch  ws-content
+  workshop_exec remove ws-content
+  workshop_exec list | MATCH "^.+[[:space:]]+ws-content[[:space:]]+Off[[:space:]]+-$"
 
   echo "Check the workshop can be removed if in Error"
-  workshop_exec --project "$project" launch ws
-  rm -f "$project"/.workshop.ws.yaml
-  workshop_exec --project "$project" remove ws
+  workshop_exec launch ws
+  rm -f .workshop.ws.yaml
+  workshop_exec remove ws

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -1,21 +1,20 @@
 summary: Check workshop start
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
-
+  workshop_exec remove ws
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  echo "Launch a workshop"
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws
-  workshop_exec --project "$project" stop ws
+  workshop_exec stop ws
 
   echo "Check the workshop is in Stopped state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Stopped[[:space:]]+-$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Stopped[[:space:]]+-$"
 
   echo "Start the workshop"
-  workshop_exec --project "$project" start ws
+  workshop_exec start ws
 
   echo "Check the workshop is in Ready state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/stop/task.yaml
+++ b/tests/main/stop/task.yaml
@@ -1,22 +1,21 @@
 summary: Check workshop stop
+prepare: |  
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws
 restore: |
   . "$TESTSLIB"/utils.sh
-  cleanup ./
+  workshop_exec remove ws
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  echo "Launch a workshop"
-  project=$(pwd)
-  workshop_exec --project "$project" launch ws
-
   echo "Stop the workshop"
-  workshop_exec stop --project $project ws
+  workshop_exec stop ws
 
   echo "Check the workshop is in Stopped state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Stopped[[:space:]]+-$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Stopped[[:space:]]+-$"
 
   echo "Check stopping the Stopped workshop does not result in error"
-  workshop_exec --project "$project" stop ws
+  workshop_exec stop ws
 
   echo "Check the workshop is in Stopped state"
-  workshop_exec --project "$project" list | MATCH "^.+[[:space:]]+ws[[:space:]]+Stopped[[:space:]]+-$"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws[[:space:]]+Stopped[[:space:]]+-$"


### PR DESCRIPTION
# Description

This is a transitory PR that enables Workshop to use the original workshop configuration provided in a workshop file at launch or refresh task-sets. This will be used by such features as plug binding.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
