### PR TITLE
Wait for snapd to finish seeding in spread's prepare scripts

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -61,8 +61,9 @@ jobs:
         run: |
           # go install is not supported for forks...
           git clone https://github.com/dmitry-lyfar/spread
-          cd spread
+          pushd spread
           go install ./...
+          popd
       - name: Run spread
         run: |  
           spread tests/${{matrix.suite}}/

--- a/.spread.yaml
+++ b/.spread.yaml
@@ -34,7 +34,7 @@ suites:
     summary: LXD integration tests
     prepare: |
       . "$TESTSLIB"/utils.sh
-      init_lxd
+      setup_lxd
       snap install go --classic --channel=1.21/stable
     kill-timeout: 30m
   tests/documentation/:

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# Install and uninstall workshopd
-
-function init_lxd() {
+function setup_lxd() {
   snap install --classic lxd
   snap refresh --channel=5.21/stable lxd
+  lxd waitready --timeout=30
   
   # can already be initialised if reused
   # https://discuss.linuxcontainers.org/t/how-do-i-know-if-lxd-is-initialized/15473/3
@@ -16,8 +15,12 @@ function init_lxd() {
 function prepare_environment() {
   systemctl unmask snapd.service
   systemctl start snapd.service
+  snap wait system seed.loaded
+  # The /snap directory does not exist in some environments
+  [ ! -d /snap ] && ln -s /var/lib/snapd/snap /snap
   
-  init_lxd  
+  setup_lxd
+  
   snap install --classic --channel=1.21/stable go
   snap install yq
   apt update


### PR DESCRIPTION
# Description
This is required to avoid occasional "error: too early for operation, device not yet seeded or device model not acknowledged" on snap launch or refresh.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
