### PR TITLE
Add basic camera interface

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -13,7 +13,7 @@ repack: |
 backends:
   lxd:
     systems:
-      - ubuntu-22.04:
+      - ubuntu-24.04:
           workers: 2
 suites:
   tests/main/:

--- a/docs/explanation/interfaces/camera-interface.rst
+++ b/docs/explanation/interfaces/camera-interface.rst
@@ -26,8 +26,8 @@ can be invoked manually after the workshop has started:
 Establishing a connection means
 that all currently connected USB-based cameras
 will be made available inside the workshop.
-New cameras can be added by disconnecting and then reconnecting
-the camera interface.
+New cameras can be added
+by disconnecting and then reconnecting the camera interface.
 
 To check if the interface is connected:
 

--- a/docs/explanation/interfaces/camera-interface.rst
+++ b/docs/explanation/interfaces/camera-interface.rst
@@ -1,0 +1,71 @@
+.. _exp_camera_interface:
+
+Camera interface
+================
+
+The camera interface
+enables access to the host system's cameras
+and other video capture devices inside the workshop.
+
+By using the interface,
+the SDK publisher allows the workshop to access the host's cameras,
+which can be useful in various SDK-specific tasks
+such as testing hardware or embedded devices.
+
+The interface isn't connected automatically at launch and refresh
+for security reasons.
+The :command:`workshop connect` and :command:`workshop disconnect` commands
+can be invoked manually after the workshop has started:
+
+.. code-block:: console
+
+   $ workshop connect ws/camera-sdk:camera
+   $ workshop disconnect ws/camera-sdk:camera
+
+
+Establishing a connection means
+that all currently connected USB-based cameras
+will be made available inside the workshop.
+New cameras can be added by disconnecting and then reconnecting
+the camera interface.
+
+To check if the interface is connected:
+
+.. code-block:: console
+
+   $ workshop connections --all
+
+     Interface  Plug              Slot     Notes
+     ...
+     camera     ws/camera:camera  :camera  manual
+
+
+This means the host's cameras are available inside the workshop:
+
+.. code-block:: console
+
+   $ workshop shell ws
+   workshop@ws-8584e571$ ls /dev/video*
+
+     /dev/video0  /dev/video1
+
+
+See also
+--------
+
+Explanation:
+
+- :ref:`exp_interfaces`
+- :ref:`exp_plugs_slots`
+- :ref:`exp_sdk_definition`
+- :ref:`exp_workshop_def`
+
+
+Reference:
+
+- :ref:`ref_workshop_connect`
+- :ref:`ref_workshop_connections`
+- :ref:`ref_workshop_disconnect`
+- :ref:`ref_workshop_launch`
+- :ref:`ref_workshop_refresh`
+- :ref:`ref_workshop_shell`

--- a/docs/explanation/interfaces/index.rst
+++ b/docs/explanation/interfaces/index.rst
@@ -51,8 +51,8 @@ This behaviour varies by interface,
 but the overall aim is to provide a reasonably seamless, logical experience:
 the :ref:`mount <exp_mount_interface>`
 and the :ref:`GPU <exp_gpu_interface>` interfaces are auto-connected,
-whereas the :ref:`Camera <exp_camera_interface>` and :ref:`SSH <exp_ssh_interface>`
-interfaces require manual connection.
+whereas the :ref:`camera <exp_camera_interface>`
+and :ref:`SSH <exp_ssh_interface>` interfaces require manual connection.
 
 
 .. _exp_system_sdk:

--- a/docs/explanation/interfaces/index.rst
+++ b/docs/explanation/interfaces/index.rst
@@ -51,7 +51,8 @@ This behaviour varies by interface,
 but the overall aim is to provide a reasonably seamless, logical experience:
 the :ref:`mount <exp_mount_interface>`
 and the :ref:`GPU <exp_gpu_interface>` interfaces are auto-connected,
-whereas the :ref:`SSH interface <exp_ssh_interface>` requires manual connection.
+whereas the :ref:`Camera <exp_camera_interface>` and :ref:`SSH <exp_ssh_interface>`
+interfaces require manual connection.
 
 
 .. _exp_system_sdk:

--- a/docs/explanation/workshops-sdks/sdks.rst
+++ b/docs/explanation/workshops-sdks/sdks.rst
@@ -102,10 +102,10 @@ Specific interfaces are predefined and implemented by |project_markup|,
 so you can't create a custom interface type.
 Currently, |project_markup| supports the following:
 
+- :ref:`Camera interface <exp_camera_interface>` (manually connected)
 - :ref:`GPU interface <exp_gpu_interface>` (auto-connected)
 - :ref:`Mount interface <exp_mount_interface>` (auto-connected)
 - :ref:`SSH interface <exp_ssh_interface>` (manually connected)
-- :ref:`Camera interface <exp_camera_interface>` (manually connected)
 
 
 .. _exp_plugs_slots:

--- a/docs/explanation/workshops-sdks/sdks.rst
+++ b/docs/explanation/workshops-sdks/sdks.rst
@@ -105,6 +105,7 @@ Currently, |project_markup| supports the following:
 - :ref:`GPU interface <exp_gpu_interface>` (auto-connected)
 - :ref:`Mount interface <exp_mount_interface>` (auto-connected)
 - :ref:`SSH interface <exp_ssh_interface>` (manually connected)
+- :ref:`Camera interface <exp_camera_interface>` (manually connected)
 
 
 .. _exp_plugs_slots:

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -683,7 +683,7 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slots(s.project.ProjectId, "basic", sdk.System.String()), check.HasLen, 3)
+	c.Assert(repo.Slots(s.project.ProjectId, "basic", sdk.System.String()), check.HasLen, 4)
 }
 
 func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {

--- a/internal/interfaces/builtin/camera.go
+++ b/internal/interfaces/builtin/camera.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+const cameraSummary = `allows sharing video cameras with SDKs`
+
+const cameraBaseDeclarationSlots = `
+  camera:
+    allow-installation:
+      slot-sdk-type:
+        - system
+      slot-names:
+        - $INTERFACE
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+const cameraBaseDeclarationPlugs = `
+  camera:
+    allow-installation:
+      plug-sdk-type:
+        - regular
+      plug-names:
+        - $INTERFACE
+    allow-connection: true
+    allow-auto-connection: false
+`
+
+type cameraInterface struct{}
+
+func (iface *cameraInterface) Name() string {
+	return "camera"
+}
+
+func (iface *cameraInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              cameraSummary,
+		BaseDeclarationPlugs: cameraBaseDeclarationPlugs,
+		BaseDeclarationSlots: cameraBaseDeclarationSlots,
+		AffectsPlugOnRefresh: true,
+	}
+}
+
+func (iface *cameraInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+func (iface *cameraInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	return spec.SetCamera(workshop.Camera{Name: plug.Name()})
+}
+
+func init() {
+	registerIface(&cameraInterface{})
+}

--- a/internal/interfaces/builtin/camera_test.go
+++ b/internal/interfaces/builtin/camera_test.go
@@ -1,0 +1,55 @@
+package builtin_test
+
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshop"
+	"gopkg.in/check.v1"
+)
+
+type cameraSuite struct {
+	iface     interfaces.Interface
+	projectId string
+}
+
+var _ = check.Suite(&cameraSuite{
+	iface: builtin.MustInterface("camera"),
+})
+
+func (s *cameraSuite) SetUpTest(c *check.C) {
+	s.projectId = "42424242"
+}
+
+func (s *cameraSuite) TestName(c *check.C) {
+	c.Assert(s.iface.Name(), check.Equals, "camera")
+}
+
+func (s *cameraSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *cameraSuite) TestCameraInterface(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ camera:
+  interface: camera
+`, s.projectId, "ws", "consumer", "camera")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  camera:
+`, s.projectId, "ws", "producer", "camera")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the device specification.
+	expectedDevice := &workshop.Camera{Name: "camera"}
+	c.Assert(deviceSpec.Profile.Camera, check.DeepEquals, expectedDevice)
+}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/usbid"
 	"github.com/canonical/x-go/randutil"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -207,6 +209,37 @@ func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string,
 	return nil
 }
 
+func detectCameras(conn lxd.InstanceServer, camera *workshop.Camera, sdk string) (map[string]map[string]string, map[string]string, error) {
+	resources, err := conn.GetServerResources()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	isWebcam := func(iface api.ResourcesUSBDeviceInterface) bool {
+		classID := usbid.ClassCode(iface.ClassID)
+		return classID == usbid.ClassVideo || classID == usbid.ClassAudioVideo
+	}
+
+	devices := map[string]map[string]string{}
+	config := map[string]string{}
+	for _, device := range resources.USB.Devices {
+		if slices.ContainsFunc(device.Interfaces, isWebcam) {
+			// This name is unique because '/' is not permitted in plug names.
+			name := fmt.Sprintf("%s/%s:%s", camera.Name, device.VendorID, device.ProductID)
+			devices[name] = map[string]string{
+				"type":      "unix-hotplug",
+				"vendorid":  device.VendorID,
+				"productid": device.ProductID,
+				"required":  "false",
+			}
+			config[lxdbackend.DeviceTypeConfigKey(sdk, name)] = "camera"
+		}
+	}
+
+	// TODO: warn if no devices were detected
+	return devices, config, nil
+}
+
 func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop string) error {
 	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
 	if err != nil {
@@ -242,6 +275,13 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 	}
 	spec := s.(*Specification)
 
+	name := lxdbackend.ProfileName(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Sdk)
+	newp := api.ProfilePut{
+		Devices:     spec.devices,
+		Config:      spec.config,
+		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkInfo.Sdk, sdkInfo.Workshop),
+	}
+
 	conn, err := lxdClient(ctx)
 	if err != nil {
 		return err
@@ -276,18 +316,20 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		}
 	}
 
+	if spec.Profile.Camera != nil {
+		cameraDevices, cameraConfig, err := detectCameras(conn, spec.Profile.Camera, sdkInfo.Sdk)
+		if err != nil {
+			return err
+		}
+		maps.Copy(newp.Devices, cameraDevices)
+		maps.Copy(newp.Config, cameraConfig)
+	}
+
 	if spec.Profile.Agent != nil {
 		err = installSshAgent(fs, *spec.Profile.Agent, sdkInfo.Workshop)
 		if err != nil {
 			return err
 		}
-	}
-
-	name := lxdbackend.ProfileName(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Sdk)
-	newp := api.ProfilePut{
-		Devices:     spec.devices,
-		Config:      spec.config,
-		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkInfo.Sdk, sdkInfo.Workshop),
 	}
 
 	// Either create or update an existing LXD profile for the SDK so that later
@@ -310,6 +352,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 				}
 			}
 		}
+		// TODO: re-add old cameras
 		return conn.UpdateProfile(name, newp, "")
 	}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -14,7 +13,6 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/usbid"
 	"github.com/canonical/x-go/randutil"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -209,37 +207,6 @@ func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string,
 	return nil
 }
 
-func detectCameras(conn lxd.InstanceServer, camera *workshop.Camera, sdk string) (map[string]map[string]string, map[string]string, error) {
-	resources, err := conn.GetServerResources()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	isWebcam := func(iface api.ResourcesUSBDeviceInterface) bool {
-		classID := usbid.ClassCode(iface.ClassID)
-		return classID == usbid.ClassVideo || classID == usbid.ClassAudioVideo
-	}
-
-	devices := map[string]map[string]string{}
-	config := map[string]string{}
-	for _, device := range resources.USB.Devices {
-		if slices.ContainsFunc(device.Interfaces, isWebcam) {
-			// This name is unique because '/' is not permitted in plug names.
-			name := fmt.Sprintf("%s/%s:%s", camera.Name, device.VendorID, device.ProductID)
-			devices[name] = map[string]string{
-				"type":      "unix-hotplug",
-				"vendorid":  device.VendorID,
-				"productid": device.ProductID,
-				"required":  "false",
-			}
-			config[lxdbackend.DeviceTypeConfigKey(sdk, name)] = "camera"
-		}
-	}
-
-	// TODO: warn if no devices were detected
-	return devices, config, nil
-}
-
 func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop string) error {
 	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
 	if err != nil {
@@ -316,15 +283,6 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		}
 	}
 
-	if spec.Profile.Camera != nil {
-		cameraDevices, cameraConfig, err := detectCameras(conn, spec.Profile.Camera, sdkInfo.Sdk)
-		if err != nil {
-			return err
-		}
-		maps.Copy(newp.Devices, cameraDevices)
-		maps.Copy(newp.Config, cameraConfig)
-	}
-
 	if spec.Profile.Agent != nil {
 		err = installSshAgent(fs, *spec.Profile.Agent, sdkInfo.Workshop)
 		if err != nil {
@@ -352,7 +310,6 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 				}
 			}
 		}
-		// TODO: re-add old cameras
 		return conn.UpdateProfile(name, newp, "")
 	}
 

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -2,6 +2,7 @@ package lxd_device
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/sdk"
@@ -134,6 +135,29 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 	}
 	s.config[lxdbackend.DeviceConfigKey(s.Profile.Sdk, camera.Name)] = string(buf)
 	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, camera.Name)] = "camera"
+
+	for i := 0; i < 10; i++ {
+		// This name is unique because '/' is not permitted in plug names.
+		name := fmt.Sprintf("%s/video%d", camera.Name, i)
+		path := fmt.Sprintf("/dev/video%d", i)
+		// The default workshop user must be able to acces the video devices.
+		// Workshop assigns the devices to workshop.workshop. A more
+		// traditional way here would be to add them device to the video
+		// groups, but it requires an additional workshop exec to find out the
+		// groups' ids at the LXD profile generation time. Given that we are
+		// solving the problem of access in a confined environment and workshop
+		// is a passwordless sudo user anyway, it was decided that it is OK if
+		// the workshop user owns video devices.
+		s.devices[name] = map[string]string{
+			"type":     "unix-char",
+			"source":   path,
+			"path":     path,
+			"required": "false",
+			"uid":      "1000",
+			"gid":      "1000",
+		}
+		s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, name)] = "camera"
+	}
 
 	return nil
 }

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -123,3 +123,17 @@ func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 
 	return nil
 }
+
+func (s *Specification) SetCamera(camera workshop.Camera) error {
+	s.Profile.Camera = &camera
+
+	s.devices[camera.Name] = map[string]string{"type": "none"}
+	buf, err := json.Marshal(camera)
+	if err != nil {
+		return err
+	}
+	s.config[lxdbackend.DeviceConfigKey(s.Profile.Sdk, camera.Name)] = string(buf)
+	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, camera.Name)] = "camera"
+
+	return nil
+}

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -104,23 +104,22 @@ func (s *Specification) SetSshAgent(agent workshop.SshAgent) error {
 }
 
 func (s *Specification) SetGpu(gpu workshop.Gpu) error {
+	s.Profile.Gpu = &gpu
+
+	// The default workshop user must be able to acces the GPU device.
+	// Workshop assigns the GPU devices to workshop.workshop. A more
+	// traditional way here would be to add dri devices to the video/render
+	// groups, but it requires an additional workshop exec to find out the
+	// groups' ids at the LXD profile generation time. Given that we are
+	// solving the problem of access in a confined environment and workshop
+	// is a passwordless sudo user anyway, it was decided that it is OK if
+	// the workshop user owns GPU devices.
+
+	// On another note, the render and video groups are not assigned to the
+	// card*/render* dri devices by LXD properly. Both will be assigned to
+	// the group provided in "gid"; there is no way to assign video to card*
+	// and render to render* devices.
 	s.devices[gpu.Name] = map[string]string{"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"}
 
-	s.Profile.Gpu = &workshop.Gpu{
-		Name: gpu.Name,
-		// The default workshop user must be able to acces the GPU device.
-		// Workshop assigns the GPU devices to workshop.workshop. A more
-		// traditional way here would be to add dri devices to the video/render
-		// groups, but it requires an additional workshop exec to find out the
-		// groups' ids at the LXD profile generation time. Given that we are
-		// solving the problem of access in a confined environment and workshop
-		// is a passwordless sudo user anyway, it was decided that it is OK if
-		// the workshop user owns GPU devices.
-
-		// On another note, the render and video groups are not assigned to the
-		// card*/render* dri devices by LXD properly. Both will be assigned to
-		// the group provided in "gid"; there is no way to assign video to card*
-		// and render to render* devices.
-	}
 	return nil
 }

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -144,7 +144,22 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 	}
 }
 
-func (s *baseDeclSuite) TestContentAutoConnection(c *check.C) {
+func (s *baseDeclSuite) TestManualConnection(c *C) {
+	all := builtin.Interfaces()
+
+	for _, iface := range all {
+		comm := Commentf(iface.Name())
+
+		// check base declaration
+		cand := s.connectCand(c, iface.Name(), "", "", "", "", "", "")
+		arity, err := cand.Check()
+		c.Check(err, IsNil, comm)
+		// not currently used outside of tests
+		c.Check(arity.SlotsPerPlugAny(), Equals, true)
+	}
+}
+
+func (s *baseDeclSuite) TestMountAutoConnection(c *check.C) {
 	slotYaml := fmt.Sprintf(`name: slot-sdk
 base: ubuntu@22.04
 slots:
@@ -165,8 +180,8 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *check.C) {
 	}
 }
 
-func (s *baseDeclSuite) TestContentSlotInstallation(c *check.C) {
-	// test content specially
+func (s *baseDeclSuite) TestMountSlotInstallation(c *check.C) {
+	// test mount specially
 	ic := s.installSlotCand(c, "mount", sdk.Regular, ``)
 	err := ic.Check()
 	c.Assert(err, IsNil)

--- a/internal/overlord/ifacestate/export_test.go
+++ b/internal/overlord/ifacestate/export_test.go
@@ -6,9 +6,10 @@ import (
 )
 
 var (
-	GetConns          = getConns
-	SetConns          = setConns
-	ReloadConnections = (*InterfaceManager).reloadConnections
+	AutoConnectChecker = autoConnectChecker
+	GetConns           = getConns
+	SetConns           = setConns
+	ReloadConnections  = (*InterfaceManager).reloadConnections
 )
 
 func UpdateConnectionInConnState(conns map[string]*schema.ConnState, conn *interfaces.Connection, autoConnect, undesired bool) {

--- a/internal/overlord/ifacestate/helpers_test.go
+++ b/internal/overlord/ifacestate/helpers_test.go
@@ -24,9 +24,11 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/ifacestate/schema"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 type helpersSuite struct {
@@ -49,6 +51,52 @@ sdks:
       channel: {{.Channel}}
   {{ end }} 
 `
+
+var consumerYaml = `name: consumer
+base: ubuntu@22.04
+plugs:
+  plug-mount:
+    interface: mount
+    workshop-target: /project/mount
+`
+
+var producerYaml = `name: producer
+base: ubuntu@22.04
+slots:
+  mount:
+    interface: mount
+  slot-mount:
+    interface: mount
+`
+
+func (s *helpersSuite) TestAutoConnectChecker(c *check.C) {
+	consumer := sdk.MockInfo(c, consumerYaml, "42424242", "ws")
+	plugMount := interfaces.NewConnectedPlug(consumer.Plugs["plug-mount"], nil, nil)
+
+	producer := sdk.MockInfo(c, producerYaml, "42424242", "ws")
+	autoMount := interfaces.NewConnectedSlot(producer.Slots["mount"], nil, nil)
+	slotMount := interfaces.NewConnectedSlot(producer.Slots["slot-mount"], nil, nil)
+
+	workshopConns := []interfaces.ConnRef{}
+	policyCheck := ifacestate.AutoConnectChecker(workshopConns)
+
+	// slots named "mount" can be auto-connected
+	ok, err := policyCheck(plugMount, autoMount)
+	c.Assert(err, check.IsNil)
+	c.Assert(ok, check.Equals, true)
+
+	// other slots can be auto-connected via the workshop definition
+	_, err = policyCheck(plugMount, slotMount)
+	c.Assert(err, check.NotNil)
+
+	connRef := interfaces.ConnRef{PlugRef: *plugMount.Ref(), SlotRef: *slotMount.Ref()}
+	workshopConns = append(workshopConns, connRef)
+	policyCheck = ifacestate.AutoConnectChecker(workshopConns)
+
+	ok, err = policyCheck(plugMount, slotMount)
+	c.Assert(err, check.IsNil)
+	c.Assert(ok, check.Equals, true)
+}
 
 func (s *helpersSuite) TestGetConns(c *check.C) {
 	s.st.Lock()

--- a/internal/sdk/system.go
+++ b/internal/sdk/system.go
@@ -8,6 +8,8 @@ var systemSdkYaml = `name: system
 base: %s
 type: system
 slots:
+  camera:
+    interface: camera
   mount:
     interface: mount
   gpu:

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -8,6 +8,10 @@ const (
 	Volume
 )
 
+type Camera struct {
+	Name string `json:"name"`
+}
+
 type Mount struct {
 	Name  string    `json:"name"`
 	What  string    `json:"what"`
@@ -28,6 +32,7 @@ type Gpu struct {
 type SdkProfile struct {
 	Sdk string
 
+	Camera *Camera
 	Mounts map[string]Mount
 	Agent  *SshAgent
 	Gpu    *Gpu

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -48,6 +48,14 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			pr.Gpu = &workshop.Gpu{Name: name}
 		case "proxy":
 			pr.Agent = &workshop.SshAgent{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
+		case "unix-hotplug":
+			devtype := config[DeviceTypeConfigKey(profile, name)]
+			if devtype == "camera" {
+				// TODO: retain this device until the camera interface disconnects
+				continue
+			}
+
+			logger.Noticef("On reading %q SDK profile: unknown device type: %s", profile, devtype)
 		case "none":
 			cfg, exist := config[DeviceConfigKey(profile, name)]
 			if !exist {
@@ -56,16 +64,22 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			}
 
 			devtype := config[DeviceTypeConfigKey(profile, name)]
-			if devtype == "mount" {
+			switch devtype {
+			case "camera":
+				var camera workshop.Camera
+				if err := json.Unmarshal([]byte(cfg), &camera); err != nil {
+					return pr, err
+				}
+				pr.Camera = &camera
+			case "mount":
 				var mnt workshop.Mount
 				if err := json.Unmarshal([]byte(cfg), &mnt); err != nil {
 					return pr, err
 				}
 				pr.Mounts[name] = mnt
-				continue
+			default:
+				logger.Noticef("On reading %q SDK profile: unknown device type: %s", profile, devtype)
 			}
-
-			logger.Noticef("On reading %q SDK profile: unknown device type: %s", profile, devtype)
 		default:
 			logger.Noticef("On reading %q SDK profile: unknown device type: %s", profile, dev["type"])
 		}

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -48,10 +48,9 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			pr.Gpu = &workshop.Gpu{Name: name}
 		case "proxy":
 			pr.Agent = &workshop.SshAgent{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
-		case "unix-hotplug":
+		case "unix-char":
 			devtype := config[DeviceTypeConfigKey(profile, name)]
 			if devtype == "camera" {
-				// TODO: retain this device until the camera interface disconnects
 				continue
 			}
 

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -15,6 +15,8 @@ var _ = check.Suite(&ProfileSuite{})
 
 func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 	expected := []workshop.SdkProfile{
+		{Sdk: "sdk", Camera: &workshop.Camera{Name: "camera"}, Mounts: map[string]workshop.Mount{}},
+		{Sdk: "sdk", Camera: &workshop.Camera{Name: "camera"}, Mounts: map[string]workshop.Mount{}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Gpu: &workshop.Gpu{Name: "gpu"}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"userdisk": {Name: "userdisk", What: "/home", Where: "/opt", Type: workshop.HostWorkshop}}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}},
@@ -26,6 +28,8 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		devs map[string]map[string]string
 		cfg  map[string]string
 	}{
+		{"sdk", map[string]map[string]string{"camera": {"type": "none"}}, map[string]string{"user.workshop.sdk.camera": `{"name": "camera"}`, "user.workshop.sdk.camera.type": "camera"}},
+		{"sdk", map[string]map[string]string{"camera": {"type": "none"}, "camera/1234:5678": {"type": "unix-hotplug", "vendorid": "1234", "productid": "5678", "required": "false"}}, map[string]string{"user.workshop.sdk.camera": `{"name": "camera"}`, "user.workshop.sdk.camera.type": "camera", "user.workshop.sdk.camera/1234:5678.type": "camera"}},
 		{"sdk", map[string]map[string]string{"gpu": {"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"}}, map[string]string{}},
 		{"sdk", map[string]map[string]string{"userdisk": {"type": "disk", "source": "/home", "path": "/opt"}}, map[string]string{}},
 		{"sdk", map[string]map[string]string{"ssh-agent": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{}},
@@ -33,12 +37,9 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 	} {
 		res, err := lxdbackend.LxdToSdkProfile(t.name, t.devs, t.cfg)
 		c.Assert(err, check.IsNil)
-		if res.Agent != nil {
-			c.Assert(*res.Agent, check.DeepEquals, *expected[i].Agent)
-		}
-		if res.Gpu != nil {
-			c.Assert(*res.Gpu, check.DeepEquals, *expected[i].Gpu)
-		}
+		c.Assert(res.Agent, check.DeepEquals, expected[i].Agent)
+		c.Assert(res.Camera, check.DeepEquals, expected[i].Camera)
+		c.Assert(res.Gpu, check.DeepEquals, expected[i].Gpu)
 		c.Assert(res.Mounts, testutil.DeepUnsortedMatches, expected[i].Mounts)
 	}
 }

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -16,7 +16,6 @@ var _ = check.Suite(&ProfileSuite{})
 func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 	expected := []workshop.SdkProfile{
 		{Sdk: "sdk", Camera: &workshop.Camera{Name: "camera"}, Mounts: map[string]workshop.Mount{}},
-		{Sdk: "sdk", Camera: &workshop.Camera{Name: "camera"}, Mounts: map[string]workshop.Mount{}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Gpu: &workshop.Gpu{Name: "gpu"}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"userdisk": {Name: "userdisk", What: "/home", Where: "/opt", Type: workshop.HostWorkshop}}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}},
@@ -28,8 +27,7 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		devs map[string]map[string]string
 		cfg  map[string]string
 	}{
-		{"sdk", map[string]map[string]string{"camera": {"type": "none"}}, map[string]string{"user.workshop.sdk.camera": `{"name": "camera"}`, "user.workshop.sdk.camera.type": "camera"}},
-		{"sdk", map[string]map[string]string{"camera": {"type": "none"}, "camera/1234:5678": {"type": "unix-hotplug", "vendorid": "1234", "productid": "5678", "required": "false"}}, map[string]string{"user.workshop.sdk.camera": `{"name": "camera"}`, "user.workshop.sdk.camera.type": "camera", "user.workshop.sdk.camera/1234:5678.type": "camera"}},
+		{"sdk", map[string]map[string]string{"camera": {"type": "none"}, "camera/video0": {"type": "unix-char", "source": "/dev/video0", "path": "/dev/video0", "required": "false", "uid": "1000", "gid": "1000"}}, map[string]string{"user.workshop.sdk.camera": `{"name": "camera"}`, "user.workshop.sdk.camera.type": "camera", "user.workshop.sdk.camera/video0.type": "camera"}},
 		{"sdk", map[string]map[string]string{"gpu": {"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"}}, map[string]string{}},
 		{"sdk", map[string]map[string]string{"userdisk": {"type": "disk", "source": "/home", "path": "/opt"}}, map[string]string{}},
 		{"sdk", map[string]map[string]string{"ssh-agent": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{}},

--- a/tests/lib/sdk/test-sdk-camera/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-camera/meta/sdk.yaml
@@ -1,0 +1,10 @@
+name: test-sdk-camera
+title: test-sdk-camera
+base: ubuntu@20.04
+
+summary: test-sdk-camera SDK
+description: |
+  test-sdk-camera SDK
+plugs:
+  camera:
+    interface: camera

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -27,7 +27,7 @@ function prepare_environment() {
   # and can break a spread run.
   apt-get remove -y unattended-upgrades
   apt-get update
-  apt-get install -y --no-install-recommends moreutils jq
+  apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)" moreutils jq
 
   snap install --dangerous --classic /workshop/tests/*.snap
   snap set workshop store.url=http://localhost:8080/storage/v1/

--- a/tests/main/interface-camera/.workshop/workshop.ws-camera-fail.yaml
+++ b/tests/main/interface-camera/.workshop/workshop.ws-camera-fail.yaml
@@ -1,0 +1,9 @@
+name: ws-camera-fail
+base: ubuntu@22.04
+sdks:
+  system:
+    slots:
+      user-camera:
+        interface: camera
+  test-sdk-camera:
+    channel: latest/stable

--- a/tests/main/interface-camera/.workshop/workshop.ws-camera.yaml
+++ b/tests/main/interface-camera/.workshop/workshop.ws-camera.yaml
@@ -1,0 +1,5 @@
+name: ws-camera
+base: ubuntu@22.04
+sdks:
+  test-sdk-camera:
+    channel: latest/stable

--- a/tests/main/interface-camera/task.yaml
+++ b/tests/main/interface-camera/task.yaml
@@ -18,6 +18,40 @@ execute: |
   workshop_exec disconnect ws-camera/test-sdk-camera:camera
   workshop_exec connections ws-camera | MATCH "^camera.+ws-camera/test-sdk-camera:camera.+\-.+\-$"
 
+  echo "Ensure video devices are created when connected"
+  if ! modprobe v4l2loopback card_label=v4l2loopback; then
+    # old VM images use a custom kernel which lacks video4linux support
+    [ "$(lsb_release -rs)" = '22.04' ]
+  else
+    detect_device() {
+      device_name="$(grep -l '^v4l2loopback$' /sys/class/video4linux/*/name)"
+      read -r device_index < "$(dirname -- "$device_name")/index"
+      device_node="/dev/video$device_index"
+    }
+    detect_device
+
+    workshop_exec exec ws-camera -- test ! -e "$device_node"
+    workshop_exec connect ws-camera/test-sdk-camera:camera
+    workshop_exec exec ws-camera -- test -e "$device_node"
+
+    echo "Ensure video devices can be hotplugged"
+    rmmod v4l2loopback
+    # this check could fail if another device is immediately plugged in,
+    # but within a VM this should be unlikely/impossible
+    workshop_exec exec ws-camera -- test ! -e "$device_node"
+
+    modprobe v4l2loopback card_label=v4l2loopback
+    detect_device
+    workshop_exec exec ws-camera -- test -e "$device_node"
+
+    echo "Ensure workshop user can access video devices"
+    workshop_exec exec ws-camera -- test -r "$device_node"
+    workshop_exec exec ws-camera -- test -w "$device_node"
+
+    workshop_exec disconnect ws-camera/test-sdk-camera:camera
+    workshop_exec exec ws-camera -- test ! -e "$device_node"
+  fi
+
   echo "Check a user cannot install a camera slot (violates slot declaration)"
   workshop_exec launch ws-camera-fail > launch.log || true
   MATCH ".*installation not allowed by \"user-camera\" slot rule of interface \"camera\"" < launch.log

--- a/tests/main/interface-camera/task.yaml
+++ b/tests/main/interface-camera/task.yaml
@@ -1,0 +1,23 @@
+summary: Check camera interface scenarios
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-camera
+restore: |
+  . "$TESTSLIB"/utils.sh
+  rmmod v4l2loopback || true
+  workshop_exec remove ws-camera
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check the camera interface plug cannot be auto-connected"
+  workshop_exec connections ws-camera | MATCH "^camera.+ws-camera/test-sdk-camera:camera.+\-.+\-$"
+
+  echo "Check the camera interface plug can be connected and disconnected manually"
+  workshop_exec connect ws-camera/test-sdk-camera:camera
+  workshop_exec connections ws-camera | MATCH "^camera.+ws-camera/test-sdk-camera:camera.+:camera.+manual$"
+  workshop_exec disconnect ws-camera/test-sdk-camera:camera
+  workshop_exec connections ws-camera | MATCH "^camera.+ws-camera/test-sdk-camera:camera.+\-.+\-$"
+
+  echo "Check a user cannot install a camera slot (violates slot declaration)"
+  workshop_exec launch ws-camera-fail > launch.log || true
+  MATCH ".*installation not allowed by \"user-camera\" slot rule of interface \"camera\"" < launch.log


### PR DESCRIPTION
# Description

This is a first attempt, we plan on using `unix-hotplug` devices after https://github.com/canonical/lxd/issues/14266 is resolved (ideally we could ask LXD to expose all devices in the `media` and `video4linux` subsystems).

For now we just expose `/dev/video[0-9]` as `unix-char` devices. This also supports hotplugging but is limited to 10 devices and requires manually setting the device user and group to `1000`.

So far we have a 1-1 correspondence between plugs and devices. This implementation creates a `none` device with the plug name, to help reconstruct an `SdkProfile` from a LXD profile (similar to the mount interface). The `unix-char` devices are named like `<PLUG>/video<N>`, which shouldn't clash with other plugs because their names cannot contain `/`. The other [suitable separators](https://github.com/canonical/lxd/blob/7eff9d101e3a7c3407ab8dee8a3249ec6778da50/shared/validate/validate.go#L750) are `._:`. All of these [can also be used](https://github.com/canonical/lxd/blob/7eff9d101e3a7c3407ab8dee8a3249ec6778da50/lxd/config/map.go#L200) in `user.workshop` config values, but `.` might be confusing. I think `:` is also a reasonable choice, but for the hotplug devices I was using the convention `<PLUG>/<VENDORID>:<PRODUCTID>` so I slightly prefer `/` in that case.

Another detail is that spread now uses 24.04 VM images. This is to enable fake camera devices using `v4l2loopback`. The 22.04 images use a custom kernel which doesn't include the `videodev` module (even as a separate package, as far as I could tell). I ran into an issue with spread choosing container images instead of VM images, which I have a fix for in [my fork](https://github.com/jonathan-conder/spread).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
