### PR TITLE
Add shellcheck and rectify existing linting issues

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,17 +1,19 @@
 name: Lint
 on:
-    pull_request:
-    push:
-      branches: [main]
+  pull_request:
+  push:
+    branches: [main]
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: "1.21"
           cache: false
 
       - name: golangci-lint
@@ -19,8 +21,13 @@ jobs:
         id: lint
         with:
           version: latest
-          args: '-c .github/.golangci.yml --out-format=colored-line-number'
+          args: "-c .github/.golangci.yml --out-format=colored-line-number"
           skip-cache: true
+
+      - name: shellcheck
+        run: |
+          git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck
+          snapd-testing-tools/utils/spread-shellcheck tests/integration
 
       - name: Print error message
         if: always() && steps.lint.outcome == 'failure'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
-[submodule "tools/external"]
-	path = tools/external
-	url = https://github.com/snapcore/snapd-testing-tools.git
-	branch = main
+[submodule "snapd-testing-tools"]
+	path = snapd-testing-tools
+	url = https://github.com/canonical/snapd-testing-tools.git

--- a/tests/integration/fake-store/task.yaml
+++ b/tests/integration/fake-store/task.yaml
@@ -1,9 +1,11 @@
 summary: Run LXD integration tests for SDK profiles
 prepare: |
+  # shellcheck source=/dev/null
   . "$TESTSLIB"/utils.sh
   start_sdk_store
 restore: |
+  # shellcheck source=/dev/null
   . "$TESTSLIB"/utils.sh
   stop_sdk_store
 execute: |
-  go test $SPREAD_PATH/internal/fakestore/ -timeout=30m -tags=integration -check.v -check.f storeIntegration
+  go test "$SPREAD_PATH"/internal/fakestore/ -timeout=30m -tags=integration -check.v -check.f storeIntegration

--- a/tests/integration/profile/task.yaml
+++ b/tests/integration/profile/task.yaml
@@ -1,4 +1,4 @@
 summary: Run LXD integration tests for SDK profiles
 
 execute: |
-  go test $SPREAD_PATH/internal/interfaces/lxd_device/tests/integration -timeout=30m -tags=integration -check.v -check.f backendDeviceSuite
+  go test "$SPREAD_PATH"/internal/interfaces/lxd_device/tests/integration -timeout=30m -tags=integration -check.v -check.f backendDeviceSuite

--- a/tests/integration/project-tracking/task.yaml
+++ b/tests/integration/project-tracking/task.yaml
@@ -1,4 +1,4 @@
 summary: Run LXD integration tests for project tracking
 
 execute: |
-  go test $SPREAD_PATH/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsProject
+  go test "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsProject

--- a/tests/integration/workshop-exec/task.yaml
+++ b/tests/integration/workshop-exec/task.yaml
@@ -1,4 +1,4 @@
-summary: Run LXD integration tests for workshop exec 
+summary: Run LXD integration tests for workshop exec
 
 execute: |
-  go test $SPREAD_PATH/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsExec
+  go test "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsExec

--- a/tests/integration/workshop-ops/task.yaml
+++ b/tests/integration/workshop-ops/task.yaml
@@ -1,4 +1,4 @@
 summary: Run LXD integration tests for workshop operations (launch, delete, attach storage, etc.)
 
 execute: |
-  go test $SPREAD_PATH/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsOps
+  go test "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsOps

--- a/tests/lib/sdk/test-sdk-content-broken/sdk/hooks/restore-state
+++ b/tests/lib/sdk/test-sdk-content-broken/sdk/hooks/restore-state
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
-state=$(cat $SDK_STATE_DIR/state)
+state=$(cat "$SDK_STATE_DIR/state")
 echo "latest/stable restore-state to ~/state: $state"
-cp -f $SDK_STATE_DIR/state ~/ || true
+cp -f "$SDK_STATE_DIR"/state ~/ || true

--- a/tests/lib/sdk/test-sdk-content-broken/sdk/hooks/save-state
+++ b/tests/lib/sdk/test-sdk-content-broken/sdk/hooks/save-state
@@ -2,4 +2,4 @@
 
 state=$(cat ~/state)
 echo "latest/stable save-state from ~/state: $state"
-cp ~/state $SDK_STATE_DIR 2>/dev/null || true
+cp ~/state "$SDK_STATE_DIR" 2>/dev/null || true

--- a/tests/lib/sdk/test-sdk-go/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/sdk/hooks/setup-base
@@ -5,4 +5,4 @@ echo "PATH=/home/workshop/go/bin:$PATH" >> /home/workshop/.bashrc
 
 # create a mod cache to be mounted from the host using the content interface
 cache=$(sudo -u workshop -- go env GOMODCACHE)
-sudo -u workshop -- mkdir -p $cache
+sudo -u workshop -- mkdir -p "$cache"

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -4,10 +4,10 @@ function setup_lxd() {
   snap install --classic lxd
   snap refresh --channel=5.21/stable lxd
   lxd waitready --timeout=180
-  
+
   # can already be initialised if reused
   # https://discuss.linuxcontainers.org/t/how-do-i-know-if-lxd-is-initialized/15473/3
-  if [ $(lxc storage list -f compact | grep -c default) -eq 0  ]; then   
+  if [ "$(lxc storage list -f compact | grep -c default)" -eq 0  ]; then
       lxd init --auto --storage-backend=zfs
   fi
 }
@@ -18,9 +18,9 @@ function prepare_environment() {
   snap wait system seed.loaded
   # The /snap directory does not exist in some environments
   [ ! -d /snap ] && ln -s /var/lib/snapd/snap /snap
-  
+
   setup_lxd
-  
+
   snap install --classic --channel=1.21/stable go
   snap install yq
   # The unattended upgrades hold locks on reusable instances
@@ -28,7 +28,7 @@ function prepare_environment() {
   apt-get remove -y unattended-upgrades
   apt-get update
   apt-get install -y --no-install-recommends moreutils jq
-  
+
   snap install --dangerous --classic /workshop/tests/*.snap
   snap set workshop store.url=http://localhost:8080/storage/v1/
   snap set workshop workshop.image.server.url="$IMAGE_SERVER"
@@ -36,7 +36,7 @@ function prepare_environment() {
 }
 
 function cleanup_environment() {
-  snap remove workshop --purge   
+  snap remove workshop --purge
   find /workshop -name .workshop.lock -delete
 }
 
@@ -44,10 +44,10 @@ function start_sdk_store() {
   # run fake GCS bucket storage to emulate SDK store
   publish_test_sdk_content "$SDKS" "$SDK_STORE_BUCKET_DIR"
   # a bug with fake-gcs-server that returns 404 if not owned by the user
-  chown -R ubuntu.ubuntu /data 
+  chown -R ubuntu.ubuntu /data
   mkdir -p /storage
   chown -R ubuntu.ubuntu /storage
-  
+
   /bin/sh -c "nohup go run github.com/fsouza/fake-gcs-server@latest -data /data -scheme http -port 8080 -public-host localhost:8080 > ~/fake_sdk_store.log 2>&1 &"
 
   echo "Waiting for the fake SDK store to start on port 8080..."
@@ -70,6 +70,8 @@ function publish_test_sdk_content() {
       SDK_PATH=$(readlink -f "$i")
       STORE_PATH="$2"/"$SDK_NAME"/latest/stable/
 
+      # we want word splitting when reading the output of `ls -A $SDK_PATH`
+      # shellcheck disable=SC2046
       tar czf "$SDK_FILE" -C "$SDK_PATH" $(ls -A "$SDK_PATH")
       mkdir -p "$STORE_PATH"
       mv "$SDK_FILE" "$STORE_PATH"


### PR DESCRIPTION
# Description
Shellcheck is a well known shell script static analysis tool. 
- Add shellcheck actions covering standard shell scripts and scripts contained in spread files
- Add snapd-testing-tools as a submodule to facilitate spread shell testing
- Rectify existing shellcheck warnings

# Self-review quick check
 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.