### PR TITLE
Rename 'agent' SDK to 'host' SDK

### DIFF
--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -23,10 +23,10 @@ This command connects a plug to a target slot
 that is specified as the second argument or deduced from the context.
 
 - If the second argument is omitted entirely, the target is assumed to be
-  <WORKSHOP>/agent:<PLUG>; <WORKSHOP> and <PLUG> come from the first argument
+  <WORKSHOP>/host:<PLUG>; <WORKSHOP> and <PLUG> come from the first argument
 
 - If the second argument only names the slot itself, the target is
-  <WORKSHOP>/agent:<SLOT>; <WORKSHOP> comes from the first argument
+  <WORKSHOP>/host:<SLOT>; <WORKSHOP> comes from the first argument
 
 - If the second argument only names the workshop and SDK, the target is
   <WORKSHOP>/<SDK>:<INTERFACE>;
@@ -80,10 +80,10 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 
 	slotRef := &client.SlotRef{}
 	if len(av) > 1 {
-		// check if the second arg is a short version of the agent-provided slot reference
+		// check if the second arg is a short version of the host-provided slot reference
 		if strings.HasPrefix(av[1], ":") {
 			slotRef.Workshop = plugRef.Workshop
-			slotRef.Sdk = "agent"
+			slotRef.Sdk = "host"
 			slotRef.Name = av[1][1:]
 		} else {
 			slotRef, err = client.ParseShortSlotRef(av[1])
@@ -98,11 +98,11 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 		slotRef.ProjectId = plugRef.ProjectId
 	} else {
 		// workshop connect <workshop>/<sdk>:plug which means that the plug will
-		// be attempted to connect to the same name slot in the agent SDK (if
+		// be attempted to connect to the same name slot in the host SDK (if
 		// exists)
 		slotRef.ProjectId = plugRef.ProjectId
 		slotRef.Workshop = plugRef.Workshop
-		slotRef.Sdk = "agent"
+		slotRef.Sdk = "host"
 		slotRef.Name = plugRef.Name
 	}
 

--- a/cmd/workshop/connect_test.go
+++ b/cmd/workshop/connect_test.go
@@ -37,7 +37,7 @@ func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 			map[string]interface{}{
 				"project-id": "42424242",
 				"workshop":   "ws",
-				"sdk":        "agent",
+				"sdk":        "host",
 				"slot":       "content",
 			},
 		},
@@ -135,7 +135,7 @@ func (m *connectSuite) TestDisconnectSlotNotProvided(c *check.C) {
 			map[string]interface{}{
 				"project-id": "42424242",
 				"workshop":   "ws",
-				"sdk":        "agent",
+				"sdk":        "host",
 				"slot":       "plug",
 			},
 		},

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -45,12 +45,12 @@ Notes:
 	return cmd
 }
 
-func isAgentSdk(sdkName string) bool {
-	return sdkName == "agent"
+func isHostSdk(sdkName string) bool {
+	return sdkName == "host"
 }
 
 func endpoint(workshop, sdkName, name string) string {
-	if isAgentSdk(sdkName) {
+	if isHostSdk(sdkName) {
 		return ":" + name
 	}
 	return workshop + "/" + sdkName + ":" + name
@@ -186,7 +186,7 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 		}
 	}
 	for _, slot := range connections.Slots {
-		if isAgentSdk(slot.Sdk) {
+		if isHostSdk(slot.Sdk) {
 			// displaying unconnected system snap slots is boring,
 			// unless explicitly asked to show them
 			continue

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -254,12 +254,12 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 				Interface: "leds",
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "numlock-led"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "host", Name: "numlock-led"},
 				Interface: "leds",
 				Manual:    true,
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "scrollock"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "scrollock-led"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "host", Name: "scrollock-led"},
 				Interface: "leds",
 			},
 		},
@@ -285,7 +285,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "keyboard-lights",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "numlock-led",
 				}},
 			}, {
@@ -297,7 +297,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "keyboard-lights",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "scrollock-led",
 				}},
 			},
@@ -306,7 +306,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 			{
 				ProjectId: "42424242",
 				Workshop:  "keyboard-lights",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "numlock-led",
 				Interface: "leds",
 				Connections: []client.PlugRef{{
@@ -318,7 +318,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 			}, {
 				ProjectId: "42424242",
 				Workshop:  "keyboard-lights",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "scrollock-led",
 				Interface: "leds",
 				Connections: []client.PlugRef{{
@@ -386,12 +386,12 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 				Interface: "leds",
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "numlock-led"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "host", Name: "numlock-led"},
 				Interface: "leds",
 				Manual:    true,
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "scrollock"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "scrollock-led"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "host", Name: "scrollock-led"},
 				Interface: "leds",
 				Manual:    true,
 			},
@@ -424,7 +424,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "keyboard-lights",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "numlock-led",
 				}},
 			}, {
@@ -436,7 +436,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "keyboard-lights",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "scrollock-led",
 				}},
 			},
@@ -445,7 +445,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 			{
 				ProjectId: "42424242",
 				Workshop:  "keyboard-lights",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "numlock-led",
 				Interface: "leds",
 				Connections: []client.PlugRef{{
@@ -457,7 +457,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 			}, {
 				ProjectId: "42424242",
 				Workshop:  "keyboard-lights",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "scrollock-led",
 				Interface: "leds",
 				Connections: []client.PlugRef{{
@@ -521,7 +521,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 		Established: []client.Connection{
 			{
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "scrollock"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "scrollock-led"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "host", Name: "scrollock-led"},
 				Interface: "leds",
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "capslock"},
@@ -532,7 +532,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 		Undesired: []client.Connection{
 			{
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "numlock-led"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "host", Name: "numlock-led"},
 				Interface: "leds",
 				Manual:    true,
 			},
@@ -565,7 +565,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "keyboard-lights",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "scrollock-led",
 				}},
 			},
@@ -574,19 +574,19 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 			{
 				ProjectId: "42424242",
 				Workshop:  "leds-provider",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "capslock-led",
 				Interface: "leds",
 			}, {
 				ProjectId: "42424242",
 				Workshop:  "keyboard-lights",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "numlock-led",
 				Interface: "leds",
 			}, {
 				ProjectId: "42424242",
 				Workshop:  "keyboard-lights",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "scrollock-led",
 				Interface: "leds",
 				Connections: []client.PlugRef{{
@@ -667,7 +667,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 		Undesired: []client.Connection{
 			{
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "lights", Name: "numlock"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "agent", Name: "numlock-led"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "keyboard-lights", Sdk: "host", Name: "numlock-led"},
 				Interface: "leds",
 				Manual:    true,
 			},
@@ -709,19 +709,19 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 			{
 				ProjectId: "42424242",
 				Workshop:  "leds-provider",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "capslock-led",
 				Interface: "leds",
 			}, {
 				ProjectId: "42424242",
 				Workshop:  "keyboard-lights",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "numlock-led",
 				Interface: "leds",
 			}, {
 				ProjectId: "42424242",
 				Workshop:  "keyboard-lights",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "scrollock-led",
 				Interface: "leds",
 			}, {
@@ -907,15 +907,15 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 				Interface: "content",
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "foo", Name: "desktop-plug"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "agent", Name: "desktop"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "host", Name: "desktop"},
 				Interface: "desktop",
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "foo", Name: "x11-plug"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "agent", Name: "x11"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "abc", Sdk: "host", Name: "x11"},
 				Interface: "x11",
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "def", Sdk: "foo", Name: "a-x11-plug"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "def", Sdk: "agent", Name: "x11"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "def", Sdk: "host", Name: "x11"},
 				Interface: "x11",
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "abc", Sdk: "a-foo", Name: "plug"},
@@ -923,7 +923,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 				Interface: "content",
 			}, {
 				Plug:      client.PlugRef{ProjectId: "42424242", Workshop: "def", Sdk: "keyboard-app", Name: "x11"},
-				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "def", Sdk: "agent", Name: "x11"},
+				Slot:      client.SlotRef{ProjectId: "42424242", Workshop: "def", Sdk: "host", Name: "x11"},
 				Interface: "x11",
 				Manual:    true,
 			},
@@ -963,7 +963,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "abc",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "desktop",
 				}},
 			}, {
@@ -975,7 +975,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "abc",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "x11",
 				}},
 			}, {
@@ -987,7 +987,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "abc",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "x11",
 				}},
 			}, {
@@ -1011,7 +1011,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 				Connections: []client.SlotRef{{
 					ProjectId: "42424242",
 					Workshop:  "abc",
-					Sdk:       "agent",
+					Sdk:       "host",
 					Name:      "x11",
 				}},
 			}, {
@@ -1061,7 +1061,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 			}, {
 				ProjectId: "42424242",
 				Workshop:  "def",
-				Sdk:       "agent",
+				Sdk:       "host",
 				Name:      "x11",
 				Interface: "x11",
 				Connections: []client.PlugRef{{

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -26,7 +26,7 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
   with two arguments, the first one is the plug, and the second one is the slot
 
 - If the second argument only names the slot itself, the target is
-  <WORKSHOP>/agent:<SLOT>; <WORKSHOP> comes from the first argument
+  <WORKSHOP>/host:<SLOT>; <WORKSHOP> comes from the first argument
 
 - If the second argument only names the workshop and SDK, the target is
   <WORKSHOP>/<SDK>:<INTERFACE>;
@@ -77,10 +77,10 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 
 	slotRef := &client.SlotRef{}
 	if len(av) > 1 {
-		// check if the second arg is a short version of the agent-provided slot reference
+		// check if the second arg is a short version of the host-provided slot reference
 		if strings.HasPrefix(av[1], ":") {
 			slotRef.Workshop = plugRef.Workshop
-			slotRef.Sdk = "agent"
+			slotRef.Sdk = "host"
 			slotRef.Name = av[1][1:]
 		} else {
 			slotRef, err = client.ParseShortSlotRef(av[1])

--- a/cmd/workshop/disconnect_test.go
+++ b/cmd/workshop/disconnect_test.go
@@ -37,7 +37,7 @@ func (m *disconnectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 			map[string]interface{}{
 				"project-id": "42424242",
 				"workshop":   "ws",
-				"sdk":        "agent",
+				"sdk":        "host",
 				"slot":       "content",
 			},
 		},

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -24,7 +24,7 @@ var (
 
 	ruleSubrules = []string{"allow-installation", "deny-installation", "allow-connection", "deny-connection", "allow-auto-connection", "deny-auto-connection"}
 
-	validSdkType = regexp.MustCompile(`^(?:agent|regular)$`)
+	validSdkType = regexp.MustCompile(`^(?:host|regular)$`)
 
 	validIDConstraints = map[string]*regexp.Regexp{
 		"slot-sdk-type": validSdkType,

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -22,14 +22,14 @@ type plugSlotRulesSuite struct{}
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstraints(c *check.C) {
 	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
 		"allow-installation": map[string]interface{}{
-			"slot-sdk-type": []interface{}{"agent", "regular"},
+			"slot-sdk-type": []interface{}{"host", "regular"},
 		},
 	})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(rule.AllowInstallation, check.HasLen, 1)
 	cstrs := rule.AllowInstallation[0]
-	c.Check(cstrs.SlotTypes, check.DeepEquals, []string{"agent", "regular"})
+	c.Check(cstrs.SlotTypes, check.DeepEquals, []string{"host", "regular"})
 }
 
 func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.SlotConnectionConstraints, always bool) {

--- a/internal/asserts/sdk_asserts_test.go
+++ b/internal/asserts/sdk_asserts_test.go
@@ -22,13 +22,13 @@ slots:
     deny-installation: true
     allow-auto-connection:
       plug-sdk-type:
-        - agent
+        - host
   interface4:
     allow-connection: true
     deny-connection: false
     allow-installation:
       slot-sdk-type:
-        - agent
+        - host
         - regular
 timestamp: 2016-09-29T19:50:49Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
@@ -49,11 +49,11 @@ AXNpZw==`
 	c.Assert(slotRule3, check.NotNil)
 	c.Assert(slotRule3.DenyInstallation, check.HasLen, 1)
 	c.Assert(slotRule3.AllowAutoConnection, check.HasLen, 1)
-	c.Check(slotRule3.AllowAutoConnection[0].PlugSdkTypes, check.DeepEquals, []string{"agent"})
+	c.Check(slotRule3.AllowAutoConnection[0].PlugSdkTypes, check.DeepEquals, []string{"host"})
 
 	slotRule4 := baseDecl.SlotRule("interface4")
 	c.Assert(slotRule4, check.NotNil)
-	c.Check(slotRule4.AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"agent", "regular"})
+	c.Check(slotRule4.AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"host", "regular"})
 	c.Assert(slotRule4.DenyInstallation, check.HasLen, 1)
 	c.Assert(slotRule3.AllowConnection, check.HasLen, 1)
 	c.Assert(slotRule3.DenyConnection, check.HasLen, 1)
@@ -108,7 +108,7 @@ slots:
   network:
     allow-installation:
       slot-sdk-type:
-        - agent
+        - host
 `
 
 	err := asserts.InitBuiltinBaseDeclaration([]byte(headers))
@@ -122,7 +122,7 @@ slots:
 
 	c.Check(baseDecl.AuthorityID(), check.Equals, "canonical")
 	c.Check(baseDecl.Series(), check.Equals, "1")
-	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"agent"})
+	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"host"})
 
 	enc := asserts.Encode(baseDecl)
 	// it's expected that it cannot be decoded

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -484,7 +484,7 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(s.b.AssignProfileCalls, check.HasLen, 0)
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slots(s.project.ProjectId, "basic", "agent"), check.HasLen, 3)
+	c.Assert(repo.Slots(s.project.ProjectId, "basic", "host"), check.HasLen, 3)
 }
 
 func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
@@ -523,8 +523,8 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
 
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "agent"), check.HasLen, 0)
-	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "agent"), check.HasLen, 0)
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "host"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "host"), check.HasLen, 0)
 
 	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk"), check.HasLen, 0)
 	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk"), check.HasLen, 0)
@@ -704,7 +704,7 @@ func (s *apiSuite) TestRefreshWorkshopFailed(c *check.C) {
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
 			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk", Name: "data"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "agent", Name: "content"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "host", Name: "content"},
 		},
 	})
 
@@ -713,11 +713,11 @@ func (s *apiSuite) TestRefreshWorkshopFailed(c *check.C) {
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
 			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk-2", Name: "photos"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "agent", Name: "content"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "host", Name: "content"},
 		},
 		{
 			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk-2", Name: "gpu"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "agent", Name: "gpu"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "host", Name: "gpu"},
 		},
 	})
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -112,7 +112,7 @@ func (s *daemonSuite) TestExplicitPaths(c *C) {
 }
 
 func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
-	fakeUserAgent := "some-agent-talking-to-pebble/1.0"
+	fakeUserAgent := "some-agent-talking-to-workshop/1.0"
 
 	cmd := &Command{d: s.newDaemon(c)}
 	handler := &fakeHandler{cmd: cmd}

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -40,7 +40,7 @@ const contentBaseDeclarationSlots = `
   content:
     allow-installation:
       slot-sdk-type:
-        - agent
+        - host
     allow-connection: true
     allow-auto-connection: true
 `

--- a/internal/interfaces/builtin/gpu.go
+++ b/internal/interfaces/builtin/gpu.go
@@ -32,7 +32,7 @@ const gpuBaseDeclarationSlots = `
   gpu:
     allow-installation:
       slot-sdk-type:
-        - agent
+        - host
       allow-connection: true
       allow-auto-connection: true
 `

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -41,7 +41,7 @@ const sshAgentBaseDeclarationSlots = `
   ssh-agent:
     allow-installation:
       slot-sdk-type:
-        - agent
+        - host
     allow-connection: true
     deny-auto-connection: true
 `

--- a/internal/interfaces/policy/basedeclaration.go
+++ b/internal/interfaces/policy/basedeclaration.go
@@ -51,26 +51,26 @@ import (
 //     manual-connected-implicit-slot:
 //       allow-installation:
 //         slot-sdk-type:
-//           - agent                     # implicit slot
+//           - host                     # implicit slot
 //       deny-auto-connection: true     # force manual connect
 //
 //     auto-connected-implicit-slot:
 //       allow-installation:
 //         slot-sdk-type:
-//           - agent                     # implicit slot
+//           - host                     # implicit slot
 //       allow-auto-connection: true    # allow auto-connect
 //
 //     manual-connected-provided-slot:
 //       allow-installation:
 //         slot-sdk-type:
-//           - sdk                      # sdk provided slot
+//           - regular                      # sdk provided slot
 //       deny-connection: true          # require allow-connection in sdk decl
 //       deny-auto-connection: true     # force manual connect
 //
 //     auto-connected-provided-slot:
 //       allow-installation:
 //         slot-sdk-type:
-//           - sdk                      # sdk provided slot
+//           - regular                      # sdk provided slot
 //       deny-connection: true          # require allow-connection in sdk decl
 
 const baseDeclarationHeader = `

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -138,7 +138,7 @@ func (s *baseDeclSuite) TestContentSlotInstallation(c *C) {
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "installation not allowed by \"content\" slot rule of interface \"content\"")
 
-	ic = s.installSlotCand(c, "content", sdk.Agent, ``)
+	ic = s.installSlotCand(c, "content", sdk.Host, ``)
 	err = ic.Check()
 	c.Assert(err, IsNil)
 }
@@ -164,7 +164,7 @@ func (s *baseDeclSuite) TestDoesNotPanic(c *C) {
 func (s *baseDeclSuite) TestSlotPlugFromSameWorkshop(c *C) {
 	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
-type: agent
+type: host
 slots:
     content:
 `
@@ -178,13 +178,13 @@ slots:
 func (s *baseDeclSuite) TestSlotPlugDifferentProjects(c *C) {
 	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
-type: agent
+type: host
 slots:
     content:
 `
 	plugYaml := `name: plug-sdk
 base: ubuntu@22.04
-type: agent
+type: host
 plugs:
     content:      
 `
@@ -198,13 +198,13 @@ plugs:
 func (s *baseDeclSuite) TestSlotPlugDifferentWorkshop(c *C) {
 	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
-type: agent
+type: host
 slots:
     content:
 `
 	plugYaml := `name: plug-sdk
 base: ubuntu@22.04
-type: agent
+type: host
 plugs:
     content:      
 `

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -1072,10 +1072,10 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 	}
 
 	if slotSdkName == "" {
-		// Use the agent SDK if the slot-side snap name is empty
+		// Use the host SDK if the slot-side snap name is empty
 		slotProjectId = plugProjectId
 		slotWorkshop = plugWorkshop
-		slotSdkName = sdk.Agent.String()
+		slotSdkName = sdk.Host.String()
 	}
 
 	slotKey := plugOrSlotKey(slotProjectId, slotWorkshop, slotSdkName)

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1664,7 +1664,7 @@ slots:
 	s3 := sdk.MockInfo(c, `
 name: s3
 base: ubuntu@22.04
-type: agent
+type: host
 slots:
   i2:
 `, s.projectId, "ws")

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -450,10 +450,10 @@ plugs:
         interface: content
         target: /home/workshop
 `
-	var agentYaml = `
-name: agent
+	var hostYaml = `
+name: host
 base: ubuntu@22.04
-type: agent
+type: host
 slots:
     slot:
         interface: content        
@@ -462,11 +462,11 @@ slots:
 	c.Assert(err, check.IsNil)
 	wm.Running = true
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
-	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, agentYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, hostYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
-		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/agent:slot": map[string]interface{}{
+		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/host:slot": map[string]interface{}{
 			"interface":    "content",
 			"auto":         true,
 			"plug-static":  map[string]interface{}{"target": "/opt"},
@@ -806,7 +806,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	var attrs map[string]interface{}
 	c.Assert(chg.Get("remounts", &attrs), check.IsNil)
 	c.Assert(attrs, check.HasLen, 1)
-	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/agent:slot"],
+	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/host:slot"],
 		check.DeepEquals, source)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -150,11 +150,11 @@ func (m *InterfaceManager) StartUp() error {
 					logger.Noticef("Cannot create internal mounts for %q workshop: %v", workshop.Name, err)
 				}
 
-				agent, err := workshop.SdkInfo(pctx, sdk.Agent.String())
+				host, err := workshop.SdkInfo(pctx, sdk.Host.String())
 				if err != nil {
 					continue
 				}
-				if err = m.repo.AddSdk(agent); err != nil {
+				if err = m.repo.AddSdk(host); err != nil {
 					continue
 				}
 
@@ -244,13 +244,13 @@ func (m *InterfaceManager) ResolveDisconnect(
 	// 1: <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot>
 	// Return exactly one plug/slot or an error if it doesn't exist.
 	case plugName != "" && slotName != "":
-		// The SDK name can be omitted to implicitly refer to the agent SDK.
+		// The SDK name can be omitted to implicitly refer to the host SDK.
 		if plugSdk == "" {
-			plugSdk = sdk.Agent.String()
+			plugSdk = sdk.Host.String()
 		}
-		// The SDK name can be omitted to implicitly refer to the agent SDK.
+		// The SDK name can be omitted to implicitly refer to the host SDK.
 		if slotSdk == "" {
-			slotSdk = sdk.Agent.String()
+			slotSdk = sdk.Host.String()
 		}
 		// Ensure that slot and plug are connected
 		isConnected, err := connected(plugProject, plugWorkshop, plugSdk, plugName, slotProject, slotWorkshop, slotSdk, slotName)
@@ -274,14 +274,14 @@ func (m *InterfaceManager) ResolveDisconnect(
 	// Return a list of connections involving specified plug or slot.
 	case plugWorkshop != "" && plugName != "" && slotWorkshop == "" && slotName == "":
 		if plugSdk == "" {
-			plugSdk = sdk.Agent.String()
+			plugSdk = sdk.Host.String()
 		}
 		return connectedPlugOrSlot(plugProject, plugWorkshop, plugSdk, plugName)
 	// 2: <workshop>/<sdk>:<plug or slot> (through 2nd pair)
 	// Return a list of connections involving specified plug or slot.
 	case plugWorkshop == "" && plugName == "" && slotWorkshop != "" && slotName != "":
 		if slotSdk == "" {
-			slotSdk = sdk.Agent.String()
+			slotSdk = sdk.Host.String()
 		}
 		return connectedPlugOrSlot(slotProject, slotWorkshop, slotSdk, slotName)
 	default:

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -91,16 +91,16 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdkYamls m
 	c.Assert(err, check.IsNil)
 	defer wsfs.Close()
 
-	var agentYaml = `name: agent
+	var hostYaml = `name: host
 base: ubuntu@22.04
-type: agent
+type: host
 slots:
   slot:
     interface: content
     attr: slot-value
 `
-	c.Assert(wsfs.MkdirAll(filepath.Join(dirs.WorkshopSdksDir, "agent", "current", "meta", "sdk.yaml"), 0655), check.IsNil)
-	s.writeSDKMetaFile(c, wsfs, "agent", agentYaml)
+	c.Assert(wsfs.MkdirAll(filepath.Join(dirs.WorkshopSdksDir, "host", "current", "meta", "sdk.yaml"), 0655), check.IsNil)
+	s.writeSDKMetaFile(c, wsfs, "host", hostYaml)
 	for sdk, yaml := range sdkYamls {
 		s.writeSDKMetaFile(c, wsfs, sdk.Name, yaml)
 	}
@@ -123,7 +123,7 @@ plugs:
 	})
 
 	s.state.Lock()
-	key := fmt.Sprintf("%s/ws/consumer:plug %s/ws/agent:slot", s.prj.ProjectId, s.prj.ProjectId)
+	key := fmt.Sprintf("%s/ws/consumer:plug %s/ws/host:slot", s.prj.ProjectId, s.prj.ProjectId)
 	s.state.Set("conns", map[string]interface{}{
 		key: map[string]interface{}{
 			"interface": "content",
@@ -149,7 +149,7 @@ plugs:
 	c.Assert(ifaces.Connections, check.HasLen, 1)
 	cref := &interfaces.ConnRef{
 		PlugRef: interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "agent", Name: "slot"}}
+		SlotRef: interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "host", Name: "slot"}}
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{cref})
 
 	conn, err := repo.Connection(cref)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -82,7 +82,7 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return store.DownloadSdk(ctx, rec, reporter)
 }
 
-func (m *SdkManager) doInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error {
+func (m *SdkManager) doInstallHostSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -96,10 +96,10 @@ func (m *SdkManager) doInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error 
 		return err
 	}
 
-	return wp.InstallAgentSdk(ctx)
+	return wp.InstallHostSdk(ctx)
 }
 
-func (m *SdkManager) undoInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) error {
+func (m *SdkManager) undoInstallHostSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (m *SdkManager) undoInstallAgentSdk(task *state.Task, tomb *tomb.Tomb) erro
 	}
 	defer wfs.Close()
 
-	return wfs.RemoveAll(sdk.SdkRootPath("agent"))
+	return wfs.RemoveAll(sdk.SdkRootPath("host"))
 }
 
 func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -296,13 +296,13 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	c.Check(exist, check.Equals, false)
 }
 
-func (s *sdkStateSuite) TestDoInstallAgentSdkSuccess(c *check.C) {
+func (s *sdkStateSuite) TestDoInstallHostSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: "agent"}
+	newSdk := sdk.Setup{Name: "host"}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
-	t1 := s.state.NewTask("install-agent-sdk", "test")
+	t1 := s.state.NewTask("install-host-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
 
 	chg := s.state.NewChange("sample", "...")
@@ -319,18 +319,18 @@ func (s *sdkStateSuite) TestDoInstallAgentSdkSuccess(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	info, err := wfs.Stat("/var/lib/workshop/sdk/agent/current/meta/sdk.yaml")
+	info, err := wfs.Stat("/var/lib/workshop/sdk/host/current/meta/sdk.yaml")
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Mode().Perm(), check.Equals, fs.FileMode(0666))
 }
 
-func (s *sdkStateSuite) TestUndoInstallAgentSdkSuccess(c *check.C) {
+func (s *sdkStateSuite) TestUndoInstallHostSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: "agent"}
+	newSdk := sdk.Setup{Name: "host"}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
-	t1 := s.state.NewTask("install-agent-sdk", "test")
+	t1 := s.state.NewTask("install-host-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
 
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
@@ -353,7 +353,7 @@ func (s *sdkStateSuite) TestUndoInstallAgentSdkSuccess(c *check.C) {
 	c.Check(chg.Err(), check.NotNil)
 	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	_, err = wfs.Stat("/var/lib/workshop/sdk/agent")
+	_, err = wfs.Stat("/var/lib/workshop/sdk/host")
 	c.Assert(osutil.IsDirNotExist(err), check.Equals, true)
 }
 

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -17,7 +17,7 @@ func New(runner *state.TaskRunner, repo *interfaces.Repository, server backend.B
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
 	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.undoInstallSdk)
-	runner.AddHandler("install-agent-sdk", OnDo(manager.doInstallAgentSdk), manager.undoInstallAgentSdk)
+	runner.AddHandler("install-host-sdk", OnDo(manager.doInstallHostSdk), manager.undoInstallHostSdk)
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.undoLinkSdk)
 
 	return manager

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -13,9 +13,9 @@ func Retrieve(st *state.State, s sdk.Setup) *state.Task {
 	return download
 }
 
-func InstallAgent(st *state.State) *state.TaskSet {
-	name := sdk.Agent.String()
-	install := st.NewTask("install-agent-sdk", fmt.Sprintf("Install %q SDK", name))
+func InstallHostSdk(st *state.State) *state.TaskSet {
+	name := sdk.Host.String()
+	install := st.NewTask("install-host-sdk", fmt.Sprintf("Install %q SDK", name))
 	install.Set("sdk-setup", sdk.Setup{
 		Name: name,
 	})

--- a/internal/overlord/sdkstate/request_test.go
+++ b/internal/overlord/sdkstate/request_test.go
@@ -23,7 +23,7 @@ func (i *SdkStateTasks) TestInstall(c *check.C) {
 	i.state.Lock()
 	defer i.state.Unlock()
 
-	sdk := workshop.SdkRecord{Name: "sdk", Channel: "latest/stable"}
+	sdk := workshop.SdkRecord{Name: "sdk"}
 
 	tasks := sdkstate.Install(i.state, sdk.Name, "retrieve").Tasks()
 

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -246,7 +246,7 @@ func (s *workshopHandlers) TestCreateWorkshopNoWorkshopConfigurationFound(c *che
 	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*internal error: "ws" workshop configuration is not found.*`)
 }
 
-func (s *workshopHandlers) TestCreateWorkshopWithAgentSdk(c *check.C) {
+func (s *workshopHandlers) TestCreateWorkshopWithHostSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	err := os.WriteFile(filepath.Join(s.project.Path, ".workshop.ws.yaml"), []byte(`name: ws

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -158,14 +158,14 @@ func retrieveSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 }
 
 func installSdks(st *state.State, w string, sdks []sdk.Setup, retrieveSet *state.TaskSet) *state.TaskSet {
-	var prevInstall = sdkstate.InstallAgent(st)
+	var prevInstall = sdkstate.InstallHostSdk(st)
 	install := state.NewTaskSet(prevInstall.Tasks()...)
 
 	var prevSetup *state.Task
 	setupHook := state.NewTaskSet()
 
-	var prevAuto = st.NewTask("auto-connect", `Auto-connect interfaces of "agent" SDK`)
-	prevAuto.Set("sdk", "agent")
+	var prevAuto = st.NewTask("auto-connect", `Auto-connect interfaces of "host" SDK`)
+	prevAuto.Set("sdk", "host")
 	autoConnect := state.NewTaskSet(prevAuto)
 
 	for idx, sdk := range sdks {
@@ -460,8 +460,8 @@ func refresh(st *state.State, file *workshop.File, installed []sdk.Setup, newCon
 }
 
 func disconnectSdks(content []sdk.Setup, st *state.State) *state.TaskSet {
-	prev := st.NewTask("auto-disconnect", `Disconnect interfaces of "agent" SDK`)
-	prev.Set("sdk", "agent")
+	prev := st.NewTask("auto-disconnect", `Disconnect interfaces of "host" SDK`)
+	prev.Set("sdk", "host")
 	disconnectSet := state.NewTaskSet(prev)
 	for _, s := range content {
 		disc := st.NewTask("auto-disconnect", fmt.Sprintf("Disconnect interfaces of %q SDK", s.Name))

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -138,7 +138,7 @@ func (s *requestSuite) TestLaunchWorkshopNoSdk(c *check.C) {
 
 	expected := []string{"download-base", "create-workshop",
 		"mount-project",
-		"start-workshop", "install-agent-sdk", "link-sdk", "auto-connect"}
+		"start-workshop", "install-host-sdk", "link-sdk", "auto-connect"}
 	tasks := ts.Tasks()
 
 	verifyExpectedTasks(c, tasks, expected)
@@ -171,10 +171,10 @@ func (s *requestSuite) TestRefreshEmptyWorkshop(c *check.C) {
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
-		"install-agent-sdk",
+		"install-host-sdk",
 		"link-sdk",
-		"auto-connect",    // "agent" SDK
-		"auto-disconnect", // "agent" SDK
+		"auto-connect",    // "host" SDK
+		"auto-disconnect", // "host" SDK
 	}
 
 	tasks := ts.Tasks()
@@ -208,7 +208,7 @@ func (s *requestSuite) TestRefreshWorkshopWithSdks(c *check.C) {
 		"create-state-storage",
 		"run-hook",        // save-state sdk-1
 		"run-hook",        // save-state sdk-2
-		"auto-disconnect", // "agent" SDK
+		"auto-disconnect", // "host" SDK
 		"auto-disconnect",
 		"auto-disconnect",
 		"stash-workshop",
@@ -216,13 +216,13 @@ func (s *requestSuite) TestRefreshWorkshopWithSdks(c *check.C) {
 		"create-workshop",
 		"mount-project",
 		"start-workshop",
-		"install-agent-sdk",
+		"install-host-sdk",
 		"link-sdk",
 		"install-sdk",
 		"link-sdk",
 		"install-sdk",
 		"link-sdk",
-		"auto-connect", // "agent" SDK
+		"auto-connect", // "host" SDK
 		"auto-connect",
 		"auto-connect",
 		"run-hook", // setup-base sdk-1
@@ -397,10 +397,10 @@ func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 		"stash-workshop",
 		"mount-project",
 		"start-workshop",
-		"install-agent-sdk",
+		"install-host-sdk",
 		"link-sdk",
-		"auto-disconnect", // agent SDK
-		"auto-connect",    // agent SDK
+		"auto-disconnect", // host SDK
+		"auto-connect",    // host SDK
 		"remove-workshop-stash",
 	}
 
@@ -408,18 +408,18 @@ func (s *requestSuite) TestRefreshManyOneWorkshopHasNoSdks(c *check.C) {
 		"retrieve-sdk",
 		"create-state-storage",
 		"run-hook",        // save-state hook
-		"auto-disconnect", // agent SDK
+		"auto-disconnect", // host SDK
 		"auto-disconnect",
 		"stash-workshop",
 		"download-base",
 		"create-workshop",
 		"mount-project",
 		"start-workshop",
-		"install-agent-sdk",
+		"install-host-sdk",
 		"link-sdk",
 		"install-sdk",
 		"link-sdk",
-		"auto-connect", // agent SDK
+		"auto-connect", // host SDK
 		"auto-connect",
 		"run-hook", // setup-base hook
 		"run-hook", // restore-state hook
@@ -496,12 +496,12 @@ func (s *requestSuite) TestRefreshManyAllWorkshopsHaveSdks(c *check.C) {
 		"create-workshop",
 		"mount-project",
 		"start-workshop",
-		"install-agent-sdk",
+		"install-host-sdk",
 		"link-sdk",
 		"install-sdk",
 		"link-sdk",
-		"auto-disconnect", // agent SDK
-		"auto-connect",    // agent SDK
+		"auto-disconnect", // host SDK
+		"auto-connect",    // host SDK
 		"auto-connect",
 		"run-hook", // setup-base hook
 		"run-hook", // restore state hook

--- a/internal/sdk/host.go
+++ b/internal/sdk/host.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 )
 
-var agentSdkYamlTemplate = `name: agent
+var hostSdkYaml = `name: host
 base: %s
-type: agent
+type: host
 slots:
   content:
     interface: content
@@ -16,6 +16,6 @@ slots:
     interface: ssh-agent
 `
 
-func AgentSdkMeta(base string) string {
-	return fmt.Sprintf(agentSdkYamlTemplate, base)
+func HostSdkMeta(base string) string {
+	return fmt.Sprintf(hostSdkYaml, base)
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -38,7 +38,7 @@ type Type string
 
 const (
 	Regular Type = "regular"
-	Agent   Type = "agent"
+	Host    Type = "host"
 )
 
 func (t Type) String() string {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -42,7 +42,7 @@ type Workshop struct {
 // the SDK to the workshop content. This method is idempotent, so if an SDK
 // existed, the result will be a no-op
 func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
-	if s.Name == sdk.Agent.String() {
+	if s.Name == sdk.Host.String() {
 		return nil
 	}
 
@@ -89,7 +89,7 @@ func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
 // removing the SDK to the workshop content. This method is idempotent, so if an
 // SDK did not exist, the result will be a no-op
 func (w *Workshop) UnlinkSdk(ctx context.Context, name string) error {
-	if name == sdk.Agent.String() {
+	if name == sdk.Host.String() {
 		return nil
 	}
 
@@ -136,7 +136,7 @@ func WorkshopStateVolumeName(ws, pid string) string {
 // Reads information about the installed SDK from its meta file.
 func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, error) {
 	setup, ok := w.Content[sdkName]
-	if sdkName != sdk.Agent.String() && !ok {
+	if sdkName != sdk.Host.String() && !ok {
 		return nil, fmt.Errorf("SDK %q is not installed in %q workshop", sdkName, w.Name)
 	}
 
@@ -174,7 +174,7 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 }
 
 func (w *Workshop) setupPlugBinds(info *sdk.Info) error {
-	if info.Type == sdk.Agent {
+	if info.Type == sdk.Host {
 		return nil
 	}
 
@@ -210,25 +210,26 @@ func (w *Workshop) ContentInfo(ctx context.Context) ([]*sdk.Info, error) {
 	return infos, nil
 }
 
-func (w *Workshop) InstallAgentSdk(ctx context.Context) error {
+func (w *Workshop) InstallHostSdk(ctx context.Context) error {
 	wfs, err := w.Backend.WorkshopFs(ctx, w.Name)
 	if err != nil {
 		return err
 	}
 	defer wfs.Close()
 
-	agentMetaDir := filepath.Join(sdk.SdkCurrentPath("agent"), "meta")
-	if err := wfs.MkdirAll(agentMetaDir, 0655); err != nil {
+	hostMetaDir := filepath.Join(sdk.SdkCurrentPath("host"), "meta")
+	if err := wfs.MkdirAll(hostMetaDir, 0655); err != nil {
 		return err
 	}
 
-	// /var/lib/workshop/sdk/agent/current/meta
-	file, err := wfs.OpenFile(filepath.Join(agentMetaDir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	// /var/lib/workshop/sdk/host/current/meta
+	file, err := wfs.OpenFile(filepath.Join(hostMetaDir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
-	if _, err = file.Write([]byte(sdk.AgentSdkMeta(w.Base))); err != nil {
+	if _, err = file.Write([]byte(sdk.HostSdkMeta(w.Base))); err != nil {
 		return err
 	}
 	return nil

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -21,7 +21,7 @@ var (
 	// recommended "official" extension: https://yaml.org/faq.html. Also, having a
 	// single way of naming workshop files avoids unneccesary inconsistencies.
 	filename     = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
-	sdkBlacklist = []string{"agent"}
+	sdkBlacklist = []string{"agent", "host"}
 )
 
 type Plug struct {
@@ -152,7 +152,7 @@ func readWorkshop(pathname string) (*File, error) {
 			masters[mr] = append(masters[mr], sl)
 			slaves[sl] = mr
 
-			if ixd := slices.IndexFunc(file.Sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }); ixd == -1 {
+			if !slices.ContainsFunc(file.Sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }) {
 				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", fmt.Sprintf("%s:%s", p.Bind.Sdk, p.Bind.Plug))
 			}
 			if p.Bind.Sdk == s.Name && p.Bind.Plug == name {
@@ -178,8 +178,8 @@ func readWorkshop(pathname string) (*File, error) {
 	}
 
 	for _, s := range file.Sdks {
-		if idx := slices.Index(sdkBlacklist, s.Name); idx != -1 {
-			return nil, fmt.Errorf(`"agent" is a reserved SDK name`)
+		if slices.Contains(sdkBlacklist, s.Name) {
+			return nil, fmt.Errorf("%q is a reserved SDK name", s.Name)
 		}
 		if matches := channel.FindStringSubmatch(s.Channel); matches != nil {
 			continue

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -111,13 +111,13 @@ func (f *workshopFile) TestWorkshopFileReservedNames(c *check.C) {
 	buf := []byte(`name: xbert-gpu
 base: ubuntu@20.04
 sdks:
-  agent:
+  host:
     channel: latest/stable
 `)
 	dir := c.MkDir()
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	file, err := workshop.ReadWorkshop(workshopFilePath(dir, "xbert-gpu"))
-	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
+	c.Assert(err, check.ErrorMatches, `"host" is a reserved SDK name`)
 	c.Assert(file, check.IsNil)
 }
 

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -62,9 +62,9 @@ execute: |
   # Disconnect, Connect
   workshop_exec disconnect nimble/test-sdk-go:mod-cache
   workshop_exec connect nimble/test-sdk-go:mod-cache :content
-  workshop_exec disconnect nimble/test-sdk-go:mod-cache nimble/agent:content
-  workshop_exec connect nimble/test-sdk-go:mod-cache nimble/agent:content
-  workshop_exec disconnect nimble/agent:content
+  workshop_exec disconnect nimble/test-sdk-go:mod-cache nimble/host:content
+  workshop_exec connect nimble/test-sdk-go:mod-cache nimble/host:content
+  workshop_exec disconnect nimble/host:content
   workshop_exec connect nimble/test-sdk-go:mod-cache :content
 
   # Remount

--- a/tests/main/connect/task.yaml
+++ b/tests/main/connect/task.yaml
@@ -9,13 +9,13 @@ execute: |
   . "$TESTSLIB"/utils.sh
   
   echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot> form"  
-  workshop_exec disconnect ws-conn/test-sdk-content:content-plug-one ws-conn/agent:content  
-  workshop_exec connect ws-conn/test-sdk-content:content-plug-one ws-conn/agent:content
+  workshop_exec disconnect ws-conn/test-sdk-content:content-plug-one ws-conn/host:content  
+  workshop_exec connect ws-conn/test-sdk-content:content-plug-one ws-conn/host:content
   workshop_exec connections ws-conn | MATCH "^content.+ws-conn/test-sdk-content:content-plug-one.+:content.+manual$"  
   
   echo "Check connect <workshop>/<sdk>:<plug> <workshop>/<sdk> form"
   workshop_exec disconnect ws-conn/test-sdk-content:content-plug-two :content
-  workshop_exec connect ws-conn/test-sdk-content:content-plug-two ws-conn/agent
+  workshop_exec connect ws-conn/test-sdk-content:content-plug-two ws-conn/host
   workshop_exec connections ws-conn | MATCH "^content.+ws-conn/test-sdk-content:content-plug-two.+:content.+manual$"
   
   echo "Check connect <workshop>/<sdk>:<plug> form"

--- a/tests/main/disconnect/task.yaml
+++ b/tests/main/disconnect/task.yaml
@@ -9,10 +9,10 @@ execute: |
   . "$TESTSLIB"/utils.sh
   
   echo "Check disconnect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot> form"
-  workshop_exec disconnect ws-disconn/test-sdk-content:content-plug-one ws-disconn/agent:content  
+  workshop_exec disconnect ws-disconn/test-sdk-content:content-plug-one ws-disconn/host:content  
   workshop_exec connections ws-disconn | MATCH "^content.+ws-disconn/test-sdk-content:content-plug-one.+-.+\-$"
   
-  echo "Check disconnect <workshop>/<sdk>:<plug> :<slot> form (agent SDK)"
+  echo "Check disconnect <workshop>/<sdk>:<plug> :<slot> form (host SDK)"
   workshop_exec disconnect ws-disconn/test-sdk-content:content-plug-two :content  
   workshop_exec connections ws-disconn | MATCH "^content.+ws-disconn/test-sdk-content:content-plug-two.+-.+\-$"
   
@@ -23,7 +23,7 @@ execute: |
   workshop_exec connections ws-disconn | MATCH "^content.+ws-disconn/test-sdk-content:content-plug-two.+:content.+\-$"  
 
   echo "Check disconnect <workshop>/<sdk>:<plug or slot> form (must disconnect all slots auto connections)"
-  workshop_exec disconnect ws-disconn/agent:content
+  workshop_exec disconnect ws-disconn/host:content
   workshop_exec connections ws-disconn | MATCH "^content.+ws-disconn/test-sdk-content:content-plug-one.+-.+\-$"
   workshop_exec connections ws-disconn | MATCH "^content.+ws-disconn/test-sdk-content:content-plug-one.+-.+\-$"  
   


### PR DESCRIPTION
# Description

It was decided that 'host' reflects the gist of a special SDK that exposes system resources better.
Supposedly, 'host' is self-explanatory too when compared to 'agent' that requires an introduction.

Also, it removes name collision with the ssh-agent interface.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
