### PR TITLE
Allow exec to inherit environment variables via `--env NAME`

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -108,7 +108,7 @@ func (c *CmdExec) Command() *cobra.Command {
 
 	cmd.Flags().SortFlags = false
 	cmd.Flags().StringVarP(&c.WorkingDir, "cwd", "w", "/project", "Set the working directory in the workshop")
-	cmd.Flags().StringArrayVar(&c.Env, "env", []string{}, "Set an environment variable, e.g. 'FOO=bar'")
+	cmd.Flags().StringArrayVar(&c.Env, "env", []string{}, "Set an environment variable, e.g. 'FOO=bar'; if only the name is provided, the value is inherited from the CLI environment.")
 	cmd.Flags().IntVar(&c.UserId, "uid", 1000, "Run as a specific workshop user")
 	cmd.Flags().IntVar(&c.GroupId, "gid", 1000, "Run as a member of a specific workshop group")
 	cmd.Flags().DurationVar(&c.Timeout, "timeout", 0, "Set a timeout; valid units are 'ns', 'us'/'µs', 'ms', 's', 'm', 'h'")
@@ -162,10 +162,17 @@ func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
 	for _, kv := range c.Env {
 		parts := strings.SplitN(kv, "=", 2)
 		key := parts[0]
-		value := ""
+
+		var value string
 		if len(parts) == 2 {
 			value = parts[1]
+		} else {
+			value, ok = os.LookupEnv(key)
+			if !ok {
+				continue
+			}
 		}
+
 		env[key] = value
 	}
 

--- a/docs/reference/cli/workshop-exec.rst
+++ b/docs/reference/cli/workshop-exec.rst
@@ -89,9 +89,10 @@ Options
 
   Set the working directory in the workshop (default: :file:`/project/`).
 
---env <KEY=VALUE>
+--env <KEY>[=<VALUE>]
 
-  Set an environment variable.
+  Set an environment variable, e.g. 'FOO=bar';
+  if only the name is provided, the value is inherited from the CLI environment.
 
 --uid <USER ID>
 

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -9,7 +9,12 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Check an environment variable can be set"
-  workshop_exec exec --env 'Foo=bar'  ws-exec -- bash -c 'echo -n $Foo' | MATCH bar
+  workshop_exec exec --env 'Foo=bar'  ws-exec -- bash -c '[ "$Foo" = bar ]'
+
+  echo "Check that environment variables are inherited"
+  sudo -u ubuntu 2>&1 -- env Foo=bar workshop exec --env Foo ws-exec -- bash -c '[ "$Foo" = bar ]'
+  sudo -u ubuntu 2>&1 -- env Foo= workshop exec --env Foo ws-exec -- bash -c '[ -z "${Foo-x}" ]'
+  sudo -u ubuntu 2>&1 -- env --unset=Foo workshop exec --env Foo ws-exec -- bash -c '[ -z "${Foo+x}" ]'
 
   echo "Check default user and group"
   workshop_exec exec ws-exec -- bash -c 'id -u -n' | MATCH workshop


### PR DESCRIPTION
# Description

This can save some typing: instead of `--env "FOO=$FOO"` you can write `--env FOO`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
