### PR TITLE
Define slots and connections in a workshop file

### DIFF
--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -49,6 +49,10 @@ func isHostSdk(sdkName string) bool {
 	return sdkName == "host"
 }
 
+func isDefaultHostSlot(slot client.Slot) bool {
+	return isHostSdk(slot.Sdk) && slot.Interface == slot.Name
+}
+
 func endpoint(workshop, sdkName, name string) string {
 	if isHostSdk(sdkName) {
 		return ":" + name
@@ -186,7 +190,7 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 		}
 	}
 	for _, slot := range connections.Slots {
-		if isHostSdk(slot.Sdk) {
+		if isDefaultHostSlot(slot) {
 			// displaying unconnected system snap slots is boring,
 			// unless explicitly asked to show them
 			continue

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -647,6 +647,8 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                          Notes\n" +
+		"leds       -                                 :capslock-led                                 -\n" +
+		"leds       -                                 :numlock-led                                  -\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
 		"leds       keyboard-lights/lights:numlock    -                                             -\n" +
@@ -710,7 +712,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 				ProjectId: "42424242",
 				Workshop:  "leds-provider",
 				Sdk:       "host",
-				Name:      "capslock-led",
+				Name:      "leds",
 				Interface: "leds",
 			}, {
 				ProjectId: "42424242",
@@ -776,10 +778,12 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                          Notes\n" +
+		"leds       -                                 :numlock-led                                  -\n" +
+		"leds       -                                 :scrollock-led                                -\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
-		"leds       keyboard-lights/lights:numlock    -                                             bind.4\n" +
-		"leds       keyboard-lights/lights:scrollock  -                                             bind.4\n"
+		"leds       keyboard-lights/lights:numlock    -                                             bind.6\n" +
+		"leds       keyboard-lights/lights:scrollock  -                                             bind.6\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -105,14 +105,11 @@ func (c *CmdList) runList() error {
 		}
 		for _, i := range projects {
 			workshops, err := c.cli.ListWorkshops(&client.ListOptions{ProjectId: i.Id})
-			slices.SortFunc(workshops, func(a, b *client.Workshop) int { return cmp.Compare(a.Name, b.Name) })
-			if len(workshops) > 0 {
-				header.Do(printHeader)
-			}
-
 			if err != nil {
 				return err
 			}
+			slices.SortFunc(workshops, func(a, b *client.Workshop) int { return cmp.Compare(a.Name, b.Name) })
+
 			for _, j := range workshops {
 				// --global flag would not list Off workshops for consistency.
 				// We may not be aware of all the project directories on the system
@@ -120,6 +117,7 @@ func (c *CmdList) runList() error {
 				// to the workshops that are in any other state, i.e. running instances, which we always know
 				// about from the workshop backend)
 				if j.Status != "Off" {
+					header.Do(printHeader)
 					fmt.Fprintln(w, strings.Join(printWorkshop(j, i), "\t"))
 				}
 			}

--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -29,7 +29,6 @@ import (
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/version"
-	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
 
 var shortRunHelp = "Run the workshop daemon"
@@ -140,12 +139,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 
 	dopts.HTTPAddress = rcmd.HTTP
 
-	wbe, err := lxdbackend.New()
-	if err != nil {
-		return err
-	}
-
-	d, err := daemon.New(&dopts, wbe)
+	d, err := daemon.New(&dopts)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -73,5 +73,5 @@ require (
 	google.golang.org/genproto v0.0.0-20240205150955-31a09d347014 // indirect
 	google.golang.org/grpc v1.61.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/internal/asserts/constraint_test.go
+++ b/internal/asserts/constraint_test.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/asserts"
 	"github.com/canonical/workshop/internal/metautil"

--- a/internal/asserts/export_test.go
+++ b/internal/asserts/export_test.go
@@ -4,8 +4,9 @@ import "io"
 
 // Headers helpers to test
 var (
-	ParseHeaders    = parseHeaders
-	CompileSlotRule = compileSlotRule
+	ParseHeaders           = parseHeaders
+	CompileSlotRule        = compileSlotRule
+	CompileNameConstraints = compileNameConstraints
 )
 
 func init() {

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 		"plug-sdk-type": validSdkType,
 	}
 
+	nameConstraints      = []string{"plug-names", "slot-names"}
 	attributeConstraints = []string{"plug-attributes", "slot-attributes"}
 
 	slotIDConstraints = []string{"plug-sdk-type"}
@@ -42,11 +44,33 @@ var (
 	}
 )
 
+const (
+	// feature label for plug-names/slot-names constraints
+	nameConstraintsFeature = "name-constraints"
+)
+
 // SlotInstallationConstraints specifies a set of constraints on an
 // interface slot relevant to the installation of SDK.
 type SlotInstallationConstraints struct {
 	SlotTypes      []string
 	SlotAttributes *AttributeConstraints
+	SlotNames      *NameConstraints
+}
+
+func (c *SlotInstallationConstraints) feature(flabel string) bool {
+	if flabel == nameConstraintsFeature {
+		return c.SlotNames != nil
+	}
+	return c.SlotAttributes.feature(flabel)
+}
+
+func (c *SlotInstallationConstraints) setNameConstraints(field string, cstrs *NameConstraints) {
+	switch field {
+	case "slot-names":
+		c.SlotNames = cstrs
+	default:
+		panic("unknown SlotInstallationConstraints field " + field)
+	}
 }
 
 func (c *SlotInstallationConstraints) setIDConstraints(field string, cstrs []string) {
@@ -94,6 +118,9 @@ func (ac SideArityConstraint) Any() bool {
 type SlotConnectionConstraints struct {
 	PlugSdkTypes []string
 
+	SlotNames *NameConstraints
+	PlugNames *NameConstraints
+
 	SlotAttributes *AttributeConstraints
 	PlugAttributes *AttributeConstraints
 
@@ -101,6 +128,24 @@ type SlotConnectionConstraints struct {
 	SlotsPerPlug SideArityConstraint
 	// PlugsPerSlot is always * (any) (for now)
 	PlugsPerSlot SideArityConstraint
+}
+
+func (c *SlotConnectionConstraints) feature(flabel string) bool {
+	if flabel == nameConstraintsFeature {
+		return c.PlugNames != nil || c.SlotNames != nil
+	}
+	return c.PlugAttributes.feature(flabel) || c.SlotAttributes.feature(flabel)
+}
+
+func (c *SlotConnectionConstraints) setNameConstraints(field string, cstrs *NameConstraints) {
+	switch field {
+	case "plug-names":
+		c.PlugNames = cstrs
+	case "slot-names":
+		c.SlotNames = cstrs
+	default:
+		panic("unknown SlotConnectionConstraints field " + field)
+	}
 }
 
 func (c *SlotConnectionConstraints) setIDConstraints(field string, cstrs []string) {
@@ -164,6 +209,91 @@ func normalizeSideArityConstraints(context *subruleContext, c sideArityConstrain
 		// connection slots-per-plug can be only any
 		c.setSlotsPerPlug(any)
 	}
+}
+
+type nameMatcher interface {
+	match(name string, special map[string]string) error
+}
+
+var (
+	// validates special name constraints like $INTERFACE
+	validSpecialNameConstraint = regexp.MustCompile(`^\$[A-Z][A-Z0-9_]*$`)
+)
+
+func compileNameMatcher(whichName string, v interface{}) (nameMatcher, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, fmt.Errorf("%s constraint entry must be a regexp or special $ value", whichName)
+	}
+	if strings.HasPrefix(s, "$") {
+		if !validSpecialNameConstraint.MatchString(s) {
+			return nil, fmt.Errorf("%s constraint entry special value %q is invalid", whichName, s)
+		}
+		return specialNameMatcher{special: s}, nil
+	}
+	if strings.IndexFunc(s, unicode.IsSpace) != -1 {
+		return nil, fmt.Errorf("%s constraint entry regexp contains unexpected spaces", whichName)
+	}
+	rx, err := regexp.Compile("^(" + s + ")$")
+	if err != nil {
+		return nil, fmt.Errorf("cannot compile %s constraint entry %q: %v", whichName, s, err)
+	}
+	return regexpNameMatcher{rx}, nil
+}
+
+type regexpNameMatcher struct {
+	*regexp.Regexp
+}
+
+func (matcher regexpNameMatcher) match(name string, special map[string]string) error {
+	if !matcher.Regexp.MatchString(name) {
+		return fmt.Errorf("%q does not match %v", name, matcher.Regexp)
+	}
+	return nil
+}
+
+type specialNameMatcher struct {
+	special string
+}
+
+func (matcher specialNameMatcher) match(name string, special map[string]string) error {
+	expected := special[matcher.special]
+	if expected == "" || expected != name {
+		return fmt.Errorf("%q does not match %v", name, matcher.special)
+	}
+	return nil
+}
+
+// NameConstraints implements a set of constraints on the names of slots or plugs.
+// See https://forum.snapcraft.io/t/plug-slot-rules-plug-names-slot-names-constraints/12439
+type NameConstraints struct {
+	matchers []nameMatcher
+}
+
+func compileNameConstraints(whichName string, constraints interface{}) (*NameConstraints, error) {
+	l, ok := constraints.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s constraints must be a list of regexps and special $ values", whichName)
+	}
+	matchers := make([]nameMatcher, 0, len(l))
+	for _, nm := range l {
+		matcher, err := compileNameMatcher(whichName, nm)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, matcher)
+	}
+	return &NameConstraints{matchers: matchers}, nil
+}
+
+// Check checks whether name doesn't match the constraints.
+func (nc *NameConstraints) Check(whichName, name string, special map[string]string) error {
+	for _, m := range nc.matchers {
+		if err := m.match(name, special); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s %q does not match constraints", whichName, name)
 }
 
 // SlotRule holds the rule of what is allowed, wrt installation and
@@ -232,7 +362,7 @@ func castSlotInstallationConstraints(cstrs []constraintsHolder) (res []*SlotInst
 
 func compileSlotInstallationConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
 	slotInstCstrs := &SlotInstallationConstraints{}
-	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-attributes"}, []string{"slot-sdk-type"})
+	err := baseCompileConstraints(context, cDef, slotInstCstrs, []string{"slot-names"}, []string{"slot-attributes"}, []string{"slot-sdk-type"})
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +371,7 @@ func compileSlotInstallationConstraints(context *subruleContext, cDef constraint
 
 func compileSlotConnectionConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
 	slotConnCstrs := &SlotConnectionConstraints{}
-	err := baseCompileConstraints(context, cDef, slotConnCstrs, attributeConstraints, slotIDConstraints)
+	err := baseCompileConstraints(context, cDef, slotConnCstrs, nameConstraints, attributeConstraints, slotIDConstraints)
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +463,7 @@ type Attrer interface {
 	Lookup(path string) (interface{}, bool)
 }
 
-func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target constraintsHolder, attrConstraints, idConstraints []string) error {
+func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target constraintsHolder, nameConstraints, attrConstraints, idConstraints []string) error {
 	cMap := cDef.cMap
 	if cMap == nil {
 		fixed := AlwaysMatchAttributes // "true"
@@ -346,6 +476,18 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 		return nil
 	}
 	defaultUsed := 0
+	for _, field := range nameConstraints {
+		v := cMap[field]
+		if v != nil {
+			nc, err := compileNameConstraints(field, v)
+			if err != nil {
+				return err
+			}
+			target.setNameConstraints(field, nc)
+		} else {
+			defaultUsed++
+		}
+	}
 	for _, field := range attrConstraints {
 		cstrs := AlwaysMatchAttributes
 		v := cMap[field]
@@ -385,6 +527,9 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 		} else {
 			defaultUsed++
 		}
+	}
+	if defaultUsed == len(nameConstraints)+len(attributeConstraints)+len(idConstraints)+len(sideArityConstraints) {
+		return fmt.Errorf("%s must specify at least one of %s, %s, %s, %s", context, strings.Join(nameConstraints, ", "), strings.Join(attrConstraints, ", "), strings.Join(idConstraints, ", "), strings.Join(sideArityConstraints, ", "))
 	}
 	return nil
 }
@@ -441,6 +586,7 @@ type constraintsDef struct {
 }
 
 type constraintsHolder interface {
+	setNameConstraints(field string, cstrs *NameConstraints)
 	setIDConstraints(field string, cstrs []string)
 	setAttributeConstraints(field string, cstrs *AttributeConstraints)
 }

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -1,6 +1,7 @@
 package asserts_test
 
 import (
+	"fmt"
 	"strings"
 
 	"gopkg.in/check.v1"
@@ -18,6 +19,112 @@ var (
 )
 
 type plugSlotRulesSuite struct{}
+
+func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsSlotNames(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`iface:
+  allow-installation: true`))
+	c.Assert(err, check.IsNil)
+
+	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	c.Check(rule.AllowInstallation[0].SlotNames, check.IsNil)
+
+	tests := []struct {
+		rule        string
+		matching    []string
+		notMatching []string
+	}{
+		{`iface:
+  allow-installation:
+    slot-names:
+      - foo`, []string{"foo"}, []string{"bar"}},
+		{`iface:
+  allow-installation:
+    slot-names:
+      - foo
+      - bar`, []string{"foo", "bar"}, []string{"baz"}},
+		{`iface:
+  allow-installation:
+    slot-names:
+      - foo[0-9]
+      - bar`, []string{"foo0", "foo1", "bar"}, []string{"baz", "fooo", "foo12"}},
+	}
+	for _, t := range tests {
+		m, err = asserts.ParseHeaders([]byte(t.rule))
+		c.Assert(err, check.IsNil)
+
+		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+		c.Assert(err, check.IsNil)
+
+		for _, matching := range t.matching {
+			c.Check(rule.AllowInstallation[0].SlotNames.Check("slot name", matching, nil), check.IsNil)
+		}
+		for _, notMatching := range t.notMatching {
+			c.Check(rule.AllowInstallation[0].SlotNames.Check("slot name", notMatching, nil), check.NotNil)
+		}
+	}
+}
+
+func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsPlugNamesSlotNames(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`iface:
+  allow-connection: true`))
+	c.Assert(err, check.IsNil)
+
+	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	c.Check(rule.AllowConnection[0].PlugNames, check.IsNil)
+	c.Check(rule.AllowConnection[0].SlotNames, check.IsNil)
+
+	tests := []struct {
+		rule        string
+		matching    []string
+		notMatching []string
+	}{
+		{`iface:
+  allow-connection:
+    plug-names:
+      - Pfoo
+    slot-names:
+      - Sfoo`, []string{"foo"}, []string{"bar"}},
+		{`iface:
+  allow-connection:
+    plug-names:
+      - Pfoo
+      - Pbar
+    slot-names:
+      - Sfoo
+      - Sbar`, []string{"foo", "bar"}, []string{"baz"}},
+		{`iface:
+  allow-connection:
+    plug-names:
+      - Pfoo[0-9]
+      - Pbar
+    slot-names:
+      - Sfoo[0-9]
+      - Sbar`, []string{"foo0", "foo1", "bar"}, []string{"baz", "fooo", "foo12"}},
+	}
+	for _, t := range tests {
+		m, err = asserts.ParseHeaders([]byte(t.rule))
+		c.Assert(err, check.IsNil)
+
+		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+		c.Assert(err, check.IsNil)
+
+		for _, matching := range t.matching {
+			c.Check(rule.AllowConnection[0].PlugNames.Check("plug name", "P"+matching, nil), check.IsNil)
+
+			c.Check(rule.AllowConnection[0].SlotNames.Check("slot name", "S"+matching, nil), check.IsNil)
+		}
+
+		for _, notMatching := range t.notMatching {
+			c.Check(rule.AllowConnection[0].SlotNames.Check("plug name", "P"+notMatching, nil), check.NotNil)
+
+			c.Check(rule.AllowConnection[0].SlotNames.Check("slot name", "S"+notMatching, nil), check.NotNil)
+		}
+	}
+}
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstraints(c *check.C) {
 	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
@@ -177,6 +284,14 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
     plug-sdk-type:
       - xapp`, `plug-sdk-type in allow-connection in slot rule for interface "iface" contains an invalid element: "xapp"`},
 		{`iface:
+  allow-connection:
+    plug-sdk-ids:
+      - foo`, `allow-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slots-per-plug, plugs-per-slot`},
+		{`iface:
+  deny-connection:
+    plug-sdk-ids:
+        - foo`, `deny-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slots-per-plug, plugs-per-slot`},
+		{`iface:
   allow-connect: true`, `slot rule for interface "iface" must specify at least one of allow-installation, deny-installation, allow-connection, deny-connection, allow-auto-connection, deny-auto-connection`},
 		{`iface:
   allow-installation:
@@ -184,6 +299,10 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
 		{`iface:
   deny-auto-connection:
     slots-per-plug: 1`, `deny-auto-connection in slot rule for interface "iface" cannot specify a slots-per-plug constraint, they apply only to allow-\*connection`},
+		{`iface:
+  deny-auto-connection:
+    plug-sdk-ids:
+      - foo`, `deny-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slots-per-plug, plugs-per-slot`},
 		{`iface:
   allow-auto-connection:
     plugs-per-slot: any`, `plugs-per-slot in allow-auto-connection in slot rule for interface "iface" must be an integer >=1 or \*`},
@@ -200,6 +319,13 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
   allow-auto-connection:
     slots-per-plug:
       what: 1`, `slots-per-plug in allow-auto-connection in slot rule for interface "iface" must be an integer >=1 or \*`},
+		{`iface:
+  allow-auto-connection:
+    slot-names: true`, `slot-names constraints must be a list of regexps and special \$ values`},
+		{`iface:
+  allow-auto-connection:
+    plug-sdk-ids:
+      - foo`, `allow-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slots-per-plug, plugs-per-slot`},
 	}
 
 	for i, t := range tests {
@@ -208,4 +334,49 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
 		_, err = asserts.CompileSlotRule("iface", m["iface"])
 		c.Assert(err, check.ErrorMatches, t.err, check.Commentf("%d: %s", i, t.stanza))
 	}
+}
+
+type nameConstraintsSuite struct{}
+
+func (s *nameConstraintsSuite) TestCompileErrors(c *check.C) {
+	_, err := asserts.CompileNameConstraints("slot-names", "true")
+	c.Check(err, check.ErrorMatches, `slot-names constraints must be a list of regexps and special \$ values`)
+
+	_, err = asserts.CompileNameConstraints("slot-names", []interface{}{map[string]interface{}{"foo": "bar"}})
+	c.Check(err, check.ErrorMatches, `slot-names constraint entry must be a regexp or special \$ value`)
+
+	_, err = asserts.CompileNameConstraints("plug-names", []interface{}{"["})
+	c.Check(err, check.ErrorMatches, `cannot compile plug-names constraint entry "\[":.*`)
+
+	_, err = asserts.CompileNameConstraints("plug-names", []interface{}{"$"})
+	c.Check(err, check.ErrorMatches, `plug-names constraint entry special value "\$" is invalid`)
+
+	_, err = asserts.CompileNameConstraints("slot-names", []interface{}{"$12"})
+	c.Check(err, check.ErrorMatches, `slot-names constraint entry special value "\$12" is invalid`)
+
+	_, err = asserts.CompileNameConstraints("plug-names", []interface{}{"a b"})
+	c.Check(err, check.ErrorMatches, `plug-names constraint entry regexp contains unexpected spaces`)
+}
+
+func (s *nameConstraintsSuite) TestCheck(c *check.C) {
+	nc, err := asserts.CompileNameConstraints("slot-names", []interface{}{"foo[0-9]", "bar"})
+	c.Assert(err, check.IsNil)
+
+	for _, matching := range []string{"foo0", "foo1", "bar"} {
+		c.Check(nc.Check("slot name", matching, nil), check.IsNil)
+	}
+
+	for _, notMatching := range []string{"baz", "fooo", "foo12"} {
+		c.Check(nc.Check("slot name", notMatching, nil), check.ErrorMatches, fmt.Sprintf(`slot name %q does not match constraints`, notMatching))
+	}
+
+}
+
+func (s *nameConstraintsSuite) TestCheckSpecial(c *check.C) {
+	nc, err := asserts.CompileNameConstraints("slot-names", []interface{}{"$INTERFACE"})
+	c.Assert(err, check.IsNil)
+
+	c.Check(nc.Check("slot name", "foo", nil), check.ErrorMatches, `slot name "foo" does not match constraints`)
+	c.Check(nc.Check("slot name", "foo", map[string]string{"$INTERFACE": "foo"}), check.IsNil)
+	c.Check(nc.Check("slot name", "bar", map[string]string{"$INTERFACE": "foo"}), check.ErrorMatches, `slot name "bar" does not match constraints`)
 }

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -86,12 +86,19 @@ func (s *apiSuite) workshopFile(ws string, sdks []*sdk.Info) *workshop.File {
 }
 
 func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop.Workshop {
+
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
-	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
 	wf := s.workshopFile(w, []*sdk.Info{info})
 	c.Assert(s.b.LaunchWorkshop(s.ctx, wf), check.IsNil)
+
 	wp, err := s.b.Workshop(s.ctx, w)
 	c.Check(err, check.IsNil)
+
+	err = wp.LinkSdk(s.ctx, sdk.Setup{Name: info.Name, Channel: info.Channel, Revision: info.Revision})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
+
 	return wp
 }
 

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1102,7 +1102,7 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 	wp, err := s.b.Workshop(s.ctx, "consumer-ws")
 	c.Check(err, check.IsNil)
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug2"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug"}}
+	wp.File.Sdks[0].Plugs["plug2"] = workshop.Plug{Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug"}}
 
 	d.Overlord().Loop()
 	defer d.Overlord().Stop()
@@ -1532,7 +1532,7 @@ func (s *apiSuite) TestDisconnectPlugForgetSuccess(c *check.C) {
 func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 	opts := &disconnectOpts{
 		bind: map[string]workshop.Plug{
-			"plug2": {Bind: workshop.Bind{Sdk: "consumer", Plug: "plug"}},
+			"plug2": {Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
@@ -1546,7 +1546,7 @@ func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
 	opts := &disconnectOpts{
 		bind: map[string]workshop.Plug{
-			"plug2": {Bind: workshop.Bind{Sdk: "consumer", Plug: "plug"}},
+			"plug2": {Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}
 	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot", opts)
@@ -1560,7 +1560,7 @@ func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
 func (s *apiSuite) TestDisconnectBoundPlugSlaveSuccess(c *check.C) {
 	opts := &disconnectOpts{
 		bind: map[string]workshop.Plug{
-			"plug2": {Bind: workshop.Bind{Sdk: "consumer", Plug: "plug"}},
+			"plug2": {Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug2", "producer-ws", "producer", "slot", opts)

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -46,13 +47,18 @@ type apiSuite struct {
 
 	vars map[string]string
 
-	restoreMuxVars   func()
-	restoreProjectId func()
-	restoreUser      func()
-	restoreTime      func()
+	restoreMuxVars    func()
+	restoreProjectId  func()
+	restoreUser       func()
+	restoreTime       func()
+	restoreBackendNew func()
 }
 
 func TestApi(t *testing.T) { check.TestingT(t) }
+
+func (s *apiSuite) backendNew() (workshop.Backend, error) {
+	return s.b, nil
+}
 
 func (s *apiSuite) SetUpTest(c *check.C) {
 	s.restoreMuxVars = FakeMuxVars(s.muxVars)
@@ -71,8 +77,12 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 		Path:      s.workshopDir,
 		ProjectId: "b8639dea",
 	}
-	s.b = fakebackend.New()
+
 	s.store = &sdk.FakeStore{}
+
+	b, _ := fakebackend.New()
+	s.b = b.(*fakebackend.FakeWorkshopBackend)
+	s.restoreBackendNew = overlord.MockBackendNew(s.backendNew)
 
 	s.installTime = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
 	s.restoreTime = testutil.FakeFunc(func() time.Time { return s.installTime }, &workshop.InstallTimeNow)
@@ -94,6 +104,7 @@ func (s *apiSuite) TearDownTest(c *check.C) {
 	s.restoreProjectId()
 	s.restoreUser()
 	s.restoreTime()
+	s.restoreBackendNew()
 }
 
 func (s *apiSuite) muxVars(*http.Request) map[string]string {
@@ -106,7 +117,7 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	}
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(dirs.CreateDirs(), check.IsNil)
-	d, err := New(&Options{Dir: s.workshopDir}, s.b)
+	d, err := New(&Options{Dir: s.workshopDir})
 	c.Assert(err, check.IsNil)
 	c.Assert(d.overlord.StartUp(), check.IsNil)
 	d.addRoutes()

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -27,13 +27,14 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 var _ = check.Suite(&apiSuite{})
 
 type apiSuite struct {
 	d     *Daemon
-	b     *workshop.FakeWorkshopBackend
+	b     *fakebackend.FakeWorkshopBackend
 	store *sdk.FakeStore
 
 	workshopDir string
@@ -70,7 +71,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 		Path:      s.workshopDir,
 		ProjectId: "b8639dea",
 	}
-	s.b = workshop.NewFakeWorkshopBackend()
+	s.b = fakebackend.New()
 	s.store = &sdk.FakeStore{}
 
 	s.installTime = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -2,14 +2,10 @@ package daemon
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 
 	"gopkg.in/check.v1"
-
-	"github.com/canonical/workshop/client"
 )
 
 func (s *apiSuite) runMountTest(c *check.C, wp string, buffers []*bytes.Buffer, expected []*expectedResp) {
@@ -76,73 +72,6 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 	}
 
 	s.runMountTest(c, "manysdks", requests, expected)
-}
-
-func (s *apiSuite) TestWorkshopRemountWorkshopSlot(c *check.C) {
-	// Setup
-	s.daemon(c)
-	s.d.Overlord().Loop()
-	defer s.d.Overlord().Stop()
-
-	s.launchWorkshop(c, "workshopslot", workshopslot, testsdks)
-
-	actions := []*client.InterfaceAction{
-		{
-			Action: "disconnect",
-			Plugs:  []client.Plug{{ProjectId: s.project.ProjectId, Workshop: "workshopslot", Sdk: "test-sdk", Name: "data"}},
-			Slots:  []client.Slot{{ProjectId: s.project.ProjectId, Workshop: "workshopslot", Sdk: "host", Name: "content"}},
-		},
-		{
-			Action: "connect",
-			Plugs:  []client.Plug{{ProjectId: s.project.ProjectId, Workshop: "workshopslot", Sdk: "test-sdk", Name: "data"}},
-			Slots:  []client.Slot{{ProjectId: s.project.ProjectId, Workshop: "workshopslot", Sdk: "host", Name: "training"}},
-		},
-	}
-
-	// content the content interface plug to the slot provided in the workshop.
-	for _, act := range actions {
-		text, err := json.Marshal(act)
-		c.Assert(err, check.IsNil)
-		buf := bytes.NewBuffer(text)
-		cmd := apiCmd("/v1/connections")
-		req, err := http.NewRequest("POST", cmd.Path, buf)
-		c.Assert(err, check.IsNil)
-		rec := httptest.NewRecorder()
-		v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
-		c.Check(rec.Code, check.Equals, 202)
-		var body map[string]interface{}
-		err = json.Unmarshal(rec.Body.Bytes(), &body)
-		c.Check(err, check.IsNil)
-		id := body["change"].(string)
-		st := s.d.Overlord().State()
-		st.Lock()
-		chg := st.Change(id)
-		st.Unlock()
-		c.Assert(chg, check.NotNil)
-
-		<-chg.Ready()
-
-		st.Lock()
-		err = chg.Err()
-		st.Unlock()
-		c.Assert(err, check.IsNil)
-	}
-
-	requests := []*bytes.Buffer{
-		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"source":%q}`, c.MkDir())),
-	}
-
-	expected := []*expectedResp{
-		{
-			Type:      ResponseTypeAsync,
-			Status:    http.StatusAccepted,
-			Kind:      "remount",
-			Summary:   `Remount workshopslot/test-sdk:data`,
-			ChangeErr: `(?s).*cannot change attribute \"source\" as it was statically specified in the "host" sdk details.*`,
-		},
-	}
-
-	s.runMountTest(c, "workshopslot", requests, expected)
 }
 
 func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -2,10 +2,14 @@ package daemon
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
 )
 
 func (s *apiSuite) runMountTest(c *check.C, wp string, buffers []*bytes.Buffer, expected []*expectedResp) {
@@ -25,7 +29,7 @@ func (s *apiSuite) runMountTest(c *check.C, wp string, buffers []*bytes.Buffer, 
 
 		// Verify
 		c.Check(rsp.Type, check.Equals, expected[num].Type)
-		c.Assert(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v: %v", num, rsp))
+		c.Check(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v: %v", num, rsp))
 		if rsp.Type == ResponseTypeError {
 			c.Assert(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
 		}
@@ -39,7 +43,11 @@ func (s *apiSuite) runMountTest(c *check.C, wp string, buffers []*bytes.Buffer, 
 			c.Assert(change.Kind(), check.Equals, expected[num].Kind)
 			c.Assert(change.Summary(), check.Equals, expected[num].Summary)
 			<-change.Ready()
-			c.Assert(change.Err(), check.IsNil)
+			if expected[num].ChangeErr != "" {
+				c.Assert(change.Err(), check.ErrorMatches, expected[num].ChangeErr)
+			} else {
+				c.Assert(change.Err(), check.IsNil)
+			}
 		}
 	}
 }
@@ -66,6 +74,73 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 	}
 
 	s.runMountTest(c, "manysdks", requests, expected)
+}
+
+func (s *apiSuite) TestWorkshopRemountWorkshopSlot(c *check.C) {
+	// Setup
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "workshopslot", workshopslot, testsdks)
+
+	actions := []*client.InterfaceAction{
+		{
+			Action: "disconnect",
+			Plugs:  []client.Plug{{ProjectId: s.project.ProjectId, Workshop: "workshopslot", Sdk: "test-sdk", Name: "data"}},
+			Slots:  []client.Slot{{ProjectId: s.project.ProjectId, Workshop: "workshopslot", Sdk: "host", Name: "content"}},
+		},
+		{
+			Action: "connect",
+			Plugs:  []client.Plug{{ProjectId: s.project.ProjectId, Workshop: "workshopslot", Sdk: "test-sdk", Name: "data"}},
+			Slots:  []client.Slot{{ProjectId: s.project.ProjectId, Workshop: "workshopslot", Sdk: "host", Name: "training"}},
+		},
+	}
+
+	// content the content interface plug to the slot provided in the workshop.
+	for _, act := range actions {
+		text, err := json.Marshal(act)
+		c.Assert(err, check.IsNil)
+		buf := bytes.NewBuffer(text)
+		cmd := apiCmd("/v1/connections")
+		req, err := http.NewRequest("POST", cmd.Path, buf)
+		c.Assert(err, check.IsNil)
+		rec := httptest.NewRecorder()
+		v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+		c.Check(rec.Code, check.Equals, 202)
+		var body map[string]interface{}
+		err = json.Unmarshal(rec.Body.Bytes(), &body)
+		c.Check(err, check.IsNil)
+		id := body["change"].(string)
+		st := s.d.Overlord().State()
+		st.Lock()
+		chg := st.Change(id)
+		st.Unlock()
+		c.Assert(chg, check.NotNil)
+
+		<-chg.Ready()
+
+		st.Lock()
+		err = chg.Err()
+		st.Unlock()
+		c.Assert(err, check.IsNil)
+	}
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"source":%q}`, c.MkDir())),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "remount",
+			Summary:   `Remount workshopslot/test-sdk:data`,
+			ChangeErr: `(?s).*cannot change attribute \"source\" as it was statically specified in the "host" sdk details.*`,
+		},
+	}
+
+	s.runMountTest(c, "workshopslot", requests, expected)
 }
 
 func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
@@ -97,7 +172,7 @@ func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	conn, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
-	c.Assert(conn.Plug.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"source": src})
+	c.Assert(conn.Slot.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"source": src})
 }
 
 func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -43,11 +43,13 @@ func (s *apiSuite) runMountTest(c *check.C, wp string, buffers []*bytes.Buffer, 
 			c.Assert(change.Kind(), check.Equals, expected[num].Kind)
 			c.Assert(change.Summary(), check.Equals, expected[num].Summary)
 			<-change.Ready()
+			st.Lock()
 			if expected[num].ChangeErr != "" {
 				c.Assert(change.Err(), check.ErrorMatches, expected[num].ChangeErr)
 			} else {
 				c.Assert(change.Err(), check.IsNil)
 			}
+			st.Unlock()
 		}
 	}
 }

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -252,3 +252,28 @@ func (s *apiSuite) TestWorkshopRemountInvalidInterface(c *check.C) {
 
 	s.runMountTest(c, "manysdks", requests, expected)
 }
+
+func (s *apiSuite) TestWorkshopRemountStaticSlotSourceFails(c *check.C) {
+	// Setup
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "workshopconns", workshopconns, testsdks)
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"source":%q}`, c.MkDir())),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "remount",
+			Summary:   `Remount workshopconns/test-sdk:data`,
+			ChangeErr: `(?s).*cannot change attribute \"source\" as it was statically specified in the \"host\" sdk details.*`,
+		},
+	}
+
+	s.runMountTest(c, "workshopconns", requests, expected)
+}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -83,6 +83,20 @@ sdks:
     channel: latest/stable
 `
 
+	workshopslot = `name: workshopslot
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      training:
+        interface: content
+        source: .
+  test-sdk:
+    channel: latest/stable
+  test-sdk-2:
+    channel: latest/stable
+`
+
 	testsdk = `
 name: test-sdk
 base: ubuntu@20.04
@@ -335,11 +349,12 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 }
 
 type expectedResp struct {
-	Type    ResponseType
-	Status  int
-	Message string
-	Kind    string
-	Summary string
+	Type      ResponseType
+	Status    int
+	Message   string
+	Kind      string
+	Summary   string
+	ChangeErr string // an error that happens during the change execution
 }
 
 func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp) {
@@ -485,6 +500,33 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 	c.Assert(s.b.AssignProfileCalls, check.HasLen, 0)
 	repo := s.d.overlord.InterfaceManager().Repository()
 	c.Assert(repo.Slots(s.project.ProjectId, "basic", "host"), check.HasLen, 3)
+}
+
+func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {
+	// Setup
+	s.createWFile(c, "workshopslot", workshopslot)
+	defer s.mockInstalledSdks(c, testsdks)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshopslot"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "workshopslot" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	_, err := s.b.Workshop(s.ctx, "workshopslot")
+	c.Assert(err, check.IsNil)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.Slot(s.project.ProjectId, "workshopslot", "host", "training"), check.Not(check.IsNil))
 }
 
 func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1226,5 +1226,5 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 
 	_, err := s.b.Workshop(s.ctx, "workshopconns")
 	c.Check(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
-	c.Check(s.b.RemoveProfileCalls, check.HasLen, 4)
+	c.Check(s.b.RemoveProfileCalls, check.HasLen, 3)
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -405,7 +405,7 @@ func (s *apiSuite) createWFile(c *check.C, name, yaml string) {
 	c.Assert(err, check.IsNil)
 }
 
-func storeAction(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
+func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
 	var result = []sdk.SdkResult{}
 	for _, act := range actions {
 		info, err := sdk.ReadSdkInfo([]byte(testsdks[act.Name]), act.ProjectId, act.Workshop)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -53,7 +53,7 @@ sdks:
   test-sdk:
     channel: latest/stable
     plugs:
-      data:
+      unknown-data:
         bind: test-sdk-2:unknown
   test-sdk-2:
     channel: latest/stable
@@ -95,6 +95,35 @@ sdks:
     channel: latest/stable
   test-sdk-2:
     channel: latest/stable
+`
+
+	workshopconns = `name: workshopconns
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      training:
+        interface: content
+        source: .
+  test-sdk:
+    channel: latest/stable
+  test-sdk-2:
+    channel: latest/stable
+connections:
+  - plug: test-sdk:data
+    slot: host:training
+`
+
+	workshopbrokenconn = `name: workshopbrokenconn
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+  test-sdk-2:
+    channel: latest/stable
+connections:
+  - plug: test-sdk:data-unknown-plug
+    slot: host:content
 `
 
 	testsdk = `
@@ -410,6 +439,9 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 			}
 			c.Check(change.Kind(), check.Equals, expected[num].Kind)
 			c.Check(change.Summary(), check.Equals, expected[num].Summary)
+			if expected[num].ChangeErr != "" {
+				c.Check(change.Err(), check.ErrorMatches, expected[num].ChangeErr)
+			}
 		}
 	}
 }
@@ -610,8 +642,8 @@ func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {
 
 func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
 	// Setup
-
 	s.createWFile(c, "masterunknown", masterunknown)
+	defer s.mockInstalledSdks(c, testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["masterunknown"],"action":"launch"}`),
@@ -619,9 +651,11 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
 
 	expected := []*expectedResp{
 		{
-			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: `cannot bind: SDK "test-sdk-2" does not have a plug "unknown"`,
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "launch",
+			Summary:   `Launch "masterunknown" workshop`,
+			ChangeErr: `(?s).*SDK masterunknown/test-sdk has no "unknown-data" plug.*`,
 		},
 	}
 
@@ -630,8 +664,8 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
 
 func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
 	// Setup
-
 	s.createWFile(c, "slaveunknown", slaveunknown)
+	defer s.mockInstalledSdks(c, testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["slaveunknown"],"action":"launch"}`),
@@ -639,9 +673,11 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
 
 	expected := []*expectedResp{
 		{
-			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: `cannot bind: SDK "test-sdk" does not have a plug "unknown"`,
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "launch",
+			Summary:   `Launch "slaveunknown" workshop`,
+			ChangeErr: `(?s).*SDK slaveunknown/test-sdk has no "unknown" plug.*`,
 		},
 	}
 
@@ -651,6 +687,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
 func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 	// Setup
 	s.createWFile(c, "bindincompatible", bindincompatible)
+	defer s.mockInstalledSdks(c, testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["bindincompatible"],"action":"launch"}`),
@@ -658,13 +695,93 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 
 	expected := []*expectedResp{
 		{
-			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: `cannot bind: test-sdk-2:gpu and test-sdk:data must be of the same interface`,
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "launch",
+			Summary:   `Launch "bindincompatible" workshop`,
+			ChangeErr: `(?s).*cannot bind bindincompatible/test-sdk:data \("content" interface\) to bindincompatible/test-sdk-2:gpu \("gpu" interface\).*`,
 		},
 	}
 
 	s.runActionTest(c, requests, expected)
+}
+
+func (s *apiSuite) TestLaunchWorkshopConnectionsOK(c *check.C) {
+	// Setup
+	s.createWFile(c, "workshopconns", workshopconns)
+	defer s.mockInstalledSdks(c, testsdks)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "workshopconns" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	_, err := s.b.Workshop(s.ctx, "workshopconns")
+	c.Assert(err, check.IsNil)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.Slot(s.project.ProjectId, "workshopconns", "host", "training"), check.Not(check.IsNil))
+
+	conns, err := repo.Connections(s.project.ProjectId, "workshopconns", "test-sdk")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk", Name: "data"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "host", Name: "training"},
+		},
+	})
+
+	conns, err = repo.Connections(s.project.ProjectId, "workshopconns", "test-sdk-2")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "photos"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "host", Name: "content"},
+		}, {
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "gpu"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "host", Name: "gpu"},
+		},
+	})
+}
+
+func (s *apiSuite) TestLaunchWorkshopMalformedConnections(c *check.C) {
+	// Setup
+	s.createWFile(c, "workshopbrokenconn", workshopbrokenconn)
+	defer s.mockInstalledSdks(c, testsdks)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshopbrokenconn"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "launch",
+			Summary:   `Launch "workshopbrokenconn" workshop`,
+			ChangeErr: `(?s).*SDK "workshopbrokenconn/test-sdk" has no plug named "data-unknown-plug".*`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	conns, err := repo.Connections(s.project.ProjectId, "workshopbrokenconn", "test-sdk")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 0)
+	conns, err = repo.Connections(s.project.ProjectId, "workshopbrokenconn", "test-sdk-2")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 0)
 }
 
 func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -26,6 +26,16 @@ var (
 	basic = `name: basic
 base: ubuntu@22.04
 `
+
+	basic_refreshed = `name: basic
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+  test-sdk-2:
+    channel: latest/stable
+`
+
 	manysdks = `name: manysdks
 base: ubuntu@22.04
 sdks:
@@ -33,6 +43,17 @@ sdks:
     channel: latest/stable
   test-sdk-2:
     channel: latest/stable
+`
+	manysdks_refreshed = `name: manysdks
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+  test-sdk-2:
+    channel: latest/stable
+connections:
+  - plug: test-sdk:data-non-existent
+    slot: host:content
 `
 
 	somebound = `name: somebound
@@ -114,6 +135,15 @@ connections:
     slot: host:training
 `
 
+	workshopconns_refreshed = `name: workshopconns
+base: ubuntu@22.04
+sdks:
+  test-sdk:
+    channel: latest/stable
+  test-sdk-2:
+    channel: latest/stable
+`
+
 	workshopbrokenconn = `name: workshopbrokenconn
 base: ubuntu@22.04
 sdks:
@@ -189,7 +219,7 @@ func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string, sdks map[string
 	s.createWFile(c, name, yaml)
 
 	defer s.store.SetActionCallback(storeAction)()
-	defer s.mockInstalledSdks(c, sdks)()
+	defer s.mockDoInstallSdk(c, name, sdks)()
 
 	reqbuf := bytes.NewBufferString(fmt.Sprintf(`{"names":["%s"],"action":"launch"}`, name))
 	s.vars = map[string]string{"id": s.project.ProjectId}
@@ -412,7 +442,6 @@ type expectedResp struct {
 }
 
 func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp) {
-	s.daemon(c)
 	defer s.store.SetActionCallback(storeAction)()
 
 	s.vars = map[string]string{"id": s.project.ProjectId}
@@ -423,9 +452,6 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 		c.Assert(err, check.IsNil)
 		requests = append(requests, req)
 	}
-
-	s.d.Overlord().Loop()
-	defer s.d.Overlord().Stop()
 
 	for num, req := range requests {
 		// Execute
@@ -464,9 +490,13 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 			}
 			c.Check(change.Kind(), check.Equals, expected[num].Kind)
 			c.Check(change.Summary(), check.Equals, expected[num].Summary)
+			st.Lock()
 			if expected[num].ChangeErr != "" {
 				c.Check(change.Err(), check.ErrorMatches, expected[num].ChangeErr)
+			} else {
+				c.Assert(change.Err(), check.IsNil)
 			}
+			st.Unlock()
 		}
 	}
 }
@@ -490,38 +520,48 @@ func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult,
 	return result, nil
 }
 
-func (s *apiSuite) mockInstalledSdks(c *check.C, sdks map[string]string) func() {
-	fs := workshop.NewFakeWorkshopFs()
+func (s *apiSuite) mockDoInstallSdk(c *check.C, ws string, sdks map[string]string) func() {
+	s.b.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+		// check if the command is to install an SDK
+		if args.Command[0] != "tar" {
+			return workshop.ExecContext{WaitExecution: func(ctx context.Context) error { return nil }}, nil
+		}
 
-	for n, s := range sdks {
-		metadir := filepath.Join(sdk.SdkCurrentPath(n), "meta")
-		err := fs.MkdirAll(metadir, 0655)
-		c.Assert(err, check.IsNil)
+		fs, err := s.b.WorkshopFs(s.ctx, ws)
+		c.Check(err, check.IsNil)
+		defer fs.Close()
+		// Get the SDK name from the exec command (we don't have a separate
+		// method to install an SDK now).
+		sdkname, found := strings.CutSuffix(filepath.Base(args.Command[3]), "_0.sdk")
+		c.Check(found, check.Equals, true)
+		metadir := filepath.Join(sdk.SdkCurrentPath(sdkname), "meta")
+		err = fs.MkdirAll(metadir, 0655)
+		c.Check(err, check.IsNil)
 
 		file, err := fs.OpenFile(filepath.Join(metadir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
-		c.Assert(err, check.IsNil)
+		c.Check(err, check.IsNil)
 		defer file.Close()
 
-		_, err = file.Write([]byte(s))
-		c.Assert(err, check.IsNil)
+		syaml, exists := sdks[sdkname]
+		c.Check(exists, check.Equals, true)
+		_, err = file.Write([]byte(syaml))
+		c.Check(err, check.IsNil)
 
 		for _, hook := range []string{"setup-base", "save-state", "restore-state"} {
-			setuphook, err := fs.OpenFile(sdk.SdkHookPath(n, hook), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0744)
-			c.Assert(err, check.IsNil)
+			setuphook, err := fs.OpenFile(sdk.SdkHookPath(sdkname, hook), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0744)
+			c.Check(err, check.IsNil)
 			defer setuphook.Close()
 		}
+		return workshop.ExecContext{WaitExecution: func(ctx context.Context) error { return nil }}, nil
 	}
-
-	s.b.WorkshopFsCallback = func(ctx context.Context, name string) (workshop.WorkshopFs, error) {
-		wp, ok := s.b.Workshops[s.project.ProjectId][name]
-		c.Assert(ok, check.Equals, true)
-		wp.WorkshopFilesystem = fs
-		return fs, nil
-	}
-	return func() { s.b.WorkshopFsCallback = nil }
+	return func() { s.b.ExecCallback = nil }
 }
 
 func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
 	// Setup
 	s.createWFile(c, "basic", basic)
 
@@ -560,9 +600,12 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 }
 
 func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopslot", workshopslot)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "workshopslot", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopslot"],"action":"launch"}`),
@@ -587,21 +630,17 @@ func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {
 }
 
 func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
 
-	s.b.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
-		cmd := args.Command
-		if strings.Contains(cmd[len(cmd)-1], "setup-base") {
-			return workshop.ExecContext{}, errors.New("cannot execute setup-base")
-		}
-		return workshop.ExecContext{
-			Environment:   args.Environment,
-			WaitExecution: func(ctx context.Context) error { return nil },
-		}, nil
+	s.b.AssignProfileCallback = func(ctx context.Context, workshop string, profile workshop.SdkProfile) error {
+		return fmt.Errorf(`cannot assign profile to %q`, workshop)
 	}
-	defer func() { s.b.ExecCallback = nil }()
+	defer func() { s.b.AssignProfileCallback = nil }()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -609,10 +648,11 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 
 	expected := []*expectedResp{
 		{
-			Type:    ResponseTypeAsync,
-			Status:  http.StatusAccepted,
-			Kind:    "launch",
-			Summary: `Launch "manysdks" workshop`,
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "launch",
+			Summary:   `Launch "manysdks" workshop`,
+			ChangeErr: `(?s).*cannot assign profile to "manysdks".*`,
 		},
 	}
 
@@ -633,9 +673,12 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 }
 
 func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "somebound", somebound)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "somebound", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["somebound"],"action":"launch"}`),
@@ -666,9 +709,12 @@ func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {
 }
 
 func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "masterunknown", masterunknown)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "masterunknown", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["masterunknown"],"action":"launch"}`),
@@ -688,9 +734,12 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
 }
 
 func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "slaveunknown", slaveunknown)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "slaveunknown", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["slaveunknown"],"action":"launch"}`),
@@ -710,9 +759,12 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
 }
 
 func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "bindincompatible", bindincompatible)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "bindincompatible", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["bindincompatible"],"action":"launch"}`),
@@ -732,9 +784,12 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 }
 
 func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "workshopconns", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
@@ -780,9 +835,12 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 }
 
 func (s *apiSuite) TestConnectionsUnknownPlug(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopbrokenconn", workshopbrokenconn)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "workshopbrokenconn", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopbrokenconn"],"action":"launch"}`),
@@ -810,9 +868,12 @@ func (s *apiSuite) TestConnectionsUnknownPlug(c *check.C) {
 }
 
 func (s *apiSuite) TestWorkshopConnectionsPlugIsBound(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "connsplugbound", connsplugbound)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "connsplugbound", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["connsplugbound"],"action":"launch"}`),
@@ -850,14 +911,15 @@ func (s *apiSuite) TestWorkshopConnectionsPlugIsBound(c *check.C) {
 }
 
 func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
-		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"transactional"}}`),
 	}
-
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
@@ -865,6 +927,16 @@ func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
 			Kind:    "launch",
 			Summary: `Launch "basic" workshop`,
 		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.createWFile(c, "basic", basic_refreshed)
+	defer s.mockDoInstallSdk(c, "basic", testsdks)()
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"refresh-mode":"transactional"}}`),
+	}
+	expected = []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
@@ -874,44 +946,61 @@ func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
 	}
 
 	s.runActionTest(c, requests, expected)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+
+	conns, err := repo.Connections(s.project.ProjectId, "basic", "test-sdk")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk", Name: "data"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "host", Name: "content"},
+		},
+	})
+
+	conns, err = repo.Connections(s.project.ProjectId, "basic", "test-sdk-2")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk-2", Name: "photos"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "host", Name: "content"},
+		}, {
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk-2", Name: "gpu"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "host", Name: "gpu"},
+		},
+	})
 }
 
-func (s *apiSuite) TestRefreshWorkshopFailed(c *check.C) {
+func (s *apiSuite) TestRefreshWorkshopReturnsPreviousWorkshopIfFailed(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockInstalledSdks(c, testsdks)()
-
-	s.b.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
-		cmd := args.Command
-		if strings.Contains(cmd[len(cmd)-1], "restore-state") {
-			return workshop.ExecContext{}, errors.New("cannot execute restore-state")
-		}
-		return workshop.ExecContext{
-			Environment:   args.Environment,
-			WaitExecution: func(ctx context.Context) error { return nil },
-		}, nil
-	}
-	defer func() { s.b.ExecCallback = nil }()
+	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
 
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`)}
+
+	expected := []*expectedResp{{
+		Type:    ResponseTypeAsync,
+		Status:  http.StatusAccepted,
+		Kind:    "launch",
+		Summary: `Launch "manysdks" workshop`,
+	}}
+	s.runActionTest(c, requests, expected)
+
+	// Setup "refresh" with a new workshop that will trigger an error
+	s.createWFile(c, "manysdks", manysdks_refreshed)
+	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options": {"refresh-mode":"transactional"}}`)}
-
-	expected := []*expectedResp{
-		{
-			Type:    ResponseTypeAsync,
-			Status:  http.StatusAccepted,
-			Kind:    "launch",
-			Summary: `Launch "manysdks" workshop`,
-		},
-		{
-			Type:    ResponseTypeAsync,
-			Status:  http.StatusAccepted,
-			Kind:    "refresh",
-			Summary: `Refresh "manysdks" workshop`,
-		},
-	}
-
+	expected = []*expectedResp{{
+		Type:      ResponseTypeAsync,
+		Status:    http.StatusAccepted,
+		Kind:      "refresh",
+		Summary:   `Refresh "manysdks" workshop`,
+		ChangeErr: `(?s).*SDK "manysdks/test-sdk" has no plug named "data-non-existent".*`,
+	}}
 	s.runActionTest(c, requests, expected)
 
 	wp, err := s.b.Workshop(s.ctx, "manysdks")
@@ -947,6 +1036,9 @@ func (s *apiSuite) TestRefreshWorkshopFailed(c *check.C) {
 }
 
 func (s *apiSuite) TestRefreshWorkshopIncorrectInput(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	requests := []*bytes.Buffer{
 		// try continue without starting wait-on-error
@@ -987,6 +1079,9 @@ func (s *apiSuite) TestRefreshWorkshopIncorrectInput(c *check.C) {
 }
 
 func (s *apiSuite) TestRefreshWorkshopContinueSuccess(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	s.createWFile(c, "basic", basic)
 
 	var errOnce sync.Once
@@ -1036,6 +1131,9 @@ func (s *apiSuite) TestRefreshWorkshopContinueSuccess(c *check.C) {
 }
 
 func (s *apiSuite) TestRefreshWorkshopNoRefreshInProgress(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
 
@@ -1068,6 +1166,9 @@ func (s *apiSuite) TestRefreshWorkshopNoRefreshInProgress(c *check.C) {
 }
 
 func (s *apiSuite) TestRefreshWorkshopRefreshAbort(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
 
@@ -1100,10 +1201,11 @@ func (s *apiSuite) TestRefreshWorkshopRefreshAbort(c *check.C) {
 			Summary: `Refresh "basic" workshop`,
 		},
 		{
-			Type:    ResponseTypeAsync,
-			Status:  http.StatusAccepted,
-			Kind:    "refresh",
-			Summary: `Refresh "basic" workshop`,
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "refresh",
+			Summary:   `Refresh "basic" workshop`,
+			ChangeErr: `(?s).*cannot remove profile.*`,
 		},
 	}
 
@@ -1117,7 +1219,89 @@ func (s *apiSuite) TestRefreshWorkshopRefreshAbort(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
+func (s *apiSuite) TestRefreshWorkshopRestoreUserDefinedConnsIfFailed(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	// Setup "launch"
+	s.createWFile(c, "workshopconns", workshopconns)
+	defer s.mockDoInstallSdk(c, "workshopconns", testsdks)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{{
+		Type:    ResponseTypeAsync,
+		Status:  http.StatusAccepted,
+		Kind:    "launch",
+		Summary: `Launch "workshopconns" workshop`,
+	}}
+	s.runActionTest(c, requests, expected)
+
+	// Validate
+	wp, err := s.b.Workshop(s.ctx, "workshopconns")
+	c.Assert(err, check.IsNil)
+
+	// Setup "refresh"
+	s.createWFile(c, "workshopconns", workshopconns_refreshed)
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshopconns"],"action":"refresh","options": {"refresh-mode":"transactional"}}`),
+	}
+	expected = []*expectedResp{{
+		Type:      ResponseTypeAsync,
+		Status:    http.StatusAccepted,
+		Kind:      "refresh",
+		Summary:   `Refresh "workshopconns" workshop`,
+		ChangeErr: `(?s)*.cannot assign profile to "workshopconns".*`,
+	}}
+	var errOnce sync.Once
+	s.b.AssignProfileCallback = func(ctx context.Context, workshop string, profile workshop.SdkProfile) error {
+		var err error
+		// trigger the refresh failure
+		errOnce.Do(func() {
+			err = fmt.Errorf(`cannot assign profile to %q`, workshop)
+		})
+		return err
+	}
+	defer func() { s.b.AssignProfileCallback = nil }()
+
+	s.runActionTest(c, requests, expected)
+
+	content, err := wp.ContentInfo(s.ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(content, check.HasLen, 2)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	conns, err := repo.Connections(s.project.ProjectId, "workshopconns", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk", Name: "data"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "host", Name: "training"},
+		},
+	})
+
+	conns, err = repo.Connections(s.project.ProjectId, "workshopconns", "test-sdk-2")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "photos"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "host", Name: "content"},
+		},
+		{
+			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "gpu"},
+			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "host", Name: "gpu"},
+		},
+	})
+}
+
 func (s *apiSuite) TestStartWorkshop(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
 	// Setup
@@ -1165,6 +1349,9 @@ func (s *apiSuite) TestStartWorkshop(c *check.C) {
 }
 
 func (s *apiSuite) TestStopWorkshop(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
 
@@ -1197,10 +1384,13 @@ func (s *apiSuite) TestStopWorkshop(c *check.C) {
 }
 
 func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
-	// Setup
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
 
+	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
-	defer s.mockInstalledSdks(c, testsdks)()
+	defer s.mockDoInstallSdk(c, "workshopconns", testsdks)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -126,6 +126,31 @@ connections:
     slot: host:content
 `
 
+	connsplugbound = `name: connsplugbound
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      training:
+        interface: content
+        source: .
+      photos:
+        interface: content
+        source: .
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: test-sdk-2:photos
+  test-sdk-2:
+    channel: latest/stable
+connections:
+  - plug: test-sdk:data
+    slot: host:training
+  - plug: test-sdk-2:photos
+    slot: host:photos
+`
+
 	testsdk = `
 name: test-sdk
 base: ubuntu@20.04
@@ -706,7 +731,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestLaunchWorkshopConnectionsOK(c *check.C) {
+func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
 	defer s.mockInstalledSdks(c, testsdks)()
@@ -754,7 +779,7 @@ func (s *apiSuite) TestLaunchWorkshopConnectionsOK(c *check.C) {
 	})
 }
 
-func (s *apiSuite) TestLaunchWorkshopMalformedConnections(c *check.C) {
+func (s *apiSuite) TestConnectionsUnknownPlug(c *check.C) {
 	// Setup
 	s.createWFile(c, "workshopbrokenconn", workshopbrokenconn)
 	defer s.mockInstalledSdks(c, testsdks)()
@@ -782,6 +807,46 @@ func (s *apiSuite) TestLaunchWorkshopMalformedConnections(c *check.C) {
 	conns, err = repo.Connections(s.project.ProjectId, "workshopbrokenconn", "test-sdk-2")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 0)
+}
+
+func (s *apiSuite) TestWorkshopConnectionsPlugIsBound(c *check.C) {
+	// Setup
+	s.createWFile(c, "connsplugbound", connsplugbound)
+	defer s.mockInstalledSdks(c, testsdks)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["connsplugbound"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "connsplugbound" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	// The explicit connection for "test-sdk:data" will be ignored as the plug is bound to another
+	// plug.
+	repo := s.d.overlord.InterfaceManager().Repository()
+	conns, err := repo.Connected(s.project.ProjectId, "connsplugbound", "test-sdk", "data")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].SlotRef.Name, check.Equals, "photos")
+
+	connection, err := repo.Connection(conns[0])
+	c.Assert(err, check.IsNil)
+	_, bound := connection.CheckBound()
+	c.Assert(bound, check.Equals, true)
+
+	// The explicit connection for "test-sdk-2:photo" will be set as usual.
+	conns, err = repo.Connected(s.project.ProjectId, "connsplugbound", "test-sdk-2", "photos")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].SlotRef.Name, check.Equals, "photos")
 }
 
 func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
@@ -1134,11 +1199,12 @@ func (s *apiSuite) TestStopWorkshop(c *check.C) {
 func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 	// Setup
 
-	s.createWFile(c, "basic", basic)
+	s.createWFile(c, "workshopconns", workshopconns)
+	defer s.mockInstalledSdks(c, testsdks)()
 
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
-		bytes.NewBufferString(`{"names":["basic"],"action":"remove"}`),
+		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["workshopconns"],"action":"remove"}`),
 	}
 
 	expected := []*expectedResp{
@@ -1146,19 +1212,19 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "launch",
-			Summary: `Launch "basic" workshop`,
+			Summary: `Launch "workshopconns" workshop`,
 		},
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "remove",
-			Summary: `Remove "basic" workshop`,
+			Summary: `Remove "workshopconns" workshop`,
 		},
 	}
 
 	s.runActionTest(c, requests, expected)
 
-	_, err := s.b.Workshop(s.ctx, "basic")
+	_, err := s.b.Workshop(s.ctx, "workshopconns")
 	c.Check(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
-	c.Check(s.b.RemoveProfileCalls, check.HasLen, 1)
+	c.Check(s.b.RemoveProfileCalls, check.HasLen, 4)
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -755,7 +755,7 @@ func (d *Daemon) RebootIsMissing(st *state.State) error {
 	return errExpectedReboot
 }
 
-func New(opts *Options, be workshop.Backend) (*Daemon, error) {
+func New(opts *Options) (*Daemon, error) {
 	d := &Daemon{
 		workshopDir:         opts.Dir,
 		normalSocketPath:    opts.SocketPath,
@@ -763,7 +763,7 @@ func New(opts *Options, be workshop.Backend) (*Daemon, error) {
 		httpAddress:         opts.HTTPAddress,
 	}
 
-	ovld, err := overlord.New(opts.Dir, be, d)
+	ovld, err := overlord.New(opts.Dir, d)
 	if err == errExpectedReboot {
 		// we proceed without overlord until we reach Stop
 		// where we will schedule and wait again for a system restart.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/testutil"
-	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -77,7 +77,7 @@ func (s *daemonSuite) newDaemon(c *check.C) *Daemon {
 		Dir:         s.workshopDir,
 		SocketPath:  s.socketPath,
 		HTTPAddress: s.httpAddress,
-	}, workshop.NewFakeWorkshopBackend())
+	}, fakebackend.New())
 	c.Assert(err, check.IsNil)
 	d.addRoutes()
 	return d

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"gopkg.in/check.v1"
-
 	// XXX Delete import above and make this file like the other ones.
 	. "gopkg.in/check.v1"
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/patch"
 	"github.com/canonical/workshop/internal/overlord/restart"
 	"github.com/canonical/workshop/internal/overlord/standby"
@@ -47,13 +48,14 @@ import (
 // Hook up check.v1 into the "go test" runner
 
 type daemonSuite struct {
-	workshopDir string
-	socketPath  string
-	httpAddress string
-	statePath   string
-	authorized  bool
-	err         error
-	notified    []string
+	workshopDir       string
+	socketPath        string
+	httpAddress       string
+	statePath         string
+	authorized        bool
+	err               error
+	notified          []string
+	restoreBackendNew func()
 }
 
 var _ = check.Suite(&daemonSuite{})
@@ -62,6 +64,8 @@ func (s *daemonSuite) SetUpTest(c *check.C) {
 	s.workshopDir = c.MkDir()
 	dirs.SetRootDir(s.workshopDir)
 	s.statePath = filepath.Join(s.workshopDir, "state.json")
+	s.restoreBackendNew = overlord.MockBackendNew(fakebackend.New)
+
 	systemdSdNotify = func(notif string) error {
 		s.notified = append(s.notified, notif)
 		return nil
@@ -69,6 +73,7 @@ func (s *daemonSuite) SetUpTest(c *check.C) {
 }
 
 func (s *daemonSuite) TearDownTest(c *check.C) {
+	s.restoreBackendNew()
 	systemdSdNotify = systemd.SdNotify
 	s.notified = nil
 	s.authorized = false
@@ -80,7 +85,7 @@ func (s *daemonSuite) newDaemon(c *check.C) *Daemon {
 		Dir:         s.workshopDir,
 		SocketPath:  s.socketPath,
 		HTTPAddress: s.httpAddress,
-	}, fakebackend.New())
+	})
 	c.Assert(err, check.IsNil)
 	d.addRoutes()
 	return d

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -29,9 +29,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"gopkg.in/check.v1"
+
 	// XXX Delete import above and make this file like the other ones.
 	. "gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/patch"
 	"github.com/canonical/workshop/internal/overlord/restart"
@@ -58,6 +60,7 @@ var _ = check.Suite(&daemonSuite{})
 
 func (s *daemonSuite) SetUpTest(c *check.C) {
 	s.workshopDir = c.MkDir()
+	dirs.SetRootDir(s.workshopDir)
 	s.statePath = filepath.Join(s.workshopDir, "state.json")
 	systemdSdNotify = func(notif string) error {
 		s.notified = append(s.notified, notif)

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -42,6 +42,8 @@ var (
 	SdkDir string
 	// Path to the daemon's unix socket
 	SocketPath string
+	// State lock file
+	WorkshopStateLockFile string
 	// Base for the XDG runtime directory of a host user
 	XdgRuntimeDirBase string
 	// Run directory
@@ -91,6 +93,7 @@ func SetRootDir(rootdir string) {
 	}
 	BaseDir = rootdir
 	SdkDir = filepath.Join(BaseDir, "sdk")
+	WorkshopStateLockFile = filepath.Join(BaseDir, "state.lock")
 	WorkshopTlsDir = filepath.Join(BaseDir, "tls")
 	WorkshopdRunDir = filepath.Join(BaseDir, "/run/workshopd")
 	WorkshopdLocksDir = filepath.Join(WorkshopdRunDir, "locks")

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -22,8 +22,11 @@ var (
 	// SDKs directory to install an SDK in a workshop
 	WorkshopSdksDir = filepath.Join(WorkshopBaseDir, "sdk")
 
-	// Base directory for the workshop state storage
+	// Base directory for the state storage
 	WorkshopStateDir = filepath.Join(WorkshopBaseDir, "/state")
+
+	// Base directory for the SDK state storage
+	WorkshopSdkStateDir = filepath.Join(WorkshopStateDir, "/sdk")
 
 	// Run directory inside workshop
 	WorkshopRunDir = filepath.Join(WorkshopBaseDir, "/run")

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -148,7 +148,7 @@ func (s *storeIntegration) TestSdkActionInstallStoreError(c *check.C) {
 		Name:      "test-sdk-unknown",
 		Channel:   "latest/stable",
 	}}
-	res, err := store.SdkAction(context.Background(), nil, acts)
+	res, err := store.SdkAction(context.Background(), acts)
 	c.Assert(res, check.HasLen, 0)
 	c.Assert(err, check.ErrorMatches, `(?s).*SDK not found in "latest/stable".*`)
 }

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -68,7 +68,7 @@ type ClientWrapper struct {
 	isTesting bool
 }
 
-func (c *GcsStore) SdkAction(ctx context.Context, currentSdks map[string]*sdk.Info, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
+func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
 	results := []sdk.SdkResult{}
 	actError := &SdkActionError{
 		errors: make(map[string]error),
@@ -76,6 +76,9 @@ func (c *GcsStore) SdkAction(ctx context.Context, currentSdks map[string]*sdk.In
 	for _, act := range actions {
 		switch act.Action {
 		case sdk.Install:
+			if act.Channel == "" {
+				continue
+			}
 			s, err := storeSdkInfo(ctx, act.Name, act.Channel)
 			if err != nil {
 				actError.errors[act.Name] = err
@@ -212,7 +215,7 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 
 	var sa = strings.Split(channel, "/")
 	if len(sa) != 2 {
-		return sSdk, fmt.Errorf("%s has an invalid channel %s, must take the form <track>/<risk>", name, channel)
+		return sSdk, fmt.Errorf("%q has an invalid channel %q, must take the form <track>/<risk>", name, channel)
 	}
 	track, risk := sa[0], sa[1]
 	obj := bkt.Object(fmt.Sprintf("%s/%s/%s/%s.sdk", name, track, risk, name))

--- a/internal/fakestore/store_test.go
+++ b/internal/fakestore/store_test.go
@@ -56,7 +56,7 @@ func (s *storeSuite) TestSdkActionInstallOK(c *check.C) {
 		Channel:   "latest/stable",
 	},
 	}
-	res, _ := store.SdkAction(context.Background(), nil, acts)
+	res, _ := store.SdkAction(context.Background(), acts)
 	c.Assert(res, check.HasLen, 1)
 }
 
@@ -95,7 +95,7 @@ func (s *storeSuite) TestSdkActionInstallCannotParseSdkInfo(c *check.C) {
 		Name:      "test-sdk-valid",
 		Channel:   "latest/stable",
 	}}
-	res, err := store.SdkAction(context.Background(), nil, acts)
+	res, err := store.SdkAction(context.Background(), acts)
 	c.Assert(res, check.HasLen, 1)
 	c.Assert(err, check.ErrorMatches, "(?s)*.test-sdk-broken: yaml: block sequence entries are not allowed in this context")
 }

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -44,6 +45,9 @@ const contentBaseDeclarationSlots = `
       slot-names:
         - $INTERFACE
 `
+
+var knownPlugAttributes = []string{"target"}
+var knownSlotAttributes = []string{"source"}
 
 // contentInterface allows sharing content between sdks
 type contentInterface struct{}
@@ -72,6 +76,11 @@ func validatePath(path string) error {
 }
 
 func (iface *contentInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
+	for name := range plug.Attrs {
+		if !slices.Contains(knownPlugAttributes, name) {
+			return fmt.Errorf(`unknown attribute for content interface plug: %q`, name)
+		}
+	}
 	target, ok := plug.Attrs["target"].(string)
 	if !ok || len(target) == 0 {
 		return fmt.Errorf("content plug must contain target path")
@@ -79,11 +88,15 @@ func (iface *contentInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 	if err := validatePath(target); err != nil {
 		return err
 	}
-
 	return nil
 }
 
 func (iface *contentInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
+	for name := range slot.Attrs {
+		if !slices.Contains(knownSlotAttributes, name) {
+			return fmt.Errorf(`unknown attribute for content interface slot: %q`, name)
+		}
+	}
 	source, exist := slot.Attrs["source"]
 	if !exist {
 		// perfectly fine scenario for the default content slot

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -42,7 +42,9 @@ const contentBaseDeclarationSlots = `
       slot-sdk-type:
         - host
     allow-connection: true
-    allow-auto-connection: true
+    allow-auto-connection:
+      slot-attributes:
+        source: $MISSING
 `
 
 // contentInterface allows sharing content between sdks

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -41,8 +41,8 @@ const contentBaseDeclarationSlots = `
         - host
     allow-connection: true
     allow-auto-connection:
-      slot-attributes:
-        source: $MISSING
+      slot-names:
+        - $INTERFACE
 `
 
 // contentInterface allows sharing content between sdks

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -22,13 +22,11 @@ package builtin
 import (
 	"errors"
 	"fmt"
-	"os/user"
 	"path/filepath"
 	"strings"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/device"
-	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -85,6 +83,22 @@ func (iface *contentInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 	return nil
 }
 
+func (iface *contentInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
+	source, exist := slot.Attrs["source"]
+	if !exist {
+		// perfectly fine scenario for the default content slot
+		return nil
+	}
+	path, ok := source.(string)
+	if !ok {
+		return fmt.Errorf(`content slot "source" is not a string (found %T)`, source)
+	}
+	if !filepath.IsLocal(path) {
+		return fmt.Errorf(`content slot "source" must be within project subtree`)
+	}
+	return nil
+}
+
 func (iface *contentInterface) target(attrs interfaces.Attrer) string {
 	var target string
 
@@ -94,10 +108,9 @@ func (iface *contentInterface) target(attrs interfaces.Attrer) string {
 	return ""
 }
 
-func (iface *contentInterface) source(user *user.User, plug *interfaces.ConnectedPlug) (string, error) {
+func (iface *contentInterface) source(baseDir string, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (string, error) {
 	var source string
-	// see if the plug's mount has been remounted to a new location
-	err := plug.Attr("source", &source)
+	err := slot.Attr("source", &source)
 	if err == nil {
 		return source, nil
 	}
@@ -105,7 +118,7 @@ func (iface *contentInterface) source(user *user.User, plug *interfaces.Connecte
 		return source, err
 	}
 	// default dir: <workshop>_<sdk>_plug.sdk
-	return sdk.SdkContentSource(user.HomeDir, plug.Sdk().ProjectId, plug.Sdk().Workshop, plug.Sdk().Name, plug.Name()), nil
+	return sdk.SdkContentSource(baseDir, slot.Sdk().ProjectId, slot.Sdk().Workshop, plug.Sdk().Name, plug.Name()), nil
 }
 
 func (iface *contentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
@@ -124,17 +137,8 @@ func (iface *contentInterface) MountConnectedPlug(spec *device.Specification, pl
 		return err
 	}
 
-	source, err := iface.source(user, plug)
+	source, err := iface.source(user.HomeDir, plug, slot)
 	if err != nil {
-		return err
-	}
-
-	uid, gid, err := osutil.UidGid(user)
-	if err != nil {
-		return err
-	}
-
-	if err = osutil.MkdirAllChown(source, 0744, uid, gid); err != nil {
 		return err
 	}
 

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -42,8 +42,12 @@ const contentBaseDeclarationSlots = `
         - host
     allow-connection: true
     allow-auto-connection:
-      slot-names:
-        - $INTERFACE
+      -
+        slot-names:
+          - $INTERFACE
+      -
+        plug-attributes:
+          auto-explicit: true
 `
 
 var knownPlugAttributes = []string{"target"}

--- a/internal/interfaces/builtin/content_test.go
+++ b/internal/interfaces/builtin/content_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/device"
-	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -87,7 +86,6 @@ base: ubuntu@22.04
 plugs:
  content-plug:
   interface: content
-  content: mycont
 `
 	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	plug := info.Plugs["content-plug"]
@@ -100,12 +98,62 @@ base: ubuntu@22.04
 plugs:
  content-plug:
   interface: content
-  content: mycont
   target: ../foo
 `
 	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	plug := info.Plugs["content-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "content interface path is not clean:.*")
+}
+
+func (s *contentSuite) TestSanitizeSlotOK(c *check.C) {
+	const mockSdkYaml = `name: content-slot-sdk
+base: ubuntu@22.04
+slots:
+ content-slot:
+  interface: content
+  source: images/low-res
+`
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
+	slot := info.Slots["content-slot"]
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+}
+
+func (s *contentSuite) TestSanitizeSlotNoSource(c *check.C) {
+	const mockSdkYaml = `name: content-slot-sdk
+base: ubuntu@22.04
+slots:
+ content-slot:
+  interface: content
+`
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
+	slot := info.Slots["content-slot"]
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+}
+
+func (s *contentSuite) TestSanitizeSlotAbsSourceFails(c *check.C) {
+	const mockSdkYaml = `name: content-slot-sdk
+base: ubuntu@22.04
+slots:
+ content-slot:
+  interface: content
+  source: /root
+`
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
+	slot := info.Slots["content-slot"]
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.ErrorMatches, `content slot \"source\" must be within project subtree`)
+}
+
+func (s *contentSuite) TestSanitizeSlotNonLocalSourceFails(c *check.C) {
+	const mockSdkYaml = `name: content-slot-sdk
+base: ubuntu@22.04
+slots:
+ content-slot:
+  interface: content
+  source: ../../../../../../../../root/
+`
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
+	slot := info.Slots["content-slot"]
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.ErrorMatches, `content slot \"source\" must be within project subtree`)
 }
 
 func (s *contentSuite) TestInterfaces(c *check.C) {
@@ -132,8 +180,6 @@ slots:
 	homeDir := c.MkDir()
 	usr, err := user.Current()
 	c.Assert(err, check.IsNil)
-	
-	
 
 	restore := testutil.FakeFunc(func(name string) (*user.User, error) {
 		u := &user.User{
@@ -153,10 +199,4 @@ slots:
 	sourceDir := filepath.Join(homeDir, "/.local/share/workshop/project/42424242/content/ws_consumer_content.sdk")
 	expectedMnt := lxdbackend.Mount(plug.Name, sourceDir, "/project/training")
 	c.Assert(deviceSpec.DeviceEntries(), check.DeepEquals, []workshop.Device{expectedMnt})
-
-	// Validate the source directory was created correctly
-	exists, isDir, err := osutil.ExistsIsDir(sourceDir)
-	c.Assert(exists, check.Equals, true)
-	c.Assert(isDir, check.Equals, true)
-	c.Assert(err, check.IsNil)
 }

--- a/internal/interfaces/builtin/gpu.go
+++ b/internal/interfaces/builtin/gpu.go
@@ -33,8 +33,10 @@ const gpuBaseDeclarationSlots = `
     allow-installation:
       slot-sdk-type:
         - host
-      allow-connection: true
-      allow-auto-connection: true
+      slot-names:
+        - $INTERFACE
+    allow-connection: true
+    allow-auto-connection: true
 `
 
 type gpuInterface struct{}

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -42,6 +42,8 @@ const sshAgentBaseDeclarationSlots = `
     allow-installation:
       slot-sdk-type:
         - host
+      slot-names:
+        - $INTERFACE
     allow-connection: true
     deny-auto-connection: true
 `

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -184,7 +184,7 @@ func (plug *ConnectedPlug) Lookup(path string) (interface{}, bool) {
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
 func (plug *ConnectedPlug) SetAttr(key string, value interface{}) error {
 	if _, ok := plug.staticAttrs[key]; ok {
-		return fmt.Errorf("cannot change attribute %q as it was statically specified in the sdk details", key)
+		return fmt.Errorf("cannot change attribute %q as it was statically specified in the %q sdk details", key, plug.plugInfo.Sdk.Name)
 	}
 	if plug.dynamicAttrs == nil {
 		plug.dynamicAttrs = make(map[string]interface{})
@@ -242,7 +242,7 @@ func (slot *ConnectedSlot) Lookup(path string) (interface{}, bool) {
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
 func (slot *ConnectedSlot) SetAttr(key string, value interface{}) error {
 	if _, ok := slot.staticAttrs[key]; ok {
-		return fmt.Errorf("cannot change attribute %q as it was statically specified in the sdk details", key)
+		return fmt.Errorf("cannot change attribute %q as it was statically specified in the %q sdk details", key, slot.slotInfo.Sdk.Name)
 	}
 	if slot.dynamicAttrs == nil {
 		slot.dynamicAttrs = make(map[string]interface{})

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -307,11 +307,11 @@ func (s *connSuite) TestOverwriteStaticAttrError(c *check.C) {
 
 	err := plug.SetAttr("attr", "overwrite")
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the sdk details`)
+	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the "consumer" sdk details`)
 
 	err = slot.SetAttr("attr", "overwrite")
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the sdk details`)
+	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the "producer" sdk details`)
 }
 
 func (s *connSuite) TestCopyAttributes(c *check.C) {

--- a/internal/interfaces/device/backend.go
+++ b/internal/interfaces/device/backend.go
@@ -35,7 +35,10 @@ func (b *Backend) Setup(context context.Context, sdkInfo sdk.Ref, repo *interfac
 	for _, dev := range spec.devices {
 		profile.AddDevice(dev)
 	}
-	return b.profile.AssignProfile(context, sdkInfo.Workshop, profile)
+	if err = b.profile.AssignProfile(context, sdkInfo.Workshop, profile); err != nil {
+		return fmt.Errorf("%q SDK setup failed: %v", sdkInfo.Sdk, err)
+	}
+	return err
 }
 
 // Remove removes profile of a given sdk.

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -36,7 +36,21 @@ func checkSlotType(sdkInfo *sdk.Info, types []string) error {
 	return nil
 }
 
+func checkNameConstraints(c *asserts.NameConstraints, iface, which, name string) error {
+	if c == nil {
+		return nil
+	}
+	special := map[string]string{
+		"$INTERFACE": iface,
+	}
+	return c.Check(which, name, special)
+}
+
 func checkSlotInstallationConstraints(ic *InstallCandidate, slot *sdk.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
+	if err := checkNameConstraints(constraints.SlotNames, slot.Interface, "slot name", slot.Name); err != nil {
+		return err
+	}
+
 	if err := constraints.SlotAttributes.Check(slot, nil); err != nil {
 		return err
 	}
@@ -78,6 +92,12 @@ func checkSlotConnectionAltConstraints(connc *ConnectCandidate, altConstraints [
 }
 
 func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asserts.SlotConnectionConstraints) error {
+	if err := checkNameConstraints(constraints.PlugNames, connc.Plug.Interface(), "plug name", connc.Plug.Name()); err != nil {
+		return err
+	}
+	if err := checkNameConstraints(constraints.SlotNames, connc.Slot.Interface(), "slot name", connc.Slot.Name()); err != nil {
+		return err
+	}
 	if err := constraints.PlugAttributes.Check(connc.Plug, connc); err != nil {
 		return err
 	}

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -992,7 +992,6 @@ func (r *Repository) AutoConnectCandidateSlots(projectId, workshop, plugSdkName,
 			}
 			iface := slotInfo.Interface
 
-			// declaration based checks disallow
 			ok, err := policyCheck(NewConnectedPlug(plugInfo, nil, nil), NewConnectedSlot(slotInfo, nil, nil))
 			if !ok || err != nil {
 				continue

--- a/internal/osutil/kcmdline_test.go
+++ b/internal/osutil/kcmdline_test.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/osutil"
 )

--- a/internal/overlord/cmdstate/manager.go
+++ b/internal/overlord/cmdstate/manager.go
@@ -30,12 +30,15 @@ type CommandManager struct {
 }
 
 // New creates a new CommandManager.
-func New(runner *state.TaskRunner, backend workshop.Backend) *CommandManager {
+func New(st *state.State, runner *state.TaskRunner) *CommandManager {
 	manager := &CommandManager{
 		executions:     make(map[string]*execution),
 		executionsCond: sync.NewCond(&sync.Mutex{}),
-		backend:        backend,
 	}
+	st.Lock()
+	manager.backend = workshop.WorkshopBackend(st)
+	st.Unlock()
+
 	runner.AddHandler("exec", manager.doExec, nil)
 	return manager
 }

--- a/internal/overlord/export_test.go
+++ b/internal/overlord/export_test.go
@@ -18,6 +18,8 @@ import (
 	"time"
 )
 
+var LockWithTimeout = lockWithTimeout
+
 // FakeEnsureInterval sets the overlord ensure interval for tests.
 func FakeEnsureInterval(d time.Duration) (restore func()) {
 	old := ensureInterval
@@ -51,6 +53,26 @@ func FakePruneTicker(f func(t *time.Ticker) <-chan time.Time) (restore func()) {
 // FakeEnsureNext sets o.ensureNext for tests.
 func FakeEnsureNext(o *Overlord, t time.Time) {
 	o.ensureNext = t
+}
+
+func FakeSystemdSdNotify(f func(notifyState string) error) (restore func()) {
+	old := systemdSdNotify
+	systemdSdNotify = f
+	return func() {
+		systemdSdNotify = old
+	}
+}
+
+// MockStateLockTimeout sets the overlord state lock timeout for the tests.
+func MockStateLockTimeout(timeout, retryInterval time.Duration) (restore func()) {
+	oldTimeout := stateLockTimeout
+	oldRetryInterval := stateLockRetryInterval
+	stateLockTimeout = timeout
+	stateLockRetryInterval = retryInterval
+	return func() {
+		stateLockTimeout = oldTimeout
+		stateLockRetryInterval = oldRetryInterval
+	}
 }
 
 // Engine exposes the state engine in an Overlord for tests.

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 func TestHealthState(t *testing.T) { check.TestingT(t) }
@@ -41,7 +42,7 @@ type healthSuite struct {
 	se      *overlord.StateEngine
 	state   *state.State
 	runner  *state.TaskRunner
-	backend *workshop.FakeWorkshopBackend
+	backend *fakebackend.FakeWorkshopBackend
 	hookMgr *hookstate.HookManager
 	project *workshop.Project
 	ctx     context.Context
@@ -56,7 +57,7 @@ func (s *healthSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.runner = state.NewTaskRunner(s.state)
 
-	s.backend = workshop.NewFakeWorkshopBackend()
+	s.backend = fakebackend.New()
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 	var err error
 	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())
@@ -206,7 +207,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one", true)
@@ -279,7 +280,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one", true)
@@ -336,7 +337,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one", true)
@@ -379,7 +380,7 @@ func (s *healthSuite) TestExecCheckHealthTimeout(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one", true)

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -57,14 +57,17 @@ func (s *healthSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.runner = state.NewTaskRunner(s.state)
 
-	s.backend = fakebackend.New()
+	be, _ := fakebackend.New()
+	s.backend = be.(*fakebackend.FakeWorkshopBackend)
+	workshop.ReplaceBackend(s.state, s.backend)
+
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 	var err error
 	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
 	s.ctx = context.WithValue(ctx, workshop.ContextProjectId, s.project.ProjectId)
 
-	s.hookMgr = hookstate.New(s.state, s.runner, s.backend)
+	s.hookMgr = hookstate.New(s.state, s.runner)
 
 	s.se = overlord.NewStateEngine(s.state)
 	s.se.AddManager(s.hookMgr)

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -8,13 +8,11 @@ import (
 	"github.com/spf13/afero"
 	"gopkg.in/tomb.v2"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
-	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
 
 func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
@@ -37,13 +35,13 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 
 	if hook.HookType == SaveState || hook.HookType == RestoreState {
 		volume := workshop.WorkshopStateVolumeName(w, prj.ProjectId)
-		if err := h.backend.AddWorkshopDevice(ctx, w, lxdbackend.Volume(volume, dirs.WorkshopStateDir, volume)); err != nil {
+		if err := h.backend.AttachStateStorage(ctx, w, volume); err != nil {
 			return fmt.Errorf("cannot run hook %q for SDK %q: %w", hook.Type(), hook.Sdk, err)
 		}
 
 		defer func() {
-			if err := h.backend.RemoveWorkshopDevice(ctx, w, volume); err != nil {
-				logger.Noticef("Cannot remove SDK state storage volume %s", volume)
+			if err := h.backend.DetachStateStorage(ctx, w, volume); err != nil {
+				logger.Noticef("RunHook on Do: Cannot detach SDK state storage volume %s", volume)
 			}
 		}()
 	}

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -47,7 +47,8 @@ func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
 }
 
 func (s *hookSuite) SetUpTest(c *check.C) {
-	s.backend = fakebackend.New()
+	be, _ := fakebackend.New()
+	s.backend = be.(*fakebackend.FakeWorkshopBackend)
 
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 	var err error
@@ -57,11 +58,12 @@ func (s *hookSuite) SetUpTest(c *check.C) {
 
 	s.state = state.New(nil)
 	s.runner = state.NewTaskRunner(s.state)
+	workshop.ReplaceBackend(s.state, s.backend)
 
 	// empty task handler
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
 	s.mockHandler = hooktest.NewMockHandler()
-	s.hookmgr = hookstate.New(s.state, s.runner, s.backend)
+	s.hookmgr = hookstate.New(s.state, s.runner)
 	s.hookmgr.Register(regexp.MustCompile("^fake-hook$"), func(context *hookstate.Context) hookstate.Handler {
 		return s.mockHandler
 	})

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -17,10 +17,11 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 type hookSuite struct {
-	backend     *workshop.FakeWorkshopBackend
+	backend     *fakebackend.FakeWorkshopBackend
 	state       *state.State
 	runner      *state.TaskRunner
 	se          *overlord.StateEngine
@@ -46,7 +47,7 @@ func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
 }
 
 func (s *hookSuite) SetUpTest(c *check.C) {
-	s.backend = workshop.NewFakeWorkshopBackend()
+	s.backend = fakebackend.New()
 
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 	var err error
@@ -197,7 +198,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.state.Unlock()
@@ -237,7 +238,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.state.Unlock()
@@ -296,7 +297,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerUnhappyPath(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.launchWorkshop(c, "one")
@@ -336,7 +337,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerErrorFails(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.state.Unlock()
@@ -373,7 +374,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerIgnoresError(c *check.C) {
 		}, nil
 	}
 	defer func() {
-		s.backend.ExecCallback = workshop.DoExecDefault
+		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
 	s.state.Unlock()

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -126,7 +126,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
 
 	// ensure that the save-state handler has created the required state
-	// directory (reattacg the storage to the workshop to check).W
+	// directory (reattach the storage to the workshop to check).
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
 	defer ws.Close()

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -122,8 +122,12 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
 		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
 
-	// ensure that the save-state handler has created the required state directory
+	// ensure that the save-state handler has created the required state
+	// directory (reattacg the storage to the workshop to check).W
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Check(err, check.IsNil)
+	defer ws.Close()
+	err = s.backend.AttachStateStorage(s.ctx, "ws", workshop.WorkshopStateVolumeName("ws", s.project.ProjectId))
 	c.Check(err, check.IsNil)
 	info, err := ws.Stat("/var/lib/workshop/state/sdk/one")
 	c.Check(err, check.IsNil)
@@ -151,9 +155,11 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	// setup state storage (usually already set by the save-state)
+	// setup state storage (must be already set by the save-state in a real use
+	// case).
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
+	defer ws.Close()
 	err = ws.MkdirAll("/var/lib/workshop/state/sdk/one", 0755)
 	c.Check(err, check.IsNil)
 
@@ -470,6 +476,7 @@ func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
 	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
+	defer ws.Close()
 	c.Check(err, check.IsNil)
 	err = ws.MkdirAll(sdk.SdkHooksDir(newsdk), 0744)
 	c.Check(err, check.IsNil)

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -65,13 +65,16 @@ type HookManager struct {
 	contexts      map[string]*Context
 }
 
-func New(s *state.State, runner *state.TaskRunner, server workshop.Backend) *HookManager {
+func New(s *state.State, runner *state.TaskRunner) *HookManager {
 	manager := &HookManager{
 		state:      s,
-		backend:    server,
 		repository: newRepository(),
 		contexts:   make(map[string]*Context),
 	}
+
+	s.Lock()
+	manager.backend = workshop.WorkshopBackend(s)
+	s.Unlock()
 
 	runner.AddHandler("run-hook", handlersetup.OnDo(manager.doRunHook), nil)
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"syscall"
 
 	"golang.org/x/exp/maps"
@@ -21,35 +20,6 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
-
-func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
-	allPlugs := m.repo.AllPlugs("content")
-
-	for _, plug := range sdkInfo.Plugs {
-		if plug.Interface != "content" {
-			continue
-		}
-		candidateTarget, _ := plug.Lookup("target")
-
-		idx := slices.IndexFunc(allPlugs, func(pi *sdk.PlugInfo) bool {
-			// only plugs from the same workshop will be considered
-			if pi.Sdk.ProjectId != plug.Sdk.ProjectId || pi.Sdk.Workshop != plug.Sdk.Workshop {
-				return false
-			}
-			// exclude oneself
-			if pi.Sdk.Ref() == plug.Sdk.Ref() && pi.Name == plug.Name {
-				return false
-			}
-			target, _ := pi.Lookup("target")
-			return target == candidateTarget
-		})
-		if idx != -1 {
-			return fmt.Errorf(`cannot connect "%s/%s:%s": target %s is also mounted by %s/%s:%s`, plug.Sdk.Workshop, plug.Sdk.Name, plug.Name, candidateTarget,
-				allPlugs[idx].Sdk.Workshop, allPlugs[idx].Sdk.Name, allPlugs[idx].Name)
-		}
-	}
-	return nil
-}
 
 func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err error) {
 	st := task.State()
@@ -95,10 +65,16 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
+	// Ensure that connections requested via the workshop file use existing and
+	// compatible plugs and slots.
+	if err = m.resolveWorkshopConnections(wp); err != nil {
+		return err
+	}
+
 	// Ensure that if the SDK is connected there will be no conflicting bind
 	// mount targets in the workshop, i.e. the situation when a two or more
 	// sources are bind mount at the same target in the workshop.
-	if err := m.checkConflictingTargets(info); err != nil {
+	if err = m.checkConflictingTargets(info); err != nil {
 		return err
 	}
 
@@ -174,6 +150,17 @@ func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sd
 	return connectTs, nil
 }
 
+func workshopConns(wp *workshop.Workshop) []interfaces.ConnRef {
+	conns := []interfaces.ConnRef{}
+	for _, wconn := range wp.File.Connections {
+		conns = append(conns, interfaces.ConnRef{
+			PlugRef: interfaces.PlugRef{ProjectId: wp.Project.ProjectId, Workshop: wp.Name, Sdk: wconn.PlugRef.Sdk, Name: wconn.PlugRef.Name},
+			SlotRef: interfaces.SlotRef{ProjectId: wp.Project.ProjectId, Workshop: wp.Name, Sdk: wconn.SlotRef.Sdk, Name: wconn.SlotRef.Name},
+		})
+	}
+	return conns
+}
+
 func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, info *sdk.Info, remounts map[string]string) error {
 	conns, err := getConns(m.state)
 	if err != nil {
@@ -181,6 +168,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 	}
 
 	var connectRefs = []*interfaces.ConnRef{}
+	var wconns = workshopConns(wp)
 	var plugDynamic = make(map[string]map[string]interface{})
 	var slotDynamic = make(map[string]map[string]interface{})
 
@@ -193,7 +181,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 			continue
 		}
 		candidates := m.repo.AutoConnectCandidateSlots(info.ProjectId, info.Workshop,
-			info.Name, plug.Name, autoConnectCheck)
+			info.Name, plug.Name, autoConnectChecker(wconns))
 
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
@@ -228,7 +216,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 
 	for _, slot := range info.Slots {
 		candidates := m.repo.AutoConnectCandidatePlugs(info.ProjectId, info.Workshop,
-			info.Name, slot.Name, autoConnectCheck)
+			info.Name, slot.Name, autoConnectChecker(wconns))
 		for _, plug := range candidates {
 			ref := interfaces.NewPlugRef(plug)
 			master, slaves := MaybeBound(wp, ref)
@@ -250,6 +238,17 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 			slotRef := interfaces.NewSlotRef(slot)
 			for _, slave := range slaves {
 				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
+
+				slaveInfo := m.repo.Plug(slave.ProjectId, slave.Workshop, slave.Sdk, slave.Name)
+				if slaveInfo == nil {
+					return fmt.Errorf("SDK %s/%s has no %q plug", slave.Workshop, slave.Sdk, slave.Name)
+				}
+
+				if slaveInfo.Interface != plug.Interface {
+					return fmt.Errorf("cannot bind %s/%s:%s (%q interface) to %s/%s:%s (%q interface)",
+						slave.Workshop, slave.Sdk, slave.Name, slaveInfo.Interface, master.Workshop, master.Sdk, master.Name, plug.Interface)
+				}
+
 				if _, ok := conns[slref.ID()]; !ok {
 					connectRefs = append(connectRefs, slref)
 					plugDynamic[slref.ID()] = make(map[string]interface{})
@@ -388,7 +387,7 @@ func MaybeBound(w *workshop.Workshop, ref interfaces.PlugRef) (interfaces.PlugRe
 
 	for _, s := range w.File.Sdks {
 		for name, pl := range s.Plugs {
-			sdk, plug := pl.Bind.Sdk, pl.Bind.Plug
+			sdk, plug := pl.Bind.Sdk, pl.Bind.Name
 			mkey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: sdk, Name: plug}
 			skey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: s.Name, Name: name}
 			masters[mkey] = append(masters[mkey], skey)

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -121,7 +121,7 @@ func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]str
 			continue
 		}
 		if conn.Interface() == "content" {
-			attrs := conn.Plug.DynamicAttrs()
+			attrs := conn.Slot.DynamicAttrs()
 			if attrs != nil && attrs["source"] != nil {
 				candidates[cref.ID()] = attrs["source"].(string)
 			}
@@ -182,6 +182,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 
 	var connectRefs = []*interfaces.ConnRef{}
 	var plugDynamic = make(map[string]map[string]interface{})
+	var slotDynamic = make(map[string]map[string]interface{})
 
 	for _, plug := range info.Plugs {
 		ref := interfaces.NewPlugRef(plug)
@@ -196,15 +197,16 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
-			if plugDynamic[connRef.ID()] == nil {
-				plugDynamic[connRef.ID()] = make(map[string]interface{})
+			if slotDynamic[connRef.ID()] == nil {
+				slotDynamic[connRef.ID()] = make(map[string]interface{})
 			}
 
 			if src, ok := remounts[connRef.ID()]; ok {
-				plugDynamic[connRef.ID()]["source"] = src
+				slotDynamic[connRef.ID()]["source"] = src
 			}
 
 			slotRef := interfaces.NewSlotRef(slot)
+			// save associated binds as a dynamic attribute
 			for _, slave := range slaves {
 				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
 				if _, ok := conns[slref.ID()]; !ok {
@@ -237,12 +239,12 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 			}
 			connRef := interfaces.NewConnRef(plug, slot)
 
-			if plugDynamic[connRef.ID()] == nil {
-				plugDynamic[connRef.ID()] = make(map[string]interface{})
+			if slotDynamic[connRef.ID()] == nil {
+				slotDynamic[connRef.ID()] = make(map[string]interface{})
 			}
 
 			if src, ok := remounts[connRef.ID()]; ok {
-				plugDynamic[connRef.ID()]["source"] = src
+				slotDynamic[connRef.ID()]["source"] = src
 			}
 
 			slotRef := interfaces.NewSlotRef(slot)
@@ -268,7 +270,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 	// without changes to its 'source' attribute in the new workshop
 	// (given the new workshop also has an SDK with exactly the same
 	// plug; the target directory may change in the new workshop).
-	ts, err := m.batchAutoConnectTasks(wp, info, connectRefs, plugDynamic, nil)
+	ts, err := m.batchAutoConnectTasks(wp, info, connectRefs, plugDynamic, slotDynamic)
 	if err != nil {
 		return err
 	}
@@ -976,13 +978,13 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, user s
 	}
 
 	var oldSource string
-	if err := connection.Plug.Attr("source", &oldSource); err != nil && !errors.Is(err, sdk.AttributeNotFoundError{}) {
+	if err := connection.Slot.Attr("source", &oldSource); err != nil && !errors.Is(err, sdk.AttributeNotFoundError{}) {
 		return err
 	} else if errors.Is(err, sdk.AttributeNotFoundError{}) {
 		oldSource = sdk.SdkContentSource(usr.HomeDir, plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name)
 	}
 
-	if err := connection.Plug.SetAttr("source", source); err != nil {
+	if err := connection.Slot.SetAttr("source", source); err != nil {
 		return err
 	}
 
@@ -994,7 +996,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, user s
 	}
 
 	revert.Add(func() {
-		_ = connection.Plug.SetAttr("source", oldSource)
+		_ = connection.Slot.SetAttr("source", oldSource)
 		if _, err := m.repo.Connect(connRef, connection.Plug.StaticAttrs(), connection.Plug.DynamicAttrs(), connection.Slot.StaticAttrs(), connection.Slot.DynamicAttrs(), nil); err != nil {
 			logger.Debugf("cannot reconnect %q plug on a failed remount", plug.ShortRef())
 		}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -466,12 +466,23 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	rev := revert.New()
+	defer rev.Fail()
+
 	cref := &interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
 	conn, err := m.repo.Connect(cref, plug.Attrs, plugDynamicAttrs,
 		slot.Attrs, slotDynamicAttrs, connectCheck)
 	if err != nil || conn == nil {
 		return err
 	}
+
+	rev.Add(func() {
+		err := m.repo.Disconnect(cref.PlugRef.ProjectId, cref.PlugRef.Workshop, cref.PlugRef.Sdk, cref.PlugRef.Name,
+			cref.SlotRef.ProjectId, cref.PlugRef.Workshop, cref.SlotRef.Sdk, cref.SlotRef.Name)
+		if err != nil {
+			logger.Noticef("On doConnect: Cannot revert connection %q", cref.ID())
+		}
+	})
 
 	if old, ok := conns[cref.ID()]; ok && old.Undesired {
 		task.Set("old-conn", old)
@@ -502,6 +513,8 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		Auto:             autoConnect,
 	}
 	setConns(st, conns)
+
+	rev.Success()
 
 	return nil
 }

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -638,6 +638,17 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		return fmt.Errorf("workshop changed, please retry the operation: %v", err)
 	}
 
+	rev := revert.New()
+	defer rev.Fail()
+
+	rev.Add(func() {
+		_, err1 := m.repo.Connect(&cref, conn.StaticPlugAttrs, conn.DynamicPlugAttrs, conn.StaticSlotAttrs,
+			conn.DynamicSlotAttrs, nil)
+		if err1 != nil {
+			logger.Noticef("On doDisconnect: Cannot recover disconnected %q", cref.ID())
+		}
+	})
+
 	switch {
 	case forget:
 		delete(conns, cref.ID())
@@ -665,6 +676,8 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 			}
 		}
 	}
+
+	rev.Success()
 	return nil
 }
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -95,7 +95,7 @@ func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 	s.restoreSimple = builtin.MockInterface(simpleIface{name: "mock-network"})
 	s.restoreDeny = builtin.MockInterface(denyAutoIface{name: "mock-ssh-agent"})
 
-	s.mgr = ifacestate.New(s.state, s.runner, s.wsbackend)
+	s.mgr = ifacestate.New(s.state, s.runner)
 	c.Assert(s.mgr, check.NotNil)
 
 	s.runner.AddHandler("fake-task", fakeHandler, nil)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -223,7 +223,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
 	c.Check(err, check.IsNil)
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.Bind{Sdk: "consumer", Plug: "plug2"}}
+	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug2"}}
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -414,7 +414,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 			"interface":    "mock-network",
 			"auto":         true,
 			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"source": "/old/source"},
+			"slot-dynamic": map[string]interface{}{"source": "/old/source"},
 		},
 	})
 
@@ -470,7 +470,7 @@ slots:
 			"interface":    "content",
 			"auto":         true,
 			"plug-static":  map[string]interface{}{"target": "/opt"},
-			"plug-dynamic": map[string]interface{}{"source": source},
+			"slot-dynamic": map[string]interface{}{"source": source},
 		},
 	})
 	_, err = ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws-consumer", "consumer")
@@ -505,7 +505,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
 	var remountSource string
-	c.Assert(connection.Plug.Attr("source", &remountSource), check.IsNil)
+	c.Assert(connection.Slot.Attr("source", &remountSource), check.IsNil)
 	c.Assert(remountSource, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
@@ -519,9 +519,9 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 		Interface:        "content",
 		Undesired:        false,
 		StaticPlugAttrs:  map[string]interface{}{"target": "/opt"},
-		DynamicPlugAttrs: map[string]interface{}{"source": newSource},
+		DynamicPlugAttrs: map[string]interface{}{},
 		StaticSlotAttrs:  map[string]interface{}{},
-		DynamicSlotAttrs: map[string]interface{}{}})
+		DynamicSlotAttrs: map[string]interface{}{"source": newSource}})
 	c.Assert(conns, check.HasLen, 1)
 }
 
@@ -549,7 +549,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
 	var remountSource string
-	c.Assert(connection.Plug.Attr("source", &remountSource), check.IsNil)
+	c.Assert(connection.Slot.Attr("source", &remountSource), check.IsNil)
 	c.Assert(remountSource, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
@@ -565,9 +565,9 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 		Interface:        "content",
 		Undesired:        false,
 		StaticPlugAttrs:  map[string]interface{}{"target": "/opt"},
-		DynamicPlugAttrs: map[string]interface{}{"source": newSource},
+		DynamicPlugAttrs: map[string]interface{}{},
 		StaticSlotAttrs:  map[string]interface{}{},
-		DynamicSlotAttrs: map[string]interface{}{}})
+		DynamicSlotAttrs: map[string]interface{}{"source": newSource}})
 	c.Assert(conns, check.HasLen, 1)
 }
 
@@ -597,7 +597,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *chec
 	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
 	var src string
-	c.Assert(connection.Plug.Attr("source", &src), check.IsNil)
+	c.Assert(connection.Slot.Attr("source", &src), check.IsNil)
 	c.Assert(src, check.Equals, oldSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
@@ -635,7 +635,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
 	var src string
-	c.Assert(connection.Plug.Attr("source", &src), check.IsNil)
+	c.Assert(connection.Slot.Attr("source", &src), check.IsNil)
 	c.Assert(src, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
@@ -673,7 +673,7 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(err, check.IsNil)
 	c.Assert(err, check.IsNil)
 	var src string
-	c.Assert(connection.Plug.Attr("source", &src), check.IsNil)
+	c.Assert(connection.Slot.Attr("source", &src), check.IsNil)
 	c.Assert(src, check.Equals, oldSource)
 
 	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
@@ -705,7 +705,7 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C)
 	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
 	var src string
-	c.Assert(connection.Plug.Attr("source", &src), check.IsNil)
+	c.Assert(connection.Slot.Attr("source", &src), check.IsNil)
 	c.Assert(src, check.Equals, newSource)
 
 	c.Assert(osutil.FileExists(newSource), check.Equals, true)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -1331,6 +1331,37 @@ func (s *interfaceHandlersSuite) TestConnectSuccessSetupBackend(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
+func (s *interfaceHandlersSuite) TestConnectDisconnectsIfBackedSetupFailed(c *check.C) {
+	// Setup
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{
+		csetup: consumer,
+		psetup: producer,
+	})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+		return errors.New("cannot finish backend setup")
+	}
+	defer func() { s.secBackend.SetupCallback = nil }()
+
+	// Execute
+	chg := s.connectChange("ws", false, false)
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Validate that even if a connection was created in the repository, it
+	// won't persist if the backend setup fails.
+	c.Check(chg.Tasks()[0].Status(), check.Equals, state.ErrorStatus)
+	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 0)
+}
+
 func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	// Setup
 	s.launchWorkshop(c, "ws", map[sdk.Setup]string{

--- a/internal/overlord/ifacestate/helpers.go
+++ b/internal/overlord/ifacestate/helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/canonical/workshop/internal/asserts"
 	"github.com/canonical/workshop/internal/interfaces"
@@ -14,6 +15,39 @@ import (
 	"github.com/canonical/workshop/internal/overlord/ifacestate/schema"
 	"github.com/canonical/workshop/internal/overlord/state"
 )
+
+type checker = func(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (bool, error)
+
+func autoConnectChecker(workshopConns []interfaces.ConnRef) checker {
+	return func(p *interfaces.ConnectedPlug, s *interfaces.ConnectedSlot) (bool, error) {
+		conn := interfaces.ConnRef{PlugRef: *p.Ref(), SlotRef: *s.Ref()}
+		// The pair is explicitly connected in a workshop file.
+		if slices.Contains(workshopConns, conn) {
+			// The interface's policy will be able to determine whether the
+			// allow-auto-connection rule is still passable based on the
+			// "auto-explicit" property (meaning the connection was explicit in
+			// the workshop definition).
+			if err := p.SetAttr("auto-explicit", "true"); err != nil {
+				return false, err
+			}
+			return autoConnectCheck(p, s)
+		}
+
+		// The pair is not explicitly connected but the plug is used in other
+		// explicit workshop connections; reject this candidate pair. Example:
+		// content interface plug connected explicitly should reject connections
+		// to other slots.
+		if slices.ContainsFunc(workshopConns, func(conn interfaces.ConnRef) bool {
+			return conn.PlugRef == *p.Ref()
+		}) {
+			return false, nil
+		}
+
+		// Not mentioned in the workshop file connections list; fallback to a
+		// regular policy check.
+		return autoConnectCheck(p, s)
+	}
+}
 
 func autoConnectCheck(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (bool, error) {
 	baseDecl := asserts.BuiltinBaseDeclaration()

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -24,12 +24,15 @@ type InterfaceManager struct {
 	repo    *interfaces.Repository
 }
 
-func New(s *state.State, r *state.TaskRunner, be workshop.Backend) *InterfaceManager {
+func New(s *state.State, r *state.TaskRunner) *InterfaceManager {
 	m := &InterfaceManager{
-		state:   s,
-		backend: be,
-		repo:    interfaces.NewRepository(),
+		state: s,
+		repo:  interfaces.NewRepository(),
 	}
+
+	s.Lock()
+	m.backend = workshop.WorkshopBackend(s)
+	s.Unlock()
 
 	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), nil)
 	r.AddHandler("auto-disconnect", OnDo(m.doDisconnectInterfaces), nil)

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
@@ -395,6 +396,46 @@ func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string
 		setConns(m.state, conns)
 	}
 	return affected, nil
+}
+
+func (m *InterfaceManager) resolveWorkshopConnections(w *workshop.Workshop) error {
+	for _, conn := range w.File.Connections {
+		_, err := m.repo.ResolveConnect(w.Project.ProjectId, w.Name, conn.PlugRef.Sdk, conn.PlugRef.Name,
+			w.Project.ProjectId, w.Name, conn.SlotRef.Sdk, conn.SlotRef.Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
+	allPlugs := m.repo.AllPlugs("content")
+
+	for _, plug := range sdkInfo.Plugs {
+		if plug.Interface != "content" {
+			continue
+		}
+		candidateTarget, _ := plug.Lookup("target")
+
+		idx := slices.IndexFunc(allPlugs, func(pi *sdk.PlugInfo) bool {
+			// only plugs from the same workshop will be considered
+			if pi.Sdk.ProjectId != plug.Sdk.ProjectId || pi.Sdk.Workshop != plug.Sdk.Workshop {
+				return false
+			}
+			// exclude oneself
+			if pi.Sdk.Ref() == plug.Sdk.Ref() && pi.Name == plug.Name {
+				return false
+			}
+			target, _ := pi.Lookup("target")
+			return target == candidateTarget
+		})
+		if idx != -1 {
+			return fmt.Errorf(`cannot connect "%s/%s:%s": target %s is also mounted by %s/%s:%s`, plug.Sdk.Workshop, plug.Sdk.Name, plug.Name, candidateTarget,
+				allPlugs[idx].Sdk.Workshop, allPlugs[idx].Sdk.Name, allPlugs[idx].Name)
+		}
+	}
+	return nil
 }
 
 var securityBackendsOverride []interfaces.SecurityBackend

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -105,7 +105,16 @@ slots:
 		s.writeSDKMetaFile(c, wsfs, sdk.Name, yaml)
 	}
 
-	return s.wsbackend.Workshop(ctx, ws)
+	w, err := s.wsbackend.Workshop(ctx, ws)
+	c.Assert(err, check.IsNil)
+
+	for s := range sdkYamls {
+		if err = w.LinkSdk(ctx, s); err != nil {
+			c.Assert(err, check.IsNil)
+		}
+	}
+
+	return w, nil
 }
 
 func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *check.C) {

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -53,7 +53,10 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 
 	s.restoreProjectId = testutil.FakeFunc(func() (string, error) { return "42424242", nil }, &workshop.NewProjectId)
 
-	s.wsbackend = fakebackend.New()
+	be, _ := fakebackend.New()
+	s.wsbackend = be.(*fakebackend.FakeWorkshopBackend)
+	workshop.ReplaceBackend(s.state, s.wsbackend)
+
 	s.ctx = context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 	s.prj, _, err = s.wsbackend.CreateOrLoadProject(s.ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
@@ -149,7 +152,7 @@ plugs:
 	})
 	s.state.Unlock()
 
-	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
+	mgr := ifacestate.New(s.state, s.o.TaskRunner())
 	err := mgr.StartUp()
 	c.Assert(err, check.IsNil)
 
@@ -212,7 +215,7 @@ slots:
 	})
 	s.state.Unlock()
 
-	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
+	mgr := ifacestate.New(s.state, s.o.TaskRunner())
 	err := mgr.StartUp()
 	c.Assert(err, check.IsNil)
 
@@ -255,7 +258,7 @@ slots:
 	})
 	s.state.Unlock()
 
-	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
+	mgr := ifacestate.New(s.state, s.o.TaskRunner())
 	err := mgr.StartUp()
 	c.Assert(err, check.IsNil)
 
@@ -323,7 +326,7 @@ slots:
         interface: test
         attr2: value2
 `, "pid", "ws")
-	mgr := ifacestate.New(s.state, s.o.TaskRunner(), s.wsbackend)
+	mgr := ifacestate.New(s.state, s.o.TaskRunner())
 	err := mgr.StartUp()
 	c.Assert(err, check.IsNil)
 

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 type interfaceManagerSuite struct {
@@ -52,7 +53,7 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 
 	s.restoreProjectId = testutil.FakeFunc(func() (string, error) { return "42424242", nil }, &workshop.NewProjectId)
 
-	s.wsbackend = workshop.NewFakeWorkshopBackend()
+	s.wsbackend = fakebackend.New()
 	s.ctx = context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 	s.prj, _, err = s.wsbackend.CreateOrLoadProject(s.ctx, c.MkDir())
 	c.Assert(err, check.IsNil)

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/internal/dirs"
+	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 	"github.com/canonical/x-go/randutil"
 	"gopkg.in/tomb.v2"
 
@@ -39,10 +40,10 @@ import (
 	"github.com/canonical/workshop/internal/overlord/restart"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
-	workshop "github.com/canonical/workshop/internal/overlord/workshopstate"
+	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/systemd"
-	backend "github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 var (
@@ -68,9 +69,8 @@ var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
 type Overlord struct {
 	stateFLock *osutil.FileLock
 
-	stateDir        string
-	stateEng        *StateEngine
-	workshopBackend backend.Backend
+	stateDir string
+	stateEng *StateEngine
 
 	// ensure loop
 	loopTomb    *tomb.Tomb
@@ -83,8 +83,8 @@ type Overlord struct {
 	// managers
 	inited      bool
 	startedUp   bool
-	sdk         *sdkstate.SdkManager
-	workshopmgr *workshop.WorkshopManager
+	sdkmgr      *sdkstate.SdkManager
+	workshopmgr *workshopstate.WorkshopManager
 	hookmgr     *hookstate.HookManager
 	commandmgr  *cmdstate.CommandManager
 	ifacemgr    *ifacestate.InterfaceManager
@@ -93,9 +93,11 @@ type Overlord struct {
 	startOfOperationTime time.Time
 }
 
+var workshopBackendNew = lxdbackend.New
+
 // New creates a new Overlord with all its state managers.
 // It can be provided with an optional restart.Handler.
-func New(dir string, b backend.Backend, restartHandler restart.Handler) (*Overlord, error) {
+func New(dir string, restartHandler restart.Handler) (*Overlord, error) {
 	o := &Overlord{
 		stateDir: dir,
 		loopTomb: new(tomb.Tomb),
@@ -110,8 +112,6 @@ func New(dir string, b backend.Backend, restartHandler restart.Handler) (*Overlo
 	if !osutil.IsDir(dir) {
 		return nil, fmt.Errorf("directory %q does not exist", dir)
 	}
-
-	o.workshopBackend = b
 
 	statePath := filepath.Join(dir, "state.json")
 
@@ -130,28 +130,34 @@ func New(dir string, b backend.Backend, restartHandler restart.Handler) (*Overlo
 	sto := store.New()
 	sdk.ReplaceStore(s, sto)
 
+	wbe, err := workshopBackendNew()
+	if err != nil {
+		return nil, err
+	}
+	workshop.ReplaceBackend(s, wbe)
+
 	// any unknown task should be ignored and succeed
 	matchAnyUnknownTask := func(_ *state.Task) bool {
 		return true
 	}
 	o.runner.AddOptionalHandler(matchAnyUnknownTask, handleUnknownTask, nil)
 
-	o.workshopmgr = workshop.New(s, o.runner, o.workshopBackend)
+	o.workshopmgr = workshopstate.New(s, o.runner)
 	o.addManager(o.workshopmgr)
 
-	o.hookmgr = hookstate.New(s, o.runner, o.workshopBackend)
+	o.hookmgr = hookstate.New(s, o.runner)
 	o.addManager(o.hookmgr)
 
 	healthstate.Init(o.hookmgr)
 
-	o.commandmgr = cmdstate.New(o.runner, o.workshopBackend)
+	o.commandmgr = cmdstate.New(s, o.runner)
 	o.addManager(o.commandmgr)
 
-	o.ifacemgr = ifacestate.New(s, o.runner, o.workshopBackend)
+	o.ifacemgr = ifacestate.New(s, o.runner)
 	o.addManager(o.ifacemgr)
 
-	o.sdk = sdkstate.New(o.runner, o.ifacemgr.Repository(), o.workshopBackend)
-	o.addManager(o.sdk)
+	o.sdkmgr = sdkstate.New(s, o.runner, o.ifacemgr.Repository())
+	o.addManager(o.sdkmgr)
 
 	// the shared task runner should be added last!
 	o.stateEng.AddManager(o.runner)
@@ -501,11 +507,11 @@ func (o *Overlord) TaskRunner() *state.TaskRunner {
 	return o.runner
 }
 
-func (o *Overlord) WorkshopBackend() backend.Backend {
-	return o.workshopBackend
+func (o *Overlord) WorkshopBackend() workshop.Backend {
+	return workshop.WorkshopBackend(o.State())
 }
 
-func (o *Overlord) WorkshopManager() *workshop.WorkshopManager {
+func (o *Overlord) WorkshopManager() *workshopstate.WorkshopManager {
 	return o.workshopmgr
 }
 
@@ -519,6 +525,13 @@ func (o *Overlord) HookManager() *hookstate.HookManager {
 
 func (o *Overlord) InterfaceManager() *ifacestate.InterfaceManager {
 	return o.ifacemgr
+}
+
+func MockBackendNew(new func() (workshop.Backend, error)) (restore func()) {
+	workshopBackendNew = new
+	return func() {
+		workshopBackendNew = lxdbackend.New
+	}
 }
 
 // Fake creates an Overlord without any managers and with a backend

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -24,11 +24,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/canonical/workshop/internal/dirs"
-	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 	"github.com/canonical/x-go/randutil"
 	"gopkg.in/tomb.v2"
 
+	"github.com/canonical/workshop/internal/dirs"
 	store "github.com/canonical/workshop/internal/fakestore"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
@@ -44,6 +43,7 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
+	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
 
 var (

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -24,10 +24,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/x-go/randutil"
 	"gopkg.in/tomb.v2"
 
 	store "github.com/canonical/workshop/internal/fakestore"
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/cmdstate"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
@@ -39,6 +41,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	workshop "github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/systemd"
 	backend "github.com/canonical/workshop/internal/workshop"
 )
 
@@ -48,7 +51,12 @@ var (
 	pruneWait      = 24 * time.Hour * 1
 	abortWait      = 24 * time.Hour * 7
 
+	stateLockTimeout       = 1 * time.Minute
+	stateLockRetryInterval = 1 * time.Second
+
 	pruneMaxChanges = 500
+
+	systemdSdNotify = systemd.SdNotify
 )
 
 var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
@@ -58,6 +66,8 @@ var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
 // Overlord is the central manager of the system, keeping track
 // of all available state managers and related helpers.
 type Overlord struct {
+	stateFLock *osutil.FileLock
+
 	stateDir        string
 	stateEng        *StateEngine
 	workshopBackend backend.Backend
@@ -81,9 +91,6 @@ type Overlord struct {
 	runner      *state.TaskRunner
 
 	startOfOperationTime time.Time
-
-	// exclusive file lock for the state to avoid multiple running workshops (temporary)
-	stateFileLock *osutil.FileLock
 }
 
 // New creates a new Overlord with all its state managers.
@@ -104,23 +111,6 @@ func New(dir string, b backend.Backend, restartHandler restart.Handler) (*Overlo
 		return nil, fmt.Errorf("directory %q does not exist", dir)
 	}
 
-	o.stateFileLock, err = osutil.NewFileLock(filepath.Join(dir, ".lock"))
-	if err != nil {
-		return nil, err
-	}
-
-	for {
-		err = o.stateFileLock.TryLock()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "cannot start, could another workshopd be running?")
-			fmt.Fprintln(os.Stderr, "retry in 5 seconds...")
-
-			time.Sleep(5 * time.Second)
-		} else {
-			break
-		}
-	}
-
 	o.workshopBackend = b
 
 	statePath := filepath.Join(dir, "state.json")
@@ -129,7 +119,7 @@ func New(dir string, b backend.Backend, restartHandler restart.Handler) (*Overlo
 		path:         statePath,
 		ensureBefore: o.ensureBefore,
 	}
-	s, err := loadState(statePath, restartHandler, backend)
+	s, err := o.loadState(statePath, restartHandler, backend)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +199,57 @@ func (o *Overlord) addManager(mgr StateManager) {
 	o.stateEng.AddManager(mgr)
 }
 
-func loadState(statePath string, restartHandler restart.Handler, backend state.Backend) (*state.State, error) {
+func initStateFileLock() (*osutil.FileLock, error) {
+	lockFilePath := dirs.WorkshopStateLockFile
+	if err := os.MkdirAll(filepath.Dir(lockFilePath), 0755); err != nil {
+		return nil, err
+	}
+
+	return osutil.NewFileLockWithMode(lockFilePath, 0644)
+}
+
+func lockWithTimeout(l *osutil.FileLock, timeout time.Duration) error {
+	startTime := time.Now()
+	systemdWasNotified := false
+	for {
+		err := l.TryLock()
+		if err != osutil.ErrAlreadyLocked {
+			// We return nil if err is nil (that is, if we got the lock); we
+			// also return for any error except for ErrAlreadyLocked, because
+			// in that case we want to continue trying.
+			return err
+		}
+
+		// The state is locked. Let's notify systemd that our startup might be
+		// longer than usual, or we risk getting killed if we overstep the
+		// systemd timeout.
+		if !systemdWasNotified {
+			logger.Noticef("Adjusting startup timeout by %v", timeout)
+			systemdSdNotify(fmt.Sprintf("EXTEND_TIMEOUT_USEC=%d", timeout.Microseconds()))
+			systemdWasNotified = true
+		}
+
+		if time.Since(startTime) >= timeout {
+			return errors.New("timeout for state lock file expired")
+		}
+		time.Sleep(stateLockRetryInterval)
+	}
+}
+
+func (o *Overlord) loadState(statePath string, restartHandler restart.Handler, backend state.Backend) (*state.State, error) {
+	flock, err := initStateFileLock()
+	if err != nil {
+		return nil, fmt.Errorf("fatal: error opening lock file: %v", err)
+	}
+	o.stateFLock = flock
+
+	logger.Noticef("Acquiring state lock file")
+	if err := lockWithTimeout(o.stateFLock, stateLockTimeout); err != nil {
+		logger.Noticef("Failed to lock state file")
+		return nil, fmt.Errorf("fatal: could not lock state file: %v", err)
+	}
+	logger.Noticef("Acquired state lock file")
+
 	curBootID, err := osutil.BootID()
 	if err != nil {
 		return nil, fmt.Errorf("fatal: cannot find current boot ID: %w", err)

--- a/internal/overlord/overlord_test.go
+++ b/internal/overlord/overlord_test.go
@@ -18,7 +18,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -27,6 +30,7 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/patch"
@@ -68,6 +72,7 @@ func fakePruneTicker() (w *ticker, restore func()) {
 
 func (ovs *overlordSuite) SetUpTest(c *C) {
 	ovs.dir = c.MkDir()
+	dirs.SetRootDir(ovs.dir)
 	ovs.statePath = filepath.Join(ovs.dir, "state.json")
 }
 
@@ -1049,4 +1054,66 @@ func (ovs *overlordSuite) TestOverlordCanStandby(c *C) {
 	}
 
 	c.Assert(o.CanStandby(), Equals, true)
+}
+
+func (ovs *overlordSuite) TestLockWithTimeoutHappy(c *C) {
+	f, err := ioutil.TempFile("", "testlock-*")
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	c.Assert(err, IsNil)
+	flock, err := osutil.NewFileLock(f.Name())
+	c.Assert(err, IsNil)
+
+	err = overlord.LockWithTimeout(flock, time.Second)
+	c.Check(err, IsNil)
+}
+
+func (ovs *overlordSuite) TestLockWithTimeoutFailed(c *C) {
+	// Set the state lock retry interval to 0.1 ms; the timeout is not used in
+	// this test (we specify the timeout when calling the lockWithTimeout()
+	// function below); we set it to a big value in order to trigger a test
+	// failure in case the logic gets modified and it suddenly becomes
+	// relevant.
+	restoreTimeout := overlord.MockStateLockTimeout(time.Hour, 100*time.Microsecond)
+	defer restoreTimeout()
+
+	var notifyCalls []string
+	restoreNotify := overlord.FakeSystemdSdNotify(func(notifyState string) error {
+		notifyCalls = append(notifyCalls, notifyState)
+		return nil
+	})
+	defer restoreNotify()
+
+	f, err := ioutil.TempFile("", "testlock-*")
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	c.Assert(err, IsNil)
+	flock, err := osutil.NewFileLock(f.Name())
+	c.Assert(err, IsNil)
+
+	cmd := exec.Command("flock", "-w", "2", f.Name(), "-c", "echo acquired && sleep 5")
+	stdout, err := cmd.StdoutPipe()
+	c.Assert(err, IsNil)
+	err = cmd.Start()
+	c.Assert(err, IsNil)
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
+
+	// Wait until the shell command prints "acquired"
+	buf := make([]byte, 8)
+	bytesRead, err := io.ReadAtLeast(stdout, buf, len(buf))
+	c.Assert(err, IsNil)
+	c.Assert(bytesRead, Equals, len(buf))
+
+	err = overlord.LockWithTimeout(flock, 5*time.Millisecond)
+	c.Check(err, ErrorMatches, "timeout for state lock file expired")
+	c.Check(notifyCalls, DeepEquals, []string{
+		"EXTEND_TIMEOUT_USEC=5000",
+	})
 }

--- a/internal/overlord/overlord_test.go
+++ b/internal/overlord/overlord_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/version"
-	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 func TestOverlord(t *testing.T) { TestingT(t) }
@@ -201,7 +201,7 @@ func (wm *witnessManager) Ensure() error {
 }
 
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
-	o, err := overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), nil)
+	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
 	c.Assert(err, IsNil)
 
 	err = o.StartUp()
@@ -214,7 +214,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 }
 
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
-	o, err := overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), nil)
+	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
 	c.Assert(err, IsNil)
 
 	// unknown tasks are ignored and succeed
@@ -536,7 +536,7 @@ func (ovs *overlordSuite) TestOverlordStartUpSetsStartOfOperation(c *C) {
 	restoreIntv := overlord.FakePruneInterval(100*time.Millisecond, 1000*time.Millisecond, 1*time.Hour)
 	defer restoreIntv()
 
-	o, err := overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), nil)
+	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -558,7 +558,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneDoesntAbortShortlyAfterStartOfOpera
 	w, restoreTicker := fakePruneTicker()
 	defer restoreTicker()
 
-	o, err := overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), nil)
+	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
 	c.Assert(err, IsNil)
 
 	// avoid immediate transition to Done due to unknown kind
@@ -609,7 +609,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneAbortsOld(c *C) {
 	w, restoreTicker := fakePruneTicker()
 	defer restoreTicker()
 
-	o, err := overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), nil)
+	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
 	c.Assert(err, IsNil)
 
 	// avoid immediate transition to Done due to having unknown kind
@@ -938,7 +938,7 @@ func (rb *testRestartHandler) RebootIsMissing(_ *state.State) error {
 func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
 	rb := &testRestartHandler{}
 
-	o, err := overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), rb)
+	o, err := overlord.New(ovs.dir, fakebackend.New(), rb)
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -957,7 +957,7 @@ func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), rb)
+	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -970,7 +970,7 @@ func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), rb)
+	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -984,7 +984,7 @@ func (ovs *overlordSuite) TestVerifyRebootOKButError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), rb)
+	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -1000,7 +1000,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissing(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), rb)
+	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")
@@ -1017,7 +1017,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissingError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(ovs.dir, workshop.NewFakeWorkshopBackend(), rb)
+	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")

--- a/internal/overlord/overlord_test.go
+++ b/internal/overlord/overlord_test.go
@@ -46,6 +46,8 @@ func TestOverlord(t *testing.T) { TestingT(t) }
 type overlordSuite struct {
 	dir       string
 	statePath string
+
+	restoreBackendNew func()
 }
 
 var _ = Suite(&overlordSuite{})
@@ -74,16 +76,18 @@ func (ovs *overlordSuite) SetUpTest(c *C) {
 	ovs.dir = c.MkDir()
 	dirs.SetRootDir(ovs.dir)
 	ovs.statePath = filepath.Join(ovs.dir, "state.json")
+	ovs.restoreBackendNew = overlord.MockBackendNew(fakebackend.New)
 }
 
 func (ovs *overlordSuite) TearDownTest(c *C) {
+	ovs.restoreBackendNew()
 }
 
 func (ovs *overlordSuite) TestNew(c *C) {
 	restore := patch.Mock(42, 2, nil)
 	defer restore()
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 	c.Check(o, NotNil)
 
@@ -108,7 +112,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	err := os.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -136,7 +140,7 @@ func (ovs *overlordSuite) TestNewWithInvalidState(c *C) {
 	err := os.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	_, err = overlord.New(ovs.dir, nil, nil)
+	_, err = overlord.New(ovs.dir, nil)
 	c.Assert(err, ErrorMatches, "cannot read state: EOF")
 }
 
@@ -155,7 +159,7 @@ func (ovs *overlordSuite) TestNewWithPatches(c *C) {
 	err := os.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -206,7 +210,7 @@ func (wm *witnessManager) Ensure() error {
 }
 
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
-	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	err = o.StartUp()
@@ -219,7 +223,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 }
 
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
-	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	// unknown tasks are ignored and succeed
@@ -541,7 +545,7 @@ func (ovs *overlordSuite) TestOverlordStartUpSetsStartOfOperation(c *C) {
 	restoreIntv := overlord.FakePruneInterval(100*time.Millisecond, 1000*time.Millisecond, 1*time.Hour)
 	defer restoreIntv()
 
-	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -563,7 +567,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneDoesntAbortShortlyAfterStartOfOpera
 	w, restoreTicker := fakePruneTicker()
 	defer restoreTicker()
 
-	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	// avoid immediate transition to Done due to unknown kind
@@ -614,7 +618,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneAbortsOld(c *C) {
 	w, restoreTicker := fakePruneTicker()
 	defer restoreTicker()
 
-	o, err := overlord.New(ovs.dir, fakebackend.New(), nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	// avoid immediate transition to Done due to having unknown kind
@@ -669,7 +673,7 @@ func (ovs *overlordSuite) TestCheckpoint(c *C) {
 	oldUmask := syscall.Umask(0)
 	defer syscall.Umask(oldUmask)
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	s := o.State()
@@ -910,7 +914,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 }
 
 func (ovs *overlordSuite) TestRequestRestartNoHandler(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil)
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -943,7 +947,7 @@ func (rb *testRestartHandler) RebootIsMissing(_ *state.State) error {
 func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
 	rb := &testRestartHandler{}
 
-	o, err := overlord.New(ovs.dir, fakebackend.New(), rb)
+	o, err := overlord.New(ovs.dir, rb)
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -962,7 +966,7 @@ func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
+	_, err = overlord.New(ovs.dir, rb)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -975,7 +979,7 @@ func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
+	_, err = overlord.New(ovs.dir, rb)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -989,7 +993,7 @@ func (ovs *overlordSuite) TestVerifyRebootOKButError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
+	_, err = overlord.New(ovs.dir, rb)
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -1005,7 +1009,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissing(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
+	_, err = overlord.New(ovs.dir, rb)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")
@@ -1022,7 +1026,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissingError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(ovs.dir, fakebackend.New(), rb)
+	_, err = overlord.New(ovs.dir, rb)
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -268,10 +268,12 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		}
 	})
 
-	// validate that the SDK is of the acceptable type, no non-regular SDKs are
-	// allowed from outside
 	info, err := wp.SdkInfo(ctx, setup.Name)
 	if err != nil {
+		return err
+	}
+
+	if err = policy.CheckInterfaces(info); err != nil {
 		return err
 	}
 
@@ -287,9 +289,6 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		}
 	})
 
-	if err = policy.CheckInterfaces(info); err != nil {
-		return err
-	}
 	if len(info.BadInterfaces) > 0 {
 		st := task.State()
 		st.Lock()

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -24,11 +24,12 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 type sdkStateSuite struct {
 	fs          afero.Fs
-	backend     *workshop.FakeWorkshopBackend
+	backend     *fakebackend.FakeWorkshopBackend
 	state       *state.State
 	runner      *state.TaskRunner
 	se          *overlord.StateEngine
@@ -94,7 +95,7 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	ctx := context.WithValue(context.TODO(), workshop.ContextProjectId, "projectId")
 	s.ctx = context.WithValue(ctx, workshop.ContextUser, "testuser")
 
-	s.backend = workshop.NewFakeWorkshopBackend()
+	s.backend = fakebackend.New()
 	s.project = &workshop.Project{
 		Path:      c.MkDir(),
 		ProjectId: "projectId",

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -95,7 +95,9 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	ctx := context.WithValue(context.TODO(), workshop.ContextProjectId, "projectId")
 	s.ctx = context.WithValue(ctx, workshop.ContextUser, "testuser")
 
-	s.backend = fakebackend.New()
+	be, _ := fakebackend.New()
+	s.backend = be.(*fakebackend.FakeWorkshopBackend)
+
 	s.project = &workshop.Project{
 		Path:      c.MkDir(),
 		ProjectId: "projectId",
@@ -106,12 +108,14 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.runner = state.NewTaskRunner(s.state)
 
+	workshop.ReplaceBackend(s.state, s.backend)
+
 	/* empty task handler */
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
 
 	s.repo = interfaces.NewRepository()
 	mockIface(c, s.repo, &ifacetest.TestInterface{InterfaceName: "test-interface"})
-	s.sdkmgr = sdkstate.New(s.runner, s.repo, s.backend)
+	s.sdkmgr = sdkstate.New(s.state, s.runner, s.repo)
 
 	/* error-provoking task handler */
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -4,6 +4,7 @@ import (
 	"github.com/canonical/workshop/internal/interfaces"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/workshop"
 	backend "github.com/canonical/workshop/internal/workshop"
 )
 
@@ -12,8 +13,12 @@ type SdkManager struct {
 	repo    *interfaces.Repository
 }
 
-func New(runner *state.TaskRunner, repo *interfaces.Repository, server backend.Backend) *SdkManager {
-	manager := &SdkManager{backend: server, repo: repo}
+func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) *SdkManager {
+	manager := &SdkManager{repo: repo}
+
+	s.Lock()
+	manager.backend = workshop.WorkshopBackend(s)
+	s.Unlock()
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
 	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.undoInstallSdk)

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -42,9 +42,9 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 	}
 
 	st := task.State()
-	var wf workshop.File
+	var base string
 	st.Lock()
-	err = task.Get("workshop-file", &wf)
+	err = task.Get("workshop-base", &base)
 	st.Unlock()
 	if err != nil {
 		return fmt.Errorf("internal error: %q workshop configuration is not found (task ID: %s)", w, task.ID())
@@ -62,7 +62,7 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 		},
 	}
 
-	return m.backend.Download(ctx, wf.Base, reporter)
+	return m.backend.Download(ctx, base, reporter)
 }
 
 func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -20,11 +20,12 @@ import (
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 type workshopHandlers struct {
 	fs                afero.Fs
-	backend           *workshop.FakeWorkshopBackend
+	backend           *fakebackend.FakeWorkshopBackend
 	state             *state.State
 	runner            *state.TaskRunner
 	se                *overlord.StateEngine
@@ -54,7 +55,7 @@ func (s *workshopHandlers) SetUpTest(c *check.C) {
 	s.fs = afero.NewMemMapFs()
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 
-	s.backend = workshop.NewFakeWorkshopBackend()
+	s.backend = fakebackend.New()
 
 	var err error
 	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -292,7 +292,7 @@ base: ubuntu@22.04
 
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("download-base", "...")
-	t1.Set("workshop-file", wf)
+	t1.Set("workshop-base", wf.Base)
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -55,7 +55,8 @@ func (s *workshopHandlers) SetUpTest(c *check.C) {
 	s.fs = afero.NewMemMapFs()
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 
-	s.backend = fakebackend.New()
+	be, _ := fakebackend.New()
+	s.backend = be.(*fakebackend.FakeWorkshopBackend)
 
 	var err error
 	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())
@@ -77,8 +78,9 @@ func (s *workshopHandlers) SetUpTest(c *check.C) {
 	s.runner = state.NewTaskRunner(s.state)
 
 	// empty task handler
+	workshop.ReplaceBackend(s.state, s.backend)
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
-	s.wrkmgr = workshopstate.New(s.state, s.runner, s.backend)
+	s.wrkmgr = workshopstate.New(s.state, s.runner)
 
 	// error-provoking task handler
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -20,11 +20,14 @@ type WorkshopManager struct {
 	state   *state.State
 }
 
-func New(st *state.State, runner *state.TaskRunner, server workshop.Backend) *WorkshopManager {
+func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	manager := &WorkshopManager{
-		backend: server,
-		state:   st,
+		state: st,
 	}
+
+	st.Lock()
+	manager.backend = workshop.WorkshopBackend(st)
+	st.Unlock()
 
 	runner.AddHandler("download-base", OnDo(manager.doDownloadBase), nil)
 	runner.AddHandler("create-workshop", OnDo(manager.doCreateWorkshop), manager.undoCreateWorkshop)

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 type managerSuite struct {
@@ -32,7 +33,7 @@ var _ = check.Suite(&managerSuite{})
 
 func (s *managerSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
-	s.backend = workshop.NewFakeWorkshopBackend()
+	s.backend = fakebackend.New()
 	s.runner = state.NewTaskRunner(s.state)
 	s.manager = workshopstate.New(s.state, s.runner, s.backend)
 	ctx := context.WithValue(context.TODO(), workshop.ContextUser, "testuser")

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -33,9 +33,10 @@ var _ = check.Suite(&managerSuite{})
 
 func (s *managerSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
-	s.backend = fakebackend.New()
+	s.backend, _ = fakebackend.New()
+	workshop.ReplaceBackend(s.state, s.backend)
 	s.runner = state.NewTaskRunner(s.state)
-	s.manager = workshopstate.New(s.state, s.runner, s.backend)
+	s.manager = workshopstate.New(s.state, s.runner)
 	ctx := context.WithValue(context.TODO(), workshop.ContextUser, "testuser")
 	s.project, _, _ = s.backend.CreateOrLoadProject(ctx, c.MkDir())
 	s.ctx = context.WithValue(ctx, workshop.ContextProjectId, s.project.ProjectId)
@@ -43,7 +44,7 @@ func (s *managerSuite) SetUpTest(c *check.C) {
 }
 
 func (s *managerSuite) TestAddHandlers(c *check.C) {
-	workshopstate.New(s.state, s.runner, s.backend)
+	workshopstate.New(s.state, s.runner)
 
 	c.Assert(s.runner.KnownTaskKinds(), testutil.DeepUnsortedMatches, []string{
 		"download-base",

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -93,6 +93,8 @@ func launchStoreInfo(st *state.State, ctx context.Context, projectid string, fil
 	sto := sdk.StoreService(st)
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
+		// "host" SDK is bootstrapped and installed by Workshop locally in a
+		// separate task.
 		if sd.Name == sdk.Host.String() {
 			continue
 		}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -78,6 +78,9 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, err
 		}
 
+		// Plug binds can only be fully validated when all SDKs meta data of the
+		// workshop is obtained from the store. Therefore, we validate it here
+		// in addition to essential checks in readWorkshop().
 		if err = validatePlugBinds(sdks, file); err != nil {
 			return nil, err
 		}
@@ -100,7 +103,7 @@ func launchStoreInfo(st *state.State, ctx context.Context, projectid string, fil
 		act := sdk.SdkAction{ProjectId: projectid, Workshop: file.Name, Name: sd.Name, Channel: sd.Channel, Action: sdk.Install}
 		acts = append(acts, act)
 	}
-	res, err := sto.SdkAction(ctx, nil, acts)
+	res, err := sto.SdkAction(ctx, acts)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +224,7 @@ func checkHealthHooks(st *state.State, file *workshop.File) *state.TaskSet {
 
 func constructWorkshop(st *state.State, file *workshop.File, project *workshop.Project) *state.TaskSet {
 	base := st.NewTask("download-base", fmt.Sprintf("Download %q base image", file.Base))
-	base.Set("workshop-file", file)
+	base.Set("workshop-base", file.Base)
 
 	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", file.Name))
 	create.Set("workshop-file", file)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -100,6 +100,9 @@ func launchStoreInfo(st *state.State, ctx context.Context, projectid string, fil
 	sto := sdk.StoreService(st)
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
+		if sd.Name == sdk.Host.String() {
+			continue
+		}
 		act := sdk.SdkAction{ProjectId: projectid, Workshop: file.Name, Name: sd.Name, Channel: sd.Channel, Action: sdk.Install}
 		acts = append(acts, act)
 	}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -78,13 +78,6 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, err
 		}
 
-		// Plug binds can only be fully validated when all SDKs meta data of the
-		// workshop is obtained from the store. Therefore, we validate it here
-		// in addition to essential checks in readWorkshop().
-		if err = validatePlugBinds(sdks, file); err != nil {
-			return nil, err
-		}
-
 		sets := []sdk.Setup{}
 		for _, s := range sdks {
 			sets = append(sets, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
@@ -111,47 +104,6 @@ func launchStoreInfo(st *state.State, ctx context.Context, projectid string, fil
 		return nil, err
 	}
 	return res, nil
-}
-
-func validatePlugBinds(sdks []sdk.SdkResult, file *workshop.File) error {
-	type plug struct {
-		sdk  string
-		name string
-	}
-	allbinds := make(map[plug][]plug)
-	for _, sk := range file.Sdks {
-		for n, master := range sk.Plugs {
-			master := plug{master.Bind.Sdk, master.Bind.Plug}
-			slave := plug{sk.Name, n}
-			allbinds[master] = append(allbinds[slave], slave)
-		}
-	}
-
-	allplugs := make(map[plug]*sdk.PlugInfo)
-	for _, s := range sdks {
-		for name, p := range s.Plugs {
-			allplugs[plug{s.Name, name}] = p
-		}
-	}
-
-	for master, slaves := range allbinds {
-		minfo, ok := allplugs[master]
-		if !ok {
-			return fmt.Errorf("cannot bind: SDK %q does not have a plug %q", master.sdk, master.name)
-		}
-
-		for _, sl := range slaves {
-			sinfo, ok := allplugs[sl]
-			if !ok {
-				return fmt.Errorf("cannot bind: SDK %q does not have a plug %q", sl.sdk, sl.name)
-			}
-			if minfo.Interface != sinfo.Interface {
-				return fmt.Errorf("cannot bind: %s:%s and %s:%s must be of the same interface", master.sdk, master.name, sl.sdk, sl.name)
-			}
-		}
-	}
-
-	return nil
 }
 
 func retrieveSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -69,6 +69,10 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks worksh
 	w, err := s.backend.Workshop(s.ctx, ws)
 	c.Assert(err, check.IsNil)
 
+	for _, sd := range sdks {
+		c.Assert(w.LinkSdk(s.ctx, sdk.Setup{Name: sd.Name, Channel: sd.Channel}), check.IsNil)
+	}
+
 	return w
 }
 

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 type requestSuite struct {
@@ -37,7 +38,7 @@ func (s *requestSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.ctx = context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 
-	s.backend = workshop.NewFakeWorkshopBackend()
+	s.backend = fakebackend.New()
 	s.mgr = workshopstate.New(s.state, state.NewTaskRunner(s.state), s.backend)
 	s.project, _, _ = s.backend.CreateOrLoadProject(s.ctx, c.MkDir())
 	s.ctx = context.WithValue(s.ctx, workshop.ContextProjectId, s.project.ProjectId)

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -38,8 +38,9 @@ func (s *requestSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.ctx = context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 
-	s.backend = fakebackend.New()
-	s.mgr = workshopstate.New(s.state, state.NewTaskRunner(s.state), s.backend)
+	s.backend, _ = fakebackend.New()
+	workshop.ReplaceBackend(s.state, s.backend)
+	s.mgr = workshopstate.New(s.state, state.NewTaskRunner(s.state))
 	s.project, _, _ = s.backend.CreateOrLoadProject(s.ctx, c.MkDir())
 	s.ctx = context.WithValue(s.ctx, workshop.ContextProjectId, s.project.ProjectId)
 }

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -144,7 +144,7 @@ func (s *requestSuite) TestLaunchWorkshopNoSdk(c *check.C) {
 	verifyExpectedTasks(c, tasks, expected)
 
 	var wf workshop.File
-	err := tasks[0].Get("workshop-file", &wf)
+	err := tasks[1].Get("workshop-file", &wf)
 	c.Assert(err, check.Equals, nil)
 	c.Assert(&wf, check.DeepEquals, file)
 	s.ensureTaskHasWorkshopAndProjectKeys(c, "test", ts.Tasks())

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -69,8 +69,26 @@ func (i *Info) Ref() Ref {
 	}
 }
 
+func (i *Info) SetupPlugBinds(binds map[string]*PlugBind) error {
+	if i.Type == Host {
+		return nil
+	}
+
+	for name, plug := range binds {
+		if _, ok := i.Plugs[name]; ok {
+			// The existence of plugs that are bound to it will be checked at
+			// the connecting stage, i.e. when all plugs from all SDKs are in
+			// the repository already.
+			i.PlugBinds[name] = plug
+		} else {
+			return fmt.Errorf("SDK %s/%s has no %q plug", i.Workshop, i.Name, name)
+		}
+	}
+	return nil
+}
+
 // Adds slots defined for this SDK in a workshop file.
-func (i *Info) SetWorkshopSlots(slots map[string]interface{}) error {
+func (i *Info) SetupWorkshopSlots(slots map[string]interface{}) error {
 	for name, data := range slots {
 		if _, exist := i.Slots[name]; exist {
 			return fmt.Errorf("cannot add %q slot to %q SDK: already exists", name, i.Name)

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/metautil"
@@ -69,6 +69,29 @@ func (i *Info) Ref() Ref {
 	}
 }
 
+// Adds slots defined for this SDK in a workshop file.
+func (i *Info) SetWorkshopSlots(slots map[string]interface{}) error {
+	for name, data := range slots {
+		if _, exist := i.Slots[name]; exist {
+			return fmt.Errorf("cannot add %q slot to %q SDK: already exists", name, i.Name)
+		}
+		iface, label, attrs, err := convertToSlotOrPlugData("slot", name, data)
+		if err != nil {
+			return err
+		}
+		i.Slots[name] = &SlotInfo{
+			Sdk:       i,
+			Name:      name,
+			Interface: iface,
+			Attrs:     attrs,
+			Label:     label,
+		}
+	}
+
+	SanitizePlugsSlots(i)
+	return nil
+}
+
 type Ref struct {
 	ProjectId string
 	Workshop  string
@@ -124,7 +147,6 @@ func setPlugsFromSdkYaml(y *sdkYaml, sdk *Info) error {
 		if err != nil {
 			return err
 		}
-
 		sdk.Plugs[name] = &PlugInfo{
 			Sdk:       sdk,
 			Name:      name,
@@ -162,14 +184,8 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, 
 		return data.(string), "", nil, nil
 	case nil:
 		return name, "", nil, nil
-	case map[interface{}]interface{}:
-		for keyData, valueData := range data.(map[interface{}]interface{}) {
-			key, ok := keyData.(string)
-			if !ok {
-				err := fmt.Errorf("%s %q has attribute key that is not a string (found %T)",
-					plugOrSlot, name, keyData)
-				return "", "", nil, err
-			}
+	case map[string]interface{}:
+		for key, valueData := range data.(map[string]interface{}) {
 			if strings.HasPrefix(key, "$") {
 				err := fmt.Errorf("%s %q uses reserved attribute %q", plugOrSlot, name, key)
 				return "", "", nil, err

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -503,7 +503,7 @@ slots:
 			"source":    "/var/cache",
 		},
 	}
-	err = info.SetWorkshopSlots(slots)
+	err = info.SetupWorkshopSlots(slots)
 	c.Assert(err, check.IsNil)
 	c.Assert(info.Slots, check.HasLen, 2)
 	c.Assert(info.Plugs, check.HasLen, 0)
@@ -539,6 +539,6 @@ slots:
 			"source": "/data",
 		},
 	}
-	err = info.SetWorkshopSlots(slots)
+	err = info.SetupWorkshopSlots(slots)
 	c.Assert(err, check.ErrorMatches, `cannot add "training" slot to "sdk" SDK: already exists`)
 }

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -114,9 +114,9 @@ plugs:
 	})
 }
 
-func (s *SdkSuite) TestUnmarshalLastPlugDefinitionWins(c *check.C) {
+func (s *SdkSuite) TestUnmarshalDuplicatePlugFails(c *check.C) {
 	// NOTE: yaml content cannot use tabs, indent the section with spaces.
-	info, err := sdk.ReadSdkInfo([]byte(`
+	_, err := sdk.ReadSdkInfo([]byte(`
 name: sdk
 plugs:
     net:
@@ -126,15 +126,7 @@ plugs:
         interface: content
         attr: 2
 `), s.projectId, "ws")
-	c.Assert(err, check.IsNil)
-	c.Assert(info.Plugs, check.HasLen, 1)
-	c.Assert(info.Slots, check.HasLen, 0)
-	c.Assert(info.Plugs["net"], check.DeepEquals, &sdk.PlugInfo{
-		Sdk:       info,
-		Name:      "net",
-		Interface: "content",
-		Attrs:     map[string]interface{}{"attr": int64(2)},
-	})
+	c.Assert(err, check.ErrorMatches, `(?s).*line 7: mapping key \"net\" already defined at line 4`)
 }
 
 func (s *SdkSuite) TestUnmarshalPlugWithoutInterfaceName(c *check.C) {
@@ -208,7 +200,7 @@ plugs:
     net:
         1: ok
 `), s.projectId, "ws")
-	c.Assert(err, check.ErrorMatches, `plug "net" has attribute key that is not a string \(found int\)`)
+	c.Assert(err, check.ErrorMatches, `plug "net" has malformed definition \(found map\[interface {}\]interface {}\)`)
 }
 
 func (s *SdkSuite) TestUnmarshalCorruptedPlugWithEmptyAttributeKey(c *check.C) {
@@ -353,9 +345,9 @@ slots:
 	})
 }
 
-func (s *SdkSuite) TestUnmarshalLastSlotDefinitionWins(c *check.C) {
+func (s *SdkSuite) TestUnmarshalDuplicateSlotFail(c *check.C) {
 	// NOTE: yaml content cannot use tabs, indent the section with spaces.
-	info, err := sdk.ReadSdkInfo([]byte(`
+	_, err := sdk.ReadSdkInfo([]byte(`
 name: sdk
 slots:
     net:
@@ -365,15 +357,7 @@ slots:
         interface: content
         attr: 2
 `), s.projectId, "ws")
-	c.Assert(err, check.IsNil)
-	c.Check(info.Plugs, check.HasLen, 0)
-	c.Check(info.Slots, check.HasLen, 1)
-	c.Assert(info.Slots["net"], check.DeepEquals, &sdk.SlotInfo{
-		Sdk:       info,
-		Name:      "net",
-		Interface: "content",
-		Attrs:     map[string]interface{}{"attr": int64(2)},
-	})
+	c.Assert(err, check.ErrorMatches, `(?s).*line 7: mapping key \"net\" already defined at line 4`)
 }
 
 func (s *SdkSuite) TestUnmarshalSlotWithoutInterfaceName(c *check.C) {
@@ -446,7 +430,7 @@ slots:
     net:
         1: ok
 `), s.projectId, "ws")
-	c.Assert(err, check.ErrorMatches, `slot "net" has attribute key that is not a string \(found int\)`)
+	c.Assert(err, check.ErrorMatches, `slot \"net\" has malformed definition \(found map\[interface {}\]interface {}\)`)
 }
 
 func (s *SdkSuite) TestUnmarshalCorruptedSlotWithEmptyAttributeKey(c *check.C) {
@@ -492,4 +476,69 @@ slots:
         foo: null
 `), s.projectId, "ws")
 	c.Assert(err, check.ErrorMatches, `attribute "foo" of slot \"serial\": invalid scalar:.*`)
+}
+
+func (s *SdkSuite) TestAddingWorkshopSlotOK(c *check.C) {
+	var mockYaml = []byte(`name: sdk
+base: ubuntu@20.04
+slots:
+  training:
+    interface: content
+    source: /project
+`)
+
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Slots, check.HasLen, 1)
+	c.Assert(info.Plugs, check.HasLen, 0)
+	c.Assert(*info.Slots["training"], check.DeepEquals, sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "training",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"source": "/project"},
+	})
+	slots := map[string]interface{}{
+		"cache": map[string]interface{}{
+			"interface": "content",
+			"source":    "/var/cache",
+		},
+	}
+	err = info.SetWorkshopSlots(slots)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Slots, check.HasLen, 2)
+	c.Assert(info.Plugs, check.HasLen, 0)
+	c.Assert(*info.Slots["cache"], check.DeepEquals, sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "cache",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"source": "/var/cache"},
+	})
+}
+
+func (s *SdkSuite) TestAddingAlreadyExistingSlotFails(c *check.C) {
+	var mockYaml = []byte(`name: sdk
+base: ubuntu@20.04
+slots:
+  training:
+    interface: content
+    source: /project
+`)
+
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Slots, check.HasLen, 1)
+	c.Assert(info.Plugs, check.HasLen, 0)
+	c.Assert(*info.Slots["training"], check.DeepEquals, sdk.SlotInfo{
+		Sdk:       info,
+		Name:      "training",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"source": "/project"},
+	})
+	slots := map[string]interface{}{
+		"training": map[string]interface{}{
+			"source": "/data",
+		},
+	}
+	err = info.SetWorkshopSlots(slots)
+	c.Assert(err, check.ErrorMatches, `cannot add "training" slot to "sdk" SDK: already exists`)
 }

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -59,7 +59,7 @@ func StoreService(st *state.State) Store {
 }
 
 type Store interface {
-	SdkAction(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error)
+	SdkAction(ctx context.Context, actions []SdkAction) ([]SdkResult, error)
 	DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) error
 }
 
@@ -70,8 +70,7 @@ func NewFakeStore() Store {
 }
 
 type TestActionCall struct {
-	CurrentSdks map[string]*Info
-	Actions     []SdkAction
+	Actions []SdkAction
 }
 
 type TestDownloadCall struct {
@@ -84,11 +83,11 @@ type FakeStore struct {
 	downloadLock  sync.Mutex
 	DownloadCalls []TestDownloadCall
 
-	ActionCallback   func(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error)
+	ActionCallback   func(ctx context.Context, actions []SdkAction) ([]SdkResult, error)
 	DownloadCallback func(ctx context.Context, setup Setup, report *progress.Reporter) error
 }
 
-func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error)) func() {
+func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, actions []SdkAction) ([]SdkResult, error)) func() {
 	old := f.ActionCallback
 	f.ActionCallback = fa
 	return func() {
@@ -104,13 +103,12 @@ func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup
 	}
 }
 
-func (f *FakeStore) SdkAction(ctx context.Context, currentSdks map[string]*Info, actions []SdkAction) ([]SdkResult, error) {
+func (f *FakeStore) SdkAction(ctx context.Context, actions []SdkAction) ([]SdkResult, error) {
 	f.ActionCalls = append(f.ActionCalls, TestActionCall{
-		CurrentSdks: currentSdks,
-		Actions:     actions,
+		Actions: actions,
 	})
 	if f.ActionCallback != nil {
-		return f.ActionCallback(ctx, currentSdks, actions)
+		return f.ActionCallback(ctx, actions)
 	}
 	return nil, nil
 }

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -17,7 +17,6 @@ var (
 )
 
 func Validate(sdk *Info) error {
-
 	if !sdkName.MatchString(sdk.Name) {
 		return fmt.Errorf("invalid sdk name: %q", sdk.Name)
 	}

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
 )
 
@@ -177,6 +178,33 @@ type Backend interface {
 	// and redirect its IO using args.ExecControls. ExecContext.Environment will
 	// contain full (actual)
 	Exec(ctx context.Context, name string, args *Execution) (ExecContext, error)
+}
+
+type cachedBackendKey struct{}
+
+// ReplaceBackend replaces the store used by the manager.
+func ReplaceBackend(state *state.State, backend Backend) {
+	state.Lock()
+	state.Cache(cachedBackendKey{}, backend)
+	state.Unlock()
+}
+
+func cachedBackend(st *state.State) Backend {
+	backend := st.Cached(cachedBackendKey{})
+	if backend == nil {
+		return nil
+	}
+	return backend.(Backend)
+}
+
+// Store returns the store service provided by the optional device context or
+// the one used by the snapstate package if the former has no
+// override.
+func WorkshopBackend(st *state.State) Backend {
+	if cachedStore := cachedBackend(st); cachedStore != nil {
+		return cachedStore
+	}
+	panic("internal error: needing the store before managers have initialized it")
 }
 
 func FakeUserLookup(f func(name string) (*user.User, error)) func() {

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -68,14 +68,17 @@ type Stash interface {
 }
 
 type StateStorage interface {
-	// Create a temporary state storage volume for the workshop. It can be
-	// mounted to the instance separately. This does not mount the device to the
-	// workshop, it must be mounted to the required workshop as a separate
-	// operation (see AddWorkshopDevice).
+	// Create a temporary state storage volume for the workshop. It does not
+	// mount the device to the workshop, it must be mounted to the required
+	// workshop as a separate operation.
 	CreateStateStorage(ctx context.Context, name string) error
 
-	// Delete a temporary state storage volume for the workshop. It does
-	// not unmount the volume from the workshop if mounted.
+	AttachStateStorage(ctx context.Context, wp, name string) error
+
+	DetachStateStorage(ctx context.Context, wp, name string) error
+
+	// Delete a temporary state storage volume for the workshop. It does not
+	// unmount the volume from the workshop if mounted.
 	DeleteStateStorage(ctx context.Context, name string) error
 }
 

--- a/internal/workshop/fake_backend.go
+++ b/internal/workshop/fake_backend.go
@@ -141,6 +141,7 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *File) er
 	}
 
 	ws := &FakeWorkshop{}
+	ws.WorkshopFilesystem = NewFakeWorkshopFs()
 	ws.Workshop = &Workshop{Backend: f,
 		Name:    file.Name,
 		Running: false,
@@ -149,30 +150,12 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *File) er
 		File:    file,
 	}
 	ws.Config = make(map[string]string)
+	ws.Config[ConfigWorkshopContent] = `{}`
 	ws.Devices = make(map[string]map[string]string)
-	ws.WorkshopFilesystem = NewFakeWorkshopFs()
 	ws.Content = make(map[string]sdk.Setup)
-
-	content := make(map[string]sdk.Setup)
-	f.Workshops[projectId][file.Name] = ws
-
-	for _, s := range file.Sdks {
-		setup := sdk.Setup{
-			Name:    s.Name,
-			Channel: s.Channel,
-		}
-		ws.LinkSdk(ctx, setup)
-		content[setup.Name] = setup
-	}
-
-	buf, err := json.Marshal(content)
-	if err != nil {
-		return err
-	}
-
-	ws.Config[ConfigWorkshopContent] = string(buf)
-
 	ws.Profiles = make([]SdkProfile, 0)
+
+	f.Workshops[projectId][file.Name] = ws
 	return nil
 }
 

--- a/internal/workshop/fake_backend.go
+++ b/internal/workshop/fake_backend.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 
 	"github.com/canonical/lxd/shared/api"
+	"github.com/spf13/afero"
 	"golang.org/x/exp/slices"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 )
@@ -54,6 +57,8 @@ type FakeWorkshopBackend struct {
 	Workshops map[string]map[string]*FakeWorkshop
 	// workshops put to stash (e.g. during refresh)
 	StashedWorkshops map[string]map[string]*FakeWorkshop
+	// state storages, the key is a volume name
+	WorkshopStateStorages map[string]map[string]bool
 	// the key is a username
 	projects map[string][]*Project
 
@@ -77,6 +82,7 @@ func NewFakeWorkshopBackend() *FakeWorkshopBackend {
 	var be FakeWorkshopBackend
 	be.Workshops = make(map[string]map[string]*FakeWorkshop)
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
+	be.WorkshopStateStorages = make(map[string]map[string]bool)
 	be.projects = make(map[string][]*Project)
 
 	be.ExecCallback = DoExecDefault
@@ -405,6 +411,41 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	workshop.Name = StashNamePrefix + name
 	delete(s.Workshops[projectId], name)
 	return nil
+}
+
+func (s *FakeWorkshopBackend) AttachStateStorage(ctx context.Context, wp, name string) error {
+	paths := s.WorkshopStateStorages[name]
+	if paths == nil {
+		s.WorkshopStateStorages[name] = map[string]bool{}
+		return nil
+	}
+	wfs, err := s.WorkshopFs(ctx, wp)
+	if err != nil {
+		return err
+	}
+	defer wfs.Close()
+	for path := range paths {
+		if err = wfs.MkdirAll(path, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *FakeWorkshopBackend) DetachStateStorage(ctx context.Context, wp, name string) error {
+	wfs, err := s.WorkshopFs(ctx, wp)
+	if err != nil {
+		return err
+	}
+	defer wfs.Close()
+
+	afero.Walk(wfs, dirs.WorkshopStateDir, func(path string, info fs.FileInfo, err error) error {
+		s.WorkshopStateStorages[name][path] = true
+		return nil
+	})
+
+	err = wfs.RemoveAll(dirs.WorkshopStateDir)
+	return err
 }
 
 func (s *FakeWorkshopBackend) CreateStateStorage(ctx context.Context, name string) error {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -1,4 +1,4 @@
-package workshop
+package fakebackend
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"os"
 
 	"github.com/canonical/lxd/shared/api"
 	"github.com/spf13/afero"
@@ -15,23 +16,24 @@ import (
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 /* Fake backend implementation for tests */
 
-type ExecFunc func(ctx context.Context, name string, args *Execution) (ExecContext, error)
+type ExecFunc func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error)
 
 type FakeWorkshop struct {
-	*Workshop
+	*workshop.Workshop
 	Config             map[string]string
 	Devices            map[string]map[string]string
-	WorkshopFilesystem WorkshopFs
-	Profiles           []SdkProfile
+	WorkshopFilesystem workshop.WorkshopFs
+	Profiles           []workshop.SdkProfile
 }
 
 type ExecCall struct {
 	Name string
-	Args *Execution
+	Args *workshop.Execution
 }
 
 type FsCall struct {
@@ -40,7 +42,7 @@ type FsCall struct {
 
 type AssignProfileCall struct {
 	Name    string
-	Profile SdkProfile
+	Profile workshop.SdkProfile
 }
 
 type RemoveProfileCall struct {
@@ -60,15 +62,15 @@ type FakeWorkshopBackend struct {
 	// state storages, the key is a volume name
 	WorkshopStateStorages map[string]map[string]bool
 	// the key is a username
-	projects map[string][]*Project
+	projects map[string][]*workshop.Project
 
 	ExecCallback ExecFunc
 	ExecCalls    []*ExecCall
 
-	WorkshopFsCallback func(ctx context.Context, name string) (WorkshopFs, error)
+	WorkshopFsCallback func(ctx context.Context, name string) (workshop.WorkshopFs, error)
 	WorkshopFsCalls    []*FsCall
 
-	AssignProfileCallback func(ctx context.Context, workshop string, profile SdkProfile) error
+	AssignProfileCallback func(ctx context.Context, workshop string, profile workshop.SdkProfile) error
 	AssignProfileCalls    []*AssignProfileCall
 
 	RemoveProfileCallback func(ctx context.Context, workshop string, profile string) error
@@ -78,60 +80,60 @@ type FakeWorkshopBackend struct {
 	DownloadBaseCalls    []*DownloadCall
 }
 
-func NewFakeWorkshopBackend() *FakeWorkshopBackend {
+func New() *FakeWorkshopBackend {
 	var be FakeWorkshopBackend
 	be.Workshops = make(map[string]map[string]*FakeWorkshop)
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
 	be.WorkshopStateStorages = make(map[string]map[string]bool)
-	be.projects = make(map[string][]*Project)
+	be.projects = make(map[string][]*workshop.Project)
 
 	be.ExecCallback = DoExecDefault
 
 	return &be
 }
 
-func (s *FakeWorkshopBackend) CreateOrLoadProject(ctx context.Context, path string) (*Project, bool, error) {
-	username, ok := ctx.Value(ContextUser).(string)
+func (s *FakeWorkshopBackend) CreateOrLoadProject(ctx context.Context, path string) (*workshop.Project, bool, error) {
+	username, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
 		return nil, false, errors.New("user not found")
 	}
 	if val, ok := s.projects[username]; ok {
-		idx := slices.IndexFunc(val, func(p *Project) bool { return p.Path == path })
+		idx := slices.IndexFunc(val, func(p *workshop.Project) bool { return p.Path == path })
 		if idx != -1 {
 			return val[idx], false, nil
 		}
 	} else {
-		s.projects[username] = make([]*Project, 0)
+		s.projects[username] = make([]*workshop.Project, 0)
 	}
 
-	prjId, _ := NewProjectId()
-	newPrj := &Project{ProjectId: prjId, Path: path}
+	prjId, _ := workshop.NewProjectId()
+	newPrj := &workshop.Project{ProjectId: prjId, Path: path}
 	s.projects[username] = append(s.projects[username], newPrj)
 	return newPrj, true, nil
 }
 
-func (f *FakeWorkshopBackend) Projects(ctx context.Context) (map[string][]*Project, error) {
-	userName, ok := ctx.Value(ContextUser).(string)
+func (f *FakeWorkshopBackend) Projects(ctx context.Context) (map[string][]*workshop.Project, error) {
+	userName, ok := ctx.Value(workshop.ContextUser).(string)
 	if ok {
-		return map[string][]*Project{userName: f.projects[userName]}, nil
+		return map[string][]*workshop.Project{userName: f.projects[userName]}, nil
 	}
-	all := map[string][]*Project{}
+	all := map[string][]*workshop.Project{}
 	for name, prjs := range f.projects {
 		all[name] = prjs
 	}
 	return all, nil
 }
 
-func (f *FakeWorkshopBackend) project(user, id string) *Project {
+func (f *FakeWorkshopBackend) project(user, id string) *workshop.Project {
 	prjs := f.projects[user]
-	idx := slices.IndexFunc(prjs, func(p *Project) bool { return p.ProjectId == id })
+	idx := slices.IndexFunc(prjs, func(p *workshop.Project) bool { return p.ProjectId == id })
 	if idx != -1 {
 		return prjs[idx]
 	}
 	return nil
 }
 
-func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *File) error {
+func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *workshop.File) error {
 	user, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -147,8 +149,8 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *File) er
 	}
 
 	ws := &FakeWorkshop{}
-	ws.WorkshopFilesystem = NewFakeWorkshopFs()
-	ws.Workshop = &Workshop{Backend: f,
+	ws.WorkshopFilesystem = NewWorkshopFs()
+	ws.Workshop = &workshop.Workshop{Backend: f,
 		Name:    file.Name,
 		Running: false,
 		Project: prj,
@@ -156,10 +158,10 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *File) er
 		File:    file,
 	}
 	ws.Config = make(map[string]string)
-	ws.Config[ConfigWorkshopContent] = `{}`
+	ws.Config[workshop.ConfigWorkshopContent] = `{}`
 	ws.Devices = make(map[string]map[string]string)
 	ws.Content = make(map[string]sdk.Setup)
-	ws.Profiles = make([]SdkProfile, 0)
+	ws.Profiles = make([]workshop.SdkProfile, 0)
 
 	f.Workshops[projectId][file.Name] = ws
 	return nil
@@ -174,7 +176,7 @@ func (f *FakeWorkshopBackend) RemoveWorkshop(ctx context.Context, name string) e
 	prj := f.project(user, projectId)
 
 	if _, ok := f.Workshops[prj.ProjectId][name]; !ok {
-		return ErrWorkshopNotFound
+		return workshop.ErrWorkshopNotFound
 	}
 
 	delete(f.Workshops[prj.ProjectId], name)
@@ -202,7 +204,7 @@ func (s *FakeWorkshopBackend) StopWorkshop(ctx context.Context, name string, for
 	return nil
 }
 
-func (f *FakeWorkshopBackend) AddWorkshopDevice(ctx context.Context, name string, props Device) error {
+func (f *FakeWorkshopBackend) AddWorkshopDevice(ctx context.Context, name string, props workshop.Device) error {
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -220,7 +222,7 @@ func (f *FakeWorkshopBackend) RemoveWorkshopDevice(ctx context.Context, name str
 	return nil
 }
 
-func (f *FakeWorkshopBackend) AssignProfile(ctx context.Context, workshop string, profile SdkProfile) error {
+func (f *FakeWorkshopBackend) AssignProfile(ctx context.Context, workshop string, profile workshop.SdkProfile) error {
 	f.AssignProfileCalls = append(f.AssignProfileCalls, &AssignProfileCall{Name: workshop, Profile: profile})
 
 	_, projectId, err := f.userProject(ctx)
@@ -235,44 +237,44 @@ func (f *FakeWorkshopBackend) AssignProfile(ctx context.Context, workshop string
 	return nil
 }
 
-func (s *FakeWorkshopBackend) Profile(ctx context.Context, w string, pr string) (SdkProfile, error) {
+func (s *FakeWorkshopBackend) Profile(ctx context.Context, w string, pr string) (workshop.SdkProfile, error) {
 	_, projectId, err := s.userProject(ctx)
 	if err != nil {
-		return SdkProfile{}, err
+		return workshop.SdkProfile{}, err
 	}
 	wp, ok := s.Workshops[projectId][w]
 	if !ok {
-		return SdkProfile{}, ErrWorkshopNotFound
+		return workshop.SdkProfile{}, workshop.ErrWorkshopNotFound
 	}
 
 	profiles := wp.Profiles
-	idx := slices.IndexFunc(profiles, func(p SdkProfile) bool { return p.Name() == pr })
+	idx := slices.IndexFunc(profiles, func(p workshop.SdkProfile) bool { return p.Name() == pr })
 	if idx != -1 {
 		return s.Workshops[projectId][w].Profiles[idx], nil
 	}
-	return SdkProfile{}, ErrSdkProfileNotFound
+	return workshop.SdkProfile{}, workshop.ErrSdkProfileNotFound
 }
 
-func (s *FakeWorkshopBackend) RemoveProfile(ctx context.Context, workshop string, profile string) error {
-	s.RemoveProfileCalls = append(s.RemoveProfileCalls, &RemoveProfileCall{Name: workshop, Profile: profile})
+func (s *FakeWorkshopBackend) RemoveProfile(ctx context.Context, wp string, profile string) error {
+	s.RemoveProfileCalls = append(s.RemoveProfileCalls, &RemoveProfileCall{Name: wp, Profile: profile})
 
 	if s.RemoveProfileCallback != nil {
-		return s.RemoveProfileCallback(ctx, workshop, profile)
+		return s.RemoveProfileCallback(ctx, wp, profile)
 	}
 	_, projectId, err := s.userProject(ctx)
 	if err != nil {
 		return err
 	}
-	profiles := s.Workshops[projectId][workshop].Profiles
-	idx := slices.IndexFunc(profiles, func(p SdkProfile) bool { return p.Name() == profile })
+	profiles := s.Workshops[projectId][wp].Profiles
+	idx := slices.IndexFunc(profiles, func(p workshop.SdkProfile) bool { return p.Name() == profile })
 	if idx != -1 {
-		s.Workshops[projectId][workshop].Profiles = slices.Delete(profiles, idx, idx+1)
+		s.Workshops[projectId][wp].Profiles = slices.Delete(profiles, idx, idx+1)
 		return nil
 	}
-	return ErrSdkProfileNotFound
+	return workshop.ErrSdkProfileNotFound
 }
 
-func (f *FakeWorkshopBackend) Profiles(ctx context.Context, workshop string) ([]SdkProfile, error) {
+func (f *FakeWorkshopBackend) Profiles(ctx context.Context, workshop string) ([]workshop.SdkProfile, error) {
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return nil, err
@@ -280,7 +282,7 @@ func (f *FakeWorkshopBackend) Profiles(ctx context.Context, workshop string) ([]
 	return f.Workshops[projectId][workshop].Profiles, nil
 }
 
-func (f *FakeWorkshopBackend) AddWorkshopConfig(ctx context.Context, name string, item *WorkshopConfigValue) error {
+func (f *FakeWorkshopBackend) AddWorkshopConfig(ctx context.Context, name string, item *workshop.WorkshopConfigValue) error {
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -298,7 +300,7 @@ func (f *FakeWorkshopBackend) RemoveWorkshopConfig(ctx context.Context, name str
 	return nil
 }
 
-func (f *FakeWorkshopBackend) Workshop(ctx context.Context, name string) (*Workshop, error) {
+func (f *FakeWorkshopBackend) Workshop(ctx context.Context, name string) (*workshop.Workshop, error) {
 	user, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return nil, err
@@ -308,26 +310,26 @@ func (f *FakeWorkshopBackend) Workshop(ctx context.Context, name string) (*Works
 	if project == nil {
 		return nil, api.StatusErrorf(404, "project not found")
 	}
-	workshop := f.Workshops[projectId][name]
-	if workshop == nil {
-		return nil, ErrWorkshopNotFound
+	wp := f.Workshops[projectId][name]
+	if wp == nil {
+		return nil, workshop.ErrWorkshopNotFound
 	}
 
 	var c map[string]sdk.Setup
-	if err := json.Unmarshal([]byte(f.Workshops[projectId][name].Config[ConfigWorkshopContent]), &c); err != nil {
+	if err := json.Unmarshal([]byte(f.Workshops[projectId][name].Config[workshop.ConfigWorkshopContent]), &c); err != nil {
 		return nil, err
 	}
-	workshop.Content = c
-	return workshop.Workshop, nil
+	wp.Content = c
+	return wp.Workshop, nil
 }
 
-func (f *FakeWorkshopBackend) ProjectWorkshops(ctx context.Context) ([]*File, []*Workshop, error) {
+func (f *FakeWorkshopBackend) ProjectWorkshops(ctx context.Context) ([]*workshop.File, []*workshop.Workshop, error) {
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var workshops = make([]*Workshop, 0)
+	var workshops = make([]*workshop.Workshop, 0)
 	for _, i := range f.Workshops[projectId] {
 		ws, _ := f.Workshop(ctx, i.Name)
 		workshops = append(workshops, ws)
@@ -335,8 +337,8 @@ func (f *FakeWorkshopBackend) ProjectWorkshops(ctx context.Context) ([]*File, []
 	return nil, workshops, nil
 }
 
-func (f *FakeWorkshopBackend) GetWorkshopsByConfig(ctx context.Context, filter WorkshopConfigFilter) ([]*Workshop, error) {
-	res := make([]*Workshop, 0)
+func (f *FakeWorkshopBackend) GetWorkshopsByConfig(ctx context.Context, filter workshop.WorkshopConfigFilter) ([]*workshop.Workshop, error) {
+	res := make([]*workshop.Workshop, 0)
 	for _, i := range f.Workshops {
 		for _, j := range i {
 			if filter(j.Config) {
@@ -347,7 +349,7 @@ func (f *FakeWorkshopBackend) GetWorkshopsByConfig(ctx context.Context, filter W
 	return res, nil
 }
 
-func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (WorkshopFs, error) {
+func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (workshop.WorkshopFs, error) {
 	s.WorkshopFsCalls = append(s.WorkshopFsCalls, &FsCall{Name: name})
 	if s.WorkshopFsCallback != nil {
 		return s.WorkshopFsCallback(ctx, name)
@@ -360,13 +362,13 @@ func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (Work
 	return s.Workshops[projectId][name].WorkshopFilesystem, nil
 }
 
-func (f *FakeWorkshopBackend) Exec(ctx context.Context, name string, args *Execution) (ExecContext, error) {
+func (f *FakeWorkshopBackend) Exec(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 	f.ExecCalls = append(f.ExecCalls, &ExecCall{name, args})
 	return f.ExecCallback(ctx, name, args)
 }
 
-func DoExecDefault(ctx context.Context, name string, args *Execution) (ExecContext, error) {
-	return ExecContext{
+func DoExecDefault(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	return workshop.ExecContext{
 		WaitExecution: func(ctx context.Context) error {
 			return nil
 		},
@@ -383,13 +385,13 @@ func (s *FakeWorkshopBackend) UnstashWorkshop(ctx context.Context, name string) 
 		return err
 	}
 
-	workshop := s.StashedWorkshops[projectId][StashNamePrefix+name]
-	if workshop == nil {
-		return ErrWorkshopNotFound
+	wp := s.StashedWorkshops[projectId][workshop.StashNamePrefix+name]
+	if wp == nil {
+		return workshop.ErrWorkshopNotFound
 	}
-	delete(s.StashedWorkshops[projectId], StashNamePrefix+name)
-	workshop.Name = name
-	s.Workshops[projectId][name] = workshop
+	delete(s.StashedWorkshops[projectId], workshop.StashNamePrefix+name)
+	wp.Name = name
+	s.Workshops[projectId][name] = wp
 	return nil
 }
 
@@ -399,16 +401,16 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 		return err
 	}
 
-	workshop := s.Workshops[projectId][name]
-	if workshop == nil {
-		return ErrWorkshopNotFound
+	wp := s.Workshops[projectId][name]
+	if wp == nil {
+		return workshop.ErrWorkshopNotFound
 	}
 
 	if s.StashedWorkshops[projectId] == nil {
 		s.StashedWorkshops[projectId] = make(map[string]*FakeWorkshop)
 	}
-	s.StashedWorkshops[projectId][StashNamePrefix+name] = workshop
-	workshop.Name = StashNamePrefix + name
+	s.StashedWorkshops[projectId][workshop.StashNamePrefix+name] = wp
+	wp.Name = workshop.StashNamePrefix + name
 	delete(s.Workshops[projectId], name)
 	return nil
 }
@@ -457,12 +459,12 @@ func (s *FakeWorkshopBackend) DeleteStateStorage(ctx context.Context, name strin
 }
 
 func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, error) {
-	projectId, ok := ctx.Value(ContextProjectId).(string)
+	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return "", "", fmt.Errorf("context key project-id not found")
 	}
 
-	userName, ok := ctx.Value(ContextUser).(string)
+	userName, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
 		return "", "", fmt.Errorf("context key user not found")
 	}
@@ -474,4 +476,23 @@ func (b *FakeWorkshopBackend) Download(ctx context.Context, base string, report 
 		return b.DownloadBaseCallback(ctx, base, report)
 	}
 	return nil
+}
+
+/* Fake workshop fs implementation for tests */
+
+type FakeInstanceFs struct {
+	afero.Fs
+}
+
+func NewWorkshopFs() workshop.WorkshopFs {
+	var fs FakeInstanceFs
+	fs.Fs = afero.NewMemMapFs()
+	return &fs
+}
+
+func (w *FakeInstanceFs) Symlink(source, target string) error {
+	return w.Fs.Mkdir(target, os.ModeSymlink)
+}
+
+func (w *FakeInstanceFs) Close() {
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -80,7 +80,7 @@ type FakeWorkshopBackend struct {
 	DownloadBaseCalls    []*DownloadCall
 }
 
-func New() *FakeWorkshopBackend {
+func New() (workshop.Backend, error) {
 	var be FakeWorkshopBackend
 	be.Workshops = make(map[string]map[string]*FakeWorkshop)
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
@@ -89,7 +89,7 @@ func New() *FakeWorkshopBackend {
 
 	be.ExecCallback = DoExecDefault
 
-	return &be
+	return &be, nil
 }
 
 func (s *FakeWorkshopBackend) CreateOrLoadProject(ctx context.Context, path string) (*workshop.Project, bool, error) {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -22,13 +22,6 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-type Backend struct {
-	nvidiaRuntime bool
-
-	imageLock        sync.Mutex
-	currentDownloads map[string]*downloadOp
-}
-
 const (
 	LxdSock     = "/var/snap/lxd/common/lxd/unix.socket"
 	storagePool = "default"
@@ -37,6 +30,25 @@ const (
 var (
 	defaultDevices = createDefaultDevices
 )
+
+var (
+	// However many backend instances are created, downloads are always a single
+	// instance map with the LXD backend.
+	imageLock        sync.Mutex
+	currentDownloads map[string]*downloadOp
+)
+
+func init() {
+	imageLock.Lock()
+	defer imageLock.Unlock()
+	if currentDownloads == nil {
+		currentDownloads = make(map[string]*downloadOp)
+	}
+}
+
+type Backend struct {
+	nvidiaRuntime bool
+}
 
 func InstanceName(name string, project_id string) string {
 	return fmt.Sprintf("%s-%s", name, project_id)
@@ -47,9 +59,7 @@ func ImageAlias(name string) string {
 }
 
 func New() (workshop.Backend, error) {
-	server := Backend{
-		currentDownloads: make(map[string]*downloadOp),
-	}
+	server := Backend{}
 
 	if srv := os.Getenv("WORKSHOP_IMAGE_SERVER"); srv != "" {
 		imageServer = srv

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -290,7 +290,7 @@ func (s *Backend) AddWorkshopDevice(ctx context.Context, name string, device wor
 		return err
 	}
 
-	return op.Wait()
+	return op.WaitContext(ctx)
 }
 
 func (s *Backend) RemoveWorkshopDevice(ctx context.Context, name string, device string) error {
@@ -311,9 +311,12 @@ func (s *Backend) RemoveWorkshopDevice(ctx context.Context, name string, device 
 	}
 
 	delete(inst.Devices, device)
-	op, _ := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+	op, err := conn.UpdateInstance(inst.Name, inst.InstancePut, etag)
+	if err != nil {
+		return err
+	}
 
-	return op.Wait()
+	return op.WaitContext(ctx)
 }
 
 func (s *Backend) execCommand(conn lxd.InstanceServer, ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
@@ -632,6 +635,14 @@ func (s *Backend) CreateStateStorage(ctx context.Context, name string) error {
 	vol.Config = map[string]string{}
 
 	return conn.CreateStoragePoolVolume(storagePool, vol)
+}
+
+func (s *Backend) AttachStateStorage(ctx context.Context, wp, name string) error {
+	return s.AddWorkshopDevice(ctx, wp, Volume(name, dirs.WorkshopStateDir, name))
+}
+
+func (s *Backend) DetachStateStorage(ctx context.Context, wp, name string) error {
+	return s.RemoveWorkshopDevice(ctx, wp, name)
 }
 
 func (s *Backend) DeleteStateStorage(ctx context.Context, name string) error {

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -66,7 +66,7 @@ func (s *Backend) AssignProfile(ctx context.Context, w string, profile workshop.
 					return err
 				}
 			} else if !info.IsDir() {
-				return fmt.Errorf(`"target" %s is not a directory`, target)
+				return fmt.Errorf(`%s:%s's "target" %s is not a directory`, profile.Sdk, dev.Name, target)
 			}
 
 			source := dev.Properties["source"]
@@ -82,7 +82,7 @@ func (s *Backend) AssignProfile(ctx context.Context, w string, profile workshop.
 				// fail but there will still be changes made to the instance
 				// configuration which is not acceptable.
 				if !osutil.IsDir(abs) {
-					return fmt.Errorf(`"source" %s is not an existing directory`, abs)
+					return fmt.Errorf(`%s:%s's "source" %s is not an existing directory`, profile.Sdk, dev.Name, abs)
 				}
 				dev.Properties["source"] = abs
 				continue

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -27,9 +27,24 @@ func (s *Backend) AssignProfile(ctx context.Context, w string, profile workshop.
 	}
 	defer conn.Disconnect()
 
-	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
+	uname, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return fmt.Errorf("context key user not found")
+	}
+
+	user, err := workshop.LookupUsername(uname)
+	if err != nil {
+		return err
+	}
+
+	pid, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return fmt.Errorf("context key project-id not found")
+	}
+
+	p, err := s.loadProjectFromId(conn, ctx, pid)
+	if err != nil {
+		return err
 	}
 
 	fs, err := s.WorkshopFs(ctx, w)
@@ -51,7 +66,39 @@ func (s *Backend) AssignProfile(ctx context.Context, w string, profile workshop.
 					return err
 				}
 			} else if !info.IsDir() {
-				return fmt.Errorf("cannot create a workshop mount with target %q: the target is not a directory", target)
+				return fmt.Errorf(`"target" %s is not a directory`, target)
+			}
+
+			source := dev.Properties["source"]
+			// A path relative to the project directory (from the slot
+			// declared in a workshop).
+			if filepath.IsLocal(source) {
+				abs := filepath.Join(p.Path, source)
+				// Ensure that the source path exists here. LXD allows to
+				// require the source attribute when updating an instance
+				// configuration but it would fail and still save changes to the
+				// instace profile even if the source does not exist. For
+				// Workshop that would mean that the interface connection would
+				// fail but there will still be changes made to the instance
+				// configuration which is not acceptable.
+				if !osutil.IsDir(abs) {
+					return fmt.Errorf(`"source" %s is not an existing directory`, abs)
+				}
+				dev.Properties["source"] = abs
+				continue
+			}
+
+			// The dir is being dynamically created (no source attribute
+			// provided by the slot).
+			if !osutil.IsDir(source) {
+				uid, gid, err := osutil.UidGid(user)
+				if err != nil {
+					return err
+				}
+
+				if err = osutil.MkdirAllChown(source, 0744, uid, gid); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -63,7 +110,7 @@ func (s *Backend) AssignProfile(ctx context.Context, w string, profile workshop.
 		}
 	}
 
-	lxdname := profileName(projectId, w, profile.Name())
+	lxdname := profileName(pid, w, profile.Name())
 	lxddevs := make(map[string]map[string]string)
 	for _, dev := range profile.Devices {
 		if lxddevs[dev.Name] == nil {
@@ -77,7 +124,7 @@ func (s *Backend) AssignProfile(ctx context.Context, w string, profile workshop.
 	}
 
 	// Either create or update an existing LXD profile for the SDK so that later
-	// it can be assigned to the required workshop
+	// it can be assigned to the required workshop.
 	oldProfile, etag, err := conn.GetProfile(lxdname)
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return err
@@ -100,16 +147,16 @@ func (s *Backend) AssignProfile(ctx context.Context, w string, profile workshop.
 		}
 	}
 
-	inst, etag, err := conn.GetInstance(InstanceName(w, projectId))
+	inst, etag, err := conn.GetInstance(InstanceName(w, pid))
 	if err != nil {
 		return err
 	}
 
 	if slices.Index(inst.Profiles, lxdname) == -1 {
-		// Assigning the profile for the first time
+		// Assigning the profile for the first time.
 		put := inst.InstancePut
 		put.Profiles = append(put.Profiles, lxdname)
-		op, err := conn.UpdateInstance(InstanceName(w, projectId), put, etag)
+		op, err := conn.UpdateInstance(InstanceName(w, pid), put, etag)
 		if err != nil {
 			return err
 		}

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -74,6 +74,29 @@ func createOrLoadLxdProject(conn lxd.InstanceServer, projectName string) error {
 	return nil
 }
 
+func (s *Backend) loadProjectFromId(client lxd.InstanceServer, ctx context.Context, id string) (*workshop.Project, error) {
+	user, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
+	}
+
+	lxdPrj, _, err := client.GetProject(LxdProjectName(user))
+	if err != nil {
+		return nil, err
+	}
+
+	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
+	if err != nil {
+		return nil, err
+	}
+
+	idx := slices.IndexFunc(projects, func(p *workshop.Project) bool { return p.ProjectId == id })
+	if idx == -1 {
+		return nil, workshop.ErrProjectNotFound
+	}
+	return projects[idx], nil
+}
+
 func (s *Backend) loadProjectFromPath(client lxd.InstanceServer, ctx context.Context, path string) (*workshop.Project, error) {
 	user, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -234,8 +234,8 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workshop.SdkList{
 			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{
-				"one-plug":     {Bind: workshop.Bind{Sdk: "two", Plug: "two-plug"}},
-				"one-plug-two": {Bind: workshop.Bind{Sdk: "two", Plug: "two-plug"}},
+				"one-plug":     {Bind: workshop.PlugRef{Sdk: "two", Name: "two-plug"}},
+				"one-plug-two": {Bind: workshop.PlugRef{Sdk: "two", Name: "two-plug"}},
 			}},
 			{Name: "two", Channel: "latest/edge"},
 		},

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -32,21 +32,21 @@ var (
 func (b *Backend) Download(ctx context.Context, base string, report *progress.Reporter) error {
 	defer func() {
 		if report != nil {
-			b.imageLock.Lock()
-			if op, exist := b.currentDownloads[base]; exist {
+			imageLock.Lock()
+			if op, exist := currentDownloads[base]; exist {
 				op.RemoveReporter(report.Name)
 			}
-			b.imageLock.Unlock()
+			imageLock.Unlock()
 		}
 	}()
 
-	b.imageLock.Lock()
-	op, exist := b.currentDownloads[base]
+	imageLock.Lock()
+	op, exist := currentDownloads[base]
 	if exist {
 		if report != nil {
 			op.AddReporter(report)
 		}
-		b.imageLock.Unlock()
+		imageLock.Unlock()
 		return waitDownloadOp(ctx, op)
 	}
 
@@ -54,8 +54,8 @@ func (b *Backend) Download(ctx context.Context, base string, report *progress.Re
 	if report != nil {
 		op.AddReporter(report)
 	}
-	b.currentDownloads[base] = op
-	b.imageLock.Unlock()
+	currentDownloads[base] = op
+	imageLock.Unlock()
 
 	go b.download(ctx, op, base)
 
@@ -67,9 +67,9 @@ func (b *Backend) download(ctx context.Context, op *downloadOp, base string) (er
 		op.waitCh <- err
 		close(op.waitCh)
 
-		b.imageLock.Lock()
-		delete(b.currentDownloads, base)
-		b.imageLock.Unlock()
+		imageLock.Lock()
+		delete(currentDownloads, base)
+		imageLock.Unlock()
 	}()
 
 	// LXD cannot cancel download operations
@@ -130,6 +130,10 @@ func (b *Backend) download(ctx context.Context, op *downloadOp, base string) (er
 	})
 
 	if err = copyop.Wait(); err == nil {
+		// The LXD image alias must be updated separately as if provided to CopyImage in
+		// multiple concurrent calls it will fail with "Alias already exists" once the
+		// image is downloaded. This happens because LXD's CopyImage handles image
+		// download and creating an alias separately and not as a single transaction.
 		b.maybeUpdateAlias(conn, base, imageInfo.Fingerprint)
 	}
 
@@ -232,10 +236,6 @@ func waitDownloadOp(ctx context.Context, op *downloadOp) error {
 	}
 }
 
-// The LXD image alias must be updated separately as if provided to CopyImage in
-// multiple concurrent calls it will fail with "Alias already exists" once the
-// image is downloaded. This happens because LXD's CopyImage handles image
-// download and creating an alias separately and not as a single transaction.
 func (b *Backend) maybeUpdateAlias(conn lxd.InstanceServer, base, fingerprint string) {
 	alias := api.ImageAliasesPost{}
 	alias.Target = fingerprint

--- a/internal/workshop/lxd/tests/integration/profile_test.go
+++ b/internal/workshop/lxd/tests/integration/profile_test.go
@@ -5,6 +5,7 @@ package workshopbackend_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"os/user"
@@ -128,6 +129,62 @@ func (f *profileTest) TestSdkProfileBindMountFailsIfTargetIsAFile(c *check.C) {
 	// Execute
 	err = backend.AssignProfile(f.ctx, "test", profile)
 	c.Assert(err, check.ErrorMatches, `.*cannot create a workshop mount with target "/root/.profile": the target is not a directory`)
+}
+
+func (f *profileTest) TestSdkProfileBindMountAbsSourceOK(c *check.C) {
+	// Setup
+	pd := c.MkDir()
+	launchTestWorkshop(c, f.ctx, f.be, pd)
+	defer f.be.RemoveWorkshop(f.ctx, "test")
+
+	var backend workshop.Profile = &lxdbackend.Backend{}
+	profile := workshop.NewSdkProfile("sdk")
+	abs := filepath.Join(c.MkDir(), "absolute", "source")
+	device := lxdbackend.Mount("sdk-device", abs, "/opt")
+	err := profile.AddDevice(device)
+	c.Assert(err, check.IsNil)
+
+	// Execute
+	err = backend.AssignProfile(f.ctx, "test", profile)
+	c.Assert(err, check.IsNil)
+	c.Assert(abs, testutil.FilePresent)
+}
+
+func (f *profileTest) TestSdkProfileBindMountRelativeSourceOK(c *check.C) {
+	// Setup
+	pd := c.MkDir()
+	launchTestWorkshop(c, f.ctx, f.be, pd)
+	defer f.be.RemoveWorkshop(f.ctx, "test")
+
+	err := os.MkdirAll(filepath.Join(pd, "relpath"), 0744)
+	c.Assert(err, check.IsNil)
+
+	var backend workshop.Profile = &lxdbackend.Backend{}
+	profile := workshop.NewSdkProfile("sdk")
+	device := lxdbackend.Mount("sdk-device", "relpath", "/opt")
+	err = profile.AddDevice(device)
+	c.Assert(err, check.IsNil)
+
+	// Execute
+	err = backend.AssignProfile(f.ctx, "test", profile)
+	c.Assert(err, check.IsNil)
+}
+
+func (f *profileTest) TestSdkProfileBindMountRelativeSourceNotExist(c *check.C) {
+	// Setup
+	pd := c.MkDir()
+	launchTestWorkshop(c, f.ctx, f.be, pd)
+	defer f.be.RemoveWorkshop(f.ctx, "test")
+
+	var backend workshop.Profile = &lxdbackend.Backend{}
+	profile := workshop.NewSdkProfile("sdk")
+	device := lxdbackend.Mount("sdk-device", "relpath", "/opt")
+	err := profile.AddDevice(device)
+	c.Assert(err, check.IsNil)
+
+	// Execute
+	err = backend.AssignProfile(f.ctx, "test", profile)
+	c.Assert(err, check.ErrorMatches, fmt.Sprintf(`"source" %s is not an existing directory`, filepath.Join(pd, "relpath")))
 }
 
 func (f *profileTest) TestSdkProfileSshAgentProxy(c *check.C) {

--- a/internal/workshop/lxd/tests/integration/profile_test.go
+++ b/internal/workshop/lxd/tests/integration/profile_test.go
@@ -128,7 +128,7 @@ func (f *profileTest) TestSdkProfileBindMountFailsIfTargetIsAFile(c *check.C) {
 
 	// Execute
 	err = backend.AssignProfile(f.ctx, "test", profile)
-	c.Assert(err, check.ErrorMatches, `.*cannot create a workshop mount with target "/root/.profile": the target is not a directory`)
+	c.Assert(err, check.ErrorMatches, `sdk:sdk-device's "target" /root/.profile is not a directory`)
 }
 
 func (f *profileTest) TestSdkProfileBindMountAbsSourceOK(c *check.C) {
@@ -184,7 +184,7 @@ func (f *profileTest) TestSdkProfileBindMountRelativeSourceNotExist(c *check.C) 
 
 	// Execute
 	err = backend.AssignProfile(f.ctx, "test", profile)
-	c.Assert(err, check.ErrorMatches, fmt.Sprintf(`"source" %s is not an existing directory`, filepath.Join(pd, "relpath")))
+	c.Assert(err, check.ErrorMatches, fmt.Sprintf(`sdk:sdk-device's "source" %s is not an existing directory`, filepath.Join(pd, "relpath")))
 }
 
 func (f *profileTest) TestSdkProfileSshAgentProxy(c *check.C) {

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -51,7 +51,7 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 	d, err := daemon.New(&daemon.Options{
 		Dir:        c.MkDir(),
 		SocketPath: socketPath,
-	}, f.be)
+	})
 	c.Assert(err, check.IsNil)
 	err = d.Init()
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -166,24 +166,36 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	info.Revision = setup.Revision
 	info.Channel = setup.Channel
 
-	if err = w.setupPlugBinds(info); err != nil {
+	// Now add changes defined for this SDK in the workshop file (e.g. plug
+	// binds, slots).
+	idx := slices.IndexFunc(w.File.Sdks, func(sr SdkRecord) bool { return sr.Name == info.Name })
+	if idx == -1 && sdkName != sdk.Host.String() {
+		return nil, fmt.Errorf("internal error: %q SDK is installed but not declared in the workshop file", info.Name)
+	}
+
+	// host SDK is an optional entry in a workshop file, so it's not an error
+	// scenario.
+	if idx == -1 && sdkName == sdk.Host.String() {
+		return info, nil
+	}
+
+	if err = w.setupPlugBinds(info, w.File.Sdks[idx]); err != nil {
+		return nil, err
+	}
+
+	if err = info.SetWorkshopSlots(w.File.Sdks[idx].Slots); err != nil {
 		return nil, err
 	}
 
 	return info, nil
 }
 
-func (w *Workshop) setupPlugBinds(info *sdk.Info) error {
+func (w *Workshop) setupPlugBinds(info *sdk.Info, sr SdkRecord) error {
 	if info.Type == sdk.Host {
 		return nil
 	}
 
-	idx := slices.IndexFunc(w.File.Sdks, func(sr SdkRecord) bool { return sr.Name == info.Name })
-	if idx == -1 {
-		return fmt.Errorf("internal error: %q SDK is installed but not declared in the workshop file", info.Name)
-	}
-
-	for n, plug := range w.File.Sdks[idx].Plugs {
+	for n, plug := range sr.Plugs {
 		if _, ok := info.Plugs[n]; ok {
 			info.PlugBinds[n] = &sdk.PlugBind{
 				ProjectId: w.Project.ProjectId,

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -28,14 +28,13 @@ var (
 var InstallTimeNow = time.Now
 
 type Workshop struct {
-	Name string
-
 	Backend Backend
 	Project *Project
 	File    *File
+	Name    string
 	Base    string
-	Content map[string]sdk.Setup
 	Running bool
+	Content map[string]sdk.Setup
 }
 
 // Associate an SDK with the workshop by creating a 'current' symlink and adding
@@ -179,33 +178,19 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 		return info, nil
 	}
 
-	if err = w.setupPlugBinds(info, w.File.Sdks[idx]); err != nil {
+	binds := map[string]*sdk.PlugBind{}
+	for name, m := range w.File.Sdks[idx].Plugs {
+		binds[name] = &sdk.PlugBind{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: m.Bind.Sdk, Name: m.Bind.Name}
+	}
+	if err = info.SetupPlugBinds(binds); err != nil {
 		return nil, err
 	}
 
-	if err = info.SetWorkshopSlots(w.File.Sdks[idx].Slots); err != nil {
+	if err = info.SetupWorkshopSlots(w.File.Sdks[idx].Slots); err != nil {
 		return nil, err
 	}
 
 	return info, nil
-}
-
-func (w *Workshop) setupPlugBinds(info *sdk.Info, sr SdkRecord) error {
-	if info.Type == sdk.Host {
-		return nil
-	}
-
-	for n, plug := range sr.Plugs {
-		if _, ok := info.Plugs[n]; ok {
-			info.PlugBinds[n] = &sdk.PlugBind{
-				ProjectId: w.Project.ProjectId,
-				Workshop:  w.Name,
-				Sdk:       plug.Bind.Sdk,
-				Name:      plug.Bind.Plug,
-			}
-		}
-	}
-	return nil
 }
 
 // Returns a list of SDK info for installed SDKs. The info includes SDK details

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/canonical/workshop/internal/sdk"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
@@ -25,35 +26,37 @@ var (
 )
 
 type Plug struct {
-	Bind Bind `yaml:"bind"`
+	Bind PlugRef `yaml:"bind,omitempty"`
 }
 
-type Bind struct {
+type PlugRef struct {
 	Sdk  string
-	Plug string
+	Name string
 }
 
-func (b *Bind) UnmarshalYAML(value *yaml.Node) error {
-	var bindStr string
-	if err := value.Decode(&bindStr); err != nil {
+type SlotRef = PlugRef
+
+func (b *PlugRef) UnmarshalYAML(value *yaml.Node) error {
+	var refStr string
+	if err := value.Decode(&refStr); err != nil {
 		return err
 	}
 
-	parts := strings.SplitN(bindStr, ":", 2)
+	parts := strings.SplitN(refStr, ":", 2)
 	if len(parts) != 2 {
-		return fmt.Errorf("incorrect bind plug reference: %q (use <sdk>:<plug>)", bindStr)
+		return fmt.Errorf("invalid plug or slot reference: %q (use <sdk>:<plug or slot>)", refStr)
 	}
 	if !workshopName.MatchString(parts[0]) {
 		return fmt.Errorf("%q isn't a valid SDK name", parts[0])
 	}
 
 	b.Sdk = parts[0]
-	b.Plug = parts[1]
+	b.Name = parts[1]
 	return nil
 }
 
-func (b Bind) MarshalYAML() (interface{}, error) {
-	return fmt.Sprintf("%s:%s", b.Sdk, b.Plug), nil
+func (b PlugRef) MarshalYAML() (interface{}, error) {
+	return fmt.Sprintf("%s:%s", b.Sdk, b.Name), nil
 }
 
 type SdkRecord struct {
@@ -63,12 +66,18 @@ type SdkRecord struct {
 	Slots   map[string]interface{} `yaml:"slots,omitempty"`
 }
 
+type Connection struct {
+	PlugRef PlugRef `yaml:"plug"`
+	SlotRef SlotRef `yaml:"slot"`
+}
+
 type SdkList []SdkRecord
 
 type File struct {
-	Name string  `yaml:"name"`
-	Base string  `yaml:"base"`
-	Sdks SdkList `yaml:"sdks,omitempty"`
+	Name        string       `yaml:"name"`
+	Base        string       `yaml:"base"`
+	Sdks        SdkList      `yaml:"sdks,omitempty"`
+	Connections []Connection `yaml:"connections,omitempty"`
 }
 
 func (p SdkList) MarshalYAML() (interface{}, error) {
@@ -138,50 +147,25 @@ func readWorkshop(pathname string) (*File, error) {
 		return nil, fmt.Errorf("unsupported base: %s", file.Base)
 	}
 
-	// All bindings must refer to the existing SDKs and meet the name validity
-	// checks (at this stage). Later, when SDK metadata will be received, the
-	// plugs must be checked again (e.g. ensure all those plugs actually exist).
-	type plug struct {
-		sdk  string
-		name string
-	}
-	var masters map[plug][]plug = make(map[plug][]plug)
-	var slaves map[plug]plug = make(map[plug]plug)
-	for _, s := range file.Sdks {
-		for name, p := range s.Plugs {
-			mr := plug{sdk: p.Bind.Sdk, name: p.Bind.Plug}
-			sl := plug{sdk: s.Name, name: name}
-			masters[mr] = append(masters[mr], sl)
-			slaves[sl] = mr
-
-			if !slices.ContainsFunc(file.Sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }) {
-				return nil, fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", fmt.Sprintf("%s:%s", p.Bind.Sdk, p.Bind.Plug))
-			}
-			if p.Bind.Sdk == s.Name && p.Bind.Plug == name {
-				return nil, fmt.Errorf("cannot bind plug %s:%s to itself", s.Name, name)
-			}
-		}
+	if err = validateSdks(file.Sdks); err != nil {
+		return nil, err
 	}
 
-	// Ensure that there are no "multi-level" binds, e.g. s1 bind to m1 bind to m2.
-	slaveKeysOrdered := maps.Keys(slaves)
-	slices.SortFunc(slaveKeysOrdered, func(a, b plug) int {
-		c := cmp.Compare(a.sdk, b.sdk)
-		if c == 0 {
-			return cmp.Compare(a.name, b.name)
-		}
-		return c
-	})
-	for _, sl := range slaveKeysOrdered {
-		m := slaves[sl]
-		if _, ok := masters[sl]; ok {
-			return nil, fmt.Errorf("cannot bind %s:%s to %s:%s; plug %s:%s must not be bound", sl.sdk, sl.name, m.sdk, m.name, sl.sdk, sl.name)
-		}
+	if err = validateBinding(file.Sdks); err != nil {
+		return nil, err
 	}
 
-	for _, s := range file.Sdks {
+	if err = validateConnections(&file); err != nil {
+		return nil, err
+	}
+
+	return &file, nil
+}
+
+func validateSdks(sdks SdkList) error {
+	for _, s := range sdks {
 		if slices.Contains(sdkBlacklist, s.Name) {
-			return nil, fmt.Errorf("%q is a reserved SDK name", s.Name)
+			return fmt.Errorf("%q is a reserved SDK name", s.Name)
 		}
 
 		// an SDK installed from a local source does not have a channel.
@@ -189,9 +173,60 @@ func readWorkshop(pathname string) (*File, error) {
 			continue
 		}
 		if matches := channel.FindStringSubmatch(s.Channel); matches == nil {
-			return nil, fmt.Errorf("unsupported channel %s for \"%s\"", s.Channel, s.Name)
+			return fmt.Errorf("unsupported channel %s for \"%s\"", s.Channel, s.Name)
+		}
+	}
+	return nil
+}
+
+func validateBinding(sdks SdkList) error {
+	// All bindings must refer to the existing SDKs and meet the name validity
+	// checks (at this stage). Later, when SDK metadata will be received, the
+	// plugs must be checked again (e.g. ensure all those plugs actually exist).
+	var masters map[PlugRef][]PlugRef = make(map[PlugRef][]PlugRef)
+	var slaves map[PlugRef]PlugRef = make(map[PlugRef]PlugRef)
+	for _, s := range sdks {
+		for name, p := range s.Plugs {
+			mr := PlugRef{Sdk: p.Bind.Sdk, Name: p.Bind.Name}
+			sl := PlugRef{Sdk: s.Name, Name: name}
+			masters[mr] = append(masters[mr], sl)
+			slaves[sl] = mr
+
+			if !slices.ContainsFunc(sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }) {
+				return fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", fmt.Sprintf("%s:%s", p.Bind.Sdk, p.Bind.Name))
+			}
+			if p.Bind.Sdk == s.Name && p.Bind.Name == name {
+				return fmt.Errorf("cannot bind plug %s:%s to itself", s.Name, name)
+			}
 		}
 	}
 
-	return &file, nil
+	// Ensure that there are no "multi-level" binds, e.g. s1 bind to m1 bind to m2.
+	slaveKeysOrdered := maps.Keys(slaves)
+	slices.SortFunc(slaveKeysOrdered, func(a, b PlugRef) int {
+		c := cmp.Compare(a.Sdk, b.Sdk)
+		if c == 0 {
+			return cmp.Compare(a.Name, b.Name)
+		}
+		return c
+	})
+	for _, sl := range slaveKeysOrdered {
+		m := slaves[sl]
+		if _, ok := masters[sl]; ok {
+			return fmt.Errorf("cannot bind %s:%s to %s:%s; plug %s:%s must not be bound", sl.Sdk, sl.Name, m.Sdk, m.Name, sl.Sdk, sl.Name)
+		}
+	}
+	return nil
+}
+
+func validateConnections(wfile *File) error {
+	for _, conn := range wfile.Connections {
+		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.PlugRef.Sdk || conn.PlugRef.Sdk == sdk.Host.String() }) {
+			return fmt.Errorf(`invalid plug reference "%s:%s": %q SDK is not found in %q workshop`, conn.PlugRef.Sdk, conn.PlugRef.Name, conn.PlugRef.Sdk, wfile.Name)
+		}
+		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.SlotRef.Sdk || conn.SlotRef.Sdk == sdk.Host.String() }) {
+			return fmt.Errorf(`invalid slot reference "%s:%s": %q SDK is not found in %q workshop`, conn.SlotRef.Sdk, conn.SlotRef.Name, conn.SlotRef.Sdk, wfile.Name)
+		}
+	}
+	return nil
 }

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -21,7 +21,7 @@ var (
 	// recommended "official" extension: https://yaml.org/faq.html. Also, having a
 	// single way of naming workshop files avoids unneccesary inconsistencies.
 	filename     = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
-	sdkBlacklist = []string{"agent", "host"}
+	sdkBlacklist = []string{"agent"}
 )
 
 type Plug struct {
@@ -57,9 +57,10 @@ func (b Bind) MarshalYAML() (interface{}, error) {
 }
 
 type SdkRecord struct {
-	Name    string          `yaml:"name"`
-	Channel string          `yaml:"channel"`
-	Plugs   map[string]Plug `yaml:"plugs,omitempty"`
+	Name    string                 `yaml:"name"`
+	Channel string                 `yaml:"channel"`
+	Plugs   map[string]Plug        `yaml:"plugs,omitempty"`
+	Slots   map[string]interface{} `yaml:"slots,omitempty"`
 }
 
 type SdkList []SdkRecord
@@ -72,13 +73,14 @@ type File struct {
 
 func (p SdkList) MarshalYAML() (interface{}, error) {
 	type sdkDef struct {
-		Channel string          `yaml:"channel"`
-		Plugs   map[string]Plug `yaml:"plugs,omitempty"`
+		Channel string                 `yaml:"channel"`
+		Plugs   map[string]Plug        `yaml:"plugs,omitempty"`
+		Slots   map[string]interface{} `yaml:"slots,omitempty"`
 	}
 	b := map[string]sdkDef{}
 
 	for _, v := range p {
-		b[v.Name] = sdkDef{Channel: v.Channel, Plugs: v.Plugs}
+		b[v.Name] = sdkDef{Channel: v.Channel, Plugs: v.Plugs, Slots: v.Slots}
 	}
 
 	node := &yaml.Node{}
@@ -181,9 +183,12 @@ func readWorkshop(pathname string) (*File, error) {
 		if slices.Contains(sdkBlacklist, s.Name) {
 			return nil, fmt.Errorf("%q is a reserved SDK name", s.Name)
 		}
-		if matches := channel.FindStringSubmatch(s.Channel); matches != nil {
+
+		// an SDK installed from a local source does not have a channel.
+		if s.Channel == "" {
 			continue
-		} else {
+		}
+		if matches := channel.FindStringSubmatch(s.Channel); matches == nil {
 			return nil, fmt.Errorf("unsupported channel %s for \"%s\"", s.Channel, s.Name)
 		}
 	}

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -7,10 +7,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/canonical/workshop/internal/sdk"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 var (

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -69,8 +69,8 @@ func (f *workshopFile) TestWorkshopFileSave(c *check.C) {
 		Name: "test-workshop",
 		Base: "ubuntu@22.04",
 		Sdks: []workshop.SdkRecord{
-			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: workshop.Bind{Sdk: "two", Plug: "plug"}}}},
-			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: workshop.Bind{Sdk: "one", Plug: "plug"}}}},
+			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: workshop.PlugRef{Sdk: "two", Name: "plug"}}}},
+			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
 		},
 	}
 	out, err := yaml.Marshal(fl)
@@ -142,8 +142,8 @@ sdks:
 	file, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshop.SdkList{
-		workshop.SdkRecord{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Bind: workshop.Bind{Sdk: "etl-sdk", Plug: "cache"}}}},
-		workshop.SdkRecord{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: workshop.Bind{Sdk: "data-sdk", Plug: "aux"}}}},
+		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Bind: workshop.PlugRef{Sdk: "etl-sdk", Name: "cache"}}}},
+		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
 	})
 }
 
@@ -191,7 +191,7 @@ sdks:
 	c.Assert(err, check.ErrorMatches, `"workshop/no-sdk" isn't a valid SDK name`)
 }
 
-func (f *workshopFile) TestBindPlugIncorrectPlugRef(c *check.C) {
+func (f *workshopFile) TestBindPlugInvalidPlugRef(c *check.C) {
 	buf := []byte(`name: xbert-gpu
 base: ubuntu@20.04
 sdks:
@@ -205,7 +205,7 @@ sdks:
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `incorrect bind plug reference: "cache" \(use <sdk>:<plug>\)`)
+	c.Assert(err, check.ErrorMatches, `invalid plug or slot reference: "cache" \(use <sdk>:<plug or slot>\)`)
 }
 
 func (f *workshopFile) TestBindToAlreadyBoundPlug(c *check.C) {
@@ -271,5 +271,108 @@ sdks:
 	file, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshop.SdkList{
-		workshop.SdkRecord{Name: "host", Slots: map[string]interface{}{"training-data": map[string]interface{}{"source": "relative/path"}}}})
+		{Name: "host", Slots: map[string]interface{}{"training-data": map[string]interface{}{"source": "relative/path"}}}})
+}
+
+func (f *workshopFile) TestWorkshopConnectionsOK(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+  etl-sdk:
+    channel: latest/stable
+connections:
+  - plug: data-sdk:data
+    slot: host:content
+  - plug: etl-sdk:data
+    slot: data-sdk:data-slot
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	file, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.IsNil)
+	c.Assert(file.Connections, testutil.DeepUnsortedMatches, []workshop.Connection{
+		{PlugRef: workshop.PlugRef{Sdk: "data-sdk", Name: "data"}, SlotRef: workshop.SlotRef{Sdk: "host", Name: "content"}},
+		{PlugRef: workshop.PlugRef{Sdk: "etl-sdk", Name: "data"}, SlotRef: workshop.SlotRef{Sdk: "data-sdk", Name: "data-slot"}},
+	})
+}
+
+func (f *workshopFile) TestWorkshopConnectionsInvalidRefs(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+  etl-sdk:
+    channel: latest/stable
+connections:
+  - plug: data-sdk
+    slot: host:content
+  - plug: etl-sdk:data
+    slot: data-sdk:data-slot
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `invalid plug or slot reference: "data-sdk" \(use <sdk>:<plug or slot>\)`)
+}
+
+func (f *workshopFile) TestWorkshopConnectionsSlotSdkNotInTheList(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+  etl-sdk:
+    channel: latest/stable
+connections:
+  - plug: data-sdk:data
+    slot: lost-sdk:content
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `invalid slot reference "lost-sdk:content": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
+}
+
+func (f *workshopFile) TestWorkshopConnectionsPlugSdkNotInTheList(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+  etl-sdk:
+    channel: latest/stable
+connections:
+  - plug: lost-sdk:data
+    slot: data-sdk:content
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `invalid plug reference "lost-sdk:data": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
+}
+
+func (f *workshopFile) TestWorkshopConnectionsImplicitHostSdkPlugSlot(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+  etl-sdk:
+    channel: latest/stable
+connections:
+  - plug: host:data
+    slot: host:content
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.IsNil)
 }

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -111,13 +111,13 @@ func (f *workshopFile) TestWorkshopFileReservedNames(c *check.C) {
 	buf := []byte(`name: xbert-gpu
 base: ubuntu@20.04
 sdks:
-  host:
+  agent:
     channel: latest/stable
 `)
 	dir := c.MkDir()
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	file, err := workshop.ReadWorkshop(workshopFilePath(dir, "xbert-gpu"))
-	c.Assert(err, check.ErrorMatches, `"host" is a reserved SDK name`)
+	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
 	c.Assert(file, check.IsNil)
 }
 
@@ -254,4 +254,22 @@ sdks:
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.ErrorMatches, `cannot bind data-sdk:aux to etl-sdk:cache; plug data-sdk:aux must not be bound`)
+}
+
+func (f *workshopFile) TestHostSdkSlot(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  host:    
+    slots:
+      training-data:
+        source: relative/path
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	file, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.IsNil)
+	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshop.SdkList{
+		workshop.SdkRecord{Name: "host", Slots: map[string]interface{}{"training-data": map[string]interface{}{"source": "relative/path"}}}})
 }

--- a/internal/workshop/workshop_fs.go
+++ b/internal/workshop/workshop_fs.go
@@ -36,22 +36,3 @@ func (w *InstanceFs) Symlink(source, target string) error {
 func (w *InstanceFs) Close() {
 	w.client.Close()
 }
-
-/* Fake workshop fs implementation for tests */
-
-type FakeInstanceFs struct {
-	afero.Fs
-}
-
-func NewFakeWorkshopFs() WorkshopFs {
-	var fs FakeInstanceFs
-	fs.Fs = afero.NewMemMapFs()
-	return &fs
-}
-
-func (w *FakeInstanceFs) Symlink(source, target string) error {
-	return w.Fs.Mkdir(target, os.ModeSymlink)
-}
-
-func (w *FakeInstanceFs) Close() {
-}

--- a/tests/main/interface-gpu/.workshop.ws-gpu-fail.yaml
+++ b/tests/main/interface-gpu/.workshop.ws-gpu-fail.yaml
@@ -1,0 +1,9 @@
+name: ws-gpu-fail
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      user-gpu:
+        interface: gpu
+  test-sdk-gpu:
+    channel: latest/stable

--- a/tests/main/interface-gpu/task.yaml
+++ b/tests/main/interface-gpu/task.yaml
@@ -1,5 +1,5 @@
 summary: Check GPU interface scenarios
-prepare: |  
+prepare: |
   . "$TESTSLIB"/utils.sh
   workshop_exec launch ws-gpu
 restore: |
@@ -7,17 +7,17 @@ restore: |
   workshop_exec remove ws-gpu
 execute: |
   . "$TESTSLIB"/utils.sh
-  
+
   echo "Check the GPU interface plug can be auto-connected"
   workshop_exec connections ws-gpu | MATCH "^gpu.+ws-gpu/test-sdk-gpu:gpu.+:gpu.+\-$"
-  
+
   echo "Check the GPU interface plug can be connected and disconnected manually"
   workshop_exec disconnect ws-gpu/test-sdk-gpu:gpu  
   workshop_exec connect ws-gpu/test-sdk-gpu:gpu
   workshop_exec connections ws-gpu | MATCH "^gpu.+ws-gpu/test-sdk-gpu:gpu.+:gpu.+manual$"
-  
+
   echo "Ensure a GPU device is created when connected"
-  
+
   # Ideally, check that a GPU device exists in the workshop (as a side effect of
   # the interface being connected). However, given the VM env without a card0,
   # ensure that the LXD profile contains a gpu device with a proper
@@ -28,3 +28,7 @@ execute: |
   MATCH "gputype: physical" < output.log
   MATCH 'uid: "1000"' < output.log
   MATCH 'gid: "1000"' < output.log
+
+  echo "Check a user cannot install a GPU slot (violates slot declaration)"
+  workshop_exec launch ws-gpu-fail > launch.log || true
+  MATCH ".*installation not allowed by \"user-gpu\" slot rule of interface \"gpu\"" < launch.log

--- a/tests/main/interface-ssh-agent/.workshop.ws-ssh-fail.yaml
+++ b/tests/main/interface-ssh-agent/.workshop.ws-ssh-fail.yaml
@@ -1,0 +1,9 @@
+name: ws-ssh-fail
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      user-ssh:
+        interface: ssh-agent
+  test-sdk-ssh-agent:
+    channel: latest/stable

--- a/tests/main/interface-ssh-agent/.workshop.ws-ssh.yaml
+++ b/tests/main/interface-ssh-agent/.workshop.ws-ssh.yaml
@@ -1,0 +1,8 @@
+name: ws-ssh
+base: ubuntu@22.04
+sdks:
+  test-sdk-ssh-agent:
+    channel: latest/stable
+connections:
+  - plug: test-sdk-ssh-agent:ssh-agent
+    slot: host:ssh-agent

--- a/tests/main/interface-ssh-agent/task.yaml
+++ b/tests/main/interface-ssh-agent/task.yaml
@@ -1,0 +1,20 @@
+summary: Check ssh-agent interface scenarios
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  # required to keep /lib/systemd/systemd --user running for a regular user
+  # which is used by the interface to get info about the agent socket path
+  loginctl enable-linger ubuntu
+  workshop_exec launch ws-ssh
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove ws-ssh
+  loginctl disable-linger ubuntu
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check the ssh-agent interface plug cannot be auto-connected"
+  workshop_exec connections ws-ssh | MATCH "^ssh-agent.+ws-ssh/test-sdk-ssh-agent:ssh-agent.+\-.+\-$"
+
+  echo "Check a user cannot install an SSH slot (violates slot declaration)"
+  workshop_exec launch ws-ssh-fail > launch.log || true
+  MATCH ".*installation not allowed by \"user-ssh\" slot rule of interface \"ssh-agent\"" < launch.log

--- a/tests/main/workshop-connections/.workshop.ws-user-conns.yaml
+++ b/tests/main/workshop-connections/.workshop.ws-user-conns.yaml
@@ -1,0 +1,18 @@
+name: ws-user-conns
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      user-slot:
+        interface: content
+        source: user-data
+      user-slot-2:
+        interface: content
+        source: user-data-2
+  test-sdk-content:
+    channel: latest/stable
+connections:
+  - plug: test-sdk-content:content-plug-one
+    slot: host:user-slot
+  - plug: test-sdk-content:content-plug-two
+    slot: host:user-slot-2

--- a/tests/main/workshop-connections/.workshop.ws-user-conns.yaml.new
+++ b/tests/main/workshop-connections/.workshop.ws-user-conns.yaml.new
@@ -1,0 +1,13 @@
+name: ws-user-conns
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      user-slot-2:
+        interface: content
+        source: user-data-2
+  test-sdk-content:
+    channel: latest/stable
+connections:
+  - plug: test-sdk-content:content-plug-two
+    slot: host:user-slot-2

--- a/tests/main/workshop-connections/task.yaml
+++ b/tests/main/workshop-connections/task.yaml
@@ -1,0 +1,31 @@
+summary: Check that "workshop connections" works as expected
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  mkdir user-data user-data-2
+  workshop_exec launch ws-user-conns
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove ws-user-conns
+  rm -rf user-data user-data-2
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check connections"
+  workshop_exec connections ws-user-conns | MATCH "^content.+ws-user-conns/test-sdk-content:content-plug-one.+:user-slot.+\-$"
+  workshop_exec connections ws-user-conns | MATCH "^content.+ws-user-conns/test-sdk-content:content-plug-two.+:user-slot-2.+\-$"
+
+  echo "Check mounts"
+  workshop_exec info ws-user-conns | grep -v notes > mounts.log
+  yq '.content["test-sdk-content"].mounts["content-plug-one"]' < mounts.log | MATCH "^host:.*$(pwd)/user-data" 
+  yq '.content["test-sdk-content"].mounts["content-plug-two"]' < mounts.log | MATCH "^host:.*$(pwd)/user-data-2"
+
+  echo "Check refresh that removes a connection"
+  mv -f .workshop.ws-user-conns.yaml.new .workshop.ws-user-conns.yaml
+  workshop_exec refresh ws-user-conns
+  workshop_exec connections ws-user-conns | MATCH "^content.+ws-user-conns/test-sdk-content:content-plug-one.+:content.+\-$"
+  workshop_exec connections ws-user-conns | MATCH "^content.+ws-user-conns/test-sdk-content:content-plug-two.+:user-slot-2.+\-$"
+
+  echo "Check mounts"
+  workshop_exec info ws-user-conns | grep -v notes > mounts.log
+  yq '.content["test-sdk-content"].mounts["content-plug-one"]' < mounts.log | MATCH "^host:.*ws-user-conns_test-sdk-content_content-plug-one.sdk" 
+  yq '.content["test-sdk-content"].mounts["content-plug-two"]' < mounts.log | MATCH "^host:.*$(pwd)/user-data-2"


### PR DESCRIPTION
# Description

Slots and connections can now be introduced in a workshop definition:

```
base: ubuntu@22.04
name: ws
sdks:
  host:
    slots:
      training:
        interface: content
        source: my-training-data/images    # must be relative to the project dir
  ai-sdk:
    channel: latest/candidate
connections:
  - plug: ai-sdk:images
    slot: host:training
```

The plugs or slots defined as part of the SDK in the workshop’s definition:
- Cannot override static attributes defined by the SDK.
- Must respect the interface policies defined for built-in interfaces.

There are multiple tidy ups coming together with this PR as separate commits, e.g.:
- Overlord.New.
- Extract fake workshop backend implementation to a separate package.
- Replace all direct yaml.v2 dependencies with yaml.v3.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
