### PR TITLE
Plug binding

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -4,7 +4,7 @@ environment:
       PATH: $PATH:~/go/bin
       PROJECT_PATH: /workshop
       TESTSLIB: $PROJECT_PATH/tests/lib
-      SDKCONTENT: $PROJECT_PATH/tests/lib/sdk
+      SDKS: $PROJECT_PATH/tests/lib/sdk
       SDK_STORE_BUCKET_DIR: /data/sdk-store
 repack: |
     test -f tests/*.snap || snapcraft -o tests/

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -33,6 +33,7 @@ type Plug struct {
 	Interface   string                 `json:"interface,omitempty"`
 	Attrs       map[string]interface{} `json:"attrs,omitempty"`
 	Label       string                 `json:"label,omitempty"`
+	Bind        *PlugRef               `json:"bind,omitempty"`
 	Connections []SlotRef              `json:"connections,omitempty"`
 }
 
@@ -95,7 +96,28 @@ type DisconnectOptions struct {
 	Forget bool
 }
 
-func ParsePlugRef(plug string) (*PlugRef, error) {
+func ParseFullPlugRef(plug string) (*PlugRef, error) {
+	// the expected format of the plug ref is <workshop>[/<sdk>]:<plug>
+	var plugRef PlugRef
+
+	parts := strings.Split(plug, ":")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("unknown plug or slot reference %q", plug)
+	}
+
+	wssdk := strings.Split(parts[0], "/")
+	if len(wssdk) != 3 {
+		return nil, fmt.Errorf("unknown plug or slot reference %q", plug)
+	}
+
+	plugRef.ProjectId = wssdk[0]
+	plugRef.Workshop = wssdk[1]
+	plugRef.Sdk = wssdk[2]
+	plugRef.Name = parts[1]
+	return &plugRef, nil
+}
+
+func ParseShortPlugRef(plug string) (*PlugRef, error) {
 	// the expected format of the plug ref is <workshop>[/<sdk>]:<plug>
 	var plugRef PlugRef
 
@@ -119,9 +141,9 @@ func ParsePlugRef(plug string) (*PlugRef, error) {
 // change when/if go will enable individual fields access for generic types
 // which would allow to have one generic function returning plug or slot
 // reference type on request.
-func ParseSlotRef(slot string) (*SlotRef, error) {
+func ParseShortSlotRef(slot string) (*SlotRef, error) {
 	// the expected format of the plug ref is <workshop>/<sdk>:<plug>
-	plugRef, err := ParsePlugRef(slot)
+	plugRef, err := ParseShortPlugRef(slot)
 	if err != nil {
 		return nil, err
 	}

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -37,6 +37,10 @@ type Plug struct {
 	Connections []SlotRef              `json:"connections,omitempty"`
 }
 
+func (p *Plug) Ref() PlugRef {
+	return PlugRef{ProjectId: p.ProjectId, Workshop: p.Workshop, Sdk: p.Sdk, Name: p.Name}
+}
+
 // PlugRef is a reference to a plug.
 type PlugRef struct {
 	ProjectId string `json:"project-id"`

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -14,7 +14,7 @@ func FuzzRemount(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, a string) {
-		ref, err := client.ParsePlugRef(a)
+		ref, err := client.ParseShortPlugRef(a)
 		if err == nil {
 			if fmt.Sprintf("%s/%s:%s", ref.Workshop, ref.Sdk, ref.Name) != a {
 				t.Errorf("plug %s cannot be reverted to a PlugRef after parsing", a)

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -67,7 +67,7 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	plugRef, err := client.ParsePlugRef(av[0])
+	plugRef, err := client.ParseShortPlugRef(av[0])
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 			slotRef.Sdk = "agent"
 			slotRef.Name = av[1][1:]
 		} else {
-			slotRef, err = client.ParseSlotRef(av[1])
+			slotRef, err = client.ParseShortSlotRef(av[1])
 			if err != nil {
 				// see if an SDK (empty slot) reference provided
 				slotRef, err = client.ParseSlotSdkRef(av[1])

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -93,6 +93,8 @@ func (b byConnectionData) Less(i, j int) bool {
 
 func maybeBound(plug client.PlugRef, plugs []client.Plug) string {
 	var bind string
+
+	// check if this plug is bound to
 	idx := slices.IndexFunc(plugs, func(p client.Plug) bool {
 		return p.Workshop == plug.Workshop && p.Sdk == plug.Sdk && p.Name == plug.Name
 	})
@@ -100,9 +102,24 @@ func maybeBound(plug client.PlugRef, plugs []client.Plug) string {
 		info := plugs[idx]
 		if info.Bind != nil {
 			bind = endpoint(info.Bind.Workshop, info.Bind.Sdk, info.Bind.Name)
+			return bind
 		}
 	}
-	return bind
+
+	// check if other plugs are bound to this one
+	idx = slices.IndexFunc(plugs, func(p client.Plug) bool {
+		if p.Bind != nil {
+			return *p.Bind == plug
+		}
+		return false
+	})
+	if idx != -1 {
+		bind = endpoint(plug.Workshop, plug.Sdk, plug.Name)
+		return bind
+	}
+
+	// not bound or bound to
+	return ""
 }
 
 func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
@@ -156,10 +173,7 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 
 	for _, plug := range connections.Plugs {
 		if len(plug.Connections) == 0 && c.all {
-			var bind string
-			if plug.Bind != nil {
-				bind = endpoint(plug.Bind.Workshop, plug.Bind.Sdk, plug.Bind.Name)
-			}
+			var bind = maybeBound(plug.Ref(), connections.Plugs)
 			annotatedConns = append(annotatedConns, connection{
 				plug:          endpoint(plug.Workshop, plug.Sdk, plug.Name),
 				slot:          "-",
@@ -186,6 +200,7 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 	sort.Sort(byConnectionData(annotatedConns))
 
 	for _, note := range annotatedConns {
+		// find the plug that the current connection is bound to
 		idx := slices.IndexFunc(annotatedConns, func(c connection) bool { return c.plug != "" && note.bind != "" && c.plug == note.bind })
 		note.bindIdx = idx + 1
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", note.interfaceName, note.plug, note.slot, note)

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -68,7 +68,7 @@ func (cn connection) String() string {
 		opts = append(opts, "manual")
 	}
 	if cn.bind != "" && cn.bindIdx > 0 {
-		opts = append(opts, fmt.Sprintf("bind:%d", cn.bindIdx))
+		opts = append(opts, fmt.Sprintf("bind.%d", cn.bindIdx))
 	}
 	if len(opts) == 0 {
 		return "-"

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -57,12 +58,17 @@ type connection struct {
 	plug          string
 	interfaceName string
 	manual        bool
+	bind          string
+	bindIdx       int
 }
 
 func (cn connection) String() string {
 	opts := []string{}
 	if cn.manual {
 		opts = append(opts, "manual")
+	}
+	if cn.bind != "" && cn.bindIdx > 0 {
+		opts = append(opts, fmt.Sprintf("bind:%d", cn.bindIdx))
 	}
 	if len(opts) == 0 {
 		return "-"
@@ -83,6 +89,20 @@ func (b byConnectionData) Less(i, j int) bool {
 		return iCon.plug < jCon.plug
 	}
 	return iCon.slot < jCon.slot
+}
+
+func maybeBound(plug client.PlugRef, plugs []client.Plug) string {
+	var bind string
+	idx := slices.IndexFunc(plugs, func(p client.Plug) bool {
+		return p.Workshop == plug.Workshop && p.Sdk == plug.Sdk && p.Name == plug.Name
+	})
+	if idx != -1 {
+		info := plugs[idx]
+		if info.Bind != nil {
+			bind = endpoint(info.Bind.Workshop, info.Bind.Sdk, info.Bind.Name)
+		}
+	}
+	return bind
 }
 
 func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
@@ -127,6 +147,7 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 			slot:          endpoint(conn.Slot.Workshop, conn.Slot.Sdk, conn.Slot.Name),
 			manual:        conn.Manual,
 			interfaceName: conn.Interface,
+			bind:          maybeBound(conn.Plug, connections.Plugs),
 		})
 	}
 
@@ -135,10 +156,15 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 
 	for _, plug := range connections.Plugs {
 		if len(plug.Connections) == 0 && c.all {
+			var bind string
+			if plug.Bind != nil {
+				bind = endpoint(plug.Bind.Workshop, plug.Bind.Sdk, plug.Bind.Name)
+			}
 			annotatedConns = append(annotatedConns, connection{
 				plug:          endpoint(plug.Workshop, plug.Sdk, plug.Name),
 				slot:          "-",
 				interfaceName: plug.Interface,
+				bind:          bind,
 			})
 		}
 	}
@@ -160,6 +186,8 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 	sort.Sort(byConnectionData(annotatedConns))
 
 	for _, note := range annotatedConns {
+		idx := slices.IndexFunc(annotatedConns, func(c connection) bool { return c.plug != "" && note.bind != "" && c.plug == note.bind })
+		note.bindIdx = idx + 1
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", note.interfaceName, note.plug, note.slot, note)
 	}
 

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -377,6 +377,144 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 	c.Assert(s.Stderr(), Equals, "")
 }
 
+func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
+	result := client.Connections{
+		Established: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "capslock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "leds-provider", Sdk: "provider", Name: "capslock-led"},
+				Interface: "leds",
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "numlock-led"},
+				Interface: "leds",
+				Manual:    true,
+			}, {
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "scrollock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "scrollock-led"},
+				Interface: "leds",
+			},
+		},
+		Plugs: []client.Plug{
+			{
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "capslock",
+				Interface: "leds",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "leds-provider",
+					Sdk:       "provider",
+					Name:      "capslock-led",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "numlock",
+				Interface: "leds",
+				Bind: &client.PlugRef{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "scrollock",
+				},
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "agent",
+					Name:      "numlock-led",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "scrollock",
+				Interface: "leds",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "agent",
+					Name:      "scrollock-led",
+				}},
+			},
+		},
+		Slots: []client.Slot{
+			{
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "agent",
+				Name:      "numlock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "numlock",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "agent",
+				Name:      "scrollock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "scrollock",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "provider",
+				Name:      "capslock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "capslock",
+				}},
+			},
+		},
+	}
+	n := 0
+	query := url.Values{"project-id": []string{"42424242"}}
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := io.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+	cmd := &CmdConnections{}
+	err := cmd.Run(cmd.Command(), []string{})
+	c.Assert(err, IsNil)
+	expectedStdout := "" +
+		"Interface  Plug                              Slot                                 Notes\n" +
+		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led  -\n" +
+		"leds       keyboard-lights/lights:numlock    :numlock-led                         manual,bind:3\n" +
+		"leds       keyboard-lights/lights:scrollock  :scrollock-led                       -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
 func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 	result := client.Connections{
 		Established: []client.Connection{
@@ -512,6 +650,135 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
 		"leds       keyboard-lights/lights:numlock    -                                             -\n" +
 		"leds       keyboard-lights/lights:scrollock  :scrollock-led                                -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
+	result := client.Connections{
+		Established: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "capslock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "leds-provider", Sdk: "provider", Name: "capslock-led"},
+				Interface: "leds",
+			},
+		},
+		Undesired: []client.Connection{
+			{
+				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "numlock-led"},
+				Interface: "leds",
+				Manual:    true,
+			},
+		},
+		Plugs: []client.Plug{
+			{
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "capslock",
+				Interface: "leds",
+				Connections: []client.SlotRef{{
+					ProjectId: "42424242",
+					Workshop:  "leds-provider",
+					Sdk:       "provider",
+					Name:      "capslock-led",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "numlock",
+				Interface: "leds",
+				Bind: &client.PlugRef{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "scrollock",
+				},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "lights",
+				Name:      "scrollock",
+				Interface: "leds",
+			},
+		},
+		Slots: []client.Slot{
+			{
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "agent",
+				Name:      "capslock-led",
+				Interface: "leds",
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "agent",
+				Name:      "numlock-led",
+				Interface: "leds",
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "agent",
+				Name:      "scrollock-led",
+				Interface: "leds",
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "leds-provider",
+				Sdk:       "provider",
+				Name:      "capslock-led",
+				Interface: "leds",
+				Connections: []client.PlugRef{{
+					ProjectId: "42424242",
+					Workshop:  "keyboard-lights",
+					Sdk:       "lights",
+					Name:      "capslock",
+				}},
+			}, {
+				ProjectId: "42424242",
+				Workshop:  "keyboard-lights",
+				Sdk:       "numlock-provider",
+				Name:      "numlock-led",
+				Interface: "leds",
+			},
+		},
+	}
+	n := 0
+	query := url.Values{"project-id": []string{"42424242"}, "select": []string{"all"}}
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
+			body, err := io.ReadAll(r.Body)
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
+			EncodeResponseBody(c, w, map[string]interface{}{
+				"type":   "sync",
+				"result": result,
+			})
+		}
+	})
+
+	cmd := &CmdConnections{}
+	cmdAll := cmd.Command()
+	cmd.all = true
+	err := cmd.Run(cmdAll, []string{})
+	c.Assert(err, IsNil)
+	expectedStdout := "" +
+		"Interface  Plug                              Slot                                          Notes\n" +
+		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
+		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
+		"leds       keyboard-lights/lights:numlock    -                                             bind:4\n" +
+		"leds       keyboard-lights/lights:scrollock  -                                             -\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -510,8 +510,8 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                 Notes\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led  -\n" +
-		"leds       keyboard-lights/lights:numlock    :numlock-led                         manual,bind:3\n" +
-		"leds       keyboard-lights/lights:scrollock  :scrollock-led                       manual,bind:3\n"
+		"leds       keyboard-lights/lights:numlock    :numlock-led                         manual,bind.3\n" +
+		"leds       keyboard-lights/lights:scrollock  :scrollock-led                       manual,bind.3\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
@@ -778,8 +778,8 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 		"Interface  Plug                              Slot                                          Notes\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
-		"leds       keyboard-lights/lights:numlock    -                                             bind:4\n" +
-		"leds       keyboard-lights/lights:scrollock  -                                             bind:4\n"
+		"leds       keyboard-lights/lights:numlock    -                                             bind.4\n" +
+		"leds       keyboard-lights/lights:scrollock  -                                             bind.4\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -393,6 +393,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "scrollock"},
 				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "scrollock-led"},
 				Interface: "leds",
+				Manual:    true,
 			},
 		},
 		Plugs: []client.Plug{
@@ -510,7 +511,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 		"Interface  Plug                              Slot                                 Notes\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led  -\n" +
 		"leds       keyboard-lights/lights:numlock    :numlock-led                         manual,bind:3\n" +
-		"leds       keyboard-lights/lights:scrollock  :scrollock-led                       -\n"
+		"leds       keyboard-lights/lights:scrollock  :scrollock-led                       manual,bind:3\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
@@ -778,7 +779,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
 		"leds       keyboard-lights/lights:numlock    -                                             bind:4\n" +
-		"leds       keyboard-lights/lights:scrollock  -                                             -\n"
+		"leds       keyboard-lights/lights:scrollock  -                                             bind:4\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -66,7 +66,7 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	plugRef, err := client.ParsePlugRef(av[0])
+	plugRef, err := client.ParseShortPlugRef(av[0])
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 			slotRef.Sdk = "agent"
 			slotRef.Name = av[1][1:]
 		} else {
-			slotRef, err = client.ParseSlotRef(av[1])
+			slotRef, err = client.ParseShortSlotRef(av[1])
 			if err != nil {
 				return err
 			}

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -51,7 +51,7 @@ Notes:
 func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 	var err error
 
-	plugRef, err := client.ParsePlugRef(av[0])
+	plugRef, err := client.ParseShortPlugRef(av[0])
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -345,11 +345,11 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		connRef, err = repo.ResolveConnect(a.Plugs[0].ProjectId, a.Plugs[0].Workshop, a.Plugs[0].Sdk, a.Plugs[0].Name,
 			a.Slots[0].ProjectId, a.Slots[0].Workshop, a.Slots[0].Sdk, a.Slots[0].Name)
 		if err == nil {
-			w, err := c.d.overlord.WorkshopManager().Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
+			plugW, err := c.d.overlord.WorkshopManager().Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
 			if err != nil {
 				break
 			}
-			ts, connErr := ifacestate.Connect(st, w, connRef)
+			ts, connErr := ifacestate.Connect(st, plugW, connRef)
 			if connErr != nil {
 				if _, ok := connErr.(*ifacestate.ErrAlreadyConnected); !ok {
 					return statusBadRequest(connErr.Error())
@@ -370,6 +370,10 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		repo := c.d.overlord.InterfaceManager().Repository()
 		for _, connRef := range conns {
 			var ts *state.TaskSet
+			plugW, werr := c.d.overlord.WorkshopManager().Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
+			if werr != nil {
+				break
+			}
 
 			if !a.Forget {
 				// Ensure the connection exists if it is not going to be
@@ -380,7 +384,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 					break
 				}
 			}
-			ts, err = ifacestate.Disconnect(st, connRef, a.Forget)
+			ts, err = ifacestate.Disconnect(st, plugW, connRef, a.Forget)
 			if err != nil {
 				break
 			}

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -345,7 +345,11 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		connRef, err = repo.ResolveConnect(a.Plugs[0].ProjectId, a.Plugs[0].Workshop, a.Plugs[0].Sdk, a.Plugs[0].Name,
 			a.Slots[0].ProjectId, a.Slots[0].Workshop, a.Slots[0].Sdk, a.Slots[0].Name)
 		if err == nil {
-			ts, connErr := ifacestate.Connect(st, connRef)
+			w, err := c.d.overlord.WorkshopManager().Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
+			if err != nil {
+				break
+			}
+			ts, connErr := ifacestate.Connect(st, w, connRef)
 			if connErr != nil {
 				if _, ok := connErr.(*ifacestate.ErrAlreadyConnected); !ok {
 					return statusBadRequest(connErr.Error())

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -370,24 +370,19 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		repo := c.d.overlord.InterfaceManager().Repository()
 		for _, connRef := range conns {
 			var ts *state.TaskSet
-			var conn *interfaces.Connection
 
-			if a.Forget {
-				// Forget must use a connRef as the connection may only exist in
-				// the state and not in the repo.
-				ts, err = ifacestate.Forget(st, connRef, a.Forget)
+			if !a.Forget {
+				// Ensure the connection exists if it is not going to be
+				// forgotten (if forget is true the conenction may present only
+				// in the state and not in the repository).
+				_, err = repo.Connection(connRef)
 				if err != nil {
 					break
 				}
-			} else {
-				conn, err = repo.Connection(connRef)
-				if err != nil {
-					break
-				}
-				ts, err = ifacestate.Disconnect(st, conn, a.Forget)
-				if err != nil {
-					break
-				}
+			}
+			ts, err = ifacestate.Disconnect(st, connRef, a.Forget)
+			if err != nil {
+				break
 			}
 
 			ts.JoinLane(st.NewLane())

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -373,6 +373,8 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 			var conn *interfaces.Connection
 
 			if a.Forget {
+				// Forget must use a connRef as the connection may only exist in
+				// the state and not in the repo.
 				ts, err = ifacestate.Forget(st, connRef, a.Forget)
 				if err != nil {
 					break

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -178,6 +178,15 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 			continue
 		}
 		sort.Sort(bySlotRef(connectedSlots))
+		var bind *interfaces.PlugRef
+		if pb, ok := plug.Sdk.PlugBinds[plug.Name]; ok {
+			bind = &interfaces.PlugRef{
+				ProjectId: pb.ProjectId,
+				Workshop:  pb.Workshop,
+				Sdk:       pb.Sdk,
+				Name:      pb.Name,
+			}
+		}
 		pj := &plugJSON{
 			ProjectId:   plugRef.ProjectId,
 			Workshop:    plugRef.Workshop,
@@ -186,6 +195,7 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 			Interface:   plug.Interface,
 			Attrs:       plug.Attrs,
 			Label:       plug.Label,
+			Bind:        bind,
 			Connections: connectedSlots,
 		}
 		connsjson.Plugs = append(connsjson.Plugs, pj)

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -76,13 +76,32 @@ slots:
 func (s *apiSuite) workshopFile(ws string, sdks []*sdk.Info) *workshop.File {
 	file := &workshop.File{Name: ws, Base: "ubuntu@20.04"}
 	for _, s := range sdks {
-		file.Sdks = append(file.Sdks, workshop.SdkRecord{Name: s.Name, Channel: "latest/stable"})
+		file.Sdks = append(file.Sdks, workshop.SdkRecord{
+			Name:    s.Name,
+			Channel: "latest/stable",
+			Plugs:   make(map[string]workshop.Plug),
+		})
 	}
 	return file
 }
 
 func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop.Workshop {
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
+	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
+	wf := s.workshopFile(w, []*sdk.Info{info})
+	c.Assert(s.b.LaunchWorkshop(s.ctx, wf), check.IsNil)
+	wp, err := s.b.Workshop(s.ctx, w)
+	c.Check(err, check.IsNil)
+	return wp
+}
+
+func (s *apiSuite) mockInstalledSDKBoundPlug(c *check.C, yaml string, w string, from, to string) *workshop.Workshop {
+	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
+	info.PlugBinds[from] = &sdk.PlugBind{
+		ProjectId: s.project.ProjectId,
+		Workshop:  w,
+		Sdk:       info.Name,
+		Name:      to}
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
 	wf := s.workshopFile(w, []*sdk.Info{info})
 	c.Assert(s.b.LaunchWorkshop(s.ctx, wf), check.IsNil)
@@ -700,6 +719,94 @@ func (s *apiSuite) TestConnectionsDefaultAuto(c *check.C) {
 	})
 }
 
+func (s *apiSuite) TestConnectionsBoundPlug(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDKBoundPlug(c, consumerYamlBound, "consumer-ws", "plug", "plug2")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+			"interface": "test",
+			"auto":      true,
+			"plug-static": map[string]interface{}{
+				"key": "value",
+			},
+			"plug-dynamic": map[string]interface{}{
+				"foo-plug-dynamic": "bar-dynamic",
+			},
+			"slot-static": map[string]interface{}{
+				"key": "value",
+			},
+			"slot-dynamic": map[string]interface{}{
+				"foo-slot-dynamic": "bar-dynamic",
+			},
+		},
+	}, nil, map[string]interface{}{
+		"result": map[string]interface{}{
+			"plugs": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"bind":       map[string]interface{}{"plug": "plug2", "project-id": "b8639dea", "sdk": "consumer", "workshop": "consumer-ws"},
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					},
+				},
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "consumer-ws",
+					"sdk":        "consumer",
+					"plug":       "plug2",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value2"},
+					"label":      "label2",
+				},
+			},
+			"slots": []interface{}{
+				map[string]interface{}{
+					"project-id": "b8639dea",
+					"workshop":   "producer-ws",
+					"sdk":        "producer",
+					"slot":       "slot",
+					"interface":  "test",
+					"attrs":      map[string]interface{}{"key": "value"},
+					"label":      "label",
+					"connections": []interface{}{
+						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					},
+				},
+			},
+			"established": []interface{}{
+				map[string]interface{}{
+					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"interface": "test",
+					"plug-attrs": map[string]interface{}{
+						"key":              "value",
+						"foo-plug-dynamic": "bar-dynamic",
+					},
+					"slot-attrs": map[string]interface{}{
+						"key":              "value",
+						"foo-slot-dynamic": "bar-dynamic",
+					},
+				},
+			},
+		},
+		"status":      "OK",
+		"status-code": 200.0,
+		"type":        "sync",
+	})
+}
+
 func (s *apiSuite) TestConnectionsAll(c *check.C) {
 	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer restore()
@@ -995,7 +1102,7 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 	wp, err := s.b.Workshop(s.ctx, "consumer-ws")
 	c.Check(err, check.IsNil)
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug2"] = workshop.Plug{Bind: "consumer:plug"}
+	wp.File.Sdks[0].Plugs["plug2"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug"}}
 
 	d.Overlord().Loop()
 	defer d.Overlord().Stop()
@@ -1425,7 +1532,7 @@ func (s *apiSuite) TestDisconnectPlugForgetSuccess(c *check.C) {
 func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 	opts := &disconnectOpts{
 		bind: map[string]workshop.Plug{
-			"plug2": {Bind: "consumer:plug"},
+			"plug2": {Bind: workshop.Bind{Sdk: "consumer", Plug: "plug"}},
 		},
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
@@ -1439,7 +1546,7 @@ func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 func (s *apiSuite) TestDisconnectBoundPlugSlaveSuccess(c *check.C) {
 	opts := &disconnectOpts{
 		bind: map[string]workshop.Plug{
-			"plug2": {Bind: "consumer:plug"},
+			"plug2": {Bind: workshop.Bind{Sdk: "consumer", Plug: "plug"}},
 		},
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug2", "producer-ws", "producer", "slot", opts)

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -73,11 +73,22 @@ slots:
 `
 )
 
-func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) {
+func (s *apiSuite) workshopFile(ws string, sdks []*sdk.Info) *workshop.File {
+	file := &workshop.File{Name: ws, Base: "ubuntu@20.04"}
+	for _, s := range sdks {
+		file.Sdks = append(file.Sdks, workshop.SdkRecord{Name: s.Name, Channel: "latest/stable"})
+	}
+	return file
+}
+
+func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop.Workshop {
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
-	wf := &workshop.File{Name: w, Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{{Name: info.Name, Channel: "latest/stable"}}}
+	wf := s.workshopFile(w, []*sdk.Info{info})
 	c.Assert(s.b.LaunchWorkshop(s.ctx, wf), check.IsNil)
+	wp, err := s.b.Workshop(s.ctx, w)
+	c.Check(err, check.IsNil)
+	return wp
 }
 
 func (s *apiSuite) testConnectionsConnected(c *check.C, d *Daemon, query string, connsState map[string]interface{}, repoConnected []string, expected map[string]interface{}) {
@@ -1272,31 +1283,46 @@ func (s *apiSuite) TestConnectFailureOnConflict(c *check.C) {
 	})
 }
 
-func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, slotWorkshop, slotSdk, slotName string, auto, forget bool) {
+type disconnectOpts struct {
+	auto   bool
+	forget bool
+	bind   map[string]workshop.Plug
+}
+
+func (s *apiSuite) connect(c *check.C, plug string, auto bool) *interfaces.ConnRef {
+	repo := s.d.Overlord().InterfaceManager().Repository()
+	connRef := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: plug},
+		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+	}
+	_, err := repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, check.IsNil)
+	return connRef
+}
+
+func (s *apiSuite) testDisconnect(c *check.C, pW, pSdk, pName string, sW, sSdk, sName string, opts *disconnectOpts) {
 	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer restore()
 
 	d := s.daemon(c)
 
-	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	wp := s.mockInstalledSDK(c, consumerYamlBound, "consumer-ws")
+	wp.File.Sdks[0].Plugs = opts.bind
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
-	repo := d.Overlord().InterfaceManager().Repository()
-	connRef := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+	conns := map[string]interface{}{}
+	connRef := s.connect(c, "plug", opts.auto)
+	conns[connRef.ID()] = map[string]interface{}{"interface": "test", "auto": opts.auto}
+
+	for n := range opts.bind {
+		cRef := s.connect(c, n, opts.auto)
+		conns[cRef.ID()] = map[string]interface{}{"interface": "test", "auto": opts.auto,
+			"plug-dynamic": map[string]interface{}{"bind": connRef.ID()}}
 	}
-	_, err := repo.Connect(connRef, nil, nil, nil, nil, nil)
-	c.Assert(err, check.IsNil)
 
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
-			"interface": "test",
-			"auto":      auto,
-		},
-	})
+	st.Set("conns", conns)
 	st.Unlock()
 
 	d.Overlord().Loop()
@@ -1304,9 +1330,9 @@ func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, s
 
 	action := &client.InterfaceAction{
 		Action: "disconnect",
-		Forget: forget,
-		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: plugWorkshop, Sdk: plugSdk, Name: plugName}},
-		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: slotWorkshop, Sdk: slotSdk, Name: slotName}},
+		Forget: opts.forget,
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: pW, Sdk: pSdk, Name: pName}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: sW, Sdk: sSdk, Name: sName}},
 	}
 	text, err := json.Marshal(action)
 	c.Assert(err, check.IsNil)
@@ -1326,7 +1352,7 @@ func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, s
 	chg := st.Change(id)
 	st.Unlock()
 	c.Assert(chg, check.NotNil)
-	c.Assert(chg.Summary(), check.Equals, fmt.Sprintf(`Disconnect %s/%s:%s`, plugWorkshop, plugSdk, plugName))
+	c.Assert(chg.Summary(), check.Equals, fmt.Sprintf(`Disconnect %s/%s:%s`, pW, pSdk, pName))
 
 	<-chg.Ready()
 
@@ -1335,12 +1361,13 @@ func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, s
 	st.Unlock()
 	c.Assert(err, check.IsNil)
 
+	repo := s.d.overlord.InterfaceManager().Repository()
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, check.HasLen, 0)
 }
 
 func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
-	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", false, false)
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", &disconnectOpts{})
 	s.d.state.Lock()
 	var conns map[string]interface{}
 	s.d.state.Get("conns", &conns)
@@ -1349,30 +1376,66 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 }
 
 func (s *apiSuite) TestDisconnectPlugAutoSuccess(c *check.C) {
-	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", true, false)
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", &disconnectOpts{auto: true})
 	s.d.state.Lock()
 	var conns map[string]interface{}
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns, check.DeepEquals, map[string]interface{}{"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{"auto": true, "interface": "test", "undesired": true}})
+	c.Assert(conns, check.DeepEquals,
+		map[string]interface{}{
+			"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+				"auto": true, "interface": "test", "undesired": true,
+			}})
 	s.d.state.Unlock()
 }
 
 func (s *apiSuite) TestDisconnectPlugForgetSuccess(c *check.C) {
-	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", true, true)
-	var conns map[string]interface{}
+	opts := &disconnectOpts{
+		auto:   true,
+		forget: true,
+	}
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
+	var conns map[string]interface{}
+	s.d.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 0)
+	s.d.state.Unlock()
+}
+
+func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
+	opts := &disconnectOpts{
+		bind: map[string]workshop.Plug{
+			"plug2": {Bind: "consumer:plug"},
+		},
+	}
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
+	s.d.state.Lock()
+	var conns map[string]interface{}
+	s.d.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 0)
+	s.d.state.Unlock()
+}
+
+func (s *apiSuite) TestDisconnectBoundPlugSlaveSuccess(c *check.C) {
+	opts := &disconnectOpts{
+		bind: map[string]workshop.Plug{
+			"plug2": {Bind: "consumer:plug"},
+		},
+	}
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug2", "producer-ws", "producer", "slot", opts)
+	s.d.state.Lock()
+	var conns map[string]interface{}
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
 	s.d.state.Unlock()
 }
 
 func (s *apiSuite) TestDisconnectPlugSuccessWithEmptyPlug(c *check.C) {
-	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot", false, false)
+	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot", &disconnectOpts{})
 }
 
 func (s *apiSuite) TestDisconnectPlugSuccessWithEmptySlot(c *check.C) {
-	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "", "", "", false, false)
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "", "", "", &disconnectOpts{})
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -49,6 +49,19 @@ plugs:
   key: value
   label: label
 `
+	consumerYamlBound = `
+name: consumer
+base: ubuntu@22.04
+plugs:
+ plug:
+  interface: test
+  key: value
+  label: label
+ plug2:
+  interface: test
+  key: value2
+  label: label2
+`
 	producerYaml = `
 name: producer
 base: ubuntu@22.04
@@ -957,6 +970,70 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
 		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}})
+}
+
+func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
+	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
+	defer restore()
+
+	d := s.daemon(c)
+
+	s.mockInstalledSDK(c, consumerYamlBound, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	wp, err := s.b.Workshop(s.ctx, "consumer-ws")
+	c.Check(err, check.IsNil)
+	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
+	wp.File.Sdks[0].Plugs["plug2"] = workshop.Plug{Bind: "consumer:plug"}
+
+	d.Overlord().Loop()
+	defer d.Overlord().Stop()
+
+	action := &client.InterfaceAction{
+		Action: "connect",
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"}},
+	}
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	cmd := apiCmd("/v1/connections")
+	req, err := http.NewRequest("POST", cmd.Path, buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 202)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	id := body["change"].(string)
+
+	st := d.Overlord().State()
+	st.Lock()
+	chg := st.Change(id)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+
+	<-chg.Ready()
+
+	st.Lock()
+	err = chg.Err()
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+
+	repo := d.Overlord().InterfaceManager().Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, check.HasLen, 2)
+
+	mainConn := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+	}
+	boundConn := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug2"},
+		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+	}
+	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{mainConn, boundConn})
 }
 
 func mockIface(c *check.C, d *Daemon, iface interfaces.Interface) {

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1272,7 +1272,7 @@ func (s *apiSuite) TestConnectFailureOnConflict(c *check.C) {
 	})
 }
 
-func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, slotWorkshop, slotSdk, slotName string) {
+func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, slotWorkshop, slotSdk, slotName string, auto, forget bool) {
 	restore := builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	defer restore()
 
@@ -1294,6 +1294,7 @@ func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, s
 	st.Set("conns", map[string]interface{}{
 		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
 			"interface": "test",
+			"auto":      auto,
 		},
 	})
 	st.Unlock()
@@ -1303,6 +1304,7 @@ func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, s
 
 	action := &client.InterfaceAction{
 		Action: "disconnect",
+		Forget: forget,
 		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: plugWorkshop, Sdk: plugSdk, Name: plugName}},
 		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: slotWorkshop, Sdk: slotSdk, Name: slotName}},
 	}
@@ -1338,15 +1340,39 @@ func (s *apiSuite) testDisconnect(c *check.C, plugWorkshop, plugSdk, plugName, s
 }
 
 func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
-	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot")
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", false, false)
+	s.d.state.Lock()
+	var conns map[string]interface{}
+	s.d.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 0)
+	s.d.state.Unlock()
+}
+
+func (s *apiSuite) TestDisconnectPlugAutoSuccess(c *check.C) {
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", true, false)
+	s.d.state.Lock()
+	var conns map[string]interface{}
+	s.d.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns, check.DeepEquals, map[string]interface{}{"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{"auto": true, "interface": "test", "undesired": true}})
+	s.d.state.Unlock()
+}
+
+func (s *apiSuite) TestDisconnectPlugForgetSuccess(c *check.C) {
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", true, true)
+	var conns map[string]interface{}
+	s.d.state.Lock()
+	s.d.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 0)
+	s.d.state.Unlock()
 }
 
 func (s *apiSuite) TestDisconnectPlugSuccessWithEmptyPlug(c *check.C) {
-	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot")
+	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot", false, false)
 }
 
 func (s *apiSuite) TestDisconnectPlugSuccessWithEmptySlot(c *check.C) {
-	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "", "", "")
+	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "", "", "", false, false)
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1045,6 +1045,26 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{mainConn, boundConn})
+
+	var conns map[string]interface{}
+	s.d.state.Lock()
+	s.d.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 2)
+	c.Assert(conns, check.DeepEquals,
+		map[string]interface{}{
+			"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+				"interface":   "test",
+				"plug-static": map[string]interface{}{"key": "value"},
+				"slot-static": map[string]interface{}{"key": "value"},
+			},
+			"b8639dea/consumer-ws/consumer:plug2 b8639dea/producer-ws/producer:slot": map[string]interface{}{
+				"interface":    "test",
+				"plug-static":  map[string]interface{}{"key": "value2"},
+				"slot-static":  map[string]interface{}{"key": "value"},
+				"plug-dynamic": map[string]interface{}{"bind": "b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot"},
+			},
+		})
+	s.d.state.Unlock()
 }
 
 func mockIface(c *check.C, d *Daemon, iface interfaces.Interface) {
@@ -1289,7 +1309,7 @@ type disconnectOpts struct {
 	bind   map[string]workshop.Plug
 }
 
-func (s *apiSuite) connect(c *check.C, plug string, auto bool) *interfaces.ConnRef {
+func (s *apiSuite) connect(c *check.C, plug string) *interfaces.ConnRef {
 	repo := s.d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
 		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: plug},
@@ -1311,11 +1331,11 @@ func (s *apiSuite) testDisconnect(c *check.C, pW, pSdk, pName string, sW, sSdk, 
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
 	conns := map[string]interface{}{}
-	connRef := s.connect(c, "plug", opts.auto)
+	connRef := s.connect(c, "plug")
 	conns[connRef.ID()] = map[string]interface{}{"interface": "test", "auto": opts.auto}
 
 	for n := range opts.bind {
-		cRef := s.connect(c, n, opts.auto)
+		cRef := s.connect(c, n)
 		conns[cRef.ID()] = map[string]interface{}{"interface": "test", "auto": opts.auto,
 			"plug-dynamic": map[string]interface{}{"bind": connRef.ID()}}
 	}

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -25,6 +25,11 @@ base: ubuntu@20.04`), 0644)
 
 	err := s.b.LaunchWorkshop(s.ctx, wf)
 	c.Assert(err, check.IsNil)
+
+	wp, err := s.b.Workshop(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	wp.Running = true
+
 	return projectsCmd
 }
 

--- a/internal/daemon/api_json.go
+++ b/internal/daemon/api_json.go
@@ -32,6 +32,7 @@ type plugJSON struct {
 	Interface string                 `json:"interface,omitempty"`
 	Attrs     map[string]interface{} `json:"attrs,omitempty"`
 	Label     string                 `json:"label,omitempty"`
+	Bind      *interfaces.PlugRef    `json:"bind,omitempty"`
 	// Connections are synthesized, they are not on the original type.
 	Connections []interfaces.SlotRef `json:"connections,omitempty"`
 }

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -39,9 +39,8 @@ type apiSuite struct {
 
 	vars map[string]string
 
-	restoreMuxVars    func()
-	restoreUserLookup func()
-	restoreProjectId  func()
+	restoreMuxVars   func()
+	restoreProjectId func()
 }
 
 func TestApi(t *testing.T) { check.TestingT(t) }
@@ -49,24 +48,22 @@ func TestApi(t *testing.T) { check.TestingT(t) }
 func (s *apiSuite) SetUpTest(c *check.C) {
 	s.restoreMuxVars = FakeMuxVars(s.muxVars)
 	s.workshopDir = c.MkDir()
-	s.username = "testuser"
+	usr, err := user.Current()
+	c.Assert(err, check.IsNil)
+	s.username = usr.Name
 	s.project = &workshop.Project{
 		Path:      s.workshopDir,
 		ProjectId: "b8639dea",
 	}
 	s.b = workshop.NewFakeWorkshopBackend()
 
-	s.restoreUserLookup = testutil.FakeFunc(func(uid string) (*user.User, error) {
-		return &user.User{Username: s.username}, nil
-	}, &workshop.LookupUsername)
-
 	// will be called when project is created
 	s.restoreProjectId = testutil.FakeFunc(func() (string, error) { return s.project.ProjectId, nil }, &workshop.NewProjectId)
 
 	ctx := context.WithValue(context.TODO(), workshop.ContextProjectId, s.project.ProjectId)
-	s.ctx = context.WithValue(ctx, workshop.ContextUser, "testuser")
+	s.ctx = context.WithValue(ctx, workshop.ContextUser, s.username)
 
-	_, _, err := s.b.CreateOrLoadProject(s.ctx, s.project.Path)
+	_, _, err = s.b.CreateOrLoadProject(s.ctx, s.project.Path)
 	c.Assert(err, check.IsNil)
 }
 
@@ -74,7 +71,6 @@ func (s *apiSuite) TearDownTest(c *check.C) {
 	s.d = nil
 	s.workshopDir = ""
 	s.restoreMuxVars()
-	s.restoreUserLookup()
 	s.restoreProjectId()
 }
 

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -19,9 +19,11 @@ import (
 	"net/http"
 	"os/user"
 	"testing"
+	"time"
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -36,6 +38,8 @@ type apiSuite struct {
 
 	workshopDir string
 	username    string
+	userhome    string
+	installTime time.Time
 	project     *workshop.Project
 	ctx         context.Context
 
@@ -43,6 +47,8 @@ type apiSuite struct {
 
 	restoreMuxVars   func()
 	restoreProjectId func()
+	restoreUser      func()
+	restoreTime      func()
 }
 
 func TestApi(t *testing.T) { check.TestingT(t) }
@@ -50,15 +56,25 @@ func TestApi(t *testing.T) { check.TestingT(t) }
 func (s *apiSuite) SetUpTest(c *check.C) {
 	s.restoreMuxVars = FakeMuxVars(s.muxVars)
 	s.workshopDir = c.MkDir()
-	usr, err := user.Current()
+
+	s.username = "testuser"
+	s.userhome = c.MkDir()
+	cur, err := user.Current()
 	c.Assert(err, check.IsNil)
-	s.username = usr.Name
+	s.restoreUser = workshop.FakeUserLookup(func(name string) (*user.User, error) {
+		c.Check(name, check.Equals, s.username)
+		return &user.User{Name: s.username, HomeDir: s.userhome, Uid: cur.Uid, Gid: cur.Gid}, nil
+	})
+
 	s.project = &workshop.Project{
 		Path:      s.workshopDir,
 		ProjectId: "b8639dea",
 	}
 	s.b = workshop.NewFakeWorkshopBackend()
 	s.store = &sdk.FakeStore{}
+
+	s.installTime = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
+	s.restoreTime = testutil.FakeFunc(func() time.Time { return s.installTime }, &workshop.InstallTimeNow)
 
 	// will be called when project is created
 	s.restoreProjectId = testutil.FakeFunc(func() (string, error) { return s.project.ProjectId, nil }, &workshop.NewProjectId)
@@ -75,6 +91,8 @@ func (s *apiSuite) TearDownTest(c *check.C) {
 	s.workshopDir = ""
 	s.restoreMuxVars()
 	s.restoreProjectId()
+	s.restoreUser()
+	s.restoreTime()
 }
 
 func (s *apiSuite) muxVars(*http.Request) map[string]string {
@@ -85,6 +103,8 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	if s.d != nil {
 		panic("called daemon() twice")
 	}
+	dirs.SetRootDir(c.MkDir())
+	c.Assert(dirs.CreateDirs(), check.IsNil)
 	d, err := New(&Options{Dir: s.workshopDir}, s.b)
 	c.Assert(err, check.IsNil)
 	c.Assert(d.overlord.StartUp(), check.IsNil)

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -30,7 +30,7 @@ var _ = check.Suite(&apiSuite{})
 
 type apiSuite struct {
 	d *Daemon
-	b workshop.Backend
+	b *workshop.FakeWorkshopBackend
 
 	workshopDir string
 	username    string

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -22,6 +22,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -29,8 +30,9 @@ import (
 var _ = check.Suite(&apiSuite{})
 
 type apiSuite struct {
-	d *Daemon
-	b *workshop.FakeWorkshopBackend
+	d     *Daemon
+	b     *workshop.FakeWorkshopBackend
+	store *sdk.FakeStore
 
 	workshopDir string
 	username    string
@@ -56,6 +58,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 		ProjectId: "b8639dea",
 	}
 	s.b = workshop.NewFakeWorkshopBackend()
+	s.store = &sdk.FakeStore{}
 
 	// will be called when project is created
 	s.restoreProjectId = testutil.FakeFunc(func() (string, error) { return s.project.ProjectId, nil }, &workshop.NewProjectId)
@@ -87,6 +90,8 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	c.Assert(d.overlord.StartUp(), check.IsNil)
 	d.addRoutes()
 	s.d = d
+
+	sdk.ReplaceStore(s.d.state, s.store)
 	return d
 }
 

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -2,88 +2,22 @@ package daemon
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"path/filepath"
 
 	"gopkg.in/check.v1"
-
-	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/workshop"
 )
 
-var wp = `name: %s
-base: ubuntu@20.04
-sdks:
-  test-sdk:
-    channel: latest/stable
-`
-
-var workshopBind = `name: %s
-base: ubuntu@20.04
-sdks:
-  test-sdk:
-    channel: latest/stable
-    plugs:
-      test-plug:
-        bind: test-sdk:test-plug2
-`
-
-func (s *apiSuite) launchWorkshopWithPlug(c *check.C, ctx context.Context, name string, wsyaml string) *workshop.Workshop {
-	b := s.d.overlord.WorkshopBackend()
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(wsyaml, name)), 0644)
-	wf, err := s.project.Workshop(name)
-	c.Assert(err, check.IsNil)
-	err = b.LaunchWorkshop(ctx, wf)
-	c.Assert(err, check.IsNil)
-	ws, err := b.Workshop(ctx, name)
-	c.Assert(err, check.IsNil)
-
-	sdkInfo := &sdk.Info{ProjectId: s.project.ProjectId, Workshop: name, Name: "test-sdk"}
-	plug := &sdk.PlugInfo{
-		Sdk:       sdkInfo,
-		Name:      "test-plug",
-		Interface: "content",
-	}
-	plug2 := &sdk.PlugInfo{
-		Sdk:       sdkInfo,
-		Name:      "test-plug2",
-		Interface: "content",
-	}
-	slot := &sdk.SlotInfo{
-		Sdk:       sdkInfo,
-		Name:      "test-slot",
-		Interface: "content",
-	}
-
-	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.AddPlug(plug), check.IsNil)
-	c.Assert(repo.AddPlug(plug2), check.IsNil)
-	c.Assert(repo.AddSlot(slot), check.IsNil)
-	_, err = repo.Connect(interfaces.NewConnRef(plug, slot), nil, nil, nil, nil, nil)
-	_, err = repo.Connect(interfaces.NewConnRef(plug2, slot), nil, nil, nil, nil, nil)
-
-	c.Assert(err, check.IsNil)
-
-	return ws
-}
-
-func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp) {
-	s.vars = map[string]string{"id": s.project.ProjectId, "name": "ws"}
+func (s *apiSuite) runMountTest(c *check.C, wp string, buffers []*bytes.Buffer, expected []*expectedResp) {
+	s.vars = map[string]string{"id": s.project.ProjectId, "name": wp}
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}/mounts")
 	requests := []*http.Request{}
 
 	for _, i := range buffers {
-		req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workshops/ws/mounts", i)
+		req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workshops/"+wp+"/mounts", i)
 		c.Assert(err, check.IsNil)
 		requests = append(requests, req)
 	}
-
-	s.d.overlord.Loop()
-	defer s.d.overlord.Stop()
 
 	for num, req := range requests {
 		// Execute
@@ -91,7 +25,7 @@ func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []
 
 		// Verify
 		c.Check(rsp.Type, check.Equals, expected[num].Type)
-		c.Assert(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v", num))
+		c.Assert(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v: %v", num, rsp))
 		if rsp.Type == ResponseTypeError {
 			c.Assert(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
 		}
@@ -111,13 +45,15 @@ func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []
 }
 
 func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
-	s.daemon(c)
-
-	s.launchWorkshopWithPlug(c, s.ctx, "ws", wp)
-
 	// Setup
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":%q}`, c.MkDir())),
+		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"source":%q}`, c.MkDir())),
 	}
 
 	expected := []*expectedResp{
@@ -125,21 +61,25 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "remount",
-			Summary: `Remount ws/test-sdk:test-plug`,
+			Summary: `Remount manysdks/test-sdk:data`,
 		},
 	}
 
-	s.runMountTest(c, requests, expected)
+	s.runMountTest(c, "manysdks", requests, expected)
 }
 
 func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
+	// Setup
 	s.daemon(c)
-	s.launchWorkshopWithPlug(c, s.ctx, "ws", workshopBind)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
 
 	// Setup
 	src := c.MkDir()
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":%q}`, src)),
+		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"source":%q}`, src)),
 	}
 
 	expected := []*expectedResp{
@@ -147,13 +87,13 @@ func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "remount",
-			Summary: `Remount ws/test-sdk:test-plug`,
+			Summary: `Remount manysdks/test-sdk:data`,
 		},
 	}
 
-	s.runMountTest(c, requests, expected)
+	s.runMountTest(c, "manysdks", requests, expected)
 	repo := s.d.overlord.InterfaceManager().Repository()
-	ref, err := repo.Connected(s.project.ProjectId, "ws", "test-sdk", "test-plug2")
+	ref, err := repo.Connected(s.project.ProjectId, "manysdks", "test-sdk", "data")
 	c.Assert(err, check.IsNil)
 	conn, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
@@ -163,33 +103,40 @@ func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
 func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
 	// Setup
 	s.daemon(c)
-	s.launchWorkshopWithPlug(c, s.ctx, "ws", wp)
-	_, err := s.d.overlord.InterfaceManager().Repository().DisconnectSdk(s.project.ProjectId, "ws", "test-sdk")
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+
+	_, err := s.d.overlord.InterfaceManager().Repository().DisconnectSdk(s.project.ProjectId, "manysdks", "test-sdk")
 	c.Check(err, check.IsNil)
 
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":"/srv/data"}`),
+		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"source":"/srv/data"}`),
 	}
 
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `"ws/test-sdk:test-plug" must be connected for remount`,
+			Message: `"manysdks/test-sdk:data" must be connected for remount`,
 		},
 	}
 
-	s.runMountTest(c, requests, expected)
+	s.runMountTest(c, "manysdks", requests, expected)
 }
 
 func (s *apiSuite) TestWorkshopRemountInvalidSetup(c *check.C) {
 	s.daemon(c)
-	s.launchWorkshop(s.ctx, "ws", c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
 
 	// Setup
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"action":"mount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":"/srv/data"}`),
-		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug","source":"/srv/data"}`),
+		bytes.NewBufferString(`{"action":"mount","plug":{"sdk":"test-sdk","plug":"data"},"source":"/srv/data"}`),
+		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data","source":"/srv/data"}`),
 	}
 
 	expected := []*expectedResp{
@@ -205,34 +152,19 @@ func (s *apiSuite) TestWorkshopRemountInvalidSetup(c *check.C) {
 		},
 	}
 
-	s.runMountTest(c, requests, expected)
+	s.runMountTest(c, "manysdks", requests, expected)
 }
 
 func (s *apiSuite) TestWorkshopRemountInvalidInterface(c *check.C) {
 	s.daemon(c)
-	s.launchWorkshop(s.ctx, "ws", c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 
-	sdkInfo := &sdk.Info{ProjectId: s.project.ProjectId, Workshop: "ws", Name: "test-sdk"}
-	plug := &sdk.PlugInfo{
-		Sdk:       sdkInfo,
-		Name:      "test-plug",
-		Interface: "gpu",
-	}
-	slot := &sdk.SlotInfo{
-		Sdk:       sdkInfo,
-		Name:      "test-slot",
-		Interface: "gpu",
-	}
-
-	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.AddPlug(plug), check.IsNil)
-	c.Assert(repo.AddSlot(slot), check.IsNil)
-	_, err := repo.Connect(interfaces.NewConnRef(plug, slot), nil, nil, nil, nil, nil)
-	c.Assert(err, check.IsNil)
+	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
 
 	// Setup
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":"/srv/data"}`),
+		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk-2","plug":"gpu"},"source":"/srv/data"}`),
 	}
 
 	expected := []*expectedResp{
@@ -243,7 +175,5 @@ func (s *apiSuite) TestWorkshopRemountInvalidInterface(c *check.C) {
 		},
 	}
 
-	soon := 0
-	s.runMountTest(c, requests, expected)
-	c.Assert(soon, check.Equals, 0)
+	s.runMountTest(c, "manysdks", requests, expected)
 }

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -7,26 +7,36 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"time"
 
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-func (s *apiSuite) launchWorkshopWithPlug(c *check.C, ctx context.Context, name string) *workshop.Workshop {
-	b := s.d.overlord.WorkshopBackend()
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
+var wp = `name: %s
 base: ubuntu@20.04
 sdks:
   test-sdk:
     channel: latest/stable
-`, name)), 0644)
-	wf := &workshop.File{Name: name, Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{{Name: "test-sdk", Channel: "latest/stable"}}}
+`
+
+var workshopBind = `name: %s
+base: ubuntu@20.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      test-plug:
+        bind: test-sdk:test-plug2
+`
+
+func (s *apiSuite) launchWorkshopWithPlug(c *check.C, ctx context.Context, name string, wsyaml string) *workshop.Workshop {
+	b := s.d.overlord.WorkshopBackend()
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(wsyaml, name)), 0644)
+	wf, err := s.project.Workshop(name)
+	c.Assert(err, check.IsNil)
 	err = b.LaunchWorkshop(ctx, wf)
 	c.Assert(err, check.IsNil)
 	ws, err := b.Workshop(ctx, name)
@@ -38,6 +48,11 @@ sdks:
 		Name:      "test-plug",
 		Interface: "content",
 	}
+	plug2 := &sdk.PlugInfo{
+		Sdk:       sdkInfo,
+		Name:      "test-plug2",
+		Interface: "content",
+	}
 	slot := &sdk.SlotInfo{
 		Sdk:       sdkInfo,
 		Name:      "test-slot",
@@ -46,14 +61,17 @@ sdks:
 
 	repo := s.d.overlord.InterfaceManager().Repository()
 	c.Assert(repo.AddPlug(plug), check.IsNil)
+	c.Assert(repo.AddPlug(plug2), check.IsNil)
 	c.Assert(repo.AddSlot(slot), check.IsNil)
 	_, err = repo.Connect(interfaces.NewConnRef(plug, slot), nil, nil, nil, nil, nil)
+	_, err = repo.Connect(interfaces.NewConnRef(plug2, slot), nil, nil, nil, nil, nil)
+
 	c.Assert(err, check.IsNil)
 
 	return ws
 }
 
-func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp, ens func(st *state.State, d time.Duration)) {
+func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp) {
 	s.vars = map[string]string{"id": s.project.ProjectId, "name": "ws"}
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}/mounts")
 	requests := []*http.Request{}
@@ -64,8 +82,8 @@ func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []
 		requests = append(requests, req)
 	}
 
-	restoreEnsure := testutil.FakeFunc(ens, &ensureStateSoon)
-	defer restoreEnsure()
+	s.d.overlord.Loop()
+	defer s.d.overlord.Stop()
 
 	for num, req := range requests {
 		// Execute
@@ -86,17 +104,20 @@ func (s *apiSuite) runMountTest(c *check.C, buffers []*bytes.Buffer, expected []
 			c.Assert(change, check.NotNil)
 			c.Assert(change.Kind(), check.Equals, expected[num].Kind)
 			c.Assert(change.Summary(), check.Equals, expected[num].Summary)
+			<-change.Ready()
+			c.Assert(change.Err(), check.IsNil)
 		}
 	}
 }
 
 func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 	s.daemon(c)
-	s.launchWorkshopWithPlug(c, s.ctx, "ws")
+
+	s.launchWorkshopWithPlug(c, s.ctx, "ws", wp)
 
 	// Setup
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":"/srv/data"}`),
+		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":%q}`, c.MkDir())),
 	}
 
 	expected := []*expectedResp{
@@ -108,15 +129,41 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 		},
 	}
 
-	soon := 0
-	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) { soon++ })
-	c.Assert(soon, check.Equals, 1)
+	s.runMountTest(c, requests, expected)
+}
+
+func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
+	s.daemon(c)
+	s.launchWorkshopWithPlug(c, s.ctx, "ws", workshopBind)
+
+	// Setup
+	src := c.MkDir()
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"test-plug"},"source":%q}`, src)),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "remount",
+			Summary: `Remount ws/test-sdk:test-plug`,
+		},
+	}
+
+	s.runMountTest(c, requests, expected)
+	repo := s.d.overlord.InterfaceManager().Repository()
+	ref, err := repo.Connected(s.project.ProjectId, "ws", "test-sdk", "test-plug2")
+	c.Assert(err, check.IsNil)
+	conn, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	c.Assert(conn.Plug.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"source": src})
 }
 
 func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
 	// Setup
 	s.daemon(c)
-	s.launchWorkshopWithPlug(c, s.ctx, "ws")
+	s.launchWorkshopWithPlug(c, s.ctx, "ws", wp)
 	_, err := s.d.overlord.InterfaceManager().Repository().DisconnectSdk(s.project.ProjectId, "ws", "test-sdk")
 	c.Check(err, check.IsNil)
 
@@ -132,7 +179,7 @@ func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
 		},
 	}
 
-	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) {})
+	s.runMountTest(c, requests, expected)
 }
 
 func (s *apiSuite) TestWorkshopRemountInvalidSetup(c *check.C) {
@@ -158,7 +205,7 @@ func (s *apiSuite) TestWorkshopRemountInvalidSetup(c *check.C) {
 		},
 	}
 
-	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) {})
+	s.runMountTest(c, requests, expected)
 }
 
 func (s *apiSuite) TestWorkshopRemountInvalidInterface(c *check.C) {
@@ -197,6 +244,6 @@ func (s *apiSuite) TestWorkshopRemountInvalidInterface(c *check.C) {
 	}
 
 	soon := 0
-	s.runMountTest(c, requests, expected, func(st *state.State, d time.Duration) { soon++ })
+	s.runMountTest(c, requests, expected)
 	c.Assert(soon, check.Equals, 0)
 }

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
@@ -132,29 +131,46 @@ func sdkConnsToMounts(st *state.State, repo *interfaces.Repository, projectId, w
 	for _, conn := range connections {
 		connection, err := repo.Connection(conn)
 		if err != nil {
+			st.Warnf("cannot obtain %s plug connection: %v", conn.PlugRef.ShortRef(), err)
 			continue
 		}
-
 		if connection.Interface() == "content" {
-			var source, target string
-			err = connection.Plug.Attr("source", &source)
+			source, target, err := sourceTarget(repo, connection)
 			if err != nil {
-				logger.Noticef(`Cannot obtain '`)
-				continue
-			}
-			// check if the source exists as otherwise the mount is broken
-			if _, err = os.Stat(source); osutil.IsDirNotExist(err) {
-				st.Warnf("%s/%s:%s mount is broken: %s does not exist", w, sdk, connection.Plug.Name(), source)
-			}
-
-			err = connection.Plug.Attr("target", &target)
-			if err != nil {
+				st.Warnf("cannot obtain %s mount properties: %v", conn.PlugRef.ShortRef(), err)
 				continue
 			}
 			mounts = append(mounts, &Mount{Source: source, Target: target, Plug: conn.PlugRef})
 		}
 	}
 	return mounts
+}
+
+func sourceTarget(repo *interfaces.Repository, connection *interfaces.Connection) (string, string, error) {
+	var source, target string
+
+	if bref, ok := connection.CheckBound(); ok {
+		bind, err := repo.Connection(bref)
+		if err != nil {
+			return source, target, err
+		}
+		connection = bind
+	}
+
+	err := connection.Plug.Attr("source", &source)
+	if err != nil {
+		return source, target, err
+	}
+	// check if the source exists as otherwise the mount is broken
+	if _, err = os.Stat(source); osutil.IsDirNotExist(err) {
+		return source, target, fmt.Errorf("%s mount is broken: %s does not exist", connection.Plug.Ref().ShortRef(), source)
+	}
+
+	err = connection.Plug.Attr("target", &target)
+	if err != nil {
+		return source, target, err
+	}
+	return source, target, nil
 }
 
 func newWorkshopChange(st *state.State, kind string, user, projectId string, reqData *workshopReq) *state.Change {

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
@@ -138,6 +139,7 @@ func sdkConnsToMounts(st *state.State, repo *interfaces.Repository, projectId, w
 			var source, target string
 			err = connection.Plug.Attr("source", &source)
 			if err != nil {
+				logger.Noticef(`Cannot obtain '`)
 				continue
 			}
 			// check if the source exists as otherwise the mount is broken

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -65,7 +66,7 @@ type WorkshopInfo struct {
 }
 
 var ensureStateSoon = stateEnsureBefore
-var sdkMounts = mounts
+var workshopMounts = mounts
 
 func workshopFileToInfo(file *workshop.File, pid string) *WorkshopInfo {
 	var ws WorkshopInfo
@@ -122,7 +123,7 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState, mounts
 	return &info
 }
 
-func mounts(ctx context.Context, back workshop.Backend, w *workshop.Workshop) (map[string][]*Mount, error) {
+func mounts(ctx context.Context, w *workshop.Workshop) (map[string][]*Mount, error) {
 	var mnts = map[string][]*Mount{}
 
 	content, err := w.ContentInfo(ctx)
@@ -140,10 +141,13 @@ func mounts(ctx context.Context, back workshop.Backend, w *workshop.Workshop) (m
 	}
 
 	for _, sk := range content {
-		prof, err := back.Profile(ctx, w.Name, sk.Name)
-		if err != nil {
+		prof, err := w.Backend.Profile(ctx, w.Name, sk.Name)
+		if err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
 			logger.Noticef("Failed to obtain mounts for %s/%s: %v", w.Name, sk.Name, err)
 			return mnts, err
+		}
+		if errors.Is(err, workshop.ErrSdkProfileNotFound) {
+			continue
 		}
 		for n, dev := range prof.Devices {
 			if dev.Type == workshop.BindMount {
@@ -336,7 +340,7 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	health := workshopHealth(wrkmgr, w)
 
 	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
-	ms, err := sdkMounts(ctx, c.d.overlord.WorkshopBackend(), w)
+	ms, err := workshopMounts(ctx, w)
 	if err != nil {
 		return statusBadRequest(err.Error())
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -2,10 +2,10 @@ package daemon
 
 import (
 	"cmp"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -65,7 +65,7 @@ type WorkshopInfo struct {
 }
 
 var ensureStateSoon = stateEnsureBefore
-var sdkMounts = sdkConnsToMounts
+var sdkMounts = mounts
 
 func workshopFileToInfo(file *workshop.File, pid string) *WorkshopInfo {
 	var ws WorkshopInfo
@@ -122,55 +122,53 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState, mounts
 	return &info
 }
 
-func sdkConnsToMounts(st *state.State, repo *interfaces.Repository, projectId, w, sdk string) []*Mount {
-	connections, err := repo.Connections(projectId, w, sdk)
+func mounts(ctx context.Context, back workshop.Backend, w *workshop.Workshop) (map[string][]*Mount, error) {
+	var mnts = map[string][]*Mount{}
+
+	content, err := w.ContentInfo(ctx)
 	if err != nil {
-		return nil
+		return mnts, err
 	}
-	var mounts []*Mount
-	for _, conn := range connections {
-		connection, err := repo.Connection(conn)
-		if err != nil {
-			st.Warnf("cannot obtain %s plug connection: %v", conn.PlugRef.ShortRef(), err)
-			continue
+
+	masters := map[interfaces.PlugRef][]interfaces.PlugRef{}
+	for _, sk := range content {
+		for s, m := range sk.PlugBinds {
+			ref := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: m.Sdk, Name: m.Name}
+			sref := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: sk.Name, Name: s}
+			masters[ref] = append(masters[ref], sref)
 		}
-		if connection.Interface() == "content" {
-			source, target, err := sourceTarget(repo, connection)
-			if err != nil {
-				st.Warnf("cannot obtain %s mount properties: %v", conn.PlugRef.ShortRef(), err)
-				continue
+	}
+
+	for _, sk := range content {
+		prof, err := back.Profile(ctx, w.Name, sk.Name)
+		if err != nil {
+			logger.Noticef("Failed to obtain mounts for %s/%s: %v", w.Name, sk.Name, err)
+			return mnts, err
+		}
+		for n, dev := range prof.Devices {
+			if dev.Type == workshop.BindMount {
+				pref := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: sk.Name, Name: n}
+				mnt := &Mount{
+					Plug:   pref,
+					Source: dev.Properties["source"],
+					Target: dev.Properties["path"],
+				}
+				mnts[sk.Name] = append(mnts[sk.Name], mnt)
+				if slaves, ok := masters[pref]; ok {
+					for _, slave := range slaves {
+						mnt := &Mount{
+							Plug:   slave,
+							Source: dev.Properties["source"],
+							Target: dev.Properties["path"],
+						}
+						mnts[slave.Sdk] = append(mnts[slave.Sdk], mnt)
+					}
+				}
 			}
-			mounts = append(mounts, &Mount{Source: source, Target: target, Plug: conn.PlugRef})
 		}
 	}
-	return mounts
-}
 
-func sourceTarget(repo *interfaces.Repository, connection *interfaces.Connection) (string, string, error) {
-	var source, target string
-
-	if bref, ok := connection.CheckBound(); ok {
-		bind, err := repo.Connection(bref)
-		if err != nil {
-			return source, target, err
-		}
-		connection = bind
-	}
-
-	err := connection.Plug.Attr("source", &source)
-	if err != nil {
-		return source, target, err
-	}
-	// check if the source exists as otherwise the mount is broken
-	if _, err = os.Stat(source); osutil.IsDirNotExist(err) {
-		return source, target, fmt.Errorf("%s mount is broken: %s does not exist", connection.Plug.Ref().ShortRef(), source)
-	}
-
-	err = connection.Plug.Attr("target", &target)
-	if err != nil {
-		return source, target, err
-	}
-	return source, target, nil
+	return mnts, nil
 }
 
 func newWorkshopChange(st *state.State, kind string, user, projectId string, reqData *workshopReq) *state.Change {
@@ -337,11 +335,11 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 	health := workshopHealth(wrkmgr, w)
 
-	repo := c.d.overlord.InterfaceManager().Repository()
-	mounts := map[string][]*Mount{}
-	for _, sdk := range w.Content {
-		mounts[sdk.Name] = sdkMounts(state, repo, projectId, name, sdk.Name)
+	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
+	ms, err := sdkMounts(ctx, c.d.overlord.WorkshopBackend(), w)
+	if err != nil {
+		return statusBadRequest(err.Error())
 	}
 
-	return SyncResponse(workshopToInfo(w, health, mounts), http.StatusOK)
+	return SyncResponse(workshopToInfo(w, health, ms), http.StatusOK)
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -3,50 +3,153 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/overlord/healthstate"
+	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-func (s *apiSuite) launchWorkshop(ctx context.Context, name string, c *check.C) *workshop.Workshop {
-	b := s.d.overlord.WorkshopBackend()
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
+var (
+	basic = `name: basic
+base: ubuntu@22.04
+`
+	manysdks = `name: manysdks
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+  test-sdk-2:
+    channel: latest/stable
+`
+
+	somebound = `name: somebound
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: test-sdk-2:photos
+  test-sdk-2:
+    channel: latest/stable
+`
+
+	masterunknown = `name: masterunknown
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: test-sdk-2:unknown
+  test-sdk-2:
+    channel: latest/stable
+`
+
+	slaveunknown = `name: slaveunknown
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      unknown:
+        bind: test-sdk-2:photos
+  test-sdk-2:
+    channel: latest/stable
+`
+
+	bindincompatible = `name: bindincompatible
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: test-sdk-2:gpu
+  test-sdk-2:
+    channel: latest/stable
+`
+
+	testsdk = `
+name: test-sdk
 base: ubuntu@20.04
-`, name)), 0644)
-	c.Assert(err, check.IsNil)
-	wf := &workshop.File{Name: name, Base: "ubuntu@20.04"}
-	err = b.LaunchWorkshop(ctx, wf)
-	c.Assert(err, check.IsNil)
-	ws, err := b.Workshop(ctx, name)
-	c.Assert(err, check.IsNil)
-	return ws
+title: title
+summary: summary
+description: SDK
+plugs:
+  data:
+    interface: content
+    target: /opt/data
+  ssh-agent:
+    interface: test
+`
+
+	testsdk2 = `
+name: test-sdk-2
+base: ubuntu@20.04
+title: title
+summary: summary
+description: SDK
+plugs:
+  photos:
+    interface: content
+    target: /opt/data2
+  gpu:
+    interface: gpu
+`
+)
+
+var testsdks = map[string]string{
+	"test-sdk":   testsdk,
+	"test-sdk-2": testsdk2,
 }
 
-func (s *apiSuite) TestProjectsGetWorkshops(c *check.C) {
+func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string, sdks map[string]string) {
+	s.createWFile(c, name, yaml)
+
+	defer s.store.SetActionCallback(storeAction)()
+	defer s.mockWorkshopFs(c, sdks)()
+
+	reqbuf := bytes.NewBufferString(fmt.Sprintf(`{"names":["%s"],"action":"launch"}`, name))
+	s.vars = map[string]string{"id": s.project.ProjectId}
+	req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workshops", reqbuf)
+	c.Assert(err, check.IsNil)
+
+	rsp := v1PostProjectWorkshop(apiCmd("/v1/projects/{id}/workshops"), req, nil).(*resp)
+	st := s.d.state
+	st.Lock()
+	change := st.Change(rsp.Change)
+	st.Unlock()
+	<-change.Ready()
+
+	c.Assert(change.Err(), check.IsNil)
+}
+
+func (s *apiSuite) TestGetWorkshops(c *check.C) {
 	// Setup
 	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+	s.launchWorkshop(c, "basic", basic, map[string]string{})
+
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	s.vars = map[string]string{"id": s.project.ProjectId}
 	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops", nil)
 	c.Assert(err, check.IsNil)
-
-	restore := testutil.FakeFunc(func() time.Time { return time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC) }, &workshop.InstallTimeNow)
-	defer restore()
-
-	w := s.launchWorkshop(s.ctx, "ws-test", c)
-	w.LinkSdk(s.ctx, sdk.Setup{Name: "go", Channel: "latest/stable", Revision: 234})
 
 	// Execute
 	rsp := v1GetProjectWorkshops(projectsCmd, req, nil).(*resp)
@@ -57,57 +160,53 @@ func (s *apiSuite) TestProjectsGetWorkshops(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
-	t := time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
+	// for DeepEqual to work correctly
+	t1, t2 := s.installTime, s.installTime
 	c.Check(rsp.Result, check.DeepEquals, []*WorkshopInfo{
 		{
-			Name:      "ws-test",
-			Base:      "ubuntu@20.04",
+			Name:      "manysdks",
+			Base:      "ubuntu@22.04",
 			ProjectId: s.project.ProjectId,
 			Status:    "Ready",
 			Content: []*SdkInfo{
 				{
-					Name:        "go",
+					Name:        "test-sdk",
 					Channel:     "latest/stable",
-					Revision:    "234",
-					InstallTime: &t,
+					Revision:    "0",
+					InstallTime: &t1,
+				},
+				{
+					Name:        "test-sdk-2",
+					Channel:     "latest/stable",
+					Revision:    "0",
+					InstallTime: &t2,
 				},
 			},
 			Notes: nil,
+		}, {
+			Name:      "basic",
+			Base:      "ubuntu@22.04",
+			ProjectId: s.project.ProjectId,
+			Status:    "Ready",
+			Notes:     nil,
 		},
 	})
 }
 
-func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
-	// Setup
+func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
+	// Setup (create a running workshop)
 	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+
+	// Get Workshop info
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}")
-	s.vars = map[string]string{"id": s.project.ProjectId, "name": "ws-test"}
-	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops/ws-test", nil)
-	c.Assert(err, check.IsNil)
-
-	w := s.launchWorkshop(s.ctx, "ws-test", c)
-	restoreTime := testutil.FakeFunc(func() time.Time { return time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC) }, &workshop.InstallTimeNow)
-	w.LinkSdk(s.ctx, sdk.Setup{Name: "go", Channel: "latest/stable", Revision: 234})
-	w.LinkSdk(s.ctx, sdk.Setup{Name: "java", Channel: "latest/stable", Revision: 324})
-	restoreTime()
-
-	// Execute
-	restoreHealth := FakeWorkshopHealth(func(mgr *workshopstate.WorkshopManager, w *workshop.Workshop) healthstate.HealthState {
-		return healthstate.HealthState{Status: healthstate.ReadyStatus, SdkHealth: map[string]healthstate.HealthCheck{
-			"go": {Sdk: "go", Message: "test health check message", Code: "check-waiting", CheckResult: healthstate.CheckWaiting},
-		}}
-	})
-	restoreMounts := FakeSdkMounts(func(ctx context.Context, back workshop.Backend, w *workshop.Workshop) (map[string][]*Mount, error) {
-		return map[string][]*Mount{
-			"go":   {{Source: "/home/user/go", Target: "/home/workshop/go", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "go", Name: "content-plug"}}},
-			"java": {{Source: "/home/user/java", Target: "/home/workshop/java", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "java", Name: "content-plug"}}},
-		}, nil
-	})
+	s.vars = map[string]string{"id": s.project.ProjectId, "name": "manysdks"}
+	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops/manysdks", nil)
 
 	rsp := v1GetProjectWorkshop(projectsCmd, req, nil).(*resp)
-
-	restoreHealth()
-	restoreMounts()
 
 	// Verify
 	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
@@ -115,33 +214,120 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
-	t := time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
+	// for DeepEqual to work correctly
+	t1, t2 := s.installTime, s.installTime
 	c.Check(rsp.Result, check.DeepEquals, &WorkshopInfo{
-		Name:      "ws-test",
-		Base:      "ubuntu@20.04",
+		Name:      "manysdks",
+		Base:      "ubuntu@22.04",
 		ProjectId: s.project.ProjectId,
 		Status:    "Ready",
 		Notes:     nil,
 		Content: []*SdkInfo{
 			{
-				Name:        "go",
+				Name:        "test-sdk",
 				Channel:     "latest/stable",
-				Revision:    "234",
-				InstallTime: &t,
-				Health: &HealthCheckInfo{
-					Message: "test health check message",
-					Code:    "check-waiting",
-				},
+				Revision:    "0",
+				InstallTime: &t1,
 				Mounts: []*Mount{
-					{Source: "/home/user/go", Target: "/home/workshop/go", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "go", Name: "content-plug"}}},
+					{
+						Source: sdk.DefaultContentSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk", "data"),
+						Target: "/opt/data",
+						Plug: interfaces.PlugRef{
+							ProjectId: s.project.ProjectId,
+							Workshop:  "manysdks",
+							Sdk:       "test-sdk",
+							Name:      "data",
+						},
+					},
+				},
 			},
 			{
-				Name:        "java",
+				Name:        "test-sdk-2",
 				Channel:     "latest/stable",
-				Revision:    "324",
-				InstallTime: &t,
+				Revision:    "0",
+				InstallTime: &t2,
 				Mounts: []*Mount{
-					{Source: "/home/user/java", Target: "/home/workshop/java", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "java", Name: "content-plug"}}},
+					{
+						Source: sdk.DefaultContentSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk-2", "photos"),
+						Target: "/opt/data2",
+						Plug: interfaces.PlugRef{
+							ProjectId: s.project.ProjectId,
+							Workshop:  "manysdks",
+							Sdk:       "test-sdk-2",
+							Name:      "photos",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
+	// Setup (create a running workshop)
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "somebound", somebound, testsdks)
+
+	// Get Workshop info
+	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}")
+	s.vars = map[string]string{"id": s.project.ProjectId, "name": "somebound"}
+	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops/somebound", nil)
+
+	rsp := v1GetProjectWorkshop(projectsCmd, req, nil).(*resp)
+
+	// Verify
+	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Assert(rsp.Status, check.Equals, http.StatusOK)
+
+	_, err = rsp.MarshalJSON()
+	c.Assert(err, check.IsNil)
+	// for DeepEqual to work correctly
+	t1, t2 := s.installTime, s.installTime
+	c.Check(rsp.Result, check.DeepEquals, &WorkshopInfo{
+		Name:      "somebound",
+		Base:      "ubuntu@22.04",
+		ProjectId: s.project.ProjectId,
+		Status:    "Ready",
+		Notes:     nil,
+		Content: []*SdkInfo{
+			{
+				Name:        "test-sdk",
+				Channel:     "latest/stable",
+				Revision:    "0",
+				InstallTime: &t1,
+				Mounts: []*Mount{
+					{
+						Source: sdk.DefaultContentSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
+						Target: "/opt/data2",
+						Plug: interfaces.PlugRef{
+							ProjectId: s.project.ProjectId,
+							Workshop:  "somebound",
+							Sdk:       "test-sdk",
+							Name:      "data",
+						},
+					},
+				},
+			},
+			{
+				Name:        "test-sdk-2",
+				Channel:     "latest/stable",
+				Revision:    "0",
+				InstallTime: &t2,
+				Mounts: []*Mount{
+					{
+						Source: sdk.DefaultContentSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
+						Target: "/opt/data2",
+						Plug: interfaces.PlugRef{
+							ProjectId: s.project.ProjectId,
+							Workshop:  "somebound",
+							Sdk:       "test-sdk-2",
+							Name:      "photos",
+						},
+					},
+				},
 			},
 		},
 	})
@@ -155,10 +341,11 @@ type expectedResp struct {
 	Summary string
 }
 
-func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp, ens func(st *state.State, d time.Duration)) {
+func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp) {
 	s.daemon(c)
+	defer s.store.SetActionCallback(storeAction)()
+
 	s.vars = map[string]string{"id": s.project.ProjectId}
-	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	requests := []*http.Request{}
 
 	for _, i := range buffers {
@@ -167,48 +354,99 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 		requests = append(requests, req)
 	}
 
-	restoreEnsure := testutil.FakeFunc(ens, &ensureStateSoon)
-	defer restoreEnsure()
-
-	s.launchWorkshop(s.ctx, "ws", c)
-	s.launchWorkshop(s.ctx, "ws1", c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 
 	for num, req := range requests {
 		// Execute
-		rsp := v1PostProjectWorkshop(projectsCmd, req, nil).(*resp)
+		rsp := v1PostProjectWorkshop(apiCmd("/v1/projects/{id}/workshops"), req, nil).(*resp)
+
+		st := s.d.state
+		st.Lock()
+		change := st.Change(rsp.Change)
+		st.Unlock()
 
 		// Verify
 		c.Check(rsp.Type, check.Equals, expected[num].Type)
 		c.Check(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v", num))
+
 		if rsp.Type == ResponseTypeError {
 			c.Check(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
 		}
 
 		if rsp.Type == ResponseTypeAsync {
-			st := s.d.state
-			st.Lock()
-			change := s.d.state.Change(rsp.Change)
-			st.Unlock()
-			c.Check(change, check.NotNil)
+			ticker := time.NewTicker(100 * time.Millisecond)
+		End:
+			for {
+				select {
+				case <-change.Ready():
+					break End
+				case <-ticker.C:
+					st.Lock()
+					status := change.Status()
+					st.Unlock()
+					if status == state.WaitStatus {
+						break End
+					}
+				}
+			}
 			c.Check(change.Kind(), check.Equals, expected[num].Kind)
 			c.Check(change.Summary(), check.Equals, expected[num].Summary)
 		}
 	}
 }
 
-func (s *apiSuite) TestProjectWorkshopLaunchBasic(c *check.C) {
-	// Setup
+func (s *apiSuite) createWFile(c *check.C, name, yaml string) {
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)),
+		[]byte(yaml), 0644)
+	c.Assert(err, check.IsNil)
+}
 
-	name := "workshop"
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
-base: ubuntu@20.04
-`, name)), 0644)
-	c.Check(err, check.IsNil)
+func storeAction(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
+	var result = []sdk.SdkResult{}
+	for _, act := range actions {
+		info, err := sdk.ReadSdkInfo([]byte(testsdks[act.Name]), act.ProjectId, act.Workshop)
+		if err != nil {
+			return nil, err
+		}
+		info.Channel = act.Channel
+		result = append(result, sdk.SdkResult{Info: info})
+	}
+	return result, nil
+}
+
+func (s *apiSuite) mockWorkshopFs(c *check.C, sdks map[string]string) func() {
+	fs := workshop.NewFakeWorkshopFs()
+
+	for n, s := range sdks {
+		metadir := filepath.Join(sdk.SdkCurrentPath(n), "meta")
+		err := fs.MkdirAll(metadir, 0655)
+		c.Assert(err, check.IsNil)
+
+		file, err := fs.OpenFile(filepath.Join(metadir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
+		c.Assert(err, check.IsNil)
+
+		_, err = file.Write([]byte(s))
+		c.Assert(err, check.IsNil)
+	}
+
+	s.b.WorkshopFsCallback = func(ctx context.Context, name string) (workshop.WorkshopFs, error) {
+		wp, ok := s.b.Workshops[s.project.ProjectId][name]
+		c.Assert(ok, check.Equals, true)
+		wp.WorkshopFilesystem = fs
+		return fs, nil
+	}
+	return func() { s.b.WorkshopFsCallback = nil }
+}
+
+func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
+	// Setup
+	s.createWFile(c, "basic", basic)
 
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["workshop", "workshop", "workshop"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic", "basic", "basic"],"action":"launch"}`),
 		bytes.NewBufferString(`{"names":[],"action":"launch"}`),
-		bytes.NewBufferString(`{"names":["ws"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
 	}
 
 	expected := []*expectedResp{
@@ -216,7 +454,7 @@ base: ubuntu@20.04
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "launch",
-			Summary: `Launch "workshop" workshop`,
+			Summary: `Launch "basic" workshop`,
 		},
 		{
 			Type:    ResponseTypeError,
@@ -225,65 +463,27 @@ base: ubuntu@20.04
 		},
 		{
 			Type:    ResponseTypeError,
-			Message: "cannot launch: \"ws\" already exists",
+			Message: `cannot launch: "basic" already exists`,
 			Status:  http.StatusBadRequest,
 		},
 	}
 
-	soon := 0
-	ensure := func(st *state.State, d time.Duration) {
-		soon++
-	}
+	s.runActionTest(c, requests, expected)
 
-	s.runActionTest(c, requests, expected, ensure)
-
-	// all successful responses must initiate the ensure call
-	c.Assert(soon, check.Equals, 1)
+	_, err := s.b.Workshop(s.ctx, "basic")
+	c.Assert(err, check.IsNil)
+	c.Assert(s.b.AssignProfileCalls, check.HasLen, 0)
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.Slots(s.project.ProjectId, "basic", "agent"), check.HasLen, 3)
 }
 
-var testsdk = `
-name: test-sdk
-base: ubuntu@20.04
-title: title
-summary: summary
-description: SDK
-plugs:
-  data:
-    interface: content
-    target: /opt/data
-  cache:
-    interface: content
-    target: /opt/cache
-  ssh-agent:
-    interface: ssh-agent
-`
-
-func (s *apiSuite) TestProjectWorkshopLaunchPlugBindsSuccess(c *check.C) {
+func (s *apiSuite) TestWorkshopLaunchPlugBindsSuccess(c *check.C) {
 	// Setup
-
-	name := "workshop"
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
-base: ubuntu@20.04
-sdks: 
-  test-sdk:
-    channel: latest/stable
-    plugs:
-      data:
-        bind: test-sdk:cache
-`, name)), 0644)
-	c.Check(err, check.IsNil)
-
-	s.store.ActionCallback = func(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
-		info, err := sdk.ReadSdkInfo([]byte(testsdk), s.project.ProjectId, "workshop")
-		c.Assert(err, check.IsNil)
-		return []sdk.SdkResult{{info}}, nil
-	}
-	defer func() {
-		s.store.ActionCallback = nil
-	}()
+	s.createWFile(c, "somebound", somebound)
+	defer s.mockWorkshopFs(c, testsdks)()
 
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["workshop"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["somebound"],"action":"launch"}`),
 	}
 
 	expected := []*expectedResp{
@@ -291,47 +491,52 @@ sdks:
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "launch",
-			Summary: `Launch "workshop" workshop`,
+			Summary: `Launch "somebound" workshop`,
 		},
 	}
 
-	soon := 0
-	ensure := func(st *state.State, d time.Duration) {
-		soon++
-	}
+	s.runActionTest(c, requests, expected)
+	_, err := s.b.Workshop(s.ctx, "somebound")
+	c.Assert(err, check.IsNil)
 
-	s.runActionTest(c, requests, expected, ensure)
+	repo := s.d.overlord.InterfaceManager().Repository()
+	conns, err := repo.Connected(s.project.ProjectId, "somebound", "test-sdk", "data")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
 
-	// all successful responses must initiate the ensure call
-	c.Assert(soon, check.Equals, 1)
+	connection, err := repo.Connection(conns[0])
+	c.Assert(err, check.IsNil)
+	_, bound := connection.CheckBound()
+	c.Assert(bound, check.Equals, true)
 }
 
-func (s *apiSuite) TestProjectWorkshopLaunchBindPlugNoMasterPlug(c *check.C) {
+func (s *apiSuite) TestWorkshopLaunchBindPlugNoMasterPlug(c *check.C) {
 	// Setup
 
-	name := "workshop"
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
-base: ubuntu@20.04
-sdks: 
-  test-sdk:
-    channel: latest/stable
-    plugs:
-      data:
-        bind: test-sdk:unknown
-`, name)), 0644)
-	c.Check(err, check.IsNil)
-
-	s.store.ActionCallback = func(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
-		info, err := sdk.ReadSdkInfo([]byte(testsdk), s.project.ProjectId, "workshop")
-		c.Assert(err, check.IsNil)
-		return []sdk.SdkResult{{info}}, nil
-	}
-	defer func() {
-		s.store.ActionCallback = nil
-	}()
+	s.createWFile(c, "masterunknown", masterunknown)
 
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["workshop"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["masterunknown"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot bind: SDK "test-sdk-2" does not have a plug "unknown"`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+}
+
+func (s *apiSuite) TestWorkshopLaunchBindPlugNoSlavePlug(c *check.C) {
+	// Setup
+
+	s.createWFile(c, "slaveunknown", slaveunknown)
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["slaveunknown"],"action":"launch"}`),
 	}
 
 	expected := []*expectedResp{
@@ -342,116 +547,69 @@ sdks:
 		},
 	}
 
-	soon := 0
-	ensure := func(st *state.State, d time.Duration) {
-		soon++
-	}
-
-	s.runActionTest(c, requests, expected, ensure)
+	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestProjectWorkshopLaunchBindPlugNoSlavePlug(c *check.C) {
+func (s *apiSuite) TestWorkshopLaunchBindPlugIncompatibleIface(c *check.C) {
 	// Setup
-
-	name := "workshop"
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
-base: ubuntu@20.04
-sdks: 
-  test-sdk:
-    channel: latest/stable
-    plugs:
-      unknown:
-        bind: test-sdk:data
-`, name)), 0644)
-	c.Check(err, check.IsNil)
-
-	s.store.ActionCallback = func(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
-		info, err := sdk.ReadSdkInfo([]byte(testsdk), s.project.ProjectId, "workshop")
-		c.Assert(err, check.IsNil)
-		return []sdk.SdkResult{{info}}, nil
-	}
-	defer func() {
-		s.store.ActionCallback = nil
-	}()
+	s.createWFile(c, "bindincompatible", bindincompatible)
 
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["workshop"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["bindincompatible"],"action":"launch"}`),
 	}
 
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot bind: SDK "test-sdk" does not have a plug "unknown"`,
+			Message: `cannot bind: test-sdk-2:gpu and test-sdk:data must be of the same interface`,
 		},
 	}
 
-	soon := 0
-	ensure := func(st *state.State, d time.Duration) {
-		soon++
-	}
-
-	s.runActionTest(c, requests, expected, ensure)
+	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestProjectWorkshopLaunchBindPlugIncompatibleIface(c *check.C) {
+func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
 	// Setup
-
-	name := "workshop"
-	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
-base: ubuntu@20.04
-sdks: 
-  test-sdk:
-    channel: latest/stable
-    plugs:
-      cache:
-        bind: test-sdk:ssh-agent
-`, name)), 0644)
-	c.Check(err, check.IsNil)
-
-	s.store.ActionCallback = func(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
-		info, err := sdk.ReadSdkInfo([]byte(testsdk), s.project.ProjectId, "workshop")
-		c.Assert(err, check.IsNil)
-		return []sdk.SdkResult{{info}}, nil
-	}
-	defer func() {
-		s.store.ActionCallback = nil
-	}()
+	s.createWFile(c, "basic", basic)
 
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["workshop"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"transactional"}}`),
 	}
 
 	expected := []*expectedResp{
 		{
-			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: `cannot bind: test-sdk:ssh-agent and test-sdk:cache must be of the same interface`,
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
+		},
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "basic" workshop`,
 		},
 	}
 
-	soon := 0
-	ensure := func(st *state.State, d time.Duration) {
-		soon++
-	}
-
-	s.runActionTest(c, requests, expected, ensure)
+	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestProjectsRefreshWorkshopIncorrectInput(c *check.C) {
+func (s *apiSuite) TestRefreshWorkshopIncorrectInput(c *check.C) {
 	// Setup
 	requests := []*bytes.Buffer{
 		// try continue without starting wait-on-error
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh", "options": {"refresh-mode":"continue"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh", "options": {"refresh-mode":"continue"}}`),
 
 		// unknown refresh option
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh", "options": {"refresh-mode":"unknown"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh", "options": {"refresh-mode":"unknown"}}`),
 
 		// a workshop name is a must
 		bytes.NewBufferString(`{"names":[],"action":"refresh"}`),
 
 		// non-transactional refresh is only supported for a single workshop
-		bytes.NewBufferString(`{"names":["ws", "ws1"],"action":"refresh","options": {"refresh-mode":"wait-on-error"}}`),
+		bytes.NewBufferString(`{"names":["basic", "basic1"],"action":"refresh","options": {"refresh-mode":"wait-on-error"}}`),
 	}
 
 	expected := []*expectedResp{
@@ -475,45 +633,75 @@ func (s *apiSuite) TestProjectsRefreshWorkshopIncorrectInput(c *check.C) {
 		},
 	}
 
-	s.runActionTest(c, requests, expected, func(st *state.State, d time.Duration) {})
+	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestProjectsRefreshWorkshopContinue(c *check.C) {
+func (s *apiSuite) TestRefreshWorkshopContinueSuccess(c *check.C) {
+	s.createWFile(c, "basic", basic)
+
+	var errOnce sync.Once
+	s.b.RemoveProfileCallback = func(ctx context.Context, workshop, profile string) error {
+		var err error
+		errOnce.Do(func() { err = errors.New("cannot remove profile") })
+		return err
+	}
+	defer func() { s.b.RemoveProfileCallback = nil }()
+
 	// Setup
 	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
 		// start - continue (success) - continue (fail, already finished)
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh","options": {"refresh-mode":"wait-on-error"}}`),
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh","options": {"refresh-mode":"continue"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"wait-on-error"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"continue"}}`),
 	}
 
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
-			Kind:    "refresh",
-			Summary: `Refresh "ws" workshop`,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
 		},
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "refresh",
-			Summary: `Refresh "ws" workshop`,
+			Summary: `Refresh "basic" workshop`,
+		},
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "basic" workshop`,
 		},
 	}
-	s.runActionTest(c, requests, expected, func(st *state.State, d time.Duration) {
-		chg := s.d.state.Change("1")
-		chg.SetStatus(state.WaitStatus)
-	})
+	s.runActionTest(c, requests, expected)
+
+	st := s.d.state
+	st.Lock()
+	defer st.Unlock()
+	// no refresh in progress after continue was successful
+	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "basic", "")
+	c.Assert(err, check.IsNil)
 }
 
-func (s *apiSuite) TestProjectsRefreshWorkshopContinueAbortNoRefreshInProgress(c *check.C) {
+func (s *apiSuite) TestRefreshWorkshopNoRefreshInProgress(c *check.C) {
 	// Setup
+	s.createWFile(c, "basic", basic)
+
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh","options": {"refresh-mode":"continue"}}`),
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh","options": {"refresh-mode":"abort"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"continue"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"abort"}}`),
 	}
 
 	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
+		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
@@ -526,168 +714,166 @@ func (s *apiSuite) TestProjectsRefreshWorkshopContinueAbortNoRefreshInProgress(c
 		},
 	}
 
-	s.runActionTest(c, requests, expected, func(st *state.State, d time.Duration) {})
+	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestProjectsRefreshWorkshopTransactional(c *check.C) {
+func (s *apiSuite) TestRefreshWorkshopRefreshAbort(c *check.C) {
 	// Setup
-	requests := []*bytes.Buffer{
-		// start transactional (success) - attempt abort or continue (failure)
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh","options": {"refresh-mode":"transactional"}}`),
+	s.createWFile(c, "basic", basic)
+
+	var errOnce sync.Once
+	s.b.RemoveProfileCallback = func(ctx context.Context, workshop, profile string) error {
+		var err error
+		errOnce.Do(func() { err = errors.New("cannot remove profile") })
+		return err
 	}
+	defer func() { s.b.RemoveProfileCallback = nil }()
 
-	expected := []*expectedResp{
-		{
-			Type:    ResponseTypeAsync,
-			Status:  http.StatusAccepted,
-			Kind:    "refresh",
-			Summary: `Refresh "ws" workshop`,
-		},
-	}
-
-	soon := 0
-	s.runActionTest(c, requests, expected, func(st *state.State, d time.Duration) { soon++ })
-	c.Assert(soon, check.Equals, 1)
-}
-
-func (s *apiSuite) TestProjectsRefreshWorkshopRefreshAbort(c *check.C) {
-	// Setup
 	requests := []*bytes.Buffer{
-
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
 		// start - abort (both success)
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh","options": {"refresh-mode":"wait-on-error"}}`),
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh","options": {"refresh-mode":"abort"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"wait-on-error"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"abort"}}`),
 	}
 
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
-			Kind:    "refresh",
-			Summary: `Refresh "ws" workshop`,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
 		},
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "refresh",
-			Summary: `Refresh "ws" workshop`,
+			Summary: `Refresh "basic" workshop`,
+		},
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "basic" workshop`,
 		},
 	}
 
-	soon := 0
-	s.runActionTest(c, requests, expected, func(st *state.State, d time.Duration) {
-		chg := s.d.state.Change("1")
-		chg.SetStatus(state.WaitStatus)
-		soon++
-	})
-	c.Assert(soon, check.Equals, 2)
+	s.runActionTest(c, requests, expected)
+
+	st := s.d.state
+	st.Lock()
+	defer st.Unlock()
+	// no refresh in progress after continue was successful
+	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "basic", "")
+	c.Assert(err, check.IsNil)
 }
 
-func (s *apiSuite) TestProjectsPostProjectWorkshopStart(c *check.C) {
+func (s *apiSuite) TestStartWorkshop(c *check.C) {
+	// Setup
+	s.createWFile(c, "basic", basic)
 	// Setup
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["ws"],"action":"stop"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+
+		bytes.NewBufferString(`{"names":["basic"],"action":"stop"}`),
 		//
-		bytes.NewBufferString(`{"names":["ws"],"action":"start"}`),
-		// a second attempt to start the workshop that is already in Pending (i.e. being started)
-		bytes.NewBufferString(`{"names":["ws"],"action":"start"}`),
-		// ensure another operation is not going to work when the workshop in Pending
-		bytes.NewBufferString(`{"names":["ws"],"action":"refresh", "options": {"refresh-mode":"transactional"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"start"}`),
+		// a second attempt to start the workshop that is already in Started
+		bytes.NewBufferString(`{"names":["basic"],"action":"start"}`),
 	}
 
 	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
+		},
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "stop",
-			Summary: `Stop "ws" workshop`,
+			Summary: `Stop "basic" workshop`,
 		},
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "start",
-			Summary: `Start "ws" workshop`,
+			Summary: `Start "basic" workshop`,
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot start: "ws" status is "Pending", must be one of: "Stopped"`,
-		},
-		{
-			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: `cannot refresh: "ws" status is "Pending", must be one of: "Ready"`,
+			Message: `cannot start: "basic" status is "Ready", must be one of: "Stopped"`,
 		},
 	}
 
-	soon := 0
-	s.runActionTest(c, requests, expected, func(st *state.State, d time.Duration) {
-		if soon == 0 {
-			err := s.b.StopWorkshop(s.ctx, "ws", true)
-			c.Assert(err, check.IsNil)
-			chg := s.d.state.Change("1")
-			c.Assert(chg, check.NotNil)
-			chg.SetStatus(state.DoneStatus)
-		}
-		soon++
-	})
+	s.runActionTest(c, requests, expected)
 
-	// all successful responses must initiate the ensure call
-	c.Assert(soon, check.Equals, 2)
+	wp, err := s.b.Workshop(s.ctx, "basic")
+	c.Assert(err, check.IsNil)
+	c.Assert(wp.Running, check.Equals, true)
 }
 
-func (s *apiSuite) TestProjectsPostProjectWorkshopStop(c *check.C) {
+func (s *apiSuite) TestStopWorkshop(c *check.C) {
 	// Setup
+	s.createWFile(c, "basic", basic)
+
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["ws"],"action":"stop"}`),
-		// a second attempt to stop the workshop that is already in Pending (e.g being stopped)
-		bytes.NewBufferString(`{"names":["ws"],"action":"stop"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+
+		bytes.NewBufferString(`{"names":["basic"],"action":"stop"}`),
 	}
 
 	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
+		},
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "stop",
-			Summary: `Stop "ws" workshop`,
-		},
-		{
-			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: `cannot stop: "ws" status is "Pending", must be one of: "Ready", "Stopped"`,
+			Summary: `Stop "basic" workshop`,
 		},
 	}
 
-	soon := 0
-	s.runActionTest(c, requests, expected, func(st *state.State, d time.Duration) { soon++ })
-	// all successful responses must initiate the ensure call
-	c.Assert(soon, check.Equals, 1)
+	s.runActionTest(c, requests, expected)
+
+	wp, err := s.b.Workshop(s.ctx, "basic")
+	c.Assert(err, check.IsNil)
+	c.Assert(wp.Running, check.Equals, false)
 }
 
-func (s *apiSuite) TestProjectsPostProjectWorkshopRemove(c *check.C) {
+func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 	// Setup
 
+	s.createWFile(c, "basic", basic)
+
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["ws"],"action":"remove"}`),
-		bytes.NewBufferString(`{"names":["ws"],"action":"remove"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"remove"}`),
 	}
 
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
-			Kind:    "remove",
-			Summary: `Remove "ws" workshop`,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
 		},
 		{
-			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: `cannot remove: "ws" status is "Pending", must be one of: "Ready", "Error", "Stopped"`,
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "remove",
+			Summary: `Remove "basic" workshop`,
 		},
 	}
 
-	soon := 0
-	s.runActionTest(c, requests, expected, func(st *state.State, d time.Duration) { soon++ })
-	// all successful responses must initiate the ensure call
-	c.Assert(soon, check.Equals, 1)
+	s.runActionTest(c, requests, expected)
+
+	_, err := s.b.Workshop(s.ctx, "basic")
+	c.Check(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
+	c.Check(s.b.RemoveProfileCalls, check.HasLen, 1)
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -162,7 +162,7 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 	c.Assert(err, check.IsNil)
 	// for DeepEqual to work correctly
 	t1, t2 := s.installTime, s.installTime
-	c.Check(rsp.Result, check.DeepEquals, []*WorkshopInfo{
+	c.Check(rsp.Result, testutil.DeepUnsortedMatches, []*WorkshopInfo{
 		{
 			Name:      "manysdks",
 			Base:      "ubuntu@22.04",

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -120,7 +121,7 @@ func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string, sdks map[string
 	s.createWFile(c, name, yaml)
 
 	defer s.store.SetActionCallback(storeAction)()
-	defer s.mockWorkshopFs(c, sdks)()
+	defer s.mockInstalledSdks(c, sdks)()
 
 	reqbuf := bytes.NewBufferString(fmt.Sprintf(`{"names":["%s"],"action":"launch"}`, name))
 	s.vars = map[string]string{"id": s.project.ProjectId}
@@ -230,7 +231,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 				InstallTime: &t1,
 				Mounts: []*Mount{
 					{
-						Source: sdk.DefaultContentSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk", "data"),
+						Source: sdk.SdkContentSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk", "data"),
 						Target: "/opt/data",
 						Plug: interfaces.PlugRef{
 							ProjectId: s.project.ProjectId,
@@ -248,7 +249,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 				InstallTime: &t2,
 				Mounts: []*Mount{
 					{
-						Source: sdk.DefaultContentSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk-2", "photos"),
+						Source: sdk.SdkContentSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk-2", "photos"),
 						Target: "/opt/data2",
 						Plug: interfaces.PlugRef{
 							ProjectId: s.project.ProjectId,
@@ -300,7 +301,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 				InstallTime: &t1,
 				Mounts: []*Mount{
 					{
-						Source: sdk.DefaultContentSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
+						Source: sdk.SdkContentSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
 						Target: "/opt/data2",
 						Plug: interfaces.PlugRef{
 							ProjectId: s.project.ProjectId,
@@ -318,7 +319,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 				InstallTime: &t2,
 				Mounts: []*Mount{
 					{
-						Source: sdk.DefaultContentSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
+						Source: sdk.SdkContentSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
 						Target: "/opt/data2",
 						Plug: interfaces.PlugRef{
 							ProjectId: s.project.ProjectId,
@@ -386,6 +387,8 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 					status := change.Status()
 					st.Unlock()
 					if status == state.WaitStatus {
+						// some tests (refresh continue/abort) leave the change
+						// in the wait state and this is expected.
 						break End
 					}
 				}
@@ -415,7 +418,7 @@ func storeAction(ctx context.Context, currentSdks map[string]*sdk.Info, actions 
 	return result, nil
 }
 
-func (s *apiSuite) mockWorkshopFs(c *check.C, sdks map[string]string) func() {
+func (s *apiSuite) mockInstalledSdks(c *check.C, sdks map[string]string) func() {
 	fs := workshop.NewFakeWorkshopFs()
 
 	for n, s := range sdks {
@@ -425,9 +428,16 @@ func (s *apiSuite) mockWorkshopFs(c *check.C, sdks map[string]string) func() {
 
 		file, err := fs.OpenFile(filepath.Join(metadir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
 		c.Assert(err, check.IsNil)
+		defer file.Close()
 
 		_, err = file.Write([]byte(s))
 		c.Assert(err, check.IsNil)
+
+		for _, hook := range []string{"setup-base", "save-state", "restore-state"} {
+			setuphook, err := fs.OpenFile(sdk.SdkHookPath(n, hook), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0744)
+			c.Assert(err, check.IsNil)
+			defer setuphook.Close()
+		}
 	}
 
 	s.b.WorkshopFsCallback = func(ctx context.Context, name string) (workshop.WorkshopFs, error) {
@@ -477,10 +487,56 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 	c.Assert(repo.Slots(s.project.ProjectId, "basic", "agent"), check.HasLen, 3)
 }
 
-func (s *apiSuite) TestWorkshopLaunchPlugBindsSuccess(c *check.C) {
+func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	defer s.mockInstalledSdks(c, testsdks)()
+
+	s.b.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+		cmd := args.Command
+		if strings.Contains(cmd[len(cmd)-1], "setup-base") {
+			return workshop.ExecContext{}, errors.New("cannot execute setup-base")
+		}
+		return workshop.ExecContext{
+			Environment:   args.Environment,
+			WaitExecution: func(ctx context.Context) error { return nil },
+		}, nil
+	}
+	defer func() { s.b.ExecCallback = nil }()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	_, err := s.b.Workshop(s.ctx, "manysdks")
+	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "agent"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "agent"), check.HasLen, 0)
+
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk"), check.HasLen, 0)
+
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
+}
+
+func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {
 	// Setup
 	s.createWFile(c, "somebound", somebound)
-	defer s.mockWorkshopFs(c, testsdks)()
+	defer s.mockInstalledSdks(c, testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["somebound"],"action":"launch"}`),
@@ -510,7 +566,7 @@ func (s *apiSuite) TestWorkshopLaunchPlugBindsSuccess(c *check.C) {
 	c.Assert(bound, check.Equals, true)
 }
 
-func (s *apiSuite) TestWorkshopLaunchBindPlugNoMasterPlug(c *check.C) {
+func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
 	// Setup
 
 	s.createWFile(c, "masterunknown", masterunknown)
@@ -530,7 +586,7 @@ func (s *apiSuite) TestWorkshopLaunchBindPlugNoMasterPlug(c *check.C) {
 	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestWorkshopLaunchBindPlugNoSlavePlug(c *check.C) {
+func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
 	// Setup
 
 	s.createWFile(c, "slaveunknown", slaveunknown)
@@ -550,7 +606,7 @@ func (s *apiSuite) TestWorkshopLaunchBindPlugNoSlavePlug(c *check.C) {
 	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestWorkshopLaunchBindPlugIncompatibleIface(c *check.C) {
+func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 	// Setup
 	s.createWFile(c, "bindincompatible", bindincompatible)
 
@@ -594,6 +650,76 @@ func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
 	}
 
 	s.runActionTest(c, requests, expected)
+}
+
+func (s *apiSuite) TestRefreshWorkshopFailed(c *check.C) {
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	defer s.mockInstalledSdks(c, testsdks)()
+
+	s.b.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+		cmd := args.Command
+		if strings.Contains(cmd[len(cmd)-1], "restore-state") {
+			return workshop.ExecContext{}, errors.New("cannot execute restore-state")
+		}
+		return workshop.ExecContext{
+			Environment:   args.Environment,
+			WaitExecution: func(ctx context.Context) error { return nil },
+		}, nil
+	}
+	defer func() { s.b.ExecCallback = nil }()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options": {"refresh-mode":"transactional"}}`)}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	wp, err := s.b.Workshop(s.ctx, "manysdks")
+	c.Assert(err, check.IsNil)
+
+	content, err := wp.ContentInfo(s.ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(content, check.HasLen, 2)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	conns, err := repo.Connections(s.project.ProjectId, "manysdks", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk", Name: "data"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "agent", Name: "content"},
+		},
+	})
+
+	conns, err = repo.Connections(s.project.ProjectId, "manysdks", "test-sdk-2")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk-2", Name: "photos"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "agent", Name: "content"},
+		},
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk-2", Name: "gpu"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "agent", Name: "gpu"},
+		},
+	})
 }
 
 func (s *apiSuite) TestRefreshWorkshopIncorrectInput(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -97,10 +97,11 @@ func (s *apiSuite) TestProjectsGetWorkshop(c *check.C) {
 			"go": {Sdk: "go", Message: "test health check message", Code: "check-waiting", CheckResult: healthstate.CheckWaiting},
 		}}
 	})
-	restoreMounts := FakeSdkMounts(func(st *state.State, repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount {
-		return []*Mount{
-			{Source: "/home/user/" + sdk, Target: "/home/workshop/" + sdk, Plug: interfaces.PlugRef{ProjectId: projectId, Workshop: workshop, Sdk: sdk, Name: "content-plug"}},
-		}
+	restoreMounts := FakeSdkMounts(func(ctx context.Context, back workshop.Backend, w *workshop.Workshop) (map[string][]*Mount, error) {
+		return map[string][]*Mount{
+			"go":   {{Source: "/home/user/go", Target: "/home/workshop/go", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "go", Name: "content-plug"}}},
+			"java": {{Source: "/home/user/java", Target: "/home/workshop/java", Plug: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-test", Sdk: "java", Name: "content-plug"}}},
+		}, nil
 	})
 
 	rsp := v1GetProjectWorkshop(projectsCmd, req, nil).(*resp)
@@ -178,9 +179,9 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 
 		// Verify
 		c.Check(rsp.Type, check.Equals, expected[num].Type)
-		c.Assert(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v", num))
+		c.Check(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v", num))
 		if rsp.Type == ResponseTypeError {
-			c.Assert(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
+			c.Check(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
 		}
 
 		if rsp.Type == ResponseTypeAsync {
@@ -188,14 +189,14 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 			st.Lock()
 			change := s.d.state.Change(rsp.Change)
 			st.Unlock()
-			c.Assert(change, check.NotNil)
-			c.Assert(change.Kind(), check.Equals, expected[num].Kind)
-			c.Assert(change.Summary(), check.Equals, expected[num].Summary)
+			c.Check(change, check.NotNil)
+			c.Check(change.Kind(), check.Equals, expected[num].Kind)
+			c.Check(change.Summary(), check.Equals, expected[num].Summary)
 		}
 	}
 }
 
-func (s *apiSuite) TestProjectsPostProjectWorkshopLaunch(c *check.C) {
+func (s *apiSuite) TestProjectWorkshopLaunchBasic(c *check.C) {
 	// Setup
 
 	name := "workshop"
@@ -238,6 +239,203 @@ base: ubuntu@20.04
 
 	// all successful responses must initiate the ensure call
 	c.Assert(soon, check.Equals, 1)
+}
+
+var testsdk = `
+name: test-sdk
+base: ubuntu@20.04
+title: title
+summary: summary
+description: SDK
+plugs:
+  data:
+    interface: content
+    target: /opt/data
+  cache:
+    interface: content
+    target: /opt/cache
+  ssh-agent:
+    interface: ssh-agent
+`
+
+func (s *apiSuite) TestProjectWorkshopLaunchPlugBindsSuccess(c *check.C) {
+	// Setup
+
+	name := "workshop"
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
+base: ubuntu@20.04
+sdks: 
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: test-sdk:cache
+`, name)), 0644)
+	c.Check(err, check.IsNil)
+
+	s.store.ActionCallback = func(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
+		info, err := sdk.ReadSdkInfo([]byte(testsdk), s.project.ProjectId, "workshop")
+		c.Assert(err, check.IsNil)
+		return []sdk.SdkResult{{info}}, nil
+	}
+	defer func() {
+		s.store.ActionCallback = nil
+	}()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshop"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "workshop" workshop`,
+		},
+	}
+
+	soon := 0
+	ensure := func(st *state.State, d time.Duration) {
+		soon++
+	}
+
+	s.runActionTest(c, requests, expected, ensure)
+
+	// all successful responses must initiate the ensure call
+	c.Assert(soon, check.Equals, 1)
+}
+
+func (s *apiSuite) TestProjectWorkshopLaunchBindPlugNoMasterPlug(c *check.C) {
+	// Setup
+
+	name := "workshop"
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
+base: ubuntu@20.04
+sdks: 
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: test-sdk:unknown
+`, name)), 0644)
+	c.Check(err, check.IsNil)
+
+	s.store.ActionCallback = func(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
+		info, err := sdk.ReadSdkInfo([]byte(testsdk), s.project.ProjectId, "workshop")
+		c.Assert(err, check.IsNil)
+		return []sdk.SdkResult{{info}}, nil
+	}
+	defer func() {
+		s.store.ActionCallback = nil
+	}()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshop"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot bind: SDK "test-sdk" does not have a plug "unknown"`,
+		},
+	}
+
+	soon := 0
+	ensure := func(st *state.State, d time.Duration) {
+		soon++
+	}
+
+	s.runActionTest(c, requests, expected, ensure)
+}
+
+func (s *apiSuite) TestProjectWorkshopLaunchBindPlugNoSlavePlug(c *check.C) {
+	// Setup
+
+	name := "workshop"
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
+base: ubuntu@20.04
+sdks: 
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      unknown:
+        bind: test-sdk:data
+`, name)), 0644)
+	c.Check(err, check.IsNil)
+
+	s.store.ActionCallback = func(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
+		info, err := sdk.ReadSdkInfo([]byte(testsdk), s.project.ProjectId, "workshop")
+		c.Assert(err, check.IsNil)
+		return []sdk.SdkResult{{info}}, nil
+	}
+	defer func() {
+		s.store.ActionCallback = nil
+	}()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshop"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot bind: SDK "test-sdk" does not have a plug "unknown"`,
+		},
+	}
+
+	soon := 0
+	ensure := func(st *state.State, d time.Duration) {
+		soon++
+	}
+
+	s.runActionTest(c, requests, expected, ensure)
+}
+
+func (s *apiSuite) TestProjectWorkshopLaunchBindPlugIncompatibleIface(c *check.C) {
+	// Setup
+
+	name := "workshop"
+	err := os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(`.workshop.%s.yaml`, name)), []byte(fmt.Sprintf(`name: %s
+base: ubuntu@20.04
+sdks: 
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      cache:
+        bind: test-sdk:ssh-agent
+`, name)), 0644)
+	c.Check(err, check.IsNil)
+
+	s.store.ActionCallback = func(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
+		info, err := sdk.ReadSdkInfo([]byte(testsdk), s.project.ProjectId, "workshop")
+		c.Assert(err, check.IsNil)
+		return []sdk.SdkResult{{info}}, nil
+	}
+	defer func() {
+		s.store.ActionCallback = nil
+	}()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshop"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot bind: test-sdk:ssh-agent and test-sdk:cache must be of the same interface`,
+		},
+	}
+
+	soon := 0
+	ensure := func(st *state.State, d time.Duration) {
+		soon++
+	}
+
+	s.runActionTest(c, requests, expected, ensure)
 }
 
 func (s *apiSuite) TestProjectsRefreshWorkshopIncorrectInput(c *check.C) {

--- a/internal/daemon/export_test.go
+++ b/internal/daemon/export_test.go
@@ -49,11 +49,11 @@ func FakeWorkshopHealth(f func(mgr *workshopstate.WorkshopManager, w *workshop.W
 	}
 }
 
-func FakeSdkMounts(f func(ctx context.Context, back workshop.Backend, w *workshop.Workshop) (map[string][]*Mount, error)) (restore func()) {
-	old := sdkMounts
-	sdkMounts = f
+func FakeSdkMounts(f func(ctx context.Context, w *workshop.Workshop) (map[string][]*Mount, error)) (restore func()) {
+	old := workshopMounts
+	workshopMounts = f
 	return func() {
-		sdkMounts = old
+		workshopMounts = old
 	}
 }
 

--- a/internal/daemon/export_test.go
+++ b/internal/daemon/export_test.go
@@ -15,10 +15,10 @@
 package daemon
 
 import (
+	"context"
 	"net/http"
 	"time"
 
-	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
@@ -49,7 +49,7 @@ func FakeWorkshopHealth(f func(mgr *workshopstate.WorkshopManager, w *workshop.W
 	}
 }
 
-func FakeSdkMounts(f func(state *state.State, repo *interfaces.Repository, projectId, workshop, sdk string) []*Mount) (restore func()) {
+func FakeSdkMounts(f func(ctx context.Context, back workshop.Backend, w *workshop.Workshop) (map[string][]*Mount, error)) (restore func()) {
 	old := sdkMounts
 	sdkMounts = f
 	return func() {

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -205,10 +207,31 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 	} else {
 		// Emulate meta data for the test SDKs. We need the name/base pair for
 		// the e2e scenarios to work.
-		sSdk.SdkYAML = fmt.Sprintf(`name: %s
-base: ubuntu@22.04`, name)
+		sSdk.SdkYAML, err = readTestMetadata(ctx, client, name, track, risk)
+		if err != nil {
+			return sSdk, err
+		}
 	}
 	return sSdk, nil
+}
+
+// Only relevant for the end to end tests
+func readTestMetadata(ctx context.Context, client *ClientWrapper, name, track, risk string) (string, error) {
+	var b bytes.Buffer
+	meta := bufio.NewWriter(&b)
+
+	bkt := client.Bucket(SDK_STORE_BUCKET_NAME)
+	obj := bkt.Object(fmt.Sprintf("%s/%s/%s/sdk.yaml", name, track, risk))
+	r, err := obj.NewReader(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+
+	if _, err = io.Copy(meta, r); err != nil {
+		return "", err
+	}
+	return b.String(), nil
 }
 
 func storeSdkReaderImpl(ctx context.Context, setup sdk.Setup) (io.ReadCloser, error) {

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -103,7 +103,7 @@ func (iface *contentInterface) source(user *user.User, plug *interfaces.Connecte
 		return source, err
 	}
 	// default dir: <workshop>_<sdk>_plug.sdk
-	return sdk.DefaultContentSource(user.HomeDir, plug.Sdk().ProjectId, plug.Sdk().Workshop, plug.Sdk().Name, plug.Name()), nil
+	return sdk.SdkContentSource(user.HomeDir, plug.Sdk().ProjectId, plug.Sdk().Workshop, plug.Sdk().Name, plug.Name()), nil
 }
 
 func (iface *contentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"errors"
 	"fmt"
 	"os/user"
 	"path/filepath"
@@ -94,19 +95,15 @@ func (iface *contentInterface) target(attrs interfaces.Attrer) string {
 func (iface *contentInterface) source(user *user.User, plug *interfaces.ConnectedPlug) (string, error) {
 	var source string
 	// see if the plug's mount has been remounted to a new location
-	if err := plug.Attr("source", &source); err == nil {
+	err := plug.Attr("source", &source)
+	if err == nil {
 		return source, nil
 	}
-
-	// <workshop>_<sdk>_plug.sdk
-	dir := strings.Join([]string{plug.Sdk().Workshop, plug.Sdk().Name, plug.Name()}, "_") + ".sdk"
-	source = filepath.Join(user.HomeDir, ".local", "share", "workshop", "project", plug.Ref().ProjectId, "content", dir)
-
-	if err := plug.SetAttr("source", source); err != nil {
-		return "", err
+	if !errors.Is(err, sdk.AttributeNotFoundError{}) {
+		return source, err
 	}
-
-	return source, nil
+	// default dir: <workshop>_<sdk>_plug.sdk
+	return sdk.DefaultContentSource(user.HomeDir, plug.Sdk().ProjectId, plug.Sdk().Workshop, plug.Sdk().Name, plug.Name()), nil
 }
 
 func (iface *contentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -152,11 +152,6 @@ slots:
 	expectedMnt := lxdbackend.Mount(plug.Name, sourceDir, "/project/training")
 	c.Assert(deviceSpec.DeviceEntries(), check.DeepEquals, []workshop.Device{expectedMnt})
 
-	// Vaildate plug attribute
-	var src string
-	c.Assert(connectedPlug.Attr("source", &src), check.IsNil)
-	c.Assert(src, check.Equals, sourceDir)
-
 	// Validate the source directory was created correctly
 	exists, isDir, err := osutil.ExistsIsDir(sourceDir)
 	c.Assert(exists, check.Equals, true)

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -132,6 +132,8 @@ slots:
 	homeDir := c.MkDir()
 	usr, err := user.Current()
 	c.Assert(err, check.IsNil)
+	
+	
 
 	restore := testutil.FakeFunc(func(name string) (*user.User, error) {
 		u := &user.User{

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -35,6 +35,14 @@ type Connection struct {
 }
 
 func (c *Connection) CheckBound() (*ConnRef, bool) {
+	// info := c.Plug.plugInfo.Sdk
+	// if bind, ok := info.PlugBinds[c.Plug.Name()]; ok {
+	// 	return &ConnRef{
+	// 		PlugRef: PlugRef{ProjectId: info.ProjectId, Workshop: info.Workshop, Sdk: bind.Name, Name: bind.Name},
+	// 		SlotRef: SlotRef{ProjectId: info.ProjectId, Workshop: info.Workshop, Sdk: c.Slot.slotInfo.Sdk.Name, Name: c.Slot.Name()},
+	// 	}, true
+	// }
+	// return NewConnRef(c.Plug.plugInfo, c.Slot.slotInfo), false
 	attr, ok := c.Plug.Lookup("bind")
 	if attr == nil {
 		return nil, false

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -34,6 +34,23 @@ type Connection struct {
 	Slot *ConnectedSlot
 }
 
+func (c *Connection) CheckBound() (*ConnRef, bool) {
+	attr, ok := c.Plug.Lookup("bind")
+	if attr == nil {
+		return nil, false
+	}
+	id, ok := attr.(string)
+	if !ok {
+		return nil, false
+	}
+
+	cref, err := ParseConnRef(id)
+	if err != nil {
+		ok = false
+	}
+	return cref, ok
+}
+
 // ConnectedPlug represents a plug that is connected to a slot.
 type ConnectedPlug struct {
 	plugInfo     *sdk.PlugInfo

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -35,14 +35,6 @@ type Connection struct {
 }
 
 func (c *Connection) CheckBound() (*ConnRef, bool) {
-	// info := c.Plug.plugInfo.Sdk
-	// if bind, ok := info.PlugBinds[c.Plug.Name()]; ok {
-	// 	return &ConnRef{
-	// 		PlugRef: PlugRef{ProjectId: info.ProjectId, Workshop: info.Workshop, Sdk: bind.Name, Name: bind.Name},
-	// 		SlotRef: SlotRef{ProjectId: info.ProjectId, Workshop: info.Workshop, Sdk: c.Slot.slotInfo.Sdk.Name, Name: c.Slot.Name()},
-	// 	}, true
-	// }
-	// return NewConnRef(c.Plug.plugInfo, c.Slot.slotInfo), false
 	attr, ok := c.Plug.Lookup("bind")
 	if attr == nil {
 		return nil, false

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -66,9 +66,14 @@ type PlugRef struct {
 	Name      string `json:"plug"`
 }
 
-// String returns the "workshop/sdk:plug" representation of a plug reference.
+// String returns the "project-id/workshop/sdk:plug" representation of a plug reference.
 func (ref PlugRef) String() string {
 	return fmt.Sprintf("%s/%s/%s:%s", ref.ProjectId, ref.Workshop, ref.Sdk, ref.Name)
+}
+
+// String returns the "workshop/sdk:plug" representation of a plug reference (human-friendly).
+func (ref PlugRef) ShortRef() string {
+	return fmt.Sprintf("%s/%s:%s", ref.Workshop, ref.Sdk, ref.Name)
 }
 
 // SortsBefore returns true when plug should be sorted before the other
@@ -103,9 +108,14 @@ type SlotRef struct {
 	Name      string `json:"slot"`
 }
 
-// String returns the "workshop:sdk:slot" representation of a slot reference.
+// String returns the "project-id/workshop/sdk:slot" representation of a slot reference.
 func (ref SlotRef) String() string {
 	return fmt.Sprintf("%s/%s/%s:%s", ref.ProjectId, ref.Workshop, ref.Sdk, ref.Name)
+}
+
+// String returns the "workshop/sdk:slot" representation of a slot reference (human-friendly).
+func (ref SlotRef) ShortRef() string {
+	return fmt.Sprintf("%s/%s:%s", ref.Workshop, ref.Sdk, ref.Name)
 }
 
 // SortsBefore returns true when slot should be sorted before the other

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -66,6 +66,10 @@ type PlugRef struct {
 	Name      string `json:"plug"`
 }
 
+func NewPlugRef(info *sdk.PlugInfo) PlugRef {
+	return PlugRef{ProjectId: info.Sdk.ProjectId, Workshop: info.Sdk.Workshop, Sdk: info.Sdk.Name, Name: info.Name}
+}
+
 // String returns the "project-id/workshop/sdk:plug" representation of a plug reference.
 func (ref PlugRef) String() string {
 	return fmt.Sprintf("%s/%s/%s:%s", ref.ProjectId, ref.Workshop, ref.Sdk, ref.Name)
@@ -106,6 +110,10 @@ type SlotRef struct {
 	Workshop  string `json:"workshop"`
 	Sdk       string `json:"sdk"`
 	Name      string `json:"slot"`
+}
+
+func NewSlotRef(info *sdk.SlotInfo) SlotRef {
+	return SlotRef{ProjectId: info.Sdk.ProjectId, Workshop: info.Sdk.Workshop, Sdk: info.Sdk.Name, Name: info.Name}
 }
 
 // String returns the "project-id/workshop/sdk:slot" representation of a slot reference.
@@ -154,8 +162,8 @@ type ConnRef struct {
 // NewConnRef creates a connection reference for given plug and slot
 func NewConnRef(plug *sdk.PlugInfo, slot *sdk.SlotInfo) *ConnRef {
 	return &ConnRef{
-		PlugRef: PlugRef{ProjectId: plug.Sdk.ProjectId, Sdk: plug.Sdk.Name, Name: plug.Name, Workshop: plug.Sdk.Workshop},
-		SlotRef: SlotRef{ProjectId: slot.Sdk.ProjectId, Sdk: slot.Sdk.Name, Name: slot.Name, Workshop: slot.Sdk.Workshop},
+		PlugRef: PlugRef{ProjectId: plug.Sdk.ProjectId, Workshop: plug.Sdk.Workshop, Sdk: plug.Sdk.Name, Name: plug.Name},
+		SlotRef: SlotRef{ProjectId: slot.Sdk.ProjectId, Workshop: slot.Sdk.Workshop, Sdk: slot.Sdk.Name, Name: slot.Name},
 	}
 }
 

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -161,21 +161,7 @@ func (s *baseDeclSuite) TestDoesNotPanic(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *baseDeclSuite) TestAgentSlotConnectionPlugFromDifferentWorkshop(c *C) {
-	slotYaml := `name: slot-sdk
-base: ubuntu@22.04
-type: agent
-slots:
-    content:
-`
-	cand := s.connectCand(c, "content", slotYaml, "", "mock424242", "mock424242", "slot-ws", "plug-ws")
-	_, err := cand.Check()
-	c.Check(err, check.ErrorMatches, `connection not allowed by slot rule of interface "content"`)
-	_, err = cand.CheckAutoConnect()
-	c.Check(err, check.ErrorMatches, `auto-connection not allowed by slot rule of interface "content"`)
-}
-
-func (s *baseDeclSuite) TestAgentSlotConnectionPlugFromSameWorkshop(c *C) {
+func (s *baseDeclSuite) TestSlotPlugFromSameWorkshop(c *C) {
 	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
 type: agent
@@ -189,14 +175,40 @@ slots:
 	c.Check(err, check.IsNil)
 }
 
-func (s *baseDeclSuite) TestAgentSlotConnectionPlugFromSameWorkshopDifferentProject(c *C) {
+func (s *baseDeclSuite) TestSlotPlugDifferentProjects(c *C) {
 	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
 type: agent
 slots:
     content:
 `
-	cand := s.connectCand(c, "content", slotYaml, "", "slot-project", "mock424242", "ws", "ws")
+	plugYaml := `name: plug-sdk
+base: ubuntu@22.04
+type: agent
+plugs:
+    content:      
+`
+	cand := s.connectCand(c, "content", slotYaml, plugYaml, "slot-project", "mock424242", "ws", "ws")
+	_, err := cand.Check()
+	c.Check(err, check.ErrorMatches, `connection not allowed by slot rule of interface "content"`)
+	_, err = cand.CheckAutoConnect()
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by slot rule of interface "content"`)
+}
+
+func (s *baseDeclSuite) TestSlotPlugDifferentWorkshop(c *C) {
+	slotYaml := `name: slot-sdk
+base: ubuntu@22.04
+type: agent
+slots:
+    content:
+`
+	plugYaml := `name: plug-sdk
+base: ubuntu@22.04
+type: agent
+plugs:
+    content:      
+`
+	cand := s.connectCand(c, "content", slotYaml, plugYaml, "mock424242", "mock424242", "ws", "ws-1")
 	_, err := cand.Check()
 	c.Check(err, check.ErrorMatches, `connection not allowed by slot rule of interface "content"`)
 	_, err = cand.CheckAutoConnect()

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -31,7 +31,7 @@ import (
 // check helpers
 func checkSlotType(sdkInfo *sdk.Info, types []string) error {
 	if !slices.Contains(types, string(sdkInfo.Type)) {
-		return fmt.Errorf("invalid sdk type %q", sdkInfo.Type)
+		return fmt.Errorf("invalid SDK type %q", sdkInfo.Type)
 	}
 	return nil
 }
@@ -84,11 +84,11 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	if err := constraints.SlotAttributes.Check(connc.Slot, connc); err != nil {
 		return err
 	}
-	if connc.Slot.Sdk().Type == sdk.Agent {
-		plugSdk, slotSdk := connc.Plug.Sdk(), connc.Slot.Sdk()
-		if plugSdk.ProjectId != slotSdk.ProjectId || plugSdk.Workshop != slotSdk.Workshop {
-			return fmt.Errorf("%q cannot be connected to the agent SDK from a different workshop", connc.Plug.Ref())
-		}
+
+	plugSdk, slotSdk := connc.Plug.Sdk(), connc.Slot.Sdk()
+	if plugSdk.ProjectId != slotSdk.ProjectId || plugSdk.Workshop != slotSdk.Workshop {
+		return fmt.Errorf("%q cannot be connected to the %q (SDK from a different workshop)", connc.Plug.Ref(), connc.Slot.Ref())
 	}
+
 	return nil
 }

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -822,6 +822,9 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 			return nil, err
 		}
 		for _, conn := range r.slotPlugs[slotInfo] {
+			if _, ok := conn.Plug.Lookup("bind"); ok {
+				continue
+			}
 			if err := spec.AddConnectedSlot(iface, conn.Plug, conn.Slot); err != nil {
 				return nil, err
 			}
@@ -834,6 +837,9 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 			return nil, err
 		}
 		for _, conn := range r.plugSlots[plugInfo] {
+			if _, ok := conn.Plug.Lookup("bind"); ok {
+				continue
+			}
 			if err := spec.AddConnectedPlug(iface, conn.Plug, conn.Slot); err != nil {
 				return nil, err
 			}

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -822,7 +822,7 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 			return nil, err
 		}
 		for _, conn := range r.slotPlugs[slotInfo] {
-			if _, ok := conn.Plug.Lookup("bind"); ok {
+			if _, ok := conn.CheckBound(); ok {
 				continue
 			}
 			if err := spec.AddConnectedSlot(iface, conn.Plug, conn.Slot); err != nil {
@@ -837,7 +837,7 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 			return nil, err
 		}
 		for _, conn := range r.plugSlots[plugInfo] {
-			if _, ok := conn.Plug.Lookup("bind"); ok {
+			if _, ok := conn.CheckBound(); ok {
 				continue
 			}
 			if err := spec.AddConnectedPlug(iface, conn.Plug, conn.Slot); err != nil {

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -971,7 +971,6 @@ func (s *RepositorySuite) TestSdkSpecification(c *C) {
 	c.Assert(repo.AddPlug(s.plug), IsNil)
 	c.Assert(repo.AddSlot(s.slot), IsNil)
 
-	// Snaps should get static security now
 	spec, err := repo.SdkSpecification(s.context, testSecurity, s.plug.Sdk.Ref())
 	c.Assert(err, IsNil)
 	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{"static plug snippet"})
@@ -985,7 +984,6 @@ func (s *RepositorySuite) TestSdkSpecification(c *C) {
 	_, err = repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
-	// Snaps should get static and connection-specific security now
 	spec, err = repo.SdkSpecification(s.context, testSecurity, s.plug.Sdk.Ref())
 	c.Assert(err, IsNil)
 	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{
@@ -1001,7 +999,46 @@ func (s *RepositorySuite) TestSdkSpecification(c *C) {
 	})
 }
 
-func (s *RepositorySuite) TestSnapSpecificationFailureWithConnectionSnippets(c *C) {
+func (s *RepositorySuite) TestSdkSpecificationBoundPlugs(c *C) {
+	repo := s.emptyRepo
+	backend := &ifacetest.TestSecurityBackend{BackendName: testSecurity}
+	c.Assert(repo.AddBackend(backend), IsNil)
+	c.Assert(repo.AddInterface(testInterface), IsNil)
+	// the plug's connection is bound which means it has the "bind" dynamic
+	// attribute that points to the connection it is bound to
+	s.plug.Attrs["bind"] = map[string]interface{}{}
+	c.Assert(repo.AddPlug(s.plug), IsNil)
+	c.Assert(repo.AddSlot(s.slot), IsNil)
+
+	spec, err := repo.SdkSpecification(s.context, testSecurity, s.plug.Sdk.Ref())
+	c.Assert(err, IsNil)
+	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{"static plug snippet"})
+
+	spec, err = repo.SdkSpecification(s.context, testSecurity, s.slot.Sdk.Ref())
+	c.Assert(err, IsNil)
+	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{"static slot snippet"})
+
+	// Establish connection between plug and slot
+	connRef := NewConnRef(s.plug, s.slot)
+	_, err = repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	// Ensure that the connection snippet is not generated for the bound plug's
+	// connection (it will use the bind's plug connection instead).
+	spec, err = repo.SdkSpecification(s.context, testSecurity, s.plug.Sdk.Ref())
+	c.Assert(err, IsNil)
+	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{
+		"static plug snippet",
+	})
+
+	spec, err = repo.SdkSpecification(s.context, testSecurity, s.slot.Sdk.Ref())
+	c.Assert(err, IsNil)
+	c.Check(spec.(*ifacetest.Specification).Snippets, DeepEquals, []string{
+		"static slot snippet",
+	})
+}
+
+func (s *RepositorySuite) TestSdkSpecificationFailureWithConnectionSnippets(c *C) {
 	var testSecurity SecuritySystem = "security"
 	backend := &ifacetest.TestSecurityBackend{BackendName: testSecurity}
 	iface := &ifacetest.TestInterface{
@@ -1032,7 +1069,7 @@ func (s *RepositorySuite) TestSnapSpecificationFailureWithConnectionSnippets(c *
 	c.Assert(spec, IsNil)
 }
 
-func (s *RepositorySuite) TestSnapSpecificationFailureWithPermanentSnippets(c *C) {
+func (s *RepositorySuite) TestSdkSpecificationFailureWithPermanentSnippets(c *C) {
 	var testSecurity SecuritySystem = "security"
 	iface := &ifacetest.TestInterface{
 		InterfaceName: "interface",

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/interfaces"
 	. "github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
 	"github.com/canonical/workshop/internal/sdk"
@@ -1006,7 +1007,11 @@ func (s *RepositorySuite) TestSdkSpecificationBoundPlugs(c *C) {
 	c.Assert(repo.AddInterface(testInterface), IsNil)
 	// the plug's connection is bound which means it has the "bind" dynamic
 	// attribute that points to the connection it is bound to
-	s.plug.Attrs["bind"] = map[string]interface{}{}
+	bref := interfaces.ConnRef{
+		PlugRef: PlugRef{ProjectId: s.plug.Sdk.ProjectId, Workshop: s.plug.Sdk.Workshop, Sdk: s.plug.Sdk.Name, Name: "some-plug"},
+		SlotRef: SlotRef{ProjectId: s.slot.Sdk.ProjectId, Workshop: s.slot.Sdk.Workshop, Sdk: s.slot.Sdk.Name, Name: s.slot.Name},
+	}
+	s.plug.Attrs["bind"] = bref.ID()
 	c.Assert(repo.AddPlug(s.plug), IsNil)
 	c.Assert(repo.AddSlot(s.slot), IsNil)
 

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -102,6 +102,8 @@ func checkWorkshop(task *state.Task, projectId, workshop string) (bool, error) {
 	return false, nil
 }
 
+// Iterates over the list of running tasks and returns a ChangeConflictError if
+// there is another change running for the provided projectID / workshop pair.
 func CheckChangeConflict(st *state.State, projectId, workshop string, ignoreChange string) error {
 	for _, task := range st.Tasks() {
 		chg := task.Change()
@@ -128,7 +130,7 @@ func CheckChangeConflict(st *state.State, projectId, workshop string, ignoreChan
 
 // Attempt to resume the change associated with the refresh operation for the
 // given workshop. Depending on the mode the change will either be turned
-// into Doing (Continue mode) or Abort (Abort mode)
+// into Doing (Continue mode) or Abort (Abort mode).
 func ResumeRefresh(st *state.State,
 	workshop string, projectId string, mode RefreshMode) (*state.Change, error) {
 	if mode != RefreshAbort && mode != RefreshContinue {

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -12,12 +12,14 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-// The Do handler decoractor that helps to decide whether:
+// OnDo helps to decide whether:
 // 1. The task needs to be put on Wait (wait-on-error for refresh).
+//
 // 2. The error needs to be reported but safely ingored (ContextCancelled can
 // happen if a user cancells or something gets interrupted during the execution
 // due to abortion, e.g. a running hook is called off because their change was
 // aborted.
+//
 // 3. The error needs to be reported as is which will abort the change (or the
 // affected lanes).
 func OnDo(handler state.HandlerFunc) state.HandlerFunc {
@@ -110,4 +112,32 @@ func BackendContext(tomb *tomb.Tomb, user string, projectId string) (context.Con
 	ctxUser := context.WithValue(ctxProject, workshop.ContextUser, user)
 	ctxCancel, cancel := context.WithCancel(ctxUser)
 	return ctxCancel, cancel
+}
+
+// InjectTasks makes all the halt tasks of the mainTask wait for extraTasks;
+// extraTasks join the same lane and change as the mainTask.
+func InjectTasks(mainTask *state.Task, extraTasks *state.TaskSet) {
+	lanes := mainTask.Lanes()
+	if len(lanes) == 1 && lanes[0] == 0 {
+		lanes = nil
+	}
+	for _, l := range lanes {
+		extraTasks.JoinLane(l)
+	}
+
+	chg := mainTask.Change()
+	// Change shouldn't normally be nil, except for cases where
+	// this helper is used before tasks are added to a change.
+	if chg != nil {
+		chg.AddAll(extraTasks)
+	}
+
+	// make all halt tasks of the mainTask wait on extraTasks
+	ht := mainTask.HaltTasks()
+	for _, t := range ht {
+		t.WaitAll(extraTasks)
+	}
+
+	// make the extra tasks wait for main task
+	extraTasks.WaitFor(mainTask)
 }

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -71,6 +71,18 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 	}
 }
 
+func Workshop(task *state.Task) (string, error) {
+	var w string
+	err := task.Get("workshop", &w)
+	return w, err
+}
+
+func Sdk(task *state.Task) (string, error) {
+	var s string
+	err := task.Get("sdk", &s)
+	return s, err
+}
+
 func UserProjectWorkshop(task *state.Task) (string, *workshop.Project, string, error) {
 	st := task.State()
 	var prj workshop.Project

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -71,6 +71,12 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 	}
 }
 
+func User(change *state.Change) (string, error) {
+	var user string
+	err := change.Get("user", &user)
+	return user, err
+}
+
 func Workshop(task *state.Task) (string, error) {
 	var w string
 	err := task.Get("workshop", &w)

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -2,7 +2,6 @@ package handlersetup
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"gopkg.in/tomb.v2"
@@ -33,14 +32,7 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 		st.Lock()
 		defer st.Unlock()
 
-		switch {
-		case errors.Is(err, context.Canceled):
-			task.Logf("The task execution was cancelled")
-			// the context cancellation here means the change was aborted and
-			// the undo logic chain started. we don't report the context
-			// cancellation as error here as it is an expected interruption
-			return nil
-		case err != nil:
+		if err != nil {
 			change := task.Change()
 			if change.Kind() == "refresh" {
 				var setup conflict.RefreshSetup
@@ -63,7 +55,6 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 				}
 
 			}
-
 			return err
 		}
 

--- a/internal/overlord/handlersetup/handler_setup_test.go
+++ b/internal/overlord/handlersetup/handler_setup_test.go
@@ -1,9 +1,7 @@
 package handlersetup_test
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"testing"
 
@@ -42,23 +40,6 @@ func (s *CommonStateFuncs) setupTask() *state.Task {
 func (s *CommonStateFuncs) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.project = &workshop.Project{Path: c.MkDir(), ProjectId: "42ws42ws"}
-}
-
-func (s *CommonStateFuncs) TestContextCancelled(c *check.C) {
-	task := s.setupTask()
-
-	s.state.Lock()
-	chg := task.Change()
-	chg.Set("refresh-setup", conflict.RefreshSetup{Mode: conflict.RefreshWaitOnError.String()})
-	chg.Set("project-id", s.project.ProjectId)
-	task.Change().Abort()
-	s.state.Unlock()
-
-	handler := handlersetup.OnDo(func(task *state.Task, tomb *tomb.Tomb) error {
-		return fmt.Errorf("execution error %w", context.Canceled)
-	})
-	err := handler(task, nil)
-	c.Assert(err, check.IsNil)
 }
 
 func (s *CommonStateFuncs) TestRefreshWaitOnError(c *check.C) {

--- a/internal/overlord/handlersetup/handler_setup_test.go
+++ b/internal/overlord/handlersetup/handler_setup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -93,4 +94,74 @@ func (s *CommonStateFuncs) TestExecutionOnDoRetry(c *check.C) {
 	err := handler(task, nil)
 	c.Assert(err, check.ErrorMatches, "task should be retried")
 	c.Assert(err.(*state.Retry).Reason, check.Equals, "not enough time")
+}
+
+func (s *CommonStateFuncs) TestInjectTasks(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	lane := s.state.NewLane()
+
+	// setup main task and two tasks waiting for it; all part of same change
+	chg := s.state.NewChange("change", "")
+	t0 := s.state.NewTask("task1", "")
+	chg.AddTask(t0)
+	t0.JoinLane(lane)
+	t01 := s.state.NewTask("task1-1", "")
+	t01.WaitFor(t0)
+	chg.AddTask(t01)
+	t02 := s.state.NewTask("task1-2", "")
+	t02.WaitFor(t0)
+	chg.AddTask(t02)
+
+	// setup extra tasks
+	t1 := s.state.NewTask("task2", "")
+	t2 := s.state.NewTask("task3", "")
+	ts := state.NewTaskSet(t1, t2)
+
+	handlersetup.InjectTasks(t0, ts)
+
+	// verify that extra tasks are now part of same change
+	c.Assert(t1.Change().ID(), check.Equals, t0.Change().ID())
+	c.Assert(t2.Change().ID(), check.Equals, t0.Change().ID())
+	c.Assert(t1.Change().ID(), check.Equals, chg.ID())
+
+	c.Assert(t1.Lanes(), check.DeepEquals, []int{lane})
+
+	// verify that halt tasks of the main task now wait for extra tasks
+	c.Assert(t1.HaltTasks(), check.HasLen, 2)
+	c.Assert(t2.HaltTasks(), check.HasLen, 2)
+	c.Assert(t1.HaltTasks(), check.DeepEquals, t2.HaltTasks())
+
+	ids := []string{t1.HaltTasks()[0].Kind(), t2.HaltTasks()[1].Kind()}
+	sort.Strings(ids)
+	c.Assert(ids, check.DeepEquals, []string{"task1-1", "task1-2"})
+
+	// verify that extra tasks wait for the main task
+	c.Assert(t1.WaitTasks(), check.HasLen, 1)
+	c.Assert(t1.WaitTasks()[0].Kind(), check.Equals, "task1")
+	c.Assert(t2.WaitTasks(), check.HasLen, 1)
+	c.Assert(t2.WaitTasks()[0].Kind(), check.Equals, "task1")
+}
+
+func (s *CommonStateFuncs) TestInjectTasksWithNullChange(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// setup main task
+	t0 := s.state.NewTask("task1", "")
+	t01 := s.state.NewTask("task1-1", "")
+	t01.WaitFor(t0)
+
+	// setup extra task
+	t1 := s.state.NewTask("task2", "")
+	ts := state.NewTaskSet(t1)
+
+	handlersetup.InjectTasks(t0, ts)
+
+	c.Assert(t1.Lanes(), check.DeepEquals, []int{0})
+
+	// verify that halt tasks of the main task now wait for extra tasks
+	c.Assert(t1.HaltTasks(), check.HasLen, 1)
+	c.Assert(t1.HaltTasks()[0].Kind(), check.Equals, "task1-1")
 }

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -191,7 +191,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 	}
 
 	var hookContext *hookstate.Context
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				// emulate workshopctl set-health --code=<code> error <message>
@@ -206,7 +206,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one", true)
@@ -258,7 +258,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 		CheckResult: healthstate.CheckOkay,
 	}
 
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				hookCtx, err := s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
@@ -279,7 +279,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one", true)
@@ -321,7 +321,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 	}
 
 	var hookContext *hookstate.Context
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				var err error
@@ -336,7 +336,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one", true)
@@ -371,7 +371,7 @@ func (s *healthSuite) TestExecCheckHealthTimeout(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				return context.DeadlineExceeded
@@ -379,7 +379,7 @@ func (s *healthSuite) TestExecCheckHealthTimeout(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one", true)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -183,7 +183,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 	chg.AddTask(t1)
 
 	s.launchWorkshop(c, "one")
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				return errors.New("hook execution error")
@@ -191,7 +191,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.state.Unlock()
@@ -220,7 +220,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				child, cancel := context.WithTimeout(ctx, args.Timeout)
@@ -231,7 +231,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.state.Unlock()
@@ -282,7 +282,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerUnhappyPath(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				return errors.New("hook execution error")
@@ -290,7 +290,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerUnhappyPath(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one")
@@ -322,7 +322,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerErrorFails(c *check.C) {
 	chg.AddTask(t1)
 
 	s.launchWorkshop(c, "one")
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				return errors.New("hook execution error")
@@ -330,7 +330,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerErrorFails(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.state.Unlock()
@@ -359,7 +359,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerIgnoresError(c *check.C) {
 	chg.AddTask(t1)
 
 	s.launchWorkshop(c, "one")
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				return errors.New("hook execution error")
@@ -367,7 +367,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerIgnoresError(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.DoExec = workshop.DoExecDefault
+		s.backend.ExecCallback = workshop.DoExecDefault
 	}()
 
 	s.state.Unlock()

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -54,7 +54,6 @@ func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
 			}
 			target, _ := pi.Lookup("target")
 			return target == candidateTarget
-
 		})
 		if idx != -1 {
 			return fmt.Errorf(`cannot connect "%s/%s:%s": target %s is also mounted by %s/%s:%s`, plug.Sdk.Workshop, plug.Sdk.Name, plug.Name, candidateTarget,
@@ -165,47 +164,34 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 	st.Lock()
 	defer st.Unlock()
 
-	// this can be a refresh for an existing SDK, hence, reconnect the SDK's
-	// connections from scratch. Consider the following scenarios for an
-	// SDK:
-	// 1. workshop launch (no previous connection for any of the plugs/slots). The task must:
-	// - find slot candidates and connect them
-	// - build and assign an SDK profile to the workshop
-	// 2. workshop refresh (can add/remove/update the SDK's plugs and slots)
-	// - disconnect the SDK; that affects other SDKs in the system
-	// - remove the SDK from the repository (e.g. remove all its plugs and slots)
-	// - find and connect candidates for the SDK plug and slot
-	// - rebuild SDK profiles for the affected SDKs and assign them to the corresponding workshops
-	disconnected, err := m.repo.DisconnectSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name)
-	if err != nil {
-		return err
-	}
-
-	if err := m.repo.RemoveSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name); err != nil {
-		return err
-	}
-
-	if err := m.repo.AddSdk(sdkInfo); err != nil {
-		return err
-	}
-
 	// Ensure that if the SDK is connected there will be no conflicting bind
 	// mount targets in the workshop, i.e. the situation when a two or more
-	// sources are bind mount at the same target in the workshop. Do it after
-	// the SDK was added to the repository to also validate that it does not
-	// contain conflicting targets itself (though, this kind of validation must
-	// be caught by the craft tool).
-	if err = m.checkConflictingTargets(sdkInfo); err != nil {
+	// sources are bind mount at the same target in the workshop.
+	if err := m.checkConflictingTargets(sdkInfo); err != nil {
 		return err
 	}
-
 	if len(sdkInfo.BadInterfaces) > 0 {
 		task.Logf("%s", sdk.BadInterfacesSummary(sdkInfo))
 	}
 
-	// reload the existing connections to make sure that those that are getting
-	// removed with this auto-connect task are also removed from the state
+	// Disconnect and remove a previous version of the SDK if any (a common case
+	// if the task is part of a refresh change).
+	disconnected, err := m.repo.DisconnectSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name)
+	if err != nil {
+		return err
+	}
+	if err := m.repo.RemoveSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name); err != nil {
+		return err
+	}
+
+	// Reload connections to make sure that those that are getting removed with
+	// the removal of a previous version of this SDK (if any) are also removed
+	// from the state.
 	if _, err := m.reloadConnections("", "", ""); err != nil {
+		return err
+	}
+
+	if err := m.repo.AddSdk(sdkInfo); err != nil {
 		return err
 	}
 
@@ -214,11 +200,11 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 		return err
 	}
 
-	// At the moment, only searching for auto-connect-able slots
 	var connected = map[sdk.Ref]*sdk.Info{}
 	var connectRefs = []*interfaces.ConnRef{}
 	var revertConnections revert.Reverter
 	defer revertConnections.Fail()
+
 	for _, plug := range sdkInfo.Plugs {
 		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
 		for _, slot := range candidates {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -203,7 +203,8 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *worksh
 		if ref.PlugRef != master && len(slaves) > 0 {
 			// the plug is bound which excludes other dynamicq attributes
 			maps.Clear(plugDynamic[ref.ID()])
-			plugDynamic[ref.ID()]["bind"] = map[string]interface{}{"plug": master, "slot": ref.SlotRef}
+			bref := interfaces.ConnRef{PlugRef: master, SlotRef: ref.SlotRef}
+			plugDynamic[ref.ID()]["bind"] = bref.ID()
 		}
 
 		if plugDynamic != nil {
@@ -628,6 +629,9 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		if forget && (notConnected || noPlugOrSlot) {
 			delete(conns, cref.ID())
 			setConns(st, conns)
+			// NB: If undo is executed in this scenario, it would restore a
+			// previously undesired connection, but will not run a profile
+			// setup.
 			return nil
 		}
 		return fmt.Errorf("workshop changed, please retry the operation: %v", err)
@@ -693,7 +697,7 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 	plug := m.repo.Plug(cref.PlugRef.ProjectId, cref.PlugRef.Workshop, cref.PlugRef.Sdk, cref.PlugRef.Name)
 	slot := m.repo.Slot(cref.SlotRef.ProjectId, cref.SlotRef.Workshop, cref.SlotRef.Sdk, cref.SlotRef.Name)
 
-	if forget && (plug == nil || slot == nil) {
+	if forget && (plug == nil || slot == nil || oldconn.Undesired) {
 		// we were trying to forget an inactive connection that was
 		// referring to a non-existing plug or slot; just restore it
 		// in the conns state but do not reconnect via repository.

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -82,9 +82,16 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	if err = policy.CheckInterfaces(sdkInfo); err != nil {
 		return err
 	}
+	if len(sdkInfo.BadInterfaces) > 0 {
+		task.Logf("%s", sdk.BadInterfacesSummary(sdkInfo))
+	}
 
 	st.Lock()
 	defer st.Unlock()
+
+	if err := m.repo.AddSdk(sdkInfo); err != nil {
+		return err
+	}
 
 	chg := task.Change()
 	// If auto-connect is executed during refresh, chances are, that there are
@@ -100,42 +107,14 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
-	conns, err := getConns(m.state)
-	if err != nil {
+	// Ensure that if the SDK is connected there will be no conflicting bind
+	// mount targets in the workshop, i.e. the situation when a two or more
+	// sources are bind mount at the same target in the workshop.
+	if err := m.checkConflictingTargets(sdkInfo); err != nil {
 		return err
 	}
 
-	var connectRefs = []*interfaces.ConnRef{}
-
-	for _, plug := range sdkInfo.Plugs {
-		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
-		for _, slot := range candidates {
-			connRef := interfaces.NewConnRef(plug, slot)
-
-			if _, ok := conns[connRef.ID()]; ok {
-				// Suggested connection already exist (or has
-				// Undesired flag set) so don't clobber it.
-				// NOTE: we don't log anything here as this is
-				// a normal and common condition.
-				continue
-			}
-
-			connectRefs = append(connectRefs, connRef)
-		}
-	}
-
-	// remounts may be not nil when a previously existing content
-	// interface connection (e.g. pre-refresh) needs to be recreated
-	// without changes to its 'source' attribute in the new workshop
-	// (given the new workshop also has an SDK with exactly the same
-	// plug; the target directory may change in the new workshop).
-	connectTs := m.batchAutoConnectTasks(project, sdkInfo, connectRefs, remounts, nil)
-
-	handlersetup.InjectTasks(task, connectTs)
-	m.state.EnsureBefore(0)
-	task.SetStatus(state.DoneStatus)
-
-	return nil
+	return m.setupAutoConnections(task, project, sdkInfo, remounts)
 }
 
 func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) error {
@@ -170,7 +149,7 @@ func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) er
 
 // Returns content interface connection IDs of the SDK and their corresponding
 // plug's dynamic attributes.
-func (m *InterfaceManager) contentSources(projectId, w, s string) map[string]map[string]interface{} {
+func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]map[string]interface{} {
 	// [ref.ID]source
 	var candidates = map[string]map[string]interface{}{}
 	refs, err := m.repo.Connections(projectId, w, s)
@@ -196,11 +175,12 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, info *sdk.
 	connectTs := state.NewTaskSet()
 	var affected = map[sdk.Ref]bool{}
 	for _, ref := range refs {
-		connect := m.state.NewTask("connect", fmt.Sprintf("Connect %s to %s", ref.PlugRef.String(), ref.SlotRef.String()))
+		connect := m.state.NewTask("connect", fmt.Sprintf("Connect %s to %s", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
 
 		connect.Set("plug", ref.PlugRef)
 		connect.Set("slot", ref.SlotRef)
 		connect.Set("auto", true)
+		connect.Set("delayed-setup-profile", true)
 		// Remove connection instead of making it undesired in undo logic if an
 		// error happens.
 		connect.Set("forget", true)
@@ -238,37 +218,6 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, info *sdk.
 }
 
 func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Project, sdkInfo *sdk.Info, remounts map[string]map[string]interface{}) error {
-	// Ensure that if the SDK is connected there will be no conflicting bind
-	// mount targets in the workshop, i.e. the situation when a two or more
-	// sources are bind mount at the same target in the workshop.
-	if err := m.checkConflictingTargets(sdkInfo); err != nil {
-		return err
-	}
-	if len(sdkInfo.BadInterfaces) > 0 {
-		task.Logf("%s", sdk.BadInterfacesSummary(sdkInfo))
-	}
-
-	// Disconnect and remove a previous version of the SDK if any (a common case
-	// if the task is part of a refresh change).
-	_, err := m.repo.DisconnectSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name)
-	if err != nil {
-		return err
-	}
-	if err := m.repo.RemoveSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name); err != nil {
-		return err
-	}
-
-	// Reload connections to make sure that those that are getting removed with
-	// the removal of a previous version of this SDK (if any) are also removed
-	// from the state.
-	if _, err := m.reloadConnections("", "", ""); err != nil {
-		return err
-	}
-
-	if err := m.repo.AddSdk(sdkInfo); err != nil {
-		return err
-	}
-
 	conns, err := getConns(m.state)
 	if err != nil {
 		return err
@@ -277,7 +226,8 @@ func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Pr
 	var connectRefs = []*interfaces.ConnRef{}
 
 	for _, plug := range sdkInfo.Plugs {
-		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
+		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop,
+			sdkInfo.Name, plug.Name, autoConnectCheck)
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
 
@@ -286,6 +236,20 @@ func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Pr
 				// Undesired flag set) so don't clobber it.
 				// NOTE: we don't log anything here as this is
 				// a normal and common condition.
+				continue
+			}
+
+			connectRefs = append(connectRefs, connRef)
+		}
+	}
+
+	for _, slot := range sdkInfo.Slots {
+		candidates := m.repo.AutoConnectCandidatePlugs(sdkInfo.ProjectId, sdkInfo.Workshop,
+			sdkInfo.Name, slot.Name, autoConnectCheck)
+		for _, plug := range candidates {
+			connRef := interfaces.NewConnRef(plug, slot)
+
+			if _, ok := conns[connRef.ID()]; ok {
 				continue
 			}
 
@@ -307,19 +271,54 @@ func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Pr
 	return nil
 }
 
-func (m *InterfaceManager) doAutoDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {
+func (m *InterfaceManager) batchDisconnectTasks(p *workshop.Project, workshop, sdkName string,
+	conns map[string]*schema.ConnState, refs []*interfaces.ConnRef) *state.TaskSet {
+	ts := state.NewTaskSet()
+
+	var prev *state.Task
+	for _, ref := range refs {
+		task := m.state.NewTask("disconnect",
+			fmt.Sprintf("Disconnnect %s from %s", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
+		task.Set("plug", ref.PlugRef)
+		task.Set("slot", ref.SlotRef)
+		if conn := conns[ref.ID()]; conn != nil && conn.Undesired {
+			continue
+		}
+		task.Set("forget", true)
+
+		if prev != nil {
+			task.WaitFor(prev)
+		}
+		prev = task
+		ts.AddTask(task)
+	}
+
+	setup := m.state.NewTask("remove-profiles", fmt.Sprintf("Remove %q SDK profile", sdkName))
+	setup.WaitAll(ts)
+
+	ts.AddTask(setup)
+
+	for _, tsk := range ts.Tasks() {
+		tsk.Set("workshop", workshop)
+		tsk.Set("sdk", sdkName)
+		tsk.Set("project", p)
+	}
+	return ts
+}
+
+// Disconnects SDK's interface connections and removes the SDK from the
+// repository / connections. The SDK must have its manual connections stored and
+// reconnected on undo (the auto connections will be reconnected automatically).
+func (m *InterfaceManager) doDisconnectInterfaces(task *state.Task, tomb *tomb.Tomb) (err error) {
 	st := task.State()
-	user, project, w, err := handlersetup.UserProjectWorkshop(task)
+	_, project, w, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
-	defer cancel()
-
 	st.Lock()
+	defer st.Unlock()
 	s, err := handlersetup.Sdk(task)
-	st.Unlock()
 	if err != nil {
 		return err
 	}
@@ -327,90 +326,37 @@ func (m *InterfaceManager) doAutoDisconnect(task *state.Task, tomb *tomb.Tomb) (
 	// Save 'source' attributes for the content interface connections as some of
 	// them may have been remounted to a non-default locations, so these can be
 	// set after refresh for this SDK.
-	cattrs := m.contentSources(project.ProjectId, w, s)
+	cattrs := m.remountSources(project.ProjectId, w, s)
 
 	if len(cattrs) > 0 {
-		st.Lock()
 		chg := task.Change()
 		var remounts map[string]map[string]interface{}
 		if err = chg.Get("remounts", &remounts); errors.Is(err, state.ErrNoState) {
 			remounts = make(map[string]map[string]interface{})
 		} else if err != nil {
-			st.Unlock()
 			return err
 		}
 		maps.Copy(remounts, cattrs)
 		chg.Set("remounts", remounts)
-		st.Unlock()
 	}
 
-	disconnected, err := m.repo.DisconnectSdk(project.ProjectId, w, s)
+	conns, err := getConns(m.state)
 	if err != nil {
 		return err
 	}
 
-	if err := m.repo.RemoveSdk(project.ProjectId, w, s); err != nil {
-		return err
-	}
-
-	st.Lock()
-	_, err = m.reloadConnections(project.ProjectId, w, s)
-	st.Unlock()
+	connections, err := m.repo.Connections(project.ProjectId, w, s)
 	if err != nil {
 		return err
 	}
 
-	for _, backend := range m.repo.Backends() {
-		// If there are not plugs or slots declared by the SDK the profile does
-		// not neccessarily exist for the SDK.
-		if err := backend.Remove(ctx, w, s); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
-			return err
-		}
-	}
+	ts := m.batchDisconnectTasks(project, w, s, conns, connections)
 
-	ref := sdk.Ref{ProjectId: project.ProjectId, Workshop: w, Sdk: s}
-	for _, s := range disconnected {
-		if ref != s.Ref() {
-			for _, backend := range m.repo.Backends() {
-				if err = backend.Setup(ctx, s.Ref(), m.repo); err != nil {
-					return err
-				}
-			}
-		}
-	}
+	handlersetup.InjectTasks(task, ts)
+	m.state.EnsureBefore(0)
+	task.SetStatus(state.DoneStatus)
+
 	return nil
-}
-
-func (m *InterfaceManager) undoAutoDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {
-	st := task.State()
-	user, project, w, err := handlersetup.UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
-	defer cancel()
-
-	st.Lock()
-	sdkName, err := handlersetup.Sdk(task)
-	st.Unlock()
-	if err != nil {
-		return err
-	}
-
-	inst, err := m.backend.Workshop(ctx, w)
-	if err != nil {
-		return err
-	}
-
-	sdkInfo, err := inst.SdkInfo(ctx, sdkName)
-	if err != nil {
-		return err
-	}
-
-	st.Lock()
-	defer st.Unlock()
-	return m.setupAutoConnections(task, project, sdkInfo, nil)
 }
 
 func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRef, error) {
@@ -469,11 +415,20 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	var delayedSetupProfile bool
+	if err := task.Get("delayed-setup-profile", &delayedSetupProfile); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
 	cref := &interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
 	conn, err := m.repo.Connect(cref, plug.Attrs, plugDynamicAttrs,
 		slot.Attrs, slotDynamicAttrs, connectCheck)
 	if err != nil || conn == nil {
 		return err
+	}
+
+	if old, ok := conns[cref.ID()]; ok && old.Undesired {
+		task.Set("old-conn", old)
 	}
 
 	conns[cref.ID()] = &schema.ConnState{
@@ -485,6 +440,88 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		Auto:             autoConnect,
 	}
 	setConns(st, conns)
+
+	if !delayedSetupProfile {
+		for _, ref := range []sdk.Ref{conn.Plug.Sdk().Ref(), conn.Slot.Sdk().Ref()} {
+			ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
+			defer cancel()
+			for _, backend := range m.repo.Backends() {
+				if err := backend.Setup(ctx, ref, m.repo); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *InterfaceManager) undoConnect(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var user string
+	err := task.Change().Get("user", &user)
+	if err != nil {
+		return err
+	}
+
+	plugRef, slotRef, err := getPlugAndSlotRefs(task)
+	if err != nil {
+		return err
+	}
+
+	connRef := interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
+	conns, err := getConns(st)
+	if err != nil {
+		return err
+	}
+	var old schema.ConnState
+	err = task.Get("old-conn", &old)
+	if err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if err == nil {
+		conns[connRef.ID()] = &old
+	} else {
+		delete(conns, connRef.ID())
+	}
+	setConns(st, conns)
+
+	plug := m.repo.Plug(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name)
+	if plug == nil {
+		return fmt.Errorf("SDK %q has no %q plug", plugRef.Sdk, plugRef.Name)
+	}
+
+	slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
+	if slot == nil {
+		return fmt.Errorf("SDK %q has no %q slot", slotRef.Sdk, slotRef.Name)
+	}
+
+	if err = m.repo.Disconnect(plugRef.ProjectId, plugRef.Workshop,
+		plugRef.Sdk, plugRef.Name, slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name); err != nil {
+		return err
+	}
+
+	var delayedSetupProfile bool
+	if err := task.Get("delayed-setup-profile", &delayedSetupProfile); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if delayedSetupProfile {
+		logger.Debugf("Connect undo handler: skipping setupSdkSecurity for SDKs %q and %q", connRef.PlugRef.Sdk, connRef.SlotRef.Sdk)
+		return nil
+	}
+
+	for _, ref := range []sdk.Ref{plug.Sdk.Ref(), slot.Sdk.Ref()} {
+		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
+		defer cancel()
+		for _, backend := range m.repo.Backends() {
+			if err := backend.Setup(ctx, ref, m.repo); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }
@@ -551,6 +588,84 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 	}
 	setConns(st, conns)
 
+	plugSdk, slotSdk := sdk.Ref{ProjectId: plugRef.ProjectId, Workshop: plugRef.Workshop, Sdk: plugRef.Sdk},
+		sdk.Ref{ProjectId: slotRef.ProjectId, Workshop: slotRef.Workshop, Sdk: slotRef.Sdk}
+
+	for _, ref := range []sdk.Ref{plugSdk, slotSdk} {
+		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
+		defer cancel()
+		for _, backend := range m.repo.Backends() {
+			if err := backend.Setup(ctx, ref, m.repo); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var user string
+	err = task.Change().Get("user", &user)
+
+	plugRef, slotRef, err := getPlugAndSlotRefs(task)
+	if err != nil {
+		return err
+	}
+
+	var forget bool
+	if err := task.Get("forget", &forget); err != nil && !errors.Is(err, state.ErrNoState) {
+		return fmt.Errorf("internal error: cannot read 'forget' flag: %s", err)
+	}
+	var oldconn schema.ConnState
+	if err = task.Get("old-conn", &oldconn); err != nil {
+		return err
+	}
+
+	cref := interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
+	conns, err := getConns(st)
+	if err != nil {
+		return err
+	}
+	plug := m.repo.Plug(cref.PlugRef.ProjectId, cref.PlugRef.Workshop, cref.PlugRef.Sdk, cref.PlugRef.Name)
+	slot := m.repo.Slot(cref.SlotRef.ProjectId, cref.SlotRef.Workshop, cref.SlotRef.Sdk, cref.SlotRef.Name)
+
+	if forget && (plug == nil || slot == nil) {
+		// we were trying to forget an inactive connection that was
+		// referring to a non-existing plug or slot; just restore it
+		// in the conns state but do not reconnect via repository.
+		conns[cref.ID()] = &oldconn
+		setConns(st, conns)
+		return nil
+	}
+	if plug == nil {
+		return fmt.Errorf("SDK %q has no %q plug", cref.PlugRef.Sdk, cref.PlugRef.Name)
+	}
+	if slot == nil {
+		return fmt.Errorf("SDK %q has no %q slot", cref.SlotRef.Sdk, cref.SlotRef.Name)
+	}
+
+	c, err := m.repo.Connect(&cref, oldconn.StaticPlugAttrs, oldconn.DynamicPlugAttrs,
+		oldconn.StaticSlotAttrs, oldconn.DynamicSlotAttrs, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, ref := range []sdk.Ref{c.Plug.Sdk().Ref(), c.Slot.Sdk().Ref()} {
+		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
+		defer cancel()
+		for _, backend := range m.repo.Backends() {
+			if err := backend.Setup(ctx, ref, m.repo); err != nil {
+				return err
+			}
+		}
+	}
+
+	conns[cref.ID()] = &oldconn
+	setConns(st, conns)
 	return nil
 }
 
@@ -681,6 +796,75 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 	return nil
 }
 
+func (m *InterfaceManager) doRemoveProfiles(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	user, p, w, err := handlersetup.UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	st.Lock()
+	s, err := handlersetup.Sdk(task)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := handlersetup.BackendContext(tomb, user, p.ProjectId)
+	defer cancel()
+
+	_, err = m.repo.DisconnectSdk(p.ProjectId, w, s)
+	if err != nil {
+		return err
+	}
+
+	if err = m.repo.RemoveSdk(p.ProjectId, w, s); err != nil {
+		return err
+	}
+
+	for _, backend := range m.repo.Backends() {
+		// If there are not plugs or slots declared by the SDK the profile does
+		// not neccessarily exist for the SDK.
+		if err := backend.Remove(ctx, w, s); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *InterfaceManager) undoRemoveProfiles(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	user, project, w, err := handlersetup.UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
+	defer cancel()
+
+	st.Lock()
+	sdkName, err := handlersetup.Sdk(task)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	inst, err := m.backend.Workshop(ctx, w)
+	if err != nil {
+		return err
+	}
+
+	sdkInfo, err := inst.SdkInfo(ctx, sdkName)
+	if err != nil {
+		return err
+	}
+
+	if err := m.repo.AddSdk(sdkInfo); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
@@ -726,7 +910,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 		return err
 	}
 	if len(plugConns) != 1 {
-		return fmt.Errorf("plug %q must have exactly one connection to be remounted", plug.String())
+		return fmt.Errorf("plug %q must have exactly one connection to be remounted", plug.ShortRef())
 	}
 	connRef := plugConns[0]
 	// get the connected plug-slot pair to get its existing attributes (source)
@@ -754,7 +938,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 	revert.Add(func() {
 		_ = connection.Plug.SetAttr("source", oldSource)
 		if _, err := m.repo.Connect(connRef, connection.Plug.StaticAttrs(), connection.Plug.DynamicAttrs(), connection.Slot.StaticAttrs(), connection.Slot.DynamicAttrs(), nil); err != nil {
-			logger.Debugf("cannot reconnect %q plug on a failed remount", plug.String())
+			logger.Debugf("cannot reconnect %q plug on a failed remount", plug.ShortRef())
 		}
 	})
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -114,7 +114,7 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
-	return m.setupAutoConnections(task, project, inst, sdkInfo, remounts)
+	return m.connectAuto(task, project, inst, sdkInfo, remounts)
 }
 
 func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) error {
@@ -172,8 +172,7 @@ func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]str
 	return candidates
 }
 
-func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, remounts map[string]string,
-	plugDynamic, slotDynamic map[string]map[string]interface{}) *state.TaskSet {
+func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, remounts map[string]string, plugDynamic, slotDynamic map[string]map[string]interface{}) (*state.TaskSet, error) {
 
 	connectTs := state.NewTaskSet()
 	var affected = map[sdk.Ref]bool{}
@@ -200,10 +199,29 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *worksh
 		// it in the attributes for the backend to NOT set a profile for this
 		// connection as it will be bound to its master's connection effect.
 		if ref.PlugRef != master && len(slaves) > 0 {
-			// the plug is bound which excludes other dynamicq attributes
+			// the plug is bound which excludes other dynamic attributes
 			maps.Clear(plugDynamic[ref.ID()])
-			bref := interfaces.ConnRef{PlugRef: master, SlotRef: ref.SlotRef}
+
+			// Find the master's slot reference (must also present, otherwise it
+			// breaks the auto-connection integrity -- no bound connection must
+			// be connected if the master is not auto-connectable).
+			idx := slices.IndexFunc(refs, func(r *interfaces.ConnRef) bool { return r.PlugRef == master })
+			if idx == -1 {
+				return nil, fmt.Errorf("cannot auto-connect %s: plug bind %s does not exist or not auto-connectable",
+					ref.PlugRef.ShortRef(), master.ShortRef())
+			}
+			bref := interfaces.ConnRef{PlugRef: master, SlotRef: refs[idx].SlotRef}
 			plugDynamic[ref.ID()]["bind"] = bref.ID()
+		} else {
+			// Make sure that all the plugs that are bound to this master can
+			// also be auto-connected (i.e. present in the refs). Otherwise, it
+			// breaks the integrity when a bound plug is not connected whilst
+			// its master is.
+			for _, r := range slaves {
+				if idx := slices.IndexFunc(refs, func(cr *interfaces.ConnRef) bool { return cr.PlugRef == r }); idx == -1 {
+					return nil, fmt.Errorf("cannot auto-connect %s: bound plug %s cannot be auto-connected", master.ShortRef(), r.ShortRef())
+				}
+			}
 		}
 
 		if plugDynamic != nil {
@@ -235,10 +253,10 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *worksh
 		tsk.Set("project", p)
 	}
 
-	return connectTs
+	return connectTs, nil
 }
 
-func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Project, wp *workshop.Workshop, sdkInfo *sdk.Info, remounts map[string]string) error {
+func (m *InterfaceManager) connectAuto(task *state.Task, p *workshop.Project, wp *workshop.Workshop, sdkInfo *sdk.Info, remounts map[string]string) error {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return err
@@ -283,9 +301,12 @@ func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Pr
 	// without changes to its 'source' attribute in the new workshop
 	// (given the new workshop also has an SDK with exactly the same
 	// plug; the target directory may change in the new workshop).
-	connectTs := m.batchAutoConnectTasks(p, wp, sdkInfo, connectRefs, remounts, nil, nil)
+	ts, err := m.batchAutoConnectTasks(p, wp, sdkInfo, connectRefs, remounts, nil, nil)
+	if err != nil {
+		return err
+	}
 
-	handlersetup.InjectTasks(task, connectTs)
+	handlersetup.InjectTasks(task, ts)
 	m.state.EnsureBefore(0)
 	task.SetStatus(state.DoneStatus)
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"syscall"
 
 	"golang.org/x/exp/maps"
@@ -102,7 +103,7 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	// we store the content interface connection's 'source' directories when the
 	// old workshop/SDK is removed (see the 'disconnect' task handler) and check
 	// if any of those are still relevant for the new workshop.
-	var remounts map[string]map[string]interface{}
+	var remounts map[string]string
 	if err := chg.Get("remounts", &remounts); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
@@ -114,7 +115,7 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
-	return m.setupAutoConnections(task, project, sdkInfo, remounts)
+	return m.setupAutoConnections(task, project, inst, sdkInfo, remounts)
 }
 
 func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) error {
@@ -149,9 +150,9 @@ func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) er
 
 // Returns content interface connection IDs of the SDK and their corresponding
 // plug's dynamic attributes.
-func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]map[string]interface{} {
+func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]string {
 	// [ref.ID]source
-	var candidates = map[string]map[string]interface{}{}
+	var candidates = make(map[string]string)
 	refs, err := m.repo.Connections(projectId, w, s)
 	if err != nil {
 		return nil
@@ -163,17 +164,23 @@ func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]map
 			continue
 		}
 		if conn.Interface() == "content" {
-			candidates[cref.ID()] = conn.Plug.DynamicAttrs()
+			attrs := conn.Plug.DynamicAttrs()
+			if attrs != nil && attrs["source"] != nil {
+				candidates[cref.ID()] = attrs["source"].(string)
+			}
 		}
 	}
 	return candidates
 }
 
-func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, info *sdk.Info, refs []*interfaces.ConnRef,
+func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, remounts map[string]string,
 	plugDynamic, slotDynamic map[string]map[string]interface{}) *state.TaskSet {
 
 	connectTs := state.NewTaskSet()
 	var affected = map[sdk.Ref]bool{}
+	if plugDynamic == nil {
+		plugDynamic = make(map[string]map[string]interface{})
+	}
 	for _, ref := range refs {
 		connect := m.state.NewTask("connect", fmt.Sprintf("Connect %s to %s", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
 
@@ -181,9 +188,23 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, info *sdk.
 		connect.Set("slot", ref.SlotRef)
 		connect.Set("auto", true)
 		connect.Set("delayed-setup-profile", true)
-		// Remove connection instead of making it undesired in undo logic if an
-		// error happens.
-		connect.Set("forget", true)
+		if plugDynamic[ref.ID()] == nil {
+			plugDynamic[ref.ID()] = make(map[string]interface{})
+		}
+
+		if src, ok := remounts[ref.ID()]; ok {
+			plugDynamic[ref.ID()]["source"] = src
+		}
+
+		master, slaves := maybeBound(wp, ref.PlugRef)
+		// If this plug is bound AND not a master (i.e. not bound to) then mark
+		// it in the attributes for the backend to NOT set a profile for this
+		// connection as it will be bound to its master's connection effect.
+		if ref.PlugRef != master && len(slaves) > 0 {
+			// the plug is bound which excludes other dynamicq attributes
+			maps.Clear(plugDynamic[ref.ID()])
+			plugDynamic[ref.ID()]["bind"] = map[string]interface{}{"plug": master, "slot": ref.SlotRef}
+		}
 
 		if plugDynamic != nil {
 			connect.Set("plug-dynamic", plugDynamic[ref.ID()])
@@ -217,7 +238,7 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, info *sdk.
 	return connectTs
 }
 
-func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Project, sdkInfo *sdk.Info, remounts map[string]map[string]interface{}) error {
+func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Project, wp *workshop.Workshop, sdkInfo *sdk.Info, remounts map[string]string) error {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return err
@@ -262,7 +283,7 @@ func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Pr
 	// without changes to its 'source' attribute in the new workshop
 	// (given the new workshop also has an SDK with exactly the same
 	// plug; the target directory may change in the new workshop).
-	connectTs := m.batchAutoConnectTasks(p, sdkInfo, connectRefs, remounts, nil)
+	connectTs := m.batchAutoConnectTasks(p, wp, sdkInfo, connectRefs, remounts, nil, nil)
 
 	handlersetup.InjectTasks(task, connectTs)
 	m.state.EnsureBefore(0)
@@ -330,9 +351,9 @@ func (m *InterfaceManager) doDisconnectInterfaces(task *state.Task, tomb *tomb.T
 
 	if len(cattrs) > 0 {
 		chg := task.Change()
-		var remounts map[string]map[string]interface{}
+		var remounts map[string]string
 		if err = chg.Get("remounts", &remounts); errors.Is(err, state.ErrNoState) {
-			remounts = make(map[string]map[string]interface{})
+			remounts = make(map[string]string)
 		} else if err != nil {
 			return err
 		}
@@ -369,6 +390,41 @@ func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRe
 		return plugRef, slotRef, err
 	}
 	return plugRef, slotRef, nil
+}
+
+func maybeBound(w *workshop.Workshop, ref interfaces.PlugRef) (interfaces.PlugRef, []interfaces.PlugRef) {
+	var masters = make(map[interfaces.PlugRef][]interfaces.PlugRef)
+	var slaves = make(map[interfaces.PlugRef]interfaces.PlugRef)
+
+	for _, s := range w.File.Sdks {
+		for name, bind := range s.Plugs {
+			comps := strings.Split(bind.Bind, ":")
+			mkey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: comps[0], Name: comps[1]}
+			skey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: s.Name, Name: name}
+			masters[mkey] = append(masters[mkey], skey)
+			slaves[skey] = mkey
+		}
+	}
+
+	srefs, mok := masters[ref]
+	mref, sok := slaves[ref]
+
+	if !mok && !sok {
+		// not a bound plug
+		return ref, nil
+	}
+
+	if mok {
+		// the ref is a master plug
+		return ref, srefs
+	}
+
+	if sok {
+		// the ref is bound to another plug
+		return mref, masters[mref]
+	}
+
+	return ref, nil
 }
 
 func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
@@ -441,6 +497,10 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 	}
 	setConns(st, conns)
 
+	// To setup a profile immediately it needs to be a master plug (i.e. bound
+	// to or a completely unbound plug) AND the task must request the setup on
+	// the spot and not as part of another task which usually happens with
+	// auto-connections.
 	if !delayedSetupProfile {
 		for _, ref := range []sdk.Ref{conn.Plug.Sdk().Ref(), conn.Slot.Sdk().Ref()} {
 			ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -105,36 +105,6 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	return m.connectAuto(task, wp, info, remounts)
 }
 
-func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) error {
-	_, project, w, err := handlersetup.UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	st := task.State()
-	st.Lock()
-	s, err := handlersetup.Sdk(task)
-	st.Unlock()
-	if err != nil {
-		return err
-	}
-
-	_, err = m.repo.DisconnectSdk(project.ProjectId, w, s)
-	if err != nil {
-		return err
-	}
-	if err := m.repo.RemoveSdk(project.ProjectId, w, s); err != nil {
-		return err
-	}
-	st.Lock()
-	_, err = m.reloadConnections(project.ProjectId, w, s)
-	st.Unlock()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // Returns content interface connection IDs of the SDK and their corresponding
 // plug's dynamic attributes.
 func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]string {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -473,7 +473,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 
 	slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
 	if slot == nil {
-		return fmt.Errorf("snap %q has no %q slot", slotRef.Sdk, slotRef.Name)
+		return fmt.Errorf("SDK %q has no %q slot", slotRef.Sdk, slotRef.Name)
 	}
 
 	var plugDynamicAttrs, slotDynamicAttrs map[string]interface{}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/interfaces/policy"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/handlersetup"
@@ -62,7 +61,7 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	inst, err := m.backend.Workshop(ctx, w)
+	wp, err := m.backend.Workshop(ctx, w)
 	if err != nil {
 		return err
 	}
@@ -74,24 +73,13 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
-	sdkInfo, err := inst.SdkInfo(ctx, s)
+	info, err := wp.SdkInfo(ctx, s)
 	if err != nil {
 		return err
 	}
 
-	if err = policy.CheckInterfaces(sdkInfo); err != nil {
-		return err
-	}
-	if len(sdkInfo.BadInterfaces) > 0 {
-		task.Logf("%s", sdk.BadInterfacesSummary(sdkInfo))
-	}
-
 	st.Lock()
 	defer st.Unlock()
-
-	if err := m.repo.AddSdk(sdkInfo); err != nil {
-		return err
-	}
 
 	chg := task.Change()
 	// If auto-connect is executed during refresh, chances are, that there are
@@ -110,11 +98,11 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	// Ensure that if the SDK is connected there will be no conflicting bind
 	// mount targets in the workshop, i.e. the situation when a two or more
 	// sources are bind mount at the same target in the workshop.
-	if err := m.checkConflictingTargets(sdkInfo); err != nil {
+	if err := m.checkConflictingTargets(info); err != nil {
 		return err
 	}
 
-	return m.connectAuto(task, project, inst, sdkInfo, remounts)
+	return m.connectAuto(task, wp, info, remounts)
 }
 
 func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) error {
@@ -172,13 +160,10 @@ func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]str
 	return candidates
 }
 
-func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, remounts map[string]string, plugDynamic, slotDynamic map[string]map[string]interface{}) (*state.TaskSet, error) {
+func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, plugDynamic, slotDynamic map[string]map[string]interface{}) (*state.TaskSet, error) {
 
 	connectTs := state.NewTaskSet()
 	var affected = map[sdk.Ref]bool{}
-	if plugDynamic == nil {
-		plugDynamic = make(map[string]map[string]interface{})
-	}
 	for _, ref := range refs {
 		connect := m.state.NewTask("connect", fmt.Sprintf("Connect %s to %s", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
 
@@ -186,43 +171,6 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *worksh
 		connect.Set("slot", ref.SlotRef)
 		connect.Set("auto", true)
 		connect.Set("delayed-setup-profile", true)
-		if plugDynamic[ref.ID()] == nil {
-			plugDynamic[ref.ID()] = make(map[string]interface{})
-		}
-
-		if src, ok := remounts[ref.ID()]; ok {
-			plugDynamic[ref.ID()]["source"] = src
-		}
-
-		master, slaves := MaybeBound(wp, ref.PlugRef)
-		// If this plug is bound AND not a master (i.e. not bound to) then mark
-		// it in the attributes for the backend to NOT set a profile for this
-		// connection as it will be bound to its master's connection effect.
-		if ref.PlugRef != master && len(slaves) > 0 {
-			// the plug is bound which excludes other dynamic attributes
-			maps.Clear(plugDynamic[ref.ID()])
-
-			// Find the master's slot reference (must also present, otherwise it
-			// breaks the auto-connection integrity -- no bound connection must
-			// be connected if the master is not auto-connectable).
-			idx := slices.IndexFunc(refs, func(r *interfaces.ConnRef) bool { return r.PlugRef == master })
-			if idx == -1 {
-				return nil, fmt.Errorf("cannot auto-connect %s: plug bind %s does not exist or not auto-connectable",
-					ref.PlugRef.ShortRef(), master.ShortRef())
-			}
-			bref := interfaces.ConnRef{PlugRef: master, SlotRef: refs[idx].SlotRef}
-			plugDynamic[ref.ID()]["bind"] = bref.ID()
-		} else {
-			// Make sure that all the plugs that are bound to this master can
-			// also be auto-connected (i.e. present in the refs). Otherwise, it
-			// breaks the integrity when a bound plug is not connected whilst
-			// its master is.
-			for _, r := range slaves {
-				if idx := slices.IndexFunc(refs, func(cr *interfaces.ConnRef) bool { return cr.PlugRef == r }); idx == -1 {
-					return nil, fmt.Errorf("cannot auto-connect %s: bound plug %s cannot be auto-connected", master.ShortRef(), r.ShortRef())
-				}
-			}
-		}
 
 		if plugDynamic != nil {
 			connect.Set("plug-dynamic", plugDynamic[ref.ID()])
@@ -250,43 +198,92 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *worksh
 	for _, tsk := range connectTs.Tasks() {
 		tsk.Set("workshop", info.Workshop)
 		tsk.Set("sdk", info.Name)
-		tsk.Set("project", p)
+		tsk.Set("project", wp.Project)
 	}
 
 	return connectTs, nil
 }
 
-func (m *InterfaceManager) connectAuto(task *state.Task, p *workshop.Project, wp *workshop.Workshop, sdkInfo *sdk.Info, remounts map[string]string) error {
+func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, info *sdk.Info, remounts map[string]string) error {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return err
 	}
 
 	var connectRefs = []*interfaces.ConnRef{}
+	var plugDynamic = make(map[string]map[string]interface{})
 
-	for _, plug := range sdkInfo.Plugs {
-		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop,
-			sdkInfo.Name, plug.Name, autoConnectCheck)
+	for _, plug := range info.Plugs {
+		ref := interfaces.NewPlugRef(plug)
+		master, slaves := MaybeBound(wp, ref)
+		if master != ref {
+			// the plug is bound to, its connection will be setup together with
+			// its master.
+			continue
+		}
+		candidates := m.repo.AutoConnectCandidateSlots(info.ProjectId, info.Workshop,
+			info.Name, plug.Name, autoConnectCheck)
+
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
-
-			if _, ok := conns[connRef.ID()]; ok {
-				// Suggested connection already exist (or has
-				// Undesired flag set) so don't clobber it.
-				// NOTE: we don't log anything here as this is
-				// a normal and common condition.
-				continue
+			if plugDynamic[connRef.ID()] == nil {
+				plugDynamic[connRef.ID()] = make(map[string]interface{})
 			}
 
+			if src, ok := remounts[connRef.ID()]; ok {
+				plugDynamic[connRef.ID()]["source"] = src
+			}
+
+			slotRef := interfaces.NewSlotRef(slot)
+			for _, slave := range slaves {
+				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
+				if _, ok := conns[slref.ID()]; !ok {
+					connectRefs = append(connectRefs, slref)
+					plugDynamic[slref.ID()] = make(map[string]interface{})
+					plugDynamic[slref.ID()]["bind"] = connRef.ID()
+				}
+			}
+
+			if _, ok := conns[connRef.ID()]; ok {
+				// Suggested connection already exist (or has Undesired flag
+				// set) so don't clobber it. NOTE: we don't log anything here as
+				// this is a normal and common condition.
+				continue
+			}
 			connectRefs = append(connectRefs, connRef)
 		}
 	}
 
-	for _, slot := range sdkInfo.Slots {
-		candidates := m.repo.AutoConnectCandidatePlugs(sdkInfo.ProjectId, sdkInfo.Workshop,
-			sdkInfo.Name, slot.Name, autoConnectCheck)
+	for _, slot := range info.Slots {
+		candidates := m.repo.AutoConnectCandidatePlugs(info.ProjectId, info.Workshop,
+			info.Name, slot.Name, autoConnectCheck)
 		for _, plug := range candidates {
+			ref := interfaces.NewPlugRef(plug)
+			master, slaves := MaybeBound(wp, ref)
+			if master != ref {
+				// the plug is bound to, its connection will be setup together with
+				// its master.
+				continue
+			}
 			connRef := interfaces.NewConnRef(plug, slot)
+
+			if plugDynamic[connRef.ID()] == nil {
+				plugDynamic[connRef.ID()] = make(map[string]interface{})
+			}
+
+			if src, ok := remounts[connRef.ID()]; ok {
+				plugDynamic[connRef.ID()]["source"] = src
+			}
+
+			slotRef := interfaces.NewSlotRef(slot)
+			for _, slave := range slaves {
+				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
+				if _, ok := conns[slref.ID()]; !ok {
+					connectRefs = append(connectRefs, slref)
+					plugDynamic[slref.ID()] = make(map[string]interface{})
+					plugDynamic[slref.ID()]["bind"] = connRef.ID()
+				}
+			}
 
 			if _, ok := conns[connRef.ID()]; ok {
 				continue
@@ -301,7 +298,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, p *workshop.Project, wp
 	// without changes to its 'source' attribute in the new workshop
 	// (given the new workshop also has an SDK with exactly the same
 	// plug; the target directory may change in the new workshop).
-	ts, err := m.batchAutoConnectTasks(p, wp, sdkInfo, connectRefs, remounts, nil, nil)
+	ts, err := m.batchAutoConnectTasks(wp, info, connectRefs, plugDynamic, nil)
 	if err != nil {
 		return err
 	}
@@ -977,14 +974,19 @@ func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	return m.remount(ctx, task, &plug, source, inst.Running)
+	return m.remount(ctx, task, user, &plug, source, inst.Running)
 }
 
-func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *interfaces.PlugRef, source string, workshopRunning bool) error {
+func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, user string, plug *interfaces.PlugRef, source string, workshopRunning bool) error {
 	revert := revert.New()
 	defer revert.Fail()
 
 	conns, err := getConns(m.state)
+	if err != nil {
+		return err
+	}
+
+	usr, err := workshop.LookupUsername(user)
 	if err != nil {
 		return err
 	}
@@ -1004,8 +1006,10 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 	}
 
 	var oldSource string
-	if err := connection.Plug.Attr("source", &oldSource); err != nil {
-		logger.Noticef("Plug %s is connected but the source attribute is not known", connRef.PlugRef.ShortRef())
+	if err := connection.Plug.Attr("source", &oldSource); err != nil && !errors.Is(err, sdk.AttributeNotFoundError{}) {
+		return err
+	} else if errors.Is(err, sdk.AttributeNotFoundError{}) {
+		oldSource = sdk.DefaultContentSource(usr.HomeDir, plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name)
 	}
 
 	if err := connection.Plug.SetAttr("source", source); err != nil {
@@ -1028,7 +1032,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 
 	_, err = os.Stat(oldSource)
 	if osutil.IsDirNotExist(err) {
-		task.State().Warnf("%s/%s:%s's source at %q did not exist, the mount was re-created", plug.Workshop, plug.Sdk, plug.Name, oldSource)
+		task.State().Warnf("%s/%s:%s's source at %q does not exist; will attempt to recreate", plug.Workshop, plug.Sdk, plug.Name, oldSource)
 	} else if err != nil {
 		return err
 	} else {
@@ -1066,13 +1070,18 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 		}
 	}
 
+	var auto bool
+	if old, ok := conns[connRef.ID()]; ok {
+		auto = old.Auto
+	}
+
 	conns[connRef.ID()] = &schema.ConnState{
 		Interface:        newConnection.Interface(),
 		StaticPlugAttrs:  newConnection.Plug.StaticAttrs(),
 		DynamicPlugAttrs: newConnection.Plug.DynamicAttrs(),
 		StaticSlotAttrs:  newConnection.Slot.StaticAttrs(),
 		DynamicSlotAttrs: newConnection.Slot.DynamicAttrs(),
-		Auto:             true,
+		Auto:             auto,
 	}
 
 	setConns(m.state, conns)

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -979,7 +979,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, user s
 	if err := connection.Plug.Attr("source", &oldSource); err != nil && !errors.Is(err, sdk.AttributeNotFoundError{}) {
 		return err
 	} else if errors.Is(err, sdk.AttributeNotFoundError{}) {
-		oldSource = sdk.DefaultContentSource(usr.HomeDir, plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name)
+		oldSource = sdk.SdkContentSource(usr.HomeDir, plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name)
 	}
 
 	if err := connection.Plug.SetAttr("source", source); err != nil {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"syscall"
@@ -21,18 +22,6 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
-
-func sdkName(task *state.Task) (string, error) {
-	var sdkName string
-	st := task.State()
-	st.Lock()
-	defer st.Unlock()
-
-	if err := task.Get("sdk", &sdkName); err != nil {
-		return "", err
-	}
-	return sdkName, nil
-}
 
 func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
 	allPlugs := m.repo.AllPlugs("content")
@@ -64,6 +53,7 @@ func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
 }
 
 func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err error) {
+	st := task.State()
 	user, project, w, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -77,7 +67,9 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
-	s, err := sdkName(task)
+	st.Lock()
+	s, err := handlersetup.Sdk(task)
+	st.Unlock()
 	if err != nil {
 		return err
 	}
@@ -97,72 +89,44 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	// set to how it was in the previous workshop instance as some of those
 	// plugs may have been remounted with `workshop remount`. To preserve that,
 	// we store the content interface connection's 'source' directories when the
-	// old workshop/SDK is removed (see the 'disconnect' task handler) and see
+	// old workshop/SDK is removed (see the 'disconnect' task handler) and check
 	// if any of those are still relevant for the new workshop.
-	st := task.State()
-
 	st.Lock()
-	var alltasks = task.Change().Tasks()
-	var kind = task.Change().Kind()
-	st.Unlock()
+	defer st.Unlock()
 
-	if kind == "refresh" {
-		var sdkRef = sdk.Ref{ProjectId: project.ProjectId, Workshop: w, Sdk: s}
-		var plugsToRemount = map[string]map[string]interface{}{}
-		for _, task := range alltasks {
-			// The disconnect tasks of the refresh change store pre-refresh
-			// content interface connections.
-			if task.Kind() == "auto-disconnect" {
-				_, project, workshop, err := handlersetup.UserProjectWorkshop(task)
-				if err != nil {
-					continue
-				}
-
-				taskSdk, err := sdkName(task)
-				if err != nil {
-					continue
-				}
-				taskSdkRef := sdk.Ref{ProjectId: project.ProjectId, Workshop: workshop, Sdk: taskSdk}
-				if sdkRef.ID() == taskSdkRef.ID() {
-					st.Lock()
-					_ = task.Get("plugs-to-remount", &plugsToRemount)
-					st.Unlock()
-					break
-				}
-			}
-		}
-		return m.setupSdkConnections(task, ctx, sdkInfo, plugsToRemount)
+	chg := task.Change()
+	var remounts map[string]map[string]interface{}
+	if err := chg.Get("remounts", &remounts); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
 	}
-	return m.setupSdkConnections(task, ctx, sdkInfo, nil)
+
+	return m.setupSdkConnections(task, ctx, sdkInfo, remounts)
 }
 
 // Returns content interface connection IDs of the SDK and their corresponding
 // plug's dynamic attributes.
-func (m *InterfaceManager) findContentPlugsAttrs(projectId, w, sdkname string) map[string]map[string]interface{} {
+func (m *InterfaceManager) contentSources(projectId, w, s string) map[string]map[string]interface{} {
 	// [ref.ID]source
 	var candidates = map[string]map[string]interface{}{}
-
-	connRefs, err := m.repo.Connections(projectId, w, sdkname)
+	refs, err := m.repo.Connections(projectId, w, s)
 	if err != nil {
 		return nil
 	}
 
-	for _, conRef := range connRefs {
-		connection, err := m.repo.Connection(conRef)
+	for _, cref := range refs {
+		conn, err := m.repo.Connection(cref)
 		if err != nil {
 			continue
 		}
-		if connection.Interface() == "content" {
-			candidates[conRef.ID()] = connection.Plug.DynamicAttrs()
+		if conn.Interface() == "content" {
+			candidates[cref.ID()] = conn.Plug.DynamicAttrs()
 		}
 	}
 	return candidates
 }
 
-func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Context, sdkInfo *sdk.Info, plugsToRemount map[string]map[string]interface{}) error {
+func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Context, sdkInfo *sdk.Info, remounts map[string]map[string]interface{}) error {
 	st := task.State()
-	st.Lock()
-	defer st.Unlock()
 
 	// Ensure that if the SDK is connected there will be no conflicting bind
 	// mount targets in the workshop, i.e. the situation when a two or more
@@ -218,14 +182,14 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 				continue
 			}
 
-			// plugsToRemount can be passed in when a previously existing
-			// content interface connection (e.g. pre-refresh) needs to be
-			// recreated without changes to its 'source' attribute in the new
-			// workshop (given the new workshop also has an SDK with exactly the
-			// same plug; the target directory may change in the new workshop).
+			// remounts may be not nil when a previously existing content
+			// interface connection (e.g. pre-refresh) needs to be recreated
+			// without changes to its 'source' attribute in the new workshop
+			// (given the new workshop also has an SDK with exactly the same
+			// plug; the target directory may change in the new workshop).
 			var plugDynamicAttrs map[string]interface{}
-			if plugsToRemount != nil {
-				if attrs, ok := plugsToRemount[connRef.ID()]; ok {
+			if remounts != nil {
+				if attrs, ok := remounts[connRef.ID()]; ok {
 					plugDynamicAttrs = attrs
 				}
 			}
@@ -308,44 +272,46 @@ func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) er
 	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	sdkName, err := sdkName(task)
+	st := task.State()
+	st.Lock()
+	s, err := handlersetup.Sdk(task)
+	st.Unlock()
 	if err != nil {
 		return err
 	}
 
 	// rebuild SDK profiles for the affected SDKs
-	return m.disconnectSdk(ctx, task, project, w, sdkName)
+	return m.disconnectSdk(st, ctx, project, w, s)
 }
 
-func (m *InterfaceManager) disconnectSdk(ctx context.Context, task *state.Task, project *workshop.Project, w string, sdkName string) error {
-	st := task.State()
-	sdkRef := sdk.Ref{ProjectId: project.ProjectId, Workshop: w, Sdk: sdkName}
-
-	disconnected, err := m.repo.DisconnectSdk(project.ProjectId, w, sdkName)
+func (m *InterfaceManager) disconnectSdk(st *state.State, ctx context.Context, project *workshop.Project, w string, s string) error {
+	disconnected, err := m.repo.DisconnectSdk(project.ProjectId, w, s)
 	if err != nil {
 		return err
 	}
 
-	if err := m.repo.RemoveSdk(project.ProjectId, w, sdkName); err != nil {
+	if err := m.repo.RemoveSdk(project.ProjectId, w, s); err != nil {
 		return err
 	}
 
 	st.Lock()
-	defer st.Unlock()
-
-	if _, err := m.reloadConnections(project.ProjectId, w, sdkName); err != nil {
+	_, err = m.reloadConnections(project.ProjectId, w, s)
+	st.Unlock()
+	if err != nil {
 		return err
 	}
 
 	for _, backend := range m.repo.Backends() {
-		// if there are not plugs or slots declared by the SDK the profile does
+		// If there are not plugs or slots declared by the SDK the profile does
 		// not neccessarily exist for the SDK.
-		if err := backend.Remove(ctx, w, sdkName); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
+		if err := backend.Remove(ctx, w, s); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
 			return err
 		}
 	}
+
+	ref := sdk.Ref{ProjectId: project.ProjectId, Workshop: w, Sdk: s}
 	for _, s := range disconnected {
-		if sdkRef != s.Ref() {
+		if ref != s.Ref() {
 			for _, backend := range m.repo.Backends() {
 				if err = backend.Setup(ctx, s.Ref(), m.repo); err != nil {
 					return err
@@ -357,6 +323,7 @@ func (m *InterfaceManager) disconnectSdk(ctx context.Context, task *state.Task, 
 }
 
 func (m *InterfaceManager) doAutoDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {
+	st := task.State()
 	user, project, w, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -365,24 +332,38 @@ func (m *InterfaceManager) doAutoDisconnect(task *state.Task, tomb *tomb.Tomb) (
 	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	sdkName, err := sdkName(task)
+	st.Lock()
+	s, err := handlersetup.Sdk(task)
+	st.Unlock()
 	if err != nil {
 		return err
 	}
 
-	// Store plugs attributes for the existing content interface connections, so
-	// refresh can recover 'source' attributes for the plugs that were remount
-	// in the previous workshop instance.
-	st := task.State()
-	preRefreshPlugs := m.findContentPlugsAttrs(project.ProjectId, w, sdkName)
-	st.Lock()
-	task.Set("plugs-to-remount", preRefreshPlugs)
-	st.Unlock()
+	// Save 'source' attributes for the content interface connections as some of
+	// them may have been remounted to a non-default locations, so these can be
+	// set after refresh for this SDK.
+	cattrs := m.contentSources(project.ProjectId, w, s)
 
-	return m.disconnectSdk(ctx, task, project, w, sdkName)
+	if len(cattrs) > 0 {
+		st.Lock()
+		chg := task.Change()
+		var remounts map[string]map[string]interface{}
+		if err = chg.Get("remounts", &remounts); errors.Is(err, state.ErrNoState) {
+			remounts = make(map[string]map[string]interface{})
+		} else if err != nil {
+			st.Unlock()
+			return err
+		}
+		maps.Copy(remounts, cattrs)
+		chg.Set("remounts", remounts)
+		st.Unlock()
+	}
+
+	return m.disconnectSdk(st, ctx, project, w, s)
 }
 
 func (m *InterfaceManager) undoAutoDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {
+	st := task.State()
 	user, project, w, err := handlersetup.UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -391,7 +372,9 @@ func (m *InterfaceManager) undoAutoDisconnect(task *state.Task, tomb *tomb.Tomb)
 	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	sdkName, err := sdkName(task)
+	st.Lock()
+	sdkName, err := handlersetup.Sdk(task)
+	st.Unlock()
 	if err != nil {
 		return err
 	}
@@ -406,6 +389,8 @@ func (m *InterfaceManager) undoAutoDisconnect(task *state.Task, tomb *tomb.Tomb)
 		return err
 	}
 
+	st.Lock()
+	defer st.Unlock()
 	return m.setupSdkConnections(task, ctx, sdkInfo, nil)
 }
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -488,16 +488,6 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		task.Set("old-conn", old)
 	}
 
-	conns[cref.ID()] = &schema.ConnState{
-		Interface:        conn.Interface(),
-		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
-		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
-		StaticSlotAttrs:  conn.Slot.StaticAttrs(),
-		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
-		Auto:             autoConnect,
-	}
-	setConns(st, conns)
-
 	// To setup a profile immediately it needs to be a master plug (i.e. bound
 	// to or a completely unbound plug) AND the task must request the setup on
 	// the spot and not as part of another task which usually happens with
@@ -513,6 +503,16 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 			}
 		}
 	}
+
+	conns[cref.ID()] = &schema.ConnState{
+		Interface:        conn.Interface(),
+		StaticPlugAttrs:  conn.Plug.StaticAttrs(),
+		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
+		StaticSlotAttrs:  conn.Slot.StaticAttrs(),
+		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
+		Auto:             autoConnect,
+	}
+	setConns(st, conns)
 
 	return nil
 }

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -195,7 +195,7 @@ func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, wp *worksh
 			plugDynamic[ref.ID()]["source"] = src
 		}
 
-		master, slaves := maybeBound(wp, ref.PlugRef)
+		master, slaves := MaybeBound(wp, ref.PlugRef)
 		// If this plug is bound AND not a master (i.e. not bound to) then mark
 		// it in the attributes for the backend to NOT set a profile for this
 		// connection as it will be bound to its master's connection effect.
@@ -392,7 +392,7 @@ func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRe
 	return plugRef, slotRef, nil
 }
 
-func maybeBound(w *workshop.Workshop, ref interfaces.PlugRef) (interfaces.PlugRef, []interfaces.PlugRef) {
+func MaybeBound(w *workshop.Workshop, ref interfaces.PlugRef) (interfaces.PlugRef, []interfaces.PlugRef) {
 	var masters = make(map[interfaces.PlugRef][]interfaces.PlugRef)
 	var slaves = make(map[interfaces.PlugRef]interfaces.PlugRef)
 
@@ -984,7 +984,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 
 	var oldSource string
 	if err := connection.Plug.Attr("source", &oldSource); err != nil {
-		return err
+		logger.Noticef("Plug %s is connected but the source attribute is not known", connRef.PlugRef.ShortRef())
 	}
 
 	if err := connection.Plug.SetAttr("source", source); err != nil {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"slices"
 	"syscall"
 
+	"golang.org/x/exp/maps"
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -83,6 +83,10 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
+	st.Lock()
+	defer st.Unlock()
+
+	chg := task.Change()
 	// If auto-connect is executed during refresh, chances are, that there are
 	// SDKs that are going to be reinstalled without any changes to their
 	// content interface plugs. In this case, their 'source' directories must be
@@ -91,16 +95,77 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	// we store the content interface connection's 'source' directories when the
 	// old workshop/SDK is removed (see the 'disconnect' task handler) and check
 	// if any of those are still relevant for the new workshop.
-	st.Lock()
-	defer st.Unlock()
-
-	chg := task.Change()
 	var remounts map[string]map[string]interface{}
 	if err := chg.Get("remounts", &remounts); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
-	return m.setupSdkConnections(task, ctx, sdkInfo, remounts)
+	conns, err := getConns(m.state)
+	if err != nil {
+		return err
+	}
+
+	var connectRefs = []*interfaces.ConnRef{}
+
+	for _, plug := range sdkInfo.Plugs {
+		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
+		for _, slot := range candidates {
+			connRef := interfaces.NewConnRef(plug, slot)
+
+			if _, ok := conns[connRef.ID()]; ok {
+				// Suggested connection already exist (or has
+				// Undesired flag set) so don't clobber it.
+				// NOTE: we don't log anything here as this is
+				// a normal and common condition.
+				continue
+			}
+
+			connectRefs = append(connectRefs, connRef)
+		}
+	}
+
+	// remounts may be not nil when a previously existing content
+	// interface connection (e.g. pre-refresh) needs to be recreated
+	// without changes to its 'source' attribute in the new workshop
+	// (given the new workshop also has an SDK with exactly the same
+	// plug; the target directory may change in the new workshop).
+	connectTs := m.batchAutoConnectTasks(project, sdkInfo, connectRefs, remounts, nil)
+
+	handlersetup.InjectTasks(task, connectTs)
+	m.state.EnsureBefore(0)
+	task.SetStatus(state.DoneStatus)
+
+	return nil
+}
+
+func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) error {
+	_, project, w, err := handlersetup.UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	st := task.State()
+	st.Lock()
+	s, err := handlersetup.Sdk(task)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	_, err = m.repo.DisconnectSdk(project.ProjectId, w, s)
+	if err != nil {
+		return err
+	}
+	if err := m.repo.RemoveSdk(project.ProjectId, w, s); err != nil {
+		return err
+	}
+	st.Lock()
+	_, err = m.reloadConnections(project.ProjectId, w, s)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Returns content interface connection IDs of the SDK and their corresponding
@@ -125,9 +190,54 @@ func (m *InterfaceManager) contentSources(projectId, w, s string) map[string]map
 	return candidates
 }
 
-func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Context, sdkInfo *sdk.Info, remounts map[string]map[string]interface{}) error {
-	st := task.State()
+func (m *InterfaceManager) batchAutoConnectTasks(p *workshop.Project, info *sdk.Info, refs []*interfaces.ConnRef,
+	plugDynamic, slotDynamic map[string]map[string]interface{}) *state.TaskSet {
 
+	connectTs := state.NewTaskSet()
+	var affected = map[sdk.Ref]bool{}
+	for _, ref := range refs {
+		connect := m.state.NewTask("connect", fmt.Sprintf("Connect %s to %s", ref.PlugRef.String(), ref.SlotRef.String()))
+
+		connect.Set("plug", ref.PlugRef)
+		connect.Set("slot", ref.SlotRef)
+		connect.Set("auto", true)
+		// Remove connection instead of making it undesired in undo logic if an
+		// error happens.
+		connect.Set("forget", true)
+
+		if plugDynamic != nil {
+			connect.Set("plug-dynamic", plugDynamic[ref.ID()])
+		}
+		if slotDynamic != nil {
+			connect.Set("slot-dynamic", slotDynamic[ref.ID()])
+		}
+		connectTs.AddTask(connect)
+
+		plugSdk := sdk.Ref{ProjectId: ref.PlugRef.ProjectId, Workshop: ref.PlugRef.Workshop, Sdk: ref.PlugRef.Sdk}
+		affected[plugSdk] = true
+
+		slotSdk := sdk.Ref{ProjectId: ref.SlotRef.ProjectId, Workshop: ref.SlotRef.Workshop, Sdk: ref.SlotRef.Sdk}
+		affected[slotSdk] = true
+	}
+
+	setup := m.state.NewTask("setup-profiles", fmt.Sprintf("Setup %q SDK profile", info.Name))
+	setup.Set("sdks", maps.Keys(affected))
+	setup.WaitAll(connectTs)
+
+	if len(connectTs.Tasks()) > 0 {
+		connectTs.AddTask(setup)
+	}
+
+	for _, tsk := range connectTs.Tasks() {
+		tsk.Set("workshop", info.Workshop)
+		tsk.Set("sdk", info.Name)
+		tsk.Set("project", p)
+	}
+
+	return connectTs
+}
+
+func (m *InterfaceManager) setupAutoConnections(task *state.Task, p *workshop.Project, sdkInfo *sdk.Info, remounts map[string]map[string]interface{}) error {
 	// Ensure that if the SDK is connected there will be no conflicting bind
 	// mount targets in the workshop, i.e. the situation when a two or more
 	// sources are bind mount at the same target in the workshop.
@@ -140,7 +250,7 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 
 	// Disconnect and remove a previous version of the SDK if any (a common case
 	// if the task is part of a refresh change).
-	disconnected, err := m.repo.DisconnectSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name)
+	_, err := m.repo.DisconnectSdk(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name)
 	if err != nil {
 		return err
 	}
@@ -159,15 +269,12 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 		return err
 	}
 
-	conns, err := getConns(st)
+	conns, err := getConns(m.state)
 	if err != nil {
 		return err
 	}
 
-	var connected = map[sdk.Ref]*sdk.Info{}
 	var connectRefs = []*interfaces.ConnRef{}
-	var revertConnections revert.Reverter
-	defer revertConnections.Fail()
 
 	for _, plug := range sdkInfo.Plugs {
 		candidates := m.repo.AutoConnectCandidateSlots(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Name, plug.Name, autoConnectCheck)
@@ -182,143 +289,21 @@ func (m *InterfaceManager) setupSdkConnections(task *state.Task, ctx context.Con
 				continue
 			}
 
-			// remounts may be not nil when a previously existing content
-			// interface connection (e.g. pre-refresh) needs to be recreated
-			// without changes to its 'source' attribute in the new workshop
-			// (given the new workshop also has an SDK with exactly the same
-			// plug; the target directory may change in the new workshop).
-			var plugDynamicAttrs map[string]interface{}
-			if remounts != nil {
-				if attrs, ok := remounts[connRef.ID()]; ok {
-					plugDynamicAttrs = attrs
-				}
-			}
-
-			conn, err := m.repo.Connect(connRef, plug.Attrs, plugDynamicAttrs, slot.Attrs, nil, connectCheck)
-			if err != nil || conn == nil {
-				return err
-			}
-			connected[conn.Plug.Sdk().Ref()] = conn.Plug.Sdk()
-			connected[conn.Slot.Sdk().Ref()] = conn.Slot.Sdk()
-			revertConnections.Add(func() {
-				if err := m.repo.Disconnect(conn.Plug.Ref().ProjectId, conn.Plug.Ref().Workshop, conn.Plug.Ref().Sdk, conn.Plug.Name(),
-					conn.Slot.Ref().ProjectId, conn.Slot.Ref().Workshop, conn.Slot.Ref().Sdk, conn.Slot.Name()); err != nil {
-					logger.Noticef("cannot disconnect failed connection: %v", err)
-				}
-			})
-
 			connectRefs = append(connectRefs, connRef)
 		}
 	}
 
-	// Onces the new connections are made, reinstate those in the interface
-	// backend (e.g. regenerate a LXD profile)
-	affectedSet := make(map[sdk.Ref]*sdk.Info, len(connected)+len(disconnected))
+	// remounts may be not nil when a previously existing content
+	// interface connection (e.g. pre-refresh) needs to be recreated
+	// without changes to its 'source' attribute in the new workshop
+	// (given the new workshop also has an SDK with exactly the same
+	// plug; the target directory may change in the new workshop).
+	connectTs := m.batchAutoConnectTasks(p, sdkInfo, connectRefs, remounts, nil)
 
-	for ref, s := range connected {
-		affectedSet[ref] = s
-	}
+	handlersetup.InjectTasks(task, connectTs)
+	m.state.EnsureBefore(0)
+	task.SetStatus(state.DoneStatus)
 
-	for _, s := range disconnected {
-		affectedSet[s.Ref()] = s
-	}
-
-	var revertBackendSetup revert.Reverter
-	defer revertBackendSetup.Fail()
-	for _, s := range affectedSet {
-		for _, backend := range m.repo.Backends() {
-			if err = backend.Setup(ctx, s.Ref(), m.repo); err != nil {
-				return err
-			}
-			// fix for the Go loop variable capture (<1.22)
-			be := backend
-			w, sdkName := s.Workshop, s.Name
-			revertBackendSetup.Add(func() {
-				_ = be.Remove(ctx, w, sdkName)
-			})
-		}
-	}
-
-	// setConns must be called after all the backend calls were made as those
-	// can add/set dynamic attributes
-	for _, ref := range connectRefs {
-		conn, err := m.repo.Connection(ref)
-		if err != nil {
-			return err
-		}
-		conns[ref.ID()] = &schema.ConnState{
-			Interface:        conn.Interface(),
-			StaticPlugAttrs:  conn.Plug.StaticAttrs(),
-			DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
-			StaticSlotAttrs:  conn.Slot.StaticAttrs(),
-			DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
-			Auto:             true,
-		}
-	}
-
-	setConns(st, conns)
-	revertConnections.Success()
-	revertBackendSetup.Success()
-
-	return nil
-}
-
-func (m *InterfaceManager) undoAutoConnect(task *state.Task, tomb *tomb.Tomb) error {
-	user, project, w, err := handlersetup.UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
-	defer cancel()
-
-	st := task.State()
-	st.Lock()
-	s, err := handlersetup.Sdk(task)
-	st.Unlock()
-	if err != nil {
-		return err
-	}
-
-	// rebuild SDK profiles for the affected SDKs
-	return m.disconnectSdk(st, ctx, project, w, s)
-}
-
-func (m *InterfaceManager) disconnectSdk(st *state.State, ctx context.Context, project *workshop.Project, w string, s string) error {
-	disconnected, err := m.repo.DisconnectSdk(project.ProjectId, w, s)
-	if err != nil {
-		return err
-	}
-
-	if err := m.repo.RemoveSdk(project.ProjectId, w, s); err != nil {
-		return err
-	}
-
-	st.Lock()
-	_, err = m.reloadConnections(project.ProjectId, w, s)
-	st.Unlock()
-	if err != nil {
-		return err
-	}
-
-	for _, backend := range m.repo.Backends() {
-		// If there are not plugs or slots declared by the SDK the profile does
-		// not neccessarily exist for the SDK.
-		if err := backend.Remove(ctx, w, s); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
-			return err
-		}
-	}
-
-	ref := sdk.Ref{ProjectId: project.ProjectId, Workshop: w, Sdk: s}
-	for _, s := range disconnected {
-		if ref != s.Ref() {
-			for _, backend := range m.repo.Backends() {
-				if err = backend.Setup(ctx, s.Ref(), m.repo); err != nil {
-					return err
-				}
-			}
-		}
-	}
 	return nil
 }
 
@@ -359,7 +344,41 @@ func (m *InterfaceManager) doAutoDisconnect(task *state.Task, tomb *tomb.Tomb) (
 		st.Unlock()
 	}
 
-	return m.disconnectSdk(st, ctx, project, w, s)
+	disconnected, err := m.repo.DisconnectSdk(project.ProjectId, w, s)
+	if err != nil {
+		return err
+	}
+
+	if err := m.repo.RemoveSdk(project.ProjectId, w, s); err != nil {
+		return err
+	}
+
+	st.Lock()
+	_, err = m.reloadConnections(project.ProjectId, w, s)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	for _, backend := range m.repo.Backends() {
+		// If there are not plugs or slots declared by the SDK the profile does
+		// not neccessarily exist for the SDK.
+		if err := backend.Remove(ctx, w, s); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
+			return err
+		}
+	}
+
+	ref := sdk.Ref{ProjectId: project.ProjectId, Workshop: w, Sdk: s}
+	for _, s := range disconnected {
+		if ref != s.Ref() {
+			for _, backend := range m.repo.Backends() {
+				if err = backend.Setup(ctx, s.Ref(), m.repo); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (m *InterfaceManager) undoAutoDisconnect(task *state.Task, tomb *tomb.Tomb) (err error) {
@@ -391,7 +410,7 @@ func (m *InterfaceManager) undoAutoDisconnect(task *state.Task, tomb *tomb.Tomb)
 
 	st.Lock()
 	defer st.Unlock()
-	return m.setupSdkConnections(task, ctx, sdkInfo, nil)
+	return m.setupAutoConnections(task, project, sdkInfo, nil)
 }
 
 func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRef, error) {
@@ -422,8 +441,6 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	cref := &interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
-
 	conns, err := getConns(st)
 	if err != nil {
 		return err
@@ -439,22 +456,24 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		return fmt.Errorf("snap %q has no %q slot", slotRef.Sdk, slotRef.Name)
 	}
 
-	conn, err := m.repo.Connect(cref, plug.Attrs, nil, slot.Attrs, nil, connectCheck)
-	if err != nil || conn == nil {
+	var plugDynamicAttrs, slotDynamicAttrs map[string]interface{}
+	if err = task.Get("plug-dynamic", &plugDynamicAttrs); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+	if err = task.Get("slot-dynamic", &slotDynamicAttrs); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 
-	plugSdkRef := sdk.Ref{ProjectId: plugRef.ProjectId, Workshop: plugRef.Workshop, Sdk: plugRef.Sdk}
-	slotSdkRef := sdk.Ref{ProjectId: slotRef.ProjectId, Workshop: slotRef.Workshop, Sdk: slotRef.Sdk}
+	var autoConnect bool
+	if err := task.Get("auto", &autoConnect); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
 
-	for _, ref := range []sdk.Ref{plugSdkRef, slotSdkRef} {
-		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
-		defer cancel()
-		for _, backend := range m.repo.Backends() {
-			if err = backend.Setup(ctx, ref, m.repo); err != nil {
-				return err
-			}
-		}
+	cref := &interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
+	conn, err := m.repo.Connect(cref, plug.Attrs, plugDynamicAttrs,
+		slot.Attrs, slotDynamicAttrs, connectCheck)
+	if err != nil || conn == nil {
+		return err
 	}
 
 	conns[cref.ID()] = &schema.ConnState{
@@ -463,7 +482,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		DynamicPlugAttrs: conn.Plug.DynamicAttrs(),
 		StaticSlotAttrs:  conn.Slot.StaticAttrs(),
 		DynamicSlotAttrs: conn.Slot.DynamicAttrs(),
-		Auto:             false,
+		Auto:             autoConnect,
 	}
 	setConns(st, conns)
 
@@ -503,7 +522,8 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 	// store old connection for undo
 	task.Set("old-conn", conn)
 
-	err = m.repo.Disconnect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name, slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
+	err = m.repo.Disconnect(plugRef.ProjectId, plugRef.Workshop,
+		plugRef.Sdk, plugRef.Name, slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
 	if err != nil {
 		_, notConnected := err.(*interfaces.NotConnectedError)
 		_, noPlugOrSlot := err.(*interfaces.NoPlugOrSlotError)
@@ -514,21 +534,6 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 			return nil
 		}
 		return fmt.Errorf("workshop changed, please retry the operation: %v", err)
-	}
-
-	plugSdkRef := sdk.Ref{ProjectId: plugRef.ProjectId, Workshop: plugRef.Workshop, Sdk: plugRef.Sdk}
-	slotSdkRef := sdk.Ref{ProjectId: slotRef.ProjectId, Workshop: slotRef.Workshop, Sdk: slotRef.Sdk}
-
-	affected := []sdk.Ref{plugSdkRef, slotSdkRef}
-
-	for _, ref := range affected {
-		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
-		defer cancel()
-		for _, backend := range m.repo.Backends() {
-			if err = backend.Setup(ctx, ref, m.repo); err != nil {
-				return err
-			}
-		}
 	}
 
 	switch {
@@ -602,6 +607,77 @@ func (m *InterfaceManager) undoDiscard(task *state.Task, tomb *tomb.Tomb) error 
 	}
 	setConns(st, conns)
 	task.Set("removed", nil)
+	return nil
+}
+
+func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	st.Lock()
+	user, err := handlersetup.User(task.Change())
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	var sdks []sdk.Ref
+	st.Lock()
+	err = task.Get("sdks", &sdks)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	for _, ref := range sdks {
+		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
+		defer cancel()
+		for _, backend := range m.repo.Backends() {
+			if err := backend.Setup(ctx, ref, m.repo); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	user, p, w, err := handlersetup.UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	st.Lock()
+	s, err := handlersetup.Sdk(task)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	sdkRef := sdk.Ref{ProjectId: p.ProjectId, Workshop: w, Sdk: s}
+
+	var sdks []sdk.Ref
+	st.Lock()
+	err = task.Get("sdks", &sdks)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	for _, ref := range sdks {
+		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
+		defer cancel()
+		for _, backend := range m.repo.Backends() {
+			if ref != sdkRef {
+				if err := backend.Setup(ctx, ref, m.repo); err != nil {
+					return err
+				}
+			} else {
+				if err := backend.Remove(ctx, w, sdkRef.Sdk); err != nil {
+					return err
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"strings"
 	"syscall"
 
 	"golang.org/x/exp/maps"
@@ -398,9 +397,9 @@ func maybeBound(w *workshop.Workshop, ref interfaces.PlugRef) (interfaces.PlugRe
 	var slaves = make(map[interfaces.PlugRef]interfaces.PlugRef)
 
 	for _, s := range w.File.Sdks {
-		for name, bind := range s.Plugs {
-			comps := strings.Split(bind.Bind, ":")
-			mkey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: comps[0], Name: comps[1]}
+		for name, pl := range s.Plugs {
+			sdk, plug := pl.Bind.Sdk, pl.Bind.Plug
+			mkey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: sdk, Name: plug}
 			skey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: s.Name, Name: name}
 			masters[mkey] = append(masters[mkey], skey)
 			slaves[skey] = mkey

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -1382,8 +1382,19 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 
 	chg := s.connectChange("ws", false, true)
 	s.state.Lock()
-	chg.Tasks()[0].Set("plug-dynamic", map[string]interface{}{"dynamic": "value"})
+	tsk := chg.Tasks()[0]
+	tsk.Set("plug-dynamic", map[string]interface{}{"dynamic": "value"})
+	tsk.Set("delayed-setup-profile", false)
 	s.state.Unlock()
+
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+		conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+		c.Check(err, check.IsNil)
+		conn, err := repo.Connection(conns[0])
+		c.Check(err, check.IsNil)
+		conn.Plug.SetAttr("set-from-profile-setup", "value")
+		return nil
+	}
 
 	// Execute
 	s.settle(c)
@@ -1403,6 +1414,8 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	conn, err := repo.Connection(conns[0])
 	c.Assert(err, check.IsNil)
 	v, _ := conn.Plug.Lookup("dynamic")
+	c.Assert(v, check.Equals, "value")
+	v, _ = conn.Plug.Lookup("set-from-profile-setup")
 	c.Assert(v, check.Equals, "value")
 }
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/user"
 	"path/filepath"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/ifacestate/schema"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -26,6 +28,7 @@ type interfaceHandlersSuite struct {
 	restoreSimple            func()
 	restoreDeny              func()
 	restoreSecurtityBackends func()
+	restoreUserLookup        func()
 }
 
 var _ = check.Suite(&interfaceHandlersSuite{})
@@ -108,12 +111,24 @@ func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 	s.o.AddManager(s.runner)
 	err := s.o.StartUp()
 	c.Assert(err, check.IsNil)
+
+	s.restoreUserLookup = testutil.FakeFunc(func(name string) (*user.User, error) {
+		u := &user.User{
+			Name:     name,
+			Username: name,
+			Uid:      "1000",
+			Gid:      "1000",
+			HomeDir:  c.MkDir(),
+		}
+		return u, nil
+	}, &workshop.LookupUsername)
 }
 
 func (s *interfaceHandlersSuite) TearDownTest(c *check.C) {
 	s.restoreSimple()
 	s.restoreDeny()
 	s.restoreSecurtityBackends()
+	s.restoreUserLookup()
 }
 
 func (s *interfaceHandlersSuite) settle(c *check.C) {
@@ -161,6 +176,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -197,7 +213,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectBoundPlugConnectSuccess(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
@@ -208,6 +224,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBoundPlugConnectSuccess(c *check
 	c.Check(err, check.IsNil)
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
 	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug2"}}
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -222,16 +239,16 @@ func (s *interfaceHandlersSuite) TestAutoconnectBoundPlugConnectSuccess(c *check
 
 	// Validate
 	pconns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
-	c.Assert(pconns, check.HasLen, 3)
-	c.Assert(err, check.IsNil)
+	c.Check(pconns, check.HasLen, 3)
+	c.Check(err, check.IsNil)
 
 	ref, err := repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
-	c.Assert(ref, check.HasLen, 3)
-	c.Assert(err, check.IsNil)
+	c.Check(ref, check.HasLen, 3)
+	c.Check(err, check.IsNil)
 
 	var conns map[string]interface{}
 	s.state.Get("conns", &conns)
-	c.Assert(conns, check.DeepEquals, map[string]interface{}{
+	c.Check(conns, check.DeepEquals, map[string]interface{}{
 		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
 			"interface":    "mock-network",
 			"auto":         true,
@@ -298,6 +315,9 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingContentTargets
 		{Name: "conflict-1", Channel: "latest/stable"}: conflictingTarget1,
 		{Name: "conflict-2", Channel: "latest/stable"}: conflictingTarget2,
 	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget1, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget2, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
@@ -319,7 +339,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingContentTargets
 	defer s.state.Unlock()
 
 	// Validate
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target /home/workshop is also mounted by ws/conflict-1:plug.*`)
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target /home/workshop is also mounted by.*`)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.C) {
@@ -363,6 +383,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
@@ -398,36 +419,6 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectFailInstallPolicyCheck(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	var sdkYaml = `
-name: consumer
-base: ubuntu@22.04
-slots:
-  slot:
-    interface: content
-`
-	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: sdkYaml})
-
-	t1 := s.state.NewTask("auto-connect", "test")
-	t1.Set("sdk", "consumer")
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.prj, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	s.settle(c)
-
-	s.state.Lock()
-
-	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
-	c.Assert(t1.Log()[0], check.Matches, ".*installation not allowed.*")
-}
-
 func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
@@ -437,6 +428,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -473,68 +465,6 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 
 	// ensure that backend profiles were set for both SDKs
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
-	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
-}
-
-func (s *interfaceHandlersSuite) TestAutoconnectPlugFailsIfMasterNotAutoconnected(c *check.C) {
-	// Setup
-	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
-
-	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
-	c.Check(err, check.IsNil)
-	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	// the bound to does not exist (or will not be pulled in the auto-connect candidate search)
-	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug4"}}
-
-	// Execute
-	s.state.Lock()
-	chg := s.newAutoconnectChange()
-	s.state.Unlock()
-
-	s.settle(c)
-
-	s.state.Lock()
-	defer s.state.Unlock()
-	c.Check(chg.Err(), check.ErrorMatches, "(?s).*cannot auto-connect ws/consumer:plug: plug bind ws/consumer:plug4 does not exist or not auto-connectable.*")
-
-	// Validate
-	var conns map[string]interface{}
-	s.state.Get("conns", &conns)
-	c.Assert(conns, check.HasLen, 0)
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
-	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
-}
-
-func (s *interfaceHandlersSuite) TestAutoconnectFailIfSomeBoundNotAutoconnectable(c *check.C) {
-	// Setup
-	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
-
-	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
-	c.Check(err, check.IsNil)
-	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug2"}}
-	wp.File.Sdks[0].Plugs["plug-ssh"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug2"}}
-
-	// Execute
-	s.state.Lock()
-	chg := s.newAutoconnectChange()
-	s.state.Unlock()
-
-	s.settle(c)
-
-	s.state.Lock()
-	defer s.state.Unlock()
-	c.Check(chg.Err(), check.ErrorMatches, "(?s).*cannot auto-connect ws/consumer:plug2: bound plug ws/consumer:plug-ssh cannot be auto-connected.*")
-
-	// Validate
-	var conns map[string]interface{}
-	s.state.Get("conns", &conns)
-	c.Assert(conns, check.HasLen, 0)
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -139,16 +139,6 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
 
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		connections, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
-		c.Assert(err, check.IsNil)
-		connection, err := repo.Connection(connections[0])
-		c.Assert(err, check.IsNil)
-		c.Assert(connection.Plug.SetAttr("test-dynamic-attr", "new-dynamic-value"), check.IsNil)
-		return nil
-	}
-	defer func() { s.secBackend.SetupCallback = nil }()
-
 	// Execute
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
@@ -159,14 +149,15 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	chg.AddTask(t1)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	s.state.Lock()
 	defer s.state.Unlock()
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus, check.Commentf("%v", t1.Log()))
 	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
@@ -179,10 +170,9 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.DeepEquals, map[string]interface{}{
 		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
-			"interface":    "mock-network",
-			"auto":         true,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]interface{}{"attribute": "one"},
 		},
 	})
 
@@ -191,9 +181,9 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectBackendEnsureDisconnectsIfBackendSetupFails(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 	// Setup
-	// Create an already installed workshop with a candidate SDK/slot
+	// Create an already launched workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
@@ -215,18 +205,15 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendEnsureDisconnectsIfBacken
 	chg.AddTask(t1)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	s.state.Lock()
 	defer s.state.Unlock()
 	c.Check(chg.Err(), check.NotNil)
 
 	// Validate
-	for _, plug := range []string{"plug", "plug2", "plug3"} {
-		ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", plug)
-		c.Assert(ref, check.HasLen, 0)
-		c.Assert(err, check.IsNil)
-	}
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 
 	ref, err := repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
 	c.Assert(ref, check.HasLen, 0)
@@ -237,44 +224,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendEnsureDisconnectsIfBacken
 	c.Assert(conns, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectUndoAllBackendSetupsIfEitherFailed(c *check.C) {
-	// Setup
-	// Create an already installed workshop with a candidate SDK/slot
-	repo := s.mgr.Repository()
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		if len(s.secBackend.SetupCalls) <= 1 {
-			return nil
-		}
-		return errors.New("cannot finish backend setup")
-	}
-	defer func() { s.secBackend.SetupCallback = nil }()
-
-	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
-
-	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerManyPlugs})
-
-	// Execute
-	s.state.Lock()
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws-consumer", s.prj, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-	s.state.Unlock()
-
-	s.o.Settle(5 * time.Second)
-
-	s.state.Lock()
-	defer s.state.Unlock()
-	c.Check(chg.Err(), check.NotNil)
-
-	// Validate
-	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
-}
-
-func (s *interfaceHandlersSuite) TestAutoconnectFailsIfWorkshopHasConflictingContentTargets(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingContentTargets(c *check.C) {
 	// Setup
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
 		{Name: "conflict-1", Channel: "latest/stable"}: conflictingTarget1,
@@ -295,7 +245,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsIfWorkshopHasConflictingCon
 	s.state.Unlock()
 
 	// Execute
-	s.o.Settle(5 * time.Second)
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -304,10 +255,10 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsIfWorkshopHasConflictingCon
 	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target /home/workshop is also mounted by ws/conflict-1:plug.*`)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectNoConnections(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	// Launch another workshop with a candidate plug
+	// Launch a workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
 
 	// Execute
@@ -322,23 +273,21 @@ func (s *interfaceHandlersSuite) TestAutoconnectNoConnections(c *check.C) {
 	chg.AddTask(t2)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	s.state.Lock()
 	defer s.state.Unlock()
 
 	// Validate
-	c.Assert(t1.Status(), check.Equals, state.UndoneStatus)
-	_, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
-	c.Assert(err, check.ErrorMatches, "sdk \"consumer\" has no plug or slot named \"plug\"")
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 0)
 
 	var conns map[string]interface{}
 	s.state.Get("conns", &conns)
-	c.Assert(conns, check.DeepEquals, map[string]interface{}{})
+	c.Assert(conns, check.DeepEquals, map[string]interface{}(nil))
 
 	// ensure that backend profiles were set for both SDKs
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
-	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
@@ -358,12 +307,14 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
 	t2 := s.state.NewTask("error-trigger", "...")
 	setWorkshopProject("ws", s.prj, t1)
 	setWorkshopProject("ws", s.prj, t2)
+	t2.WaitFor(t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 	chg.AddTask(t2)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -388,59 +339,50 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemovesNonExistingConnections(c 
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumer})
+	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerNoPlugs})
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+
+	// to be removed after the auto-connect as the plug does not exist anymore
+	conns := map[string]*schema.ConnState{
+		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/producer:slot": {
+			Auto:      true,
+			Interface: "mock-network",
+		},
+	}
 
 	s.state.Lock()
+	ifacestate.SetConns(s.state, conns)
+	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
+	c.Assert(err, check.IsNil)
+
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("auto-connect", "...")
 	t1.Set("sdk", "consumer")
 	setWorkshopProject("ws-consumer", s.prj, t1)
+
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
-
-	s.state.Lock()
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
-
-	// simulate refresh, which will install the consumer SDK again
-	chg = s.state.NewChange("refresh", "...")
-	t2 := s.state.NewTask("auto-connect", "...")
-	t2.Set("sdk", "consumer")
-	chg.AddTask(t2)
-	chg.Set("user", "testuser")
-	setWorkshopProject("ws-consumer", s.prj, t2)
-
-	// overwrite the SDK meta file so the auto-connect task will
-	// now be installing an SDK with no plugs
-	// for simplicity of the test it does so into the same workshop
-	// but in practice this scenario is possible when the workshop is refreshed
-	// and some of the SDKs have their plugs and slots changed.
-	fs, err := s.wsbackend.WorkshopFs(s.ctx, "ws-consumer")
-	c.Assert(err, check.IsNil)
-	s.writeSDKMetaFile(c, fs, csetup.Name, consumerNoPlugs)
-	s.state.Unlock()
-
-	s.o.Settle(5 * time.Second)
-
-	s.state.Lock()
-	defer s.state.Unlock()
+	err = s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	// Validate
 	// Confirm that the previously existing connection of the mock-network
-	// interface has now been removed from the connections list.
-	c.Assert(t2.Status(), check.Equals, state.DoneStatus)
+	// interface has now been removed from connections.
+	s.state.Lock()
+	defer s.state.Unlock()
 
-	var conns map[string]interface{}
-	s.state.Get("conns", &conns)
-	c.Assert(conns, check.DeepEquals, map[string]interface{}{})
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
 
-	// Also confirm that the SDK profile does not exist any more as
-	// the plug has been removed.
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+2)
-	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+	var updated map[string]interface{}
+	s.state.Get("conns", &updated)
+	c.Assert(updated, check.DeepEquals, map[string]interface{}{})
+
+	repoconns, err := repo.Connections(s.prj.ProjectId, "ws-consumer", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(repoconns, check.HasLen, 0)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectReconnectsExistingConnections(c *check.C) {
@@ -462,7 +404,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectReconnectsExistingConnections(c 
 	chg.AddTask(t1)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	s.state.Lock()
 	// simulate refresh, which will install the consumer SDK again
@@ -528,7 +471,8 @@ slots:
 	chg.AddTask(t1)
 
 	s.state.Unlock()
-	s.o.Settle(5 * time.Second)
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	s.state.Lock()
 
@@ -536,16 +480,12 @@ slots:
 	c.Assert(t1.Log()[0], check.Matches, ".*installation not allowed.*")
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugs(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
-	cref := interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-producer", Sdk: "producer", Name: "slot"},
-	}
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
@@ -553,22 +493,19 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugs(c *check.C) {
 	// Execute
 	s.state.Lock()
 	chg := s.state.NewChange("refresh", "...")
-	t := s.state.NewTask("auto-disconnect", "...")
-	// see doAutoConnect and doDisconnect handlers for details
-	chg.Set("remounts", map[string]map[string]interface{}{
-		cref.ID(): {"source": "/old/source"},
+	// existing remounts that should be preserved after refresh
+	chg.Set("remounts", map[string]interface{}{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{"source": "/old/source"},
 	})
-	t.Set("sdk", "consumer")
-	t.SetStatus(state.DoneStatus)
 	t1 := s.state.NewTask("auto-connect", "...")
 	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws", s.prj, t, t1)
+	setWorkshopProject("ws", s.prj, t1)
 	chg.Set("user", "testuser")
-	chg.AddTask(t)
 	chg.AddTask(t1)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -615,8 +552,9 @@ func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Chang
 	return chg
 }
 
-func (s *interfaceHandlersSuite) setupPlugConnectionAttribute(c *check.C, repo *interfaces.Repository, oldSource string) {
-	connections, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+func (s *interfaceHandlersSuite) setContentSource(c *check.C, ws, sname, p string, oldSource string) {
+	repo := s.mgr.Repository()
+	connections, err := repo.Connected(s.prj.ProjectId, ws, sname, p)
 	c.Assert(err, check.IsNil)
 	c.Assert(connections, check.HasLen, 1)
 
@@ -667,7 +605,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 		// the remount handler expects that a plug IS connected and HAS a
 		// "source" attribute
 		setup.Do(func() {
-			s.setupPlugConnectionAttribute(c, repo, oldSource)
+			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
 		})
 		return nil
 	}
@@ -725,7 +663,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 		// the remount handler expects that a plug IS connected and HAS a
 		// "source" attribute
 		s.setup.Do(func() {
-			s.setupPlugConnectionAttribute(c, repo, oldSource)
+			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
 		})
 		return nil
 	}
@@ -786,7 +724,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *chec
 		// the remount handler expects that a plug IS connected and HAS a
 		// "source" attribute
 		setup.Do(func() {
-			s.setupPlugConnectionAttribute(c, repo, oldSource)
+			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
 		})
 		return nil
 	}
@@ -838,7 +776,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 		// the remount handler expects that a plug IS connected and HAS a
 		// "source" attribute
 		setup.Do(func() {
-			s.setupPlugConnectionAttribute(c, repo, oldSource)
+			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
 		})
 		return nil
 	}
@@ -883,7 +821,7 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 		// the remount handler expects that a plug IS connected and HAS a
 		// "source" attribute
 		setup.Do(func() {
-			s.setupPlugConnectionAttribute(c, repo, oldSource)
+			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
 		})
 		// Emulate the case when remount could not update the LXD profile for
 		// the SDK (the first two calls come from the auto-connect task)
@@ -934,7 +872,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameOldSourceDoesNotExist(c *check
 		// the remount handler expects that a plug IS connected and HAS a
 		// "source" attribute
 		setup.Do(func() {
-			s.setupPlugConnectionAttribute(c, repo, oldSource)
+			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
 		})
 		return nil
 	}
@@ -1154,8 +1092,6 @@ func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 	conns, err = repo.Connections(s.prj.ProjectId, "ws", "producer")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 0)
-
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 }
 
 func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
@@ -1202,8 +1138,6 @@ func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 1)
 	c.Assert(conns[connRefKey].Undesired, check.Equals, true)
-
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 }
 
 func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
@@ -1249,8 +1183,131 @@ func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 	var conns map[string]*schema.ConnState
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
+}
 
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+func (s *interfaceHandlersSuite) connectChange(c *check.C, workshop string, auto bool) *state.Change {
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("connect", "...")
+	plugRef := interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "consumer", Name: "plug"}
+	slotRef := interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "producer", Name: "slot"}
+	t1.Set("plug", plugRef)
+	t1.Set("slot", slotRef)
+	t1.Set("auto", auto)
+	setWorkshopProject(workshop, s.prj, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	s.state.Unlock()
+
+	return chg
+}
+
+func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
+	// Setup
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	chg := s.connectChange(c, "ws", false)
+
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	c.Assert(chg.Tasks()[0].Status(), check.Equals, state.DoneStatus)
+	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+}
+
+func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
+	// Setup
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	chg := s.connectChange(c, "ws", false)
+	s.state.Lock()
+	chg.Tasks()[0].Set("plug-dynamic", map[string]interface{}{"dynamic": "value"})
+	s.state.Unlock()
+
+	// Execute
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	c.Assert(chg.Tasks()[0].Status(), check.Equals, state.DoneStatus)
+	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+
+	conn, err := repo.Connection(conns[0])
+	c.Assert(err, check.IsNil)
+	v, _ := conn.Plug.Lookup("dynamic")
+	c.Assert(v, check.Equals, "value")
+}
+
+func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
+	// Setup
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	chg := s.connectChange(c, "ws", true)
+
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	c.Assert(chg.Tasks()[0].Status(), check.Equals, state.DoneStatus)
+	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+
+	stateConns, err := ifacestate.GetConns(s.state)
+	c.Assert(err, check.IsNil)
+	c.Assert(stateConns, check.DeepEquals, map[string]*schema.ConnState{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": {
+			Auto:             true,
+			Interface:        "mock-network",
+			StaticPlugAttrs:  map[string]interface{}{"attribute": "one"},
+			DynamicPlugAttrs: map[string]interface{}{},
+			StaticSlotAttrs:  map[string]interface{}{},
+			DynamicSlotAttrs: map[string]interface{}{},
+		},
+	})
 }
 
 func (s *interfaceHandlersSuite) TestDiscardConnsSuccess(c *check.C) {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -23,7 +23,8 @@ import (
 type interfaceHandlersSuite struct {
 	interfaceManagerSuite
 	mgr                      *ifacestate.InterfaceManager
-	restoreInterface         func()
+	restoreSimple            func()
+	restoreDeny              func()
 	restoreSecurtityBackends func()
 }
 
@@ -60,6 +61,8 @@ plugs:
   plug3:
     interface: mock-network
     attribute: three
+  plug-ssh:
+    interface: mock-ssh-agent	
 `
 
 var conflictingTarget1 = `name: conflict-1
@@ -86,7 +89,8 @@ base: ubuntu@22.04
 
 func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 	s.interfaceManagerSuite.SetUpTest(c)
-	s.restoreInterface = builtin.MockInterface(simpleIface{name: "mock-network"})
+	s.restoreSimple = builtin.MockInterface(simpleIface{name: "mock-network"})
+	s.restoreDeny = builtin.MockInterface(denyAutoIface{name: "mock-ssh-agent"})
 
 	s.mgr = ifacestate.New(s.state, s.runner, s.wsbackend)
 	c.Assert(s.mgr, check.NotNil)
@@ -107,7 +111,8 @@ func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 }
 
 func (s *interfaceHandlersSuite) TearDownTest(c *check.C) {
-	s.restoreInterface()
+	s.restoreSimple()
+	s.restoreDeny()
 	s.restoreSecurtityBackends()
 }
 
@@ -129,6 +134,13 @@ type simpleIface struct {
 
 func (si simpleIface) Name() string                                            { return si.name }
 func (si simpleIface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool { return true }
+
+type denyAutoIface struct {
+	name string
+}
+
+func (di denyAutoIface) Name() string                                            { return di.name }
+func (di denyAutoIface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool { return false }
 
 func (s *interfaceHandlersSuite) newAutoconnectChange() *state.Change {
 	chg := s.state.NewChange("sample", "...")
@@ -185,7 +197,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectBoundPlugConnected(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoconnectBoundPlugConnectSuccess(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
@@ -461,6 +473,68 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 
 	// ensure that backend profiles were set for both SDKs
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectPlugFailsIfMasterNotAutoconnected(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
+	c.Check(err, check.IsNil)
+	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
+	// the bound to does not exist (or will not be pulled in the auto-connect candidate search)
+	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug4"}}
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange()
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*cannot auto-connect ws/consumer:plug: plug bind ws/consumer:plug4 does not exist or not auto-connectable.*")
+
+	// Validate
+	var conns map[string]interface{}
+	s.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 0)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectFailIfSomeBoundNotAutoconnectable(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
+	c.Check(err, check.IsNil)
+	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
+	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug2"}}
+	wp.File.Sdks[0].Plugs["plug-ssh"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug2"}}
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange()
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*cannot auto-connect ws/consumer:plug2: bound plug ws/consumer:plug-ssh cannot be auto-connected.*")
+
+	// Validate
+	var conns map[string]interface{}
+	s.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 0)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -221,13 +221,10 @@ func (s *interfaceHandlersSuite) TestAutoconnectBoundPlugConnected(c *check.C) {
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.DeepEquals, map[string]interface{}{
 		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
-			"interface":   "mock-network",
-			"auto":        true,
-			"plug-static": map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"bind": map[string]interface{}{
-				"plug": map[string]interface{}{"project-id": s.prj.ProjectId, "workshop": "ws", "sdk": "consumer", "plug": "plug2"},
-				"slot": map[string]interface{}{"project-id": s.prj.ProjectId, "workshop": "ws-producer", "sdk": "producer", "slot": "slot"},
-			}},
+			"interface":    "mock-network",
+			"auto":         true,
+			"plug-static":  map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"bind": "42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot"},
 		},
 		"42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot": map[string]interface{}{
 			"interface":   "mock-network",
@@ -265,8 +262,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 	chg := s.newAutoconnectChange()
 	s.state.Unlock()
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -305,8 +301,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingContentTargets
 	s.state.Unlock()
 
 	// Execute
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -332,8 +327,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.
 	chg.AddTask(t2)
 	s.state.Unlock()
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -371,8 +365,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
 	chg.AddTask(t2)
 	s.state.Unlock()
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -415,8 +408,7 @@ slots:
 	chg.AddTask(t1)
 
 	s.state.Unlock()
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 
@@ -448,8 +440,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 	chg.AddTask(t1)
 	s.state.Unlock()
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -537,7 +528,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	change := s.newRemountChange(newSource)
 
 	// Execute
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	// Validate
 	s.state.Lock()
@@ -581,7 +572,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	change := s.newRemountChange(newSource)
 
 	// Execute
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	// Validate
 	s.state.Lock()
@@ -629,7 +620,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *chec
 	change := s.newRemountChange(newSource)
 
 	// Execute
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	// Validate
 	s.state.Lock()
@@ -667,7 +658,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 	change := s.newRemountChange(newSource)
 
 	// Execute
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	// Validate
 	s.state.Lock()
@@ -704,7 +695,7 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	// Validate
 	s.state.Lock()
@@ -738,7 +729,7 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C)
 	change := s.newRemountChange(newSource)
 
 	// Execute
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	// Validate
 	s.state.Lock()
@@ -807,7 +798,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	chg := s.newDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -837,7 +828,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	chg := s.newDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -876,7 +867,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 	chg := s.newDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -907,7 +898,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectNoSdkProfile(c *check.C) {
 	chg := s.newDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -962,7 +953,7 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesSuccess(c *check.C)
 	chg := s.newUndoDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1012,7 +1003,7 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesManualRestored(c *c
 	chg := s.newUndoDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1073,7 +1064,7 @@ func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 	// Execute
 	chg := s.disconnectChange(c, "ws", false)
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1117,7 +1108,7 @@ func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
 	// Execute
 	chg := s.disconnectChange(c, "ws", false)
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1166,7 +1157,7 @@ func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 	// Execute
 	chg := s.disconnectChange(c, "ws", true)
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1187,6 +1178,115 @@ func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 	c.Assert(conns, check.HasLen, 0)
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestundoDisconnectSuccess(c *check.C) {
+	// Setup
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+			"interface":    "mock-network",
+			"auto":         false,
+			"plug-static":  map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"bind": "42424242/ws/consumer:plug2 42424242/ws/producer:slot"},
+		},
+	})
+	s.state.Unlock()
+
+	chg := s.disconnectChange(c, "ws", false)
+	s.state.Lock()
+	terr := s.state.NewTask("error-trigger", "...")
+	terr.WaitFor(chg.Tasks()[0])
+	chg.AddTask(terr)
+	s.state.Unlock()
+
+	// Execute
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*error-trigger task.*")
+
+	// Validate
+	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+
+	conns, err = repo.Connections(s.prj.ProjectId, "ws", "producer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+
+	conn, err := repo.Connection(conns[0])
+	c.Assert(err, check.IsNil)
+	_, ok := conn.CheckBound()
+	c.Assert(ok, check.Equals, true)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 4)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestundoDisconnectUndesiredSuccess(c *check.C) {
+	// Setup
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	s.state.Lock()
+	conn := map[string]interface{}{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+			"interface": "mock-network",
+			"auto":      true,
+			"undesired": true,
+		},
+	}
+	s.state.Set("conns", conn)
+	s.state.Unlock()
+
+	chg := s.disconnectChange(c, "ws", true)
+	disc, err := repo.Connections("42424242", "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(disc, check.HasLen, 1)
+	// emulate an undesired connection
+	repo.DisconnectAll(disc)
+
+	s.state.Lock()
+	terr := s.state.NewTask("error-trigger", "...")
+	terr.WaitFor(chg.Tasks()[0])
+	chg.AddTask(terr)
+	s.state.Unlock()
+
+	// Execute
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*error-trigger task.*")
+
+	// Validate
+	cons, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(cons, check.HasLen, 0)
+
+	prods, err := repo.Connections(s.prj.ProjectId, "ws", "producer")
+	c.Assert(err, check.IsNil)
+	c.Assert(prods, check.HasLen, 0)
+
+	conns := map[string]interface{}{}
+	s.state.Get("conns", &conns)
+	c.Assert(conns, check.DeepEquals, conn)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
@@ -1221,8 +1321,7 @@ func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
 	// Execute
 	chg := s.connectChange("ws", false, true)
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1253,8 +1352,7 @@ func (s *interfaceHandlersSuite) TestConnectSuccessSetupBackend(c *check.C) {
 	// Execute
 	chg := s.connectChange("ws", false, false)
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1288,8 +1386,7 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	s.state.Unlock()
 
 	// Execute
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1322,8 +1419,7 @@ func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 	// Execute
 	chg := s.connectChange("ws", true, true)
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1379,14 +1475,13 @@ func (s *interfaceHandlersSuite) TestUndoConnectUndesired(c *check.C) {
 	chg.AddTask(et)
 	s.state.Unlock()
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*error-trigger task.*")
 
 	// Validate
-	c.Assert(t.Status(), check.Equals, state.UndoneStatus)
 	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 0)
@@ -1423,14 +1518,13 @@ func (s *interfaceHandlersSuite) TestUndoConnectBackendSetup(c *check.C) {
 	chg.AddTask(et)
 	s.state.Unlock()
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*error-trigger task.*")
 
 	// Validate
-	c.Assert(t.Status(), check.Equals, state.UndoneStatus)
 	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 0)
@@ -1483,7 +1577,7 @@ func (s *interfaceHandlersSuite) TestDiscardConnsSuccess(c *check.C) {
 	chg.AddTask(t1)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1550,7 +1644,7 @@ func (s *interfaceHandlersSuite) TestUndoDiscardConnsSuccess(c *check.C) {
 	chg.AddTask(t2)
 	s.state.Unlock()
 
-	s.o.Settle(5 * time.Second)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -503,7 +503,9 @@ slots:
     slot:
         interface: content        
 `
-	s.launchWorkshop(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
+	wm, err := s.launchWorkshop(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
+	c.Assert(err, check.IsNil)
+	wm.Running = true
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, agentYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
@@ -516,7 +518,7 @@ slots:
 			"plug-dynamic": map[string]interface{}{"source": source},
 		},
 	})
-	_, err := ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws-consumer", "consumer")
+	_, err = ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws-consumer", "consumer")
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 }

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"gopkg.in/check.v1"
@@ -26,8 +25,6 @@ type interfaceHandlersSuite struct {
 	mgr                      *ifacestate.InterfaceManager
 	restoreInterface         func()
 	restoreSecurtityBackends func()
-	// pointer as to avoid test fails with -count
-	setup *sync.Once
 }
 
 var _ = check.Suite(&interfaceHandlersSuite{})
@@ -88,7 +85,6 @@ base: ubuntu@22.04
 `
 
 func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
-	s.setup = new(sync.Once)
 	s.interfaceManagerSuite.SetUpTest(c)
 	s.restoreInterface = builtin.MockInterface(simpleIface{name: "mock-network"})
 
@@ -335,120 +331,6 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectRemovesNonExistingConnections(c *check.C) {
-	// Setup
-	// Create an already installed workshop with a candidate SDK/slot
-	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerNoPlugs})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
-
-	// to be removed after the auto-connect as the plug does not exist anymore
-	conns := map[string]*schema.ConnState{
-		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/producer:slot": {
-			Auto:      true,
-			Interface: "mock-network",
-		},
-	}
-
-	s.state.Lock()
-	ifacestate.SetConns(s.state, conns)
-	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
-	c.Assert(err, check.IsNil)
-
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws-consumer", s.prj, t1)
-
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-	s.state.Unlock()
-
-	err = s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
-
-	// Validate
-	// Confirm that the previously existing connection of the mock-network
-	// interface has now been removed from connections.
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
-
-	var updated map[string]interface{}
-	s.state.Get("conns", &updated)
-	c.Assert(updated, check.DeepEquals, map[string]interface{}{})
-
-	repoconns, err := repo.Connections(s.prj.ProjectId, "ws-consumer", "consumer")
-	c.Assert(err, check.IsNil)
-	c.Assert(repoconns, check.HasLen, 0)
-}
-
-func (s *interfaceHandlersSuite) TestAutoconnectReconnectsExistingConnections(c *check.C) {
-	// Setup
-	// Create an already installed workshop with a candidate SDK/slot
-	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
-
-	// Launch another workshop with a candidate plug
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
-
-	s.state.Lock()
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws", s.prj, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-	s.state.Unlock()
-
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
-
-	s.state.Lock()
-	// simulate refresh, which will install the consumer SDK again
-	// hence the existing autoconnectios must be restored
-	chg = s.state.NewChange("refresh", "...")
-	t2 := s.state.NewTask("auto-connect", "...")
-	t2.Set("sdk", "consumer")
-	chg.AddTask(t2)
-	chg.Set("user", "testuser")
-	setWorkshopProject("ws", s.prj, t2)
-
-	c.Assert(s.wsbackend.RemoveWorkshop(s.ctx, "ws"), check.IsNil)
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
-	s.state.Unlock()
-
-	s.o.Settle(5 * time.Second)
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	// Validate
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus, check.Commentf("%v", chg.Err()))
-	c.Assert(t2.Status(), check.Equals, state.DoneStatus, check.Commentf("%v", chg.Err()))
-
-	var conns map[string]interface{}
-	s.state.Get("conns", &conns)
-	c.Assert(conns, check.DeepEquals, map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
-			"interface":   "mock-network",
-			"auto":        true,
-			"plug-static": map[string]interface{}{"attribute": "one"},
-		},
-	})
-
-	// ensure that backend profiles were set for both SDKs
-	// in the first and the second runs. First, when consumer
-	// was installed for the first time and, second, when consumer
-	// was refreshed but did not have any changes and had its auto
-	// connections restored
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+2)
-	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
-}
-
 func (s *interfaceHandlersSuite) TestAutoconnectFailInstallPolicyCheck(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -531,40 +413,20 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 
 func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Change {
 	s.state.Lock()
-	t1 := s.state.NewTask("auto-connect", "test")
-	t1.Set("sdk", "consumer")
-	t2 := s.state.NewTask("remount", "remount")
-	t2.Set("source", newSource)
-	t2.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
-	t2.WaitFor(t1)
-	setWorkshopProject("ws-consumer", s.prj, t1, t2)
+	defer s.state.Unlock()
 
-	// Prevent undoing if the remount fails, so we don't have plugs disconnected
-	// as we want to test remount in isolation, as if it was a single change.
-	connLane := s.state.NewLane()
-	t1.JoinLane(connLane)
+	t1 := s.state.NewTask("remount", "remount")
+	t1.Set("source", newSource)
+	t1.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
+	setWorkshopProject("ws-consumer", s.prj, t1)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
-	chg.AddTask(t2)
-	s.state.Unlock()
 	return chg
 }
 
-func (s *interfaceHandlersSuite) setContentSource(c *check.C, ws, sname, p string, oldSource string) {
-	repo := s.mgr.Repository()
-	connections, err := repo.Connected(s.prj.ProjectId, ws, sname, p)
-	c.Assert(err, check.IsNil)
-	c.Assert(connections, check.HasLen, 1)
-
-	connRef := connections[0]
-	connection, err := repo.Connection(connRef)
-	c.Assert(err, check.IsNil)
-	c.Assert(connection.Plug.SetAttr("source", oldSource), check.IsNil)
-}
-
-func (s *interfaceHandlersSuite) launchRemountWorkshop(c *check.C) {
+func (s *interfaceHandlersSuite) launchRemountWorkshop(c *check.C, source string) {
 	// Note: we set the source attribute for the plug in these tests, however,
 	// it is a dynamic attribute that will be defined when we install an SDK
 	// into a workshop as the default path depends on the username
@@ -587,6 +449,19 @@ slots:
 	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, agentYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/agent:slot": map[string]interface{}{
+			"interface":    "content",
+			"auto":         true,
+			"plug-static":  map[string]interface{}{"target": "/opt"},
+			"plug-dynamic": map[string]interface{}{"source": source},
+		},
+	})
+	_, err := ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws-consumer", "consumer")
+	c.Assert(err, check.IsNil)
+	s.state.Unlock()
 }
 
 func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C) {
@@ -596,20 +471,8 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	_, err := os.Create(filepath.Join(oldSource, "tempfile"))
 	c.Check(err, check.IsNil)
 
-	s.launchRemountWorkshop(c)
+	s.launchRemountWorkshop(c, oldSource)
 	change := s.newRemountChange(newSource)
-
-	var setup sync.Once
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		// Set the plug's source attribute to emulate an existing connection as
-		// the remount handler expects that a plug IS connected and HAS a
-		// "source" attribute
-		setup.Do(func() {
-			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
-		})
-		return nil
-	}
-	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
 	s.o.Settle(5 * time.Second)
@@ -632,10 +495,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	c.Assert(remountSource, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
-	// 2 calls for the autoconnect, one call for the remount
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+1)
-	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Sdk, check.Equals, "consumer")
-	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Workshop, check.Equals, "ws-consumer")
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 
 	// ensure the global conns state was updated correctly
 	conns, err := ifacestate.GetConns(s.state)
@@ -644,7 +504,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 		Auto:             true,
 		Interface:        "content",
 		Undesired:        false,
-		StaticPlugAttrs:  map[string]interface{}{"target": "/home/workshop"},
+		StaticPlugAttrs:  map[string]interface{}{"target": "/opt"},
 		DynamicPlugAttrs: map[string]interface{}{"source": newSource},
 		StaticSlotAttrs:  map[string]interface{}{},
 		DynamicSlotAttrs: map[string]interface{}{}})
@@ -655,19 +515,8 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	// Setup
 	oldSource := c.MkDir()
 	newSource := filepath.Join(c.MkDir(), "new")
-	s.launchRemountWorkshop(c)
+	s.launchRemountWorkshop(c, oldSource)
 	change := s.newRemountChange(newSource)
-
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		// Set the plug's source attribute to emulate an existing connection as
-		// the remount handler expects that a plug IS connected and HAS a
-		// "source" attribute
-		s.setup.Do(func() {
-			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
-		})
-		return nil
-	}
-	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
 	s.o.Settle(5 * time.Second)
@@ -690,10 +539,9 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	c.Assert(remountSource, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
-	// 2 calls for the autoconnect, one call for the remount
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+1)
-	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Sdk, check.Equals, "consumer")
-	c.Assert(s.secBackend.SetupCalls[2].SdkInfo.Workshop, check.Equals, "ws-consumer")
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
+	c.Assert(s.secBackend.SetupCalls[0].SdkInfo.Sdk, check.Equals, "consumer")
+	c.Assert(s.secBackend.SetupCalls[0].SdkInfo.Workshop, check.Equals, "ws-consumer")
 
 	// ensure the global conns state was updated correctly
 	conns, err := ifacestate.GetConns(s.state)
@@ -702,7 +550,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 		Auto:             true,
 		Interface:        "content",
 		Undesired:        false,
-		StaticPlugAttrs:  map[string]interface{}{"target": "/home/workshop"},
+		StaticPlugAttrs:  map[string]interface{}{"target": "/opt"},
 		DynamicPlugAttrs: map[string]interface{}{"source": newSource},
 		StaticSlotAttrs:  map[string]interface{}{},
 		DynamicSlotAttrs: map[string]interface{}{}})
@@ -715,20 +563,8 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *chec
 	newSource := c.MkDir()
 	_, err := os.Create(filepath.Join(newSource, "tempfile"))
 	c.Check(err, check.IsNil)
-	s.launchRemountWorkshop(c)
+	s.launchRemountWorkshop(c, oldSource)
 	change := s.newRemountChange(newSource)
-
-	var setup sync.Once
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		// Set the plug's source attribute to emulate an existing connection as
-		// the remount handler expects that a plug IS connected and HAS a
-		// "source" attribute
-		setup.Do(func() {
-			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
-		})
-		return nil
-	}
-	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
 	s.o.Settle(5 * time.Second)
@@ -752,8 +588,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *chec
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
 	c.Assert(osutil.FileExists(newSource), check.Equals, true)
-	// 2 calls for the autoconnect, no calls for the remount
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 }
 
 func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *check.C) {
@@ -762,25 +597,12 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 	newSource := c.MkDir()
 	_, err := os.Create(filepath.Join(newSource, "tempfile"))
 	c.Check(err, check.IsNil)
-	s.launchRemountWorkshop(c)
+	s.launchRemountWorkshop(c, oldSource)
 
 	// the remount will be performed if the workshop is not running
 	err = s.wsbackend.StopWorkshop(s.ctx, "ws-consumer", true)
 	c.Check(err, check.IsNil)
-
 	change := s.newRemountChange(newSource)
-
-	var setup sync.Once
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		// Set the plug's source attribute to emulate an existing connection as
-		// the remount handler expects that a plug IS connected and HAS a
-		// "source" attribute
-		setup.Do(func() {
-			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
-		})
-		return nil
-	}
-	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
 	s.o.Settle(5 * time.Second)
@@ -804,31 +626,18 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
 	c.Assert(osutil.FileExists(newSource), check.Equals, true)
-	// 2 calls for the autoconnect, 1 call for the remount
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 }
 
 func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.C) {
 	// Setup
 	oldSource := c.MkDir()
 	newSource := c.MkDir()
-	s.launchRemountWorkshop(c)
+	s.launchRemountWorkshop(c, oldSource)
 	change := s.newRemountChange(newSource)
 
-	var setup sync.Once
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		// Set the plug's source attribute to emulate an existing connection as
-		// the remount handler expects that a plug IS connected and HAS a
-		// "source" attribute
-		setup.Do(func() {
-			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
-		})
-		// Emulate the case when remount could not update the LXD profile for
-		// the SDK (the first two calls come from the auto-connect task)
-		if len(s.secBackend.SetupCalls) == 3 {
-			return errors.New("cannot setup LXD profile")
-		}
-		return nil
+		return errors.New("cannot setup LXD profile")
 	}
 	defer func() { s.secBackend.SetupCallback = nil }()
 
@@ -856,27 +665,15 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
 	c.Assert(osutil.FileExists(newSource), check.Equals, false)
 	// 2 calls for the autoconnect, no calls for the remount
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 }
 
-func (s *interfaceHandlersSuite) TestRemountRenameOldSourceDoesNotExist(c *check.C) {
+func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C) {
 	// Setup
 	oldSource := "/does/not/exist"
 	newSource := c.MkDir()
-	s.launchRemountWorkshop(c)
+	s.launchRemountWorkshop(c, oldSource)
 	change := s.newRemountChange(newSource)
-
-	var setup sync.Once
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		// Set the plug's source attribute to emulate an existing connection as
-		// the remount handler expects that a plug IS connected and HAS a
-		// "source" attribute
-		setup.Do(func() {
-			s.setContentSource(c, "ws-consumer", "consumer", "plug", oldSource)
-		})
-		return nil
-	}
-	defer func() { s.secBackend.SetupCallback = nil }()
 
 	// Execute
 	s.o.Settle(5 * time.Second)
@@ -898,25 +695,42 @@ func (s *interfaceHandlersSuite) TestRemountRenameOldSourceDoesNotExist(c *check
 	c.Assert(src, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(newSource), check.Equals, true)
-	// 2 calls for the autoconnect, 1 call for the remount
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
+}
+
+func (s *interfaceHandlersSuite) newDisconnectInterfacesChange(sdkName string) *state.Change {
+	t1 := s.state.NewTask("auto-disconnect", "...")
+	t1.Set("plug", interfaces.PlugRef{
+		ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
+	t1.Set("slot", interfaces.PlugRef{
+		ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "producer", Name: "slot"})
+	t1.Set("sdk", sdkName)
+	setWorkshopProject("ws-consumer", s.prj, t1)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	return chg
 }
 
 func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	// Setup
-	// Create an already installed workshop with a connected content plug
+	// Create an already installed workshop with a connected plug
 	repo := s.mgr.Repository()
-	s.launchRemountWorkshop(c)
+	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
 
 	connRef := &interfaces.ConnRef{
 		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "agent", Name: "slot"},
+		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
 	}
 
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
 		connRef.ID(): map[string]interface{}{
-			"interface":    "content",
+			"interface":    "mock-network",
 			"auto":         true,
 			"plug-static":  map[string]interface{}{"attribute": "one"},
 			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
@@ -928,12 +742,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 
 	// Execute
 	s.state.Lock()
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-disconnect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws-consumer", s.prj, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
+	chg := s.newDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
 	s.o.Settle(5 * time.Second)
@@ -943,7 +752,36 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+
+	var stateConns map[string]interface{}
+	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
+	c.Assert(stateConns, check.HasLen, 0)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
+}
+
+func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a connected content plug
+	repo := s.mgr.Repository()
+	source := c.MkDir()
+	s.launchRemountWorkshop(c, source)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newDisconnectInterfacesChange("consumer")
+	s.state.Unlock()
+
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
 	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 
@@ -954,9 +792,9 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	var attrs map[string]interface{}
 	c.Assert(chg.Get("remounts", &attrs), check.IsNil)
 	c.Assert(attrs, check.HasLen, 1)
-	c.Assert(attrs[connRef.ID()], check.DeepEquals, map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"})
-
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
+	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/agent:slot"],
+		check.DeepEquals, map[string]interface{}{"source": source})
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
@@ -973,12 +811,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 
 	// Execute
 	s.state.Lock()
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-disconnect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws", s.prj, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
+	chg := s.newDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
 	s.o.Settle(5 * time.Second)
@@ -988,7 +821,6 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
 	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 
@@ -998,7 +830,6 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestAutoDisconnectNoSdkProfile(c *check.C) {
 	// Setup
-	// Create an already installed workshop with a content plug
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
@@ -1011,12 +842,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectNoSdkProfile(c *check.C) {
 
 	// Execute
 	s.state.Lock()
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-disconnect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws", s.prj, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
+	chg := s.newDisconnectInterfacesChange("consumer")
 	s.state.Unlock()
 
 	s.o.Settle(5 * time.Second)
@@ -1026,11 +852,119 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectNoSdkProfile(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
 	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
+}
+
+func (s *interfaceHandlersSuite) newUndoDisconnectInterfacesChange(sdkName string) *state.Change {
+	chg := s.newDisconnectInterfacesChange(sdkName)
+	terr := s.state.NewTask("error-trigger", "...")
+	terr.WaitFor(chg.Tasks()[0])
+	chg.AddTask(terr)
+	return chg
+}
+
+func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesSuccess(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+
+	connRef := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
+	}
+
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		connRef.ID(): map[string]interface{}{
+			"interface":    "mock-network",
+			"auto":         true,
+			"plug-static":  map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
+		},
+	})
+	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
+	c.Assert(err, check.IsNil)
+	s.state.Unlock()
+
+	// Execute
+	s.state.Lock()
+	chg := s.newUndoDisconnectInterfacesChange("consumer")
+	s.state.Unlock()
+
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.NotNil)
+
+	// Validate
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 1)
+	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+
+	var stateConns map[string]interface{}
+	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
+	c.Assert(stateConns, check.HasLen, 1)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 4)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
+}
+
+func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesManualRestored(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+
+	connRef := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
+	}
+
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		connRef.ID(): map[string]interface{}{
+			"interface":    "mock-network",
+			"plug-static":  map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
+		},
+	})
+	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
+	c.Assert(err, check.IsNil)
+	s.state.Unlock()
+
+	// Execute
+	s.state.Lock()
+	chg := s.newUndoDisconnectInterfacesChange("consumer")
+	s.state.Unlock()
+
+	s.o.Settle(5 * time.Second)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.NotNil)
+
+	// Validate
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 1)
+	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+
+	var stateConns map[string]interface{}
+	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
+	c.Assert(stateConns, check.HasLen, 1)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 4)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
@@ -1092,6 +1026,9 @@ func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 	conns, err = repo.Connections(s.prj.ProjectId, "ws", "producer")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 0)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
 func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
@@ -1138,6 +1075,9 @@ func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 1)
 	c.Assert(conns[connRefKey].Undesired, check.Equals, true)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
 func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
@@ -1183,9 +1123,12 @@ func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 	var conns map[string]*schema.ConnState
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) connectChange(c *check.C, workshop string, auto bool) *state.Change {
+func (s *interfaceHandlersSuite) connectChange(workshop string, auto bool, delayedBacked bool) *state.Change {
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("connect", "...")
@@ -1194,6 +1137,7 @@ func (s *interfaceHandlersSuite) connectChange(c *check.C, workshop string, auto
 	t1.Set("plug", plugRef)
 	t1.Set("slot", slotRef)
 	t1.Set("auto", auto)
+	t1.Set("delayed-setup-profile", delayedBacked)
 	setWorkshopProject(workshop, s.prj, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
@@ -1213,7 +1157,7 @@ func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
-	chg := s.connectChange(c, "ws", false)
+	chg := s.connectChange("ws", false, true)
 
 	err := s.o.Settle(5 * time.Second)
 	c.Check(err, check.IsNil)
@@ -1229,6 +1173,41 @@ func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
 	c.Assert(conns, check.HasLen, 1)
 	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
 	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestConnectSuccessSetupBackend(c *check.C) {
+	// Setup
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	chg := s.connectChange("ws", false, false)
+
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	c.Assert(chg.Tasks()[0].Status(), check.Equals, state.DoneStatus)
+	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
 func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
@@ -1241,7 +1220,7 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
 
-	chg := s.connectChange(c, "ws", false)
+	chg := s.connectChange("ws", false, true)
 	s.state.Lock()
 	chg.Tasks()[0].Set("plug-dynamic", map[string]interface{}{"dynamic": "value"})
 	s.state.Unlock()
@@ -1279,7 +1258,7 @@ func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
-	chg := s.connectChange(c, "ws", true)
+	chg := s.connectChange("ws", true, true)
 
 	err := s.o.Settle(5 * time.Second)
 	c.Check(err, check.IsNil)
@@ -1308,6 +1287,94 @@ func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 			DynamicSlotAttrs: map[string]interface{}{},
 		},
 	})
+}
+
+func (s *interfaceHandlersSuite) TestUndoConnectUndesired(c *check.C) {
+	// Setup
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	s.state.Lock()
+	s.state.Set("conns", map[string]interface{}{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+			"auto":      true,
+			"interface": "mock-network",
+			"undesired": true,
+		}})
+	s.state.Unlock()
+
+	// Execute
+	chg := s.connectChange("ws", false, true)
+	s.state.Lock()
+	t := chg.Tasks()[0]
+	et := s.state.NewTask("error-trigger", "...")
+	et.WaitFor(t)
+	chg.AddTask(et)
+	s.state.Unlock()
+
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Validate
+	c.Assert(t.Status(), check.Equals, state.UndoneStatus)
+	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 0)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+
+	var afterUndo map[string]*schema.ConnState
+	err = s.state.Get("conns", &afterUndo)
+	c.Assert(afterUndo, check.DeepEquals, map[string]*schema.ConnState{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": {
+			Auto:      true,
+			Interface: "mock-network",
+			Undesired: true,
+		}})
+}
+
+func (s *interfaceHandlersSuite) TestUndoConnectBackendSetup(c *check.C) {
+	// Setup
+	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	chg := s.connectChange("ws", false, false)
+	s.state.Lock()
+	t := chg.Tasks()[0]
+	et := s.state.NewTask("error-trigger", "...")
+	et.WaitFor(t)
+	chg.AddTask(et)
+	s.state.Unlock()
+
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Validate
+	c.Assert(t.Status(), check.Equals, state.UndoneStatus)
+	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 0)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 4)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
 func (s *interfaceHandlersSuite) TestDiscardConnsSuccess(c *check.C) {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -111,6 +111,11 @@ func (s *interfaceHandlersSuite) TearDownTest(c *check.C) {
 	s.restoreSecurtityBackends()
 }
 
+func (s *interfaceHandlersSuite) settle(c *check.C) {
+	err := s.o.Settle(5 * time.Second)
+	c.Check(err, check.IsNil)
+}
+
 func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
 	for _, i := range tasks {
 		i.Set("workshop", w)
@@ -125,35 +130,38 @@ type simpleIface struct {
 func (si simpleIface) Name() string                                            { return si.name }
 func (si simpleIface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool { return true }
 
-func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) {
-	// Setup
-	// Create an already installed workshop with a candidate SDK/slot
-	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
-
-	// Launch another workshop with a candidate plug
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
-
-	// Execute
-	s.state.Lock()
+func (s *interfaceHandlersSuite) newAutoconnectChange() *state.Change {
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("auto-connect", "...")
 	t1.Set("sdk", "consumer")
 	setWorkshopProject("ws", s.prj, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
+	return chg
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a candidate SDK/slot
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	// Launch another workshop with a candidate plug
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumer})
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange()
 	s.state.Unlock()
 
-	err := s.o.Settle(5 * time.Second)
-	c.Check(err, check.IsNil)
+	s.settle(c)
 
 	s.state.Lock()
 	defer s.state.Unlock()
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus, check.Commentf("%v", t1.Log()))
 	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
@@ -177,14 +185,75 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
+func (s *interfaceHandlersSuite) TestAutoconnectBoundPlugConnected(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a candidate SDK/slot
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
+	c.Check(err, check.IsNil)
+	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
+	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: "consumer:plug2"}
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange()
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	pconns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(pconns, check.HasLen, 3)
+	c.Assert(err, check.IsNil)
+
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Assert(ref, check.HasLen, 3)
+	c.Assert(err, check.IsNil)
+
+	var conns map[string]interface{}
+	s.state.Get("conns", &conns)
+	c.Assert(conns, check.DeepEquals, map[string]interface{}{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"bind": map[string]interface{}{
+				"plug": map[string]interface{}{"project-id": s.prj.ProjectId, "workshop": "ws", "sdk": "consumer", "plug": "plug2"},
+				"slot": map[string]interface{}{"project-id": s.prj.ProjectId, "workshop": "ws-producer", "sdk": "producer", "slot": "slot"},
+			}},
+		},
+		"42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot": map[string]interface{}{
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]interface{}{"attribute": "two"},
+		},
+		"42424242/ws/consumer:plug3 42424242/ws-producer/producer:slot": map[string]interface{}{
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]interface{}{"attribute": "three"},
+		},
+	})
+
+	// ensure that backend profiles were set for both SDKs
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
 func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 	// Setup
 	// Create an already launched workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
-	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerManyPlugs})
+	s.launchWorkshop(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerManyPlugs})
 
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
 		return errors.New("cannot finish backend setup")
@@ -193,12 +262,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 
 	// Execute
 	s.state.Lock()
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws-consumer", s.prj, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
+	chg := s.newAutoconnectChange()
 	s.state.Unlock()
 
 	err := s.o.Settle(5 * time.Second)
@@ -222,7 +286,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingContentTargets(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		{Name: "conflict-1", Channel: "latest/stable"}: conflictingTarget1,
 		{Name: "conflict-2", Channel: "latest/stable"}: conflictingTarget2,
 	})
@@ -254,8 +318,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingContentTargets
 func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	// Launch a workshop with a candidate plug
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumer})
 
 	// Execute
 	s.state.Lock()
@@ -282,7 +345,6 @@ func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.DeepEquals, map[string]interface{}(nil))
 
-	// ensure that backend profiles were set for both SDKs
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 }
 
@@ -290,11 +352,11 @@ func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumer})
 
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
@@ -342,7 +404,7 @@ slots:
   slot:
     interface: content
 `
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: sdkYaml})
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: sdkYaml})
 
 	t1 := s.state.NewTask("auto-connect", "test")
 	t1.Set("sdk", "consumer")
@@ -366,18 +428,18 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumer})
 
 	// Execute
 	s.state.Lock()
 	chg := s.state.NewChange("refresh", "...")
 	// existing remounts that should be preserved after refresh
-	chg.Set("remounts", map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{"source": "/old/source"},
+	chg.Set("remounts", map[string]string{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": "/old/source",
 	})
 	t1 := s.state.NewTask("auto-connect", "...")
 	t1.Set("sdk", "consumer")
@@ -446,7 +508,7 @@ slots:
     slot:
         interface: content        
 `
-	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
+	s.launchWorkshop(c, "ws-consumer", map[sdk.Setup]string{csetup: sdkYaml})
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, agentYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
@@ -717,7 +779,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a connected plug
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws-consumer", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -793,7 +855,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	c.Assert(chg.Get("remounts", &attrs), check.IsNil)
 	c.Assert(attrs, check.HasLen, 1)
 	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/agent:slot"],
-		check.DeepEquals, map[string]interface{}{"source": source})
+		check.DeepEquals, source)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
@@ -802,7 +864,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a content plug
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -831,7 +893,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 func (s *interfaceHandlersSuite) TestAutoDisconnectNoSdkProfile(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -870,7 +932,7 @@ func (s *interfaceHandlersSuite) newUndoDisconnectInterfacesChange(sdkName strin
 func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesSuccess(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws-consumer", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -921,7 +983,7 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesSuccess(c *check.C)
 func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesManualRestored(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshopWithSDKs(c, "ws-consumer", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws-consumer", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -990,7 +1052,7 @@ func (s *interfaceHandlersSuite) disconnectChange(c *check.C, workshop string, f
 
 func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1033,7 +1095,7 @@ func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1082,7 +1144,7 @@ func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1148,7 +1210,7 @@ func (s *interfaceHandlersSuite) connectChange(workshop string, auto bool, delay
 
 func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1180,7 +1242,7 @@ func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestConnectSuccessSetupBackend(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1212,7 +1274,7 @@ func (s *interfaceHandlersSuite) TestConnectSuccessSetupBackend(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1249,7 +1311,7 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1291,7 +1353,7 @@ func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoConnectUndesired(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1344,7 +1406,7 @@ func (s *interfaceHandlersSuite) TestUndoConnectUndesired(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoConnectBackendSetup(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1379,7 +1441,7 @@ func (s *interfaceHandlersSuite) TestUndoConnectBackendSetup(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestDiscardConnsSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})
@@ -1452,7 +1514,7 @@ func (s *interfaceHandlersSuite) TestDiscardConnsSuccess(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoDiscardConnsSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		csetup: consumer,
 		psetup: producer,
 	})

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -374,51 +374,6 @@ func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectUndoSuccess(c *check.C) {
-	// Setup
-	// Create an already installed workshop with a candidate SDK/slot
-	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
-
-	// Launch another workshop with a candidate plug
-	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-
-	s.state.Lock()
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "consumer")
-	t2 := s.state.NewTask("error-trigger", "...")
-	setWorkshopProject("ws", s.prj, t1)
-	setWorkshopProject("ws", s.prj, t2)
-	t2.WaitFor(t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-	chg.AddTask(t2)
-	s.state.Unlock()
-
-	s.settle(c)
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	c.Assert(t1.Status(), check.Equals, state.UndoneStatus)
-	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
-	c.Assert(ref, check.HasLen, 0)
-	c.Assert(err, check.ErrorMatches, "sdk \"consumer\" has no plug or slot named \"plug\"")
-
-	ref, err = repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
-	c.Assert(ref, check.HasLen, 0)
-	c.Assert(err, check.IsNil)
-
-	// ensure that backend profiles were set for both SDKs in Do
-	// and unset for producer in Undo
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2+1)
-	// ensure that the backend profile was removed for consumer in Undo
-	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
-}
-
 func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -195,7 +195,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBoundPlugConnected(c *check.C) {
 	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
 	c.Check(err, check.IsNil)
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: "consumer:plug2"}
+	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug2"}}
 
 	// Execute
 	s.state.Lock()

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -26,7 +26,8 @@ type interfaceHandlersSuite struct {
 	mgr                      *ifacestate.InterfaceManager
 	restoreInterface         func()
 	restoreSecurtityBackends func()
-	setup                    sync.Once
+	// pointer as to avoid test fails with -count
+	setup *sync.Once
 }
 
 var _ = check.Suite(&interfaceHandlersSuite{})
@@ -87,6 +88,7 @@ base: ubuntu@22.04
 `
 
 func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
+	s.setup = new(sync.Once)
 	s.interfaceManagerSuite.SetUpTest(c)
 	s.restoreInterface = builtin.MockInterface(simpleIface{name: "mock-network"})
 
@@ -482,8 +484,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectReconnectsExistingConnections(c 
 	defer s.state.Unlock()
 
 	// Validate
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
-	c.Assert(t2.Status(), check.Equals, state.DoneStatus)
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus, check.Commentf("%v", chg.Err()))
+	c.Assert(t2.Status(), check.Equals, state.DoneStatus, check.Commentf("%v", chg.Err()))
 
 	var conns map[string]interface{}
 	s.state.Get("conns", &conns)
@@ -540,6 +542,10 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugs(c *check.C) {
 	repo := s.mgr.Repository()
 	s.launchWorkshopWithSDKs(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+	cref := interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-producer", Sdk: "producer", Name: "slot"},
+	}
 
 	// Launch another workshop with a candidate plug
 	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{csetup: consumer})
@@ -549,8 +555,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugs(c *check.C) {
 	chg := s.state.NewChange("refresh", "...")
 	t := s.state.NewTask("auto-disconnect", "...")
 	// see doAutoConnect and doDisconnect handlers for details
-	t.Set("plugs-to-remount", map[string]map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": {"source": "/old/source"},
+	chg.Set("remounts", map[string]map[string]interface{}{
+		cref.ID(): {"source": "/old/source"},
 	})
 	t.Set("sdk", "consumer")
 	t.SetStatus(state.DoneStatus)
@@ -964,10 +970,14 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	repo := s.mgr.Repository()
 	s.launchRemountWorkshop(c)
 
-	connRefKey := "42424242/ws-consumer/consumer:plug 42424242/ws-consumer/agent:slot"
+	connRef := &interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
+		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "agent", Name: "slot"},
+	}
+
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
-		connRefKey: map[string]interface{}{
+		connRef.ID(): map[string]interface{}{
 			"interface":    "content",
 			"auto":         true,
 			"plug-static":  map[string]interface{}{"attribute": "one"},
@@ -1004,9 +1014,9 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	c.Assert(stateConns, check.HasLen, 0)
 
 	var attrs map[string]interface{}
-	c.Assert(t1.Get("plugs-to-remount", &attrs), check.IsNil)
+	c.Assert(chg.Get("remounts", &attrs), check.IsNil)
 	c.Assert(attrs, check.HasLen, 1)
-	c.Assert(attrs[connRefKey], check.DeepEquals, map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"})
+	c.Assert(attrs[connRef.ID()], check.DeepEquals, map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"})
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -33,13 +33,13 @@ func New(s *state.State, r *state.TaskRunner, be workshop.Backend) *InterfaceMan
 	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), m.undoAutoConnect)
 	r.AddHandler("auto-disconnect", OnDo(m.doDisconnectInterfaces), nil)
 
-	r.AddHandler("connect", m.doConnect, m.undoConnect)
-	r.AddHandler("disconnect", m.doDisconnect, m.undoDisconnect)
+	r.AddHandler("connect", OnDo(m.doConnect), m.undoConnect)
+	r.AddHandler("disconnect", OnDo(m.doDisconnect), m.undoDisconnect)
 
 	r.AddHandler("discard-conns", m.doDiscard, m.undoDiscard)
 
-	r.AddHandler("setup-profiles", m.doSetupProfiles, m.undoSetupProfiles)
-	r.AddHandler("remove-profiles", m.doRemoveProfiles, m.undoRemoveProfiles)
+	r.AddHandler("setup-profiles", OnDo(m.doSetupProfiles), m.undoSetupProfiles)
+	r.AddHandler("remove-profiles", OnDo(m.doRemoveProfiles), m.undoRemoveProfiles)
 
 	// TODO: there is no use for the undo logic as remount is a single task
 	// change that will either finish successfully or fail (in which case it

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -30,7 +30,7 @@ func New(s *state.State, r *state.TaskRunner, be workshop.Backend) *InterfaceMan
 		repo:    interfaces.NewRepository(),
 	}
 
-	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), m.undoAutoConnect)
+	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), nil)
 	r.AddHandler("auto-disconnect", OnDo(m.doDisconnectInterfaces), nil)
 
 	r.AddHandler("connect", OnDo(m.doConnect), m.undoConnect)

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -33,9 +33,12 @@ func New(s *state.State, r *state.TaskRunner, be workshop.Backend) *InterfaceMan
 	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), m.undoAutoConnect)
 	r.AddHandler("auto-disconnect", OnDo(m.doAutoDisconnect), m.undoAutoDisconnect)
 
-	r.AddHandler("connect", m.doConnect, nil)
+	r.AddHandler("connect", m.doConnect, m.doDisconnect)
 	r.AddHandler("disconnect", m.doDisconnect, nil)
+
 	r.AddHandler("discard-conns", m.doDiscard, m.undoDiscard)
+
+	r.AddHandler("setup-profiles", m.doSetupProfiles, m.undoSetupProfiles)
 
 	// TODO: there is no use for the undo logic as remount is a single task
 	// change that will either finish successfully or fail (in which case it
@@ -381,8 +384,9 @@ func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string
 		} else {
 			// If the connection succeeded update the connection state and keep
 			// track of the sdks that were affected.
-			affected[sdk.Ref{ProjectId: connRef.PlugRef.ProjectId, Workshop: connRef.PlugRef.Workshop, Sdk: connRef.PlugRef.Sdk}] = true
-			affected[sdk.Ref{ProjectId: connRef.SlotRef.ProjectId, Workshop: connRef.SlotRef.Workshop, Sdk: connRef.SlotRef.Sdk}] = true
+
+			affected[plugInfo.Sdk.Ref()] = true
+			affected[slotInfo.Sdk.Ref()] = true
 		}
 	}
 	if connStateChanged {

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -31,14 +31,15 @@ func New(s *state.State, r *state.TaskRunner, be workshop.Backend) *InterfaceMan
 	}
 
 	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), m.undoAutoConnect)
-	r.AddHandler("auto-disconnect", OnDo(m.doAutoDisconnect), m.undoAutoDisconnect)
+	r.AddHandler("auto-disconnect", OnDo(m.doDisconnectInterfaces), nil)
 
-	r.AddHandler("connect", m.doConnect, m.doDisconnect)
-	r.AddHandler("disconnect", m.doDisconnect, nil)
+	r.AddHandler("connect", m.doConnect, m.undoConnect)
+	r.AddHandler("disconnect", m.doDisconnect, m.undoDisconnect)
 
 	r.AddHandler("discard-conns", m.doDiscard, m.undoDiscard)
 
 	r.AddHandler("setup-profiles", m.doSetupProfiles, m.undoSetupProfiles)
+	r.AddHandler("remove-profiles", m.doRemoveProfiles, m.undoRemoveProfiles)
 
 	// TODO: there is no use for the undo logic as remount is a single task
 	// change that will either finish successfully or fail (in which case it

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -71,7 +71,7 @@ func (s *interfaceManagerSuite) writeSDKMetaFile(c *check.C, fs workshop.Worksho
 	c.Assert(afero.WriteFile(fs, sdkPath, []byte(yaml), 0644), check.IsNil)
 }
 
-func (s *interfaceManagerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdkYamls map[sdk.Setup]string) {
+func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdkYamls map[sdk.Setup]string) (*workshop.Workshop, error) {
 	ctx := context.WithValue(s.ctx, workshop.ContextProjectId, s.prj.ProjectId)
 
 	t, err := template.New("workshop").Parse(fmt.Sprintf(workshopTemplate, ws))
@@ -104,6 +104,8 @@ slots:
 	for sdk, yaml := range sdkYamls {
 		s.writeSDKMetaFile(c, wsfs, sdk.Name, yaml)
 	}
+
+	return s.wsbackend.Workshop(ctx, ws)
 }
 
 func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *check.C) {
@@ -116,7 +118,7 @@ plugs:
   attr: plug-value
 `
 
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		{Name: "consumer", Channel: "latest/stable"}: consumerYaml,
 	})
 
@@ -184,7 +186,7 @@ slots:
   interface: content
   attr2: value2
 `
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		{Name: "consumer", Channel: "latest/stable"}: consumerYaml,
 		{Name: "producer", Channel: "latest/stable"}: producerYaml,
 	})
@@ -227,7 +229,7 @@ slots:
   interface: content
   attr2: value2
 `
-	s.launchWorkshopWithSDKs(c, "ws", map[sdk.Setup]string{
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
 		{Name: "consumer", Channel: "latest/stable"}: consumerYaml,
 		{Name: "producer", Channel: "latest/stable"}: producerYaml,
 	})

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -66,7 +66,17 @@ func Connect(st *state.State, w *workshop.Workshop, connRef *interfaces.ConnRef)
 	return ts, nil
 }
 
-func Forget(st *state.State, conn *interfaces.ConnRef, forget bool) (*state.TaskSet, error) {
+func disconnect(st *state.State, conn *interfaces.ConnRef, forget bool) *state.TaskSet {
+	dt := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", conn.PlugRef.ShortRef(), conn.SlotRef.ShortRef()))
+	dt.Set("plug", conn.PlugRef)
+	dt.Set("slot", conn.SlotRef)
+	dt.Set("forget", forget)
+
+	return state.NewTaskSet(dt)
+}
+
+// Disconnect returns a set of tasks for disconnecting an interface.
+func Disconnect(st *state.State, conn *interfaces.ConnRef, forget bool) (*state.TaskSet, error) {
 	plugProject, plugWorkshop := conn.PlugRef.ProjectId, conn.PlugRef.Workshop
 	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
 	if err != nil {
@@ -78,36 +88,5 @@ func Forget(st *state.State, conn *interfaces.ConnRef, forget bool) (*state.Task
 	if err != nil {
 		return nil, err
 	}
-
-	disconnectTask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s/%s:%s from %s/%s:%s", plugWorkshop, conn.PlugRef.Sdk, conn.PlugRef.Name,
-		slotWorkshop, conn.SlotRef.Sdk, conn.SlotRef.Name))
-
-	disconnectTask.Set("slot", conn.SlotRef)
-	disconnectTask.Set("plug", conn.PlugRef)
-	disconnectTask.Set("forget", true)
-	return state.NewTaskSet(disconnectTask), nil
-}
-
-// Disconnect returns a set of tasks for disconnecting an interface.
-func Disconnect(st *state.State, conn *interfaces.Connection, forget bool) (*state.TaskSet, error) {
-	plugProject, plugWorkshop := conn.Plug.Ref().ProjectId, conn.Plug.Ref().Workshop
-	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
-	if err != nil {
-		return nil, err
-	}
-
-	slotProject, slotWorkshop := conn.Slot.Ref().ProjectId, conn.Slot.Ref().Workshop
-	err = conflict.CheckChangeConflict(st, slotProject, slotWorkshop, "")
-	if err != nil {
-		return nil, err
-	}
-
-	disconnectTask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s/%s:%s from %s/%s:%s", plugWorkshop, conn.Plug.Ref().Sdk, conn.Plug.Name(),
-		slotWorkshop, conn.Slot.Ref().Sdk, conn.Slot.Ref().Name))
-
-	disconnectTask.Set("slot", conn.Slot.Ref())
-	disconnectTask.Set("plug", conn.Plug.Ref())
-	disconnectTask.Set("forget", forget)
-
-	return state.NewTaskSet(disconnectTask), nil
+	return disconnect(st, conn, forget), nil
 }

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -6,6 +6,7 @@ import (
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 // ErrAlreadyConnected describes the error that occurs when attempting to connect already connected interface.
@@ -18,7 +19,7 @@ func (e ErrAlreadyConnected) Error() string {
 }
 
 // Connect returns a set of tasks for connecting an interface.
-func Connect(st *state.State, connRef *interfaces.ConnRef) (*state.TaskSet, error) {
+func Connect(st *state.State, w *workshop.Workshop, connRef *interfaces.ConnRef) (*state.TaskSet, error) {
 	plugProject, plugWorkshop := connRef.PlugRef.ProjectId, connRef.PlugRef.Workshop
 	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
 	if err != nil {
@@ -40,14 +41,29 @@ func Connect(st *state.State, connRef *interfaces.ConnRef) (*state.TaskSet, erro
 		return nil, &ErrAlreadyConnected{Connection: *connRef}
 	}
 
-	connectInterface := st.NewTask("connect", fmt.Sprintf("Connect %s/%s:%s to %s/%s:%s", plugWorkshop, connRef.PlugRef.Sdk, connRef.PlugRef.Name,
-		slotWorkshop, connRef.SlotRef.Sdk, connRef.SlotRef.Name))
+	master, affected := maybeBound(w, connRef.PlugRef)
+	masterTask := st.NewTask("connect", fmt.Sprintf("Connect %s to %s", master.ShortRef(), connRef.SlotRef.ShortRef()))
 
-	connectInterface.Set("slot", connRef.SlotRef)
-	connectInterface.Set("plug", connRef.PlugRef)
-	connectInterface.Set("delayed-setup-profile", false)
+	masterTask.Set("slot", connRef.SlotRef)
+	masterTask.Set("plug", master)
+	masterTask.Set("delayed-setup-profile", false)
 
-	return state.NewTaskSet(connectInterface), nil
+	ts := state.NewTaskSet(masterTask)
+	prev := masterTask
+	for _, p := range affected {
+		slave := st.NewTask("connect", fmt.Sprintf("Connect %s to %s", p.ShortRef(), connRef.SlotRef.ShortRef()))
+		slave.Set("slot", connRef.SlotRef)
+		slave.Set("plug", p)
+		slave.Set("delayed-setup-profile", true)
+		slave.Set("plug-dynamic", map[string]interface{}{
+			"bind": map[string]interface{}{"plug": connRef.PlugRef, "slot": connRef.SlotRef}})
+
+		slave.WaitFor(prev)
+		prev = slave
+		ts.AddTask(slave)
+	}
+
+	return ts, nil
 }
 
 func Forget(st *state.State, conn *interfaces.ConnRef, forget bool) (*state.TaskSet, error) {

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -48,6 +48,10 @@ func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.Conn
 	masterTask.Set("plug", master)
 	masterTask.Set("delayed-setup-profile", false)
 
+	// master's plug connection that every other connection from affected will
+	// be bound to.
+	bref := interfaces.ConnRef{PlugRef: master, SlotRef: connRef.SlotRef}
+
 	ts := state.NewTaskSet(masterTask)
 	prev := masterTask
 	for _, p := range affected {
@@ -55,8 +59,7 @@ func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.Conn
 		slave.Set("slot", connRef.SlotRef)
 		slave.Set("plug", p)
 		slave.Set("delayed-setup-profile", true)
-		// mark the plug's connection as bound
-		bref := interfaces.ConnRef{PlugRef: master, SlotRef: connRef.SlotRef}
+
 		slave.Set("plug-dynamic", map[string]interface{}{"bind": bref.ID()})
 
 		slave.WaitFor(prev)

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -41,7 +41,7 @@ func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.Conn
 		return nil, &ErrAlreadyConnected{Connection: *connRef}
 	}
 
-	master, affected := maybeBound(plugW, connRef.PlugRef)
+	master, affected := MaybeBound(plugW, connRef.PlugRef)
 	masterTask := st.NewTask("connect", fmt.Sprintf("Connect %s to %s", master.ShortRef(), connRef.SlotRef.ShortRef()))
 
 	masterTask.Set("slot", connRef.SlotRef)
@@ -68,7 +68,7 @@ func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.Conn
 }
 
 func disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool) *state.TaskSet {
-	master, affected := maybeBound(plugW, conn.PlugRef)
+	master, affected := MaybeBound(plugW, conn.PlugRef)
 
 	mtask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", master, conn.SlotRef.ShortRef()))
 	mtask.Set("plug", master)

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -45,6 +45,7 @@ func Connect(st *state.State, connRef *interfaces.ConnRef) (*state.TaskSet, erro
 
 	connectInterface.Set("slot", connRef.SlotRef)
 	connectInterface.Set("plug", connRef.PlugRef)
+	connectInterface.Set("delayed-setup-profile", false)
 
 	return state.NewTaskSet(connectInterface), nil
 }

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -19,7 +19,7 @@ func (e ErrAlreadyConnected) Error() string {
 }
 
 // Connect returns a set of tasks for connecting an interface.
-func Connect(st *state.State, w *workshop.Workshop, connRef *interfaces.ConnRef) (*state.TaskSet, error) {
+func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.ConnRef) (*state.TaskSet, error) {
 	plugProject, plugWorkshop := connRef.PlugRef.ProjectId, connRef.PlugRef.Workshop
 	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
 	if err != nil {
@@ -41,7 +41,7 @@ func Connect(st *state.State, w *workshop.Workshop, connRef *interfaces.ConnRef)
 		return nil, &ErrAlreadyConnected{Connection: *connRef}
 	}
 
-	master, affected := maybeBound(w, connRef.PlugRef)
+	master, affected := maybeBound(plugW, connRef.PlugRef)
 	masterTask := st.NewTask("connect", fmt.Sprintf("Connect %s to %s", master.ShortRef(), connRef.SlotRef.ShortRef()))
 
 	masterTask.Set("slot", connRef.SlotRef)
@@ -55,8 +55,9 @@ func Connect(st *state.State, w *workshop.Workshop, connRef *interfaces.ConnRef)
 		slave.Set("slot", connRef.SlotRef)
 		slave.Set("plug", p)
 		slave.Set("delayed-setup-profile", true)
+		// mark the plug's connection as bound
 		slave.Set("plug-dynamic", map[string]interface{}{
-			"bind": map[string]interface{}{"plug": connRef.PlugRef, "slot": connRef.SlotRef}})
+			"bind": connRef.ID()})
 
 		slave.WaitFor(prev)
 		prev = slave
@@ -66,17 +67,31 @@ func Connect(st *state.State, w *workshop.Workshop, connRef *interfaces.ConnRef)
 	return ts, nil
 }
 
-func disconnect(st *state.State, conn *interfaces.ConnRef, forget bool) *state.TaskSet {
-	dt := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", conn.PlugRef.ShortRef(), conn.SlotRef.ShortRef()))
-	dt.Set("plug", conn.PlugRef)
-	dt.Set("slot", conn.SlotRef)
-	dt.Set("forget", forget)
+func disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool) *state.TaskSet {
+	master, affected := maybeBound(plugW, conn.PlugRef)
 
-	return state.NewTaskSet(dt)
+	mtask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", master, conn.SlotRef.ShortRef()))
+	mtask.Set("plug", master)
+	mtask.Set("slot", conn.SlotRef)
+	mtask.Set("forget", forget)
+	ts := state.NewTaskSet(mtask)
+	prev := mtask
+
+	for _, p := range affected {
+		stask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", p, conn.SlotRef.ShortRef()))
+		stask.Set("plug", p)
+		stask.Set("slot", conn.SlotRef)
+		stask.Set("forget", forget)
+
+		stask.WaitFor(prev)
+		prev = stask
+		ts.AddTask(stask)
+	}
+	return ts
 }
 
 // Disconnect returns a set of tasks for disconnecting an interface.
-func Disconnect(st *state.State, conn *interfaces.ConnRef, forget bool) (*state.TaskSet, error) {
+func Disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool) (*state.TaskSet, error) {
 	plugProject, plugWorkshop := conn.PlugRef.ProjectId, conn.PlugRef.Workshop
 	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
 	if err != nil {
@@ -88,5 +103,5 @@ func Disconnect(st *state.State, conn *interfaces.ConnRef, forget bool) (*state.
 	if err != nil {
 		return nil, err
 	}
-	return disconnect(st, conn, forget), nil
+	return disconnect(st, plugW, conn, forget), nil
 }

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -109,10 +109,5 @@ func Disconnect(st *state.State, conn *interfaces.Connection, forget bool) (*sta
 	disconnectTask.Set("plug", conn.Plug.Ref())
 	disconnectTask.Set("forget", forget)
 
-	disconnectTask.Set("slot-static", conn.Slot.StaticAttrs())
-	disconnectTask.Set("slot-dynamic", conn.Slot.DynamicAttrs())
-	disconnectTask.Set("plug-static", conn.Plug.StaticAttrs())
-	disconnectTask.Set("plug-dynamic", conn.Plug.DynamicAttrs())
-
 	return state.NewTaskSet(disconnectTask), nil
 }

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -56,8 +56,8 @@ func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.Conn
 		slave.Set("plug", p)
 		slave.Set("delayed-setup-profile", true)
 		// mark the plug's connection as bound
-		slave.Set("plug-dynamic", map[string]interface{}{
-			"bind": connRef.ID()})
+		bref := interfaces.ConnRef{PlugRef: master, SlotRef: connRef.SlotRef}
+		slave.Set("plug-dynamic", map[string]interface{}{"bind": bref.ID()})
 
 		slave.WaitFor(prev)
 		prev = slave

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -137,6 +137,9 @@ func New(dir string, b backend.Backend, restartHandler restart.Handler) (*Overlo
 	o.stateEng = NewStateEngine(s)
 	o.runner = state.NewTaskRunner(s)
 
+	sto := store.New()
+	sdk.ReplaceStore(s, sto)
+
 	// any unknown task should be ignored and succeed
 	matchAnyUnknownTask := func(_ *state.Task) bool {
 		return true
@@ -162,9 +165,6 @@ func New(dir string, b backend.Backend, restartHandler restart.Handler) (*Overlo
 
 	// the shared task runner should be added last!
 	o.stateEng.AddManager(o.runner)
-
-	sto := store.New()
-	sdk.ReplaceStore(s, sto)
 
 	return o, nil
 }

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -39,7 +39,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	workshop "github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
-	workshop1 "github.com/canonical/workshop/internal/workshop"
+	backend "github.com/canonical/workshop/internal/workshop"
 )
 
 var (
@@ -60,7 +60,7 @@ var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
 type Overlord struct {
 	stateDir        string
 	stateEng        *StateEngine
-	workshopBackend workshop1.Backend
+	workshopBackend backend.Backend
 
 	// ensure loop
 	loopTomb    *tomb.Tomb
@@ -88,7 +88,7 @@ type Overlord struct {
 
 // New creates a new Overlord with all its state managers.
 // It can be provided with an optional restart.Handler.
-func New(dir string, b workshop1.Backend, restartHandler restart.Handler) (*Overlord, error) {
+func New(dir string, b backend.Backend, restartHandler restart.Handler) (*Overlord, error) {
 	o := &Overlord{
 		stateDir: dir,
 		loopTomb: new(tomb.Tomb),
@@ -146,9 +146,6 @@ func New(dir string, b workshop1.Backend, restartHandler restart.Handler) (*Over
 	o.workshopmgr = workshop.New(s, o.runner, o.workshopBackend)
 	o.addManager(o.workshopmgr)
 
-	o.sdk = sdkstate.New(o.runner, o.workshopBackend)
-	o.addManager(o.sdk)
-
 	o.hookmgr = hookstate.New(s, o.runner, o.workshopBackend)
 	o.addManager(o.hookmgr)
 
@@ -159,6 +156,9 @@ func New(dir string, b workshop1.Backend, restartHandler restart.Handler) (*Over
 
 	o.ifacemgr = ifacestate.New(s, o.runner, o.workshopBackend)
 	o.addManager(o.ifacemgr)
+
+	o.sdk = sdkstate.New(o.runner, o.ifacemgr.Repository(), o.workshopBackend)
+	o.addManager(o.sdk)
 
 	// the shared task runner should be added last!
 	o.stateEng.AddManager(o.runner)
@@ -461,7 +461,7 @@ func (o *Overlord) TaskRunner() *state.TaskRunner {
 	return o.runner
 }
 
-func (o *Overlord) WorkshopBackend() workshop1.Backend {
+func (o *Overlord) WorkshopBackend() backend.Backend {
 	return o.workshopBackend
 }
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/dirs"
-	store "github.com/canonical/workshop/internal/fakestore"
 	"github.com/canonical/workshop/internal/interfaces/policy"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
@@ -24,8 +22,6 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
-
-var InstallTimeNow = time.Now
 
 func SdkSetup(task *state.Task) (sdk.Setup, error) {
 	st := task.State()
@@ -72,27 +68,11 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	client := store.New()
+	st.Lock()
+	store := sdk.StoreService(st)
+	st.Unlock()
 
-	return client.DownloadSdk(ctx, rec)
-}
-
-func installAgentSdk(wfs workshop.WorkshopFs, base string) error {
-	agentMetaDir := filepath.Join(sdk.SdkCurrentPath("agent"), "meta")
-	if err := wfs.MkdirAll(agentMetaDir, 0655); err != nil {
-		return err
-	}
-
-	// /var/lib/workshop/sdk/agent/current/meta
-	file, err := wfs.OpenFile(filepath.Join(agentMetaDir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
-	if err != nil {
-		return err
-	}
-
-	if _, err = file.Write([]byte(sdk.AgentSdkMeta(base))); err != nil {
-		return err
-	}
-	return nil
+	return store.DownloadSdk(ctx, rec)
 }
 
 func (m *SdkManager) doInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -109,13 +89,7 @@ func (m *SdkManager) doInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error 
 		return err
 	}
 
-	wfs, err := m.backend.WorkshopFs(ctx, w)
-	if err != nil {
-		return err
-	}
-	defer wfs.Close()
-
-	return installAgentSdk(wfs, wp.Base)
+	return wp.InstallAgentSdk(ctx)
 }
 
 func (m *SdkManager) undoInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -13,10 +14,12 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	store "github.com/canonical/workshop/internal/fakestore"
+	"github.com/canonical/workshop/internal/interfaces/policy"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -74,7 +77,66 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return client.DownloadSdk(ctx, rec)
 }
 
-func (m *SdkManager) doInstallSDK(task *state.Task, tomb *tomb.Tomb) error {
+func installAgentSdk(wfs workshop.WorkshopFs, base string) error {
+	agentMetaDir := filepath.Join(sdk.SdkCurrentPath("agent"), "meta")
+	if err := wfs.MkdirAll(agentMetaDir, 0655); err != nil {
+		return err
+	}
+
+	// /var/lib/workshop/sdk/agent/current/meta
+	file, err := wfs.OpenFile(filepath.Join(agentMetaDir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	if err != nil {
+		return err
+	}
+
+	if _, err = file.Write([]byte(sdk.AgentSdkMeta(base))); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *SdkManager) doInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error {
+	user, project, w, err := UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
+	defer cancel()
+
+	wp, err := m.backend.Workshop(ctx, w)
+	if err != nil {
+		return err
+	}
+
+	wfs, err := m.backend.WorkshopFs(ctx, w)
+	if err != nil {
+		return err
+	}
+	defer wfs.Close()
+
+	return installAgentSdk(wfs, wp.Base)
+}
+
+func (m *SdkManager) undoInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error {
+	user, project, w, err := UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
+	defer cancel()
+
+	wfs, err := m.backend.WorkshopFs(ctx, w)
+	if err != nil {
+		return err
+	}
+	defer wfs.Close()
+
+	return wfs.RemoveAll(sdk.SdkRootPath("agent"))
+}
+
+func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -192,6 +254,7 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 }
 
 func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
+	rev := revert.New()
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -205,26 +268,54 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	inst, err := m.backend.Workshop(ctx, w)
+	wp, err := m.backend.Workshop(ctx, w)
 	if err != nil {
 		return err
 	}
 
-	if err = inst.LinkSdk(ctx, setup); err != nil {
+	if err = wp.LinkSdk(ctx, setup); err != nil {
 		return err
 	}
+
+	st := task.State()
+	rev.Add(func() {
+		if err := wp.UnlinkSdk(ctx, setup.Name); err != nil {
+			st.Lock()
+			task.Logf("Link SDK cleanup: could not unlink %q SDK: %v", setup.Name, err)
+			st.Unlock()
+		}
+	})
 
 	// validate that the SDK is of the acceptable type, no non-regular SDKs are
 	// allowed from outside
-	info, err := inst.SdkInfo(ctx, setup.Name)
+	info, err := wp.SdkInfo(ctx, setup.Name)
 	if err != nil {
 		return err
 	}
 
-	if info.Type != sdk.Regular {
-		return fmt.Errorf("unknown SDK type %q", info.Type.String())
+	// add SDK's plugs and slots
+	if err := m.repo.AddSdk(info); err != nil {
+		return err
+	}
+	rev.Add(func() {
+		if err := m.repo.RemoveSdk(project.ProjectId, w, state.ErrNoState.Error()); err != nil {
+			st.Lock()
+			task.Logf("Link SDK cleanup: could not remove %q SDK: %v", setup.Name, err)
+			st.Unlock()
+		}
+	})
+
+	if err = policy.CheckInterfaces(info); err != nil {
+		return err
+	}
+	if len(info.BadInterfaces) > 0 {
+		st := task.State()
+		st.Lock()
+		task.Logf("%s", sdk.BadInterfacesSummary(info))
+		st.Unlock()
 	}
 
+	rev.Success()
 	return nil
 }
 
@@ -242,10 +333,14 @@ func (m *SdkManager) undoLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	inst, err := m.backend.Workshop(ctx, w)
+	if err := m.repo.RemoveSdk(project.ProjectId, w, sdkSetup.Name); err != nil {
+		return err
+	}
+
+	wp, err := m.backend.Workshop(ctx, w)
 	if err != nil {
 		return err
 	}
 
-	return inst.UnlinkSdk(ctx, sdkSetup.Name)
+	return wp.UnlinkSdk(ctx, sdkSetup.Name)
 }

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -229,6 +229,7 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 
 func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 	rev := revert.New()
+	defer rev.Fail()
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -272,7 +273,7 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 	rev.Add(func() {
-		if err := m.repo.RemoveSdk(project.ProjectId, w, state.ErrNoState.Error()); err != nil {
+		if err := m.repo.RemoveSdk(project.ProjectId, w, setup.Name); err != nil {
 			st.Lock()
 			task.Logf("Link SDK cleanup: could not remove %q SDK: %v", setup.Name, err)
 			st.Unlock()

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -71,7 +71,7 @@ plugs:
     attr2: value2
 `
 
-var sdkYamlBrokenPolicy = `
+var sdkYamlViolatesPolicy = `
 name: test-broken
 base: ubuntu@22.04
 plugs:
@@ -402,7 +402,7 @@ func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
 	defer s.state.Unlock()
 
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-	s.mockTestSdk(c, "test-broken", sdkYamlBrokenPolicy)
+	s.mockTestSdk(c, "test-broken", sdkYamlViolatesPolicy)
 
 	testSdk := sdk.Setup{Name: "test-broken", Channel: "latest/stable", Revision: 2, InstallTime: &s.installTime}
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -3,6 +3,7 @@ package sdkstate_test
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,9 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/ifacetest"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -22,13 +26,14 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-type H struct {
+type sdkStateSuite struct {
 	fs          afero.Fs
 	backend     *workshop.FakeWorkshopBackend
 	state       *state.State
 	runner      *state.TaskRunner
 	se          *overlord.StateEngine
-	wsmgr       *sdkstate.SdkManager
+	sdkmgr      *sdkstate.SdkManager
+	repo        *interfaces.Repository
 	ctx         context.Context
 	project     *workshop.Project
 	installTime time.Time
@@ -37,7 +42,7 @@ type H struct {
 	restoreInstallTime func()
 }
 
-var _ = check.Suite(&H{})
+var _ = check.Suite(&sdkStateSuite{})
 
 func Test(t *testing.T) { check.TestingT(t) }
 
@@ -54,7 +59,19 @@ func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
 
 var ErrTrigger = errors.New("error out")
 
-func (s *H) SetUpTest(c *check.C) {
+var sdkYaml = `
+name: test
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: test-interface
+    attr: value
+  plug2:
+    interface: test-interface
+    attr2: value2
+`
+
+func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(dirs.CreateDirs(), check.IsNil)
 
@@ -75,7 +92,10 @@ func (s *H) SetUpTest(c *check.C) {
 
 	/* empty task handler */
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
-	s.wsmgr = sdkstate.New(s.runner, s.backend)
+
+	s.repo = interfaces.NewRepository()
+	mockIface(c, s.repo, &ifacetest.TestInterface{InterfaceName: "test-interface"})
+	s.sdkmgr = sdkstate.New(s.runner, s.repo, s.backend)
 
 	/* error-provoking task handler */
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
@@ -85,7 +105,7 @@ func (s *H) SetUpTest(c *check.C) {
 
 	s.se = overlord.NewStateEngine(s.state)
 	s.se.StartUp()
-	s.se.AddManager(s.wsmgr)
+	s.se.AddManager(s.sdkmgr)
 	s.se.AddManager(s.runner)
 
 	s.installTime = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
@@ -95,31 +115,28 @@ func (s *H) SetUpTest(c *check.C) {
 	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Assert(err, check.IsNil)
 
-	var sdkYaml = `
-name: test
-base: ubuntu@22.04
-plugs:
-  plug:
-    interface: content
-    target: /project/sub
-`
-	s.mockTestSdk(c, sdkYaml)
+	s.mockTestSdk(c, "test", sdkYaml)
 }
 
-func (s *H) mockTestSdk(c *check.C, sdkYaml string) {
-	sdkPath := filepath.Join(dirs.WorkshopSdksDir, "test", "current", "meta", "sdk.yaml")
+func (s *sdkStateSuite) mockTestSdk(c *check.C, name, sdkYaml string) {
+	sdkPath := filepath.Join(dirs.WorkshopSdksDir, name, "current", "meta", "sdk.yaml")
 	fs, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
 	err = afero.WriteFile(fs, sdkPath, []byte(sdkYaml), 0644)
 	c.Assert(err, check.IsNil)
 }
 
-func (s *H) TearDownTest(c *check.C) {
+func mockIface(c *check.C, repo *interfaces.Repository, iface interfaces.Interface) {
+	err := repo.AddInterface(iface)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *sdkStateSuite) TearDownTest(c *check.C) {
 	s.restoreProjectId()
 	s.restoreInstallTime()
 }
 
-func (s *H) TestDoInstallSdkSuccess(c *check.C) {
+func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: 2, InstallTime: &s.installTime}
@@ -148,11 +165,11 @@ func (s *H) TestDoInstallSdkSuccess(c *check.C) {
 		"--one-top-level=/var/lib/workshop/sdk/test-2/2",
 		"--no-same-owner",
 	})
-
+	c.Check(chg.Err(), check.IsNil)
 	c.Check(t1.Status(), check.Equals, state.DoneStatus)
 }
 
-func (s *H) TestDoInstallSdkSuccessWhenLocked(c *check.C) {
+func (s *sdkStateSuite) TestDoInstallSdkSuccessWhenLocked(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: 2, InstallTime: &s.installTime}
@@ -192,7 +209,7 @@ func (s *H) TestDoInstallSdkSuccessWhenLocked(c *check.C) {
 	c.Check(t1.Status(), check.Equals, state.DoneStatus)
 }
 
-func (s *H) TestDoInstallSdkExecFail(c *check.C) {
+func (s *sdkStateSuite) TestDoInstallSdkExecFail(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -208,7 +225,7 @@ func (s *H) TestDoInstallSdkExecFail(c *check.C) {
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		args.Stderr.Write([]byte(os.ErrDeadlineExceeded.Error()))
 		return workshop.ExecContext{}, os.ErrDeadlineExceeded
 	}
@@ -221,7 +238,7 @@ func (s *H) TestDoInstallSdkExecFail(c *check.C) {
 	c.Check(strings.HasSuffix(t1.Log()[0], os.ErrDeadlineExceeded.Error()), check.Equals, true)
 }
 
-func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
+func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -243,7 +260,7 @@ func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
 	chg.AddTask(terr)
 
 	// emulate install behaviour that unpacks an SDK to a certain directory
-	s.backend.DoExec = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		fs, _ := s.backend.WorkshopFs(ctx, name)
 		fs.MkdirAll(filepath.Join(dirs.WorkshopSdksDir, "new"), 0755)
 		return workshop.ExecContext{}, nil
@@ -261,9 +278,72 @@ func (s *H) TestUndoInstallSdkSuccess(c *check.C) {
 	c.Check(exist, check.Equals, false)
 }
 
-func (s *H) TestDoLinkSdkSuccess(c *check.C) {
+func (s *sdkStateSuite) TestDoInstallAgentSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+	newSdk := sdk.Setup{Name: "agent"}
+	t := s.state.NewTask("fake-task", "retrieve")
+	t.Set("sdk-setup", newSdk)
+	t1 := s.state.NewTask("install-agent-sdk", "test")
+	t1.Set("sdk-retrieve-task", t.ID())
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	s.se.Ensure()
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(chg.Err(), check.IsNil)
+	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	info, err := wfs.Stat("/var/lib/workshop/sdk/agent/current/meta/sdk.yaml")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, fs.FileMode(0666))
+}
+
+func (s *sdkStateSuite) TestUndoInstallAgentSdkSuccess(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	newSdk := sdk.Setup{Name: "agent"}
+	t := s.state.NewTask("fake-task", "retrieve")
+	t.Set("sdk-setup", newSdk)
+	t1 := s.state.NewTask("install-agent-sdk", "test")
+	t1.Set("sdk-retrieve-task", t.ID())
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(t1)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t, t1, terr)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Check(chg.Err(), check.NotNil)
+	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	_, err = wfs.Stat("/var/lib/workshop/sdk/agent")
+	c.Assert(osutil.IsDirNotExist(err), check.Equals, true)
+}
+
+func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
 	testSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: 2, InstallTime: &s.installTime}
 
@@ -292,11 +372,15 @@ func (s *H) TestDoLinkSdkSuccess(c *check.C) {
 
 	sdkInfo, err := props.SdkInfo(s.ctx, info["test"].Name)
 	c.Assert(err, check.IsNil)
-	c.Assert(sdkInfo.Plugs, check.HasLen, 1)
+	c.Assert(sdkInfo.Plugs, check.HasLen, 2)
 	c.Assert(sdkInfo.Slots, check.HasLen, 0)
+
+	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 2)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.NotNil)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.NotNil)
 }
 
-func (s *H) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
+func (s *sdkStateSuite) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -329,4 +413,8 @@ func (s *H) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
 	info := props.Content
 	c.Check(info, check.HasLen, 0)
 	c.Check(link.Status(), check.Equals, state.UndoneStatus)
+
+	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
 }

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -71,6 +71,21 @@ plugs:
     attr2: value2
 `
 
+var sdkYamlBrokenPolicy = `
+name: test-broken
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: test-interface
+    attr: value
+  plug2:
+    interface: test-interface
+    attr2: value2
+slots:
+  slot:
+    interface: content	
+`
+
 func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(dirs.CreateDirs(), check.IsNil)
@@ -111,7 +126,10 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	s.installTime = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
 	s.restoreInstallTime = testutil.FakeFunc(func() time.Time { return s.installTime }, &workshop.InstallTimeNow)
 
-	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}}}
+	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{
+		{Name: "test", Channel: "latest/stable"},
+		{Name: "test-broken", Channel: "latest/stable"},
+	}}
 	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Assert(err, check.IsNil)
 
@@ -367,7 +385,6 @@ func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
 	info := props.Content
-	c.Check(info, check.HasLen, 1)
 	c.Check(info["test"], check.DeepEquals, testSdk)
 
 	sdkInfo, err := props.SdkInfo(s.ctx, info["test"].Name)
@@ -378,6 +395,52 @@ func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {
 	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 2)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.NotNil)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.NotNil)
+}
+
+func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+	s.mockTestSdk(c, "test-broken", sdkYamlBrokenPolicy)
+
+	testSdk := sdk.Setup{Name: "test-broken", Channel: "latest/stable", Revision: 2, InstallTime: &s.installTime}
+
+	t := s.state.NewTask("fake-task", "retrieve")
+	t.Set("sdk-setup", testSdk)
+	t1 := s.state.NewTask("link-sdk", "test-broken")
+	t1.Set("sdk-retrieve-task", t.ID())
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*installation not allowed by "slot" slot rule of interface "content".*`)
+
+	// not in the fs (removed)
+	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	_, err = wfs.Stat(sdk.SdkCurrentPath("test-broken"))
+	c.Check(osutil.IsDirNotExist(err), check.Equals, true)
+
+	// not in the content (unlinked)
+	wp, err := s.backend.Workshop(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	_, ok := wp.Content["test-broken"]
+	c.Check(ok, check.Equals, false)
+
+	// not in the repo (removed)
+	c.Check(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
+	c.Check(s.repo.Slots(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
 }
 
 func (s *sdkStateSuite) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
@@ -410,8 +473,8 @@ func (s *sdkStateSuite) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
 
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	info := props.Content
-	c.Check(info, check.HasLen, 0)
+	_, ok := props.Content["test"]
+	c.Check(ok, check.Equals, false)
 	c.Check(link.Status(), check.Equals, state.UndoneStatus)
 
 	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -1,6 +1,7 @@
 package sdkstate
 
 import (
+	"github.com/canonical/workshop/internal/interfaces"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	backend "github.com/canonical/workshop/internal/workshop"
@@ -8,13 +9,15 @@ import (
 
 type SdkManager struct {
 	backend backend.Backend
+	repo    *interfaces.Repository
 }
 
-func New(runner *state.TaskRunner, server backend.Backend) *SdkManager {
-	manager := &SdkManager{backend: server}
+func New(runner *state.TaskRunner, repo *interfaces.Repository, server backend.Backend) *SdkManager {
+	manager := &SdkManager{backend: server, repo: repo}
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
-	runner.AddHandler("install-sdk", OnDo(manager.doInstallSDK), manager.undoInstallSdk)
+	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.undoInstallSdk)
+	runner.AddHandler("install-agent-sdk", OnDo(manager.doInstallAgentSdk), manager.undoInstallAgentSdk)
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.undoLinkSdk)
 
 	return manager

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -13,17 +13,28 @@ func Retrieve(st *state.State, s sdk.Setup) *state.Task {
 	return download
 }
 
-func Install(st *state.State, sdk string, retrieveId string) *state.TaskSet {
-	tasks := []*state.Task{}
+func InstallAgent(st *state.State) *state.TaskSet {
+	name := sdk.Agent.String()
+	install := st.NewTask("install-agent-sdk", fmt.Sprintf("Install %q SDK", name))
+	install.Set("sdk-setup", sdk.Setup{
+		Name: name,
+	})
+	install.Set("sdk-retrieve-task", install.ID())
 
+	link := st.NewTask("link-sdk", fmt.Sprintf("Link %q SDK", name))
+	link.Set("sdk-retrieve-task", install.ID())
+	link.WaitFor(install)
+
+	return state.NewTaskSet(install, link)
+}
+
+func Install(st *state.State, sdk string, retrieveId string) *state.TaskSet {
 	install := st.NewTask("install-sdk", fmt.Sprintf("Install %q SDK", sdk))
 	install.Set("sdk-retrieve-task", retrieveId)
-	tasks = append(tasks, install)
 
 	link := st.NewTask("link-sdk", fmt.Sprintf("Link %q SDK", sdk))
 	link.Set("sdk-retrieve-task", retrieveId)
 	link.WaitFor(install)
-	tasks = append(tasks, link)
 
-	return state.NewTaskSet(tasks...)
+	return state.NewTaskSet(install, link)
 }

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
@@ -235,7 +236,8 @@ func (m *WorkshopManager) cleanUpWorkshopAfterRemoval(user, projectId, w string)
 	}
 
 	var errors []error
-	projectContent := filepath.Join(usr.HomeDir, ".local", "share", "workshop", "project", projectId, "content")
+	projectContent := sdk.ProjectContentDir(usr.HomeDir, projectId)
+
 	var contentDirs []fs.DirEntry
 	if contentDirs, err = os.ReadDir(projectContent); err != nil {
 		errors = append(errors, fmt.Errorf("%q workshop content directory is not available: %v", w, err))
@@ -252,7 +254,8 @@ func (m *WorkshopManager) cleanUpWorkshopAfterRemoval(user, projectId, w string)
 	for _, dir := range contentDirs {
 		// Remove all default content dirs that belong the workshop. These will be
 		// named as <workshop>_<sdk>_<plug>.sdk
-		if dir.IsDir() && strings.HasPrefix(filepath.Base(dir.Name()), w+"_") {
+		base := filepath.Base(dir.Name())
+		if dir.IsDir() && strings.HasPrefix(base, w+"_") {
 			if err := os.RemoveAll(filepath.Join(projectContent, dir.Name())); err != nil {
 				errors = append(errors, err)
 			}

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -13,8 +13,6 @@ import (
 
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/revert"
-	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
@@ -33,24 +31,6 @@ func (m *WorkshopManager) undoCreateWorkshop(task *state.Task, tomb *tomb.Tomb) 
 	defer cancel()
 
 	return m.backend.RemoveWorkshop(ctx, workshop)
-}
-
-func (m *WorkshopManager) installAgentSdk(wfs workshop.WorkshopFs, base string) error {
-	agentMetaDir := filepath.Join(sdk.SdkCurrentPath("agent"), "meta")
-	if err := wfs.MkdirAll(agentMetaDir, 0655); err != nil {
-		return err
-	}
-
-	// /var/lib/workshop/sdk/agent/current/meta
-	file, err := wfs.OpenFile(filepath.Join(agentMetaDir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
-	if err != nil {
-		return err
-	}
-
-	if _, err = file.Write([]byte(sdk.AgentSdkMeta(base))); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) error {
@@ -73,29 +53,9 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 		return fmt.Errorf("internal error: %q workshop configuration is not found (task ID: %s)", w, task.ID())
 	}
 
-	var rev revert.Reverter
-	defer rev.Fail()
 	if err = m.backend.LaunchWorkshop(ctx, &wf); err != nil {
 		return err
 	}
-
-	// clean up must not be cancelled if the parent was cancelled and the change
-	// is winding down
-	revertCtx := context.WithoutCancel(ctx)
-	rev.Add(func() {
-		_ = m.backend.RemoveWorkshop(revertCtx, w)
-	})
-
-	wfs, err := m.backend.WorkshopFs(ctx, w)
-	if err != nil {
-		return err
-	}
-	defer wfs.Close()
-
-	if err = m.installAgentSdk(wfs, wf.Base); err != nil {
-		return err
-	}
-	rev.Success()
 	return nil
 }
 

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -3,7 +3,6 @@ package workshopstate_test
 import (
 	"context"
 	"errors"
-	"io/fs"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -270,41 +269,4 @@ base: ubuntu@22.04
 	s.state.Lock()
 
 	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
-	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
-	c.Assert(err, check.IsNil)
-	info, err := wfs.Stat("/var/lib/workshop/sdk/agent/current/meta/sdk.yaml")
-	c.Assert(err, check.IsNil)
-	c.Assert(info.Mode().Perm(), check.Equals, fs.FileMode(0666))
-}
-
-func (s *workshopHandlers) TestCreateWorkshopAgentSdkFailedGetsUndone(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws
-base: ubuntu@22.04
-`), 0644)
-	c.Check(err, check.IsNil)
-	s.backend.WorkshopFsCallback = func(ctx context.Context, name string) (workshop.WorkshopFs, error) {
-		return nil, errors.New("cannot get WorkshopFs")
-	}
-
-	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("create-workshop", "...")
-	t1.Set("base", "ubuntu@22.04")
-	setWorkshopProject("ws", s.project, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
-		s.se.Wait()
-	}
-	s.state.Lock()
-	s.backend.WorkshopFsCallback = nil
-
-	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
-	ws, err := s.backend.Workshop(s.ctx, "ws")
-	c.Assert(ws, check.IsNil)
-	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
 }

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -73,6 +73,7 @@ func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 
 	workshop, err := s.backend.Workshop(s.ctx, ws)
 	c.Assert(err, check.IsNil)
+	workshop.Running = true
 	return workshop
 }
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -198,6 +198,7 @@ func installSdks(st *state.State, w string, sdks []sdk.Setup, retrieveSet *state
 	}
 	setupHook.WaitAll(install)
 	autoConnect.WaitAll(setupHook)
+	autoConnect.WaitAll(install)
 
 	all := state.NewTaskSet(install.Tasks()...)
 	all.AddAll(setupHook)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -407,18 +407,17 @@ func refresh(st *state.State, file *workshop.File, installed []sdk.Setup, newCon
 }
 
 func disconnectSdks(content []sdk.Setup, st *state.State) *state.TaskSet {
-	disconnectSet := []*state.Task{}
-	prev := (*state.Task)(nil)
+	prev := st.NewTask("auto-disconnect", `Disconnect interfaces of "agent" SDK`)
+	prev.Set("sdk", "agent")
+	disconnectSet := state.NewTaskSet(prev)
 	for _, s := range content {
 		disc := st.NewTask("auto-disconnect", fmt.Sprintf("Disconnect interfaces of %q SDK", s.Name))
 		disc.Set("sdk", s.Name)
-		if prev != nil {
-			disc.WaitFor(prev)
-		}
-		disconnectSet = append(disconnectSet, disc)
+		disc.WaitFor(prev)
+		disconnectSet.AddTask(disc)
 		prev = disc
 	}
-	return state.NewTaskSet(disconnectSet...)
+	return disconnectSet
 }
 
 func saveStateHooks(st *state.State, w string, content []sdk.Setup, newContent workshop.SdkList,

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -167,7 +167,6 @@ func installSdks(st *state.State, w string, sdks []sdk.Setup, retrieveSet *state
 	var prevAuto = st.NewTask("auto-connect", `Auto-connect interfaces of "agent" SDK`)
 	prevAuto.Set("sdk", "agent")
 	autoConnect := state.NewTaskSet(prevAuto)
-	autoConnect.WaitAll(install)
 
 	for idx, sdk := range sdks {
 		// The install task sets must not run concurrently as exec ops are not

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -58,7 +58,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	}
 
 	taskset := make([]*state.TaskSet, 0, len(names))
-
+	var sdks []sdk.SdkResult
 	for _, name := range names {
 		file, err := project.Workshop(name)
 		if err != nil {
@@ -73,13 +73,17 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, err
 		}
 
-		res, err := w.launchStoreInfo(ctx, projectId, *file)
+		sdks, err = launchStoreInfo(w.state, ctx, projectId, file)
 		if err != nil {
 			return nil, err
 		}
 
+		if err = validatePlugBinds(sdks, file); err != nil {
+			return nil, err
+		}
+
 		sets := []sdk.Setup{}
-		for _, s := range res {
+		for _, s := range sdks {
 			sets = append(sets, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 		}
 
@@ -89,8 +93,8 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	return taskset, nil
 }
 
-func (w *WorkshopManager) launchStoreInfo(ctx context.Context, projectid string, file workshop.File) ([]sdk.SdkResult, error) {
-	sto := sdk.StoreService(w.state)
+func launchStoreInfo(st *state.State, ctx context.Context, projectid string, file *workshop.File) ([]sdk.SdkResult, error) {
+	sto := sdk.StoreService(st)
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
 		act := sdk.SdkAction{ProjectId: projectid, Workshop: file.Name, Name: sd.Name, Channel: sd.Channel, Action: sdk.Install}
@@ -103,6 +107,47 @@ func (w *WorkshopManager) launchStoreInfo(ctx context.Context, projectid string,
 	return res, nil
 }
 
+func validatePlugBinds(sdks []sdk.SdkResult, file *workshop.File) error {
+	type plug struct {
+		sdk  string
+		name string
+	}
+	allbinds := make(map[plug][]plug)
+	for _, sk := range file.Sdks {
+		for n, master := range sk.Plugs {
+			master := plug{master.Bind.Sdk, master.Bind.Plug}
+			slave := plug{sk.Name, n}
+			allbinds[master] = append(allbinds[slave], slave)
+		}
+	}
+
+	allplugs := make(map[plug]*sdk.PlugInfo)
+	for _, s := range sdks {
+		for name, p := range s.Plugs {
+			allplugs[plug{s.Name, name}] = p
+		}
+	}
+
+	for master, slaves := range allbinds {
+		minfo, ok := allplugs[master]
+		if !ok {
+			return fmt.Errorf("cannot bind: SDK %q does not have a plug %q", master.sdk, master.name)
+		}
+
+		for _, sl := range slaves {
+			sinfo, ok := allplugs[sl]
+			if !ok {
+				return fmt.Errorf("cannot bind: SDK %q does not have a plug %q", sl.sdk, sl.name)
+			}
+			if minfo.Interface != sinfo.Interface {
+				return fmt.Errorf("cannot bind: %s:%s and %s:%s must be of the same interface", master.sdk, master.name, sl.sdk, sl.name)
+			}
+		}
+	}
+
+	return nil
+}
+
 func retrieveSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	retrieve := state.NewTaskSet()
 	for _, s := range sdks {
@@ -113,15 +158,17 @@ func retrieveSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 }
 
 func installSdks(st *state.State, w string, sdks []sdk.Setup, retrieveSet *state.TaskSet) *state.TaskSet {
-	var prevInstall *state.TaskSet
-	var prevSetup *state.Task
+	var prevInstall = sdkstate.InstallAgent(st)
+	install := state.NewTaskSet(prevInstall.Tasks()...)
 
-	install := state.NewTaskSet()
+	var prevSetup *state.Task
 	setupHook := state.NewTaskSet()
 
-	prevAuto := st.NewTask("auto-connect", `Auto-connect interfaces of "agent" SDK`)
+	var prevAuto = st.NewTask("auto-connect", `Auto-connect interfaces of "agent" SDK`)
 	prevAuto.Set("sdk", "agent")
-	autoConnectSet := state.NewTaskSet(prevAuto)
+	autoConnect := state.NewTaskSet(prevAuto)
+	autoConnect.WaitAll(install)
+
 	for idx, sdk := range sdks {
 		// The install task sets must not run concurrently as exec ops are not
 		// allowed by LXD to be run concurrently and in general case we cannot
@@ -143,18 +190,18 @@ func installSdks(st *state.State, w string, sdks []sdk.Setup, retrieveSet *state
 
 		autoconnect := st.NewTask("auto-connect", fmt.Sprintf("Auto-connect interfaces of %q SDK", sdk.Name))
 		autoconnect.Set("sdk", sdk.Name)
-		autoConnectSet.AddTask(autoconnect)
+		autoConnect.AddTask(autoconnect)
 		if prevAuto != nil {
 			autoconnect.WaitFor(prevAuto)
 		}
 		prevAuto = autoconnect
 	}
 	setupHook.WaitAll(install)
-	autoConnectSet.WaitAll(setupHook)
+	autoConnect.WaitAll(setupHook)
 
 	all := state.NewTaskSet(install.Tasks()...)
 	all.AddAll(setupHook)
-	all.AddAll(autoConnectSet)
+	all.AddAll(autoConnect)
 	return all
 }
 
@@ -192,7 +239,7 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project *wor
 	create := constructWorkshop(st, file, project)
 	create.WaitAll(retrieve)
 
-	// launch the downloaded sdks
+	// install the downloaded sdks
 	launch := installSdks(st, file.Name, sdks, retrieve)
 	launch.WaitAll(create)
 
@@ -247,7 +294,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context,
 		}
 		files = append(files, file)
 
-		res, err := w.launchStoreInfo(ctx, projectId, *file)
+		res, err := launchStoreInfo(w.state, ctx, projectId, file)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
@@ -651,10 +652,17 @@ func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug int
 		return nil, err
 	}
 
-	remount := st.NewTask("remount", fmt.Sprintf(`Remount %s/%s:%s`, plug.Workshop, plug.Sdk, plug.Name))
+	wp, err := w.Workshop(ctx, plug.Workshop, plug.ProjectId)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load workshop %q: %w", plug.Workshop, err)
+	}
+
+	master, _ := ifacestate.MaybeBound(wp, plug)
+
+	remount := st.NewTask("remount", fmt.Sprintf(`Remount %s`, plug.ShortRef()))
 	remount.Set("workshop", plug.Workshop)
 	remount.Set("project", project)
-	remount.Set("plug", plug)
+	remount.Set("plug", master)
 	remount.Set("source", source)
 
 	return state.NewTaskSet(remount), nil

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -138,7 +138,7 @@ func (s *requestSuite) TestLaunchWorkshopNoSdk(c *check.C) {
 
 	expected := []string{"create-workshop",
 		"mount-project",
-		"start-workshop", "auto-connect"}
+		"start-workshop", "install-agent-sdk", "link-sdk", "auto-connect"}
 	tasks := ts.Tasks()
 
 	verifyExpectedTasks(c, tasks, expected)
@@ -173,8 +173,10 @@ func (s *requestSuite) TestLaunchWorkshopWithSdks(c *check.C) {
 		"start-workshop",
 		"retrieve-sdk",
 		"retrieve-sdk",
+		"install-agent-sdk",
 		"install-sdk",
 		"install-sdk",
+		"link-sdk",
 		"link-sdk",
 		"link-sdk",
 		"auto-connect", // agent SDK
@@ -201,22 +203,22 @@ func (s *requestSuite) TestLaunchWorkshopWithSdks(c *check.C) {
 
 	// install-sdk task for sdk
 	var id1, id2 string
-	err = tasks[5].Get("sdk-retrieve-task", &id1)
+	err = tasks[7].Get("sdk-retrieve-task", &id1)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(id1, check.Equals, tasks[0].ID())
 
 	// link-sdk task for sdk
-	err = tasks[6].Get("sdk-retrieve-task", &id2)
+	err = tasks[8].Get("sdk-retrieve-task", &id2)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(id2, check.Equals, tasks[0].ID())
 
 	// install-sdk task for sdk_2
-	err = tasks[8].Get("sdk-retrieve-task", &id1)
+	err = tasks[9].Get("sdk-retrieve-task", &id1)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(id1, check.Equals, tasks[1].ID())
 
 	// link-sdk task for sdk_2
-	err = tasks[8].Get("sdk-retrieve-task", &id2)
+	err = tasks[10].Get("sdk-retrieve-task", &id2)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(id2, check.Equals, tasks[1].ID())
 
@@ -243,6 +245,8 @@ func (s *requestSuite) TestRefreshEmptyWorkshop(c *check.C) {
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
+		"install-agent-sdk",
+		"link-sdk",
 		"auto-connect",    // "agent" SDK
 		"auto-disconnect", // "agent" SDK
 	}
@@ -285,6 +289,8 @@ func (s *requestSuite) TestRefreshWorkshopWithSdks(c *check.C) {
 		"create-workshop",
 		"mount-project",
 		"start-workshop",
+		"install-agent-sdk",
+		"link-sdk",
 		"install-sdk",
 		"link-sdk",
 		"install-sdk",
@@ -463,6 +469,8 @@ func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
+		"install-agent-sdk",
+		"link-sdk",
 		"auto-disconnect", // agent SDK
 		"auto-connect",    // agent SDK
 		"remove-workshop-stash",
@@ -478,6 +486,8 @@ func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 		"create-workshop",
 		"mount-project",
 		"start-workshop",
+		"install-agent-sdk",
+		"link-sdk",
 		"install-sdk",
 		"link-sdk",
 		"auto-connect", // agent SDK
@@ -556,6 +566,8 @@ func (s *requestSuite) TestRefreshManyAllWorkshopsHaveSdks(c *check.C) {
 		"create-workshop",
 		"mount-project",
 		"start-workshop",
+		"install-agent-sdk",
+		"link-sdk",
 		"install-sdk",
 		"link-sdk",
 		"auto-disconnect", // agent SDK
@@ -761,37 +773,6 @@ func (s *requestSuite) TestStopMany(c *check.C) {
 
 	ts[0].Tasks()[0].Get("force", &force)
 	c.Assert(force, check.Equals, false)
-}
-
-func (s *requestSuite) TestRemoveMany(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	content := workshop.SdkList{
-		{Name: "sdk-1", Channel: "latest/stable"},
-		{Name: "sdk-2", Channel: "latest/stable"},
-		{Name: "sdk-3", Channel: "latest/stable"},
-	}
-
-	s.launchWorkshopWithSDKs(c, "ws-1", content)
-
-	ts, err := s.mgr.RemoveMany(s.ctx, []string{"ws-1"}, s.project.ProjectId, "1")
-	c.Assert(err, check.IsNil)
-	c.Assert(ts[0].Tasks(), check.HasLen, 6)
-
-	verifyDisconnectDependencies(c, ts[0])
-	// agent SDK is always the task with index 0
-	discTasks := ts[0].Tasks()[1:3]
-	for i, t := range discTasks {
-		c.Assert(t.Kind(), check.Equals, "auto-disconnect")
-		var sdkName string
-		err = t.Get("sdk", &sdkName)
-		c.Assert(err, check.IsNil)
-		c.Assert(sdkName, check.Equals, content[i].Name)
-		c.Assert(t.Summary(), check.Equals, fmt.Sprintf("Disconnect interfaces of %q SDK", content[i].Name))
-	}
-	c.Assert(ts[0].Tasks()[4].Kind(), check.Equals, "discard-conns")
-	c.Assert(ts[0].Tasks()[5].Kind(), check.Equals, "remove-workshop")
-	s.ensureTaskHasWorkshopAndProjectKeys(c, "ws-1", ts[0].Tasks())
 }
 
 func (s *requestSuite) TestRemountSuccess(c *check.C) {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -243,7 +243,8 @@ func (s *requestSuite) TestRefreshEmptyWorkshop(c *check.C) {
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
-		"auto-connect", // "agent" SDK
+		"auto-connect",    // "agent" SDK
+		"auto-disconnect", // "agent" SDK
 	}
 
 	tasks := ts.Tasks()
@@ -275,8 +276,9 @@ func (s *requestSuite) TestRefreshWorkshopWithSdks(c *check.C) {
 		"retrieve-sdk",
 		"retrieve-sdk",
 		"create-state-storage",
-		"run-hook", // save-state sdk-1
-		"run-hook", // save-state sdk-2
+		"run-hook",        // save-state sdk-1
+		"run-hook",        // save-state sdk-2
+		"auto-disconnect", // "agent" SDK
 		"auto-disconnect",
 		"auto-disconnect",
 		"stash-workshop",
@@ -461,14 +463,16 @@ func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
-		"auto-connect", // agent SDK
+		"auto-disconnect", // agent SDK
+		"auto-connect",    // agent SDK
 		"remove-workshop-stash",
 	}
 
 	expected_ws_1 := []string{
 		"retrieve-sdk",
 		"create-state-storage",
-		"run-hook", // save-state hook
+		"run-hook",        // save-state hook
+		"auto-disconnect", // agent SDK
 		"auto-disconnect",
 		"stash-workshop",
 		"create-workshop",
@@ -554,7 +558,8 @@ func (s *requestSuite) TestRefreshManyAllWorkshopsHaveSdks(c *check.C) {
 		"start-workshop",
 		"install-sdk",
 		"link-sdk",
-		"auto-connect", // agent SDK
+		"auto-disconnect", // agent SDK
+		"auto-connect",    // agent SDK
 		"auto-connect",
 		"run-hook", // setup-base hook
 		"run-hook", // restore state hook
@@ -771,10 +776,12 @@ func (s *requestSuite) TestRemoveMany(c *check.C) {
 
 	ts, err := s.mgr.RemoveMany(s.ctx, []string{"ws-1"}, s.project.ProjectId, "1")
 	c.Assert(err, check.IsNil)
-	c.Assert(ts[0].Tasks(), check.HasLen, 5)
+	c.Assert(ts[0].Tasks(), check.HasLen, 6)
 
 	verifyDisconnectDependencies(c, ts[0])
-	for i, t := range ts[0].Tasks()[0:3] {
+	// agent SDK is always the task with index 0
+	discTasks := ts[0].Tasks()[1:3]
+	for i, t := range discTasks {
 		c.Assert(t.Kind(), check.Equals, "auto-disconnect")
 		var sdkName string
 		err = t.Get("sdk", &sdkName)
@@ -782,8 +789,8 @@ func (s *requestSuite) TestRemoveMany(c *check.C) {
 		c.Assert(sdkName, check.Equals, content[i].Name)
 		c.Assert(t.Summary(), check.Equals, fmt.Sprintf("Disconnect interfaces of %q SDK", content[i].Name))
 	}
-	c.Assert(ts[0].Tasks()[3].Kind(), check.Equals, "discard-conns")
-	c.Assert(ts[0].Tasks()[4].Kind(), check.Equals, "remove-workshop")
+	c.Assert(ts[0].Tasks()[4].Kind(), check.Equals, "discard-conns")
+	c.Assert(ts[0].Tasks()[5].Kind(), check.Equals, "remove-workshop")
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "ws-1", ts[0].Tasks())
 }
 

--- a/internal/sdk/agent.go
+++ b/internal/sdk/agent.go
@@ -1,6 +1,8 @@
 package sdk
 
-import "fmt"
+import (
+	"fmt"
+)
 
 var agentSdkYamlTemplate = `name: agent
 base: %s

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -300,8 +300,12 @@ type PlugBind struct {
 	Name      string
 }
 
+func SdkRootPath(sdkName string) string {
+	return filepath.Join(dirs.WorkshopSdksDir, sdkName)
+}
+
 func SdkCurrentPath(sdkName string) string {
-	return filepath.Join(dirs.WorkshopSdksDir, sdkName, "current")
+	return filepath.Join(SdkRootPath(sdkName), "current")
 }
 
 func SdkHooksDir(sdkName string) string {
@@ -310,6 +314,11 @@ func SdkHooksDir(sdkName string) string {
 
 func SdkHookPath(sdkName, hookName string) string {
 	return filepath.Join(SdkHooksDir(sdkName), hookName)
+}
+
+func DefaultContentSource(homedir, pid, wp, sdk, plug string) string {
+	dir := strings.Join([]string{wp, sdk, plug}, "_") + ".sdk"
+	return filepath.Join(homedir, ".local", "share", "workshop", "project", pid, "content", dir)
 }
 
 func MockSanitizePlugsSlots(f func(sdkInfo *Info)) (restore func()) {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -316,9 +316,13 @@ func SdkHookPath(sdkName, hookName string) string {
 	return filepath.Join(SdkHooksDir(sdkName), hookName)
 }
 
-func DefaultContentSource(homedir, pid, wp, sdk, plug string) string {
+func ProjectContentDir(homedir, pid string) string {
+	return filepath.Join(homedir, ".local", "share", "workshop", "project", pid, "content")
+}
+
+func SdkContentSource(homedir, pid, wp, sdk, plug string) string {
 	dir := strings.Join([]string{wp, sdk, plug}, "_") + ".sdk"
-	return filepath.Join(homedir, ".local", "share", "workshop", "project", pid, "content", dir)
+	return filepath.Join(ProjectContentDir(homedir, pid), dir)
 }
 
 func MockSanitizePlugsSlots(f func(sdkInfo *Info)) (restore func()) {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -54,8 +54,9 @@ type Info struct {
 	Revision  int64
 	Channel   string
 
-	Plugs map[string]*PlugInfo
-	Slots map[string]*SlotInfo
+	Plugs     map[string]*PlugInfo
+	PlugBinds map[string]*PlugBind
+	Slots     map[string]*SlotInfo
 	// Plugs or slots with issues (they are not included in Plugs or Slots)
 	BadInterfaces map[string]string
 }
@@ -100,6 +101,7 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 		Base:          sdkYaml.Base,
 		Type:          Type(sdkYaml.Type),
 		Plugs:         make(map[string]*PlugInfo),
+		PlugBinds:     make(map[string]*PlugBind),
 		Slots:         make(map[string]*SlotInfo),
 		BadInterfaces: make(map[string]string),
 	}
@@ -289,6 +291,13 @@ func (plug *PlugInfo) Attr(key string, val interface{}) error {
 
 func (plug *PlugInfo) Lookup(key string) (interface{}, bool) {
 	return lookupAttr(plug.Attrs, key)
+}
+
+type PlugBind struct {
+	ProjectId string
+	Workshop  string
+	Sdk       string
+	Name      string
 }
 
 func SdkCurrentPath(sdkName string) string {

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -2,7 +2,6 @@ package sdk_test
 
 import (
 	"testing"
-	"time"
 
 	"gopkg.in/check.v1"
 
@@ -12,7 +11,6 @@ import (
 
 type SdkSuite struct {
 	testutil.BaseTest
-	setup     sdk.Setup
 	projectId string
 }
 
@@ -22,14 +20,6 @@ func TestSdkSuite(t *testing.T) { check.TestingT(t) }
 
 func (s *SdkSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
-	t := time.Now()
-	s.setup = sdk.Setup{
-		Name:        "sdk",
-		Channel:     "latest/stable",
-		Revision:    1,
-		InstallTime: &t,
-	}
-
 	s.projectId = "prj42prj42"
 
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -83,6 +83,22 @@ type FakeStore struct {
 	DownloadCallback func(ctx context.Context, setup Setup) error
 }
 
+func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error)) func() {
+	old := f.ActionCallback
+	f.ActionCallback = fa
+	return func() {
+		f.ActionCallback = old
+	}
+}
+
+func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup) error) func() {
+	old := f.DownloadCallback
+	f.DownloadCallback = fa
+	return func() {
+		f.DownloadCallback = old
+	}
+}
+
 func (f *FakeStore) SdkAction(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error) {
 	f.ActionCalls = append(f.ActionCalls, TestActionCall{
 		CurrentSdks: currentSdks,

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -9,21 +9,21 @@ import (
 )
 
 var (
-	ValidBases   = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
-	ValidName    = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
-	ValidChannel = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
+	AllowedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
+	sdkName      = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+	channel      = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
 	// Regular expression describing correct plug, slot and interface names.
 	validPlugSlotIface = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 )
 
 func Validate(sdk *Info) error {
 
-	if !ValidName.MatchString(sdk.Name) {
+	if !sdkName.MatchString(sdk.Name) {
 		return fmt.Errorf("invalid sdk name: %q", sdk.Name)
 	}
 
-	if !slices.Contains(ValidBases, sdk.Base) {
-		return fmt.Errorf("invalid sdk base: %q; supported bases: %s", sdk.Base, strings.Join(ValidBases, ", "))
+	if !slices.Contains(AllowedBases, sdk.Base) {
+		return fmt.Errorf("invalid sdk base: %q; supported bases: %s", sdk.Base, strings.Join(AllowedBases, ", "))
 	}
 
 	for plugName, plug := range sdk.Plugs {

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -84,5 +84,5 @@ base: ubuntu@21.04
 }
 
 func (s *ValidateSuite) TestAcceptableSdkBases(c *check.C) {
-	c.Assert(sdk.ValidBases, check.DeepEquals, []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"})
+	c.Assert(sdk.AllowedBases, check.DeepEquals, []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"})
 }

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -168,3 +168,9 @@ type Backend interface {
 	// contain full (actual)
 	Exec(ctx context.Context, name string, args *Execution) (ExecContext, error)
 }
+
+func FakeUserLookup(f func(name string) (*user.User, error)) func() {
+	oldUserLookup := LookupUsername
+	LookupUsername = f
+	return func() { LookupUsername = oldUserLookup }
+}

--- a/internal/workshop/backend_mock.go
+++ b/internal/workshop/backend_mock.go
@@ -129,13 +129,13 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *File) er
 		f.Workshops[projectId] = make(map[string]*FakeWorkshop)
 	}
 	if _, ok := f.Workshops[projectId][file.Name]; ok {
-		return api.StatusErrorf(http.StatusNotFound, "workshop exists already")
+		return errors.New("workshop exists")
 	}
 
 	ws := &FakeWorkshop{}
 	ws.Workshop = &Workshop{Backend: f,
 		Name:    file.Name,
-		Running: true,
+		Running: false,
 		Project: prj,
 		Base:    file.Base,
 		File:    file,
@@ -147,6 +147,7 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *File) er
 
 	content := make(map[string]sdk.Setup)
 	f.Workshops[projectId][file.Name] = ws
+
 	for _, s := range file.Sdks {
 		setup := sdk.Setup{
 			Name:    s.Name,
@@ -242,16 +243,25 @@ func (s *FakeWorkshopBackend) Profile(ctx context.Context, w string, pr string) 
 	if err != nil {
 		return SdkProfile{}, err
 	}
-	profiles := s.Workshops[projectId][w].Profiles
+	wp, ok := s.Workshops[projectId][w]
+	if !ok {
+		return SdkProfile{}, ErrWorkshopNotFound
+	}
+
+	profiles := wp.Profiles
 	idx := slices.IndexFunc(profiles, func(p SdkProfile) bool { return p.Name() == pr })
 	if idx != -1 {
 		return s.Workshops[projectId][w].Profiles[idx], nil
 	}
-	return SdkProfile{}, errors.New("profile not found")
+	return SdkProfile{}, ErrSdkProfileNotFound
 }
 
 func (s *FakeWorkshopBackend) RemoveProfile(ctx context.Context, workshop string, profile string) error {
 	s.RemoveProfileCalls = append(s.RemoveProfileCalls, &RemoveProfileCall{Name: workshop, Profile: profile})
+
+	if s.RemoveProfileCallback != nil {
+		return s.RemoveProfileCallback(ctx, workshop, profile)
+	}
 	_, projectId, err := s.userProject(ctx)
 	if err != nil {
 		return err
@@ -260,12 +270,9 @@ func (s *FakeWorkshopBackend) RemoveProfile(ctx context.Context, workshop string
 	idx := slices.IndexFunc(profiles, func(p SdkProfile) bool { return p.Name() == profile })
 	if idx != -1 {
 		s.Workshops[projectId][workshop].Profiles = slices.Delete(profiles, idx, idx+1)
-		if s.RemoveProfileCallback != nil {
-			return s.RemoveProfileCallback(ctx, workshop, profile)
-		}
 		return nil
 	}
-	return errors.New("profile not found")
+	return ErrSdkProfileNotFound
 }
 
 func (f *FakeWorkshopBackend) Profiles(ctx context.Context, workshop string) ([]SdkProfile, error) {
@@ -370,7 +377,7 @@ func DoExecDefault(ctx context.Context, name string, args *Execution) (ExecConte
 }
 
 func (s *FakeWorkshopBackend) RemoveWorkshopStash(ctx context.Context, name string) error {
-	panic("not implemented") // TODO: Implement
+	return nil
 }
 
 func (s *FakeWorkshopBackend) UnstashWorkshop(ctx context.Context, name string) error {
@@ -410,11 +417,11 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 }
 
 func (s *FakeWorkshopBackend) CreateStateStorage(ctx context.Context, name string) error {
-	panic("not implemented") // TODO: Implement
+	return nil
 }
 
 func (s *FakeWorkshopBackend) DeleteStateStorage(ctx context.Context, name string) error {
-	panic("not implemented") // TODO: Implement
+	return nil
 }
 
 func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, error) {

--- a/internal/workshop/backend_mock.go
+++ b/internal/workshop/backend_mock.go
@@ -138,6 +138,7 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *File) er
 		Running: true,
 		Project: prj,
 		Base:    file.Base,
+		File:    file,
 	}
 	ws.Config = make(map[string]string)
 	ws.Devices = make(map[string]map[string]string)

--- a/internal/workshop/backend_mock.go
+++ b/internal/workshop/backend_mock.go
@@ -52,8 +52,8 @@ type FakeWorkshopBackend struct {
 	// the key is a username
 	projects map[string][]*Project
 
-	DoExec    ExecFunc
-	ExecCalls []*ExecCall
+	ExecCallback ExecFunc
+	ExecCalls    []*ExecCall
 
 	WorkshopFsCallback func(ctx context.Context, name string) (WorkshopFs, error)
 	WorkshopFsCalls    []*FsCall
@@ -71,7 +71,7 @@ func NewFakeWorkshopBackend() *FakeWorkshopBackend {
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
 	be.projects = make(map[string][]*Project)
 
-	be.DoExec = DoExecDefault
+	be.ExecCallback = DoExecDefault
 
 	return &be
 }
@@ -237,6 +237,19 @@ func (f *FakeWorkshopBackend) AssignProfile(ctx context.Context, workshop string
 	return nil
 }
 
+func (s *FakeWorkshopBackend) Profile(ctx context.Context, w string, pr string) (SdkProfile, error) {
+	_, projectId, err := s.userProject(ctx)
+	if err != nil {
+		return SdkProfile{}, err
+	}
+	profiles := s.Workshops[projectId][w].Profiles
+	idx := slices.IndexFunc(profiles, func(p SdkProfile) bool { return p.Name() == pr })
+	if idx != -1 {
+		return s.Workshops[projectId][w].Profiles[idx], nil
+	}
+	return SdkProfile{}, errors.New("profile not found")
+}
+
 func (s *FakeWorkshopBackend) RemoveProfile(ctx context.Context, workshop string, profile string) error {
 	s.RemoveProfileCalls = append(s.RemoveProfileCalls, &RemoveProfileCall{Name: workshop, Profile: profile})
 	_, projectId, err := s.userProject(ctx)
@@ -345,7 +358,7 @@ func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (Work
 
 func (f *FakeWorkshopBackend) Exec(ctx context.Context, name string, args *Execution) (ExecContext, error) {
 	f.ExecCalls = append(f.ExecCalls, &ExecCall{name, args})
-	return f.DoExec(ctx, name, args)
+	return f.ExecCallback(ctx, name, args)
 }
 
 func DoExecDefault(ctx context.Context, name string, args *Execution) (ExecContext, error) {

--- a/internal/workshop/backend_mock.go
+++ b/internal/workshop/backend_mock.go
@@ -30,8 +30,18 @@ type ExecCall struct {
 	Args *Execution
 }
 
-type WorkshopExecCall struct {
+type FsCall struct {
 	Name string
+}
+
+type AssignProfileCall struct {
+	Name    string
+	Profile SdkProfile
+}
+
+type RemoveProfileCall struct {
+	Name    string
+	Profile string
 }
 
 type FakeWorkshopBackend struct {
@@ -46,7 +56,13 @@ type FakeWorkshopBackend struct {
 	ExecCalls []*ExecCall
 
 	WorkshopFsCallback func(ctx context.Context, name string) (WorkshopFs, error)
-	WorkshopFsCalls    []*WorkshopExecCall
+	WorkshopFsCalls    []*FsCall
+
+	AssignProfileCallback func(ctx context.Context, workshop string, profile SdkProfile) error
+	AssignProfileCalls    []*AssignProfileCall
+
+	RemoveProfileCallback func(ctx context.Context, workshop string, profile string) error
+	RemoveProfileCalls    []*RemoveProfileCall
 }
 
 func NewFakeWorkshopBackend() *FakeWorkshopBackend {
@@ -206,15 +222,22 @@ func (f *FakeWorkshopBackend) RemoveWorkshopDevice(ctx context.Context, name str
 }
 
 func (f *FakeWorkshopBackend) AssignProfile(ctx context.Context, workshop string, profile SdkProfile) error {
+	f.AssignProfileCalls = append(f.AssignProfileCalls, &AssignProfileCall{Name: workshop, Profile: profile})
+
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
 	}
 	f.Workshops[projectId][workshop].Profiles = append(f.Workshops[projectId][workshop].Profiles, profile)
+
+	if f.AssignProfileCallback != nil {
+		return f.AssignProfileCallback(ctx, workshop, profile)
+	}
 	return nil
 }
 
 func (s *FakeWorkshopBackend) RemoveProfile(ctx context.Context, workshop string, profile string) error {
+	s.RemoveProfileCalls = append(s.RemoveProfileCalls, &RemoveProfileCall{Name: workshop, Profile: profile})
 	_, projectId, err := s.userProject(ctx)
 	if err != nil {
 		return err
@@ -223,9 +246,20 @@ func (s *FakeWorkshopBackend) RemoveProfile(ctx context.Context, workshop string
 	idx := slices.IndexFunc(profiles, func(p SdkProfile) bool { return p.Name() == profile })
 	if idx != -1 {
 		s.Workshops[projectId][workshop].Profiles = slices.Delete(profiles, idx, idx+1)
+		if s.RemoveProfileCallback != nil {
+			return s.RemoveProfileCallback(ctx, workshop, profile)
+		}
 		return nil
 	}
 	return errors.New("profile not found")
+}
+
+func (f *FakeWorkshopBackend) Profiles(ctx context.Context, workshop string) ([]SdkProfile, error) {
+	_, projectId, err := f.userProject(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return f.Workshops[projectId][workshop].Profiles, nil
 }
 
 func (f *FakeWorkshopBackend) AddWorkshopConfig(ctx context.Context, name string, item *WorkshopConfigValue) error {
@@ -296,7 +330,7 @@ func (f *FakeWorkshopBackend) GetWorkshopsByConfig(ctx context.Context, filter W
 }
 
 func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (WorkshopFs, error) {
-	s.WorkshopFsCalls = append(s.WorkshopFsCalls, &WorkshopExecCall{Name: name})
+	s.WorkshopFsCalls = append(s.WorkshopFsCalls, &FsCall{Name: name})
 	if s.WorkshopFsCallback != nil {
 		return s.WorkshopFsCallback(ctx, name)
 	}

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -46,5 +46,6 @@ func (s SdkProfile) AddDevice(dev Device) error {
 
 type Profile interface {
 	AssignProfile(ctx context.Context, workshop string, profile SdkProfile) error
+	Profile(ctx context.Context, workshop, profile string) (SdkProfile, error)
 	RemoveProfile(ctx context.Context, workshop, profile string) error
 }

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -192,6 +192,9 @@ func (s *Backend) Profile(ctx context.Context, wp, profile string) (workshop.Sdk
 	lxdname := profileName(projectId, wp, profile)
 	lxdp, _, err := conn.GetProfile(lxdname)
 	if err != nil {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return pr, workshop.ErrSdkProfileNotFound
+		}
 		return pr, err
 	}
 	for name, dev := range lxdp.Devices {

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -175,3 +175,34 @@ func (s *Backend) RemoveProfile(ctx context.Context, w string, profile string) e
 	}
 	return err
 }
+
+func (s *Backend) Profile(ctx context.Context, wp, profile string) (workshop.SdkProfile, error) {
+	var pr = workshop.NewSdkProfile(profile)
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return pr, err
+	}
+	defer conn.Disconnect()
+
+	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
+	if !ok {
+		return pr, fmt.Errorf("context key project-id not found")
+	}
+
+	lxdname := profileName(projectId, wp, profile)
+	lxdp, _, err := conn.GetProfile(lxdname)
+	if err != nil {
+		return pr, err
+	}
+	for name, dev := range lxdp.Devices {
+		switch dev["type"] {
+		case "disk":
+			pr.Devices[name] = Mount(name, dev["source"], dev["path"])
+		case "gpu":
+			pr.Devices[name] = Gpu(name)
+		case "proxy":
+			pr.Devices[name] = SshAgent(name, dev["connect"], dev["listen"])
+		}
+	}
+	return pr, nil
+}

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -234,8 +234,8 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workshop.SdkList{
 			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{
-				"one-plug":     {Bind: "two:two-plug"},
-				"one-plug-two": {Bind: "two:two-plug"},
+				"one-plug":     {Bind: workshop.Bind{Sdk: "two", Plug: "two-plug"}},
+				"one-plug-two": {Bind: workshop.Bind{Sdk: "two", Plug: "two-plug"}},
 			}},
 			{Name: "two", Channel: "latest/edge"},
 		},

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -59,7 +59,7 @@ func (w *Project) ReadWorkshops() ([]*File, error) {
 		}
 
 		// The first element in names will contain the workshop name if matched
-		if names := validWorkshopFilename.FindStringSubmatch(info.Name()); names != nil {
+		if names := filename.FindStringSubmatch(info.Name()); names != nil {
 			f, err := readWorkshop(filepath.Join(w.Path, info.Name()))
 			if err != nil {
 				logger.Noticef("Cannot parse %s: %v", info.Name(), err)

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -42,6 +42,10 @@ type Workshop struct {
 // the SDK to the workshop content. This method is idempotent, so if an SDK
 // existed, the result will be a no-op
 func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
+	if s.Name == sdk.Agent.String() {
+		return nil
+	}
+
 	now := InstallTimeNow()
 	s.InstallTime = &now
 	w.Content[s.Name] = s
@@ -85,6 +89,10 @@ func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
 // removing the SDK to the workshop content. This method is idempotent, so if an
 // SDK did not exist, the result will be a no-op
 func (w *Workshop) UnlinkSdk(ctx context.Context, name string) error {
+	if name == sdk.Agent.String() {
+		return nil
+	}
+
 	delete(w.Content, name)
 	newSequence, err := json.Marshal(w.Content)
 	if err != nil {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/sdk"
+	"golang.org/x/exp/slices"
 )
 
 var (
@@ -137,18 +138,18 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	defer wsfs.Close()
 
 	sdkPath := sdk.SdkCurrentPath(sdkName)
-	sdkYamlFile, err := wsfs.Open(filepath.Join(sdkPath, "meta/sdk.yaml"))
+	yamlf, err := wsfs.Open(filepath.Join(sdkPath, "meta/sdk.yaml"))
 	if err != nil {
 		return nil, fmt.Errorf("cannot read %q SDK metadata (%v)", sdkName, err)
 	}
-	defer sdkYamlFile.Close()
+	defer yamlf.Close()
 
-	yamlData, err := io.ReadAll(sdkYamlFile)
+	data, err := io.ReadAll(yamlf)
 	if err != nil {
 		return nil, err
 	}
 
-	info, err := sdk.ReadSdkInfo(yamlData, w.Project.ProjectId, w.Name)
+	info, err := sdk.ReadSdkInfo(data, w.Project.ProjectId, w.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +157,34 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	info.Revision = setup.Revision
 	info.Channel = setup.Channel
 
+	if err = w.setupPlugBinds(info); err != nil {
+		return nil, err
+	}
+
 	return info, nil
+}
+
+func (w *Workshop) setupPlugBinds(info *sdk.Info) error {
+	if info.Type == sdk.Agent {
+		return nil
+	}
+
+	idx := slices.IndexFunc(w.File.Sdks, func(sr SdkRecord) bool { return sr.Name == info.Name })
+	if idx == -1 {
+		return fmt.Errorf("internal error: %q SDK is installed but not declared in the workshop file", info.Name)
+	}
+
+	for n, plug := range w.File.Sdks[idx].Plugs {
+		if _, ok := info.Plugs[n]; ok {
+			info.PlugBinds[n] = &sdk.PlugBind{
+				ProjectId: w.Project.ProjectId,
+				Workshop:  w.Name,
+				Sdk:       plug.Bind.Sdk,
+				Name:      plug.Bind.Plug,
+			}
+		}
+	}
+	return nil
 }
 
 // Returns a list of SDK info for installed SDKs. The info includes SDK details

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -209,3 +209,27 @@ func (w *Workshop) ContentInfo(ctx context.Context) ([]*sdk.Info, error) {
 	}
 	return infos, nil
 }
+
+func (w *Workshop) InstallAgentSdk(ctx context.Context) error {
+	wfs, err := w.Backend.WorkshopFs(ctx, w.Name)
+	if err != nil {
+		return err
+	}
+	defer wfs.Close()
+
+	agentMetaDir := filepath.Join(sdk.SdkCurrentPath("agent"), "meta")
+	if err := wfs.MkdirAll(agentMetaDir, 0655); err != nil {
+		return err
+	}
+
+	// /var/lib/workshop/sdk/agent/current/meta
+	file, err := wfs.OpenFile(filepath.Join(agentMetaDir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	if err != nil {
+		return err
+	}
+
+	if _, err = file.Write([]byte(sdk.AgentSdkMeta(w.Base))); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/sdk"
-	"golang.org/x/exp/slices"
 )
 
 var (

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -106,7 +106,7 @@ func readWorkshop(pathname string) (*File, error) {
 	// checks (at this stage). Later, when SDK metadata will be received, the
 	// plugs must be checked again (e.g. ensure all those plugs actually exist).
 	for _, s := range file.Sdks {
-		for _, p := range s.Plugs {
+		for name, p := range s.Plugs {
 			comps := strings.Split(p.Bind, ":")
 			if len(comps) != 2 {
 				return nil, fmt.Errorf("incorrect bind plug reference: %q (use <sdk>:<plug>)", p.Bind)
@@ -117,6 +117,11 @@ func readWorkshop(pathname string) (*File, error) {
 			if ixd := slices.IndexFunc(file.Sdks, func(sr SdkRecord) bool { return comps[0] == sr.Name }); ixd == -1 {
 				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", p.Bind)
 			}
+			if comps[0] == s.Name && name == comps[1] {
+				return nil, fmt.Errorf("cannot bind plug %s:%s to itself", s.Name, name)
+			}
+
+			// TODO: check if we try to bind to a plug that is already bound
 		}
 	}
 

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -9,12 +9,50 @@ import (
 
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
+)
 
-	"github.com/canonical/workshop/internal/sdk"
+var (
+	workshopName = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+	allowedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
+	channel      = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
+
+	// *.yaml is the only supported extension for workshop files as the only
+	// recommended "official" extension: https://yaml.org/faq.html. Also, having a
+	// single way of naming workshop files avoids unneccesary inconsistencies.
+	filename     = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
+	sdkBlacklist = []string{"agent"}
 )
 
 type Plug struct {
-	Bind string `yaml:"bind"`
+	Bind Bind `yaml:"bind"`
+}
+
+type Bind struct {
+	Sdk  string
+	Plug string
+}
+
+func (b *Bind) UnmarshalYAML(value *yaml.Node) error {
+	var bindStr string
+	if err := value.Decode(&bindStr); err != nil {
+		return err
+	}
+
+	parts := strings.SplitN(bindStr, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("incorrect bind plug reference: %q (use <sdk>:<plug>)", bindStr)
+	}
+	if !workshopName.MatchString(parts[0]) {
+		return fmt.Errorf("%q isn't a valid SDK name", parts[0])
+	}
+
+	b.Sdk = parts[0]
+	b.Plug = parts[1]
+	return nil
+}
+
+func (b Bind) MarshalYAML() (interface{}, error) {
+	return fmt.Sprintf("%s:%s", b.Sdk, b.Plug), nil
 }
 
 type SdkRecord struct {
@@ -30,11 +68,6 @@ type File struct {
 	Base string  `yaml:"base"`
 	Sdks SdkList `yaml:"sdks,omitempty"`
 }
-
-// *.yaml is the only supported extension for workshop files as the only
-// recommended "official" extension: https://yaml.org/faq.html. Also, having a
-// single way of naming workshop files avoids unneccesary inconsistencies.
-var validWorkshopFilename = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
 
 func (p SdkList) MarshalYAML() (interface{}, error) {
 	type sdkDef struct {
@@ -94,11 +127,11 @@ func readWorkshop(pathname string) (*File, error) {
 		return cmp.Compare(a.Name, b.Name)
 	})
 
-	if !sdk.ValidName.MatchString(file.Name) {
+	if !workshopName.MatchString(file.Name) {
 		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) include only lower case alpha-numeric or an underscore symbol(s)")
 	}
 
-	if !slices.Contains(sdk.ValidBases, file.Base) {
+	if !slices.Contains(allowedBases, file.Base) {
 		return nil, fmt.Errorf("unsupported base: %s", file.Base)
 	}
 
@@ -107,29 +140,21 @@ func readWorkshop(pathname string) (*File, error) {
 	// plugs must be checked again (e.g. ensure all those plugs actually exist).
 	for _, s := range file.Sdks {
 		for name, p := range s.Plugs {
-			comps := strings.Split(p.Bind, ":")
-			if len(comps) != 2 {
-				return nil, fmt.Errorf("incorrect bind plug reference: %q (use <sdk>:<plug>)", p.Bind)
+			if ixd := slices.IndexFunc(file.Sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }); ixd == -1 {
+				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", fmt.Sprintf("%s:%s", p.Bind.Sdk, p.Bind.Plug))
 			}
-			if !sdk.ValidName.MatchString(comps[0]) {
-				return nil, fmt.Errorf("%q isn't a valid SDK name", comps[0])
-			}
-			if ixd := slices.IndexFunc(file.Sdks, func(sr SdkRecord) bool { return comps[0] == sr.Name }); ixd == -1 {
-				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", p.Bind)
-			}
-			if comps[0] == s.Name && name == comps[1] {
+			if p.Bind.Sdk == s.Name && p.Bind.Plug == name {
 				return nil, fmt.Errorf("cannot bind plug %s:%s to itself", s.Name, name)
 			}
-
 			// TODO: check if we try to bind to a plug that is already bound
 		}
 	}
 
 	for _, s := range file.Sdks {
-		if s.Name == sdk.Agent.String() {
+		if idx := slices.Index(sdkBlacklist, s.Name); idx != -1 {
 			return nil, fmt.Errorf(`"agent" is a reserved SDK name`)
 		}
-		if matches := sdk.ValidChannel.FindStringSubmatch(s.Channel); matches != nil {
+		if matches := channel.FindStringSubmatch(s.Channel); matches != nil {
 			continue
 		} else {
 			return nil, fmt.Errorf("unsupported channel %s for \"%s\"", s.Channel, s.Name)

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
@@ -138,15 +139,41 @@ func readWorkshop(pathname string) (*File, error) {
 	// All bindings must refer to the existing SDKs and meet the name validity
 	// checks (at this stage). Later, when SDK metadata will be received, the
 	// plugs must be checked again (e.g. ensure all those plugs actually exist).
+	type plug struct {
+		sdk  string
+		name string
+	}
+	var masters map[plug][]plug = make(map[plug][]plug)
+	var slaves map[plug]plug = make(map[plug]plug)
 	for _, s := range file.Sdks {
 		for name, p := range s.Plugs {
+			mr := plug{sdk: p.Bind.Sdk, name: p.Bind.Plug}
+			sl := plug{sdk: s.Name, name: name}
+			masters[mr] = append(masters[mr], sl)
+			slaves[sl] = mr
+
 			if ixd := slices.IndexFunc(file.Sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }); ixd == -1 {
 				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", fmt.Sprintf("%s:%s", p.Bind.Sdk, p.Bind.Plug))
 			}
 			if p.Bind.Sdk == s.Name && p.Bind.Plug == name {
 				return nil, fmt.Errorf("cannot bind plug %s:%s to itself", s.Name, name)
 			}
-			// TODO: check if we try to bind to a plug that is already bound
+		}
+	}
+
+	// Ensure that there are no "multi-level" binds, e.g. s1 bind to m1 bind to m2.
+	slaveKeysOrdered := maps.Keys(slaves)
+	slices.SortFunc(slaveKeysOrdered, func(a, b plug) int {
+		c := cmp.Compare(a.sdk, b.sdk)
+		if c == 0 {
+			return cmp.Compare(a.name, b.name)
+		}
+		return c
+	})
+	for _, sl := range slaveKeysOrdered {
+		m := slaves[sl]
+		if _, ok := masters[sl]; ok {
+			return nil, fmt.Errorf("cannot bind %s:%s to %s:%s; plug %s:%s must not be bound", sl.sdk, sl.name, m.sdk, m.name, sl.sdk, sl.name)
 		}
 	}
 

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/spf13/afero"
 	"golang.org/x/exp/slices"
@@ -20,6 +21,8 @@ type workshopFile struct {
 }
 
 var _ = check.Suite(&workshopFile{})
+
+func TestWorkshop(t *testing.T) { check.TestingT(t) }
 
 func (f *workshopFile) SetUpTest(c *check.C) {
 	f.fs = afero.NewMemMapFs()
@@ -66,8 +69,8 @@ func (f *workshopFile) TestWorkshopFileSave(c *check.C) {
 		Name: "test-workshop",
 		Base: "ubuntu@22.04",
 		Sdks: []workshop.SdkRecord{
-			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: "two:plug"}}},
-			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: "one:plug"}}},
+			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: workshop.Bind{Sdk: "two", Plug: "plug"}}}},
+			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: workshop.Bind{Sdk: "one", Plug: "plug"}}}},
 		},
 	}
 	out, err := yaml.Marshal(fl)
@@ -139,8 +142,8 @@ sdks:
 	file, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshop.SdkList{
-		workshop.SdkRecord{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Bind: "etl-sdk:cache"}}},
-		workshop.SdkRecord{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: "data-sdk:cache"}}},
+		workshop.SdkRecord{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Bind: workshop.Bind{Sdk: "etl-sdk", Plug: "cache"}}}},
+		workshop.SdkRecord{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: workshop.Bind{Sdk: "data-sdk", Plug: "cache"}}}},
 	})
 }
 

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -134,7 +134,7 @@ sdks:
     channel: latest/stable
     plugs:
       data: 
-        bind: data-sdk:cache
+        bind: data-sdk:aux
 `)
 	dir := c.MkDir()
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
@@ -143,7 +143,7 @@ sdks:
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshop.SdkList{
 		workshop.SdkRecord{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Bind: workshop.Bind{Sdk: "etl-sdk", Plug: "cache"}}}},
-		workshop.SdkRecord{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: workshop.Bind{Sdk: "data-sdk", Plug: "cache"}}}},
+		workshop.SdkRecord{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: workshop.Bind{Sdk: "data-sdk", Plug: "aux"}}}},
 	})
 }
 
@@ -206,4 +206,52 @@ sdks:
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.ErrorMatches, `incorrect bind plug reference: "cache" \(use <sdk>:<plug>\)`)
+}
+
+func (f *workshopFile) TestBindToAlreadyBoundPlug(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+    plugs:
+      cache:
+        bind: etl-sdk:cache
+      aux:
+        bind: etl-sdk:data
+  etl-sdk:
+    channel: latest/stable
+    plugs:
+      cache: 
+        bind: etl-sdk:data
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `cannot bind etl-sdk:cache to etl-sdk:data; plug etl-sdk:cache must not be bound`)
+}
+
+func (f *workshopFile) TestIndirectBindToAlreadyBoundPlug(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: data-sdk:aux
+      aux:
+        bind: etl-sdk:cache
+  etl-sdk:
+    channel: latest/stable
+    plugs:
+      cache:
+        bind: data-sdk:data
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `cannot bind data-sdk:aux to etl-sdk:cache; plug data-sdk:aux must not be bound`)
 }

--- a/tests/lib/sdk/test-sdk-multiple-plugs/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-multiple-plugs/meta/sdk.yaml
@@ -1,0 +1,16 @@
+name: test-sdk-multiple-plugs
+title: test-sdk-multiple-plugs
+base: ubuntu@20.04
+
+summary: test-sdk-multiple-plugs SDK
+description: |
+  test-sdk-multiple-plugs SDK
+plugs:
+  data:
+    interface: content
+    target: /home/workshop/data
+  cache:
+    interface: content
+    target: /cache
+  ssh-agent:
+    interface: ssh-agent

--- a/tests/lib/sdk/test-sdk-multiple-plugs/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-multiple-plugs/sdk/hooks/setup-base
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+exit 0

--- a/tests/lib/sdk/test-sdk-ssh-agent/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-ssh-agent/meta/sdk.yaml
@@ -1,0 +1,10 @@
+name: test-sdk-ssh-agent
+title: test-sdk-ssh-agent
+base: ubuntu@20.04
+
+summary: test-sdk-ssh-agent SDK
+description: |
+  test-sdk-ssh-agent SDK
+plugs:
+  ssh-agent:
+    interface: ssh-agent

--- a/tests/lib/sdk/test-sdk-ssh-agent/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-ssh-agent/sdk/hooks/setup-base
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+exit 0

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -3,8 +3,8 @@
 # Install and uninstall workshopd
 
 function init_lxd() {
-  snap install lxd --classic
-  snap refresh lxd --channel=latest/stable
+  snap install --classic lxd
+  snap refresh --channel=5.21/stable lxd
   
   # can already be initialised if reused
   # https://discuss.linuxcontainers.org/t/how-do-i-know-if-lxd-is-initialized/15473/3
@@ -18,9 +18,10 @@ function prepare_environment() {
   systemctl start snapd.service
   
   init_lxd  
-  snap install go --classic --channel=1.21/stable
+  snap install --classic --channel=1.21/stable go
   snap install yq
-  apt install jq -y --no-install-recommends
+  apt update
+  apt install -y --no-install-recommends moreutils jq
   
   snap install --dangerous --classic /workshop/tests/*.snap
   snap set workshop store.url=http://localhost:8080/storage/v1/
@@ -66,6 +67,7 @@ function publish_test_sdk_content() {
       tar czf "$SDK_FILE" -C "$SDK_PATH" $(ls -A "$SDK_PATH")
       mkdir -p "$STORE_PATH"
       mv "$SDK_FILE" "$STORE_PATH"
+      cp -f "$SDK_PATH"/meta/sdk.yaml "$STORE_PATH"
     done
 }
 

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -36,7 +36,7 @@ function cleanup_environment() {
 
 function start_sdk_store() {
     # run fake GCS bucket storage to emulate SDK store
-  publish_test_sdk_content "$SDKCONTENT" "$SDK_STORE_BUCKET_DIR"
+  publish_test_sdk_content "$SDKS" "$SDK_STORE_BUCKET_DIR"
   chown -R ubuntu.ubuntu /data # a bug with fake-gcs-server that returns 404 if not owned by the user
   mkdir -p /storage
   chown -R ubuntu.ubuntu /storage

--- a/tests/main/connect/task.yaml
+++ b/tests/main/connect/task.yaml
@@ -23,11 +23,13 @@ execute: |
   workshop_exec connect ws-conn/test-sdk-gpu:gpu
   workshop_exec connections ws-conn | MATCH "^gpu.+ws-conn/test-sdk-gpu:gpu.+:gpu.+manual$"
   
-  echo "Check workshop refresh reconnects manually connected connections"
+  echo "Check workshop refresh does not reconnect undesired connections"
+  workshop_exec refresh ws-conn
+  workshop_exec disconnect ws-conn/test-sdk-gpu:gpu
   workshop_exec refresh ws-conn
   workshop_exec connections ws-conn > output.log
-  MATCH "^content.+ws-conn/test-sdk-content:content-plug-one.+:content.+manual$" < output.log
-  MATCH "^content.+ws-conn/test-sdk-content:content-plug-two.+:content.+manual$" < output.log
-  MATCH "^gpu.+ws-conn/test-sdk-gpu:gpu.+:gpu.+manual$" < output.log
+  MATCH "^content.+ws-conn/test-sdk-content:content-plug-one.+:content.+$" < output.log
+  MATCH "^content.+ws-conn/test-sdk-content:content-plug-two.+:content.+$" < output.log
+  NOMATCH "^gpu.+ws-conn/test-sdk-gpu:gpu.+:gpu.+$" < output.log
 
   

--- a/tests/main/connect/task.yaml
+++ b/tests/main/connect/task.yaml
@@ -8,10 +8,10 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
   
-  echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot> form"
+  echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot> form"  
   workshop_exec disconnect ws-conn/test-sdk-content:content-plug-one ws-conn/agent:content  
   workshop_exec connect ws-conn/test-sdk-content:content-plug-one ws-conn/agent:content
-  workshop_exec connections ws-conn | MATCH "^content.+ws-conn/test-sdk-content:content-plug-one.+:content.+manual$"
+  workshop_exec connections ws-conn | MATCH "^content.+ws-conn/test-sdk-content:content-plug-one.+:content.+manual$"  
   
   echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk> form"
   workshop_exec disconnect ws-conn/test-sdk-content:content-plug-two :content

--- a/tests/main/interface-content/task.yaml
+++ b/tests/main/interface-content/task.yaml
@@ -2,13 +2,14 @@ summary: Check content interface scenarios
 execute: |
   . "$TESTSLIB"/utils.sh
     
-  function validate_plug_mounts() {
+  function validate_mounts() {
     test -d "$source_one"
     test -d "$source_two"
     workshop_exec exec ws-content -- bash -c "test -d /home/workshop"
     workshop_exec exec ws-content -- bash -c "test -d /opt"
     workshop_exec exec ws-content -- bash -c "touch /home/workshop/output"
     test -f "$source_one"/output
+    rm -f "$source_one"/output
   }
   
   echo "Check the content interface plug can be installed and auto-connected"
@@ -19,23 +20,32 @@ execute: |
   
   source_one="/home/ubuntu/.local/share/workshop/project/"$project_id"/content/ws-content_test-sdk-content_content-plug-one.sdk"
   source_two="/home/ubuntu/.local/share/workshop/project/"$project_id"/content/ws-content_test-sdk-content_content-plug-two.sdk"
-  validate_plug_mounts
+  validate_mounts
 
   echo "Check the content interface plugs auto-reconnected after refresh"
   workshop_exec refresh ws-content
-  validate_plug_mounts
+  validate_mounts
   
   echo "Check the content interface plugs auto-reconnected if refresh fails"
   sed -i 's/test-sdk-content/test-sdk-fail/g' .workshop.ws-content.yaml
   workshop_exec refresh ws-content || true
   sed -i 's/test-sdk-fail/test-sdk-content/g' .workshop.ws-content.yaml
-  validate_plug_mounts
+  validate_mounts
+  
+  echo "Check manual connect/disconnect works"
+  workshop_exec disconnect ws-content/test-sdk-content:content-plug-one
+  workshop_exec exec ws-content -- bash -c "touch /home/workshop/disconnect-test"
+  # no mount exists after disconnnect
+  test ! -f "$source_one"/disconnect-test
+  workshop_exec connect ws-content/test-sdk-content:content-plug-one :content
+  workshop_exec connections ws-content | MATCH "^content.+ws-content/test-sdk-content:content-plug-one.+:content.+manual$"
+  validate_mounts
   
   echo "Check the content interface slots cannot be installed by a workshop"
   sed -i 's/test-sdk-content/test-sdk-content-broken/g' .workshop.ws-content.yaml
   workshop_exec refresh ws-content 2>&1 | MATCH ".*installation not allowed by \"one\" slot rule of interface \"content\".*"
   sed -i 's/test-sdk-content-broken/test-sdk-content/g' .workshop.ws-content.yaml
-  validate_plug_mounts
+  validate_mounts
   
   echo "Check the content interface plugs removed after refresh if they don't exist anymore"
   sed -i 's/test-sdk-content/test-sdk-basic/g' .workshop.ws-content.yaml

--- a/tests/main/interface-plug-binding/.workshop.ws-bind.yaml
+++ b/tests/main/interface-plug-binding/.workshop.ws-bind.yaml
@@ -1,0 +1,18 @@
+name: ws-bind
+base: ubuntu@22.04
+sdks:
+  test-sdk-content:
+    channel: latest/stable
+    plugs:
+      content-plug-two:
+        bind: test-sdk-multiple-plugs:cache
+  test-sdk-multiple-plugs:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: test-sdk-content:content-plug-one
+  test-sdk-ssh-agent:
+    channel: latest/stable
+    plugs:
+      ssh-agent:
+        bind: test-sdk-multiple-plugs:ssh-agent

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -3,12 +3,12 @@ execute: |
   . "$TESTSLIB"/utils.sh
      
   function check_original_binding() {
-    MATCH "content    ws-bind/test-sdk-content:content-plug-one  :content  bind:1" < conns.log
-    MATCH "content    ws-bind/test-sdk-content:content-plug-two  :content  bind:3" < conns.log
-    MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      :content  bind:3" < conns.log
-    MATCH "content    ws-bind/test-sdk-multiple-plugs:data       :content  bind:1" < conns.log
-    MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -         bind:5" < conns.log
-    MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -         bind:5" < conns.log
+    MATCH "content    ws-bind/test-sdk-content:content-plug-one  :content  bind.1" < conns.log
+    MATCH "content    ws-bind/test-sdk-content:content-plug-two  :content  bind.3" < conns.log
+    MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      :content  bind.3" < conns.log
+    MATCH "content    ws-bind/test-sdk-multiple-plugs:data       :content  bind.1" < conns.log
+    MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -         bind.5" < conns.log
+    MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -         bind.5" < conns.log
   }
   
   workshop_exec launch ws-bind
@@ -25,14 +25,14 @@ execute: |
   echo "Check disconnect affects all bound plugs"
   workshop_exec disconnect ws-bind/test-sdk-multiple-plugs:cache
   workshop_exec connections ws-bind > conns.log
-  MATCH "content    ws-bind/test-sdk-content:content-plug-two  -         bind:3" < conns.log
-  MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      -         bind:3" < conns.log
+  MATCH "content    ws-bind/test-sdk-content:content-plug-two  -         bind.3" < conns.log
+  MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      -         bind.3" < conns.log
 
   echo "Check connect affects all bound plugs"
   workshop_exec connect ws-bind/test-sdk-multiple-plugs:cache :content
   workshop_exec connections ws-bind > conns.log
-  MATCH "content    ws-bind/test-sdk-content:content-plug-two  :content  manual,bind:3" < conns.log
-  MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      :content  manual,bind:3" < conns.log
+  MATCH "content    ws-bind/test-sdk-content:content-plug-two  :content  manual,bind.3" < conns.log
+  MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      :content  manual,bind.3" < conns.log
 
   echo "Check remount affects all bound plugs"
   new_source="/home/ubuntu/remount-bound-test"

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -1,0 +1,57 @@
+summary: Check plug binding
+execute: |
+  . "$TESTSLIB"/utils.sh
+     
+  function check_original_binding() {
+    MATCH "content    ws-bind/test-sdk-content:content-plug-one  :content  bind:1" < conns.log
+    MATCH "content    ws-bind/test-sdk-content:content-plug-two  :content  bind:3" < conns.log
+    MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      :content  bind:3" < conns.log
+    MATCH "content    ws-bind/test-sdk-multiple-plugs:data       :content  bind:1" < conns.log
+    MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -         bind:5" < conns.log
+    MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -         bind:5" < conns.log
+  }
+  
+  workshop_exec launch ws-bind
+  
+  echo "Check binding on launch"
+  workshop_exec connections ws-bind > conns.log
+  check_original_binding
+
+  echo "Check bound content plugs use host directories of the plug they are bound to"  
+  workshop_exec info ws-bind | grep -v notes > mounts.log
+  yq '.content["test-sdk-multiple-plugs"].mounts["data"]' < mounts.log | MATCH "^host:.*ws-bind_test-sdk-content_content-plug-one.sdk" 
+  yq '.content["test-sdk-content"].mounts["content-plug-two"]' < mounts.log | MATCH "^host:.*ws-bind_test-sdk-multiple-plugs_cache.sdk" 
+
+  echo "Check disconnect affects all bound plugs"
+  workshop_exec disconnect ws-bind/test-sdk-multiple-plugs:cache
+  workshop_exec connections ws-bind > conns.log
+  MATCH "content    ws-bind/test-sdk-content:content-plug-two  -         bind:3" < conns.log
+  MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      -         bind:3" < conns.log
+
+  echo "Check connect affects all bound plugs"
+  workshop_exec connect ws-bind/test-sdk-multiple-plugs:cache :content
+  workshop_exec connections ws-bind > conns.log
+  MATCH "content    ws-bind/test-sdk-content:content-plug-two  :content  manual,bind:3" < conns.log
+  MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      :content  manual,bind:3" < conns.log
+
+  echo "Check remount affects all bound plugs"
+  new_source="/home/ubuntu/remount-bound-test"
+  workshop_exec remount ws-bind/test-sdk-content:content-plug-two "$new_source"
+  workshop_exec info ws-bind | grep -v notes > mounts.log
+  yq '.content["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host:.*$new_source" 
+  yq '.content["test-sdk-content"].mounts["content-plug-two"]' < mounts.log | MATCH "^host:.*$new_source" 
+
+  echo "Check refresh respects binding"
+  workshop_exec refresh ws-bind
+  workshop_exec connections ws-bind > conns.log
+  check_original_binding
+  
+  echo "Check a plug maybe unbound"
+  cat .workshop.ws-bind.yaml | yq '.sdks["test-sdk-content"].plugs = ~' | sponge .workshop.ws-bind.yaml
+  workshop_exec refresh ws-bind
+  workshop_exec connections ws-bind > conns.log
+  MATCH "content    ws-bind/test-sdk-content:content-plug-two  :content  -" < conns.log
+  MATCH "content    ws-bind/test-sdk-multiple-plugs:cache      :content  -" < conns.log  
+  workshop_exec info ws-bind | grep -v notes > mounts.log
+  yq '.content["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host:.*$new_source" 
+  yq '.content["test-sdk-content"].mounts["content-plug-two"]' < mounts.log | MATCH "^host:.*ws-bind_test-sdk-content_content-plug-two.sdk" 


### PR DESCRIPTION
# Description

An SDK's plug can be bound to another plug of the same interface. Both plugs must belong to the same workshop.

```
# .workshop.demo.yaml
base: ubuntu@22.04
name: demo
sdks:
  go:
    channel: latest/candidate    
  dev-tunnel:
    channel: latest/edge
    plugs:
      data:
        bind: go:mod-cache

> workshop connections ws
Interface  Plug                     Slot      Notes
content    demo/dev-tunnel:data     :content  bind.2
content    demo/go:mod-cache        :content  bind.2  
```

Binding affects multiple workshop commands:

- `connect`, `disconnect` are aware of the bound plugs. Any plug in a bound group can be used to connect or disconnect the entire group. The connections of bound plugs will derive the attributes of the plug's connection that they are bound to. In the example above, the `dev-tunnel:data` connection will use the attributes of `go:mod-cache`, i.e. both of them will share the created bind mount (see `workshop info`).
- `connections` will highlight bound plugs in the notes. A plug that is bound will have `bind.n` where _n_ is the output's row number of the connection that the given plug is bound to.
- `remount` will change attributes of all the bound connections.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
