### PR TITLE
Warn if project directory or workshop definition does not exist

### DIFF
--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -125,6 +125,8 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshop.Workshop) healthstate.Heal
 
 	// Check the project directory exists.
 	if !ws.Project.Exists() {
+		w.state.Warnf("%q project directory %q does not exist", ws.Name, ws.Project.Path)
+
 		healthState.Status = healthstate.ErrorStatus
 		healthState.Code = "missing-project"
 		return healthState
@@ -133,7 +135,10 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshop.Workshop) healthstate.Heal
 	// Check if the associated workshop file exists. We only check if that file
 	// exists in the project directory here; its state (e.g. if it is in sync
 	// with the workshop instance or has any errors) is not checked.
-	if !osutil.FileExists(filepath.Join(ws.Project.Path, workshop.Filename(ws.Name))) {
+	path := filepath.Join(ws.Project.Path, workshop.Filename(ws.Name))
+	if !osutil.FileExists(path) {
+		w.state.Warnf("%q workshop definition %q does not exist", ws.Name, path)
+
 		healthState.Status = healthstate.ErrorStatus
 		healthState.Code = "missing-file"
 		return healthState

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -119,6 +119,11 @@ func (s *managerSuite) TestWorkshopHealthMissingProject(c *check.C) {
 	c.Check(health.SdkHealth, check.HasLen, 0)
 	c.Check(health.Message, check.HasLen, 0)
 	c.Check(health.Code, check.Equals, "missing-project")
+
+	warnings := s.state.AllWarnings()
+	c.Check(warnings, check.HasLen, 1)
+	warning := fmt.Sprintf("%q project directory %q does not exist", workshop.Name, s.project.Path)
+	c.Check(warnings[0].String(), check.Equals, warning)
 }
 
 func (s *managerSuite) TestWorkshopHealthMissingFile(c *check.C) {
@@ -126,13 +131,19 @@ func (s *managerSuite) TestWorkshopHealthMissingFile(c *check.C) {
 	defer s.state.Unlock()
 
 	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
-	c.Assert(os.RemoveAll(filepath.Join(s.project.Path, ".workshop.test.yaml")), check.IsNil)
+	path := filepath.Join(s.project.Path, ".workshop.test.yaml")
+	c.Assert(os.RemoveAll(path), check.IsNil)
 	health := s.manager.WorkshopHealth(workshop)
 
 	c.Assert(health.Status, check.Equals, healthstate.ErrorStatus)
 	c.Check(health.SdkHealth, check.HasLen, 0)
 	c.Check(health.Message, check.HasLen, 0)
 	c.Check(health.Code, check.Equals, "missing-file")
+
+	warnings := s.state.AllWarnings()
+	c.Check(warnings, check.HasLen, 1)
+	warning := fmt.Sprintf("%q workshop definition %q does not exist", workshop.Name, path)
+	c.Check(warnings[0].String(), check.Equals, warning)
 }
 
 func (s *managerSuite) TestWorkshopHealthOperationInProgress(c *check.C) {

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -1,6 +1,9 @@
 summary: Error states tracking and recovery for the .workshop.lock
 restore: |
   . "$TESTSLIB"/utils.sh
+
+  workshop_exec warnings
+  workshop_exec okay || true
   rm -rf ./new-project
 execute: |
   . "$TESTSLIB"/utils.sh
@@ -13,6 +16,18 @@ execute: |
   rm -f "$PROJECT"/.workshop.lock
   workshop_exec --project "$PROJECT" list
   test -f "$PROJECT"/.workshop.lock
+
+  echo "Check for warnings if there is no workshop file"
+  mv "$PROJECT"/.workshop.ws.yaml "$PROJECT"/.workshop.ws.yaml.bak
+  workshop_exec --project "$PROJECT" list | MATCH "^WARNING: There is 1 new warning. See 'workshop warnings'.$"
+  mv "$PROJECT"/.workshop.ws.yaml.bak "$PROJECT"/.workshop.ws.yaml
+  # TODO: it might be better if the warning went away on its own
+  workshop_exec --project "$PROJECT" list | MATCH "^WARNING: There is 1 new warning. See 'workshop warnings'.$"
+  workshop_exec warnings | 
+    tr -d '\n' | # remove newlines
+    sed -e 's,\s\+, ,g' | # rename any extra spaces
+    MATCH '"ws" workshop definition ".*/project/.workshop.ws.yaml" does not exist'
+  workshop_exec --project "$PROJECT" list | NOMATCH 'new warning'
 
   echo "Check report a workshop state as Error if there is no workshop file"
   mv "$PROJECT"/.workshop.ws.yaml "$PROJECT"/.workshop.ws.yaml.bak

--- a/tests/main/list-global/task.yaml
+++ b/tests/main/list-global/task.yaml
@@ -5,6 +5,9 @@ restore: |
     rm -rf "$path"
   done
 
+  workshop_exec warnings
+  workshop_exec okay || true
+
 execute: |
   . "$TESTSLIB"/utils.sh
   

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -1,4 +1,9 @@
 summary: Check workshop remount scenarios
+restore: |
+  . "$TESTSLIB"/utils.sh
+
+  workshop_exec warnings
+  workshop_exec okay || true
 execute: |
   . "$TESTSLIB"/utils.sh
 
@@ -45,9 +50,15 @@ execute: |
   rmdir "${new_source}.2"
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source" | MATCH "^WARNING: There are 2 new warnings. See 'workshop warnings'.$"
   workshop_exec list | MATCH "^WARNING: There are 2 new warnings. See 'workshop warnings'.$"
-  workshop_exec warnings | MATCH "\"${new_source}\\.1\" does not exist"
+  workshop_exec warnings |
+    tr -d '\n' | # remove newlines
+    sed -e 's,\s\+, ,g' | # rename any extra spaces
+    MATCH "ws-remount/test-sdk-mount:two's source at \"${new_source}\\.1\" does not exist; will attempt to recreate"
   workshop_exec list | NOMATCH "new warning"
-  workshop_exec warnings | MATCH "\"${new_source}\\.2\" does not exist"
+  workshop_exec warnings |
+    tr -d '\n' | # remove newlines
+    sed -e 's,\s\+, ,g' | # rename any extra spaces
+    MATCH "ws-remount/test-sdk-mount:two's source at \"${new_source}\\.2\" does not exist; will attempt to recreate"
   workshop_exec okay
   workshop_exec warnings | MATCH '^No further warnings.$'
 

--- a/tests/main/remove/task.yaml
+++ b/tests/main/remove/task.yaml
@@ -1,4 +1,9 @@
 summary: Check workshop remove
+restore: |
+  . "$TESTSLIB"/utils.sh
+
+  workshop_exec warnings
+  workshop_exec okay || true
 execute: |
   . "$TESTSLIB"/utils.sh
 


### PR DESCRIPTION
# Description

Adds warnings in addition to status for `missing-file` and `missing-project` checks.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
