### PR TITLE
Report SDK download progress to clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ docs/.sphinx/styles/
 docs/__pycache__/
 package*.json
 docs/_build
+
+# sentitive files
+*.crt
+*.key

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -88,7 +88,6 @@ func CreateDirs() error {
 	if err := os.MkdirAll(BaseDir, 0755); err != nil {
 		return err
 	}
-
 	if err := os.MkdirAll(SdkDir, 0755); err != nil {
 		return err
 	}

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -40,6 +40,8 @@ var (
 	XdgRuntimeDirBase string
 	// Run directory
 	WorkshopdRunDir string
+	// Locks directory
+	WorkshopdLocksDir string
 )
 
 func getEnvPaths() (workshopdDir string, socketPath string) {
@@ -82,6 +84,7 @@ func SetRootDir(rootdir string) {
 	BaseDir = rootdir
 	SdkDir = filepath.Join(BaseDir, "sdk")
 	WorkshopdRunDir = filepath.Join(BaseDir, "/run/workshopd")
+	WorkshopdLocksDir = filepath.Join(WorkshopdRunDir, "locks")
 }
 
 func CreateDirs() error {
@@ -92,6 +95,9 @@ func CreateDirs() error {
 		return err
 	}
 	if err := os.MkdirAll(WorkshopdRunDir, 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(WorkshopdLocksDir, 0755); err != nil {
 		return err
 	}
 	return nil

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -9,12 +9,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"testing"
+	"sync"
 
 	"github.com/canonical/workshop/internal/dirs"
 	store "github.com/canonical/workshop/internal/fakestore"
 	"github.com/canonical/workshop/internal/logger"
-	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"gopkg.in/check.v1"
@@ -26,10 +26,8 @@ type storeIntegration struct {
 
 var _ = check.Suite(&storeIntegration{})
 
-func TestFakeStoreIntegration(t *testing.T) { check.TestingT(t) }
-
 func (f *storeIntegration) SetUpSuite(c *check.C) {
-	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8080"), check.IsNil)
+	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8080/storage/v1/"), check.IsNil)
 	f.oldRoot = dirs.BaseDir
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(dirs.CreateDirs(), check.IsNil)
@@ -43,9 +41,27 @@ func (f *storeIntegration) TearDownSuite(c *check.C) {
 func (f *storeIntegration) TestStoreDownloadOK(c *check.C) {
 	s := store.New()
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable"}
-	err := s.DownloadSdk(context.Background(), setup)
+	err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(setup.Filename(), testutil.FilePresent)
+	c.Assert(os.Remove(setup.Filename()), check.IsNil)
+}
+
+func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
+	s := store.New()
+	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable"}
+	done, total := 0, 0
+	r := &progress.Reporter{Name: "1", Report: func(label string, d, t int) {
+		done += d
+		total = t
+	}}
+	err := s.DownloadSdk(context.Background(), setup, r)
+	c.Assert(err, check.IsNil)
+	c.Assert(setup.Filename(), testutil.FilePresent)
+	c.Check(done > 0, check.Equals, true)
+	c.Check(total > 0, check.Equals, true)
+	c.Check(done == total, check.Equals, true)
+	c.Assert(os.Remove(setup.Filename()), check.IsNil)
 }
 
 func (f *storeIntegration) TestStoreDownloadCleanupPrevious(c *check.C) {
@@ -54,21 +70,22 @@ func (f *storeIntegration) TestStoreDownloadCleanupPrevious(c *check.C) {
 	prev := filepath.Join(dirs.SdkDir, setup.Name) + "_5.sdk"
 	_, err := os.Create(prev)
 	c.Assert(err, check.IsNil)
-	err = s.DownloadSdk(context.Background(), setup)
+	err = s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(setup.Filename(), testutil.FilePresent)
 	c.Assert(prev, check.Not(testutil.FilePresent))
+	c.Assert(os.Remove(setup.Filename()), check.IsNil)
 }
 
 func (f *storeIntegration) TestStoreDownloadNotfound(c *check.C) {
 	s := store.New()
 	setup := sdk.Setup{Name: "test-sdk-unknown", Channel: "latest/stable"}
-	err := s.DownloadSdk(context.Background(), setup)
-	c.Assert(err, check.ErrorMatches, `SDK not found`)
+	err := s.DownloadSdk(context.Background(), setup, nil)
+	c.Assert(err, check.ErrorMatches, `SDK not found in "latest/stable"`)
 	c.Assert(setup.Filename(), check.Not(testutil.FilePresent))
 }
 
-func (f *storeIntegration) TestStoreDownloadSkipIfExists(c *check.C) {
+func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.C) {
 	os.Setenv("WORKSHOP_DEBUG", "1")
 	defer os.Unsetenv("WORKSHOP_DEBUG")
 
@@ -80,20 +97,24 @@ func (f *storeIntegration) TestStoreDownloadSkipIfExists(c *check.C) {
 
 	// Lock the file to emulate a concurrent download is going on
 	target := setup.Filename()
-	fl, err := osutil.NewFileLock(target + ".lock")
+	fl, err := sdk.OpenLock(setup.Name)
 	c.Assert(err, check.IsNil)
 	c.Assert(fl.Lock(), check.IsNil)
 
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		err := s.DownloadSdk(context.Background(), setup)
-		c.Assert(err, check.IsNil)
-		c.Assert(m.String(), check.Matches, fmt.Sprintf(`*.DEBUG: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_0.sdk`, dirs.SdkDir))
+		err := s.DownloadSdk(context.Background(), setup, nil)
+		c.Check(err, check.IsNil)
+		c.Check(m.String(), check.Matches, fmt.Sprintf(`(?s)*.DEBUG: SDK Store on Download: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_0.sdk.*`, dirs.SdkDir))
+		wg.Done()
 	}()
 
 	// "download" is finished
 	_, err = os.Create(target)
 	c.Assert(err, check.IsNil)
 	fl.Close()
+	wg.Wait()
 }
 
 type failingReader struct{}
@@ -111,12 +132,12 @@ func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
 
 	s := store.New()
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: 55}
-	err := s.DownloadSdk(context.Background(), setup)
+	err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.NotNil)
 	c.Assert(setup.Filename(), check.Not(testutil.FilePresent))
 }
 
-func (s *storeSuite) TestSdkActionInstallStoreError(c *check.C) {
+func (s *storeIntegration) TestSdkActionInstallStoreError(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
 	store := store.New()
@@ -129,5 +150,5 @@ func (s *storeSuite) TestSdkActionInstallStoreError(c *check.C) {
 	}}
 	res, err := store.SdkAction(context.Background(), nil, acts)
 	c.Assert(res, check.HasLen, 0)
-	c.Assert(err, check.ErrorMatches, `SDK not found`)
+	c.Assert(err, check.ErrorMatches, `(?s).*SDK not found in "latest/stable".*`)
 }

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -87,7 +87,7 @@ func (f *storeIntegration) TestStoreDownloadSkipIfExists(c *check.C) {
 	go func() {
 		err := s.DownloadSdk(context.Background(), setup)
 		c.Assert(err, check.IsNil)
-		c.Assert(m.String(), check.Matches, fmt.Sprintf("*.DEBUG: %s/test-sdk-basic_0.sdk exists, nothing to download...", dirs.SdkDir))
+		c.Assert(m.String(), check.Matches, fmt.Sprintf(`*.DEBUG: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_0.sdk`, dirs.SdkDir))
 	}()
 
 	// "download" is finished

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -10,12 +10,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 )
 
@@ -43,6 +46,7 @@ type storeSdk struct {
 	Channel  string `json:"channel"`
 	Revision int64  `json:"revision"`
 	SdkYAML  string `json:"sdk-yaml"`
+	Size     int64  `json:"size"`
 }
 
 type SdkActionError struct {
@@ -86,7 +90,7 @@ func (c *GcsStore) SdkAction(ctx context.Context, currentSdks map[string]*sdk.In
 			info.Revision = s.Revision
 			info.Channel = s.Channel
 
-			results = append(results, sdk.SdkResult{info})
+			results = append(results, sdk.SdkResult{Info: info})
 		default:
 			return nil, fmt.Errorf("unknown SDK store action")
 		}
@@ -99,13 +103,20 @@ func (c *GcsStore) SdkAction(ctx context.Context, currentSdks map[string]*sdk.In
 	return results, nil
 }
 
-func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup) error {
-	r, err := storeSdkReader(ctx, setup)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
+type reporterWriter struct {
+	r     *progress.Reporter
+	done  int
+	total int
+}
 
+func (r *reporterWriter) Write(p []byte) (n int, err error) {
+	plen := len(p)
+	r.done += plen
+	r.r.Report("download", r.done, r.total)
+	return plen, nil
+}
+
+func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *progress.Reporter) error {
 	fl, err := sdk.OpenLock(setup.Name)
 	if err != nil {
 		return err
@@ -114,6 +125,17 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup) error {
 		return err
 	}
 	defer fl.Close()
+
+	info, err := storeSdkInfo(ctx, setup.Name, setup.Channel)
+	if err != nil {
+		return err
+	}
+
+	r, err := storeSdkReader(ctx, setup)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
 
 	target := setup.Filename()
 	if !osutil.FileExists(target) {
@@ -144,7 +166,14 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup) error {
 		}()
 		defer file.Close()
 
-		if _, err = io.Copy(file, r); err != nil {
+		var writer io.Writer
+		if report != nil {
+			writer = io.MultiWriter(file, &reporterWriter{r: report, total: int(info.Size)})
+		} else {
+			writer = file
+		}
+
+		if _, err = io.Copy(writer, r); err != nil {
 			return err
 		}
 	} else {
@@ -190,7 +219,7 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 	atr, err := obj.Attrs(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrObjectNotExist) {
-			return sSdk, errors.New("SDK not found")
+			return sSdk, fmt.Errorf("SDK not found in %q", channel)
 		}
 		return sSdk, err
 	}
@@ -198,6 +227,7 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 	sSdk.Channel = channel
 	// A simple modulo to keep revision numbers in a readable form for testing
 	sSdk.Revision = atr.Generation % 1000
+	sSdk.Size = atr.Size
 	// The test server for the SDK store cannot store metadata.
 	if !client.isTesting {
 		if _, ok := atr.Metadata["sdk-yaml"]; !ok {
@@ -247,7 +277,11 @@ func storeSdkReaderImpl(ctx context.Context, setup sdk.Setup) (io.ReadCloser, er
 	}
 	track, risk := sa[0], sa[1]
 	bkt := client.Bucket(SDK_STORE_BUCKET_NAME)
-	obj := bkt.Object(fmt.Sprintf("%s/%s/%s/%s.sdk", setup.Name, track, risk, setup.Name))
+
+	obj := bkt.Object(fmt.Sprintf("%s/%s/%s/%s.sdk", setup.Name, track, risk, setup.Name)).Retryer(
+		storage.WithBackoff(gax.Backoff{Initial: 2 * time.Second}),
+		storage.WithPolicy(storage.RetryIdempotent),
+	)
 	r, err := obj.NewReader(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrObjectNotExist) {

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -125,19 +125,19 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup) error {
 			// Remove the target as due to the error it may be corrupted.
 			if err != nil {
 				if err1 := os.Remove(target); err1 != nil {
-					logger.Noticef("Cannot remove %q on a failed download: %v", target, err1)
+					logger.Noticef("SDK Store on Download: Cannot remove %q on a failed download: %v", target, err1)
 				}
 				return
 			}
 			// If the SDK was downloaded successfully, remove its previous rev if any.
 			matches, err1 := filepath.Glob(filepath.Join(filepath.Dir(target), setup.Name+"_*.sdk"))
 			if err1 != nil {
-				logger.Noticef("Cannot cleanup previous downloads for %q: %v", setup.Name, err1)
+				logger.Noticef("SDK Store on Download: Cannot cleanup previous downloads for %q: %v", setup.Name, err1)
 			}
 			for _, m := range matches {
 				if m != target {
 					if err1 = os.Remove(m); err1 != nil {
-						logger.Noticef("Cannot cleanup previous download (%s): %v", m, err1)
+						logger.Noticef("SDK Store on Download: Cannot cleanup previous download (%s): %v", m, err1)
 					}
 				}
 			}
@@ -148,7 +148,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup) error {
 			return err
 		}
 	} else {
-		logger.Debugf("%s exists, nothing to download...", target)
+		logger.Debugf("SDK Store on Download: SDK %q found locally: %s", setup.Name, target)
 	}
 
 	return nil

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -1,12 +1,10 @@
 package sdkstate
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
-	"time"
 
 	"github.com/spf13/afero"
 	"gopkg.in/tomb.v2"
@@ -17,6 +15,7 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
@@ -64,15 +63,23 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	ctx, _ := BackendContext(tomb, user, project.ProjectId)
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
 	st.Lock()
 	store := sdk.StoreService(st)
 	st.Unlock()
 
-	return store.DownloadSdk(ctx, rec)
+	reporter := &progress.Reporter{
+		Name: task.ID(),
+		Report: func(label string, done, total int) {
+			st.Lock()
+			task.SetProgress(label, done, total)
+			st.Unlock()
+		},
+	}
+
+	return store.DownloadSdk(ctx, rec, reporter)
 }
 
 func (m *SdkManager) doInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -52,7 +53,7 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	reporter := workshop.ProgressReporter{
+	reporter := &progress.Reporter{
 		Name: task.ID(),
 		Report: func(label string, done, total int) {
 			st.Lock()
@@ -61,7 +62,7 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 		},
 	}
 
-	return m.backend.Download(ctx, wf.Base, &reporter)
+	return m.backend.Download(ctx, wf.Base, reporter)
 }
 
 func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -52,13 +52,16 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	reporter := func(label string, done, total int) {
-		st.Lock()
-		task.SetProgress(label, done, total)
-		st.Unlock()
+	reporter := workshop.ProgressReporter{
+		Name: task.ID(),
+		Report: func(label string, done, total int) {
+			st.Lock()
+			task.SetProgress(label, done, total)
+			st.Unlock()
+		},
 	}
 
-	return m.backend.Download(ctx, wf.Base, reporter)
+	return m.backend.Download(ctx, wf.Base, &reporter)
 }
 
 func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -275,7 +276,7 @@ func (s *workshopHandlers) TestDownloadBase(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.backend.DownloadBaseCallback = func(ctx context.Context, base string, report *workshop.ProgressReporter) error {
+	s.backend.DownloadBaseCallback = func(ctx context.Context, base string, report *progress.Reporter) error {
 		report.Report("download finished", 100, 100)
 		return nil
 	}

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -275,8 +275,8 @@ func (s *workshopHandlers) TestDownloadBase(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.backend.DownloadBaseCallback = func(ctx context.Context, base string, report workshop.ProgressReporter) error {
-		report("download finished", 100, 100)
+	s.backend.DownloadBaseCallback = func(ctx context.Context, base string, report *workshop.ProgressReporter) error {
+		report.Report("download finished", 100, 100)
 		return nil
 	}
 	defer func() {

--- a/internal/progress/reporter.go
+++ b/internal/progress/reporter.go
@@ -1,0 +1,6 @@
+package progress
+
+type Reporter struct {
+	Name   string
+	Report func(label string, done, total int)
+}

--- a/internal/sdk/lock.go
+++ b/internal/sdk/lock.go
@@ -9,7 +9,7 @@ import (
 
 // OpenLock creates and opens a lock file associated with a particular SDK file.
 func OpenLock(sdkName string) (*osutil.FileLock, error) {
-	flock, err := osutil.NewFileLock(filepath.Join(dirs.WorkshopdRunDir, sdkName+".lock"))
+	flock, err := osutil.NewFileLock(filepath.Join(dirs.WorkshopdLocksDir, sdkName+".lock"))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"sync"
 
 	"github.com/canonical/workshop/internal/overlord/state"
 )
@@ -77,8 +78,11 @@ type TestDownloadCall struct {
 }
 
 type FakeStore struct {
-	ActionCalls      []TestActionCall
-	DownloadCalls    []TestDownloadCall
+	ActionCalls []TestActionCall
+
+	downloadLock  sync.Mutex
+	DownloadCalls []TestDownloadCall
+
 	ActionCallback   func(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error)
 	DownloadCallback func(ctx context.Context, setup Setup) error
 }
@@ -111,6 +115,8 @@ func (f *FakeStore) SdkAction(ctx context.Context, currentSdks map[string]*Info,
 }
 
 func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup) error {
+	f.downloadLock.Lock()
+	defer f.downloadLock.Unlock()
 	f.DownloadCalls = append(f.DownloadCalls, TestDownloadCall{
 		Setup: setup,
 	})

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/progress"
 )
 
 type StoreAction int
@@ -59,7 +60,7 @@ func StoreService(st *state.State) Store {
 
 type Store interface {
 	SdkAction(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error)
-	DownloadSdk(ctx context.Context, setup Setup) error
+	DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) error
 }
 
 func NewFakeStore() Store {
@@ -84,7 +85,7 @@ type FakeStore struct {
 	DownloadCalls []TestDownloadCall
 
 	ActionCallback   func(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error)
-	DownloadCallback func(ctx context.Context, setup Setup) error
+	DownloadCallback func(ctx context.Context, setup Setup, report *progress.Reporter) error
 }
 
 func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error)) func() {
@@ -95,7 +96,7 @@ func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, currentSdks m
 	}
 }
 
-func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup) error) func() {
+func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup, report *progress.Reporter) error) func() {
 	old := f.DownloadCallback
 	f.DownloadCallback = fa
 	return func() {
@@ -114,14 +115,14 @@ func (f *FakeStore) SdkAction(ctx context.Context, currentSdks map[string]*Info,
 	return nil, nil
 }
 
-func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup) error {
+func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) error {
 	f.downloadLock.Lock()
 	defer f.downloadLock.Unlock()
 	f.DownloadCalls = append(f.DownloadCalls, TestDownloadCall{
 		Setup: setup,
 	})
 	if f.DownloadCallback != nil {
-		return f.DownloadCallback(ctx, setup)
+		return f.DownloadCallback(ctx, setup, report)
 	}
 	return nil
 }

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+
+	"github.com/canonical/workshop/internal/progress"
 )
 
 type ContextKeyProjectId string
@@ -77,13 +79,8 @@ type StateStorage interface {
 	DeleteStateStorage(ctx context.Context, name string) error
 }
 
-type ProgressReporter struct {
-	Name   string
-	Report func(label string, done, total int)
-}
-
 type BaseImageManager interface {
-	Download(ctx context.Context, base string, report *ProgressReporter) error
+	Download(ctx context.Context, base string, report *progress.Reporter) error
 }
 
 type ExecArgs struct {

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -77,10 +77,13 @@ type StateStorage interface {
 	DeleteStateStorage(ctx context.Context, name string) error
 }
 
-type ProgressReporter func(label string, done, total int)
+type ProgressReporter struct {
+	Name   string
+	Report func(label string, done, total int)
+}
 
 type BaseImageManager interface {
-	Download(ctx context.Context, base string, report ProgressReporter) error
+	Download(ctx context.Context, base string, report *ProgressReporter) error
 }
 
 type ExecArgs struct {

--- a/internal/workshop/backend_mock.go
+++ b/internal/workshop/backend_mock.go
@@ -68,7 +68,7 @@ type FakeWorkshopBackend struct {
 	RemoveProfileCallback func(ctx context.Context, workshop string, profile string) error
 	RemoveProfileCalls    []*RemoveProfileCall
 
-	DownloadBaseCallback func(ctx context.Context, base string, report ProgressReporter) error
+	DownloadBaseCallback func(ctx context.Context, base string, report *ProgressReporter) error
 	DownloadBaseCalls    []*DownloadCall
 }
 
@@ -443,7 +443,7 @@ func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, 
 	}
 	return userName, projectId, nil
 }
-func (b *FakeWorkshopBackend) Download(ctx context.Context, base string, report ProgressReporter) error {
+func (b *FakeWorkshopBackend) Download(ctx context.Context, base string, report *ProgressReporter) error {
 	b.DownloadBaseCalls = append(b.DownloadBaseCalls, &DownloadCall{Base: base})
 	if b.DownloadBaseCallback != nil {
 		return b.DownloadBaseCallback(ctx, base, report)

--- a/internal/workshop/backend_mock.go
+++ b/internal/workshop/backend_mock.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"golang.org/x/exp/slices"
 
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 )
 
@@ -68,7 +69,7 @@ type FakeWorkshopBackend struct {
 	RemoveProfileCallback func(ctx context.Context, workshop string, profile string) error
 	RemoveProfileCalls    []*RemoveProfileCall
 
-	DownloadBaseCallback func(ctx context.Context, base string, report *ProgressReporter) error
+	DownloadBaseCallback func(ctx context.Context, base string, report *progress.Reporter) error
 	DownloadBaseCalls    []*DownloadCall
 }
 
@@ -443,7 +444,7 @@ func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, 
 	}
 	return userName, projectId, nil
 }
-func (b *FakeWorkshopBackend) Download(ctx context.Context, base string, report *ProgressReporter) error {
+func (b *FakeWorkshopBackend) Download(ctx context.Context, base string, report *progress.Reporter) error {
 	b.DownloadBaseCalls = append(b.DownloadBaseCalls, &DownloadCall{Base: base})
 	if b.DownloadBaseCallback != nil {
 		return b.DownloadBaseCallback(ctx, base, report)

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -21,11 +21,50 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
+type downloadUpdate struct {
+	Label string
+	Done  int
+	Total int
+}
+
+type imageDownloadOp struct {
+	waitCh chan error
+
+	reportersLock sync.Mutex
+	reporters     map[string]*workshop.ProgressReporter
+}
+
+func newImageDownloadOp() *imageDownloadOp {
+	return &imageDownloadOp{waitCh: make(chan error), reporters: make(map[string]*workshop.ProgressReporter, 0)}
+}
+
+func (r *imageDownloadOp) AddReporter(rep *workshop.ProgressReporter) {
+	r.reportersLock.Lock()
+	defer r.reportersLock.Unlock()
+
+	r.reporters[rep.Name] = rep
+}
+
+func (r *imageDownloadOp) RemoveReporter(name string) {
+	r.reportersLock.Lock()
+	defer r.reportersLock.Unlock()
+	delete(r.reporters, name)
+}
+
+func (r *imageDownloadOp) Update(upd downloadUpdate) {
+	r.reportersLock.Lock()
+	defer r.reportersLock.Unlock()
+
+	for _, rep := range r.reporters {
+		rep.Report(upd.Label, upd.Done, upd.Total)
+	}
+}
+
 type Backend struct {
 	nvidiaRuntime bool
 
-	imageLock sync.Mutex
-	imageOps  map[string]chan error
+	imageLock        sync.Mutex
+	currentDownloads map[string]*imageDownloadOp
 }
 
 const (
@@ -47,7 +86,7 @@ func ImageAlias(name string) string {
 
 func New() (workshop.Backend, error) {
 	server := Backend{
-		imageOps: make(map[string]chan error),
+		currentDownloads: make(map[string]*imageDownloadOp),
 	}
 
 	srv, err := lxd.ConnectLXDUnixWithContext(context.Background(), LxdSock, nil)

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"runtime"
+	"sync"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -21,6 +23,9 @@ import (
 
 type Backend struct {
 	nvidiaRuntime bool
+
+	imageLock sync.Mutex
+	imageOps  map[string]chan error
 }
 
 const (
@@ -37,11 +42,13 @@ func InstanceName(name string, project_id string) string {
 }
 
 func ImageAlias(name string) string {
-	return fmt.Sprintf("workshop-%s", name)
+	return fmt.Sprintf("workshop-%s-%s", name, runtime.GOARCH)
 }
 
 func New() (workshop.Backend, error) {
-	server := Backend{}
+	server := Backend{
+		imageOps: make(map[string]chan error),
+	}
 
 	srv, err := lxd.ConnectLXDUnixWithContext(context.Background(), LxdSock, nil)
 	if err != nil {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -21,50 +21,11 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-type downloadUpdate struct {
-	Label string
-	Done  int
-	Total int
-}
-
-type imageDownloadOp struct {
-	waitCh chan error
-
-	reportersLock sync.Mutex
-	reporters     map[string]*workshop.ProgressReporter
-}
-
-func newImageDownloadOp() *imageDownloadOp {
-	return &imageDownloadOp{waitCh: make(chan error), reporters: make(map[string]*workshop.ProgressReporter, 0)}
-}
-
-func (r *imageDownloadOp) AddReporter(rep *workshop.ProgressReporter) {
-	r.reportersLock.Lock()
-	defer r.reportersLock.Unlock()
-
-	r.reporters[rep.Name] = rep
-}
-
-func (r *imageDownloadOp) RemoveReporter(name string) {
-	r.reportersLock.Lock()
-	defer r.reportersLock.Unlock()
-	delete(r.reporters, name)
-}
-
-func (r *imageDownloadOp) Update(upd downloadUpdate) {
-	r.reportersLock.Lock()
-	defer r.reportersLock.Unlock()
-
-	for _, rep := range r.reporters {
-		rep.Report(upd.Label, upd.Done, upd.Total)
-	}
-}
-
 type Backend struct {
 	nvidiaRuntime bool
 
 	imageLock        sync.Mutex
-	currentDownloads map[string]*imageDownloadOp
+	currentDownloads map[string]*downloadOp
 }
 
 const (
@@ -86,7 +47,7 @@ func ImageAlias(name string) string {
 
 func New() (workshop.Backend, error) {
 	server := Backend{
-		currentDownloads: make(map[string]*imageDownloadOp),
+		currentDownloads: make(map[string]*downloadOp),
 	}
 
 	srv, err := lxd.ConnectLXDUnixWithContext(context.Background(), LxdSock, nil)

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -18,7 +19,7 @@ import (
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
-	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/progress"
 )
 
 var (
@@ -26,7 +27,7 @@ var (
 	imageServer          = "simplestreams:https://cloud-images.ubuntu.com/releases"
 )
 
-func (b *Backend) Download(ctx context.Context, base string, report *workshop.ProgressReporter) error {
+func (b *Backend) Download(ctx context.Context, base string, report *progress.Reporter) error {
 	defer func() {
 		if report != nil {
 			b.imageLock.Lock()
@@ -59,7 +60,7 @@ func (b *Backend) Download(ctx context.Context, base string, report *workshop.Pr
 	return waitDownloadOp(ctx, op)
 }
 
-func (b *Backend) download(ctx context.Context, op *imageDownloadOp, base string) (err error) {
+func (b *Backend) download(ctx context.Context, op *downloadOp, base string) (err error) {
 	defer func() {
 		op.waitCh <- err
 		close(op.waitCh)
@@ -213,7 +214,7 @@ func connectImageServer(url string) (lxd.ImageServer, error) {
 	return nil, fmt.Errorf("unknown image server URL prefix (supported: simplestreams, lxd)")
 }
 
-func waitDownloadOp(ctx context.Context, op *imageDownloadOp) error {
+func waitDownloadOp(ctx context.Context, op *downloadOp) error {
 	select {
 	case <-ctx.Done():
 		// Do not try to cancel the target op here as LXD is unable to cancel
@@ -295,6 +296,45 @@ func handleLaunchUpdate(opmeta map[string]interface{}, imsize int) *downloadUpda
 		}
 	}
 	return nil
+}
+
+type downloadUpdate struct {
+	Label string
+	Done  int
+	Total int
+}
+
+type downloadOp struct {
+	waitCh chan error
+
+	reportersLock sync.Mutex
+	reporters     map[string]*progress.Reporter
+}
+
+func newImageDownloadOp() *downloadOp {
+	return &downloadOp{waitCh: make(chan error), reporters: make(map[string]*progress.Reporter, 0)}
+}
+
+func (r *downloadOp) AddReporter(rep *progress.Reporter) {
+	r.reportersLock.Lock()
+	defer r.reportersLock.Unlock()
+
+	r.reporters[rep.Name] = rep
+}
+
+func (r *downloadOp) RemoveReporter(name string) {
+	r.reportersLock.Lock()
+	defer r.reportersLock.Unlock()
+	delete(r.reporters, name)
+}
+
+func (r *downloadOp) Update(upd downloadUpdate) {
+	r.reportersLock.Lock()
+	defer r.reportersLock.Unlock()
+
+	for _, rep := range r.reporters {
+		rep.Report(upd.Label, upd.Done, upd.Total)
+	}
 }
 
 func FakeImageServer(server string) func() {

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -26,33 +26,47 @@ var (
 	imageServer          = "simplestreams:https://cloud-images.ubuntu.com/releases"
 )
 
-func (b *Backend) Download(ctx context.Context, base string, report workshop.ProgressReporter) error {
+func (b *Backend) Download(ctx context.Context, base string, report *workshop.ProgressReporter) error {
+	defer func() {
+		if report != nil {
+			b.imageLock.Lock()
+			if op, exist := b.currentDownloads[base]; exist {
+				op.RemoveReporter(report.Name)
+			}
+			b.imageLock.Unlock()
+		}
+	}()
+
 	b.imageLock.Lock()
-	waitCh, exist := b.imageOps[base]
+	op, exist := b.currentDownloads[base]
 	if exist {
+		if report != nil {
+			op.AddReporter(report)
+		}
 		b.imageLock.Unlock()
-		return waitDownloadOp(ctx, waitCh)
+		return waitDownloadOp(ctx, op)
 	}
 
-	waitCh = make(chan error)
-	b.imageOps[base] = waitCh
+	op = newImageDownloadOp()
+	if report != nil {
+		op.AddReporter(report)
+	}
+	b.currentDownloads[base] = op
 	b.imageLock.Unlock()
 
-	go b.download(ctx, waitCh, base, report)
+	go b.download(ctx, op, base)
 
-	err := waitDownloadOp(ctx, waitCh)
-
-	b.imageLock.Lock()
-	delete(b.imageOps, base)
-	b.imageLock.Unlock()
-
-	return err
+	return waitDownloadOp(ctx, op)
 }
 
-func (b *Backend) download(ctx context.Context, waitCh chan error, base string, report workshop.ProgressReporter) (err error) {
+func (b *Backend) download(ctx context.Context, op *imageDownloadOp, base string) (err error) {
 	defer func() {
-		waitCh <- err
-		close(waitCh)
+		op.waitCh <- err
+		close(op.waitCh)
+
+		b.imageLock.Lock()
+		delete(b.currentDownloads, base)
+		b.imageLock.Unlock()
 	}()
 
 	// LXD cannot cancel download operations
@@ -98,21 +112,21 @@ func (b *Backend) download(ctx context.Context, waitCh chan error, base string, 
 		Type:       "container",
 	}
 
-	op, err := conn.CopyImage(imageServer, *imageInfo, &copyArgs)
+	copyop, err := conn.CopyImage(imageServer, *imageInfo, &copyArgs)
 	if err != nil {
 		return fmt.Errorf("%q download failed: %w", base, err)
 	}
 
-	if report != nil {
-		op.AddHandler(func(o api.Operation) {
-			if o.Metadata == nil || imageInfo.Size <= 0 {
-				return
-			}
-			handleLaunchUpdate(o.Metadata, int(imageInfo.Size), report)
-		})
-	}
+	copyop.AddHandler(func(o api.Operation) {
+		if o.Metadata == nil || imageInfo.Size <= 0 {
+			return
+		}
+		if upd := handleLaunchUpdate(o.Metadata, int(imageInfo.Size)); upd != nil {
+			op.Update(*upd)
+		}
+	})
 
-	if err = op.Wait(); err == nil {
+	if err = copyop.Wait(); err == nil {
 		b.maybeUpdateAlias(conn, base, imageInfo.Fingerprint)
 	}
 
@@ -199,14 +213,14 @@ func connectImageServer(url string) (lxd.ImageServer, error) {
 	return nil, fmt.Errorf("unknown image server URL prefix (supported: simplestreams, lxd)")
 }
 
-func waitDownloadOp(ctx context.Context, op chan error) error {
+func waitDownloadOp(ctx context.Context, op *imageDownloadOp) error {
 	select {
 	case <-ctx.Done():
 		// Do not try to cancel the target op here as LXD is unable to cancel
 		// image download properly. Instead, we'll wait for it to finish if
 		// the task will be restarted.
 		return ctx.Err()
-	case err := <-op:
+	case err := <-op.waitCh:
 		return err
 	}
 }
@@ -240,7 +254,7 @@ var (
 // looking for specific progress labels. NOTE: There is no guarantee that the
 // LXD's progress reporting formant won't change; this meta data parser is valid
 // for LXD 5.21.
-func handleLaunchUpdate(opmeta map[string]interface{}, imsize int, progress workshop.ProgressReporter) {
+func handleLaunchUpdate(opmeta map[string]interface{}, imsize int) *downloadUpdate {
 	for key, value := range opmeta {
 		if key == "download_progress" {
 			upd, ok := value.(string)
@@ -260,7 +274,7 @@ func handleLaunchUpdate(opmeta map[string]interface{}, imsize int, progress work
 				// to calculate the download speed. Thus, covert percentages to
 				// bytes.
 				donebytes := imsize * done / 100
-				progress("download base image", donebytes, imsize)
+				return &downloadUpdate{Label: "download", Done: donebytes, Total: imsize}
 			}
 
 			// check if the response metadata comes from a lxd protocol
@@ -275,11 +289,12 @@ func handleLaunchUpdate(opmeta map[string]interface{}, imsize int, progress work
 				if err != nil {
 					continue
 				}
-				progress("download base image", int(done)*int(multiplier), imsize)
+				donebytes := int(done) * int(multiplier)
+				return &downloadUpdate{Label: "download", Done: donebytes, Total: imsize}
 			}
-
 		}
 	}
+	return nil
 }
 
 func FakeImageServer(server string) func() {

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -2,7 +2,11 @@ package lxdbackend
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"net/http"
+	"os"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -10,66 +14,93 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/units"
 
+	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
 var (
 	ConnectSimpleStreams = lxd.ConnectSimpleStreams
-	imageServer          = "https://cloud-images.ubuntu.com/releases/"
+	imageServer          = "simplestreams:https://cloud-images.ubuntu.com/releases"
 )
 
 func (b *Backend) Download(ctx context.Context, base string, report workshop.ProgressReporter) error {
-	conn, err := b.LxdClient(ctx)
+	b.imageLock.Lock()
+	waitCh, exist := b.imageOps[base]
+	if exist {
+		b.imageLock.Unlock()
+		return waitDownloadOp(ctx, waitCh)
+	}
+
+	waitCh = make(chan error)
+	b.imageOps[base] = waitCh
+	b.imageLock.Unlock()
+
+	go b.download(ctx, waitCh, base, report)
+
+	err := waitDownloadOp(ctx, waitCh)
+
+	b.imageLock.Lock()
+	delete(b.imageOps, base)
+	b.imageLock.Unlock()
+
+	return err
+}
+
+func (b *Backend) download(ctx context.Context, waitCh chan error, base string, report workshop.ProgressReporter) (err error) {
+	defer func() {
+		waitCh <- err
+		close(waitCh)
+	}()
+
+	// LXD cannot cancel download operations
+	child := context.WithoutCancel(ctx)
+
+	conn, err := b.LxdClient(child)
 	if err != nil {
 		return err
 	}
 	defer conn.Disconnect()
 
-	// Check if we have the base image stored locally
-	_, _, err = conn.GetImageAlias(ImageAlias(base))
+	alias, _, err := conn.GetImageAlias(ImageAlias(base))
 	if err == nil {
-		// the image already exists
-		return nil
+		logger.Debugf("BaseImageManager on Download: %q image already exists (%s)", alias.Name, alias.Target)
+		return
 	}
 
-	names := strings.Split(base, "@")
-	if len(names) <= 1 {
-		return fmt.Errorf("%q base is not supported", base)
+	names := strings.FieldsFunc(base, func(r rune) bool { return r == '@' })
+	if len(names) != 2 {
+		return fmt.Errorf("%q is not a correct base name", base)
 	}
 
-	imageServer, err := lxd.ConnectSimpleStreams(imageServer, nil)
+	imageServer, err := connectImageServer(imageServer)
 	if err != nil {
 		return err
 	}
 	defer imageServer.Disconnect()
 
 	var imageInfo *api.Image
-	alias, _, err := imageServer.GetImageAlias(fmt.Sprintf("%s/%s", names[1], runtime.GOARCH))
+	alias, _, err = imageServer.GetImageAlias(fmt.Sprintf("%s/%s", names[1], runtime.GOARCH))
 	if err != nil {
-		return err
+		return fmt.Errorf("%q download failed: %w", base, err)
 	}
 
 	imageInfo, _, err = imageServer.GetImage(alias.Target)
 	if err != nil {
-		return err
+		return fmt.Errorf("%q download failed: %w", base, err)
 	}
 
 	copyArgs := lxd.ImageCopyArgs{
 		AutoUpdate: true,
 		Public:     false,
-		Type:       "",
-		Aliases: []api.ImageAlias{
-			{
-				Name:        ImageAlias(base),
-				Description: "Workshop base image",
-			},
-		},
+		Type:       "container",
 	}
 
 	op, err := conn.CopyImage(imageServer, *imageInfo, &copyArgs)
 	if err != nil {
-		return err
+		return fmt.Errorf("%q download failed: %w", base, err)
 	}
 
 	if report != nil {
@@ -77,26 +108,131 @@ func (b *Backend) Download(ctx context.Context, base string, report workshop.Pro
 			if o.Metadata == nil || imageInfo.Size <= 0 {
 				return
 			}
-			// state.Task supports only int for done/total
 			handleLaunchUpdate(o.Metadata, int(imageInfo.Size), report)
 		})
 	}
 
-	chOperation := make(chan error)
-	go func() {
-		chOperation <- op.Wait()
-		close(chOperation)
-	}()
+	if err = op.Wait(); err == nil {
+		b.maybeUpdateAlias(conn, base, imageInfo.Fingerprint)
+	}
 
+	return err
+}
+
+// For the test purposes only
+func lxdConnectionArgs() (*lxd.ConnectionArgs, error) {
+	args := &lxd.ConnectionArgs{}
+
+	// Server certificate
+	if osutil.FileExists("server.crt") {
+		content, err := os.ReadFile("server.crt")
+		if err != nil {
+			return nil, err
+		}
+
+		args.TLSServerCert = string(content)
+	}
+
+	// Client certificate
+	if osutil.FileExists("client.crt") {
+		content, err := os.ReadFile("client.crt")
+		if err != nil {
+			return nil, err
+		}
+
+		args.TLSClientCert = string(content)
+	}
+
+	// Client CA
+	if osutil.FileExists("client.ca") {
+		content, err := os.ReadFile("client.ca")
+		if err != nil {
+			return nil, err
+		}
+
+		args.TLSCA = string(content)
+	}
+
+	// Client key
+	if osutil.FileExists("client.key") {
+		content, err := os.ReadFile("client.key")
+		if err != nil {
+			return nil, err
+		}
+
+		pemKey, _ := pem.Decode(content)
+		// Golang has deprecated all methods relating to PEM encryption due to a vulnerability.
+		// However, the weakness does not make PEM unsafe for our purposes as it pertains to password protection on the
+		// key file (client.key is only readable to the user in any case), so we'll ignore deprecation.
+		if x509.IsEncryptedPEMBlock(pemKey) { //nolint:staticcheck
+			return nil, fmt.Errorf("Private key is password protected and no helper was configured")
+		}
+
+		args.TLSClientKey = string(content)
+	}
+	return args, nil
+}
+
+func connectImageServer(url string) (lxd.ImageServer, error) {
+	if strings.HasPrefix(url, "simplestreams:") {
+		server, _ := strings.CutPrefix(url, "simplestreams:")
+		conn, err := ConnectSimpleStreams(server, nil)
+		if err != nil {
+			return nil, fmt.Errorf("image server is not available: %w", err)
+		}
+		return conn, err
+	}
+
+	if strings.HasPrefix(url, "lxd:") {
+		server, _ := strings.CutPrefix(url, "lxd:")
+		args, err := lxdConnectionArgs()
+		if err != nil {
+			return nil, err
+		}
+		conn, err := lxd.ConnectPublicLXD(server, args)
+		if err != nil {
+			return nil, fmt.Errorf("image server is not available: %w", err)
+		}
+		return conn, err
+	}
+
+	return nil, fmt.Errorf("unknown image server URL prefix (supported: simplestreams, lxd)")
+}
+
+func waitDownloadOp(ctx context.Context, op chan error) error {
 	select {
 	case <-ctx.Done():
-		return op.CancelTarget()
-	case err := <-chOperation:
+		// Do not try to cancel the target op here as LXD is unable to cancel
+		// image download properly. Instead, we'll wait for it to finish if
+		// the task will be restarted.
+		return ctx.Err()
+	case err := <-op:
 		return err
 	}
 }
 
-var imgDownload = regexp.MustCompile(`^rootfs: (?P<done>[0-9]+)% (?P<speed>\([\w/\.]+\))$`)
+// The LXD image alias must be updated separately as if provided to CopyImage in
+// multiple concurrent calls it will fail with "Alias already exists" once the
+// image is downloaded. This happens because LXD's CopyImage handles image
+// download and creating an alias separately and not as a single transaction.
+func (b *Backend) maybeUpdateAlias(conn lxd.InstanceServer, base, fingerprint string) {
+	alias := api.ImageAliasesPost{}
+	alias.Target = fingerprint
+	alias.Name = ImageAlias(base)
+
+	_, _, err := conn.GetImageAlias(alias.Name)
+	if api.StatusErrorCheck(err, http.StatusNotFound) {
+		if err = conn.CreateImageAlias(alias); err != nil {
+			logger.Noticef("BaseImageManager on Download: Failed to create an alias %q for %q base: %v", alias.Name, base, err)
+		}
+	}
+}
+
+var (
+	imgDownloadSS = regexp.MustCompile(`^rootfs: (?P<done>[0-9]+)% (?P<speed>\([\w/\.]+\))$`)
+	// 225.19MB (37.46MB/s)
+	imgDownloadLXD = regexp.MustCompile(`^(?P<done>[0-9\.]+)(?P<mult>\w+) (?P<speed>\([\w/\.]+\))$`)
+)
 
 // handleLaunchUpdate parses a LXD create instance operation metadata and
 // reports the opeartion's progress if available. The LXD metadata is
@@ -112,7 +248,8 @@ func handleLaunchUpdate(opmeta map[string]interface{}, imsize int, progress work
 				continue
 			}
 
-			if data := imgDownload.FindStringSubmatch(upd); len(data) == 3 {
+			// check if the response metadata comes from a simplestream protocol
+			if data := imgDownloadSS.FindStringSubmatch(upd); len(data) == 3 {
 				done, err := strconv.Atoi(data[1])
 				if err != nil {
 					// just in case, but this is ensured by the regex
@@ -125,6 +262,22 @@ func handleLaunchUpdate(opmeta map[string]interface{}, imsize int, progress work
 				donebytes := imsize * done / 100
 				progress("download base image", donebytes, imsize)
 			}
+
+			// check if the response metadata comes from a lxd protocol
+			if data := imgDownloadLXD.FindStringSubmatch(upd); len(data) == 4 {
+				done, err := strconv.ParseFloat(data[1], 32)
+				if err != nil {
+					continue
+				}
+				// ParseByteSizeString understands only int, so we use it to get
+				// a multiplier for "done".
+				multiplier, err := units.ParseByteSizeString("1" + data[2])
+				if err != nil {
+					continue
+				}
+				progress("download base image", int(done)*int(multiplier), imsize)
+			}
+
 		}
 	}
 }

--- a/internal/workshop/lxd/lxd_base_manager_test.go
+++ b/internal/workshop/lxd/lxd_base_manager_test.go
@@ -24,27 +24,23 @@ func (f *LxdBeTests) TestLaunchProgressReporter(c *check.C) {
 		total int
 	}{
 		nil,
-		{"download base image", 65, 100},
-		{"download base image", 65, 100},
+		{"download", 65, 100},
+		{"download", 65, 100},
 		nil,
 		nil,
 		nil,
 		nil,
-		{"download base image", 65, 100},
+		{"download", 65, 100},
 	}
 
 	for i, m := range metas {
-		i := i
-		reported := false
-		checker := func(label string, done, total int) {
-			c.Check(label, check.Equals, expected[i].label)
-			c.Check(done, check.Equals, expected[i].done)
-			c.Check(total, check.Equals, expected[i].total)
-			reported = true
-		}
-		lxdbackend.HandleLaunchUpdate(m, 100, checker)
+		upd := lxdbackend.HandleLaunchUpdate(m, 100)
 		if expected[i] != nil {
-			c.Assert(reported, check.Equals, true, check.Commentf("No progress was reported on %v, expected: %v", m, expected[i]))
+			c.Check(upd.Label, check.Equals, expected[i].label)
+			c.Check(upd.Done, check.Equals, expected[i].done)
+			c.Check(upd.Total, check.Equals, expected[i].total)
+		} else {
+			c.Check(upd, check.IsNil)
 		}
 	}
 }

--- a/internal/workshop/lxd/lxd_base_manager_test.go
+++ b/internal/workshop/lxd/lxd_base_manager_test.go
@@ -15,6 +15,7 @@ func (f *LxdBeTests) TestLaunchProgressReporter(c *check.C) {
 		{"download_progress": "rootfs: NaN (254Kb/s)"},
 		{"download_progress": 15},
 		{"unknown": "rootfs: 65% (254.2Kb/s)"},
+		{"download_progress": "65B (254Kb/s)"},
 	}
 
 	expected := []*struct {
@@ -29,6 +30,7 @@ func (f *LxdBeTests) TestLaunchProgressReporter(c *check.C) {
 		nil,
 		nil,
 		nil,
+		{"download base image", 65, 100},
 	}
 
 	for i, m := range metas {

--- a/internal/workshop/lxd/tests/integration/helper_test.go
+++ b/internal/workshop/lxd/tests/integration/helper_test.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-var minimalImageServer = "https://cloud-images.ubuntu.com/minimal/releases/"
+var minimalImageServer = "simplestreams:https://cloud-images.ubuntu.com/minimal/releases/"
 
 func defaultTestDevices() map[string]map[string]string {
 	return map[string]map[string]string{
@@ -78,17 +78,20 @@ func createTestContext(username, projectId string) context.Context {
 	return ctx
 }
 
-func launchTestWorkshop(c *check.C, ctx context.Context, be workshop.Backend, dir, username string) {
+func launchTestWorkshop(c *check.C, ctx context.Context, bd workshop.Backend, dir string) {
 	var err error
+
+	err = bd.Download(ctx, "ubuntu@24.04", nil)
+	c.Assert(err, check.IsNil)
 
 	wf := &workshop.File{Name: "test", Base: "ubuntu@24.04"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.test.yaml"), []byte(`name: test
 base: ubuntu@22.04`), 0644), check.IsNil)
 
-	_, _, err = be.CreateOrLoadProject(ctx, dir)
+	_, _, err = bd.CreateOrLoadProject(ctx, dir)
 	c.Assert(err, check.IsNil)
-	err = be.LaunchWorkshop(ctx, wf)
+	err = bd.LaunchWorkshop(ctx, wf)
 	c.Assert(err, check.IsNil)
-	err = be.StartWorkshop(ctx, "test")
+	err = bd.StartWorkshop(ctx, "test")
 	c.Assert(err, check.IsNil)
 }

--- a/internal/workshop/lxd/tests/integration/profile_test.go
+++ b/internal/workshop/lxd/tests/integration/profile_test.go
@@ -38,7 +38,9 @@ func (f *profileTest) SetUpSuite(c *check.C) {
 	f.username = "testuser"
 	f.ctx = createTestContext(f.username, "42424242")
 
-	f.be = &lxdbackend.Backend{}
+	var err error
+	f.be, err = lxdbackend.New()
+	c.Assert(err, check.IsNil)
 	f.client, _ = f.be.(*lxdbackend.Backend).LxdClient(f.ctx)
 
 	f.restoreUserLookup = testutil.FakeFunc(func(name string) (*user.User, error) {
@@ -52,9 +54,6 @@ func (f *profileTest) SetUpSuite(c *check.C) {
 	}, &workshop.LookupUsername)
 	f.restoreDevices = lxdbackend.FakeDefaultDevices(defaultTestDevices)
 	f.newProjectidRestore = testutil.FakeFunc(testProjectId, &workshop.NewProjectId)
-
-	err := f.be.Download(f.ctx, "ubuntu@24.04", nil)
-	c.Assert(err, check.IsNil)
 }
 
 func (f *profileTest) TearDownSuite(c *check.C) {
@@ -68,7 +67,7 @@ func (f *profileTest) TearDownSuite(c *check.C) {
 
 func (f *profileTest) TestSdkProfileCreatedAndUpdatedSuccessfully(c *check.C) {
 	// Setup
-	launchTestWorkshop(c, f.ctx, f.be, c.MkDir(), f.username)
+	launchTestWorkshop(c, f.ctx, f.be, c.MkDir())
 	defer f.be.RemoveWorkshop(f.ctx, "test")
 
 	var backend workshop.Profile = &lxdbackend.Backend{}
@@ -117,7 +116,7 @@ func (f *profileTest) TestSdkProfileCreatedAndUpdatedSuccessfully(c *check.C) {
 
 func (f *profileTest) TestSdkProfileBindMountFailsIfTargetIsAFile(c *check.C) {
 	// Setup
-	launchTestWorkshop(c, f.ctx, f.be, c.MkDir(), f.username)
+	launchTestWorkshop(c, f.ctx, f.be, c.MkDir())
 	defer f.be.RemoveWorkshop(f.ctx, "test")
 
 	var backend workshop.Profile = &lxdbackend.Backend{}
@@ -133,7 +132,7 @@ func (f *profileTest) TestSdkProfileBindMountFailsIfTargetIsAFile(c *check.C) {
 
 func (f *profileTest) TestSdkProfileSshAgentProxy(c *check.C) {
 	// Setup
-	launchTestWorkshop(c, f.ctx, f.be, c.MkDir(), f.username)
+	launchTestWorkshop(c, f.ctx, f.be, c.MkDir())
 	defer f.be.RemoveWorkshop(f.ctx, "test")
 
 	var backend workshop.Profile = &lxdbackend.Backend{}
@@ -180,7 +179,7 @@ func (f *profileTest) TestSdkProfileSshAgentProxy(c *check.C) {
 
 func (f *profileTest) TestSdkProfileRemoveNotFound(c *check.C) {
 	// Setup
-	launchTestWorkshop(c, f.ctx, f.be, c.MkDir(), f.username)
+	launchTestWorkshop(c, f.ctx, f.be, c.MkDir())
 	defer f.be.RemoveWorkshop(f.ctx, "test")
 
 	var backend workshop.Profile = &lxdbackend.Backend{}

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -101,10 +101,7 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 		return f.project.ProjectId, nil
 	}, &workshop.NewProjectId)
 
-	err = f.be.Download(f.ctx, "ubuntu@24.04", nil)
-	c.Assert(err, check.IsNil)
-
-	launchTestWorkshop(c, f.ctx, f.be, f.project.Path, f.username)
+	launchTestWorkshop(c, f.ctx, f.be, f.project.Path)
 }
 
 func (f *wsExec) TearDownSuite(c *check.C) {

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -227,9 +227,13 @@ func (f *wsOps) TestLxdBackendDownloadWorkshopBaseResumeAfterCancellation(c *che
 	wg.Add(3)
 	for i := 0; i < 3; i++ {
 		go func() {
-			err := f.bd.Download(wcancel, "ubuntu@22.04", func(label string, done, total int) {
-				once.Do(func() { cancel() })
-			})
+			r := &workshop.ProgressReporter{
+				Name: "1",
+				Report: func(label string, done, total int) {
+					once.Do(func() { cancel() })
+				},
+			}
+			err := f.bd.Download(wcancel, "ubuntu@22.04", r)
 			c.Check(err, testutil.ErrorIs, context.Canceled)
 			wg.Done()
 		}()

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"sync"
 
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -227,7 +228,7 @@ func (f *wsOps) TestLxdBackendDownloadWorkshopBaseResumeAfterCancellation(c *che
 	wg.Add(3)
 	for i := 0; i < 3; i++ {
 		go func() {
-			r := &workshop.ProgressReporter{
+			r := &progress.Reporter{
 				Name: "1",
 				Report: func(label string, done, total int) {
 					once.Do(func() { cancel() })

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"os/user"
+	"sync"
 
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -15,10 +16,7 @@ import (
 )
 
 type wsOps struct {
-	// per suite
-	be workshop.Backend
-
-	// per test
+	bd                 workshop.Backend
 	ctx                context.Context
 	username           string
 	project            *workshop.Project
@@ -33,7 +31,7 @@ var _ = check.Suite(&wsOps{})
 func (f *wsOps) SetUpSuite(c *check.C) {
 	var err error
 
-	f.be, err = lxdbackend.New()
+	f.bd, err = lxdbackend.New()
 	c.Assert(err, check.IsNil)
 
 	f.username = "testuser"
@@ -52,13 +50,10 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 	f.restoreNewId = testutil.FakeFunc(func() (string, error) {
 		return f.project.ProjectId, nil
 	}, &workshop.NewProjectId)
-
-	err = f.be.Download(f.ctx, "ubuntu@24.04", nil)
-	c.Assert(err, check.IsNil)
 }
 
 func (f *wsOps) TearDownSuite(c *check.C) {
-	lxdclient, err := f.be.(*lxdbackend.Backend).LxdClient(f.ctx)
+	lxdclient, err := f.bd.(*lxdbackend.Backend).LxdClient(f.ctx)
 	c.Check(err, check.IsNil)
 
 	cleanUpLxdProject(c, lxdclient, lxdbackend.LxdProjectName(f.username))
@@ -74,59 +69,59 @@ func (f *wsOps) TearDownSuite(c *check.C) {
 }
 
 func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
-	launchTestWorkshop(c, f.ctx, f.be, f.project.Path, f.username)
-	defer f.be.RemoveWorkshop(f.ctx, "test")
+	launchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer f.bd.RemoveWorkshop(f.ctx, "test")
 
 	// Execute
-	err := f.be.StashWorkshop(f.ctx, "test")
+	err := f.bd.StashWorkshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 
 	// Validate
 	c.Assert(err, check.IsNil)
-	_, err = f.be.Workshop(f.ctx, "test")
+	_, err = f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.NotNil)
 
 	// Execute
-	err = f.be.UnstashWorkshop(f.ctx, "test")
+	err = f.bd.UnstashWorkshop(f.ctx, "test")
 
 	// Validate
 	c.Assert(err, check.IsNil)
-	_, err = f.be.Workshop(f.ctx, "test")
+	_, err = f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 }
 
 func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
-	launchTestWorkshop(c, f.ctx, f.be, f.project.Path, f.username)
+	launchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
 
 	// Execute
-	err := f.be.StashWorkshop(f.ctx, "test")
+	err := f.bd.StashWorkshop(f.ctx, "test")
 
 	// Validate
 	c.Assert(err, check.IsNil)
-	_, err = f.be.Workshop(f.ctx, "test")
+	_, err = f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.NotNil)
 
 	// Execute
-	err = f.be.RemoveWorkshopStash(f.ctx, "test")
+	err = f.bd.RemoveWorkshopStash(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 
 	// Validate
-	err = f.be.UnstashWorkshop(f.ctx, "test")
+	err = f.bd.UnstashWorkshop(f.ctx, "test")
 	c.Assert(err, check.ErrorMatches, "workshop not found")
 }
 
 func (f *wsOps) TestLxdBackendStateStorageVolumeAddRemove(c *check.C) {
-	launchTestWorkshop(c, f.ctx, f.be, f.project.Path, f.username)
-	defer f.be.RemoveWorkshop(f.ctx, "test")
+	launchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer f.bd.RemoveWorkshop(f.ctx, "test")
 
 	// Execute
-	err := f.be.CreateStateStorage(f.ctx, "test")
+	err := f.bd.CreateStateStorage(f.ctx, "test")
 
 	// Validate
 	c.Assert(err, check.IsNil)
 
 	// Execute
-	err = f.be.DeleteStateStorage(f.ctx, "test")
+	err = f.bd.DeleteStateStorage(f.ctx, "test")
 
 	// Validate
 	c.Assert(err, check.IsNil)
@@ -134,33 +129,147 @@ func (f *wsOps) TestLxdBackendStateStorageVolumeAddRemove(c *check.C) {
 
 func (f *wsOps) TestLxdBackendRemoveWorkshopStash(c *check.C) {
 	// Setup
-	launchTestWorkshop(c, f.ctx, f.be, f.project.Path, f.username)
+	launchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
 
 	// Execute
-	err := f.be.StashWorkshop(f.ctx, "test")
+	err := f.bd.StashWorkshop(f.ctx, "test")
 
 	// Validate
 	c.Assert(err, check.IsNil)
-	_, err = f.be.Workshop(f.ctx, "test")
+	_, err = f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
 
 	// Execute
-	err = f.be.RemoveWorkshopStash(f.ctx, "test")
+	err = f.bd.RemoveWorkshopStash(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 }
 
 func (f *wsOps) TestLxdBackendDeleteWorkshop(c *check.C) {
 	// Execute
-	launchTestWorkshop(c, f.ctx, f.be, f.project.Path, f.username)
+	launchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
 
 	// Validate
-	err := f.be.RemoveWorkshop(f.ctx, "test")
+	err := f.bd.RemoveWorkshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
-	_, err = f.be.Workshop(f.ctx, "test")
+	_, err = f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
 }
 
+func (f *wsOps) image(c *check.C, alias string) (string, error) {
+	cli, err := f.bd.(*lxdbackend.Backend).LxdClient(f.ctx)
+	c.Check(err, check.IsNil)
+	entry, _, err := cli.GetImageAlias(lxdbackend.ImageAlias(alias))
+	if err != nil {
+		return "", err
+	}
+	return entry.Target, err
+}
+
+func (f *wsOps) deleteimage(c *check.C, fp string) error {
+	cli, err := f.bd.(*lxdbackend.Backend).LxdClient(f.ctx)
+	c.Check(err, check.IsNil)
+	op, err := cli.DeleteImage(fp)
+	c.Check(err, check.IsNil)
+	return op.Wait()
+}
+
 func (f *wsOps) TestLxdBackendDownloadWorkshopBase(c *check.C) {
-	err := f.be.Download(f.ctx, "ubuntu@24.04", nil)
+	// ensure there is no image in LXD storage
+	fp, err := f.image(c, "ubuntu@22.04")
+	if err == nil {
+		c.Assert(f.deleteimage(c, fp), check.IsNil)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(5)
+	for i := 0; i < 5; i++ {
+		go func() {
+			err := f.bd.Download(f.ctx, "ubuntu@22.04", nil)
+			c.Check(err, check.IsNil)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	fp, err = f.image(c, "ubuntu@22.04")
 	c.Assert(err, check.IsNil)
+	c.Assert(f.deleteimage(c, fp), check.IsNil)
+}
+func (f *wsOps) TestLxdBackendDownloadMalformedBase(c *check.C) {
+	err := f.bd.Download(f.ctx, "ubuntu:24.04", nil)
+	c.Check(err, check.ErrorMatches, `"ubuntu:24.04" is not a correct base name`)
+	err = f.bd.Download(f.ctx, "ubuntu@", nil)
+	c.Check(err, check.ErrorMatches, `"ubuntu@" is not a correct base name`)
+}
+
+func (f *wsOps) TestLxdBackendDownloadBaseImageNotFound(c *check.C) {
+	err := f.bd.Download(f.ctx, "ubuntu@1.01", nil)
+	c.Check(err, check.ErrorMatches, `"ubuntu@1.01" download failed.*`)
+}
+
+func (f *wsOps) TestLxdBackendDownloadProtocolNotSupported(c *check.C) {
+	defer lxdbackend.FakeImageServer("https://cloud-images.ubuntu.com/minimal/releases/")()
+	err := f.bd.Download(f.ctx, "ubuntu@20.04", nil)
+	c.Check(err, check.ErrorMatches, `unknown image server URL prefix \(supported: simplestreams, lxd\)`)
+}
+
+func (f *wsOps) TestLxdBackendDownloadWorkshopBaseResumeAfterCancellation(c *check.C) {
+	// ensure there is no image in LXD storage
+	fp, err := f.image(c, "ubuntu@22.04")
+	if err == nil {
+		c.Assert(f.deleteimage(c, fp), check.IsNil)
+	}
+
+	wcancel, cancel := context.WithCancel(f.ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var once sync.Once
+	wg.Add(3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			err := f.bd.Download(wcancel, "ubuntu@22.04", func(label string, done, total int) {
+				once.Do(func() { cancel() })
+			})
+			c.Check(err, testutil.ErrorIs, context.Canceled)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// attempt to download after interruption (must pickup an ongoing operation
+	// and wait for it).
+	err = f.bd.Download(f.ctx, "ubuntu@22.04", nil)
+	c.Assert(err, check.IsNil)
+
+	fp, err = f.image(c, "ubuntu@22.04")
+	c.Assert(err, check.IsNil)
+	c.Assert(f.deleteimage(c, fp), check.IsNil)
+}
+
+func (f *wsOps) TestLxdBackendDownloadMultipleBasesConcurrently(c *check.C) {
+	// ensure there is no image in LXD storage
+	for _, b := range workshop.SupportedBases {
+		fp, err := f.image(c, b)
+		if err == nil {
+			c.Assert(f.deleteimage(c, fp), check.IsNil)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(workshop.SupportedBases))
+	for i := 0; i < len(workshop.SupportedBases); i++ {
+		idx := i
+		go func() {
+			err := f.bd.Download(f.ctx, workshop.SupportedBases[idx], nil)
+			c.Check(err, check.IsNil)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	for _, b := range workshop.SupportedBases {
+		fp, err := f.image(c, b)
+		c.Assert(err, check.IsNil)
+		c.Assert(f.deleteimage(c, fp), check.IsNil)
+	}
 }

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	workshopName = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
-	allowedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
-	channel      = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
+	SupportedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
+	workshopName   = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+	channel        = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
 
 	// *.yaml is the only supported extension for workshop files as the only
 	// recommended "official" extension: https://yaml.org/faq.html. Also, having a
@@ -132,7 +132,7 @@ func readWorkshop(pathname string) (*File, error) {
 		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) include only lower case alpha-numeric or an underscore symbol(s)")
 	}
 
-	if !slices.Contains(allowedBases, file.Base) {
+	if !slices.Contains(SupportedBases, file.Base) {
 		return nil, fmt.Errorf("unsupported base: %s", file.Base)
 	}
 


### PR DESCRIPTION
# Description

Update progress of the base image and SDK downloads.

* The base image download, if interrupted, will not stop in the background as LXD cannot cancel downloads. Therefore, on the next run of `launch` or `refresh`, Workshop will pickup the image download current progress from LXD and report to the user.
* If there are two or more workshops trying to download a base image, only one will be downloading. The rest will be waiting for the download to finish.
* The SDK download progress can be interrupted and all remaining artefacts will be removed in such a case.
* If there are two or more workshops trying to download the same SDK concurrently, only one will be downloading. The rest will be waiting for the download to finish.


# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
