### PR TITLE
Plugs in a workshop file

### DIFF
--- a/internal/asserts/constraint_test.go
+++ b/internal/asserts/constraint_test.go
@@ -37,18 +37,6 @@ type attrMatcherSuite struct {
 
 var _ = Suite(&attrMatcherSuite{})
 
-type testEvalAttr struct {
-	comp func(side string, arg string) (interface{}, error)
-}
-
-func (ca testEvalAttr) SlotAttr(arg string) (interface{}, error) {
-	return ca.comp("slot", arg)
-}
-
-func (ca testEvalAttr) PlugAttr(arg string) (interface{}, error) {
-	return ca.comp("plug", arg)
-}
-
 func vals(yml string) map[string]interface{} {
 	var vs map[string]interface{}
 	err := yaml.Unmarshal([]byte(yml), &vs)

--- a/internal/asserts/export_test.go
+++ b/internal/asserts/export_test.go
@@ -4,9 +4,11 @@ import "io"
 
 // Headers helpers to test
 var (
-	ParseHeaders           = parseHeaders
-	CompileSlotRule        = compileSlotRule
-	CompileNameConstraints = compileNameConstraints
+	ParseHeaders                = parseHeaders
+	CompilePlugRule             = compilePlugRule
+	CompileSlotRule             = compileSlotRule
+	CompileNameConstraints      = compileNameConstraints
+	CompileAttributeConstraints = compileAttributeConstraints
 )
 
 func init() {
@@ -85,4 +87,12 @@ func CompileAttrMatcher(constraints interface{}, allowedOperations []string) (fu
 		})
 	}
 	return domatch, nil
+}
+
+type featureExposer interface {
+	feature(flabel string) bool
+}
+
+func RuleFeature(rule featureExposer, flabel string) bool {
+	return rule.feature(flabel)
 }

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -19,8 +19,12 @@ var (
 	}
 
 	invertedOutcome = map[string]interface{}{
-		"allow-installation": "false",
-		"deny-installation":  "true",
+		"allow-installation":    "false",
+		"allow-connection":      "false",
+		"allow-auto-connection": "false",
+		"deny-installation":     "true",
+		"deny-connection":       "true",
+		"deny-auto-connection":  "true",
 	}
 
 	ruleSubrules = []string{"allow-installation", "deny-installation", "allow-connection", "deny-connection", "allow-auto-connection", "deny-auto-connection"}
@@ -36,6 +40,7 @@ var (
 	attributeConstraints = []string{"plug-attributes", "slot-attributes"}
 
 	slotIDConstraints = []string{"plug-sdk-type"}
+	plugIDConstraints = []string{"slot-sdk-type"}
 
 	sideArityConstraints        = []string{"slots-per-plug", "plugs-per-slot"}
 	sideArityConstraintsSetters = map[string]func(sideArityConstraintsHolder, SideArityConstraint){
@@ -52,7 +57,7 @@ const (
 // SlotInstallationConstraints specifies a set of constraints on an
 // interface slot relevant to the installation of SDK.
 type SlotInstallationConstraints struct {
-	SlotTypes      []string
+	SlotSdkTypes   []string
 	SlotAttributes *AttributeConstraints
 	SlotNames      *NameConstraints
 }
@@ -76,7 +81,7 @@ func (c *SlotInstallationConstraints) setNameConstraints(field string, cstrs *Na
 func (c *SlotInstallationConstraints) setIDConstraints(field string, cstrs []string) {
 	switch field {
 	case "slot-sdk-type":
-		c.SlotTypes = cstrs
+		c.SlotSdkTypes = cstrs
 	default:
 		panic("unknown SlotInstallationConstraints field " + field)
 	}
@@ -534,10 +539,245 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 	return nil
 }
 
-// PlugRule holds the rule of what is allowed, wrt installation and
+// PlugInstallationConstraints specifies a set of constraints on an interface plug relevant to the installation of snap.
+type PlugInstallationConstraints struct {
+	PlugSdkTypes []string
+
+	PlugNames *NameConstraints
+
+	PlugAttributes *AttributeConstraints
+}
+
+func (c *PlugInstallationConstraints) feature(flabel string) bool {
+	if flabel == nameConstraintsFeature {
+		return c.PlugNames != nil
+	}
+	return c.PlugAttributes.feature(flabel)
+}
+
+func (c *PlugInstallationConstraints) setNameConstraints(field string, cstrs *NameConstraints) {
+	switch field {
+	case "plug-names":
+		c.PlugNames = cstrs
+	default:
+		panic("unknown PlugInstallationConstraints field " + field)
+	}
+}
+
+func (c *PlugInstallationConstraints) setAttributeConstraints(field string, cstrs *AttributeConstraints) {
+	switch field {
+	case "plug-attributes":
+		c.PlugAttributes = cstrs
+	default:
+		panic("unknown PlugInstallationConstraints field " + field)
+	}
+}
+
+func (c *PlugInstallationConstraints) setIDConstraints(field string, cstrs []string) {
+	switch field {
+	case "plug-sdk-type":
+		c.PlugSdkTypes = cstrs
+	default:
+		panic("unknown PlugInstallationConstraints field " + field)
+	}
+}
+
+func compilePlugInstallationConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
+	plugInstCstrs := &PlugInstallationConstraints{}
+	// plug-snap-id is supported here mainly for symmetry with the slot case
+	// see discussion there
+	err := baseCompileConstraints(context, cDef, plugInstCstrs, []string{"plug-names"}, []string{"plug-attributes"}, []string{"plug-sdk-type"})
+	if err != nil {
+		return nil, err
+	}
+	return plugInstCstrs, nil
+}
+
+// PlugConnectionConstraints specfies a set of constraints on an
+// interface plug for a snap relevant to its connection or
+// auto-connection.
+type PlugConnectionConstraints struct {
+	SlotSdkTypes []string
+
+	PlugNames *NameConstraints
+	SlotNames *NameConstraints
+
+	PlugAttributes *AttributeConstraints
+	SlotAttributes *AttributeConstraints
+
+	// SlotsPerPlug defaults to 1 for auto-connection, can be * (any)
+	SlotsPerPlug SideArityConstraint
+	// PlugsPerSlot is always * (any) (for now)
+	PlugsPerSlot SideArityConstraint
+}
+
+func (c *PlugConnectionConstraints) feature(flabel string) bool {
+	if flabel == nameConstraintsFeature {
+		return c.PlugNames != nil || c.SlotNames != nil
+	}
+	return c.PlugAttributes.feature(flabel) || c.SlotAttributes.feature(flabel)
+}
+
+func (c *PlugConnectionConstraints) setNameConstraints(field string, cstrs *NameConstraints) {
+	switch field {
+	case "plug-names":
+		c.PlugNames = cstrs
+	case "slot-names":
+		c.SlotNames = cstrs
+	default:
+		panic("unknown PlugConnectionConstraints field " + field)
+	}
+}
+
+func (c *PlugConnectionConstraints) setAttributeConstraints(field string, cstrs *AttributeConstraints) {
+	switch field {
+	case "plug-attributes":
+		c.PlugAttributes = cstrs
+	case "slot-attributes":
+		c.SlotAttributes = cstrs
+	default:
+		panic("unknown PlugConnectionConstraints field " + field)
+	}
+}
+
+func (c *PlugConnectionConstraints) setIDConstraints(field string, cstrs []string) {
+	switch field {
+	case "slot-sdk-type":
+		c.SlotSdkTypes = cstrs
+	default:
+		panic("unknown PlugConnectionConstraints field " + field)
+	}
+}
+
+func (c *PlugConnectionConstraints) setSlotsPerPlug(a SideArityConstraint) {
+	c.SlotsPerPlug = a
+}
+
+func (c *PlugConnectionConstraints) setPlugsPerSlot(a SideArityConstraint) {
+	c.PlugsPerSlot = a
+}
+
+func (c *PlugConnectionConstraints) slotsPerPlug() SideArityConstraint {
+	return c.SlotsPerPlug
+}
+
+func (c *PlugConnectionConstraints) plugsPerSlot() SideArityConstraint {
+	return c.PlugsPerSlot
+}
+
+func compilePlugConnectionConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
+	plugConnCstrs := &PlugConnectionConstraints{}
+	err := baseCompileConstraints(context, cDef, plugConnCstrs, nameConstraints, attributeConstraints, plugIDConstraints)
+	if err != nil {
+		return nil, err
+	}
+	normalizeSideArityConstraints(context, plugConnCstrs)
+	return plugConnCstrs, nil
+}
+
+// PlugRule holds the rule of what is allowed, wrt instalation and
 // connection, for a plug of a specific interface for a sdk.
 type PlugRule struct {
 	Interface string
+
+	AllowInstallation []*PlugInstallationConstraints
+	DenyInstallation  []*PlugInstallationConstraints
+
+	AllowConnection []*PlugConnectionConstraints
+	DenyConnection  []*PlugConnectionConstraints
+
+	AllowAutoConnection []*PlugConnectionConstraints
+	DenyAutoConnection  []*PlugConnectionConstraints
+}
+
+func (r *PlugRule) feature(flabel string) bool {
+	for _, cs := range [][]*PlugInstallationConstraints{r.AllowInstallation, r.DenyInstallation} {
+		for _, c := range cs {
+			if c.feature(flabel) {
+				return true
+			}
+		}
+	}
+
+	for _, cs := range [][]*PlugConnectionConstraints{r.AllowConnection, r.DenyConnection, r.AllowAutoConnection, r.DenyAutoConnection} {
+		for _, c := range cs {
+			if c.feature(flabel) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func castPlugInstallationConstraints(cstrs []constraintsHolder) (res []*PlugInstallationConstraints) {
+	res = make([]*PlugInstallationConstraints, len(cstrs))
+	for i, cstr := range cstrs {
+		res[i] = cstr.(*PlugInstallationConstraints)
+	}
+	return res
+}
+
+func castPlugConnectionConstraints(cstrs []constraintsHolder) (res []*PlugConnectionConstraints) {
+	res = make([]*PlugConnectionConstraints, len(cstrs))
+	for i, cstr := range cstrs {
+		res[i] = cstr.(*PlugConnectionConstraints)
+	}
+	return res
+}
+
+func (r *PlugRule) setConstraints(field string, cstrs []constraintsHolder) {
+	if len(cstrs) == 0 {
+		panic(fmt.Sprintf("cannot set PlugRule field %q to empty", field))
+	}
+	switch cstrs[0].(type) {
+	case *PlugInstallationConstraints:
+		switch field {
+		case "allow-installation":
+			r.AllowInstallation = castPlugInstallationConstraints(cstrs)
+			return
+		case "deny-installation":
+			r.DenyInstallation = castPlugInstallationConstraints(cstrs)
+			return
+		}
+	case *PlugConnectionConstraints:
+		switch field {
+		case "allow-connection":
+			r.AllowConnection = castPlugConnectionConstraints(cstrs)
+			return
+		case "deny-connection":
+			r.DenyConnection = castPlugConnectionConstraints(cstrs)
+			return
+		case "allow-auto-connection":
+			r.AllowAutoConnection = castPlugConnectionConstraints(cstrs)
+			return
+		case "deny-auto-connection":
+			r.DenyAutoConnection = castPlugConnectionConstraints(cstrs)
+			return
+		}
+	}
+	panic(fmt.Sprintf("cannot set PlugRule field %q with %T elements", field, cstrs[0]))
+}
+
+var plugRuleCompilers = map[string]subruleCompiler{
+	"allow-installation":    compilePlugInstallationConstraints,
+	"deny-installation":     compilePlugInstallationConstraints,
+	"allow-connection":      compilePlugConnectionConstraints,
+	"deny-connection":       compilePlugConnectionConstraints,
+	"allow-auto-connection": compilePlugConnectionConstraints,
+	"deny-auto-connection":  compilePlugConnectionConstraints,
+}
+
+func compilePlugRule(interfaceName string, rule interface{}) (*PlugRule, error) {
+	context := fmt.Sprintf("plug rule for interface %q", interfaceName)
+	plugRule := &PlugRule{
+		Interface: interfaceName,
+	}
+	err := baseCompileRule(context, rule, plugRule, ruleSubrules, plugRuleCompilers, defaultOutcome, invertedOutcome)
+	if err != nil {
+		return nil, err
+	}
+	return plugRule, nil
 }
 
 // subruleContext carries queryable context information about one the

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -2,14 +2,21 @@ package asserts_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/workshop/internal/asserts"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/testutil"
 )
 
 var (
+	_ = check.Suite(&attrConstraintsSuite{})
+	_ = check.Suite(&nameConstraintsSuite{})
+
 	_ = check.Suite(&plugSlotRulesSuite{})
 )
 
@@ -18,7 +25,926 @@ var (
 	sideArityOne = asserts.SideArityConstraint{N: 1}
 )
 
+func checkBoolPlugConnConstraints(c *check.C, subrule string, cstrs []*asserts.PlugConnectionConstraints, always bool) {
+	expected := asserts.NeverMatchAttributes
+	if always {
+		expected = asserts.AlwaysMatchAttributes
+	}
+	c.Assert(cstrs, check.HasLen, 1)
+	cstrs1 := cstrs[0]
+	c.Check(cstrs1.PlugAttributes, check.Equals, expected)
+	c.Check(cstrs1.SlotAttributes, check.Equals, expected)
+	if strings.HasPrefix(subrule, "deny-") {
+		undef := asserts.SideArityConstraint{}
+		c.Check(cstrs1.SlotsPerPlug, check.Equals, undef)
+		c.Check(cstrs1.PlugsPerSlot, check.Equals, undef)
+	} else {
+		c.Check(cstrs1.PlugsPerSlot, check.Equals, sideArityAny)
+		if strings.HasSuffix(subrule, "-auto-connection") {
+			c.Check(cstrs1.SlotsPerPlug, check.Equals, sideArityOne)
+		} else {
+			c.Check(cstrs1.SlotsPerPlug, check.Equals, sideArityAny)
+		}
+	}
+	c.Check(cstrs1.SlotSdkTypes, check.HasLen, 0)
+}
+
+type attrConstraintsSuite struct {
+	testutil.BaseTest
+}
+
+type attrerObject map[string]interface{}
+
+func (o attrerObject) Lookup(path string) (interface{}, bool) {
+	v, ok := o[path]
+	return v, ok
+}
+
+func attrs(yml string) *attrerObject {
+	var attrs map[string]interface{}
+	err := yaml.Unmarshal([]byte(yml), &attrs)
+	if err != nil {
+		panic(err)
+	}
+	sdkYaml, err := yaml.Marshal(map[string]interface{}{
+		"name": "sample",
+		"plugs": map[string]interface{}{
+			"plug": attrs,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// NOTE: it's important to go through sdk yaml here even though we're really interested in Attrs only,
+	// as InfoFromSdkYaml normalizes yaml values.
+	info, err := sdk.ReadSdkInfo(sdkYaml, "", "")
+	if err != nil {
+		panic(err)
+	}
+
+	ao := attrerObject(info.Plugs["plug"].Attrs)
+	return &ao
+}
+
+func (s *attrConstraintsSuite) SetUpTest(c *check.C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
+}
+
+func (s *attrConstraintsSuite) TearDownTest(c *check.C) {
+	s.BaseTest.TearDownTest(c)
+}
+
+func (s *attrConstraintsSuite) TestSimple(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: FOO
+  bar: BAR`))
+	c.Assert(err, check.IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	plug := attrerObject(map[string]interface{}{
+		"foo": "FOO",
+		"bar": "BAR",
+		"baz": "BAZ",
+	})
+	err = cstrs.Check(plug, nil)
+	c.Check(err, check.IsNil)
+
+	plug = attrerObject(map[string]interface{}{
+		"foo": "FOO",
+		"bar": "BAZ",
+		"baz": "BAZ",
+	})
+	err = cstrs.Check(plug, nil)
+	c.Check(err, check.ErrorMatches, `attribute "bar" value "BAZ" does not match \^\(BAR\)\$`)
+
+	plug = attrerObject(map[string]interface{}{
+		"foo": "FOO",
+		"baz": "BAZ",
+	})
+	err = cstrs.Check(plug, nil)
+	c.Check(err, check.ErrorMatches, `attribute "bar" has constraints but is unset`)
+}
+
+func (s *attrConstraintsSuite) TestMissingCheck(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: $MISSING`))
+	c.Assert(err, check.IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+	c.Check(asserts.RuleFeature(cstrs, "dollar-attr-constraints"), check.Equals, true)
+}
+
+func (s *attrConstraintsSuite) TestNested(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: FOO
+  bar:
+    bar1: BAR1
+    bar2: BAR2`))
+	c.Assert(err, check.IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	err = cstrs.Check(attrs(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2: BAR2
+  bar3: BAR3
+baz: BAZ
+`), nil)
+	c.Check(err, check.IsNil)
+
+	err = cstrs.Check(attrs(`
+foo: FOO
+bar: BAZ
+baz: BAZ
+`), nil)
+	c.Check(err, check.ErrorMatches, `attribute "bar" must be a map`)
+
+	err = cstrs.Check(attrs(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2: BAR22
+  bar3: BAR3
+baz: BAZ
+`), nil)
+	c.Check(err, check.ErrorMatches, `attribute "bar\.bar2" value "BAR22" does not match \^\(BAR2\)\$`)
+
+	err = cstrs.Check(attrs(`
+foo: FOO
+bar:
+  bar1: BAR1
+  bar2:
+    bar22: true
+  bar3: BAR3
+baz: BAZ
+`), nil)
+	c.Check(err, check.ErrorMatches, `attribute "bar\.bar2" must be a scalar or list`)
+}
+
+func (s *attrConstraintsSuite) TestAlternativeMatchingComplex(c *check.C) {
+	toMatch := attrs(`
+mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar/*", where: "/baz/*", options: ["rw", "bind"]}]
+`)
+
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  mnt:
+    -
+      what: /(bar/|dev/x)\*
+      where: /(foo|baz)/\*
+      options: rw|bind|nodev`))
+	c.Assert(err, check.IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	err = cstrs.Check(toMatch, nil)
+	c.Check(err, check.IsNil)
+
+	m, err = asserts.ParseHeaders([]byte(`attrs:
+  mnt:
+    -
+      what: /dev/x\*
+      where: /foo/\*
+      options:
+        - nodev
+        - rw
+    -
+      what: /bar/\*
+      where: /baz/\*
+      options:
+        - rw
+        - bind`))
+	c.Assert(err, check.IsNil)
+
+	cstrsExtensive, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	err = cstrsExtensive.Check(toMatch, nil)
+	c.Check(err, check.IsNil)
+
+	// not matching case
+	m, err = asserts.ParseHeaders([]byte(`attrs:
+  mnt:
+    -
+      what: /dev/x\*
+      where: /foo/\*
+      options:
+        - rw
+    -
+      what: /bar/\*
+      where: /baz/\*
+      options:
+        - rw
+        - bind`))
+	c.Assert(err, check.IsNil)
+
+	cstrsExtensiveNoMatch, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	err = cstrsExtensiveNoMatch.Check(toMatch, nil)
+	c.Check(err, check.ErrorMatches, `no alternative for attribute "mnt\.0" matches: no alternative for attribute "mnt\.0.options\.1" matches:.*`)
+}
+
+func (s *attrConstraintsSuite) TestOtherScalars(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: 1
+  bar: true`))
+	c.Assert(err, check.IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	err = cstrs.Check(attrs(`
+foo: 1
+bar: true
+`), nil)
+	c.Check(err, check.IsNil)
+}
+
+func (s *attrConstraintsSuite) TestCompileErrors(c *check.C) {
+	_, err := asserts.CompileAttributeConstraints(map[string]interface{}{
+		"foo": "[",
+	})
+	c.Check(err, check.ErrorMatches, `cannot compile "foo" constraint "\[": error parsing regexp:.*`)
+
+	_, err = asserts.CompileAttributeConstraints("FOO")
+	c.Check(err, check.ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+
+	_, err = asserts.CompileAttributeConstraints([]interface{}{"FOO"})
+	c.Check(err, check.ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+
+	wrongDollarConstraints := []string{
+		"$",
+		"$FOO(a)",
+		"$SLOT",
+		"$SLOT()",
+	}
+
+	for _, wrong := range wrongDollarConstraints {
+		_, err := asserts.CompileAttributeConstraints(map[string]interface{}{
+			"foo": wrong,
+		})
+		c.Check(err, check.ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$PLUG\(\) constraint`, regexp.QuoteMeta(wrong)))
+
+	}
+}
+
+type testEvalAttr struct {
+	comp func(side string, arg string) (interface{}, error)
+}
+
+func (ca testEvalAttr) SlotAttr(arg string) (interface{}, error) {
+	return ca.comp("slot", arg)
+}
+
+func (ca testEvalAttr) PlugAttr(arg string) (interface{}, error) {
+	return ca.comp("plug", arg)
+}
+
+func (s *attrConstraintsSuite) TestEvalCheck(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`attrs:
+  foo: $SLOT(foo)
+  bar: $PLUG(bar.baz)`))
+	c.Assert(err, check.IsNil)
+
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+	c.Check(asserts.RuleFeature(cstrs, "dollar-attr-constraints"), check.Equals, true)
+
+	err = cstrs.Check(attrs(`
+foo: foo
+bar: bar
+`), nil)
+	c.Check(err, check.ErrorMatches, `attribute "(foo|bar)" cannot be matched without context`)
+
+	calls := make(map[[2]string]bool)
+	comp1 := func(op string, arg string) (interface{}, error) {
+		calls[[2]string{op, arg}] = true
+		return arg, nil
+	}
+
+	err = cstrs.Check(attrs(`
+foo: foo
+bar: bar.baz
+`), testEvalAttr{comp1})
+	c.Check(err, check.IsNil)
+
+	c.Check(calls, check.DeepEquals, map[[2]string]bool{
+		{"slot", "foo"}:     true,
+		{"plug", "bar.baz"}: true,
+	})
+
+	comp2 := func(op string, arg string) (interface{}, error) {
+		if op == "plug" {
+			return nil, fmt.Errorf("boom")
+		}
+		return arg, nil
+	}
+
+	err = cstrs.Check(attrs(`
+foo: foo
+bar: bar.baz
+`), testEvalAttr{comp2})
+	c.Check(err, check.ErrorMatches, `attribute "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
+
+	comp3 := func(op string, arg string) (interface{}, error) {
+		if op == "slot" {
+			return "other-value", nil
+		}
+		return arg, nil
+	}
+
+	err = cstrs.Check(attrs(`
+foo: foo
+bar: bar.baz
+`), testEvalAttr{comp3})
+	c.Check(err, check.ErrorMatches, `attribute "foo" does not match \$SLOT\(foo\): foo != other-value`)
+}
+
+func (s *attrConstraintsSuite) TestNeverMatchAttributeConstraints(c *check.C) {
+	c.Check(asserts.NeverMatchAttributes.Check(nil, nil), check.NotNil)
+}
+
 type plugSlotRulesSuite struct{}
+
+func checkAttrs(c *check.C, attrs *asserts.AttributeConstraints, witness, expected string) {
+	plug := attrerObject(map[string]interface{}{
+		witness: "XYZ",
+	})
+	c.Check(attrs.Check(plug, nil), check.ErrorMatches, fmt.Sprintf(`attribute "%s".*does not match.*`, witness))
+	plug = attrerObject(map[string]interface{}{
+		witness: expected,
+	})
+	c.Check(attrs.Check(plug, nil), check.IsNil)
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleAllAllowDenyStanzas(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`iface:
+  allow-installation:
+    plug-attributes:
+      a1: A1
+  deny-installation:
+    plug-attributes:
+      a2: A2
+  allow-connection:
+    plug-attributes:
+      pa3: PA3
+    slot-attributes:
+      sa3: SA3
+  deny-connection:
+    plug-attributes:
+      pa4: PA4
+    slot-attributes:
+      sa4: SA4
+  allow-auto-connection:
+    plug-attributes:
+      pa5: PA5
+    slot-attributes:
+      sa5: SA5
+  deny-auto-connection:
+    plug-attributes:
+      pa6: PA6
+    slot-attributes:
+      sa6: SA6`))
+	c.Assert(err, check.IsNil)
+
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	c.Check(rule.Interface, check.Equals, "iface")
+	// install subrules
+	c.Assert(rule.AllowInstallation, check.HasLen, 1)
+	checkAttrs(c, rule.AllowInstallation[0].PlugAttributes, "a1", "A1")
+	c.Assert(rule.DenyInstallation, check.HasLen, 1)
+	checkAttrs(c, rule.DenyInstallation[0].PlugAttributes, "a2", "A2")
+	// connection subrules
+	c.Assert(rule.AllowConnection, check.HasLen, 1)
+	checkAttrs(c, rule.AllowConnection[0].PlugAttributes, "pa3", "PA3")
+	checkAttrs(c, rule.AllowConnection[0].SlotAttributes, "sa3", "SA3")
+	c.Assert(rule.DenyConnection, check.HasLen, 1)
+	checkAttrs(c, rule.DenyConnection[0].PlugAttributes, "pa4", "PA4")
+	checkAttrs(c, rule.DenyConnection[0].SlotAttributes, "sa4", "SA4")
+	// auto-connection subrules
+	c.Assert(rule.AllowAutoConnection, check.HasLen, 1)
+	checkAttrs(c, rule.AllowAutoConnection[0].PlugAttributes, "pa5", "PA5")
+	checkAttrs(c, rule.AllowAutoConnection[0].SlotAttributes, "sa5", "SA5")
+	c.Assert(rule.DenyAutoConnection, check.HasLen, 1)
+	checkAttrs(c, rule.DenyAutoConnection[0].PlugAttributes, "pa6", "PA6")
+	checkAttrs(c, rule.DenyAutoConnection[0].SlotAttributes, "sa6", "SA6")
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleAllAllowDenyOrStanzas(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`iface:
+  allow-installation:
+    -
+      plug-attributes:
+        a1: A1
+    -
+      plug-attributes:
+        a1: A1alt
+  deny-installation:
+    -
+      plug-attributes:
+        a2: A2
+    -
+      plug-attributes:
+        a2: A2alt
+  allow-connection:
+    -
+      plug-attributes:
+        pa3: PA3
+      slot-attributes:
+        sa3: SA3
+    -
+      plug-attributes:
+        pa3: PA3alt
+  deny-connection:
+    -
+      plug-attributes:
+        pa4: PA4
+      slot-attributes:
+        sa4: SA4
+    -
+      plug-attributes:
+        pa4: PA4alt
+  allow-auto-connection:
+    -
+      plug-attributes:
+        pa5: PA5
+      slot-attributes:
+        sa5: SA5
+    -
+      plug-attributes:
+        pa5: PA5alt
+  deny-auto-connection:
+    -
+      plug-attributes:
+        pa6: PA6
+      slot-attributes:
+        sa6: SA6
+    -
+      plug-attributes:
+        pa6: PA6alt`))
+	c.Assert(err, check.IsNil)
+
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	c.Check(rule.Interface, check.Equals, "iface")
+	// install subrules
+	c.Assert(rule.AllowInstallation, check.HasLen, 2)
+	checkAttrs(c, rule.AllowInstallation[0].PlugAttributes, "a1", "A1")
+	checkAttrs(c, rule.AllowInstallation[1].PlugAttributes, "a1", "A1alt")
+	c.Assert(rule.DenyInstallation, check.HasLen, 2)
+	checkAttrs(c, rule.DenyInstallation[0].PlugAttributes, "a2", "A2")
+	checkAttrs(c, rule.DenyInstallation[1].PlugAttributes, "a2", "A2alt")
+	// connection subrules
+	c.Assert(rule.AllowConnection, check.HasLen, 2)
+	checkAttrs(c, rule.AllowConnection[0].PlugAttributes, "pa3", "PA3")
+	checkAttrs(c, rule.AllowConnection[0].SlotAttributes, "sa3", "SA3")
+	checkAttrs(c, rule.AllowConnection[1].PlugAttributes, "pa3", "PA3alt")
+	c.Assert(rule.DenyConnection, check.HasLen, 2)
+	checkAttrs(c, rule.DenyConnection[0].PlugAttributes, "pa4", "PA4")
+	checkAttrs(c, rule.DenyConnection[0].SlotAttributes, "sa4", "SA4")
+	checkAttrs(c, rule.DenyConnection[1].PlugAttributes, "pa4", "PA4alt")
+	// auto-connection subrules
+	c.Assert(rule.AllowAutoConnection, check.HasLen, 2)
+	checkAttrs(c, rule.AllowAutoConnection[0].PlugAttributes, "pa5", "PA5")
+	checkAttrs(c, rule.AllowAutoConnection[0].SlotAttributes, "sa5", "SA5")
+	checkAttrs(c, rule.AllowAutoConnection[1].PlugAttributes, "pa5", "PA5alt")
+	c.Assert(rule.DenyAutoConnection, check.HasLen, 2)
+	checkAttrs(c, rule.DenyAutoConnection[0].PlugAttributes, "pa6", "PA6")
+	checkAttrs(c, rule.DenyAutoConnection[0].SlotAttributes, "sa6", "SA6")
+	checkAttrs(c, rule.DenyAutoConnection[1].PlugAttributes, "pa6", "PA6alt")
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleShortcutTrue(c *check.C) {
+	rule, err := asserts.CompilePlugRule("iface", "true")
+	c.Assert(err, check.IsNil)
+
+	c.Check(rule.Interface, check.Equals, "iface")
+	// install subrules
+	c.Assert(rule.AllowInstallation, check.HasLen, 1)
+	c.Check(rule.AllowInstallation[0].PlugAttributes, check.Equals, asserts.AlwaysMatchAttributes)
+	c.Assert(rule.DenyInstallation, check.HasLen, 1)
+	c.Check(rule.DenyInstallation[0].PlugAttributes, check.Equals, asserts.NeverMatchAttributes)
+	// connection subrules
+	checkBoolPlugConnConstraints(c, "allow-connection", rule.AllowConnection, true)
+	checkBoolPlugConnConstraints(c, "deny-connection", rule.DenyConnection, false)
+	// auto-connection subrules
+	checkBoolPlugConnConstraints(c, "allow-auto-connection", rule.AllowAutoConnection, true)
+	checkBoolPlugConnConstraints(c, "deny-auto-connection", rule.DenyAutoConnection, false)
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleShortcutFalse(c *check.C) {
+	rule, err := asserts.CompilePlugRule("iface", "false")
+	c.Assert(err, check.IsNil)
+
+	// install subrules
+	c.Assert(rule.AllowInstallation, check.HasLen, 1)
+	c.Check(rule.AllowInstallation[0].PlugAttributes, check.Equals, asserts.NeverMatchAttributes)
+	c.Assert(rule.DenyInstallation, check.HasLen, 1)
+	c.Check(rule.DenyInstallation[0].PlugAttributes, check.Equals, asserts.AlwaysMatchAttributes)
+	// connection subrules
+	checkBoolPlugConnConstraints(c, "allow-connection", rule.AllowConnection, false)
+	checkBoolPlugConnConstraints(c, "deny-connection", rule.DenyConnection, true)
+	// auto-connection subrules
+	checkBoolPlugConnConstraints(c, "allow-auto-connection", rule.AllowAutoConnection, false)
+	checkBoolPlugConnConstraints(c, "deny-auto-connection", rule.DenyAutoConnection, true)
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleDefaults(c *check.C) {
+	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
+		"deny-auto-connection": "true",
+	})
+	c.Assert(err, check.IsNil)
+
+	// everything follows the defaults...
+
+	// install subrules
+	c.Assert(rule.AllowInstallation, check.HasLen, 1)
+	c.Check(rule.AllowInstallation[0].PlugAttributes, check.Equals, asserts.AlwaysMatchAttributes)
+	c.Assert(rule.DenyInstallation, check.HasLen, 1)
+	c.Check(rule.DenyInstallation[0].PlugAttributes, check.Equals, asserts.NeverMatchAttributes)
+	// connection subrules
+	checkBoolPlugConnConstraints(c, "allow-connection", rule.AllowConnection, true)
+	checkBoolPlugConnConstraints(c, "deny-connection", rule.DenyConnection, false)
+	// auto-connection subrules
+	checkBoolPlugConnConstraints(c, "allow-auto-connection", rule.AllowAutoConnection, true)
+	// ... but deny-auto-connection is on
+	checkBoolPlugConnConstraints(c, "deny-auto-connection", rule.DenyAutoConnection, true)
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleInstalationConstraintsIDConstraints(c *check.C) {
+	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
+		"allow-installation": map[string]interface{}{
+			"plug-sdk-type": []interface{}{"host", "regular"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(rule.AllowInstallation, check.HasLen, 1)
+	cstrs := rule.AllowInstallation[0]
+	c.Check(cstrs.PlugSdkTypes, check.DeepEquals, []string{"host", "regular"})
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsPlugNames(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`iface:
+  allow-installation: true`))
+	c.Assert(err, check.IsNil)
+
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	c.Check(rule.AllowInstallation[0].PlugNames, check.IsNil)
+
+	tests := []struct {
+		rule        string
+		matching    []string
+		notMatching []string
+	}{
+		{`iface:
+  allow-installation:
+    plug-names:
+      - foo`, []string{"foo"}, []string{"bar"}},
+		{`iface:
+  allow-installation:
+    plug-names:
+      - foo
+      - bar`, []string{"foo", "bar"}, []string{"baz"}},
+		{`iface:
+  allow-installation:
+    plug-names:
+      - foo[0-9]
+      - bar`, []string{"foo0", "foo1", "bar"}, []string{"baz", "fooo", "foo12"}},
+	}
+	for _, t := range tests {
+		m, err = asserts.ParseHeaders([]byte(t.rule))
+		c.Assert(err, check.IsNil)
+
+		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+		c.Assert(err, check.IsNil)
+
+		for _, matching := range t.matching {
+			c.Check(rule.AllowInstallation[0].PlugNames.Check("plug name", matching, nil), check.IsNil)
+		}
+		for _, notMatching := range t.notMatching {
+			c.Check(rule.AllowInstallation[0].PlugNames.Check("plug name", notMatching, nil), check.NotNil)
+		}
+	}
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsIDConstraints(c *check.C) {
+	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
+		"allow-connection": map[string]interface{}{
+			"slot-sdk-type": []interface{}{"host", "regular"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(rule.AllowConnection, check.HasLen, 1)
+	cstrs := rule.AllowConnection[0]
+	c.Check(cstrs.SlotSdkTypes, check.DeepEquals, []string{"host", "regular"})
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsPlugNamesSlotNames(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`iface:
+  allow-connection: true`))
+	c.Assert(err, check.IsNil)
+
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	c.Check(rule.AllowConnection[0].PlugNames, check.IsNil)
+	c.Check(rule.AllowConnection[0].SlotNames, check.IsNil)
+
+	tests := []struct {
+		rule        string
+		matching    []string
+		notMatching []string
+	}{
+		{`iface:
+  allow-connection:
+    plug-names:
+      - Pfoo
+    slot-names:
+      - Sfoo`, []string{"foo"}, []string{"bar"}},
+		{`iface:
+  allow-connection:
+    plug-names:
+      - Pfoo
+      - Pbar
+    slot-names:
+      - Sfoo
+      - Sbar`, []string{"foo", "bar"}, []string{"baz"}},
+		{`iface:
+  allow-connection:
+    plug-names:
+      - Pfoo[0-9]
+      - Pbar
+    slot-names:
+      - Sfoo[0-9]
+      - Sbar`, []string{"foo0", "foo1", "bar"}, []string{"baz", "fooo", "foo12"}},
+	}
+	for _, t := range tests {
+		m, err = asserts.ParseHeaders([]byte(t.rule))
+		c.Assert(err, check.IsNil)
+
+		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+		c.Assert(err, check.IsNil)
+
+		for _, matching := range t.matching {
+			c.Check(rule.AllowConnection[0].PlugNames.Check("plug name", "P"+matching, nil), check.IsNil)
+
+			c.Check(rule.AllowConnection[0].SlotNames.Check("slot name", "S"+matching, nil), check.IsNil)
+		}
+
+		for _, notMatching := range t.notMatching {
+			c.Check(rule.AllowConnection[0].SlotNames.Check("plug name", "P"+notMatching, nil), check.NotNil)
+
+			c.Check(rule.AllowConnection[0].SlotNames.Check("slot name", "S"+notMatching, nil), check.NotNil)
+		}
+	}
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsSideArityConstraints(c *check.C) {
+	m, err := asserts.ParseHeaders([]byte(`iface:
+  allow-auto-connection: true`))
+	c.Assert(err, check.IsNil)
+
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	c.Assert(err, check.IsNil)
+
+	// defaults
+	c.Check(rule.AllowAutoConnection[0].SlotsPerPlug, check.Equals, asserts.SideArityConstraint{N: 1})
+	c.Check(rule.AllowAutoConnection[0].PlugsPerSlot.Any(), check.Equals, true)
+
+	c.Check(rule.AllowConnection[0].SlotsPerPlug.Any(), check.Equals, true)
+	c.Check(rule.AllowConnection[0].PlugsPerSlot.Any(), check.Equals, true)
+
+	// test that the arity constraints get normalized away to any
+	// under allow-connection
+	// see https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
+	allowConnTests := []string{
+		`iface:
+  allow-connection:
+    slots-per-plug: 1
+    plugs-per-slot: 2`,
+		`iface:
+  allow-connection:
+    slots-per-plug: *
+    plugs-per-slot: 1`,
+		`iface:
+  allow-connection:
+    slots-per-plug: 2
+    plugs-per-slot: *`,
+	}
+
+	for _, t := range allowConnTests {
+		m, err = asserts.ParseHeaders([]byte(t))
+		c.Assert(err, check.IsNil)
+
+		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+		c.Assert(err, check.IsNil)
+
+		c.Check(rule.AllowConnection[0].SlotsPerPlug.Any(), check.Equals, true)
+		c.Check(rule.AllowConnection[0].PlugsPerSlot.Any(), check.Equals, true)
+	}
+
+	// test that under allow-auto-connection:
+	// slots-per-plug can be * (any) or otherwise gets normalized to 1
+	// plugs-per-slot gets normalized to any (*)
+	// see https://forum.snapcraft.io/t/plug-slot-declaration-rules-greedy-plugs/12438
+	allowAutoConnTests := []struct {
+		rule         string
+		slotsPerPlug asserts.SideArityConstraint
+	}{
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 1
+    plugs-per-slot: 2`, sideArityOne},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: *
+    plugs-per-slot: 1`, sideArityAny},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 2
+    plugs-per-slot: *`, sideArityOne},
+	}
+
+	for _, t := range allowAutoConnTests {
+		m, err = asserts.ParseHeaders([]byte(t.rule))
+		c.Assert(err, check.IsNil)
+
+		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+		c.Assert(err, check.IsNil)
+
+		c.Check(rule.AllowAutoConnection[0].SlotsPerPlug, check.Equals, t.slotsPerPlug)
+		c.Check(rule.AllowAutoConnection[0].PlugsPerSlot.Any(), check.Equals, true)
+	}
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsAttributesDefault(c *check.C) {
+	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
+		"allow-connection": map[string]interface{}{
+			"slot-sdk-type": []interface{}{"regular"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	// attributes default to always matching here
+	cstrs := rule.AllowConnection[0]
+	c.Check(cstrs.PlugAttributes, check.Equals, asserts.AlwaysMatchAttributes)
+	c.Check(cstrs.SlotAttributes, check.Equals, asserts.AlwaysMatchAttributes)
+}
+
+func (s *plugSlotRulesSuite) TestCompilePlugRuleErrors(c *check.C) {
+	tests := []struct {
+		stanza string
+		err    string
+	}{
+		{`iface: foo`, `plug rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  - allow`, `plug rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  allow-installation: foo`, `allow-installation in plug rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  deny-installation: foo`, `deny-installation in plug rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  allow-connection: foo`, `allow-connection in plug rule for interface "iface" must be a map or one of the shortcuts 'true' or 'false'`},
+		{`iface:
+  allow-connection:
+    - foo`, `alternative 1 of allow-connection in plug rule for interface "iface" must be a map`},
+		{`iface:
+  allow-connection:
+    - true`, `alternative 1 of allow-connection in plug rule for interface "iface" must be a map`},
+		{`iface:
+  allow-installation:
+    plug-attributes:
+      a1: [`, `cannot compile plug-attributes in allow-installation in plug rule for interface "iface": cannot compile "a1" constraint .*`},
+		{`iface:
+  allow-connection:
+    slot-attributes:
+      a2: [`, `cannot compile slot-attributes in allow-connection in plug rule for interface "iface": cannot compile "a2" constraint .*`},
+		{`iface:
+  allow-connection:
+    slot-sdk-type:
+      - foo`, `slot-sdk-type in allow-connection in plug rule for interface "iface" contains an invalid element: "foo"`},
+		{`iface:
+  allow-connection:
+    slot-sdk-type:
+      - xapp`, `slot-sdk-type in allow-connection in plug rule for interface "iface" contains an invalid element: "xapp"`},
+		{`iface:
+  allow-connect: true`, `plug rule for interface "iface" must specify at least one of allow-installation, deny-installation, allow-connection, deny-connection, allow-auto-connection, deny-auto-connection`},
+		{`iface:
+  allow-installation:
+    slots-per-plug: 1`, `allow-installation in plug rule for interface "iface" cannot specify a slots-per-plug constraint, they apply only to allow-\*connection`},
+		{`iface:
+  deny-connection:
+    slots-per-plug: 1`, `deny-connection in plug rule for interface "iface" cannot specify a slots-per-plug constraint, they apply only to allow-\*connection`},
+		{`iface:
+  allow-auto-connection:
+    plugs-per-slot: any`, `plugs-per-slot in allow-auto-connection in plug rule for interface "iface" must be an integer >=1 or \*`},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 00`, `slots-per-plug in allow-auto-connection in plug rule for interface "iface" has invalid prefix zeros: 00`},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 99999999999999999999`, `slots-per-plug in allow-auto-connection in plug rule for interface "iface" is out of range: 99999999999999999999`},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug: 0`, `slots-per-plug in allow-auto-connection in plug rule for interface "iface" must be an integer >=1 or \*`},
+		{`iface:
+  allow-auto-connection:
+    slots-per-plug:
+      what: 1`, `slots-per-plug in allow-auto-connection in plug rule for interface "iface" must be an integer >=1 or \*`},
+		{`iface:
+  allow-auto-connection:
+    plug-names: true`, `plug-names constraints must be a list of regexps and special \$ values`},
+		{`iface:
+  allow-auto-connection:
+    slot-names: true`, `slot-names constraints must be a list of regexps and special \$ values`},
+	}
+
+	for _, t := range tests {
+		m, err := asserts.ParseHeaders([]byte(t.stanza))
+		c.Assert(err, check.IsNil, check.Commentf(t.stanza))
+
+		_, err = asserts.CompilePlugRule("iface", m["iface"])
+		c.Check(err, check.ErrorMatches, t.err, check.Commentf(t.stanza))
+	}
+}
+
+func (s *plugSlotRulesSuite) TestPlugRuleFeatures(c *check.C) {
+	combos := []struct {
+		subrule             string
+		constraintsPrefixes []string
+	}{
+		{"allow-installation", []string{"plug-"}},
+		{"deny-installation", []string{"plug-"}},
+		{"allow-connection", []string{"plug-", "slot-"}},
+		{"deny-connection", []string{"plug-", "slot-"}},
+		{"allow-auto-connection", []string{"plug-", "slot-"}},
+		{"deny-auto-connection", []string{"plug-", "slot-"}},
+	}
+
+	for _, combo := range combos {
+		for _, attrConstrPrefix := range combo.constraintsPrefixes {
+			attrConstraintMap := map[string]interface{}{
+				"a":     "ATTR",
+				"other": []interface{}{"x", "y"},
+			}
+			ruleMap := map[string]interface{}{
+				combo.subrule: map[string]interface{}{
+					attrConstrPrefix + "attributes": attrConstraintMap,
+				},
+			}
+
+			rule, err := asserts.CompilePlugRule("iface", ruleMap)
+			c.Assert(err, check.IsNil)
+			c.Check(asserts.RuleFeature(rule, "dollar-attr-constraints"), check.Equals, false, check.Commentf("%v", ruleMap))
+
+			c.Check(asserts.RuleFeature(rule, "device-scope-constraints"), check.Equals, false, check.Commentf("%v", ruleMap))
+			c.Check(asserts.RuleFeature(rule, "name-constraints"), check.Equals, false, check.Commentf("%v", ruleMap))
+
+			attrConstraintMap["a"] = "$MISSING"
+			rule, err = asserts.CompilePlugRule("iface", ruleMap)
+			c.Assert(err, check.IsNil)
+			c.Check(asserts.RuleFeature(rule, "dollar-attr-constraints"), check.Equals, true, check.Commentf("%v", ruleMap))
+
+			// covers also alternation
+			attrConstraintMap["a"] = []interface{}{"$SLOT(a)"}
+			rule, err = asserts.CompilePlugRule("iface", ruleMap)
+			c.Assert(err, check.IsNil)
+			c.Check(asserts.RuleFeature(rule, "dollar-attr-constraints"), check.Equals, true, check.Commentf("%v", ruleMap))
+
+			c.Check(asserts.RuleFeature(rule, "device-scope-constraints"), check.Equals, false, check.Commentf("%v", ruleMap))
+			c.Check(asserts.RuleFeature(rule, "name-constraints"), check.Equals, false, check.Commentf("%v", ruleMap))
+
+		}
+
+		for _, nameConstrPrefix := range combo.constraintsPrefixes {
+			ruleMap := map[string]interface{}{
+				combo.subrule: map[string]interface{}{
+					nameConstrPrefix + "names": []interface{}{"foo"},
+				},
+			}
+
+			rule, err := asserts.CompilePlugRule("iface", ruleMap)
+			c.Assert(err, check.IsNil)
+			c.Check(asserts.RuleFeature(rule, "name-constraints"), check.Equals, true, check.Commentf("%v", ruleMap))
+		}
+	}
+}
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsSlotNames(c *check.C) {
 	m, err := asserts.ParseHeaders([]byte(`iface:
@@ -136,7 +1062,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstra
 
 	c.Assert(rule.AllowInstallation, check.HasLen, 1)
 	cstrs := rule.AllowInstallation[0]
-	c.Check(cstrs.SlotTypes, check.DeepEquals, []string{"host", "regular"})
+	c.Check(cstrs.SlotSdkTypes, check.DeepEquals, []string{"host", "regular"})
 }
 
 func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.SlotConnectionConstraints, always bool) {

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/asserts"
 	"github.com/canonical/workshop/internal/sdk"

--- a/internal/asserts/sdk_asserts.go
+++ b/internal/asserts/sdk_asserts.go
@@ -28,6 +28,13 @@ import (
 )
 
 func compilePlugRules(plugs map[string]interface{}, compiled func(iface string, plugRule *PlugRule)) error {
+	for iface, rule := range plugs {
+		plugRule, err := compilePlugRule(iface, rule)
+		if err != nil {
+			return err
+		}
+		compiled(iface, plugRule)
+	}
 	return nil
 }
 

--- a/internal/asserts/sdk_asserts_test.go
+++ b/internal/asserts/sdk_asserts_test.go
@@ -17,19 +17,65 @@ func (s *baseDeclSuite) TestDecodeOK(c *check.C) {
 	encoded := `type: base-declaration
 authority-id: canonical
 series: 1
+plugs:
+  interface1:
+    deny-installation: false
+    allow-auto-connection:
+      slot-sdk-type:
+        - host
+      slot-attributes:
+        a1: /foo/.*
+      plug-attributes:
+        b1: B1
+    deny-auto-connection:
+      slot-attributes:
+        a1: !A1
+      plug-attributes:
+        b1: !B1
+  interface2:
+    allow-installation: true
+    allow-connection:
+      plug-attributes:
+        a2: A2
+      slot-attributes:
+        b2: B2
+    deny-connection:
+      plug-attributes:
+        a2: !A2
+      slot-attributes:
+        b2: !B2
 slots:
   interface3:
-    deny-installation: true
+    deny-installation: false
     allow-auto-connection:
       plug-sdk-type:
         - host
+      slot-attributes:
+        c1: /foo/.*
+      plug-attributes:
+        d1: C1
+    deny-auto-connection:
+      slot-attributes:
+        c1: !C1
+      plug-attributes:
+        d1: !D1
   interface4:
-    allow-connection: true
-    deny-connection: false
+    allow-connection:
+      plug-attributes:
+        c2: C2
+      slot-attributes:
+        d2: D2
+    deny-connection:
+      plug-attributes:
+        c2: !D2
+      slot-attributes:
+        d2: !D2
     allow-installation:
       slot-sdk-type:
         - host
         - regular
+      slot-attributes:
+        e1: E1
 timestamp: 2016-09-29T19:50:49Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
@@ -53,7 +99,7 @@ AXNpZw==`
 
 	slotRule4 := baseDecl.SlotRule("interface4")
 	c.Assert(slotRule4, check.NotNil)
-	c.Check(slotRule4.AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"host", "regular"})
+	c.Check(slotRule4.AllowInstallation[0].SlotSdkTypes, check.DeepEquals, []string{"host", "regular"})
 	c.Assert(slotRule4.DenyInstallation, check.HasLen, 1)
 	c.Assert(slotRule3.AllowConnection, check.HasLen, 1)
 	c.Assert(slotRule3.DenyConnection, check.HasLen, 1)
@@ -79,6 +125,8 @@ func (s *baseDeclSuite) TestDecodeInvalid(c *check.C) {
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"series: 16\n", "", `"series" header is mandatory`},
 		{"series: 16\n", "series: \n", `"series" header should not be empty`},
+		{"plugs:\n  interface1: true\n", "plugs: \n", `"plugs" header must be a map`},
+		{"plugs:\n  interface1: true\n", "plugs:\n  intf1:\n    foo: bar\n", `plug rule for interface "intf1" must specify at least one of.*`},
 		{"slots:\n  interface2: true\n", "slots: \n", `"slots" header must be a map`},
 		{"slots:\n  interface2: true\n", "slots:\n  intf1:\n    foo: bar\n", `slot rule for interface "intf1" must specify at least one of.*`},
 		{tsLine, "", `"timestamp" header is mandatory`},
@@ -104,6 +152,8 @@ type: base-declaration
 authority-id: canonical
 series: 1
 revision: 0
+plugs:
+  network: true
 slots:
   network:
     allow-installation:
@@ -122,7 +172,8 @@ slots:
 
 	c.Check(baseDecl.AuthorityID(), check.Equals, "canonical")
 	c.Check(baseDecl.Series(), check.Equals, "1")
-	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotTypes, check.DeepEquals, []string{"host"})
+	c.Check(baseDecl.PlugRule("network").AllowAutoConnection[0].SlotAttributes, check.Equals, asserts.AlwaysMatchAttributes)
+	c.Check(baseDecl.SlotRule("network").AllowInstallation[0].SlotSdkTypes, check.DeepEquals, []string{"host"})
 
 	enc := asserts.Encode(baseDecl)
 	// it's expected that it cannot be decoded

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1109,7 +1109,7 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 	wp, err := s.b.Workshop(s.ctx, "consumer-ws")
 	c.Check(err, check.IsNil)
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug2"] = workshop.Plug{Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug"}}
+	wp.File.Sdks[0].Plugs["plug2"] = workshop.Plug{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}}
 
 	d.Overlord().Loop()
 	defer d.Overlord().Stop()
@@ -1539,7 +1539,7 @@ func (s *apiSuite) TestDisconnectPlugForgetSuccess(c *check.C) {
 func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 	opts := &disconnectOpts{
 		bind: map[string]workshop.Plug{
-			"plug2": {Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
+			"plug2": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
@@ -1553,7 +1553,7 @@ func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
 	opts := &disconnectOpts{
 		bind: map[string]workshop.Plug{
-			"plug2": {Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
+			"plug2": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}
 	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot", opts)
@@ -1567,7 +1567,7 @@ func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
 func (s *apiSuite) TestDisconnectBoundPlugSlaveSuccess(c *check.C) {
 	opts := &disconnectOpts{
 		bind: map[string]workshop.Plug{
-			"plug2": {Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
+			"plug2": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug2", "producer-ws", "producer", "slot", opts)

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -43,9 +43,9 @@ func v1PostProjects(c *Command, r *http.Request, _ *userState) Response {
 	wBackend := c.d.overlord.WorkshopBackend()
 
 	prj, created, err := wBackend.CreateOrLoadProject(r.Context(), reqData.Path)
-	if err != nil && !errors.Is(err, workshop.ErrNotAProject) {
+	if err != nil && !errors.Is(err, workshop.ErrNotProject) {
 		return statusInternalError("cannot create or load project at %q: %v", reqData.Path, err)
-	} else if errors.Is(err, workshop.ErrNotAProject) {
+	} else if errors.Is(err, workshop.ErrNotProject) {
 		return statusBadRequest("%v", err)
 	}
 

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -52,6 +52,7 @@ type apiSuite struct {
 	restoreUser       func()
 	restoreTime       func()
 	restoreBackendNew func()
+	restoreSanitize   func()
 }
 
 func TestApi(t *testing.T) { check.TestingT(t) }
@@ -95,6 +96,8 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 
 	_, _, err = s.b.CreateOrLoadProject(s.ctx, s.project.Path)
 	c.Assert(err, check.IsNil)
+
+	s.restoreSanitize = sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})
 }
 
 func (s *apiSuite) TearDownTest(c *check.C) {
@@ -105,6 +108,7 @@ func (s *apiSuite) TearDownTest(c *check.C) {
 	s.restoreUser()
 	s.restoreTime()
 	s.restoreBackendNew()
+	s.restoreSanitize()
 }
 
 func (s *apiSuite) muxVars(*http.Request) map[string]string {

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -68,18 +68,11 @@ type WorkshopInfo struct {
 var ensureStateSoon = stateEnsureBefore
 var workshopMounts = mounts
 
-func workshopFileToInfo(file *workshop.File, pid string) *WorkshopInfo {
+func workshopFileToInfo(file string, pid string) *WorkshopInfo {
 	var ws WorkshopInfo
-	ws.Name = file.Name
-	ws.Base = file.Base
+	ws.Name = file
 	ws.ProjectId = pid
 	ws.Status = healthstate.OffStatus.String()
-	for _, i := range file.Sdks {
-		ws.Content = append(ws.Content, &SdkInfo{
-			Name:    i.Name,
-			Channel: i.Channel,
-		})
-	}
 	return &ws
 }
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -213,16 +213,14 @@ sdks:
         source: .
   test-sdk:
     channel: latest/stable
-    plugs:
-      data: 
-        bind: test-sdk-2:photos
   test-sdk-2:
     channel: latest/stable
+    plugs:
+      photos: 
+        bind: test-sdk:data
 connections:
   - plug: test-sdk:data
     slot: host:training
-  - plug: test-sdk-2:photos
-    slot: host:photos
 `
 
 	testsdk = `
@@ -980,7 +978,7 @@ func (s *apiSuite) TestWorkshopConnectionsUnknownPlug(c *check.C) {
 	c.Assert(conns, check.HasLen, 0)
 }
 
-func (s *apiSuite) TestWorkshopConnectionsPlugIsBound(c *check.C) {
+func (s *apiSuite) TestWorkshopConnectionsPlugIsBoundTo(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
@@ -1003,24 +1001,21 @@ func (s *apiSuite) TestWorkshopConnectionsPlugIsBound(c *check.C) {
 
 	s.runActionTest(c, requests, expected)
 
-	// The explicit connection for "test-sdk:data" will be ignored as the plug is bound to another
-	// plug.
 	repo := s.d.overlord.InterfaceManager().Repository()
 	conns, err := repo.Connected(s.project.ProjectId, "connsplugbound", "test-sdk", "data")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].SlotRef.Name, check.Equals, "photos")
+	c.Assert(conns[0].SlotRef.Name, check.Equals, "training")
+
+	conns, err = repo.Connected(s.project.ProjectId, "connsplugbound", "test-sdk-2", "photos")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].SlotRef.Name, check.Equals, "training")
 
 	connection, err := repo.Connection(conns[0])
 	c.Assert(err, check.IsNil)
 	_, bound := connection.CheckBound()
 	c.Assert(bound, check.Equals, true)
-
-	// The explicit connection for "test-sdk-2:photo" will be set as usual.
-	conns, err = repo.Connected(s.project.ProjectId, "connsplugbound", "test-sdk-2", "photos")
-	c.Assert(err, check.IsNil)
-	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].SlotRef.Name, check.Equals, "photos")
 }
 
 func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -827,7 +827,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 	s.runActionTest(c, requests, expected)
 }
 
-func (s *apiSuite) TestLaunchWorkshopPlugAdded(c *check.C) {
+func (s *apiSuite) TestLaunchWorkshopWithPlugOK(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -104,6 +104,50 @@ sdks:
     channel: latest/stable
 `
 
+	workshopplug = `name: workshopplug
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      training-slot:
+        interface: content
+        source: .
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      training-plug:
+        interface: content
+        target: /opt
+  test-sdk-2:
+    channel: latest/stable
+connections:
+  - plug: test-sdk:training-plug
+    slot: host:training-slot
+`
+
+	workshopplugbound = `name: workshopplugbound
+base: ubuntu@22.04
+sdks:
+  host:
+    slots:
+      training-slot:
+        interface: content
+        source: .
+  test-sdk:
+    channel: latest/stable
+    plugs:
+      training-plug:
+        interface: content
+        target: /opt
+      data:
+        bind: test-sdk:training-plug
+  test-sdk-2:
+    channel: latest/stable
+connections:
+  - plug: test-sdk:training-plug
+    slot: host:training-slot
+`
+
 	workshopslot = `name: workshopslot
 base: ubuntu@22.04
 sdks:
@@ -783,6 +827,75 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 	s.runActionTest(c, requests, expected)
 }
 
+func (s *apiSuite) TestLaunchWorkshopPlugAdded(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	// Setup
+	s.createWFile(c, "workshopplug", workshopplug)
+	defer s.mockDoInstallSdk(c, "workshopplug", testsdks)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshopplug"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "workshopplug" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.Plug(s.project.ProjectId, "workshopplug", "test-sdk", "training-plug"), check.NotNil)
+	conns, err := repo.Connected(s.project.ProjectId, "workshopplug", "test-sdk", "training-plug")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplug/test-sdk:training-plug %s/workshopplug/host:training-slot`, s.project.ProjectId, s.project.ProjectId))
+}
+
+func (s *apiSuite) TestLaunchWorkshopPlugAddedAndBound(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	// Setup
+	s.createWFile(c, "workshopplugbound", workshopplugbound)
+	defer s.mockDoInstallSdk(c, "workshopplugbound", testsdks)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshopplugbound"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "workshopplugbound" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.Plug(s.project.ProjectId, "workshopplugbound", "test-sdk", "training-plug"), check.NotNil)
+	conns, err := repo.Connected(s.project.ProjectId, "workshopplugbound", "test-sdk", "training-plug")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplugbound/test-sdk:training-plug %s/workshopplugbound/host:training-slot`, s.project.ProjectId, s.project.ProjectId))
+
+	conns, err = repo.Connected(s.project.ProjectId, "workshopplugbound", "test-sdk", "data")
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 1)
+	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplugbound/test-sdk:data %s/workshopplugbound/host:training-slot`, s.project.ProjectId, s.project.ProjectId))
+}
+
 func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
@@ -834,7 +947,7 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	})
 }
 
-func (s *apiSuite) TestConnectionsUnknownPlug(c *check.C) {
+func (s *apiSuite) TestWorkshopConnectionsUnknownPlug(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()

--- a/internal/interfaces/builtin/all_test.go
+++ b/internal/interfaces/builtin/all_test.go
@@ -115,7 +115,7 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotNames(c *C) {
 	sdkInfo := sdk.MockInvalidInfo(c, testConsumerInvalidSlotNameYaml)
 	sdk.SanitizePlugsSlots(sdkInfo)
 	c.Assert(sdkInfo.BadInterfaces, HasLen, 1)
-	c.Check(sdk.BadInterfacesSummary(sdkInfo), Matches, `sdk "consumer" has bad plugs or slots: ttyS5 \(invalid slot name: "ttyS5"\)`)
+	c.Check(sdk.BadInterfacesSummary(sdkInfo), Matches, `"consumer" SDK has bad plugs or slots: ttyS5 \(invalid slot name: "ttyS5"\)`)
 }
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
@@ -127,7 +127,7 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
 	sdkInfo := sdk.MockInvalidInfo(c, testConsumerInvalidPlugNameYaml)
 	sdk.SanitizePlugsSlots(sdkInfo)
 	c.Assert(sdkInfo.BadInterfaces, HasLen, 1)
-	c.Check(sdk.BadInterfacesSummary(sdkInfo), Matches, `sdk "consumer" has bad plugs or slots: ttyS3 \(invalid plug name: "ttyS3"\)`)
+	c.Check(sdk.BadInterfacesSummary(sdkInfo), Matches, `"consumer" SDK has bad plugs or slots: ttyS3 \(invalid plug name: "ttyS3"\)`)
 }
 
 func (s *AllSuite) TestUnexpectedSpecSignatures(c *C) {

--- a/internal/interfaces/builtin/content.go
+++ b/internal/interfaces/builtin/content.go
@@ -41,6 +41,15 @@ const contentBaseDeclarationSlots = `
       slot-sdk-type:
         - host
     allow-connection: true
+    allow-auto-connection: true
+`
+
+const contentBaseDeclarationPlugs = `
+  content:
+    allow-installation:
+      plug-sdk-type:
+        - regular
+    allow-connection: true
     allow-auto-connection:
       -
         slot-names:
@@ -63,6 +72,7 @@ func (iface *contentInterface) Name() string {
 func (iface *contentInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              contentSummary,
+		BaseDeclarationPlugs: contentBaseDeclarationPlugs,
 		BaseDeclarationSlots: contentBaseDeclarationSlots,
 		AffectsPlugOnRefresh: true,
 	}

--- a/internal/interfaces/builtin/gpu.go
+++ b/internal/interfaces/builtin/gpu.go
@@ -39,6 +39,17 @@ const gpuBaseDeclarationSlots = `
     allow-auto-connection: true
 `
 
+const gpuBaseDeclarationPlugs = `
+  gpu:
+    allow-installation:
+      plug-sdk-type:
+        - regular
+      plug-names:
+        - $INTERFACE
+    allow-connection: true
+    allow-auto-connection: true
+`
+
 type gpuInterface struct{}
 
 func (iface *gpuInterface) Name() string {
@@ -48,6 +59,7 @@ func (iface *gpuInterface) Name() string {
 func (iface *gpuInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              gpuSummary,
+		BaseDeclarationPlugs: gpuBaseDeclarationPlugs,
 		BaseDeclarationSlots: gpuBaseDeclarationSlots,
 		AffectsPlugOnRefresh: true,
 	}

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -48,6 +48,17 @@ const sshAgentBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
+const sshAgentDeclarationPlugs = `
+  ssh-agent:
+    allow-installation:
+      plug-sdk-type:
+        - regular
+      plug-names:
+        - $INTERFACE
+    allow-connection: true
+    allow-auto-connection: false
+`
+
 type sshAgentInterface struct{}
 
 func (iface *sshAgentInterface) Name() string {
@@ -57,6 +68,7 @@ func (iface *sshAgentInterface) Name() string {
 func (iface *sshAgentInterface) StaticInfo() interfaces.StaticInfo {
 	return interfaces.StaticInfo{
 		Summary:              sshAgentSummary,
+		BaseDeclarationPlugs: sshAgentDeclarationPlugs,
 		BaseDeclarationSlots: sshAgentBaseDeclarationSlots,
 		AffectsPlugOnRefresh: true,
 	}

--- a/internal/interfaces/policy/basedeclaration.go
+++ b/internal/interfaces/policy/basedeclaration.go
@@ -100,6 +100,16 @@ func composeBaseDeclaration(ifaces []interfaces.Interface) ([]byte, error) {
 	if _, err := buf.WriteString(trimTrailingNewline(baseDeclarationHeader)); err != nil {
 		return nil, err
 	}
+	if _, err := buf.WriteString(trimTrailingNewline(baseDeclarationPlugs)); err != nil {
+		return nil, err
+	}
+	for _, iface := range ifaces {
+		plugPolicy := interfaces.StaticInfoOf(iface).BaseDeclarationPlugs
+		if _, err := buf.WriteString(trimTrailingNewline(plugPolicy)); err != nil {
+			return nil, err
+		}
+	}
+
 	if _, err := buf.WriteString(trimTrailingNewline(baseDeclarationSlots)); err != nil {
 		return nil, err
 	}

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -45,16 +45,16 @@ func Test(t *testing.T) {
 	check.TestingT(t)
 }
 
-func (s *baseDeclSuite) SetUpSuite(c *C) {
+func (s *baseDeclSuite) SetUpSuite(c *check.C) {
 	s.restoreSanitize = sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})
 	s.baseDecl = asserts.BuiltinBaseDeclaration()
 }
 
-func (s *baseDeclSuite) TearDownSuite(c *C) {
+func (s *baseDeclSuite) TearDownSuite(c *check.C) {
 	s.restoreSanitize()
 }
 
-func (s *baseDeclSuite) connectCand(c *C, iface, slotYaml, plugYaml string, slotprj, plugprj string, slotws, plugws string) *policy.ConnectCandidate {
+func (s *baseDeclSuite) connectCand(c *check.C, iface, slotYaml, plugYaml string, slotprj, plugprj string, slotws, plugws string) *policy.ConnectCandidate {
 	if slotYaml == "" {
 		slotYaml = fmt.Sprintf(`name: slot-sdk
 base: ubuntu@22.04
@@ -78,7 +78,7 @@ plugs:
 	}
 }
 
-func (s *baseDeclSuite) installSlotCand(c *C, iface string, sdkType sdk.Type, yaml string) *policy.InstallCandidate {
+func (s *baseDeclSuite) installSlotCand(c *check.C, iface string, sdkType sdk.Type, yaml string) *policy.InstallCandidate {
 	if yaml == "" {
 		yaml = fmt.Sprintf(`name: install-slot-sdk
 base: ubuntu@22.04
@@ -94,7 +94,7 @@ slots:
 	}
 }
 
-func (s *baseDeclSuite) installPlugCand(c *C, iface string, sdkType sdk.Type, yaml string) *policy.InstallCandidate {
+func (s *baseDeclSuite) installPlugCand(c *check.C, iface string, sdkType sdk.Type, yaml string) *policy.InstallCandidate {
 	if yaml == "" {
 		yaml = fmt.Sprintf(`name: install-plug-sdk
 base: ubuntu@22.04
@@ -110,7 +110,41 @@ plugs:
 	}
 }
 
-func (s *baseDeclSuite) TestContentAutoConnection(c *C) {
+func (s *baseDeclSuite) TestAutoConnection(c *C) {
+	all := builtin.Interfaces()
+
+	// these have more complex or in flux policies and have their
+	// own separate tests
+	snowflakes := map[string]bool{
+		"content":   true,
+		"ssh-agent": true,
+	}
+
+	// these simply auto-connect, anything else doesn't
+	autoconnect := map[string]bool{
+		"gpu": true,
+	}
+
+	for _, iface := range all {
+		if snowflakes[iface.Name()] {
+			continue
+		}
+		expected := autoconnect[iface.Name()]
+		comm := Commentf(iface.Name())
+
+		// check base declaration
+		cand := s.connectCand(c, iface.Name(), "", "", "", "", "", "")
+		arity, err := cand.CheckAutoConnect()
+		if expected {
+			c.Check(err, IsNil, comm)
+			c.Check(arity.SlotsPerPlugAny(), Equals, false)
+		} else {
+			c.Check(err, NotNil, comm)
+		}
+	}
+}
+
+func (s *baseDeclSuite) TestContentAutoConnection(c *check.C) {
 	slotYaml := fmt.Sprintf(`name: slot-sdk
 base: ubuntu@22.04
 slots:
@@ -123,7 +157,7 @@ slots:
 	c.Check(arity.SlotsPerPlugAny(), check.Equals, false)
 }
 
-func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *C) {
+func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *check.C) {
 	all := builtin.Interfaces()
 
 	for _, iface := range all {
@@ -131,7 +165,7 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *C) {
 	}
 }
 
-func (s *baseDeclSuite) TestContentSlotInstallation(c *C) {
+func (s *baseDeclSuite) TestContentSlotInstallation(c *check.C) {
 	// test content specially
 	ic := s.installSlotCand(c, "content", sdk.Regular, ``)
 	err := ic.Check()
@@ -143,7 +177,7 @@ func (s *baseDeclSuite) TestContentSlotInstallation(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *baseDeclSuite) TestComposeBaseDeclaration(c *C) {
+func (s *baseDeclSuite) TestComposeBaseDeclaration(c *check.C) {
 	decl, err := policy.ComposeBaseDeclaration(nil)
 	c.Assert(err, IsNil)
 	c.Assert(string(decl), testutil.Contains, `
@@ -154,14 +188,14 @@ revision: 0
 `)
 }
 
-func (s *baseDeclSuite) TestDoesNotPanic(c *C) {
+func (s *baseDeclSuite) TestDoesNotPanic(c *check.C) {
 	// In case there are any issues in the actual interfaces we'd get a panic
 	// on startup. This test prevents this from happing unnoticed.
 	_, err := policy.ComposeBaseDeclaration(builtin.Interfaces())
 	c.Assert(err, IsNil)
 }
 
-func (s *baseDeclSuite) TestSlotPlugFromSameWorkshop(c *C) {
+func (s *baseDeclSuite) TestSlotPlugFromSameWorkshop(c *check.C) {
 	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
 type: host
@@ -175,7 +209,7 @@ slots:
 	c.Check(err, check.IsNil)
 }
 
-func (s *baseDeclSuite) TestSlotPlugDifferentProjects(c *C) {
+func (s *baseDeclSuite) TestSlotPlugDifferentProjects(c *check.C) {
 	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
 type: host
@@ -184,18 +218,18 @@ slots:
 `
 	plugYaml := `name: plug-sdk
 base: ubuntu@22.04
-type: host
+type: regular
 plugs:
     content:      
 `
 	cand := s.connectCand(c, "content", slotYaml, plugYaml, "slot-project", "mock424242", "ws", "ws")
 	_, err := cand.Check()
-	c.Check(err, check.ErrorMatches, `connection not allowed by slot rule of interface "content"`)
+	c.Check(err, check.ErrorMatches, `connection not allowed by plug rule of interface "content"`)
 	_, err = cand.CheckAutoConnect()
-	c.Check(err, check.ErrorMatches, `auto-connection not allowed by slot rule of interface "content"`)
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by plug rule of interface "content"`)
 }
 
-func (s *baseDeclSuite) TestSlotPlugDifferentWorkshop(c *C) {
+func (s *baseDeclSuite) TestSlotPlugDifferentWorkshop(c *check.C) {
 	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
 type: host
@@ -204,13 +238,13 @@ slots:
 `
 	plugYaml := `name: plug-sdk
 base: ubuntu@22.04
-type: host
+type: regular
 plugs:
-    content:      
+    content:
 `
 	cand := s.connectCand(c, "content", slotYaml, plugYaml, "mock424242", "mock424242", "ws", "ws-1")
 	_, err := cand.Check()
-	c.Check(err, check.ErrorMatches, `connection not allowed by slot rule of interface "content"`)
+	c.Check(err, check.ErrorMatches, `connection not allowed by plug rule of interface "content"`)
 	_, err = cand.CheckAutoConnect()
-	c.Check(err, check.ErrorMatches, `auto-connection not allowed by slot rule of interface "content"`)
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by plug rule of interface "content"`)
 }

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -28,8 +28,77 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 )
 
+func checkPlugInstallationConstraints1(ic *InstallCandidate, plug *sdk.PlugInfo, constraints *asserts.PlugInstallationConstraints) error {
+	if err := checkNameConstraints(constraints.PlugNames, plug.Interface, "plug name", plug.Name); err != nil {
+		return err
+	}
+
+	// TODO: allow evaluated attr constraints here too?
+	if err := constraints.PlugAttributes.Check(plug, nil); err != nil {
+		return err
+	}
+	if err := checkSdkType(plug.Sdk, constraints.PlugSdkTypes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkPlugInstallationAltConstraints(ic *InstallCandidate, plug *sdk.PlugInfo, altConstraints []*asserts.PlugInstallationConstraints) error {
+	var firstErr error
+	// OR of constraints
+	for _, constraints := range altConstraints {
+		err := checkPlugInstallationConstraints1(ic, plug, constraints)
+		if err == nil {
+			return nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func checkPlugConnectionConstraints1(connc *ConnectCandidate, constraints *asserts.PlugConnectionConstraints) error {
+	if err := checkNameConstraints(constraints.PlugNames, connc.Plug.Interface(), "plug name", connc.Plug.Name()); err != nil {
+		return err
+	}
+	if err := checkNameConstraints(constraints.SlotNames, connc.Slot.Interface(), "slot name", connc.Slot.Name()); err != nil {
+		return err
+	}
+
+	if err := constraints.PlugAttributes.Check(connc.Plug, connc); err != nil {
+		return err
+	}
+	if err := constraints.SlotAttributes.Check(connc.Slot, connc); err != nil {
+		return err
+	}
+	plugSdk, slotSdk := connc.Plug.Sdk(), connc.Slot.Sdk()
+	if plugSdk.ProjectId != slotSdk.ProjectId || plugSdk.Workshop != slotSdk.Workshop {
+		return fmt.Errorf("%q cannot be connected to the %q (SDK from a different workshop)", connc.Plug.Ref(), connc.Slot.Ref())
+	}
+	return nil
+}
+
+func checkPlugConnectionAltConstraints(connc *ConnectCandidate, altConstraints []*asserts.PlugConnectionConstraints) (*asserts.PlugConnectionConstraints, error) {
+	var firstErr error
+	// OR of constraints
+	for _, constraints := range altConstraints {
+		err := checkPlugConnectionConstraints1(connc, constraints)
+		if err == nil {
+			return constraints, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return nil, firstErr
+}
+
 // check helpers
-func checkSlotType(sdkInfo *sdk.Info, types []string) error {
+func checkSdkType(sdkInfo *sdk.Info, types []string) error {
+	if len(types) == 0 {
+		return nil
+	}
 	if !slices.Contains(types, string(sdkInfo.Type)) {
 		return fmt.Errorf("invalid SDK type %q", sdkInfo.Type)
 	}
@@ -55,7 +124,7 @@ func checkSlotInstallationConstraints(ic *InstallCandidate, slot *sdk.SlotInfo, 
 		return err
 	}
 
-	if err := checkSlotType(slot.Sdk, constraints.SlotTypes); err != nil {
+	if err := checkSdkType(slot.Sdk, constraints.SlotSdkTypes); err != nil {
 		return err
 	}
 	return nil

--- a/internal/interfaces/policy/policy.go
+++ b/internal/interfaces/policy/policy.go
@@ -47,6 +47,13 @@ func (ic *InstallCandidate) checkSlotRule(slot *sdk.SlotInfo, rule *asserts.Slot
 }
 
 func (ic *InstallCandidate) checkPlugRule(plug *sdk.PlugInfo, rule *asserts.PlugRule) error {
+	context := ""
+	if checkPlugInstallationAltConstraints(ic, plug, rule.DenyInstallation) == nil {
+		return fmt.Errorf("installation denied by %q plug rule of interface %q%s", plug.Name, plug.Interface, context)
+	}
+	if checkPlugInstallationAltConstraints(ic, plug, rule.AllowInstallation) != nil {
+		return fmt.Errorf("installation not allowed by %q plug rule of interface %q%s", plug.Name, plug.Interface, context)
+	}
 	return nil
 }
 
@@ -111,9 +118,23 @@ func (connc *ConnectCandidate) PlugAttr(arg string) (interface{}, error) {
 func (connc *ConnectCandidate) SlotAttr(arg string) (interface{}, error) {
 	return nestedGet("slot", connc.Slot, arg)
 }
-
 func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule, sdkRule bool) (interfaces.SideArity, error) {
-	return sideArity{asserts.SideArityConstraint{1}}, nil
+	context := ""
+	denyConst := rule.DenyConnection
+	allowConst := rule.AllowConnection
+	if kind == "auto-connection" {
+		denyConst = rule.DenyAutoConnection
+		allowConst = rule.AllowAutoConnection
+	}
+	if _, err := checkPlugConnectionAltConstraints(connc, denyConst); err == nil {
+		return nil, fmt.Errorf("%s denied by plug rule of interface %q%s", kind, connc.Plug.Interface(), context)
+	}
+
+	allowedConstraints, err := checkPlugConnectionAltConstraints(connc, allowConst)
+	if err != nil {
+		return nil, fmt.Errorf("%s not allowed by plug rule of interface %q%s", kind, connc.Plug.Interface(), context)
+	}
+	return sideArity{allowedConstraints.SlotsPerPlug}, nil
 }
 
 func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule, sdkRule bool) (interfaces.SideArity, error) {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -65,6 +65,12 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 		return err
 	}
 
+	// Ensure that all plugs that the workshop bindings bind to actually exist
+	// in the repository.
+	if err = m.resolveWorkshopBindings(wp); err != nil {
+		return err
+	}
+
 	// Ensure that connections requested via the workshop file use existing and
 	// compatible plugs and slots.
 	if err = m.resolveWorkshopConnections(wp); err != nil {
@@ -387,6 +393,9 @@ func MaybeBound(w *workshop.Workshop, ref interfaces.PlugRef) (interfaces.PlugRe
 
 	for _, s := range w.File.Sdks {
 		for name, pl := range s.Plugs {
+			if pl.Bind == nil {
+				continue
+			}
 			sdk, plug := pl.Bind.Sdk, pl.Bind.Name
 			mkey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: sdk, Name: plug}
 			skey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: s.Name, Name: name}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -829,6 +829,9 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 		return err
 	}
 
+	rev := revert.New()
+	defer rev.Fail()
+
 	for _, ref := range sdks {
 		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
 		defer cancel()
@@ -836,8 +839,17 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 			if err := backend.Setup(ctx, ref, m.repo); err != nil {
 				return err
 			}
+
+			ref := ref
+			backend := backend
+			rev.Add(func() {
+				if err1 := backend.Remove(ctx, ref.Workshop, ref.Sdk); err1 != nil {
+					logger.Noticef(`On doSetupProfiles: Failed to clean up "%s/%s" SDK backend setup`, ref.Workshop, ref.Sdk)
+				}
+			})
 		}
 	}
+	rev.Success()
 	return nil
 }
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -223,7 +223,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
 	c.Check(err, check.IsNil)
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: workshop.PlugRef{Sdk: "consumer", Name: "plug2"}}
+	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug2"}}
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
@@ -270,6 +270,40 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 	// ensure that backend profiles were set for both SDKs
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectBindMasterPlugNotFound(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a candidate SDK/slot
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	wp, err := s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs})
+	c.Check(err, check.IsNil)
+	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
+	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "no-such-plug2"}}
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange()
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, `(?s).*SDK "consumer" has no "no-such-plug2" plug.*`)
+
+	// Validate
+	pconns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Check(pconns, check.HasLen, 0)
+	c.Check(err, check.IsNil)
+
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Check(ref, check.HasLen, 0)
+	c.Check(err, check.IsNil)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -68,6 +68,14 @@ plugs:
     interface: mock-ssh-agent	
 `
 
+var consumer2 = `name: consumer2
+base: ubuntu@22.04
+plugs:
+  plug2:
+    interface: mock-network
+    attribute: one
+`
+
 var conflictingTarget1 = `name: conflict-1
 base: ubuntu@22.04
 plugs:
@@ -85,6 +93,7 @@ plugs:
 `
 
 var csetup = sdk.Setup{Name: "consumer", Channel: "latest/stable"}
+var csetup2 = sdk.Setup{Name: "consumer2", Channel: "latest/stable"}
 
 var consumerNoPlugs = `name: consumer
 base: ubuntu@22.04
@@ -313,10 +322,20 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 	s.launchWorkshop(c, "ws-producer", map[sdk.Setup]string{psetup: producer})
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
-	s.launchWorkshop(c, "ws-consumer", map[sdk.Setup]string{csetup: consumerManyPlugs})
+	s.launchWorkshop(c, "ws", map[sdk.Setup]string{csetup: consumerManyPlugs, csetup2: consumer2})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer2, s.prj.ProjectId, "ws")), check.IsNil)
 
+	n := 0
+	// One of the SDKs setup fails, we need to make sure that any partial
+	// progress will be aborted (i.e. previously created profiles for other SDKs
+	// will be removed).
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-		return errors.New("cannot finish backend setup")
+		if n > 0 {
+			return errors.New("cannot finish backend setup")
+		}
+		n++
+		return nil
 	}
 	defer func() { s.secBackend.SetupCallback = nil }()
 
@@ -329,9 +348,11 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Check(chg.Err(), check.NotNil)
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*cannot finish backend setup.*")
 
 	// Validate
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 
 	ref, err := repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -401,6 +401,20 @@ func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string
 	return affected, nil
 }
 
+func (m *InterfaceManager) resolveWorkshopBindings(w *workshop.Workshop) error {
+	for _, s := range w.File.Sdks {
+		for _, plug := range s.Plugs {
+			if plug.Bind != nil {
+				master := m.repo.Plug(w.Project.ProjectId, w.Name, plug.Bind.Sdk, plug.Bind.Name)
+				if master == nil {
+					return fmt.Errorf("SDK %q has no %q plug", plug.Bind.Sdk, plug.Bind.Name)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (m *InterfaceManager) resolveWorkshopConnections(w *workshop.Workshop) error {
 	for _, conn := range w.File.Connections {
 		_, err := m.repo.ResolveConnect(w.Project.ProjectId, w.Name, conn.PlugRef.Sdk, conn.PlugRef.Name,

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -273,6 +273,10 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	if len(info.BadInterfaces) > 0 {
+		return fmt.Errorf(sdk.BadInterfacesSummary(info))
+	}
+
 	if err = policy.CheckInterfaces(info); err != nil {
 		return err
 	}
@@ -288,13 +292,6 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 			st.Unlock()
 		}
 	})
-
-	if len(info.BadInterfaces) > 0 {
-		st := task.State()
-		st.Lock()
-		task.Logf("%s", sdk.BadInterfacesSummary(info))
-		st.Unlock()
-	}
 
 	rev.Success()
 	return nil

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -451,6 +451,7 @@ func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
 func (s *sdkStateSuite) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
 	newSdk := sdk.Info{Workshop: "ws", Name: "test"}
 	t := s.state.NewTask("fake-task", "retrieve")
@@ -481,6 +482,41 @@ func (s *sdkStateSuite) TestUndoLinkSdkAndRemoveSdk(c *check.C) {
 	_, ok := props.Content["test"]
 	c.Check(ok, check.Equals, false)
 	c.Check(link.Status(), check.Equals, state.UndoneStatus)
+
+	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
+}
+
+func (s *sdkStateSuite) TestLinkSdkBadInterfacesFound(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	newSdk := sdk.Info{Workshop: "ws", Name: "test"}
+	t := s.state.NewTask("fake-task", "retrieve")
+	t.Set("sdk-setup", newSdk)
+	link := s.state.NewTask("link-sdk", "test")
+	link.Set("sdk-retrieve-task", t.ID())
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(link)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, link, t)
+
+	chg.Set("user", "testuser")
+	chg.AddTask(link)
+	chg.AddTask(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*"test" SDK has bad plugs or slots: plug, plug2 \(unknown interface "test-interface"\).*`)
 
 	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -179,8 +179,8 @@ func (m *WorkshopManager) doRemoveWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	if err = m.cleanUpWorkshopAfterRemoval(user, prj.ProjectId, w); err != nil {
 		st := task.State()
 		st.Lock()
-		defer st.Unlock()
 		task.Logf("%v", err)
+		st.Unlock()
 	}
 
 	return nil

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -85,9 +85,9 @@ func (w *WorkshopManager) Workshop(ctx context.Context, name, pId string) (*work
 	return workshop, nil
 }
 
-// Loads all workshops for a project, the state must be locked as it is used to find out the
-// workshop state
-func (w *WorkshopManager) Workshops(ctx context.Context, pId string) ([]*workshop.File, []*workshop.Workshop, error) {
+// Returns all workshops and workshop files for a project, the state must be
+// locked as it is used to find out the workshop state.
+func (w *WorkshopManager) Workshops(ctx context.Context, pId string) ([]string, []*workshop.Workshop, error) {
 	// project-id must be in the context for this query
 	pCtx := context.WithValue(ctx, workshop.ContextProjectId, pId)
 

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -3,11 +3,13 @@ package workshopstate
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/canonical/x-go/strutil"
 	"golang.org/x/exp/slices"
 
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
@@ -121,15 +123,17 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshop.Workshop) healthstate.Heal
 		Timestamp: time.Now(),
 	}
 
-	// check the project directory exists
+	// Check the project directory exists.
 	if !ws.Project.Exists() {
 		healthState.Status = healthstate.ErrorStatus
 		healthState.Code = "missing-project"
 		return healthState
 	}
 
-	// check if the workshop file exists
-	if _, err := ws.Project.Workshop(ws.Name); err != nil {
+	// Check if the associated workshop file exists. We only check if that file
+	// exists in the project directory here; its state (e.g. if it is in sync
+	// with the workshop instance or has any errors) is not checked.
+	if !osutil.FileExists(filepath.Join(ws.Project.Path, workshop.Filename(ws.Name))) {
 		healthState.Status = healthstate.ErrorStatus
 		healthState.Code = "missing-file"
 		return healthState

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -67,7 +67,7 @@ func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	var workshopFile = bytes.NewBuffer([]byte{})
 	t.Execute(workshopFile, sdks)
 
-	err = os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(".workshop.%s.yaml", ws)), workshopFile.Bytes(), 0644)
+	err = os.WriteFile(filepath.Join(s.project.Path, workshop.Filename(ws)), workshopFile.Bytes(), 0644)
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@22.04"}

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -61,7 +61,7 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks worksh
 	var workshopFile = bytes.NewBuffer([]byte{})
 	t.Execute(workshopFile, sdks)
 
-	err = os.WriteFile(filepath.Join(s.project.Path, fmt.Sprintf(".workshop.%s.yaml", ws)), workshopFile.Bytes(), 0644)
+	err = os.WriteFile(filepath.Join(s.project.Path, workshop.Filename(ws)), workshopFile.Bytes(), 0644)
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@20.04", Sdks: sdks}

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -76,12 +76,12 @@ func (i *Info) SetupPlugBinds(binds map[string]*PlugBind) error {
 
 	for name, plug := range binds {
 		if _, ok := i.Plugs[name]; ok {
-			// The existence of plugs that are bound to it will be checked at
-			// the connecting stage, i.e. when all plugs from all SDKs are in
-			// the repository already.
+			// Check plugs that are bound. The existence of plugs that are
+			// "bound to" it will be checked at the connecting stage, i.e. when
+			// all plugs from all SDKs are in the repository already.
 			i.PlugBinds[name] = plug
 		} else {
-			return fmt.Errorf("SDK %s/%s has no %q plug", i.Workshop, i.Name, name)
+			return fmt.Errorf("plug binding failed: SDK %s/%s has no %q plug", i.Workshop, i.Name, name)
 		}
 	}
 	return nil

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -91,13 +91,36 @@ func (i *Info) SetupPlugBinds(binds map[string]*PlugBind) error {
 func (i *Info) SetupWorkshopSlots(slots map[string]interface{}) error {
 	for name, data := range slots {
 		if _, exist := i.Slots[name]; exist {
-			return fmt.Errorf("cannot add %q slot to %q SDK: already exists", name, i.Name)
+			return fmt.Errorf("cannot add slot %q to %q SDK: already exists", name, i.Name)
 		}
 		iface, label, attrs, err := convertToSlotOrPlugData("slot", name, data)
 		if err != nil {
 			return err
 		}
 		i.Slots[name] = &SlotInfo{
+			Sdk:       i,
+			Name:      name,
+			Interface: iface,
+			Attrs:     attrs,
+			Label:     label,
+		}
+	}
+
+	SanitizePlugsSlots(i)
+	return nil
+}
+
+// Adds slots defined for this SDK in a workshop file.
+func (i *Info) SetupWorkshopPlugs(plugs map[string]interface{}) error {
+	for name, data := range plugs {
+		if _, exist := i.Plugs[name]; exist {
+			return fmt.Errorf("cannot add plug %q to %q SDK: already exists", name, i.Name)
+		}
+		iface, label, attrs, err := convertToSlotOrPlugData("plug", name, data)
+		if err != nil {
+			return err
+		}
+		i.Plugs[name] = &PlugInfo{
 			Sdk:       i,
 			Name:      name,
 			Interface: iface,

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -418,7 +418,7 @@ func BadInterfacesSummary(sdkInfo *Info) string {
 		inverted[reason] = append(inverted[reason], name)
 	}
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "sdk %q has bad plugs or slots: ", sdkInfo.Name)
+	fmt.Fprintf(&buf, "%q SDK has bad plugs or slots: ", sdkInfo.Name)
 	reasons := make([]string, 0, len(inverted))
 	for reason := range inverted {
 		reasons = append(reasons, reason)

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -540,5 +540,33 @@ slots:
 		},
 	}
 	err = info.SetupWorkshopSlots(slots)
-	c.Assert(err, check.ErrorMatches, `cannot add "training" slot to "sdk" SDK: already exists`)
+	c.Assert(err, check.ErrorMatches, `cannot add slot "training" to "sdk" SDK: already exists`)
+}
+
+func (s *SdkSuite) TestAddingAlreadyExistingPlugFails(c *check.C) {
+	var mockYaml = []byte(`name: sdk
+base: ubuntu@20.04
+plugs:
+  training:
+    interface: content
+    target: /project
+`)
+
+	info, err := sdk.ReadSdkInfo(mockYaml, s.projectId, "ws")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Slots, check.HasLen, 0)
+	c.Assert(info.Plugs, check.HasLen, 1)
+	c.Assert(*info.Plugs["training"], check.DeepEquals, sdk.PlugInfo{
+		Sdk:       info,
+		Name:      "training",
+		Interface: "content",
+		Attrs:     map[string]interface{}{"target": "/project"},
+	})
+	plugs := map[string]interface{}{
+		"training": map[string]interface{}{
+			"target": "/data",
+		},
+	}
+	err = info.SetupWorkshopPlugs(plugs)
+	c.Assert(err, check.ErrorMatches, `cannot add plug "training" to "sdk" SDK: already exists`)
 }

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -141,7 +141,7 @@ type Backend interface {
 	WorkshopFs(ctx context.Context, name string) (WorkshopFs, error)
 
 	// Returns a list of workshops for the project in context.
-	ProjectWorkshops(ctx context.Context) ([]*File, []*Workshop, error)
+	ProjectWorkshops(ctx context.Context) ([]string, []*Workshop, error)
 
 	// Launch a barebone workshop instance using the base provided.
 	LaunchWorkshop(ctx context.Context, file *File) error

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -359,7 +359,11 @@ func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (work
 	if err != nil {
 		return nil, err
 	}
-	return s.Workshops[projectId][name].WorkshopFilesystem, nil
+	fs, exists := s.Workshops[projectId][name]
+	if !exists {
+		return nil, fmt.Errorf(`%q filesystem is not available`, name)
+	}
+	return fs.WorkshopFilesystem, nil
 }
 
 func (f *FakeWorkshopBackend) Exec(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -323,7 +323,7 @@ func (f *FakeWorkshopBackend) Workshop(ctx context.Context, name string) (*works
 	return wp.Workshop, nil
 }
 
-func (f *FakeWorkshopBackend) ProjectWorkshops(ctx context.Context) ([]*workshop.File, []*workshop.Workshop, error) {
+func (f *FakeWorkshopBackend) ProjectWorkshops(ctx context.Context) ([]string, []*workshop.Workshop, error) {
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/internal/workshop/lxd/export_test.go
+++ b/internal/workshop/lxd/export_test.go
@@ -1,7 +1,6 @@
 package lxdbackend
 
 var (
-	MergeInstancesAndFiles = mergeInstancesAndFiles
 	LoadWorkshop           = (*Backend).loadWorkshop
 	DefaultConfig          = (*Backend).workshopConfig
 	ReadProjects           = readProjects

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -527,14 +527,14 @@ func (s *Backend) ProjectWorkshops(ctx context.Context) ([]string, []*workshop.W
 	p = projects[user][idx]
 
 	files, err := p.ReadWorkshops()
-	// if the dir does not exist it does not mean there are no workshops. It
+	// If the dir does not exist it does not mean there are no workshops. It
 	// could be because the dir was removed with some workshops still operating
-	// resulting in a missing-project error
+	// resulting in a missing-project error.
 	if err != nil && !osutil.IsDirNotExist(err) {
 		return nil, nil, err
 	}
 
-	// get all the running workshops for this project
+	// Get all the running workshops for this project.
 	instances, err := conn.GetInstances(api.InstanceTypeContainer)
 	if err != nil {
 		return nil, nil, err

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -496,7 +496,7 @@ func (s *Backend) filterLxdInstancesByConfig(conn lxd.InstanceServer, filter wor
 	return toReturn, nil
 }
 
-func (s *Backend) ProjectWorkshops(ctx context.Context) ([]*workshop.File, []*workshop.Workshop, error) {
+func (s *Backend) ProjectWorkshops(ctx context.Context) ([]string, []*workshop.Workshop, error) {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return nil, nil, fmt.Errorf("context key project-id not found")
@@ -540,7 +540,7 @@ func (s *Backend) ProjectWorkshops(ctx context.Context) ([]*workshop.File, []*wo
 		return nil, nil, err
 	}
 
-	var projectWorkshops []*workshop.Workshop
+	var workshops []*workshop.Workshop
 	for _, i := range instances {
 		if i.Config[workshop.ConfigProjectId] == p.ProjectId {
 			ws, err := s.loadWorkshop(&i, p)
@@ -548,34 +548,15 @@ func (s *Backend) ProjectWorkshops(ctx context.Context) ([]*workshop.File, []*wo
 				logger.Debugf("error loading workshop: %v", err)
 				continue
 			}
-			projectWorkshops = append(projectWorkshops, ws)
+			workshops = append(workshops, ws)
 		}
 	}
 
-	wsFiles, wsInstances := mergeInstancesAndFiles(files, projectWorkshops)
-	return wsFiles, wsInstances, nil
-}
-
-// Examine the lists of project's workshop files and workshops. Returns two
-// lists. The first has *only* the workshop files that do not have any launched
-// workshops yet, the second contains workshops that are launched with or
-// without an associated file.
-func mergeInstancesAndFiles(f []*workshop.File, instances []*workshop.Workshop) ([]*workshop.File, []*workshop.Workshop) {
-	files := make([]*workshop.File, len(f))
-	copy(files, f)
-	// Walk both lists from to build a list of workshops with their states
-	for _, ws := range instances {
-		finder := func(p *workshop.File) bool { return p.Name == ws.Name }
-		idx := slices.IndexFunc(files, finder)
-		if idx != -1 {
-			/* Both a file and instance exist */
-			files = slices.Delete(files, idx, idx+1)
-		}
+	for _, ws := range workshops {
+		finder := func(p string) bool { return p == ws.Name }
+		files = slices.DeleteFunc(files, finder)
 	}
-
-	// At this point, files contain only inactive workshops and instances
-	// contain the workshops that have workshop files available.
-	return files, instances
+	return files, workshops, nil
 }
 
 func (s *Backend) RemoveWorkshop(ctx context.Context, name string) (err error) {

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -408,7 +408,7 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 	// no workshops found in the directory provided
 	// it means we won't be creating a project
 	if len(workshops) == 0 {
-		return nil, false, workshop.ErrNotAProject
+		return nil, false, workshop.ErrNotProject
 	}
 
 	project.ProjectId, err = workshop.ProjectId(projectDir)

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -175,8 +175,8 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: workshop.SdkList{
 			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{
-				"one-plug":     {Bind: workshop.PlugRef{Sdk: "two", Name: "two-plug"}},
-				"one-plug-two": {Bind: workshop.PlugRef{Sdk: "two", Name: "two-plug"}},
+				"one-plug":     {Bind: &workshop.PlugRef{Sdk: "two", Name: "two-plug"}},
+				"one-plug-two": {Bind: &workshop.PlugRef{Sdk: "two", Name: "two-plug"}},
 			}},
 			{Name: "two", Channel: "latest/edge"},
 		},

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -63,65 +63,6 @@ sdks:
 	})
 }
 
-func (f *LxdBeTests) TestLxdBackendMergeFilesAndInstances(c *check.C) {
-	// Setup
-	os.WriteFile(filepath.Join(f.project.Path, ".workshop.t1.yaml"), []byte(`name: t1
-base: ubuntu@20.04`), 0644)
-	os.WriteFile(filepath.Join(f.project.Path, ".workshop.t2.yaml"), []byte(`name: t2
-base: ubuntu@20.04`), 0644)
-	files, err := f.project.ReadWorkshops()
-	c.Assert(err, check.IsNil)
-
-	instances := []*workshop.Workshop{
-		{
-			Name: "t1",
-		},
-		{
-			Name: "t2",
-		},
-	}
-
-	instances[0].Running = true
-	instances[1].Running = true
-
-	// Execute
-	_, merged := lxdbackend.MergeInstancesAndFiles(files, instances)
-
-	// Validate
-	c.Assert(merged, check.HasLen, 2)
-	c.Assert(merged[0].Running, check.Equals, true)
-	c.Assert(merged[1].Running, check.Equals, true)
-}
-
-func (f *LxdBeTests) TestLxdBackendMergeFilesAndInstancesWorkshopOff(c *check.C) {
-	// Setup
-
-	os.WriteFile(filepath.Join(f.project.Path, ".workshop.t1.yaml"), []byte(`name: t1
-base: ubuntu@20.04`), 0644)
-	os.WriteFile(filepath.Join(f.project.Path, ".workshop.t2.yaml"), []byte(`name: t2
-base: ubuntu@20.04`), 0644)
-
-	files, err := f.project.ReadWorkshops()
-	c.Assert(err, check.IsNil)
-
-	instances := []*workshop.Workshop{
-		{
-			Name: "t1",
-		},
-	}
-
-	instances[0].Running = true
-
-	// Execute
-	wsFiles, merged := lxdbackend.MergeInstancesAndFiles(files, instances)
-
-	// Validate
-	c.Assert(merged, check.HasLen, 1)
-	c.Assert(wsFiles, check.HasLen, 1)
-
-	c.Assert(merged[0].Running, check.Equals, true)
-}
-
 func (f *LxdBeTests) TestProjectSubDirectoryProvideAsPath(c *check.C) {
 	root := c.MkDir()
 	cases := []struct {

--- a/internal/workshop/lxd/tests/integration/project_test.go
+++ b/internal/workshop/lxd/tests/integration/project_test.go
@@ -59,7 +59,7 @@ func (f *wsProject) TestLxdBackendCreateProjectNoWorkshopFiles(c *check.C) {
 
 	// Validate
 	c.Assert(prj, check.IsNil)
-	c.Assert(err, check.Equals, workshop.ErrNotAProject)
+	c.Assert(err, check.Equals, workshop.ErrNotProject)
 	c.Assert(workshop.LockPath(projectDir), testutil.FileAbsent)
 	projects, _ := be.Projects(f.ctx)
 	c.Assert(projects[f.username], check.HasLen, 0)

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -17,7 +17,7 @@ var (
 	ErrProjectNotFound        = errors.New("project not found")
 	ErrProjectLockNotFound    = errors.New("project lock file not found")
 	ErrProjectAlreadyExists   = errors.New("project already exists")
-	ErrNotAProject            = errors.New("not a project (no workshop files found)")
+	ErrNotProject             = errors.New("not a project (no workshop files found)")
 	ErrNoRelativePathsAllowed = errors.New("absolute project path must be used")
 
 	NewProjectId = allocateProjectId

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ func (p *Project) Exists() bool {
 }
 
 func (w *Project) Workshop(workshop string) (*File, error) {
-	return readWorkshop(filepath.Join(w.Path, fmt.Sprintf(".workshop.%s.yaml", workshop)))
+	return readWorkshop(filepath.Join(w.Path, Filename(workshop)))
 }
 
 func (w *Project) ReadWorkshops() ([]string, error) {

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/canonical/workshop/internal/logger"
@@ -47,28 +48,27 @@ func (w *Project) Workshop(workshop string) (*File, error) {
 	return readWorkshop(filepath.Join(w.Path, fmt.Sprintf(".workshop.%s.yaml", workshop)))
 }
 
-func (w *Project) ReadWorkshops() ([]*File, error) {
-	files, err := os.ReadDir(w.Path)
+func (w *Project) ReadWorkshops() ([]string, error) {
+	// *.yaml is the only supported extension for workshop files as the only
+	// recommended "official" extension: https://yaml.org/faq.html. Also, having a
+	// single way of naming workshop files avoids unneccesary inconsistencies.
+	files, err := filepath.Glob(filepath.Join(w.Path, ".workshop.*.yaml"))
 	if err != nil {
 		return nil, err
 	}
 
-	var workshops = make([]*File, 0, len(files))
-
-	for _, info := range files {
-		if info.IsDir() || !info.Type().IsRegular() {
+	var workshops = make([]string, 0, len(files))
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			logger.Noticef("On ReadWorkshops: Cannot stat a workshop file %q: %v", f, err)
 			continue
 		}
-
-		// The first element in names will contain the workshop name if matched
-		if names := filename.FindStringSubmatch(info.Name()); names != nil {
-			f, err := readWorkshop(filepath.Join(w.Path, info.Name()))
-			if err != nil {
-				logger.Noticef("Cannot parse %s: %v", info.Name(), err)
-				continue
-			}
-			workshops = append(workshops, f)
+		if !info.Mode().IsRegular() {
+			continue
 		}
+		var name = strings.TrimSuffix(strings.TrimPrefix(info.Name(), ".workshop."), ".yaml")
+		workshops = append(workshops, name)
 	}
 	return workshops, nil
 }

--- a/internal/workshop/project_test.go
+++ b/internal/workshop/project_test.go
@@ -28,7 +28,7 @@ connections:
 `
 
 func createWorkshop(dir, name string) error {
-	return os.WriteFile(filepath.Join(dir, fmt.Sprintf(".workshop.%s.yaml", name)), []byte(fmt.Sprintf(w, name)), 0644)
+	return os.WriteFile(filepath.Join(dir, workshop.Filename(name)), []byte(fmt.Sprintf(w, name)), 0644)
 }
 
 func (f *workshopFile) TestSomeWorkshopFilesBroken(c *check.C) {

--- a/internal/workshop/project_test.go
+++ b/internal/workshop/project_test.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -19,6 +20,13 @@ var w = `name: %s
 base: ubuntu@22.04
 `
 
+var wb = `name: %s
+base: ubuntu@22.04
+connections:
+  - plug:
+	- host:plug
+`
+
 func createWorkshop(dir, name string) error {
 	return os.WriteFile(filepath.Join(dir, fmt.Sprintf(".workshop.%s.yaml", name)), []byte(fmt.Sprintf(w, name)), 0644)
 }
@@ -29,7 +37,13 @@ func (f *workshopFile) TestSomeWorkshopFilesBroken(c *check.C) {
 	c.Assert(createWorkshop(d, "w1"), check.IsNil)
 	c.Assert(createWorkshop(d, "w2"), check.IsNil)
 	c.Assert(createWorkshop(d, "-"), check.IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(d, ".workshop.test-dir.yaml"), 0755), check.IsNil)
+	// broken workshop
+	c.Assert(os.WriteFile(filepath.Join(d, ".workshop.wb.yaml"), []byte(wb), 0644), check.IsNil)
+	// no match with the filename pattern
+	c.Assert(os.WriteFile(filepath.Join(d, "workshop.test-dir.yaml"), []byte{}, 0644), check.IsNil)
 	fls, err := p.ReadWorkshops()
 	c.Assert(err, check.IsNil)
-	c.Assert(fls, check.HasLen, 2)
+	c.Assert(fls, check.HasLen, 4)
+	c.Assert(fls, testutil.DeepUnsortedMatches, []string{"w1", "w2", "wb", "-"})
 }

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -30,10 +30,13 @@ var InstallTimeNow = time.Now
 type Workshop struct {
 	Backend Backend
 	Project *Project
+	// Workshop file that was used to launch it; it may be out of sync with the
+	// file in the project directory due to user's edits, etc.
 	File    *File
 	Name    string
 	Base    string
 	Running bool
+	// Installed SDKs.
 	Content map[string]sdk.Setup
 }
 

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -179,9 +179,19 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	}
 
 	binds := map[string]*sdk.PlugBind{}
+	plugs := map[string]interface{}{}
 	for name, m := range w.File.Sdks[idx].Plugs {
-		binds[name] = &sdk.PlugBind{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: m.Bind.Sdk, Name: m.Bind.Name}
+		if m.Bind == nil {
+			plugs[name] = m.Attributes
+		} else {
+			binds[name] = &sdk.PlugBind{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: m.Bind.Sdk, Name: m.Bind.Name}
+		}
 	}
+
+	if err = info.SetupWorkshopPlugs(plugs); err != nil {
+		return nil, err
+	}
+
 	if err = info.SetupPlugBinds(binds); err != nil {
 		return nil, err
 	}

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -245,13 +245,38 @@ func validateBinding(sdks SdkList) error {
 	return nil
 }
 
+func isBound(plug PlugRef, wf *File) bool {
+	return slices.ContainsFunc(wf.Sdks, func(s SdkRecord) bool {
+		if s.Name != plug.Sdk {
+			return false
+		}
+
+		for name, p := range s.Plugs {
+			if name == plug.Name && p.Bind != nil {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func validateConnections(wfile *File) error {
 	for _, conn := range wfile.Connections {
+		if isBound(conn.PlugRef, wfile) {
+			return fmt.Errorf(`cannot connect plug "%s:%s" to slot "%s:%s": plug is bound`,
+				conn.PlugRef.Sdk, conn.PlugRef.Name, conn.SlotRef.Sdk,
+				conn.SlotRef.Name)
+		}
+
 		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.PlugRef.Sdk || conn.PlugRef.Sdk == sdk.Host.String() }) {
-			return fmt.Errorf(`cannot connect plug "%s:%s": %q SDK is not found in %q workshop`, conn.PlugRef.Sdk, conn.PlugRef.Name, conn.PlugRef.Sdk, wfile.Name)
+			return fmt.Errorf(`cannot connect plug "%s:%s" to slot "%s:%s": %q SDK is not found in %q workshop`,
+				conn.PlugRef.Sdk, conn.PlugRef.Name, conn.SlotRef.Sdk,
+				conn.SlotRef.Name, conn.PlugRef.Sdk, wfile.Name)
 		}
 		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.SlotRef.Sdk || conn.SlotRef.Sdk == sdk.Host.String() }) {
-			return fmt.Errorf(`cannot connect slot "%s:%s": %q SDK is not found in %q workshop`, conn.SlotRef.Sdk, conn.SlotRef.Name, conn.SlotRef.Sdk, wfile.Name)
+			return fmt.Errorf(`cannot connect plug "%s:%s" to slot "%s:%s": %q SDK is not found in %q workshop`,
+				conn.PlugRef.Sdk, conn.PlugRef.Name,
+				conn.SlotRef.Sdk, conn.SlotRef.Name, conn.SlotRef.Sdk, wfile.Name)
 		}
 	}
 	return nil

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -21,6 +22,10 @@ var (
 	workshopName = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
 	channel      = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
 )
+
+func Filename(name string) string {
+	return fmt.Sprintf(".workshop.%s.yaml", name)
+}
 
 type Plug struct {
 	Bind       *PlugRef               `yaml:"bind,omitempty"`
@@ -44,12 +49,15 @@ func (b *PlugRef) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 
-	parts := strings.SplitN(refStr, ":", 2)
+	parts := strings.Split(refStr, ":")
 	if len(parts) != 2 {
-		return fmt.Errorf("invalid plug or slot reference: %q (use <sdk>:<plug or slot>)", refStr)
+		return fmt.Errorf("%q is not a valid plug or slot reference (use <sdk>:<plug or slot>)", refStr)
+	}
+	if len(parts[0]) == 0 {
+		parts[0] = sdk.Host.String()
 	}
 	if !workshopName.MatchString(parts[0]) {
-		return fmt.Errorf("%q isn't a valid SDK name", parts[0])
+		return fmt.Errorf("%q is not a valid plug or slot reference (%q is an invalid SDK name)", refStr, parts[0])
 	}
 
 	b.Sdk = parts[0]
@@ -137,6 +145,11 @@ func readWorkshop(pathname string) (*File, error) {
 		return nil, err
 	}
 
+	fname := filepath.Base(pathname)
+	if Filename(file.Name) != fname {
+		return nil, fmt.Errorf("%q workshop file must be named as %q (now: %s)", file.Name, Filename(file.Name), fname)
+	}
+
 	slices.SortFunc(file.Sdks, func(a, b SdkRecord) int {
 		return cmp.Compare(a.Name, b.Name)
 	})
@@ -205,7 +218,7 @@ func validateBinding(sdks SdkList) error {
 			masters[mr] = append(masters[mr], sl)
 			slaves[sl] = mr
 
-			if !slices.ContainsFunc(sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }) {
+			if p.Bind.Sdk != sdk.Host.String() && !slices.ContainsFunc(sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }) {
 				return fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", fmt.Sprintf("%s:%s", p.Bind.Sdk, p.Bind.Name))
 			}
 			if p.Bind.Sdk == s.Name && p.Bind.Name == name {
@@ -235,10 +248,10 @@ func validateBinding(sdks SdkList) error {
 func validateConnections(wfile *File) error {
 	for _, conn := range wfile.Connections {
 		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.PlugRef.Sdk || conn.PlugRef.Sdk == sdk.Host.String() }) {
-			return fmt.Errorf(`invalid plug reference "%s:%s": %q SDK is not found in %q workshop`, conn.PlugRef.Sdk, conn.PlugRef.Name, conn.PlugRef.Sdk, wfile.Name)
+			return fmt.Errorf(`cannot connect plug "%s:%s": %q SDK is not found in %q workshop`, conn.PlugRef.Sdk, conn.PlugRef.Name, conn.PlugRef.Sdk, wfile.Name)
 		}
 		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.SlotRef.Sdk || conn.SlotRef.Sdk == sdk.Host.String() }) {
-			return fmt.Errorf(`invalid slot reference "%s:%s": %q SDK is not found in %q workshop`, conn.SlotRef.Sdk, conn.SlotRef.Name, conn.SlotRef.Sdk, wfile.Name)
+			return fmt.Errorf(`cannot connect slot "%s:%s": %q SDK is not found in %q workshop`, conn.SlotRef.Sdk, conn.SlotRef.Name, conn.SlotRef.Sdk, wfile.Name)
 		}
 	}
 	return nil

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -16,14 +16,10 @@ import (
 
 var (
 	SupportedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
-	workshopName   = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
-	channel        = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
+	sdkBlacklist   = []string{"agent"}
 
-	// *.yaml is the only supported extension for workshop files as the only
-	// recommended "official" extension: https://yaml.org/faq.html. Also, having a
-	// single way of naming workshop files avoids unneccesary inconsistencies.
-	filename     = regexp.MustCompile(`^\.workshop\.(?P<name>[a-z_][a-z0-9_-]*)\.yaml$`)
-	sdkBlacklist = []string{"agent"}
+	workshopName = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+	channel      = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
 )
 
 type Plug struct {
@@ -106,7 +102,7 @@ func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
 	seen := map[string]bool{}
 	for i := 0; i < len(value.Content); i += 2 {
 		var res = &(*p)[i/2]
-		var name string
+		var name string		
 		if err := value.Content[i].Decode(&name); err != nil {
 			return err
 		} else {
@@ -197,7 +193,7 @@ func validateBinding(sdks SdkList) error {
 				return fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", fmt.Sprintf("%s:%s", p.Bind.Sdk, p.Bind.Name))
 			}
 			if p.Bind.Sdk == s.Name && p.Bind.Name == name {
-				return fmt.Errorf("cannot bind plug %s:%s to itself", s.Name, name)
+				return fmt.Errorf(`cannot bind plug "%s:%s" to itself`, s.Name, name)
 			}
 		}
 	}
@@ -214,7 +210,7 @@ func validateBinding(sdks SdkList) error {
 	for _, sl := range slaveKeysOrdered {
 		m := slaves[sl]
 		if _, ok := masters[sl]; ok {
-			return fmt.Errorf("cannot bind %s:%s to %s:%s; plug %s:%s must not be bound", sl.Sdk, sl.Name, m.Sdk, m.Name, sl.Sdk, sl.Name)
+			return fmt.Errorf(`invalid binding %s:%s to %s:%s; plug "%s:%s" must not be bound to`, sl.Sdk, sl.Name, m.Sdk, m.Name, sl.Sdk, sl.Name)
 		}
 	}
 	return nil

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -23,12 +23,17 @@ var (
 )
 
 type Plug struct {
-	Bind PlugRef `yaml:"bind,omitempty"`
+	Bind       *PlugRef               `yaml:"bind,omitempty"`
+	Attributes map[string]interface{} `yaml:",inline"`
 }
 
 type PlugRef struct {
 	Sdk  string
 	Name string
+}
+
+func (p PlugRef) String() string {
+	return fmt.Sprintf("%s:%s", p.Sdk, p.Name)
 }
 
 type SlotRef = PlugRef
@@ -102,7 +107,7 @@ func (p *SdkList) UnmarshalYAML(value *yaml.Node) error {
 	seen := map[string]bool{}
 	for i := 0; i < len(value.Content); i += 2 {
 		var res = &(*p)[i/2]
-		var name string		
+		var name string
 		if err := value.Content[i].Decode(&name); err != nil {
 			return err
 		} else {
@@ -165,12 +170,20 @@ func validateSdks(sdks SdkList) error {
 			return fmt.Errorf("%q is a reserved SDK name", s.Name)
 		}
 
-		// an SDK installed from a local source does not have a channel.
+		// An SDK installed from a local source (e.g. host SDK) does not have a
+		// channel.
 		if s.Channel == "" {
 			continue
 		}
 		if matches := channel.FindStringSubmatch(s.Channel); matches == nil {
 			return fmt.Errorf("unsupported channel %s for \"%s\"", s.Channel, s.Name)
+		}
+		// A plug must either be bound or declared/extended with dynamic
+		// attributes.
+		for _, plug := range s.Plugs {
+			if plug.Bind != nil && len(plug.Attributes) > 0 {
+				return fmt.Errorf("plug %q is bound and must not define other attributes", plug.Bind.String())
+			}
 		}
 	}
 	return nil
@@ -184,6 +197,9 @@ func validateBinding(sdks SdkList) error {
 	var slaves map[PlugRef]PlugRef = make(map[PlugRef]PlugRef)
 	for _, s := range sdks {
 		for name, p := range s.Plugs {
+			if p.Bind == nil {
+				continue
+			}
 			mr := PlugRef{Sdk: p.Bind.Sdk, Name: p.Bind.Name}
 			sl := PlugRef{Sdk: s.Name, Name: name}
 			masters[mr] = append(masters[mr], sl)

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -229,7 +229,7 @@ sdks:
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `cannot bind etl-sdk:cache to etl-sdk:data; plug etl-sdk:cache must not be bound`)
+	c.Assert(err, check.ErrorMatches, `invalid binding etl-sdk:cache to etl-sdk:data; plug "etl-sdk:cache" must not be bound to`)
 }
 
 func (f *workshopFile) TestIndirectBindToAlreadyBoundPlug(c *check.C) {
@@ -253,7 +253,7 @@ sdks:
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `cannot bind data-sdk:aux to etl-sdk:cache; plug data-sdk:aux must not be bound`)
+	c.Assert(err, check.ErrorMatches, `invalid binding data-sdk:aux to etl-sdk:cache; plug "data-sdk:aux" must not be bound to`)
 }
 
 func (f *workshopFile) TestHostSdkSlot(c *check.C) {

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -29,7 +29,7 @@ func (f *workshopFile) SetUpTest(c *check.C) {
 }
 
 func workshopFilePath(dir, name string) string {
-	return filepath.Join(dir, fmt.Sprintf(".workshop.%s.yaml", name))
+	return filepath.Join(dir, workshop.Filename(name))
 }
 
 func (f *workshopFile) TestWorkshopFileParse(c *check.C) {
@@ -89,6 +89,17 @@ sdks:
             plug:
                 bind: one:plug
 `)
+}
+
+func (f *workshopFile) TestWorkshopNamesDifferent(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+`)
+	dir := c.MkDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert.yaml"), buf, 0644), check.IsNil)
+	file, err := workshop.ReadWorkshop(workshopFilePath(dir, "xbert"))
+	c.Assert(file, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `"xbert-gpu" workshop file must be named as ".workshop.xbert-gpu.yaml" \(now: .workshop.xbert.yaml\)`)
 }
 
 func (f *workshopFile) TestWorkshopFileDuplicateSdks(c *check.C) {
@@ -215,43 +226,33 @@ sdks:
 	c.Assert(err, check.ErrorMatches, `"no-sdk:cache" tries to bind to a plug from a non-existing SDK`)
 }
 
-func (f *workshopFile) TestBindPlugIncorrectSdkName(c *check.C) {
-	buf := []byte(`name: xbert-gpu
-base: ubuntu@20.04
-sdks:
-  data-sdk:
-    channel: latest/stable
-    plugs:
-      cache:
-        bind: workshop/no-sdk:cache
-  etl-sdk:
-    channel: latest/stable
-    plugs:
-      data: 
-        bind: data-sdk:cache
-`)
-	dir := c.MkDir()
-	p := workshop.Project{Path: dir, ProjectId: "42424242"}
-	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
-	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `"workshop/no-sdk" isn't a valid SDK name`)
-}
-
 func (f *workshopFile) TestBindPlugInvalidPlugRef(c *check.C) {
-	buf := []byte(`name: xbert-gpu
+	templ := `name: xbert-gpu
 base: ubuntu@20.04
 sdks:
   etl-sdk:
     channel: latest/stable
     plugs:
-      data: 
-        bind: cache
-`)
+      %s
+`
+	invalids := []string{
+		`data:		
+           bind: cache`,
+		`data:
+           bind: workshop/no-sdk:cache`,
+		`data:
+           bind: workshop:etl-sdk:cache`,
+		`data:
+           bind: etl-sdk`,
+	}
 	dir := c.MkDir()
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
-	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
-	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `invalid plug or slot reference: "cache" \(use <sdk>:<plug or slot>\)`)
+
+	for _, ref := range invalids {
+		c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), []byte(fmt.Sprintf(templ, ref)), 0644), check.IsNil, check.Commentf(ref))
+		_, err := p.Workshop("xbert-gpu")
+		c.Assert(err, check.ErrorMatches, `.* is not a valid plug or slot reference.*`, check.Commentf(ref))
+	}
 }
 
 func (f *workshopFile) TestBindToAlreadyBoundPlug(c *check.C) {
@@ -363,7 +364,7 @@ connections:
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `invalid plug or slot reference: "data-sdk" \(use <sdk>:<plug or slot>\)`)
+	c.Assert(err, check.ErrorMatches, `"data-sdk" is not a valid plug or slot reference \(use <sdk>:<plug or slot>\)`)
 }
 
 func (f *workshopFile) TestWorkshopConnectionsSlotSdkNotInTheList(c *check.C) {
@@ -382,7 +383,7 @@ connections:
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `invalid slot reference "lost-sdk:content": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
+	c.Assert(err, check.ErrorMatches, `cannot connect slot "lost-sdk:content": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
 }
 
 func (f *workshopFile) TestWorkshopConnectionsPlugSdkNotInTheList(c *check.C) {
@@ -401,7 +402,7 @@ connections:
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `invalid plug reference "lost-sdk:data": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
+	c.Assert(err, check.ErrorMatches, `cannot connect plug "lost-sdk:data": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
 }
 
 func (f *workshopFile) TestWorkshopConnectionsImplicitHostSdkPlugSlot(c *check.C) {

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -383,7 +383,7 @@ connections:
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `cannot connect slot "lost-sdk:content": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
+	c.Assert(err, check.ErrorMatches, `cannot connect plug "data-sdk:data" to slot "lost-sdk:content": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
 }
 
 func (f *workshopFile) TestWorkshopConnectionsPlugSdkNotInTheList(c *check.C) {
@@ -402,7 +402,7 @@ connections:
 	p := workshop.Project{Path: dir, ProjectId: "42424242"}
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `cannot connect plug "lost-sdk:data": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
+	c.Assert(err, check.ErrorMatches, `cannot connect plug "lost-sdk:data" to slot "data-sdk:content": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
 }
 
 func (f *workshopFile) TestWorkshopConnectionsImplicitHostSdkPlugSlot(c *check.C) {
@@ -422,4 +422,28 @@ connections:
 	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
 	_, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
+}
+
+func (f *workshopFile) TestWorkshopConnectionsBoundPlugCannotBeConnected(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: etl-sdk:data
+  etl-sdk:
+    channel: latest/stable
+connections:
+  - plug: data-sdk:data
+    slot: host:content
+  - plug: etl-sdk:data
+    slot: data-sdk:data-slot
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `cannot connect plug "data-sdk:data" to slot "host:content": plug is bound`)
 }

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -69,8 +69,8 @@ func (f *workshopFile) TestWorkshopFileSave(c *check.C) {
 		Name: "test-workshop",
 		Base: "ubuntu@22.04",
 		Sdks: []workshop.SdkRecord{
-			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: workshop.PlugRef{Sdk: "two", Name: "plug"}}}},
-			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
+			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: &workshop.PlugRef{Sdk: "two", Name: "plug"}}}},
+			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: &workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
 		},
 	}
 	out, err := yaml.Marshal(fl)
@@ -142,9 +142,55 @@ sdks:
 	file, err := p.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshop.SdkList{
-		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Bind: workshop.PlugRef{Sdk: "etl-sdk", Name: "cache"}}}},
-		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
+		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Bind: &workshop.PlugRef{Sdk: "etl-sdk", Name: "cache"}}}},
+		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: &workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
 	})
+}
+
+func (f *workshopFile) TestPlugDefinedButNotBound(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+    plugs:
+      cache:
+        attr1: val
+  etl-sdk:
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: data-sdk:aux
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	file, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.IsNil)
+	c.Assert(file.Sdks, testutil.DeepUnsortedMatches, workshop.SdkList{
+		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Attributes: map[string]interface{}{"attr1": "val"}}}},
+		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: &workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
+	})
+}
+
+func (f *workshopFile) TestPlugDefinedAndBoundFails(c *check.C) {
+	buf := []byte(`name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+  etl-sdk:
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: data-sdk:aux
+        attr2: val
+`)
+	dir := c.MkDir()
+	p := workshop.Project{Path: dir, ProjectId: "42424242"}
+	c.Assert(os.WriteFile(filepath.Join(dir, ".workshop.xbert-gpu.yaml"), buf, 0644), check.IsNil)
+	_, err := p.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `plug "data-sdk:aux" is bound and must not define other attributes`)
 }
 
 func (f *workshopFile) TestBindPlugNoSdk(c *check.C) {

--- a/tests/main/workshop-connections/.workshop.ws-user-conns.yaml
+++ b/tests/main/workshop-connections/.workshop.ws-user-conns.yaml
@@ -11,8 +11,14 @@ sdks:
         source: user-data-2
   test-sdk-content:
     channel: latest/stable
+    plugs:
+      wp-plug:
+        interface: content
+        target: /mnt/wp-plug
 connections:
   - plug: test-sdk-content:content-plug-one
     slot: host:user-slot
   - plug: test-sdk-content:content-plug-two
+    slot: host:user-slot-2
+  - plug: test-sdk-content:wp-plug
     slot: host:user-slot-2

--- a/tests/main/workshop-connections/task.yaml
+++ b/tests/main/workshop-connections/task.yaml
@@ -13,11 +13,13 @@ execute: |
   echo "Check connections"
   workshop_exec connections ws-user-conns | MATCH "^content.+ws-user-conns/test-sdk-content:content-plug-one.+:user-slot.+\-$"
   workshop_exec connections ws-user-conns | MATCH "^content.+ws-user-conns/test-sdk-content:content-plug-two.+:user-slot-2.+\-$"
+  workshop_exec connections ws-user-conns | MATCH "^content.+ws-user-conns/test-sdk-content:wp-plug.+:user-slot-2.+\-$"
 
   echo "Check mounts"
   workshop_exec info ws-user-conns | grep -v notes > mounts.log
   yq '.content["test-sdk-content"].mounts["content-plug-one"]' < mounts.log | MATCH "^host:.*$(pwd)/user-data" 
   yq '.content["test-sdk-content"].mounts["content-plug-two"]' < mounts.log | MATCH "^host:.*$(pwd)/user-data-2"
+  yq '.content["test-sdk-content"].mounts["wp-plug"]' < mounts.log | MATCH "^host:.*$(pwd)/user-data-2"
 
   echo "Check refresh that removes a connection"
   mv -f .workshop.ws-user-conns.yaml.new .workshop.ws-user-conns.yaml


### PR DESCRIPTION
# Description

Symmetrically to slots (see https://github.com/canonical/workshop/pull/167), SDK plugs can also be defined in a workshop file if that does not violate base declarations.

Workshop changes its behaviour in respect to bad plugs or slots. Previously, these were reported via a task log without aborting the change in progress. Aborting the change immediately is a more expected behaviour for the user to then intervene and fix rather then discovering incorrect connections later on.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
