### PR TITLE
Enable linger for workshop user

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -2,6 +2,7 @@ package lxdbackend
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,6 +40,9 @@ var (
 	imageLock        sync.Mutex
 	currentDownloads map[string]*downloadOp
 )
+
+//go:embed start_command.sh
+var startCommand string
 
 func init() {
 	imageLock.Lock()
@@ -176,17 +180,12 @@ func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
 		return err
 	}
 
-	// Wait until system is up an running before returning
-	// see: https://blog.simos.info/how-to-know-when-a-lxd-container-has-finished-starting-up/
 	args := workshop.Execution{
 		ExecArgs: workshop.ExecArgs{
 			UserId:  0,
 			GroupId: 0,
 			Command: []string{
-				"bash", "-euc", fmt.Sprintf(`while
-[ "$(systemctl is-system-running 2>/dev/null)" != running ] &&
-[ "$(systemctl is-system-running 2>/dev/null)" != degraded ]; do :; done &&
-loginctl enable-linger workshop`),
+				"bash", "-euc", startCommand,
 			},
 			WorkDir: "/",
 		},

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -183,9 +183,10 @@ func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
 			UserId:  0,
 			GroupId: 0,
 			Command: []string{
-				"bash", "-eu", "-c", "while " +
-					"[ \"$(systemctl is-system-running 2>/dev/null)\" != \"running\" ] && " +
-					"[ \"$(systemctl is-system-running 2>/dev/null)\" != \"degraded\" ]; do :; done",
+				"bash", "-euc", fmt.Sprintf(`while
+[ "$(systemctl is-system-running 2>/dev/null)" != running ] &&
+[ "$(systemctl is-system-running 2>/dev/null)" != degraded ]; do :; done &&
+loginctl enable-linger workshop`),
 			},
 			WorkDir: "/",
 		},

--- a/internal/workshop/lxd/start_command.sh
+++ b/internal/workshop/lxd/start_command.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Wait until system is up an running before returning
+# see: https://blog.simos.info/how-to-know-when-a-lxd-container-has-finished-starting-up/
+while [ "$(systemctl is-system-running 2>/dev/null)" != running ] \
+&& [ "$(systemctl is-system-running 2>/dev/null)" != degraded ]
+do
+  :
+done
+# Linger starts the user manager for the specified user on boot, which then creates /run/user/$UID,
+# sets $XDG_RUNTIME_DIR and more. Interfaces such as desktop rely on both of these to be present.
+# This does not introduce any additional modification beyond what a login session would normally create.
+loginctl enable-linger workshop

--- a/tests/main/linger/.workshop/workshop.ws-linger.yaml
+++ b/tests/main/linger/.workshop/workshop.ws-linger.yaml
@@ -1,0 +1,2 @@
+name: ws-linger
+base: ubuntu@22.04

--- a/tests/main/linger/task.yaml
+++ b/tests/main/linger/task.yaml
@@ -1,0 +1,11 @@
+summary: Check that linger is enabled for the workshop user
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-linger
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove ws-linger
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  workshop_exec exec ws-linger -- bash -c 'test -f /var/lib/systemd/linger/workshop'

--- a/tests/main/linger/task.yaml
+++ b/tests/main/linger/task.yaml
@@ -9,3 +9,4 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   workshop_exec exec ws-linger -- bash -c 'test -f /var/lib/systemd/linger/workshop'
+  workshop_exec exec ws-linger -- bash -c 'test -d /run/user/1000'


### PR DESCRIPTION
# Description
## Background
`/run/user/<uid>` gets created by pam_systemd when a user has an _active_ login shell. 
This creates a problem when an interface (ie. Desktop) looks to use this directory to proxy sockets into. 

## Changes
### Linger
This PR enables lingering (`loginctl enable-linger`) for the workshop user as part of the container start script. Linger starts the user manager for `workshop` on boot, enabling interfaces that rely on resources in `$XDG_RUNTIME_DIR` to work.  

Linger introduces no modification to the system environment beyond what a normal login session does, namely:

- `/run/user/$UID` is either created or mounted
- `$XDG_SESSION_ID` is initialised
-  A new systemd scope unit is created for the session (user@1000.service, user-1000.slice)

https://www.freedesktop.org/software/systemd/man/252/pam_systemd.html

### Start Command
This PR also moves the start command to an external shell script (`start_command.sh`) to enable automated linting with CI runners. The script is embedded into workshopd at compile time.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
