### PR TITLE
Refactor Agent into generic Proxy interface

### DIFF
--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -116,7 +116,11 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 	fromSocket := sock
 	toSocket := filepath.Join(dirs.WorkshopRunDir, name+".ssh")
 
-	return spec.SetSshAgent(workshop.SshAgent{Name: name, Connect: fromSocket, Listen: toSocket})
+	return spec.AddProxyEntry(workshop.Proxy{
+		Name:    name,
+		Connect: fromSocket,
+		Listen:  toSocket,
+		Env:     []string{"SSH_AUTH_SOCK=" + strings.TrimPrefix(toSocket, "unix:")}})
 }
 
 func init() {

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -73,8 +73,11 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedProxy := &workshop.SshAgent{Name: "consumer-" + plug.Name, Connect: "/tmp/dir/ssh", Listen: "/var/lib/workshop/run/consumer-ssh-agent.ssh"}
-	c.Assert(deviceSpec.Profile.Agent, check.DeepEquals, expectedProxy)
+	expectedProxy := &workshop.Proxy{Name: "consumer-" + plug.Name, Connect: "/tmp/dir/ssh", Listen: "/var/lib/workshop/run/consumer-ssh-agent.ssh"}
+	// We cannot compare the environment characteristics, these are not part of the lxd profile however are used by the install hook
+	proxySpec := deviceSpec.Profile.Proxies["consumer-ssh-agent"]
+	proxySpec.Env = nil
+	c.Assert(proxySpec, check.DeepEquals, *expectedProxy)
 }
 
 func (s *sshAgentSuite) TestSshAgentInterfaceSystemctlFails(c *check.C) {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -9,7 +9,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -207,23 +206,24 @@ func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string,
 	return nil
 }
 
-func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop string) error {
-	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
+func installProxy(fs workshop.WorkshopFs, proxy workshop.Proxy, workshop string) error {
+	env, err := fs.Create(filepath.Join("/etc/profile.d", proxy.Name+".sh"))
 	if err != nil {
-		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
+		return fmt.Errorf("cannot add proxy device: %q: %w", workshop, err)
 	}
 	defer env.Close()
 
-	varline := fmt.Sprintln("export SSH_AUTH_SOCK=" + strings.TrimPrefix(dev.Listen, "unix:"))
-	_, err = env.Write([]byte(varline))
-	if err != nil {
-		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
+	for _, envVar := range proxy.Env {
+		_, err = env.WriteString("export " + envVar + "\n")
+		if err != nil {
+			return fmt.Errorf("cannot add proxy device %q: %w", workshop, err)
+		}
 	}
 	return nil
 }
 
-func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) error {
-	return fs.Remove(filepath.Join("/etc/profile.d", dev.Name+".sh"))
+func removeProxy(fs workshop.WorkshopFs, proxy workshop.Proxy) error {
+	return fs.Remove(filepath.Join("/etc/profile.d", proxy.Name+".sh"))
 }
 
 func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error) {
@@ -283,11 +283,8 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		}
 	}
 
-	if spec.Profile.Agent != nil {
-		err = installSshAgent(fs, *spec.Profile.Agent, sdkInfo.Workshop)
-		if err != nil {
-			return err
-		}
+	for _, proxy := range spec.Profile.Proxies {
+		err = installProxy(fs, proxy, sdkInfo.Workshop)
 	}
 
 	// Either create or update an existing LXD profile for the SDK so that later
@@ -303,9 +300,9 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 				}
 			}
 		}
-		if prevp.Agent != nil {
-			if spec.Profile.Agent == nil || *prevp.Agent != *spec.Profile.Agent {
-				if err = removeSshAgent(fs, *prevp.Agent); err != nil {
+		for key, proxy := range prevp.Proxies {
+			if _, exist := spec.Profile.Proxies[key]; !exist {
+				if err = removeProxy(fs, proxy); err != nil {
 					return err
 				}
 			}
@@ -374,8 +371,8 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 		}
 	}
 
-	if prof.Agent != nil {
-		if err = removeSshAgent(fs, *prof.Agent); err != nil {
+	for _, proxy := range prof.Proxies {
+		if err = removeProxy(fs, proxy); err != nil {
 			return err
 		}
 	}

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -92,14 +92,14 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 	return nil
 }
 
-func (s *Specification) SetSshAgent(agent workshop.SshAgent) error {
+func (s *Specification) AddProxyEntry(proxy workshop.Proxy) error {
 	// A network protocol proxy device, opens a port on the host or in a workhop.
 	// from, to are the source and destination addresses (paths in the case of unix sockets),
 	// see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
 	// bind denotes where the port is open (can be: instance, host)
-	s.Profile.Agent = &agent
+	s.Profile.Proxies[proxy.Name] = proxy
 
-	s.devices[agent.Name] = map[string]string{"type": "proxy", "connect": "unix:" + agent.Connect, "listen": "unix:" + agent.Listen, "uid": "1000", "gid": "1000", "bind": "instance"}
+	s.devices[proxy.Name] = map[string]string{"type": "proxy", "connect": "unix:" + proxy.Connect, "listen": "unix:" + proxy.Listen, "uid": "1000", "gid": "1000", "bind": "instance"}
 
 	return nil
 }

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -304,10 +304,13 @@ exit 0
 
 	prof, err := lxdbackend.Profile(f.client, f.pid, "test", "consumer")
 	c.Assert(err, check.IsNil)
-	c.Assert(prof.Agent, check.NotNil)
-	c.Check(prof.Agent.Name, check.Equals, "consumer-ssh-agent")
-	c.Check(prof.Agent.Connect, check.Equals, "unix:/run/.workshop.socket")
-	c.Check(prof.Agent.Listen, check.Equals, "unix:/run/consumer-ssh-agent.ssh")
+	agent, exists := prof.Proxies["consumer-ssh-agent"]
+	if !exists {
+		c.Fail()
+	}
+	c.Check(agent.Name, check.Equals, "consumer-ssh-agent")
+	c.Check(agent.Connect, check.Equals, "unix:/run/.workshop.socket")
+	c.Check(agent.Listen, check.Equals, "unix:/run/consumer-ssh-agent.ssh")
 
 	buf := f.readWorkshopFile(c, "/etc/profile.d/consumer-ssh-agent.sh")
 	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/consumer-ssh-agent.ssh\n")

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -19,10 +19,14 @@ type Mount struct {
 	Type  MountType `json:"type"`
 }
 
-type SshAgent struct {
+type Proxy struct {
 	Name    string
 	Connect string
 	Listen  string
+	// A more flexible alternative could either be a func() []string to generate the environment,
+	// or two embedded functions for the install and remove hooks. I don't think this will be difficult to change
+	// later if required, so I haven't implemented anything complex (I don't like to overengineer prematurely)
+	Env []string
 }
 
 type Gpu struct {
@@ -32,15 +36,16 @@ type Gpu struct {
 type SdkProfile struct {
 	Sdk string
 
-	Camera *Camera
-	Mounts map[string]Mount
-	Agent  *SshAgent
-	Gpu    *Gpu
+	Camera  *Camera
+	Mounts  map[string]Mount
+	Proxies map[string]Proxy
+	Gpu     *Gpu
 }
 
 func NewSdkProfile(sdkName string) SdkProfile {
 	return SdkProfile{
-		Sdk:    sdkName,
-		Mounts: make(map[string]Mount),
+		Sdk:     sdkName,
+		Mounts:  make(map[string]Mount),
+		Proxies: make(map[string]Proxy),
 	}
 }

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -47,7 +47,7 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 		case "gpu":
 			pr.Gpu = &workshop.Gpu{Name: name}
 		case "proxy":
-			pr.Agent = &workshop.SshAgent{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
+			pr.Proxies[name] = workshop.Proxy{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
 		case "unix-char":
 			devtype := config[DeviceTypeConfigKey(profile, name)]
 			if devtype == "camera" {

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -18,7 +18,7 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		{Sdk: "sdk", Camera: &workshop.Camera{Name: "camera"}, Mounts: map[string]workshop.Mount{}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Gpu: &workshop.Gpu{Name: "gpu"}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"userdisk": {Name: "userdisk", What: "/home", Where: "/opt", Type: workshop.HostWorkshop}}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}},
+		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Proxies: map[string]workshop.Proxy{"ssh-agent": {Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"plug": {Name: "plug", What: "/var", Where: "/etc", Type: workshop.WorkshopWorkshop}}},
 	}
 
@@ -35,9 +35,9 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 	} {
 		res, err := lxdbackend.LxdToSdkProfile(t.name, t.devs, t.cfg)
 		c.Assert(err, check.IsNil)
-		c.Assert(res.Agent, check.DeepEquals, expected[i].Agent)
 		c.Assert(res.Camera, check.DeepEquals, expected[i].Camera)
 		c.Assert(res.Gpu, check.DeepEquals, expected[i].Gpu)
+		c.Assert(res.Proxies["ssh-agent"], check.DeepEquals, expected[i].Proxies["ssh-agent"])
 		c.Assert(res.Mounts, testutil.DeepUnsortedMatches, expected[i].Mounts)
 	}
 }


### PR DESCRIPTION
# Description
The ssh-agent currently exists as a singleton proxy resource. This PR refactors ssh-agent and the handling of proxy-type devices to enable having multiple, similar to how mount currently works.

Some decisions (such as the method by which the new interface modifies the environment) have potential ramifications should variables stored in /etc/profile.d not be suitable for future proxy type devices. This however is not a 'one-way' decision and can be easily reworked should this be a requirement in future, I feel the complexity introduced is not worth it for a _potential_ future use-case. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
