### PR TITLE
Support arm64 in Workshop snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,12 +42,16 @@ parts:
     build-snaps:
       - go/1.21/stable
     build-environment:
-      - CGO_LDFLAGS: "-Wl,-rpath=/snap/core22/current/lib/x86_64-linux-gnu -Wl,--disable-new-dtags -Wl,-dynamic-linker=/snap/core22/current/lib64/ld-linux-x86-64.so.2"
       - CGO_LDFLAGS_ALLOW: ".*"
     override-build: |
-      CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/workshop" ./cmd/workshop
+      if [[ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ]]; then
+       export CGO_LDFLAGS="-Wl,-rpath=/snap/core22/current/lib/x86_64-linux-gnu -Wl,--disable-new-dtags -Wl,-dynamic-linker=/snap/core22/current/lib64/ld-linux-x86-64.so.2"
+      elif [[ "$CRAFT_ARCH_BUILD_FOR" == "arm64" ]]; then
+        export CGO_LDFLAGS="-Wl,-rpath=/snap/core22/current/lib/aarch64-linux-gnu -Wl,--disable-new-dtags -Wl,-dynamic-linker=/snap/core22/current/lib/ld-linux-aarch64.so.1"
+      fi
+      CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshop" ./cmd/workshop
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/workshopd" ./cmd/workshopd
-      CGO_ENABLED=0 go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/workshopctl" ./cmd/workshopctl
+      CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshopctl" ./cmd/workshopctl
     prime:
       - bin/workshop
       - bin/workshopd


### PR DESCRIPTION
# Description

Build Workshop snap for arm64 with a correct rpath and interpreter set explicitly. See https://snapcraft.io/docs/linters-classic for details on Go binaries.
