### PR TITLE
Use GOARCH to fetch correct LXD image

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	lxd "github.com/canonical/lxd/client"
@@ -727,7 +728,7 @@ func (s *Backend) fetchRemoteImage(base string) (lxd.ImageServer, *api.Image, er
 		return nil, nil, fmt.Errorf("cannot find a base image for the workshop")
 	}
 
-	alias, _, err := imageServer.GetImageAlias(fmt.Sprintf("%s/amd64", names[1]))
+	alias, _, err := imageServer.GetImageAlias(fmt.Sprintf("%s/%s", names[1], runtime.GOARCH))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
# Description
This enables Workshop to run images for arm64 and other supported architectures.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
