### PR TITLE
Support disconnect <slot> for bound plugs

### DIFF
--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -378,6 +378,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 			}
 		}
 		repo := c.d.overlord.InterfaceManager().Repository()
+		seen := map[interfaces.ConnRef]bool{}
 		for _, connRef := range conns {
 			var ts *state.TaskSet
 			plugW, werr := c.d.overlord.WorkshopManager().Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
@@ -394,13 +395,15 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 					break
 				}
 			}
-			ts, err = ifacestate.Disconnect(st, plugW, connRef, a.Forget)
+			ts, err = ifacestate.Disconnect(st, plugW, connRef, a.Forget, seen)
 			if err != nil {
 				break
 			}
 
-			ts.JoinLane(st.NewLane())
-			tasksets = append(tasksets, ts)
+			if len(ts.Tasks()) > 0 {
+				ts.JoinLane(st.NewLane())
+				tasksets = append(tasksets, ts)
+			}
 		}
 	}
 	if err != nil {

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -49,7 +49,7 @@ plugs:
   key: value
   label: label
 `
-	consumerYamlBound = `
+	consumerYamlManyPlugs = `
 name: consumer
 base: ubuntu@22.04
 plugs:
@@ -725,7 +725,7 @@ func (s *apiSuite) TestConnectionsBoundPlug(c *check.C) {
 
 	d := s.daemon(c)
 
-	s.mockInstalledSDKBoundPlug(c, consumerYamlBound, "consumer-ws", "plug", "plug2")
+	s.mockInstalledSDKBoundPlug(c, consumerYamlManyPlugs, "consumer-ws", "plug", "plug2")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
 	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
@@ -1096,7 +1096,7 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 
 	d := s.daemon(c)
 
-	s.mockInstalledSDK(c, consumerYamlBound, "consumer-ws")
+	s.mockInstalledSDK(c, consumerYamlManyPlugs, "consumer-ws")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
 	wp, err := s.b.Workshop(s.ctx, "consumer-ws")
@@ -1433,7 +1433,7 @@ func (s *apiSuite) testDisconnect(c *check.C, pW, pSdk, pName string, sW, sSdk, 
 
 	d := s.daemon(c)
 
-	wp := s.mockInstalledSDK(c, consumerYamlBound, "consumer-ws")
+	wp := s.mockInstalledSDK(c, consumerYamlManyPlugs, "consumer-ws")
 	wp.File.Sdks[0].Plugs = opts.bind
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
@@ -1536,6 +1536,20 @@ func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 		},
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
+	s.d.state.Lock()
+	var conns map[string]interface{}
+	s.d.state.Get("conns", &conns)
+	c.Assert(conns, check.HasLen, 0)
+	s.d.state.Unlock()
+}
+
+func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
+	opts := &disconnectOpts{
+		bind: map[string]workshop.Plug{
+			"plug2": {Bind: workshop.Bind{Sdk: "consumer", Plug: "plug"}},
+		},
+	}
+	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
 	var conns map[string]interface{}
 	s.d.state.Get("conns", &conns)

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -70,31 +70,46 @@ func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.Conn
 	return ts, nil
 }
 
-func disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool) *state.TaskSet {
-	master, affected := MaybeBound(plugW, conn.PlugRef)
-
-	mtask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", master, conn.SlotRef.ShortRef()))
-	mtask.Set("plug", master)
-	mtask.Set("slot", conn.SlotRef)
-	mtask.Set("forget", forget)
-	ts := state.NewTaskSet(mtask)
-	prev := mtask
-
-	for _, p := range affected {
-		stask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", p, conn.SlotRef.ShortRef()))
-		stask.Set("plug", p)
-		stask.Set("slot", conn.SlotRef)
-		stask.Set("forget", forget)
-
-		stask.WaitFor(prev)
-		prev = stask
-		ts.AddTask(stask)
+func maybeAddDisconnect(st *state.State, ts *state.TaskSet, conn interfaces.ConnRef, forget bool, seen map[interfaces.ConnRef]bool) error {
+	if _, ok := seen[conn]; ok {
+		return nil
 	}
-	return ts
+
+	dtask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", conn.PlugRef.ShortRef(), conn.SlotRef.ShortRef()))
+	dtask.Set("plug", conn.PlugRef)
+	dtask.Set("slot", conn.SlotRef)
+	dtask.Set("forget", forget)
+
+	l := len(ts.Tasks())
+	if l > 0 {
+		dtask.WaitFor(ts.Tasks()[l-1])
+	}
+	ts.AddTask(dtask)
+	seen[conn] = true
+
+	return nil
+}
+
+func disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool, seen map[interfaces.ConnRef]bool) (*state.TaskSet, error) {
+	master, affected := MaybeBound(plugW, conn.PlugRef)
+	var ts = state.NewTaskSet()
+
+	cref := interfaces.ConnRef{PlugRef: master, SlotRef: conn.SlotRef}
+	if err := maybeAddDisconnect(st, ts, cref, forget, seen); err != nil {
+		return nil, err
+	}
+
+	for _, slave := range affected {
+		cref = interfaces.ConnRef{PlugRef: slave, SlotRef: conn.SlotRef}
+		if err := maybeAddDisconnect(st, ts, cref, forget, seen); err != nil {
+			return nil, err
+		}
+	}
+	return ts, nil
 }
 
 // Disconnect returns a set of tasks for disconnecting an interface.
-func Disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool) (*state.TaskSet, error) {
+func Disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool, seen map[interfaces.ConnRef]bool) (*state.TaskSet, error) {
 	plugProject, plugWorkshop := conn.PlugRef.ProjectId, conn.PlugRef.Workshop
 	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
 	if err != nil {
@@ -106,5 +121,6 @@ func Disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.Conn
 	if err != nil {
 		return nil, err
 	}
-	return disconnect(st, plugW, conn, forget), nil
+
+	return disconnect(st, plugW, conn, forget, seen)
 }


### PR DESCRIPTION
# Description

When disconnect is provided with a slot only, it will be executed for every plug connected to a given slot. In the case of bound plugs, disconnect should not create a disconnect task for a bound connection twice (once for the connection from the resolved list and once for the connection that was found to be bound).

This change ensures that the slot-only form is aware of the bound plugs and disconnects them properly.



# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
