### PR TITLE
Parse and validate plug binding in workshop definition

### DIFF
--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -105,7 +105,7 @@ func (m *WorkshopManager) doMountProject(task *state.Task, tomb *tomb.Tomb) erro
 	}
 
 	// Configure workshop core properties: project directory
-	var prjMount = workshopbackend.Mount(workshopbackend.ProjectPathDevice, prj.Path, workshopbackend.WorkshopProjectPath)
+	var prjMount = workshopbackend.Mount(workshopbackend.LxdConfigProjectPathDevice, prj.Path, workshopbackend.WorkshopProjectPath)
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
 

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -125,7 +125,7 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshopbackend.Workshop) healthsta
 	}
 
 	// check if the workshop file exists
-	if _, err := ws.Project().WorkshopFile(ws.Name); err != nil {
+	if _, err := ws.Project().Workshop(ws.Name); err != nil {
 		healthState.Status = healthstate.ErrorStatus
 		healthState.Code = "missing-file"
 		return healthState

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -58,9 +58,9 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	taskset := make([]*state.TaskSet, 0, len(names))
 
 	for _, name := range names {
-		file, err := project.WorkshopFile(name)
+		file, err := project.Workshop(name)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read %q file: %w", name, err)
+			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
 
 		_, err = w.Workshop(ctx, name, projectId)
@@ -239,7 +239,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		if idx == -1 {
 			return nil, fmt.Errorf("cannot refresh: workshop %q not found", workshop)
 		}
-		file, err := project.WorkshopFile(workshops[idx].Name)
+		file, err := project.Workshop(workshops[idx].Name)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/workshopbackend/lxd_backend.go
+++ b/internal/workshopbackend/lxd_backend.go
@@ -66,9 +66,14 @@ var (
 	ConnectSimpleStreams = lxd.ConnectSimpleStreams
 	LookupUsername       = user.Lookup
 	NewProjectId         = allocateProjectId
-	defaultDevices       = createDefaultDevices
 
-	imageServer = "https://cloud-images.ubuntu.com/releases/"
+	defaultDevices = createDefaultDevices
+	imageServer    = "https://cloud-images.ubuntu.com/releases/"
+
+	LxdConfigProjectId         = "user.workshop.project-id"
+	LxdConfigWorkshopFile      = "user.workshop.file"
+	LxdConfigWorkshopContent   = "user.workshop.content"
+	LxdConfigProjectPathDevice = "workshop.project"
 )
 
 func New() (WorkshopBackend, error) {
@@ -117,12 +122,12 @@ func (s *LxdBackend) LaunchWorkshop(ctx context.Context, file *WorkshopFile) err
 		return fmt.Errorf("context key user not found")
 	}
 
-	/* Skip if the instance exists already */
+	// Skip if the instance exists already.
 	if _, _, err := conn.GetInstance(InstanceName(file.Name, projectId)); err == nil {
 		return fmt.Errorf("workshop \"%s\" already exists", file.Name)
 	}
 
-	/* Check if we have the base image stored locally */
+	// Check if we have the base image stored locally
 	if alias, _, err := conn.GetImageAlias(file.Base); err == nil {
 		if image, _, err = conn.GetImage(alias.Target); err != nil {
 			return err
@@ -472,29 +477,43 @@ func (s *LxdBackend) Workshop(ctx context.Context, name string) (*Workshop, erro
 }
 
 func installedContent(lxdConfig map[string]string) (map[string]sdk.Setup, error) {
-	content := make(map[string]sdk.Setup)
-	if sdks, ok := lxdConfig["user.workshop.content"]; ok {
-		err := json.Unmarshal([]byte(sdks), &content)
-		if err != nil {
+	c := make(map[string]sdk.Setup)
+	if sdks, ok := lxdConfig[LxdConfigWorkshopContent]; ok {
+		if err := json.Unmarshal([]byte(sdks), &c); err != nil {
 			return nil, err
 		}
 	}
-	return content, nil
+	return c, nil
 }
 
-func (s *LxdBackend) loadWorkshop(inst *api.Instance, p *Project) (*Workshop, error) {
+func workshopFile(lxdConfig map[string]string) (*WorkshopFile, error) {
+	var f WorkshopFile
+	if yml, ok := lxdConfig[LxdConfigWorkshopFile]; ok {
+		if err := yaml.Unmarshal([]byte(yml), &f); err != nil {
+			return nil, err
+		}
+	}
+	return &f, nil
+}
+
+func (b *LxdBackend) loadWorkshop(inst *api.Instance, p *Project) (*Workshop, error) {
 	base := inst.Config["image.os"] + "@" + inst.Config["image.version"]
 
-	// Fetch information about the installed SDKs
+	f, err := workshopFile(inst.Config)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load workshop: %v", err)
+	}
+
 	content, err := installedContent(inst.Config)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load workshop: installed SDK content is not readable: %v", err)
+		return nil, fmt.Errorf("cannot load workshop: %v", err)
 	}
 
 	return &Workshop{
 		Name:    WorkshopName(inst.Name),
-		backend: s,
+		backend: b,
 		project: p,
+		file:    f,
 		running: inst.StatusCode == api.Running || inst.StatusCode == api.Ready,
 		base:    base,
 		content: content,
@@ -547,7 +566,7 @@ func (s *LxdBackend) ProjectWorkshops(ctx context.Context) ([]*WorkshopFile, []*
 
 	p = projects[user][idx]
 
-	files, err := p.EnumWorkshopFiles()
+	files, err := p.ReadWorkshops()
 	// if the dir does not exist it does not mean there are no workshops. It
 	// could be because the dir was removed with some workshops still operating
 	// resulting in a missing-project error
@@ -563,7 +582,7 @@ func (s *LxdBackend) ProjectWorkshops(ctx context.Context) ([]*WorkshopFile, []*
 
 	var projectWorkshops []*Workshop
 	for _, i := range instances {
-		if i.Config[ProjectIdConfig] == p.ProjectId {
+		if i.Config[LxdConfigProjectId] == p.ProjectId {
 			ws, err := s.loadWorkshop(&i, p)
 			if err != nil {
 				logger.Debugf("error loading workshop: %v", err)
@@ -584,7 +603,7 @@ func (s *LxdBackend) ProjectWorkshops(ctx context.Context) ([]*WorkshopFile, []*
 func mergeInstancesAndFiles(f []*WorkshopFile, instances []*Workshop) ([]*WorkshopFile, []*Workshop) {
 	files := make([]*WorkshopFile, len(f))
 	copy(files, f)
-	/* Walk both lists from to build a list of workshops with their states */
+	// Walk both lists from to build a list of workshops with their states
 	for _, ws := range instances {
 		finder := func(p *WorkshopFile) bool { return p.Name == ws.Name }
 		idx := slices.IndexFunc(files, finder)
@@ -594,8 +613,8 @@ func mergeInstancesAndFiles(f []*WorkshopFile, instances []*Workshop) ([]*Worksh
 		}
 	}
 
-	/* At this point, files contain only inactive workshops and instances
-	contain the workshops that have workshop files available */
+	// At this point, files contain only inactive workshops and instances
+	// contain the workshops that have workshop files available.
 	return files, instances
 }
 
@@ -719,7 +738,7 @@ users:
     shell: /bin/bash
 `
 
-	workshopFile, err := yaml.Marshal(file)
+	f, err := yaml.Marshal(file)
 	if err != nil {
 		return map[string]string{}, nil
 	}
@@ -729,7 +748,7 @@ users:
 		"security.nesting":         "true",
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,
-		"user.workshop.file":       string(workshopFile),
+		"user.workshop.file":       string(f),
 	}
 
 	if s.nvidiaRuntime {

--- a/internal/workshopbackend/lxd_backend_project.go
+++ b/internal/workshopbackend/lxd_backend_project.go
@@ -160,13 +160,13 @@ func (s *LxdBackend) trackProject(client lxd.InstanceServer, ctx context.Context
 }
 
 func (s *LxdBackend) updateWorkshopsProjectPath(conn lxd.InstanceServer, ctx context.Context, existingProject *Project) error {
-	workshops, err := s.filterLxdInstancesByConfig(conn, NewWorkshopConfigFilter(ProjectIdConfig, existingProject.ProjectId))
+	workshops, err := s.filterLxdInstancesByConfig(conn, NewWorkshopConfigFilter(LxdConfigProjectId, existingProject.ProjectId))
 	if err != nil {
 		return err
 	}
 
 	for _, i := range workshops {
-		project := Mount(ProjectPathDevice, existingProject.Path, WorkshopProjectPath)
+		project := Mount(LxdConfigProjectPathDevice, existingProject.Path, WorkshopProjectPath)
 		err = s.AddWorkshopDevice(ctx, WorkshopName(i.Name), project)
 		if err != nil {
 			return fmt.Errorf("cannot update workshop \"%v\" project directory", i.Name)
@@ -176,7 +176,7 @@ func (s *LxdBackend) updateWorkshopsProjectPath(conn lxd.InstanceServer, ctx con
 }
 
 func (s *LxdBackend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx context.Context, p *Project) (path string, err error) {
-	workshops, err := s.filterLxdInstancesByConfig(conn, NewWorkshopConfigFilter(ProjectIdConfig, p.ProjectId))
+	workshops, err := s.filterLxdInstancesByConfig(conn, NewWorkshopConfigFilter(LxdConfigProjectId, p.ProjectId))
 	if err != nil {
 		return "", err
 	}
@@ -384,7 +384,7 @@ func (s *LxdBackend) CreateOrLoadProject(ctx context.Context, path string) (*Pro
 
 	// no project found, try to create one, note there is no ID yet at this stage
 	var project = Project{Path: projectDir}
-	workshops, err := project.EnumWorkshopFiles()
+	workshops, err := project.ReadWorkshops()
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/workshopbackend/lxd_backend_test.go
+++ b/internal/workshopbackend/lxd_backend_test.go
@@ -68,7 +68,7 @@ func (f *LxdBeTests) TestLxdBackendMergeFilesAndInstances(c *check.C) {
 base: ubuntu@20.04`), 0644)
 	os.WriteFile(filepath.Join(f.project.Path, ".workshop.t2.yaml"), []byte(`name: t2
 base: ubuntu@20.04`), 0644)
-	files, err := f.project.EnumWorkshopFiles()
+	files, err := f.project.ReadWorkshops()
 	c.Assert(err, check.IsNil)
 
 	instances := []*workshopbackend.Workshop{
@@ -100,7 +100,7 @@ base: ubuntu@20.04`), 0644)
 	os.WriteFile(filepath.Join(f.project.Path, ".workshop.t2.yaml"), []byte(`name: t2
 base: ubuntu@20.04`), 0644)
 
-	files, err := f.project.EnumWorkshopFiles()
+	files, err := f.project.ReadWorkshops()
 	c.Assert(err, check.IsNil)
 
 	instances := []*workshopbackend.Workshop{
@@ -212,33 +212,57 @@ func (f *LxdBeTests) TestReadProjectsSuccess(c *check.C) {
 	c.Assert(projects, check.HasLen, 0)
 }
 
+var marshalledWorkshop = `name: test
+base: ubuntu@22.04
+sdks:
+    one:
+        channel: latest/stable
+        plugs:
+            one-plug:
+                bind: two:two-plug
+            one-plug-two:
+                bind: two:two-plug
+    two:
+        channel: latest/edge
+`
+
 func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 	// Setup
 	b := &workshopbackend.LxdBackend{}
-	file := &workshopbackend.WorkshopFile{Name: "test", Base: "ubuntu@22.04"}
+	file := &workshopbackend.WorkshopFile{
+		Name: "test",
+		Base: "ubuntu@22.04",
+		Sdks: workshopbackend.SdkList{
+			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshopbackend.Plug{
+				"one-plug":     {Bind: "two:two-plug"},
+				"one-plug-two": {Bind: "two:two-plug"},
+			}},
+			{Name: "two", Channel: "latest/edge"},
+		},
+	}
 	b.SetNvidia(true)
 
 	// Execute
-	cfg, _ := workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file)
+	cfg, err := workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file)
 
 	// Validate
+	c.Assert(err, check.IsNil)
 	c.Assert(cfg["raw.idmap"], check.Equals, "uid 1001 1000\ngid 1001 1000")
 	c.Assert(cfg["security.nesting"], check.Equals, "true")
 	c.Assert(cfg["user.workshop.project-id"], check.Equals, f.project.ProjectId)
 
 	c.Assert(cfg["nvidia.runtime"], check.Equals, "true")
 	c.Assert(cfg["nvidia.driver.capabilities"], check.Equals, "all")
-	c.Assert(cfg["user.workshop.file"], check.Equals, `name: test
-base: ubuntu@22.04
-`)
+	c.Assert(cfg["user.workshop.file"], check.Equals, marshalledWorkshop)
 
 	// Setup
 	b.SetNvidia(false)
 
 	// Execute
-	cfg, _ = workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file)
+	cfg, err = workshopbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file)
 
 	// Validate
+	c.Assert(err, check.IsNil)
 	c.Assert(cfg["nvidia.runtime"], check.Equals, "")
 	c.Assert(cfg["nvidia.driver.capabilities"], check.Equals, "")
 }

--- a/internal/workshopbackend/project.go
+++ b/internal/workshopbackend/project.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 )
 
@@ -70,9 +71,9 @@ func (w *Project) EnumWorkshopFiles() ([]*WorkshopFile, error) {
 		if names := validWorkshopFilename.FindStringSubmatch(info.Name()); names != nil {
 			file, err := readWorkshop(filepath.Join(w.Path, info.Name()))
 			if err != nil {
-				return nil, err
+				logger.Noticef("Cannot parse %q file: %v", info.Name(), err)
+				continue
 			}
-
 			workshops = append(workshops, file)
 		}
 	}

--- a/internal/workshopbackend/project.go
+++ b/internal/workshopbackend/project.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
@@ -20,17 +19,10 @@ var (
 )
 
 const (
-	ProjectLock       = ".workshop.lock"
-	ProjectPathDevice = "workshop.project"
+	ProjectLock = ".workshop.lock"
 	// path used in workshop to mount the project directory
 	WorkshopProjectPath = "/project"
-	ProjectIdConfig     = "user.workshop.project-id"
 )
-
-// *.yaml is the only supported extension for workshop files as the only
-// recommended "official" extension: https://yaml.org/faq.html. Also, having a
-// single way of naming workshop files avoids unneccesary inconsistencies.
-var validWorkshopFilename = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
 
 func LockPath(path string) string {
 	return filepath.Join(path, ProjectLock)
@@ -46,15 +38,11 @@ func (p *Project) Exists() bool {
 	return exists && dir
 }
 
-func (w *Project) WorkshopFile(workshop string) (*WorkshopFile, error) {
-	file, err := readWorkshop(filepath.Join(w.Path, fmt.Sprintf(".workshop.%s.yaml", workshop)))
-	if err != nil {
-		return nil, err
-	}
-	return file, nil
+func (w *Project) Workshop(workshop string) (*WorkshopFile, error) {
+	return readWorkshop(filepath.Join(w.Path, fmt.Sprintf(".workshop.%s.yaml", workshop)))
 }
 
-func (w *Project) EnumWorkshopFiles() ([]*WorkshopFile, error) {
+func (w *Project) ReadWorkshops() ([]*WorkshopFile, error) {
 	files, err := os.ReadDir(w.Path)
 	if err != nil {
 		return nil, err
@@ -69,12 +57,12 @@ func (w *Project) EnumWorkshopFiles() ([]*WorkshopFile, error) {
 
 		// The first element in names will contain the workshop name if matched
 		if names := validWorkshopFilename.FindStringSubmatch(info.Name()); names != nil {
-			file, err := readWorkshop(filepath.Join(w.Path, info.Name()))
+			f, err := readWorkshop(filepath.Join(w.Path, info.Name()))
 			if err != nil {
-				logger.Noticef("Cannot parse %q file: %v", info.Name(), err)
+				logger.Noticef("Cannot parse %s: %v", info.Name(), err)
 				continue
 			}
-			workshops = append(workshops, file)
+			workshops = append(workshops, f)
 		}
 	}
 	return workshops, nil

--- a/internal/workshopbackend/project_test.go
+++ b/internal/workshopbackend/project_test.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/canonical/workshop/internal/workshopbackend"
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
 type projectSuite struct {
@@ -28,7 +29,7 @@ func (f *workshopFile) TestSomeWorkshopFilesBroken(c *check.C) {
 	c.Assert(createWorkshop(d, "w1"), check.IsNil)
 	c.Assert(createWorkshop(d, "w2"), check.IsNil)
 	c.Assert(createWorkshop(d, "-"), check.IsNil)
-	fls, err := p.EnumWorkshopFiles()
+	fls, err := p.ReadWorkshops()
 	c.Assert(err, check.IsNil)
 	c.Assert(fls, check.HasLen, 2)
 }

--- a/internal/workshopbackend/project_test.go
+++ b/internal/workshopbackend/project_test.go
@@ -1,0 +1,34 @@
+package workshopbackend_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/workshop/internal/workshopbackend"
+	"gopkg.in/check.v1"
+)
+
+type projectSuite struct {
+}
+
+var _ = check.Suite(&projectSuite{})
+
+var w = `name: %s
+base: ubuntu@22.04
+`
+
+func createWorkshop(dir, name string) error {
+	return os.WriteFile(filepath.Join(dir, fmt.Sprintf(".workshop.%s.yaml", name)), []byte(fmt.Sprintf(w, name)), 0644)
+}
+
+func (f *workshopFile) TestSomeWorkshopFilesBroken(c *check.C) {
+	d := c.MkDir()
+	p := &workshopbackend.Project{Path: d, ProjectId: "42424242"}
+	c.Assert(createWorkshop(d, "w1"), check.IsNil)
+	c.Assert(createWorkshop(d, "w2"), check.IsNil)
+	c.Assert(createWorkshop(d, "-"), check.IsNil)
+	fls, err := p.EnumWorkshopFiles()
+	c.Assert(err, check.IsNil)
+	c.Assert(fls, check.HasLen, 2)
+}

--- a/internal/workshopbackend/workshop.go
+++ b/internal/workshopbackend/workshop.go
@@ -27,6 +27,7 @@ type Workshop struct {
 
 	backend WorkshopBackend
 	project *Project
+	file    *WorkshopFile
 	base    string
 	content map[string]sdk.Setup
 	running bool
@@ -63,7 +64,7 @@ func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
 
 	err = w.backend.AddWorkshopConfig(ctx, w.Name,
 		&WorkshopConfigValue{
-			Name:  "user.workshop.content",
+			Name:  LxdConfigWorkshopContent,
 			Value: string(sequenceValue),
 		})
 
@@ -104,7 +105,7 @@ func (w *Workshop) UnlinkSdk(ctx context.Context, name string) error {
 	/* Update the workshop config */
 	err = w.backend.AddWorkshopConfig(ctx, w.Name,
 		&WorkshopConfigValue{
-			Name:  "user.workshop.content",
+			Name:  LxdConfigWorkshopContent,
 			Value: string(newSequence),
 		})
 	if err != nil {

--- a/internal/workshopbackend/workshop_file.go
+++ b/internal/workshopbackend/workshop_file.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"golang.org/x/exp/slices"
@@ -29,6 +30,11 @@ type WorkshopFile struct {
 	Base string  `yaml:"base"`
 	Sdks SdkList `yaml:"sdks,omitempty"`
 }
+
+// *.yaml is the only supported extension for workshop files as the only
+// recommended "official" extension: https://yaml.org/faq.html. Also, having a
+// single way of naming workshop files avoids unneccesary inconsistencies.
+var validWorkshopFilename = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
 
 func (p SdkList) MarshalYAML() (interface{}, error) {
 	type sdkDef struct {
@@ -59,7 +65,7 @@ func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
 			return err
 		} else {
 			if _, ok := seen[name]; ok {
-				return fmt.Errorf("cannot parse workshop file: %q SDK is not unique", name)
+				return fmt.Errorf("%q SDK must only be included once", name)
 			}
 			seen[name] = true
 			res.Name = name
@@ -88,7 +94,6 @@ func readWorkshop(pathname string) (*WorkshopFile, error) {
 		return cmp.Compare(a.Name, b.Name)
 	})
 
-	// Validate workshop properties
 	if !sdk.ValidName.MatchString(file.Name) {
 		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) include only lower case alpha-numeric or an underscore symbol(s)")
 	}
@@ -98,31 +103,31 @@ func readWorkshop(pathname string) (*WorkshopFile, error) {
 	}
 
 	// All bindings must refer to the existing SDKs and meet the name validity
-	// checks (at this stage). Later, when SDK metadata retrieved, the plugs
-	// must be checked again (e.g. ensure all those plugs actually exist).
-	for _, p := range file.Sdks {
-		for _, b := range p.Plugs {
-			comps := strings.Split(b.Bind, ":")
+	// checks (at this stage). Later, when SDK metadata will be received, the
+	// plugs must be checked again (e.g. ensure all those plugs actually exist).
+	for _, s := range file.Sdks {
+		for _, p := range s.Plugs {
+			comps := strings.Split(p.Bind, ":")
 			if len(comps) != 2 {
-				return nil, fmt.Errorf("incorrect bind plug reference: %q (use <sdk>:<plug>)", b.Bind)
+				return nil, fmt.Errorf("incorrect bind plug reference: %q (use <sdk>:<plug>)", p.Bind)
 			}
 			if !sdk.ValidName.MatchString(comps[0]) {
 				return nil, fmt.Errorf("%q isn't a valid SDK name", comps[0])
 			}
 			if ixd := slices.IndexFunc(file.Sdks, func(sr SdkRecord) bool { return comps[0] == sr.Name }); ixd == -1 {
-				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", b.Bind)
+				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", p.Bind)
 			}
 		}
 	}
 
-	for _, k := range file.Sdks {
-		if k.Name == sdk.Agent.String() {
+	for _, s := range file.Sdks {
+		if s.Name == sdk.Agent.String() {
 			return nil, fmt.Errorf(`"agent" is a reserved SDK name`)
 		}
-		if matches := sdk.ValidChannel.FindStringSubmatch(k.Channel); matches != nil {
+		if matches := sdk.ValidChannel.FindStringSubmatch(s.Channel); matches != nil {
 			continue
 		} else {
-			return nil, fmt.Errorf("unsupported channel %s for \"%s\"", k.Channel, k.Name)
+			return nil, fmt.Errorf("unsupported channel %s for \"%s\"", s.Channel, s.Name)
 		}
 	}
 

--- a/internal/workshopbackend/workshop_file.go
+++ b/internal/workshopbackend/workshop_file.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"os"
+	"strings"
 
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
@@ -11,9 +12,14 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 )
 
+type Plug struct {
+	Bind string `yaml:"bind"`
+}
+
 type SdkRecord struct {
-	Name    string `yaml:"name"`
-	Channel string `yaml:"channel"`
+	Name    string          `yaml:"name"`
+	Channel string          `yaml:"channel"`
+	Plugs   map[string]Plug `yaml:"plugs,omitempty"`
 }
 
 type SdkList []SdkRecord
@@ -22,6 +28,22 @@ type WorkshopFile struct {
 	Name string  `yaml:"name"`
 	Base string  `yaml:"base"`
 	Sdks SdkList `yaml:"sdks,omitempty"`
+}
+
+func (p SdkList) MarshalYAML() (interface{}, error) {
+	type sdkDef struct {
+		Channel string          `yaml:"channel"`
+		Plugs   map[string]Plug `yaml:"plugs,omitempty"`
+	}
+	b := map[string]sdkDef{}
+
+	for _, v := range p {
+		b[v.Name] = sdkDef{Channel: v.Channel, Plugs: v.Plugs}
+	}
+
+	node := &yaml.Node{}
+	err := node.Encode(b)
+	return node, err
 }
 
 func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
@@ -73,6 +95,24 @@ func readWorkshop(pathname string) (*WorkshopFile, error) {
 
 	if !slices.Contains(sdk.ValidBases, file.Base) {
 		return nil, fmt.Errorf("unsupported base: %s", file.Base)
+	}
+
+	// All bindings must refer to the existing SDKs and meet the name validity
+	// checks (at this stage). Later, when SDK metadata retrieved, the plugs
+	// must be checked again (e.g. ensure all those plugs actually exist).
+	for _, p := range file.Sdks {
+		for _, b := range p.Plugs {
+			comps := strings.Split(b.Bind, ":")
+			if len(comps) != 2 {
+				return nil, fmt.Errorf("incorrect bind plug reference: %q (use <sdk>:<plug>)", b.Bind)
+			}
+			if !sdk.ValidName.MatchString(comps[0]) {
+				return nil, fmt.Errorf("%q isn't a valid SDK name", comps[0])
+			}
+			if ixd := slices.IndexFunc(file.Sdks, func(sr SdkRecord) bool { return comps[0] == sr.Name }); ixd == -1 {
+				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", b.Bind)
+			}
+		}
 	}
 
 	for _, k := range file.Sdks {

--- a/internal/workshopbackend/workshop_file_test.go
+++ b/internal/workshopbackend/workshop_file_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/spf13/afero"
 	"golang.org/x/exp/slices"
 	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
 
+	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshopbackend"
 )
 
@@ -59,6 +61,33 @@ sdks:
 	c.Assert(file.Sdks[3].Channel, check.Equals, "latest/candidate")
 }
 
+func (f *workshopFile) TestWorkshopFileSave(c *check.C) {
+	fl := &workshopbackend.WorkshopFile{
+		Name: "test-workshop",
+		Base: "ubuntu@22.04",
+		Sdks: []workshopbackend.SdkRecord{
+			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshopbackend.Plug{"plug": {Bind: "two:plug"}}},
+			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshopbackend.Plug{"plug": {Bind: "one:plug"}}},
+		},
+	}
+	out, err := yaml.Marshal(fl)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(out), check.Equals, `name: test-workshop
+base: ubuntu@22.04
+sdks:
+    one:
+        channel: latest/stable
+        plugs:
+            plug:
+                bind: two:plug
+    two:
+        channel: latest/stable
+        plugs:
+            plug:
+                bind: one:plug
+`)
+}
+
 func (f *workshopFile) TestWorkshopFileDuplicateSdks(c *check.C) {
 	buf := []byte(`name: xbert-gpu
 base: ubuntu@20.04
@@ -87,4 +116,91 @@ sdks:
 	file, err := workshopbackend.ReadWorkshop(workshopFilePath(dir, "xbert-gpu"))
 	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
 	c.Assert(file, check.IsNil)
+}
+
+func (f *workshopFile) TestBindPlug(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+    plugs:
+      cache:
+        bind: etl-sdk:cache
+  etl-sdk:
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: data-sdk:cache
+`)
+	dir := c.MkDir()
+	p := workshopbackend.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	file, err := p.WorkshopFile("xbert-gpu")
+	c.Assert(err, check.IsNil)
+	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshopbackend.SdkList{
+		workshopbackend.SdkRecord{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshopbackend.Plug{"cache": {Bind: "etl-sdk:cache"}}},
+		workshopbackend.SdkRecord{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshopbackend.Plug{"data": {Bind: "data-sdk:cache"}}},
+	})
+}
+
+func (f *workshopFile) TestBindPlugNoSdk(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+    plugs:
+      cache:
+        bind: no-sdk:cache
+  etl-sdk:
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: data-sdk:cache
+`)
+	dir := c.MkDir()
+	p := workshopbackend.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.WorkshopFile("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `"no-sdk:cache" tries to bind to a plug from a non-existing SDK`)
+}
+
+func (f *workshopFile) TestBindPlugIncorrectSdkName(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+    plugs:
+      cache:
+        bind: workshop/no-sdk:cache
+  etl-sdk:
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: data-sdk:cache
+`)
+	dir := c.MkDir()
+	p := workshopbackend.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.WorkshopFile("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `"workshop/no-sdk" isn't a valid SDK name`)
+}
+
+func (f *workshopFile) TestBindPlugIncorrectPlugRef(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  etl-sdk:
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: cache
+`)
+	dir := c.MkDir()
+	p := workshopbackend.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.WorkshopFile("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `incorrect bind plug reference: "cache" \(use <sdk>:<plug>\)`)
 }

--- a/internal/workshopbackend/workshop_file_test.go
+++ b/internal/workshopbackend/workshop_file_test.go
@@ -101,7 +101,7 @@ sdks:
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	file, err := workshopbackend.ReadWorkshop(workshopFilePath(dir, "xbert-gpu"))
 	c.Assert(file, check.IsNil)
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `"cuda" SDK must only be included once`)
 }
 
 func (f *workshopFile) TestWorkshopFileReservedNames(c *check.C) {
@@ -136,7 +136,7 @@ sdks:
 	dir := c.MkDir()
 	p := workshopbackend.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
-	file, err := p.WorkshopFile("xbert-gpu")
+	file, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshopbackend.SdkList{
 		workshopbackend.SdkRecord{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshopbackend.Plug{"cache": {Bind: "etl-sdk:cache"}}},
@@ -162,7 +162,7 @@ sdks:
 	dir := c.MkDir()
 	p := workshopbackend.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
-	_, err := p.WorkshopFile("xbert-gpu")
+	_, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.ErrorMatches, `"no-sdk:cache" tries to bind to a plug from a non-existing SDK`)
 }
 
@@ -184,7 +184,7 @@ sdks:
 	dir := c.MkDir()
 	p := workshopbackend.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
-	_, err := p.WorkshopFile("xbert-gpu")
+	_, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.ErrorMatches, `"workshop/no-sdk" isn't a valid SDK name`)
 }
 
@@ -201,6 +201,6 @@ sdks:
 	dir := c.MkDir()
 	p := workshopbackend.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
-	_, err := p.WorkshopFile("xbert-gpu")
+	_, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.ErrorMatches, `incorrect bind plug reference: "cache" \(use <sdk>:<plug>\)`)
 }


### PR DESCRIPTION
# Description

This change prepares for the plug binding implementation in the interface connect and disconnect handlers:

1. When operate with workshops, load the yaml it has been created from (stored as an instance configuration record in LXD).
2. Parse and validate plug binding that can be defined as:
```
...
sdks:
  go:
    channel: latest/candidate    
  dev-tunnel:
    channel: latest/edge
    plugs:
      data:
        bind: go:mod-cache
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
