### PR TITLE
Move postRunWarnings to root command

### DIFF
--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CmdChanges struct {
-	clientMixin
+	root *CmdRoot
 }
 
 func (c *CmdChanges) Command() *cobra.Command {
@@ -42,30 +42,24 @@ Notes:
 - To investigate the details of a specific change, use 'workshop tasks' instead
 `,
 
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	return cmd
 }
 
 func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
-	var clientOpts client.ChangesOptions
-	var err error
-
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
-	}
-	c.setClient(cli)
-
-	if cmd.Parent().Flag("project").Changed {
-		clientOpts.ProjectPath = cmd.Parent().Flag("project").Value.String()
+		return err
 	}
 
-	clientOpts.Selector = client.ChangesAll
+	clientOpts := client.ChangesOptions{
+		ProjectPath: c.root.project,
+		Selector:    client.ChangesAll,
+	}
 
-	chngs, err := c.cli.Changes(&clientOpts)
+	chngs, err := cli.Changes(&clientOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/color.go
+++ b/cmd/workshop/color.go
@@ -43,7 +43,7 @@ func (mxd mixinDescs) also(m map[string]string) mixinDescs {
 }
 
 type unicodeMixin struct {
-	Unicode string `long:"unicode" default:"auto" choice:"auto" choice:"never" choice:"always"`
+	Unicode string
 }
 
 func (ux unicodeMixin) addUnicodeChars(esc *escapes) {
@@ -67,7 +67,7 @@ func (ux unicodeMixin) getEscapes() *escapes {
 }
 
 type colorMixin struct {
-	Color string `long:"color" default:"auto" choice:"auto" choice:"never" choice:"always"`
+	Color string
 	unicodeMixin
 }
 

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -11,6 +11,7 @@ import (
 
 type CmdConnect struct {
 	waitMixin
+	root *CmdRoot
 }
 
 func (c *CmdConnect) Command() *cobra.Command {
@@ -46,8 +47,7 @@ that is specified as the second argument or deduced from the context.
 
 - The 'workshop connections' output will list the connection as 'manual'
 `,
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -58,16 +58,12 @@ that is specified as the second argument or deduced from the context.
 }
 
 func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
-
-	project, err := c.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
@@ -114,13 +110,13 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 		return fmt.Errorf("cannot connect plugs and slots across different workshops")
 	}
 
-	changeId, err := c.cli.Connect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
+	changeId, err := cli.Connect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
 		slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name, nil)
 	if err != nil {
 		return err
 	}
 
-	if _, err := c.wait(changeId, false); err != nil {
+	if _, err := c.wait(cli, changeId, false); err != nil {
 		if err == errNoWait {
 			return nil
 		}

--- a/cmd/workshop/connect_test.go
+++ b/cmd/workshop/connect_test.go
@@ -22,7 +22,7 @@ func (m *connectSuite) SetUpTest(c *check.C) {
 }
 
 func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
-	cmd := &CmdConnect{}
+	cmd := &CmdConnect{root: &CmdRoot{}}
 	body := map[string]interface{}{
 		"action": "connect",
 		"plugs": []interface{}{
@@ -120,7 +120,7 @@ func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 }
 
 func (m *connectSuite) TestDisconnectSlotNotProvided(c *check.C) {
-	cmd := &CmdConnect{}
+	cmd := &CmdConnect{root: &CmdRoot{}}
 	body := map[string]interface{}{
 		"action": "connect",
 		"plugs": []interface{}{

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -13,8 +13,8 @@ import (
 )
 
 type CmdConnections struct {
-	clientMixin
-	all bool
+	root *CmdRoot
+	all  bool
 }
 
 func (c *CmdConnections) Command() *cobra.Command {
@@ -36,8 +36,7 @@ Notes:
 - The '--all' option needn't be used with an argument;
   if a workshop is supplied, disconnected plugs are also listed
 `,
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	cmd.Flags().BoolVar(&c.all, "all", false, "Include disconnected plugs in the output.")
@@ -130,16 +129,12 @@ func maybeBound(plug client.PlugRef, plugs []client.Plug) string {
 }
 
 func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
-
-	project, err := c.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
@@ -155,7 +150,7 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 		c.all = true
 	}
 
-	connections, err := c.cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, Workshop: workshop, All: c.all})
+	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, Workshop: workshop, All: c.all})
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -71,7 +71,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnected(c *check.C) {
 		}
 	})
 
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{})
 
 	c.Check(err, check.IsNil)
@@ -118,7 +118,7 @@ func (s *connectionsSuite) TestConnectionsNotInstalled(c *C) {
 			fmt.Fprintln(w, `{"type": "error", "result": {"message": "not found"}, "status-code": 404}`)
 		}
 	})
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"foo"})
 	c.Check(err, ErrorMatches, `not found`)
 	c.Assert(s.Stdout(), Equals, "")
@@ -164,7 +164,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *C) {
 		}
 	})
 
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	command := cmd.Command()
 	cmd.all = true
 	err := cmd.Run(command, []string{})
@@ -217,7 +217,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *C) {
 			})
 		}
 	})
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"foo"})
 	c.Check(err, IsNil)
 	c.Assert(s.Stdout(), check.Equals, "")
@@ -365,7 +365,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 			})
 		}
 	})
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{})
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
@@ -504,7 +504,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 			})
 		}
 	})
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{})
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
@@ -640,7 +640,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 		}
 	})
 
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	cmdAll := cmd.Command()
 	cmd.all = true
 	err := cmd.Run(cmdAll, []string{})
@@ -771,7 +771,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 		}
 	})
 
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	cmdAll := cmd.Command()
 	cmd.all = true
 	err := cmd.Run(cmdAll, []string{})
@@ -842,7 +842,7 @@ func (s *connectionsSuite) TestConnectionsOnlyDisconnected(c *C) {
 		}
 	})
 
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"leds-provider"})
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
@@ -887,7 +887,7 @@ func (s *connectionsSuite) TestConnectionsFiltering(c *C) {
 		"select":     []string{"all"},
 		"workshop":   []string{"mouse-buttons"},
 	}
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 
 	err := cmd.Run(cmd.Command(), []string{"mouse-buttons"})
 	c.Assert(err, IsNil)
@@ -1119,7 +1119,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 			})
 		}
 	})
-	cmd := &CmdConnections{}
+	cmd := &CmdConnections{root: &CmdRoot{}}
 	cmdAll := cmd.Command()
 	cmd.all = true
 	err := cmd.Run(cmdAll, []string{})

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -11,6 +10,7 @@ import (
 
 type CmdDisconnect struct {
 	waitMixin
+	root   *CmdRoot
 	forget bool
 }
 
@@ -39,8 +39,7 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
   it is reconnected during 'workshop refresh'
   only if the '--forget' option was used with 'workshop disconnect'
 `,
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.forget, "forget",
@@ -55,16 +54,12 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
 }
 
 func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
-
-	project, err := c.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
@@ -92,13 +87,13 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	var opts = client.DisconnectOptions{Forget: c.forget}
-	changeId, err := c.cli.Disconnect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
+	changeId, err := cli.Disconnect(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name,
 		slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name, &opts)
 	if err != nil {
 		return err
 	}
 
-	if _, err := c.wait(changeId, false); err != nil {
+	if _, err := c.wait(cli, changeId, false); err != nil {
 		if err == errNoWait {
 			return nil
 		}

--- a/cmd/workshop/disconnect_test.go
+++ b/cmd/workshop/disconnect_test.go
@@ -22,7 +22,7 @@ func (m *disconnectSuite) SetUpTest(c *check.C) {
 }
 
 func (m *disconnectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
-	cmd := &CmdDisconnect{}
+	cmd := &CmdDisconnect{root: &CmdRoot{}}
 	body := map[string]interface{}{
 		"action": "disconnect",
 		"plugs": []interface{}{
@@ -96,7 +96,7 @@ func (m *disconnectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 }
 
 func (m *disconnectSuite) TestDisconnectPlugOrSlotProvided(c *check.C) {
-	cmd := &CmdDisconnect{}
+	cmd := &CmdDisconnect{root: &CmdRoot{}}
 
 	n := 0
 	body := map[string]interface{}{

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -31,7 +31,7 @@ import (
 )
 
 type CmdExec struct {
-	clientMixin
+	root           *CmdRoot
 	WorkingDir     string
 	Env            []string
 	UserId         int
@@ -99,12 +99,11 @@ Notes:
 
 func (c *CmdExec) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "exec <WORKSHOP>",
-		Args:    cobra.MinimumNArgs(1),
-		Short:   shortExecHelp,
-		Long:    longExecHelp,
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		Use:   "exec <WORKSHOP>",
+		Args:  cobra.MinimumNArgs(1),
+		Short: shortExecHelp,
+		Long:  longExecHelp,
+		RunE:  c.Run,
 	}
 
 	cmd.Flags().SortFlags = false
@@ -128,29 +127,24 @@ func (c *CmdShellAlias) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	c.execCommand = &CmdExec{}
-	c.execCommand.UserId = 0
-	c.execCommand.GroupId = 0
 	return cmd
 }
 
-func (cmd *CmdShellAlias) Run(c *cobra.Command, av []string) error {
-	return cmd.execCommand.Run(c, []string{av[0], "su", "-l", "workshop"})
+func (c *CmdShellAlias) Run(cmd *cobra.Command, av []string) error {
+	return c.execCommand.Run(cmd, []string{av[0], "su", "-l", "workshop"})
 }
 
-func (cmd *CmdExec) Run(c *cobra.Command, av []string) error {
-	if cmd.Interactive && cmd.NonInteractive {
+func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
+	if c.Interactive && c.NonInteractive {
 		return errors.New("'-i' incompatible with '-I'")
 	}
 
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	cmd.setClient(cli)
-
-	project, err := cmd.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
@@ -165,7 +159,7 @@ func (cmd *CmdExec) Run(c *cobra.Command, av []string) error {
 		env["TERM"] = term
 	}
 
-	for _, kv := range cmd.Env {
+	for _, kv := range c.Env {
 		parts := strings.SplitN(kv, "=", 2)
 		key := parts[0]
 		value := ""
@@ -180,9 +174,9 @@ func (cmd *CmdExec) Run(c *cobra.Command, av []string) error {
 	// Specify Interactive=true if -i is given, or if stdin and stdout are TTYs.
 	stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
 	var interactive bool
-	if cmd.Interactive {
+	if c.Interactive {
 		interactive = true
-	} else if cmd.NonInteractive {
+	} else if c.NonInteractive {
 		interactive = false
 	} else {
 		interactive = stdinIsTerminal && stdoutIsTerminal
@@ -216,11 +210,11 @@ func (cmd *CmdExec) Run(c *cobra.Command, av []string) error {
 	opts := &client.ExecOptions{
 		Command:     command,
 		Environment: env,
-		WorkingDir:  cmd.WorkingDir,
-		UserId:      &cmd.UserId,
-		GroupId:     &cmd.GroupId,
+		WorkingDir:  c.WorkingDir,
+		UserId:      &c.UserId,
+		GroupId:     &c.GroupId,
 		Interactive: interactive,
-		Timeout:     cmd.Timeout,
+		Timeout:     c.Timeout,
 		Width:       width,
 		Height:      height,
 		Stdin:       Stdin,
@@ -229,7 +223,7 @@ func (cmd *CmdExec) Run(c *cobra.Command, av []string) error {
 	}
 
 	// Start the command.
-	process, err := cmd.cli.Exec(opts, av[0], project.Id)
+	process, err := cli.Exec(opts, av[0], project.Id)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -32,13 +32,13 @@ import (
 
 type CmdExec struct {
 	clientMixin
-	WorkingDir     string        `short:"w"`
-	Env            []string      `long:"env"`
-	UserId         int           `long:"uid"`
-	GroupId        int           `long:"gid"`
-	Timeout        time.Duration `long:"timeout"`
-	Interactive    bool          `short:"i"`
-	NonInteractive bool          `short:"I"`
+	WorkingDir     string
+	Env            []string
+	UserId         int
+	GroupId        int
+	Timeout        time.Duration
+	Interactive    bool
+	NonInteractive bool
 }
 
 type CmdShellAlias struct {

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -15,6 +15,7 @@ import (
 
 type CmdInfo struct {
 	waitMixin
+	root *CmdRoot
 }
 
 func (c *CmdInfo) Command() *cobra.Command {
@@ -40,8 +41,7 @@ Notes:
 - Avoid assumptions based on SDK channels: 'latest/stable' may be neither
 `,
 
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	return cmd
@@ -66,21 +66,17 @@ func shortenDefaulPath(source string) string {
 }
 
 func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
-	cli, err := client.New(&ClientConfig)
-	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
-	}
-
-	c.setClient(cli)
-
-	project, err := c.cli.Project(Project)
+	cli, err := c.root.client()
 	if err != nil {
 		return err
 	}
 
-	workshop, err := c.cli.Workshop(project.Id, av[0])
+	project, err := cli.Project(c.root.project)
+	if err != nil {
+		return err
+	}
+
+	workshop, err := cli.Workshop(project.Id, av[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -25,7 +25,7 @@ func (m *WorkshopInfo) SetUpTest(c *check.C) {
 var mockWorkshopWithContent = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-file"]}}`
 
 func (m *WorkshopInfo) TestWorkshopInfo(c *check.C) {
-	cmd := &CmdInfo{}
+	cmd := &CmdInfo{root: &CmdRoot{}}
 	workshop := "ws"
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +62,7 @@ content:
 var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Pending","notes":["workshop-note"],"content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z","health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}}]}}`
 
 func (m *WorkshopInfo) TestWorkshopInfoWithSdkHealthReport(c *check.C) {
-	cmd := &CmdInfo{}
+	cmd := &CmdInfo{root: &CmdRoot{}}
 	workshop := "ws"
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -105,7 +105,7 @@ var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","re
 }]}}`
 
 func (m *WorkshopInfo) TestWorkshopInfoWithSdkMounts(c *check.C) {
-	cmd := &CmdInfo{}
+	cmd := &CmdInfo{root: &CmdRoot{}}
 	workshop := "ws"
 	n := 0
 	user, err := user.Current()

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
-
-	"github.com/canonical/workshop/client"
 )
 
 type CmdLaunch struct {
 	waitMixin
+	root *CmdRoot
 }
 
 func (c *CmdLaunch) Command() *cobra.Command {
@@ -44,8 +43,7 @@ Notes:
 - SDKs are installed in alphabetical order
 `,
 
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -56,28 +54,24 @@ Notes:
 }
 
 func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
 	av = strutil.Deduplicate(av)
 
-	cli, err := client.New(&ClientConfig)
-	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
-	}
-
-	c.setClient(cli)
-
-	project, err := c.cli.Project(Project)
+	cli, err := c.root.client()
 	if err != nil {
 		return err
 	}
 
-	changeId, err := c.cli.Launch(project.Id, av)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
 
-	if _, err := c.wait(changeId, false); err != nil {
+	changeId, err := cli.Launch(project.Id, av)
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.wait(cli, changeId, false); err != nil {
 		if err == errNoWait {
 			return nil
 		}

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -22,7 +22,7 @@ func (m *WorkshopLaunch) SetUpTest(c *check.C) {
 }
 
 func (m *WorkshopLaunch) TestLaunchSuccess(c *check.C) {
-	cmd := &CmdLaunch{}
+	cmd := &CmdLaunch{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -16,7 +16,7 @@ import (
 )
 
 type CmdList struct {
-	clientMixin
+	root   *CmdRoot
 	global bool
 }
 
@@ -45,8 +45,7 @@ Notes:
 
 - For details of a single workshop, use 'workshop info' instead
 `,
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	cmd.Flags().BoolVar(&c.global, "global", false, "List workshops from all projects in the system")
@@ -63,22 +62,18 @@ func (c *CmdList) Run(cmd *cobra.Command, _ []string) error {
 }
 
 func (c *CmdList) runList() error {
-	var err error
-
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
-
 	if !c.global {
-		project, err := c.cli.Project(Project)
+		project, err := cli.Project(c.root.project)
 		if err != nil {
 			return err
 		}
 
-		workshops, err := c.cli.ListWorkshops(&client.ListOptions{ProjectId: project.Id})
+		workshops, err := cli.ListWorkshops(&client.ListOptions{ProjectId: project.Id})
 		if err != nil {
 			return err
 		}
@@ -93,7 +88,7 @@ func (c *CmdList) runList() error {
 	} else {
 		w := tabWriter()
 
-		projects, err := c.cli.Projects()
+		projects, err := cli.Projects()
 		slices.SortFunc(projects, func(a, b *client.Project) int { return cmp.Compare(a.Path, b.Path) })
 
 		if err != nil {
@@ -104,7 +99,7 @@ func (c *CmdList) runList() error {
 			fmt.Fprintf(w, "Project\tWorkshop\tStatus\tNotes\n")
 		}
 		for _, i := range projects {
-			workshops, err := c.cli.ListWorkshops(&client.ListOptions{ProjectId: i.Id})
+			workshops, err := cli.ListWorkshops(&client.ListOptions{ProjectId: i.Id})
 			if err != nil {
 				return err
 			}

--- a/cmd/workshop/list_test.go
+++ b/cmd/workshop/list_test.go
@@ -40,7 +40,7 @@ var mockWorkshopList = `{"type":"sync","status-code":200,"status":"OK","result":
 var mockWorkshopList2 = `{"type":"sync","status-code":200,"status":"OK","result":[{"name":"ws","base":"ubuntu@22.04","project-id":"2","status":"Ready"}]}`
 
 func (m *WorkshopInfo) TestWorkshopList(c *check.C) {
-	cmd := &CmdList{}
+	cmd := &CmdList{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -69,7 +69,7 @@ func (m *WorkshopInfo) TestWorkshopList(c *check.C) {
 }
 
 func (m *WorkshopInfo) TestWorkshopListGlobal(c *check.C) {
-	cmd := &CmdList{}
+	cmd := &CmdList{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -105,7 +105,7 @@ func (m *WorkshopInfo) TestWorkshopListGlobal(c *check.C) {
 }
 
 func (m *WorkshopInfo) TestWorkshopListGlobalEmpty(c *check.C) {
-	cmd := &CmdList{}
+	cmd := &CmdList{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -12,23 +12,65 @@ import (
 	"github.com/canonical/workshop/internal/logger"
 )
 
-type clientMixin struct {
-	cli *client.Client
+type CmdRoot struct {
+	cli     *client.Client
+	project string
 }
 
-func (ch *clientMixin) setClient(cli *client.Client) {
-	ch.cli = cli
+func (c *CmdRoot) Command(cwd string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "workshop",
+		// Avoid printing errors twice
+		SilenceErrors:    true,
+		SilenceUsage:     true,
+		TraverseChildren: true,
+
+		PersistentPostRun: c.postRun,
+	}
+
+	cmd.AddCommand((&CmdLaunch{root: c}).Command())
+	cmd.AddCommand((&CmdList{root: c}).Command())
+	cmd.AddCommand((&CmdChanges{root: c}).Command())
+	cmd.AddCommand((&CmdTasks{root: c}).Command())
+	cmd.AddCommand((&CmdRefresh{root: c}).Command())
+	cmd.AddCommand((&CmdStart{root: c}).Command())
+	cmd.AddCommand((&CmdStop{root: c}).Command())
+	cmd.AddCommand((&CmdInfo{root: c}).Command())
+	cmd.AddCommand((&CmdExec{root: c}).Command())
+	cmd.AddCommand((&CmdShellAlias{execCommand: &CmdExec{root: c}}).Command())
+	cmd.AddCommand((&CmdRemove{root: c}).Command())
+	cmd.AddCommand((&CmdRemount{root: c}).Command())
+	cmd.AddCommand((&CmdConnections{root: c}).Command())
+	cmd.AddCommand((&CmdConnect{root: c}).Command())
+	cmd.AddCommand((&CmdDisconnect{root: c}).Command())
+	cmd.AddCommand((&CmdWarnings{root: c}).Command())
+	cmd.AddCommand((&CmdOkay{root: c}).Command())
+
+	cmd.PersistentFlags().StringVarP(&c.project, "project", "p", cwd, "Specify the project's directory path.")
+	cmd.PersistentFlags().BoolP("help", "h", false, "Print the help message for the command.")
+
+	return cmd
 }
 
-func (ch *clientMixin) client() *client.Client {
-	return ch.cli
+func (c *CmdRoot) client() (*client.Client, error) {
+	if c.cli != nil {
+		return c.cli, nil
+	}
+
+	cli, err := client.New(&ClientConfig)
+	if err == nil {
+		c.cli = cli
+	} else {
+		err = fmt.Errorf("cannot create client: %v", err)
+	}
+
+	return cli, err
 }
 
-var rootCmd = &cobra.Command{
-	Use:              "workshop",
-	SilenceErrors:    false,
-	SilenceUsage:     true,
-	TraverseChildren: true,
+func (c *CmdRoot) postRun(cmd *cobra.Command, args []string) {
+	if c.cli != nil {
+		maybePresentWarnings(c.cli.WarningsSummary())
+	}
 }
 
 var (
@@ -37,20 +79,11 @@ var (
 	Stdout io.Writer = os.Stdout
 	Stderr io.Writer = os.Stderr
 )
-var Project string
 
 // ClientConfig is the configuration of the Client used by all commands.
 var ClientConfig = client.Config{
 	// we need the powerful socket
 	Socket: dirs.SocketPath,
-}
-
-func postRunWarnings(c *clientMixin) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
-		if c.client() != nil {
-			maybePresentWarnings(c.client().WarningsSummary())
-		}
-	}
 }
 
 func main() {
@@ -65,28 +98,7 @@ func main() {
 
 	logger.SetLogger(l)
 
-	rootCmd.PersistentFlags().StringVarP(&Project, "project", "p", cwd, "Specify the project's directory path.")
-	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print the help message for the command.")
-
-	rootCmd.AddCommand((&CmdLaunch{}).Command())
-	rootCmd.AddCommand((&CmdList{}).Command())
-	rootCmd.AddCommand((&CmdChanges{}).Command())
-	rootCmd.AddCommand((&CmdTasks{}).Command())
-	rootCmd.AddCommand((&CmdRefresh{}).Command())
-	rootCmd.AddCommand((&CmdStart{}).Command())
-	rootCmd.AddCommand((&CmdStop{}).Command())
-	rootCmd.AddCommand((&CmdInfo{}).Command())
-	rootCmd.AddCommand((&CmdExec{}).Command())
-	rootCmd.AddCommand((&CmdShellAlias{}).Command())
-	rootCmd.AddCommand((&CmdRemove{}).Command())
-	rootCmd.AddCommand((&CmdRemount{}).Command())
-	rootCmd.AddCommand((&CmdConnections{}).Command())
-	rootCmd.AddCommand((&CmdConnect{}).Command())
-	rootCmd.AddCommand((&CmdDisconnect{}).Command())
-	rootCmd.AddCommand((&CmdWarnings{}).Command())
-	rootCmd.AddCommand((&CmdOkay{}).Command())
-
-	rootCmd.SilenceErrors = true
+	rootCmd := (&CmdRoot{}).Command(cwd)
 
 	if err = rootCmd.Execute(); err != nil {
 		fmt.Fprintf(Stderr, "error: %v\n", err)

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
-
-	"github.com/canonical/workshop/client"
 )
 
 type CmdRefresh struct {
 	waitMixin
+	root        *CmdRoot
 	WaitOnError bool
 	Continue    bool
 	Abort       bool
@@ -59,8 +58,7 @@ Notes:
   set by 'workshop remount', if any
 `,
 
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",
@@ -77,8 +75,6 @@ Notes:
 }
 
 func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
 	av = strutil.Deduplicate(av)
 
 	if c.Abort && c.Continue {
@@ -97,14 +93,12 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		return fmt.Errorf("cannot refresh: '--wait-on-error' incompatible with multiple workshops")
 	}
 
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
-
-	project, err := c.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
@@ -120,12 +114,12 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		mode = "abort"
 	}
 
-	changeId, err := c.cli.Refresh(project.Id, av, mode)
+	changeId, err := cli.Refresh(project.Id, av, mode)
 	if err != nil {
 		return err
 	}
 
-	if _, err := c.wait(changeId, c.Abort); err != nil {
+	if _, err := c.wait(cli, changeId, c.Abort); err != nil {
 		if err == errNoWait {
 			return nil
 		}

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -67,7 +67,7 @@ func (m *WorkshopRefresh) SetUpTest(c *check.C) {
 }
 
 func (m *WorkshopRefresh) TestRefreshTransactionalSuccess(c *check.C) {
-	cmd := &CmdRefresh{}
+	cmd := &CmdRefresh{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -97,7 +97,7 @@ func (m *WorkshopRefresh) TestRefreshTransactionalSuccess(c *check.C) {
 }
 
 func (m *WorkshopRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
-	cmd := &CmdRefresh{}
+	cmd := &CmdRefresh{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -127,7 +127,7 @@ func (m *WorkshopRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
 }
 
 func (m *WorkshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
-	cmd := &CmdRefresh{}
+	cmd := &CmdRefresh{root: &CmdRoot{}}
 	cmd.WaitOnError = true
 
 	n := 0
@@ -161,7 +161,7 @@ func (m *WorkshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 }
 
 func (m *WorkshopRefresh) TestRefreshWaitOnErrorAbortedSuccessfully(c *check.C) {
-	cmd := &CmdRefresh{}
+	cmd := &CmdRefresh{root: &CmdRoot{}}
 	cmd.Abort = true
 
 	n := 0
@@ -195,7 +195,7 @@ func (m *WorkshopRefresh) TestRefreshWaitOnErrorAbortedSuccessfully(c *check.C) 
 }
 
 func (m *WorkshopRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C) {
-	cmd := &CmdRefresh{}
+	cmd := &CmdRefresh{root: &CmdRoot{}}
 	cmd.Continue = true
 
 	n := 0
@@ -229,7 +229,7 @@ func (m *WorkshopRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C
 }
 
 func (m *WorkshopRefresh) TestRefreshIncompatibleOptions(c *check.C) {
-	cmd := &CmdRefresh{}
+	cmd := &CmdRefresh{root: &CmdRoot{}}
 	cmd.Abort = true
 	cmd.Continue = true
 

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -11,6 +10,7 @@ import (
 
 type CmdRemount struct {
 	waitMixin
+	root *CmdRoot
 }
 
 func (c *CmdRemount) Command() *cobra.Command {
@@ -43,8 +43,7 @@ Notes:
   aren't removed
 `,
 
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -67,26 +66,24 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
-
-	project, err := c.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
 
 	plugRef.ProjectId = project.Id
 
-	changeId, err := c.cli.Remount(plugRef, source)
+	changeId, err := cli.Remount(plugRef, source)
 	if err != nil {
 		return err
 	}
 
-	if _, err := c.wait(changeId, false); err != nil {
+	if _, err := c.wait(cli, changeId, false); err != nil {
 		if err == errNoWait {
 			return nil
 		}

--- a/cmd/workshop/remount_test.go
+++ b/cmd/workshop/remount_test.go
@@ -22,7 +22,7 @@ func (m *remountSuite) SetUpTest(c *check.C) {
 }
 
 func (m *remountSuite) TestRemountSuccess(c *check.C) {
-	cmd := &CmdRemount{}
+	cmd := &CmdRemount{root: &CmdRoot{}}
 	body := map[string]interface{}{
 		"action": "remount",
 		"plug": map[string]interface{}{
@@ -62,7 +62,7 @@ func (m *remountSuite) TestRemountSuccess(c *check.C) {
 }
 
 func (m *remountSuite) TestRemountBrokenReference(c *check.C) {
-	cmd := &CmdRemount{}
+	cmd := &CmdRemount{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"ws:sdk:plug", "/new/source"})
 	c.Assert(err, check.ErrorMatches, `unknown plug or slot reference "ws:sdk:plug"`)
 }

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
-
-	"github.com/canonical/workshop/client"
 )
 
 type CmdRemove struct {
 	waitMixin
+	root *CmdRoot
 }
 
 func (c *CmdRemove) Command() *cobra.Command {
@@ -32,37 +31,33 @@ Notes:
   aren't removed
 `,
 
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	return cmd
 }
 
 func (c *CmdRemove) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
 	av = strutil.Deduplicate(av)
 
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
 	c.skipAbort = true
 
-	project, err := c.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
 
-	changeId, err := c.cli.Remove(project.Id, av)
+	changeId, err := cli.Remove(project.Id, av)
 	if err != nil {
 		return err
 	}
 
-	if _, err := c.wait(changeId, false); err != nil {
+	if _, err := c.wait(cli, changeId, false); err != nil {
 		if err == errNoWait {
 			return nil
 		}

--- a/cmd/workshop/remove_test.go
+++ b/cmd/workshop/remove_test.go
@@ -22,7 +22,7 @@ func (m *WorkshopRemove) SetUpTest(c *check.C) {
 }
 
 func (m *WorkshopRemove) TestStartSuccess(c *check.C) {
-	cmd := &CmdRemove{}
+	cmd := &CmdRemove{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
-
-	"github.com/canonical/workshop/client"
 )
 
 type CmdStart struct {
 	waitMixin
+	root *CmdRoot
 }
 
 func (c *CmdStart) Command() *cobra.Command {
@@ -38,37 +37,33 @@ Notes:
 
 - To stop a started workshop, use 'workshop stop'
 `,
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	return cmd
 }
 
 func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
 	av = strutil.Deduplicate(av)
 
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
 	c.skipAbort = true
 
-	project, err := c.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
 
-	changeId, err := c.cli.Start(project.Id, av)
+	changeId, err := cli.Start(project.Id, av)
 	if err != nil {
 		return err
 	}
 
-	if _, err := c.wait(changeId, false); err != nil {
+	if _, err := c.wait(cli, changeId, false); err != nil {
 		if err == errNoWait {
 			return nil
 		}

--- a/cmd/workshop/start_test.go
+++ b/cmd/workshop/start_test.go
@@ -22,7 +22,7 @@ func (m *WorkshopStart) SetUpTest(c *check.C) {
 }
 
 func (m *WorkshopStart) TestStartSuccess(c *check.C) {
-	cmd := &CmdStart{}
+	cmd := &CmdStart{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
-
-	"github.com/canonical/workshop/client"
 )
 
 type CmdStop struct {
 	waitMixin
+	root *CmdRoot
 }
 
 func (c *CmdStop) Command() *cobra.Command {
@@ -38,37 +37,33 @@ Notes:
 
 - To start a stopped workshop, use 'workshop start'
 `,
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	return cmd
 }
 
 func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
-	var err error
-
 	av = strutil.Deduplicate(av)
 
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
 
-	c.setClient(cli)
 	c.skipAbort = true
 
-	project, err := c.cli.Project(Project)
+	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
 	}
 
-	changeId, err := c.cli.Stop(project.Id, av)
+	changeId, err := cli.Stop(project.Id, av)
 	if err != nil {
 		return err
 	}
 
-	if _, err := c.wait(changeId, false); err != nil {
+	if _, err := c.wait(cli, changeId, false); err != nil {
 		if err == errNoWait {
 			return nil
 		}

--- a/cmd/workshop/stop_test.go
+++ b/cmd/workshop/stop_test.go
@@ -22,7 +22,7 @@ func (m *WorkshopStop) SetUpTest(c *check.C) {
 }
 
 func (m *WorkshopStop) TestStopSuccess(c *check.C) {
-	cmd := &CmdStop{}
+	cmd := &CmdStop{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -13,7 +13,7 @@ import (
 )
 
 type CmdTasks struct {
-	clientMixin
+	root *CmdRoot
 }
 
 func (c *CmdTasks) Command() *cobra.Command {
@@ -39,8 +39,7 @@ Notes:
 
 - To investigate recent changes in a project, use 'workshop changes' instead
 `,
-		RunE:    c.Run,
-		PostRun: postRunWarnings(&c.clientMixin),
+		RunE: c.Run,
 	}
 
 	return cmd
@@ -49,22 +48,12 @@ Notes:
 const line = "......................................................................"
 
 func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
-	var clientOpts client.ChangesOptions
-	var err error
-
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
-	}
-	c.setClient(cli)
-
-	if cmd.Parent().Flag("project").Changed {
-		clientOpts.ProjectPath = cmd.Parent().Flag("project").Value.String()
+		return err
 	}
 
-	clientOpts.Selector = client.ChangesAll
-
-	change, err := c.cli.Change(av[0])
+	change, err := cli.Change(av[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/times.go
+++ b/cmd/workshop/times.go
@@ -28,7 +28,7 @@ import (
 var timeutilHuman = timeutil.Human
 
 type timeMixin struct {
-	AbsTime bool `long:"abs-time"`
+	AbsTime bool
 }
 
 func (mx timeMixin) fmtTime(t time.Time) string {

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -40,7 +40,6 @@ var (
 )
 
 type waitMixin struct {
-	clientMixin
 	NoWait    bool
 	skipAbort bool
 }
@@ -58,12 +57,11 @@ func stripAbortMessage(str string) string {
 	return str
 }
 
-func (wmx waitMixin) wait(id string, abortExpected bool) (*client.Change, error) {
+func (wmx waitMixin) wait(cli *client.Client, id string, abortExpected bool) (*client.Change, error) {
 	if wmx.NoWait {
 		fmt.Fprintf(Stdout, "%s\n", id)
 		return nil, errNoWait
 	}
-	cli := wmx.cli
 	// Intercept sigint
 	c := make(chan os.Signal, 2)
 
@@ -77,7 +75,7 @@ func (wmx waitMixin) wait(id string, abortExpected bool) (*client.Change, error)
 		if sig == nil || wmx.skipAbort {
 			return
 		}
-		_, err := wmx.cli.Abort(id)
+		_, err := cli.Abort(id)
 		if err != nil {
 			fmt.Fprintf(Stderr, err.Error()+"\n")
 		}

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -41,7 +41,7 @@ var (
 
 type waitMixin struct {
 	clientMixin
-	NoWait    bool `long:"no-wait"`
+	NoWait    bool
 	skipAbort bool
 }
 

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -44,8 +44,8 @@ type CmdWarnings struct {
 	clientMixin
 	timeMixin
 	unicodeMixin
-	All     bool `long:"all"`
-	Verbose bool `long:"verbose"`
+	All     bool
+	Verbose bool
 }
 
 type CmdOkay struct{ clientMixin }

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -41,14 +41,16 @@ import (
 )
 
 type CmdWarnings struct {
-	clientMixin
 	timeMixin
 	unicodeMixin
+	root    *CmdRoot
 	All     bool
 	Verbose bool
 }
 
-type CmdOkay struct{ clientMixin }
+type CmdOkay struct {
+	root *CmdRoot
+}
 
 func (c *CmdWarnings) Command() *cobra.Command {
 	var cmd = &cobra.Command{
@@ -151,13 +153,12 @@ func printDescr(w io.Writer, descr string, termWidth int) error {
 func (c *CmdWarnings) Run(cmd *cobra.Command, av []string) error {
 	now := time.Now()
 
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
-	c.setClient(cli)
 
-	warnings, err := c.cli.Warnings(client.WarningsOptions{All: c.All})
+	warnings, err := cli.Warnings(client.WarningsOptions{All: c.All})
 	if err != nil {
 		return err
 	}
@@ -208,19 +209,18 @@ func (c *CmdWarnings) Run(cmd *cobra.Command, av []string) error {
 	return nil
 }
 
-func (cmd *CmdOkay) Run(c *cobra.Command, av []string) error {
+func (c *CmdOkay) Run(cmd *cobra.Command, av []string) error {
 	last, err := lastWarningTimestamp()
 	if err != nil {
 		return err
 	}
 
-	cli, err := client.New(&ClientConfig)
+	cli, err := c.root.client()
 	if err != nil {
-		return fmt.Errorf("cannot create client: %v", err)
+		return err
 	}
-	cmd.setClient(cli)
 
-	return cmd.cli.Okay(last)
+	return cli.Okay(last)
 }
 
 const warnFileEnvKey = "WORKSHOPD_LAST_WARNING_TIMESTAMP_FILENAME"

--- a/cmd/workshop/warnings_test.go
+++ b/cmd/workshop/warnings_test.go
@@ -40,8 +40,8 @@ var _ = check.Suite(&warningSuite{})
 
 func (m *warningSuite) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
-	m.cmdW = &CmdWarnings{}
-	m.cmdO = &CmdOkay{}
+	m.cmdW = &CmdWarnings{root: &CmdRoot{}}
+	m.cmdO = &CmdOkay{root: m.cmdW.root}
 
 	os.Setenv("WORKSHOPD_LAST_WARNING_TIMESTAMP_FILENAME", filepath.Join(c.MkDir(), "warnings.json"))
 }
@@ -222,7 +222,7 @@ func (s *warningSuite) TestListWithWarnings(c *check.C) {
 		}
 
 	})
-	cmdList := &CmdList{}
+	cmdList := &CmdList{root: &CmdRoot{}}
 	err := cmdList.runList()
 	c.Assert(err, check.IsNil)
 
@@ -231,7 +231,9 @@ func (s *warningSuite) TestListWithWarnings(c *check.C) {
 		// call it from tests and not have to do this (whole
 		// block) by hand
 
-		count, stamp := cmdList.cli.WarningsSummary()
+		cli, err := cmdList.root.client()
+		c.Assert(err, check.IsNil)
+		count, stamp := cli.WarningsSummary()
 		c.Check(count, check.Equals, 2)
 		c.Check(stamp, check.Equals, time.Date(2018, 9, 19, 12, 44, 19, 680362867, time.UTC))
 		maybePresentWarnings(count, stamp)

--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -37,9 +37,9 @@ The run command workshop and starts accepting clients requests
 `
 
 type sharedRunEnterOpts struct {
-	CreateDirs bool   `long:"create-dirs"`
-	HTTP       string `long:"http"`
-	Verbose    bool   `short:"v" long:"verbose"`
+	CreateDirs bool
+	HTTP       string
+	Verbose    bool
 }
 
 var sharedRunEnterOptsHelp = map[string]string{


### PR DESCRIPTION
# Description

- Removed some old `struct` tags which don't seem to be used.
- Replaced `PostRun` on most commands with `PersistentPostRun` on the root command. This needs access to the client, which is now stored at the `CmdRoot`.
- All subcommands now store a `*CmdRoot` and use `CmdRoot.client()` to access the client object.
- The `Project` global is now stored with the `CmdRoot`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
