### PR TITLE
Replace a Multipass adhoc backend with LXD VMs in GitHub self-hosted runners

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -37,17 +37,14 @@ jobs:
         suite: [main, documentation, integration]
     runs-on: [self-hosted, linux, jammy, x64, xlarge]
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: canonical/action-tmate@main
+      - name: Install LXD
+        uses: canonical/setup-lxd@main
+        with:
+            channel: 5.21/stable
       - name: Cleanup job workspace
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-          sudo snap remove multipass --purge || true
-          sudo snap refresh --channel=5.21/stable lxd
-          lxd init --auto
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -68,6 +65,4 @@ jobs:
           go install ./...
       - name: Run spread
         run: |  
-          # Installed docker related packages might interfere with LXD networking
-          sudo iptables -P FORWARD ACCEPT
           spread tests/${{matrix.suite}}/

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -8,6 +8,12 @@ on:
     - cron: "0 0 */2 * *"
   workflow_dispatch:
 
+# Cancel currently-running builds when pushing new commits to a PR or branch
+# https://stackoverflow.com/a/72408109
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-snap:
     runs-on: ubuntu-latest
@@ -34,12 +40,11 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
+          sudo snap remove multipass --purge || true
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
-      - name: Install multipass
-        run: sudo snap install multipass
       - name: Checkout Workshop
         uses: actions/checkout@v4
         with:
@@ -48,6 +53,8 @@ jobs:
         with:
           name: snap
           path: ${{ github.workspace }}/tests/
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
       - name: Install spread
         run: |
           # go install is not supported for forks...

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -31,16 +31,23 @@ jobs:
   snap-tests:
     needs: build-snap
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04-64]
         suite: [main, documentation, integration]
     runs-on: [self-hosted, linux, jammy, x64, xlarge]
     steps:
+      - uses: actions/checkout@v3
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: canonical/action-tmate@main
       - name: Cleanup job workspace
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
           sudo snap remove multipass --purge || true
+          sudo snap refresh --channel=5.21/stable lxd
+          lxd init --auto
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -53,8 +60,6 @@ jobs:
         with:
           name: snap
           path: ${{ github.workspace }}/tests/
-      - name: Setup tmate session
-        uses: canonical/action-tmate@main
       - name: Install spread
         run: |
           # go install is not supported for forks...
@@ -62,6 +67,7 @@ jobs:
           cd spread
           go install ./...
       - name: Run spread
-        run: | 
-          lxd init --auto
+        run: |  
+          # Installed docker related packages might interfere with LXD networking
+          sudo iptables -P FORWARD ACCEPT
           spread tests/${{matrix.suite}}/

--- a/.spread.yaml
+++ b/.spread.yaml
@@ -14,6 +14,7 @@ backends:
   lxd:
     systems:
       - ubuntu-22.04:
+          workers: 2
 suites:
   tests/main/:
     summary: Core workshop scenarios

--- a/.spread.yaml
+++ b/.spread.yaml
@@ -11,68 +11,9 @@ repack: |
   test -f tests/*.snap || snapcraft -o tests/
   cat <&3 >&4
 backends:
-  # Only for local usage, GitHub self-hosted runners
-  # fail on IP allocation for a VM (it is allocated but much later 
-  # than expected by spread).
-  # lxd:
-  #   systems:
-  #     - ubuntu-22.04:
-  #         workers: 3
-  #     - ubuntu-24.04:
-  #         workers: 3
-  multipass:
-    type: adhoc
-    allocate: |
-      if [ "$SPREAD_SYSTEM" = "ubuntu-24.04-64" ]; then
-          image="daily:devel"
-          instance_name=spread-devel
-      else
-          # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
-          # translated to an image XX.YY.
-          image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image/./}"
-      fi
-      # If the spread run in a GitHub runner was interrupted, the instance may
-      # remain.
-      multipass delete --purge "$instance_name" || true
-      
-      if [ -z "${image}" ]; then
-        FATAL "$SPREAD_SYSTEM is not supported!"
-      fi
-      multipass launch --disk 20G --memory 4G --cpus 8 --name "$instance_name" "$image"
-      # Get the IP from the instance
-      ip=$(multipass info --format csv "$instance_name" | tail -1 | cut -d\, -f3)
-      # Enable PasswordAuthertication for root over SSH.
-      multipass exec "$instance_name" -- \
-        sudo sh -c "echo root:ubuntu | sudo chpasswd"
-      multipass exec "$instance_name" -- \
-        sudo sh -c \
-        "sed -i /etc/ssh/sshd_config -e 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' -e 's/^#PermitRootLogin.*/PermitRootLogin yes/' -e 's/^KbdInteractiveAuthentication.*/KbdInteractiveAuthentication yes/'"
-      multipass exec "$instance_name" -- \
-        sudo sh -c \
-        "sed -i /etc/ssh/sshd_config.d/60-cloudimg-settings.conf -e 's/^PasswordAuthentication.*/PasswordAuthentication yes/'"
-      multipass exec "$instance_name" -- \
-        sudo systemctl restart ssh
-      ADDRESS "$ip:22"
-    discard: |
-      if [ "$SPREAD_SYSTEM" = "ubuntu-24.04-64" ]; then
-          image="daily:devel"
-          instance_name=spread-devel
-      else
-          # SPREAD_SYSTEM has the following format here 'ubuntu-XX.YY-64' and gets
-          # translated to an image XX.YY.
-          image=$(echo $SPREAD_SYSTEM | sed -e 's/ubuntu-\(.*\)-64/\1/')
-          instance_name="spread-${image/./}"
-      fi
-      if [ -z "${image}" ]; then
-        FATAL "$SPREAD_SYSTEM is not supported!"
-      fi
-      multipass delete --purge "$instance_name"
+  lxd:
     systems:
-      - ubuntu-22.04-64:
-          workers: 1
-          username: root
-          password: ubuntu
+      - ubuntu-22.04:
 suites:
   tests/main/:
     summary: Core workshop scenarios

--- a/tests/main/info-sdk-health/health.exp
+++ b/tests/main/info-sdk-health/health.exp
@@ -1,21 +1,15 @@
 #!/usr/bin/expect -f
 
-set timeout 180
 set success 0 
 
 while {1} {
     spawn workshop info ws-sdk-health
     set result [wait]
-    set exit_code [lindex $result 3]
-    if {$exit_code != 0} {
-        puts "workshop info check failed"
-        exit 1
-    }
     expect {
         -re "message:\[ \]*Cannot finish health check" {
             puts "Seen the expected SDK health messages"
             set success 1
-            exp_continue
+            continue
         }
         -re "ready" {
             if { $success == 1 } {


### PR DESCRIPTION
# Description

Replace a Multipass adhoc backend with LXD VMs to launch spread integration and end-to-end tests with self-hosted GitHub runners. This allows for a customisable number of workers and fixes issues with cleaning up the environment on self-hosted runners (e.g. removing a multipass instance on a spread test failure).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
