### PR TITLE
Fix indefinite retries if the store cannot be reached

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/workshop
 go 1.21
 
 require (
-	cloud.google.com/go/storage v1.36.0
+	cloud.google.com/go/storage v1.37.0
 	github.com/adrg/xdg v0.4.0
 	github.com/canonical/lxd v0.0.0-20240226153229-0ff71ae3cb84
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGB
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/iam v1.1.6 h1:bEa06k05IO4f4uJonbB5iAgKTPpABy1ayxaIZV/GHVc=
 cloud.google.com/go/iam v1.1.6/go.mod h1:O0zxdPeGBoFdWW3HWmBxJsk0pfvNM/p/qa82rWOGTwI=
-cloud.google.com/go/storage v1.36.0 h1:P0mOkAcaJxhCTvAkMhxMfrTKiNcub4YmmPBtlhAyTr8=
-cloud.google.com/go/storage v1.36.0/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
+cloud.google.com/go/storage v1.37.0 h1:WI8CsaFO8Q9KjPVtsZ5Cmi0dXV25zMoX0FklT7c3Jm4=
+cloud.google.com/go/storage v1.37.0/go.mod h1:i34TiT2IhiNDmcj65PqwCjcoUX7Z5pLzS8DEmoiFq1k=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
@@ -237,8 +237,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 google.golang.org/api v0.160.0 h1:SEspjXHVqE1m5a1fRy8JFB+5jSu+V0GEDKDghF3ttO4=
 google.golang.org/api v0.160.0/go.mod h1:0mu0TpK33qnydLvWqbImq2b1eQ5FHRSDCBzAxX9ZHyw=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -152,3 +152,24 @@ func (s *storeIntegration) TestSdkActionInstallStoreError(c *check.C) {
 	c.Assert(res, check.HasLen, 0)
 	c.Assert(err, check.ErrorMatches, `(?s).*SDK not found in "latest/stable".*`)
 }
+
+func (f *storeIntegration) TestSdkActionTimeout(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	// Deliberately set to malformed address
+	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8181/storage/v1/"), check.IsNil)
+	s := store.New()
+	acts := []sdk.SdkAction{{
+		ProjectId: "24242424",
+		Workshop:  "test-workshop",
+		Action:    sdk.Install,
+		Name:      "test-sdk-unknown",
+		Channel:   "latest/stable",
+	}}
+	_, err := s.SdkAction(context.Background(), acts)
+
+	// Restore address for remaining tests
+	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8080/storage/v1/"), check.IsNil)
+
+	c.Assert(err, check.ErrorMatches, `(?s).*failed to connect to store.*`)
+}

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -171,5 +171,5 @@ func (f *storeIntegration) TestSdkActionTimeout(c *check.C) {
 	// Restore address for remaining tests
 	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8080/storage/v1/"), check.IsNil)
 
-	c.Assert(err, check.ErrorMatches, `(?s).*failed to connect to store.*`)
+	c.Assert(err, check.ErrorMatches, `(?s).*cannot connect to store.*`)
 }

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -219,6 +219,10 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 	}
 	track, risk := sa[0], sa[1]
 	obj := bkt.Object(fmt.Sprintf("%s/%s/%s/%s.sdk", name, track, risk, name))
+
+	// Attrs transparently retries forever if it cannot connect to the store
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
 	atr, err := obj.Attrs(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrObjectNotExist) {

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -231,9 +232,11 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 		if errors.Is(err, storage.ErrObjectNotExist) {
 			return sSdk, fmt.Errorf("SDK not found in %q", channel)
 		}
-		urlError := &url.Error{}
-		if errors.As(err, &urlError) {
-			return sSdk, fmt.Errorf("failed to connect to store")
+		if urlErr, ok := err.(*url.Error); ok {
+			opErr, ok := urlErr.Err.(*net.OpError)
+			if ok {
+				return sSdk, fmt.Errorf("cannot connect to store: %q", opErr)
+			}
 		}
 		return sSdk, err
 	}

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -219,14 +220,20 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 	}
 	track, risk := sa[0], sa[1]
 	obj := bkt.Object(fmt.Sprintf("%s/%s/%s/%s.sdk", name, track, risk, name))
-
-	// Attrs transparently retries forever if it cannot connect to the store
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel()
+	// Max attempts prevents workshop from trying to dial the store indefinitely.
+	// Behavior is only modified for this specific Object Handle, it is not
+	// passed on to SDK download behavior
+	obj = obj.Retryer(
+		storage.WithMaxAttempts(3),
+	)
 	atr, err := obj.Attrs(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrObjectNotExist) {
 			return sSdk, fmt.Errorf("SDK not found in %q", channel)
+		}
+		urlError := &url.Error{}
+		if errors.As(err, &urlError) {
+			return sSdk, fmt.Errorf("failed to connect to store")
 		}
 		return sSdk, err
 	}


### PR DESCRIPTION
# Description
Simple, small quality of life fix for the current fake store implementation. This will time out a failed connection to the store after 10 seconds.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
