### PR TITLE
Add Desktop interface

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -15,6 +15,7 @@ Dockerfile
 Dockerfiles
 EdTech
 env
+envvar
 GCP
 gcs
 gid
@@ -86,7 +87,10 @@ workspace
 workspaces
 worktree
 worktrees
+ws
 WSL
 XDG
+X11
+XAUTHORITY
 yaml
 YYYY

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -76,7 +76,9 @@ uid
 unicode
 unmounts
 url
+wayland
 Wayland
+WAYLAND
 webhook
 workshopctl
 workshopd

--- a/docs/explanation/interfaces/desktop-interface.rst
+++ b/docs/explanation/interfaces/desktop-interface.rst
@@ -1,0 +1,77 @@
+.. _exp_desktop_interface:
+
+Desktop interface
+
+The desktop interface
+provides access to the host system's Wayland socket
+from inside the workshop, allowing it to securely
+execute Wayland GUI applications.
+
+By using the interface,
+the SDK publisher allows the workshop to access the host's Wayland socket,
+which can be useful for various SDK-specific tasks such as
+building graphical applications or using editors without remote support.
+
+The interface isn't connected automatically at launch and refresh
+for security reasons.
+The :command:`workshop connect` and :command:`workshop disconnect` commands
+can be invoked manually after the workshop has started:
+
+.. code-block:: console
+
+   $ workshop connect ws/desktop-sdk:desktop
+   $ workshop disconnect ws/desktop-sdk:desktop
+
+
+Establishing a connection means
+a proxy Unix domain socket has been created
+and the following environment variables have been set:
+
+- :envvar:`WAYLAND_DISPLAY`
+  Identifies the name of the Wayland socket
+- :envvar:`XDG_SESSION_TYPE`
+  Specifies the current display server type
+- :envvar:`QT_QPA_PLATFORM`
+  Specifies the Qt platform plugin to be used for Qt-based applications
+- :envvar:`ELECTRON_OZONE_PLATFORM_HINT`
+  Specifies the preferred platform for electron applications
+
+To check if the interface is connected:
+
+.. code-block:: console
+
+   $ workshop connections --all
+
+     Interface  Plug                   Slot       Notes
+     ...
+     desktop    ws/desktop-sdk:desktop :desktop   manual
+
+This means the host's Wayland socket is available inside the workshop
+
+.. code-block:: console
+
+   $ workshop shell ws
+   workshop@ws-8584e571$ ls $XDG_RUNTIME_DIR | grep wayland
+
+     wayland-1
+
+
+See also
+--------
+
+Explanation:
+
+- :ref:`exp_interfaces`
+- :ref:`exp_plugs_slots`
+- :ref:`exp_sdk_definition`
+- :ref:`exp_workshop_def`
+
+
+Reference:
+
+- :ref:`ref_workshop_connect`
+- :ref:`ref_workshop_connections`
+- :ref:`ref_workshop_disconnect`
+- :ref:`ref_workshop_launch`
+- :ref:`ref_workshop_refresh`
+- :ref:`ref_workshop_shell`

--- a/docs/explanation/interfaces/desktop-interface.rst
+++ b/docs/explanation/interfaces/desktop-interface.rst
@@ -4,13 +4,13 @@ Desktop interface
 
 The desktop interface
 provides access to the host system's Wayland socket
-from inside the workshop, allowing it to securely
-execute Wayland GUI applications.
+from inside the workshop,
+allowing it to securely run Wayland GUI applications.
 
 By using the interface,
 the SDK publisher allows the workshop to access the host's Wayland socket,
-which can be useful for various SDK-specific tasks such as
-building graphical applications or using editors without remote support.
+which can be useful for various SDK-specific tasks
+such as building graphical applications or using editors without remote support.
 
 The interface isn't connected automatically at launch and refresh
 for security reasons.
@@ -27,14 +27,18 @@ Establishing a connection means
 a proxy Unix domain socket has been created
 and the following environment variables have been set:
 
-- :envvar:`WAYLAND_DISPLAY`
-  Identifies the name of the Wayland socket
-- :envvar:`XDG_SESSION_TYPE`
-  Specifies the current display server type
-- :envvar:`QT_QPA_PLATFORM`
-  Specifies the Qt platform plugin to be used for Qt-based applications
-- :envvar:`ELECTRON_OZONE_PLATFORM_HINT`
-  Specifies the preferred platform for electron applications
+- :envvar:`$WAYLAND_DISPLAY`
+  Sets the Wayland socket name
+  
+- :envvar:`$XDG_SESSION_TYPE`
+  Sets the current display server type
+
+- :envvar:`$QT_QPA_PLATFORM`
+  Sets the Qt platform plugin to be used for Qt applications
+
+- :envvar:`$ELECTRON_OZONE_PLATFORM_HINT`
+  Sets the preferred platform for Electron applications
+
 
 To check if the interface is connected:
 
@@ -46,7 +50,8 @@ To check if the interface is connected:
      ...
      desktop    ws/desktop-sdk:desktop :desktop   manual
 
-This means the host's Wayland socket is available inside the workshop
+
+This means the host's Wayland socket is available inside the workshop:
 
 .. code-block:: console
 

--- a/docs/explanation/interfaces/desktop-interface.rst
+++ b/docs/explanation/interfaces/desktop-interface.rst
@@ -70,7 +70,7 @@ To check if the interface is connected:
      desktop    ws/desktop-sdk:desktop :desktop   manual
 
 
-This means the host's Wayland/X11 socket is available inside the workshop:
+This means the host's display socket (Wayland, X11 or both) is available inside the workshop:
 
 .. code-block:: console
 

--- a/docs/explanation/interfaces/desktop-interface.rst
+++ b/docs/explanation/interfaces/desktop-interface.rst
@@ -1,14 +1,15 @@
 .. _exp_desktop_interface:
 
 Desktop interface
+=================
 
 The desktop interface
-provides access to the host system's Wayland socket
+provides access to the host system's display (Wayland/X11) socket(s)
 from inside the workshop,
-allowing it to securely run Wayland GUI applications.
+allowing it to securely run GUI applications.
 
 By using the interface,
-the SDK publisher allows the workshop to access the host's Wayland socket,
+the SDK publisher allows the workshop to utilise the host's display
 which can be useful for various SDK-specific tasks
 such as building graphical applications or using editors without remote support.
 
@@ -27,17 +28,35 @@ Establishing a connection means
 a proxy Unix domain socket has been created
 and the following environment variables have been set:
 
-- :envvar:`$WAYLAND_DISPLAY`
-  Sets the Wayland socket name
-  
-- :envvar:`$XDG_SESSION_TYPE`
-  Sets the current display server type
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 30 30 30
 
-- :envvar:`$QT_QPA_PLATFORM`
-  Sets the Qt platform plugin to be used for Qt applications
+   * - Wayland
+     - X11
+     - Both
 
-- :envvar:`$ELECTRON_OZONE_PLATFORM_HINT`
-  Sets the preferred platform for Electron applications
+   * - | :envvar:`$WAYLAND_DISPLAY`
+       | :envvar:`$XDG_SESSION_TYPE`
+       | :envvar:`$QT_QPA_PLATFORM`
+       | :envvar:`$ELECTRON_OZONE_PLATFORM_HINT`
+       | :envvar:`$XDG_BACKEND`
+     - | :envvar:`$DISPLAY`
+       | :envvar:`$XDG_SESSION_TYPE`
+       | :envvar:`$QT_QPA_PLATFORM`
+       | :envvar:`$ELECTRON_OZONE_PLATFORM_HINT`
+       | :envvar:`$XDG_BACKEND`
+       | :envvar:`$XAUTHORITY`:sup:`*`
+     - | :envvar:`$WAYLAND_DISPLAY`
+       | :envvar:`$DISPLAY`
+       | :envvar:`$XDG_SESSION_TYPE`
+       | :envvar:`$QT_QPA_PLATFORM`
+       | :envvar:`$ELECTRON_OZONE_PLATFORM_HINT`
+       | :envvar:`$XDG_BACKEND`
+       | :envvar:`$XAUTHORITY`:sup:`*`
+
+*\*only set if present on the host*
 
 
 To check if the interface is connected:
@@ -51,7 +70,7 @@ To check if the interface is connected:
      desktop    ws/desktop-sdk:desktop :desktop   manual
 
 
-This means the host's Wayland socket is available inside the workshop:
+This means the host's Wayland/X11 socket is available inside the workshop:
 
 .. code-block:: console
 
@@ -60,6 +79,12 @@ This means the host's Wayland socket is available inside the workshop:
 
      wayland-1
 
+.. code-block:: console
+
+   $ workshop shell ws
+   workshop@ws-8584e571$ ls /tmp/.X11-unix
+
+     X0
 
 See also
 --------

--- a/docs/explanation/interfaces/index.rst
+++ b/docs/explanation/interfaces/index.rst
@@ -51,8 +51,9 @@ This behaviour varies by interface,
 but the overall aim is to conduct reasonably in each case:
 the :ref:`mount <exp_mount_interface>`
 and the :ref:`GPU <exp_gpu_interface>` interfaces are auto-connected,
-whereas the :ref:`camera <exp_camera_interface>`
-and :ref:`SSH <exp_ssh_interface>` interfaces require manual connection.
+whereas the :ref:`camera <exp_camera_interface>`,
+:ref:`desktop <exp_desktop_interface>` and ref:`SSH <exp_ssh_interface>`
+interfaces require manual connection.
 
 
 See also

--- a/docs/explanation/interfaces/index.rst
+++ b/docs/explanation/interfaces/index.rst
@@ -52,7 +52,7 @@ but the overall aim is to conduct reasonably in each case:
 the :ref:`mount <exp_mount_interface>`
 and the :ref:`GPU <exp_gpu_interface>` interfaces are auto-connected,
 whereas the :ref:`camera <exp_camera_interface>`,
-:ref:`desktop <exp_desktop_interface>` and ref:`SSH <exp_ssh_interface>`
+:ref:`desktop <exp_desktop_interface>` and :ref:`SSH <exp_ssh_interface>`
 interfaces require manual connection.
 
 

--- a/docs/explanation/sdks/sdks.rst
+++ b/docs/explanation/sdks/sdks.rst
@@ -103,6 +103,7 @@ so you can't create a custom interface type.
 Currently, |project_markup| supports the following:
 
 - :ref:`Camera interface <exp_camera_interface>` (manually connected)
+- :ref:`Desktop interface <exp_desktop_interface>` (manually connected)
 - :ref:`GPU interface <exp_gpu_interface>` (auto-connected)
 - :ref:`Mount interface <exp_mount_interface>` (auto-connected)
 - :ref:`SSH interface <exp_ssh_interface>` (manually connected)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -115,7 +115,7 @@ sdks:
   system:
     slots:
       training-slot:
-        interface: mount        
+        interface: mount
   test-sdk:
     channel: latest/stable
     plugs:
@@ -208,7 +208,7 @@ sdks:
   test-sdk-2:
     channel: latest/stable
     plugs:
-      photos: 
+      photos:
         bind: test-sdk:data
 connections:
   - plug: test-sdk:data
@@ -712,7 +712,7 @@ line 1: cannot unmarshal !!seq into string`,
 	c.Assert(err, check.IsNil)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slots(s.project.ProjectId, "basic", sdk.System.String()), check.HasLen, 4)
+	c.Assert(repo.Slots(s.project.ProjectId, "basic", sdk.System.String()), check.HasLen, 5)
 
 	c.Assert(s.b.DownloadBaseCalls, check.HasLen, 1)
 

--- a/internal/interfaces/backend.go
+++ b/internal/interfaces/backend.go
@@ -21,6 +21,7 @@ package interfaces
 
 import (
 	"context"
+	"os/user"
 
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/timings"
@@ -48,7 +49,7 @@ type SecurityBackend interface {
 	Remove(context context.Context, workshop, sdkName string) error
 
 	// NewSpecification returns a new specification associated with this backend.
-	NewSpecification(user, pid, sdk string) Specification
+	NewSpecification(user *user.User, pid, sdk string) Specification
 }
 
 // SecurityBackendSetupMany interface may be implemented by backends that can optimize their operations

--- a/internal/interfaces/builtin/all_test.go
+++ b/internal/interfaces/builtin/all_test.go
@@ -21,6 +21,7 @@ package builtin_test
 
 import (
 	"fmt"
+	"os/user"
 	"reflect"
 	"strings"
 
@@ -35,7 +36,12 @@ import (
 
 type AllSuite struct{}
 
-var _ = Suite(&AllSuite{})
+var (
+	_        = Suite(&AllSuite{})
+	testuser = user.User{
+		Name: "testuser",
+	}
+)
 
 // This section contains a list of *valid* defines that represent methods that
 // backends recognize and call. They are in individual interfaces as each

--- a/internal/interfaces/builtin/camera.go
+++ b/internal/interfaces/builtin/camera.go
@@ -47,7 +47,7 @@ const cameraBaseDeclarationPlugs = `
       plug-names:
         - $INTERFACE
     allow-connection: true
-    allow-auto-connection: false
+    deny-auto-connection: true
 `
 
 type cameraInterface struct{}

--- a/internal/interfaces/builtin/camera_test.go
+++ b/internal/interfaces/builtin/camera_test.go
@@ -45,7 +45,7 @@ slots:
   camera:
 `, s.projectId, "ws", "producer", "camera")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 

--- a/internal/interfaces/builtin/camera_test.go
+++ b/internal/interfaces/builtin/camera_test.go
@@ -45,7 +45,7 @@ slots:
   camera:
 `, s.projectId, "ws", "producer", "camera")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -76,19 +76,14 @@ func (iface *desktopInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInf
 }
 
 func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	usr, err := workshop.LookupUsername(spec.User())
-	if err != nil {
-		return err
-	}
-
-	env, err := systemd.UserEnvironment(usr.Username)
+	env, err := systemd.UserEnvironment(spec.User)
 	if err != nil {
 		return err
 	}
 
 	xdg := env["XDG_RUNTIME_DIR"]
 	if xdg == "" {
-		return fmt.Errorf("XDG_RUNTIME_DIR is either empty or unset for user %q", spec.User())
+		return fmt.Errorf("XDG_RUNTIME_DIR is either empty or unset for user %q", spec.User.Username)
 	}
 
 	desktop := workshop.Desktop{}
@@ -97,7 +92,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	display := env["DISPLAY"]
 
 	if wayland == "" && display == "" {
-		return fmt.Errorf("neither DISPLAY nor WAYLAND_DISPLAY are set for user %q", spec.User())
+		return fmt.Errorf("neither DISPLAY nor WAYLAND_DISPLAY are set for user %q", spec.User.Username)
 	}
 
 	if wayland != "" {
@@ -119,7 +114,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 		x.Listen = x.Connect
 	}
 
-	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, usr.Uid, ".Xauthority")
+	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, spec.User.Uid, ".Xauthority")
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
 		m := workshop.Mount{}

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -55,7 +55,7 @@ const desktopDeclarationPlugs = `
       plug-names:
         - $INTERFACE
     allow-connection: true
-    allow-auto-connection: false
+    deny-auto-connection: true
 `
 
 type desktopInterface struct{}

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -1,0 +1,141 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+const desktopSummary = `allows SDKs to use the host's wayland compositor`
+
+const desktopBaseDeclarationSlots = `
+  desktop:
+    allow-installation:
+      slot-sdk-type:
+        - system
+      slot-names:
+        - $INTERFACE
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+const desktopDeclarationPlugs = `
+  desktop:
+    allow-installation:
+      plug-sdk-type:
+        - regular
+      plug-names:
+        - $INTERFACE
+    allow-connection: true
+    allow-auto-connection: false
+`
+
+type desktopInterface struct{}
+
+func (iface *desktopInterface) Name() string {
+	return "desktop"
+}
+
+func (iface *desktopInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              desktopSummary,
+		BaseDeclarationPlugs: desktopDeclarationPlugs,
+		BaseDeclarationSlots: desktopBaseDeclarationSlots,
+		AffectsPlugOnRefresh: true,
+	}
+}
+
+// Why do we return autoconnect=true when allow-auto-connection is false?
+// Is this a case of two things named similary?
+// ie. allow is policy and the below is technical?
+func (iface *desktopInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	return true
+}
+
+func (iface *desktopInterface) MountConnectedPlug(
+	spec *lxd_device.Specification,
+	plug *interfaces.ConnectedPlug,
+	slot *interfaces.ConnectedSlot,
+) error {
+
+	user, err := workshop.LookupUsername(spec.User())
+	if err != nil {
+		return err
+	}
+
+	uid, _, err := osutil.UidGid(user)
+	if err != nil {
+		return err
+	}
+
+	// systemd is responsible for generating the "WAYLAND_DISPLAY" environment variable
+	// because of this we must parse the environment as it's set by systemd
+	cmd := exec.Command("sudo", "-E", "-u", spec.User(), "systemctl", "--user", "show-environment")
+	// XDG_RUNTIME_DIR may not be set if a command invoked by sudo or
+	// systemd-run; set it here to the default location. It is required for the
+	// systemctl to work with --user. See:
+	// https://unix.stackexchange.com/questions/346841/why-does-sudo-i-not-set-xdg-runtime-dir-for-the-target-user
+	defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, strconv.FormatUint(uint64(uid), 10))
+	cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+defaultXdg)
+	out, errOut, err := osutil.RunCmd(cmd)
+	if err != nil {
+		return fmt.Errorf(string(errOut))
+	}
+
+	rawEnv := strings.FieldsFunc(string(out), func(r rune) bool { return r == '\n' })
+	env, err := osutil.ParseEnvironment(rawEnv)
+	if err != nil {
+		return err
+	}
+
+	wayland, ok := env["WAYLAND_DISPLAY"]
+	if !ok || wayland == "" {
+		return fmt.Errorf("WAYLAND_DISPLAY is either empty or unset for user %q. Is this a wayland session?", user.Username)
+	}
+
+	xdg, ok := env["XDG_RUNTIME_DIR"]
+	if !ok || xdg == "" {
+		return fmt.Errorf("XDG_RUNTIME_DIR is either empty or unset for user %q", user.Username)
+	}
+
+	name := plug.Sdk().Name + "-" + plug.Name()
+
+	fromSocket := xdg + "/" + wayland
+	// The container XDG_RUNTIME_DIR is always /run/user/1000 for the workshop user
+	// Use the same WAYLAND_DISPLAY identifier as the host
+	toSocket := "/run/user/1000/" + wayland
+
+	return spec.SetDesktop(workshop.Desktop{Name: name, Connect: fromSocket, Listen: toSocket})
+}
+
+func init() {
+	registerIface(&desktopInterface{})
+}

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -111,7 +111,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 		x := &desktop.X11
 		x.Name = plug.Sdk().Name + "-" + "x11"
 		x.Connect = filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":"))
-		x.Listen = x.Connect
+		x.Listen = filepath.Join(dirs.WorkshopRunDir, "X"+strings.TrimPrefix(display, ":"))
 	}
 
 	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, spec.User.Uid, "Xauthority")

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -112,6 +112,9 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 		desktop.X11.Listen = desktop.X11.Connect
 	}
 
+	// We mount the Xauthority inside a parent folder to ensure that the mounted
+	// cookie is updated when the host cookie changes (ie. reboot).
+	// https://discuss.linuxcontainers.org/t/mount-single-file/17975
 	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, spec.User.Uid, "Xauthority")
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -96,22 +96,20 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	}
 
 	if wayland != "" {
-		// Add wayland to the profile string
-		w := &desktop.Wayland
-		w.Name = plug.Sdk().Name + "-" + "wayland"
-		w.Connect = filepath.Join(xdg, wayland)
-		w.Listen = filepath.Join("/run/user/1000/", wayland)
+		desktop.Wayland = &workshop.ProxyEntry{}
+		desktop.Wayland.Name = plug.Sdk().Name + "-" + "wayland"
+		desktop.Wayland.Connect = filepath.Join(xdg, wayland)
+		desktop.Wayland.Listen = filepath.Join("/run/user/1000/", wayland)
 	}
 
 	// We pass through the X11 socket regardless of whether XAUTHORITY is present
 	// on the host. This then gives users the option to modify their xhost
 	// settings to allow connections from the container and container user.
 	if display != "" {
-		// Add X11 to the profile string
-		x := &desktop.X11
-		x.Name = plug.Sdk().Name + "-" + "x11"
-		x.Connect = filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":"))
-		x.Listen = x.Connect
+		desktop.X11 = &workshop.ProxyEntry{}
+		desktop.X11.Name = plug.Sdk().Name + "-" + "x11"
+		desktop.X11.Connect = filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":"))
+		desktop.X11.Listen = desktop.X11.Connect
 	}
 
 	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, spec.User.Uid, "Xauthority")
@@ -125,7 +123,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 		spec.AddMountEntry(m)
 	}
 
-	return spec.SetDesktop(&desktop)
+	return spec.SetDesktop(desktop)
 }
 
 func init() {

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -114,14 +114,14 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 		x.Listen = x.Connect
 	}
 
-	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, spec.User.Uid, ".Xauthority")
+	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, spec.User.Uid, "Xauthority")
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
 		m := workshop.Mount{}
 		m.Name = plug.Sdk().Name + "-" + "xauth"
 		m.Type = 0
 		m.What = workshopdXauth
-		m.Where = filepath.Join(dirs.WorkshopRunDir, ".Xauthority")
+		m.Where = filepath.Join(dirs.WorkshopRunDir, "Xauthority")
 		spec.AddMountEntry(m)
 	}
 

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2024 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -118,7 +118,7 @@ func (iface *desktopInterface) MountConnectedPlug(
 
 	wayland, ok := env["WAYLAND_DISPLAY"]
 	if !ok || wayland == "" {
-		return fmt.Errorf("WAYLAND_DISPLAY is either empty or unset for user %q. Is this a wayland session?", user.Username)
+		return fmt.Errorf("WAYLAND_DISPLAY is either empty or unset for user %q. Is this a Wayland session?", user.Username)
 	}
 
 	xdg, ok := env["XDG_RUNTIME_DIR"]

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -21,16 +21,14 @@ package builtin
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
-	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -82,57 +80,62 @@ func (iface *desktopInterface) MountConnectedPlug(
 	plug *interfaces.ConnectedPlug,
 	slot *interfaces.ConnectedSlot,
 ) error {
-
-	user, err := workshop.LookupUsername(spec.User())
+	usr, err := workshop.LookupUsername(spec.User())
 	if err != nil {
 		return err
 	}
 
-	uid, _, err := osutil.UidGid(user)
+	env, err := systemd.UserEnvironment(usr)
 	if err != nil {
 		return err
 	}
 
-	// Systemd is responsible for generating the "WAYLAND_DISPLAY" environment
-	// variable. Because of this we must parse the environment as it's set by
-	// systemd.
-	cmd := exec.Command("sudo", "-E", "-u", spec.User(), "systemctl", "--user", "show-environment")
-	// XDG_RUNTIME_DIR may not be set if a command invoked by sudo or
-	// systemd-run; set it here to the default location. It is required for the
-	// systemctl to work with --user. See:
-	// https://unix.stackexchange.com/questions/346841/why-does-sudo-i-not-set-xdg-runtime-dir-for-the-target-user
-	defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, strconv.FormatUint(uint64(uid), 10))
-	cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+defaultXdg)
-	out, errOut, err := osutil.RunCmd(cmd)
-	if err != nil {
-		return fmt.Errorf(string(errOut))
+	xdg := env["XDG_RUNTIME_DIR"]
+	if xdg == "" {
+		return fmt.Errorf("XDG_RUNTIME_DIR is either empty or unset for user %q", spec.User())
 	}
 
-	rawEnv := strings.FieldsFunc(string(out), func(r rune) bool { return r == '\n' })
-	env, err := osutil.ParseEnvironment(rawEnv)
-	if err != nil {
-		return err
+	desktop := workshop.Desktop{}
+
+	wayland := env["WAYLAND_DISPLAY"]
+	display := env["DISPLAY"]
+
+	if wayland != "" {
+		// Add wayland to the profile string
+		w := &desktop.Wayland
+		w.Name = plug.Sdk().Name + "-" + "wayland"
+		w.Connect = filepath.Join(xdg, wayland)
+		w.Listen = filepath.Join("/run/user/1000/", wayland)
 	}
 
-	wayland, ok := env["WAYLAND_DISPLAY"]
-	if !ok || wayland == "" {
-		return fmt.Errorf("WAYLAND_DISPLAY is either empty or unset for user %q. Is this a Wayland session?", user.Username)
+	// We pass through the X11 socket regardless of whether XAUTHORITY is present
+	// on the host.
+	// This then gives users the option to modify their xhost settings to allow
+	// connections from the container and container user.
+	if display != "" {
+		// Add X11 to the profile string
+		x := &desktop.X11
+		x.Name = plug.Sdk().Name + "-" + "x11"
+		x.Connect = filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":"))
+		x.Listen = x.Connect
 	}
 
-	xdg, ok := env["XDG_RUNTIME_DIR"]
-	if !ok || xdg == "" {
-		return fmt.Errorf("XDG_RUNTIME_DIR is either empty or unset for user %q", user.Username)
+	if wayland == "" && display == "" {
+		return fmt.Errorf("neither DISPLAY nor WAYLAND_DISPLAY are set for user %q", spec.User())
 	}
 
-	name := plug.Sdk().Name + "-" + plug.Name()
+	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, usr.Uid, ".Xauthority")
+	xauth := env["XAUTHORITY"]
+	if xauth != "" {
+		m := workshop.Mount{}
+		m.Name = plug.Sdk().Name + "-" + "xauth"
+		m.Type = 0
+		m.What = workshopdXauth
+		m.Where = filepath.Join(dirs.WorkshopRunDir, ".Xauthority")
+		spec.AddMountEntry(m)
+	}
 
-	fromSocket := xdg + "/" + wayland
-	// The container XDG_RUNTIME_DIR is always /run/user/1000 for the workshop
-	// user.
-	// Use the same WAYLAND_DISPLAY identifier as the host.
-	toSocket := "/run/user/1000/" + wayland
-
-	return spec.SetDesktop(workshop.Desktop{Name: name, Connect: fromSocket, Listen: toSocket})
+	return spec.SetDesktop(&desktop)
 }
 
 func init() {

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -75,17 +75,13 @@ func (iface *desktopInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInf
 	return true
 }
 
-func (iface *desktopInterface) MountConnectedPlug(
-	spec *lxd_device.Specification,
-	plug *interfaces.ConnectedPlug,
-	slot *interfaces.ConnectedSlot,
-) error {
+func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	usr, err := workshop.LookupUsername(spec.User())
 	if err != nil {
 		return err
 	}
 
-	env, err := systemd.UserEnvironment(usr)
+	env, err := systemd.UserEnvironment(usr.Username)
 	if err != nil {
 		return err
 	}
@@ -100,6 +96,10 @@ func (iface *desktopInterface) MountConnectedPlug(
 	wayland := env["WAYLAND_DISPLAY"]
 	display := env["DISPLAY"]
 
+	if wayland == "" && display == "" {
+		return fmt.Errorf("neither DISPLAY nor WAYLAND_DISPLAY are set for user %q", spec.User())
+	}
+
 	if wayland != "" {
 		// Add wayland to the profile string
 		w := &desktop.Wayland
@@ -109,19 +109,14 @@ func (iface *desktopInterface) MountConnectedPlug(
 	}
 
 	// We pass through the X11 socket regardless of whether XAUTHORITY is present
-	// on the host.
-	// This then gives users the option to modify their xhost settings to allow
-	// connections from the container and container user.
+	// on the host. This then gives users the option to modify their xhost
+	// settings to allow connections from the container and container user.
 	if display != "" {
 		// Add X11 to the profile string
 		x := &desktop.X11
 		x.Name = plug.Sdk().Name + "-" + "x11"
 		x.Connect = filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":"))
 		x.Listen = x.Connect
-	}
-
-	if wayland == "" && display == "" {
-		return fmt.Errorf("neither DISPLAY nor WAYLAND_DISPLAY are set for user %q", spec.User())
 	}
 
 	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, usr.Uid, ".Xauthority")

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -73,9 +73,6 @@ func (iface *desktopInterface) StaticInfo() interfaces.StaticInfo {
 	}
 }
 
-// Why do we return autoconnect=true when allow-auto-connection is false?
-// Is this a case of two things named similary?
-// ie. allow is policy and the below is technical?
 func (iface *desktopInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
 	return true
 }
@@ -96,8 +93,9 @@ func (iface *desktopInterface) MountConnectedPlug(
 		return err
 	}
 
-	// systemd is responsible for generating the "WAYLAND_DISPLAY" environment variable
-	// because of this we must parse the environment as it's set by systemd
+	// Systemd is responsible for generating the "WAYLAND_DISPLAY" environment
+	// variable. Because of this we must parse the environment as it's set by
+	// systemd.
 	cmd := exec.Command("sudo", "-E", "-u", spec.User(), "systemctl", "--user", "show-environment")
 	// XDG_RUNTIME_DIR may not be set if a command invoked by sudo or
 	// systemd-run; set it here to the default location. It is required for the
@@ -129,8 +127,9 @@ func (iface *desktopInterface) MountConnectedPlug(
 	name := plug.Sdk().Name + "-" + plug.Name()
 
 	fromSocket := xdg + "/" + wayland
-	// The container XDG_RUNTIME_DIR is always /run/user/1000 for the workshop user
-	// Use the same WAYLAND_DISPLAY identifier as the host
+	// The container XDG_RUNTIME_DIR is always /run/user/1000 for the workshop
+	// user.
+	// Use the same WAYLAND_DISPLAY identifier as the host.
 	toSocket := "/run/user/1000/" + wayland
 
 	return spec.SetDesktop(workshop.Desktop{Name: name, Connect: fromSocket, Listen: toSocket})

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -111,7 +111,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 		x := &desktop.X11
 		x.Name = plug.Sdk().Name + "-" + "x11"
 		x.Connect = filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":"))
-		x.Listen = filepath.Join(dirs.WorkshopRunDir, "X"+strings.TrimPrefix(display, ":"))
+		x.Listen = x.Connect
 	}
 
 	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, spec.User.Uid, "Xauthority")

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -110,7 +110,7 @@ exit 0`)
 	expectedProxy := &workshop.Desktop{}
 	expectedProxy.X11.Name = "consumer-x11"
 	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
-	expectedProxy.X11.Listen = "/var/lib/workshop/run/X0"
+	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 
@@ -145,7 +145,7 @@ exit 0`)
 	expectedProxy.Wayland.Listen = "/run/user/1000/wayland-0"
 	expectedProxy.X11.Name = "consumer-x11"
 	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
-	expectedProxy.X11.Listen = "/var/lib/workshop/run/X0"
+	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -77,6 +77,7 @@ exit 0`)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 	expectedProxy := &workshop.Desktop{}
+	expectedProxy.Wayland = &workshop.ProxyEntry{}
 	expectedProxy.Wayland.Name = "consumer-wayland"
 	expectedProxy.Wayland.Connect = "/tmp/wayland-1"
 	expectedProxy.Wayland.Listen = "/run/user/1000/wayland-1"
@@ -108,6 +109,7 @@ exit 0`)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 	expectedProxy := &workshop.Desktop{}
+	expectedProxy.X11 = &workshop.ProxyEntry{}
 	expectedProxy.X11.Name = "consumer-x11"
 	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
 	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
@@ -140,6 +142,8 @@ exit 0`)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 	expectedProxy := &workshop.Desktop{}
+	expectedProxy.Wayland = &workshop.ProxyEntry{}
+	expectedProxy.X11 = &workshop.ProxyEntry{}
 	expectedProxy.Wayland.Name = "consumer-wayland"
 	expectedProxy.Wayland.Connect = "/tmp/wayland-0"
 	expectedProxy.Wayland.Listen = "/run/user/1000/wayland-0"

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -174,7 +174,7 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, ".Xauthority"), Where: "/var/lib/workshop/run/.Xauthority"}
+	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, "Xauthority"), Where: "/var/lib/workshop/run/Xauthority"}
 	c.Assert(deviceSpec.Profile.Mounts["consumer-xauth"], check.DeepEquals, *expectedMount)
 }
 

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -2,7 +2,9 @@ package builtin_test
 
 import (
 	"os/user"
+	"path/filepath"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
@@ -50,7 +52,7 @@ func (s *desktopSuite) TestInterfaces(c *check.C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
 
-func (s *desktopSuite) TestDesktopInterface(c *check.C) {
+func (s *desktopSuite) TestDesktopInterfaceWayland(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
 base: ubuntu@22.04
 plugs:
@@ -74,10 +76,137 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedProxy := &workshop.Desktop{Name: "consumer-" + plug.Name, Connect: "/tmp/wayland-1", Listen: "/run/user/1000/wayland-1"}
+	expectedProxy := &workshop.Desktop{}
+	expectedProxy.Wayland.Name = "consumer-wayland"
+	expectedProxy.Wayland.Connect = "/tmp/wayland-1"
+	expectedProxy.Wayland.Listen = "/run/user/1000/wayland-1"
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 
+func (s *desktopSuite) TestDesktopInterfaceX11(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo "XDG_RUNTIME_DIR=/tmp"
+echo "DISPLAY=:0"
+exit 0`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+	expectedProxy := &workshop.Desktop{}
+	expectedProxy.X11.Name = "consumer-x11"
+	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
+	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
+	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
+}
+
+func (s *desktopSuite) TestDesktopInterfaceBoth(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo "XDG_RUNTIME_DIR=/tmp"
+echo "DISPLAY=:0"
+echo "WAYLAND_DISPLAY=wayland-0"
+exit 0`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+	expectedProxy := &workshop.Desktop{}
+	expectedProxy.Wayland.Name = "consumer-wayland"
+	expectedProxy.Wayland.Connect = "/tmp/wayland-0"
+	expectedProxy.Wayland.Listen = "/run/user/1000/wayland-0"
+	expectedProxy.X11.Name = "consumer-x11"
+	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
+	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
+	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
+}
+
+func (s *desktopSuite) TestDesktopInterfaceXauth(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo "XDG_RUNTIME_DIR=/tmp"
+echo "DISPLAY=:0"
+echo "XAUTHORITY=/tmp/.Xauthority"
+exit 0`)
+	defer fake.Restore()
+	user, err := workshop.LookupUsername(deviceSpec.User())
+	c.Assert(err, check.IsNil)
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, user.Uid, ".Xauthority"), Where: "/var/lib/workshop/run/.Xauthority"}
+	c.Assert(deviceSpec.Profile.Mounts["consumer-xauth"], check.DeepEquals, *expectedMount)
+}
+
+func (s *desktopSuite) TestDesktopInterfaceXauthFail(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo "XDG_RUNTIME_DIR=/tmp"
+echo "DISPLAY=:0"
+exit 0`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+	_, ok := deviceSpec.Profile.Mounts["consumer-xauth"]
+	c.Assert(!ok, check.Equals, true)
+}
 func (s *desktopSuite) TestDesktopEnvWaylandFail(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
 base: ubuntu@22.04
@@ -101,7 +230,33 @@ echo WAYLAND_DISPLAY=""
 exit 0`)
 	defer fake.Restore()
 
-	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "WAYLAND_DISPLAY is either empty.*")
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "neither DISPLAY nor WAYLAND_DISPLAY.*")
+}
+
+func (s *desktopSuite) TestDesktopEnvX11Fail(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo XDG_RUNTIME_DIR="/tmp"
+echo DISPLAY=""
+exit 0`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "neither DISPLAY nor WAYLAND_DISPLAY.*")
 }
 
 func (s *desktopSuite) TestDesktopEnvXDGFail(c *check.C) {

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -67,7 +67,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -98,7 +98,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -129,7 +129,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -164,7 +164,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -193,7 +193,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -220,7 +220,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo XDG_RUNTIME_DIR="/tmp"
@@ -246,7 +246,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo XDG_RUNTIME_DIR="/tmp"
@@ -272,7 +272,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo XDG_RUNTIME_DIR=""

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -209,6 +209,7 @@ exit 0`)
 	_, ok := deviceSpec.Profile.Mounts["consumer-xauth"]
 	c.Assert(!ok, check.Equals, true)
 }
+
 func (s *desktopSuite) TestDesktopEnvWaylandFail(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
 base: ubuntu@22.04

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -1,0 +1,131 @@
+package builtin_test
+
+import (
+	"os/user"
+
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshop"
+	"gopkg.in/check.v1"
+)
+
+type desktopSuite struct {
+	iface     interfaces.Interface
+	projectId string
+	restore   func()
+}
+
+var _ = check.Suite(&desktopSuite{
+	iface: builtin.MustInterface("desktop"),
+})
+
+func (s *desktopSuite) SetUpTest(c *check.C) {
+	s.projectId = "42424242"
+	usr, err := user.Current()
+	c.Assert(err, check.IsNil)
+	homeDir := c.MkDir()
+	s.restore = testutil.FakeFunc(func(name string) (*user.User, error) {
+		u := &user.User{
+			Name:     usr.Name,
+			Username: usr.Name,
+			Uid:      usr.Uid,
+			Gid:      usr.Gid,
+			HomeDir:  homeDir,
+		}
+		return u, nil
+	}, &workshop.LookupUsername)
+}
+
+func (s *desktopSuite) TearDown(c *check.C) {
+	s.restore()
+}
+
+func (s *desktopSuite) TestName(c *check.C) {
+	c.Assert(s.iface.Name(), check.Equals, "desktop")
+}
+
+func (s *desktopSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *desktopSuite) TestDesktopInterface(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo "XDG_RUNTIME_DIR=/tmp"
+echo "WAYLAND_DISPLAY=wayland-1"
+exit 0`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+	expectedProxy := &workshop.Desktop{Name: "consumer-" + plug.Name, Connect: "/tmp/wayland-1", Listen: "/run/user/1000/wayland-1"}
+	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
+}
+
+func (s *desktopSuite) TestDesktopEnvWaylandFail(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo XDG_RUNTIME_DIR="/tmp"
+echo WAYLAND_DISPLAY=""
+exit 0`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "WAYLAND_DISPLAY is either empty.*")
+}
+
+func (s *desktopSuite) TestDesktopEnvXDGFail(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	fake := testutil.FakeCommand(c, "sudo", `
+echo XDG_RUNTIME_DIR=""
+echo WAYLAND_DISPLAY="wayland-1"
+exit 0`)
+	defer fake.Restore()
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "XDG_RUNTIME_DIR is either empty.*")
+}

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -67,7 +67,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -98,7 +98,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -129,7 +129,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -164,7 +164,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -172,11 +172,9 @@ echo "DISPLAY=:0"
 echo "XAUTHORITY=/tmp/.Xauthority"
 exit 0`)
 	defer fake.Restore()
-	user, err := workshop.LookupUsername(deviceSpec.User())
-	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, user.Uid, ".Xauthority"), Where: "/var/lib/workshop/run/.Xauthority"}
+	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, ".Xauthority"), Where: "/var/lib/workshop/run/.Xauthority"}
 	c.Assert(deviceSpec.Profile.Mounts["consumer-xauth"], check.DeepEquals, *expectedMount)
 }
 
@@ -195,7 +193,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "XDG_RUNTIME_DIR=/tmp"
@@ -222,7 +220,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo XDG_RUNTIME_DIR="/tmp"
@@ -248,7 +246,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo XDG_RUNTIME_DIR="/tmp"
@@ -274,7 +272,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo XDG_RUNTIME_DIR=""

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -110,7 +110,7 @@ exit 0`)
 	expectedProxy := &workshop.Desktop{}
 	expectedProxy.X11.Name = "consumer-x11"
 	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
-	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
+	expectedProxy.X11.Listen = "/var/lib/workshop/run/X0"
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 
@@ -145,7 +145,7 @@ exit 0`)
 	expectedProxy.Wayland.Listen = "/run/user/1000/wayland-0"
 	expectedProxy.X11.Name = "consumer-x11"
 	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
-	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
+	expectedProxy.X11.Listen = "/var/lib/workshop/run/X0"
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 

--- a/internal/interfaces/builtin/gpu_test.go
+++ b/internal/interfaces/builtin/gpu_test.go
@@ -45,7 +45,8 @@ slots:
  gpu:
 `, s.projectId, "ws", "producer", "gpu")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 

--- a/internal/interfaces/builtin/gpu_test.go
+++ b/internal/interfaces/builtin/gpu_test.go
@@ -46,7 +46,7 @@ slots:
 `, s.projectId, "ws", "producer", "gpu")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -181,11 +181,6 @@ func (iface *mountInterface) MountConnectedSlot(spec *lxd_device.Specification, 
 
 // Interactions with the mount backend.
 func (iface *mountInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	user, err := workshop.LookupUsername(spec.User())
-	if err != nil {
-		return err
-	}
-
 	source, err := iface.workshopSource(slot)
 	if err != nil && !errors.Is(err, sdk.AttributeNotFoundError{}) {
 		return err
@@ -194,7 +189,7 @@ func (iface *mountInterface) MountConnectedPlug(spec *lxd_device.Specification, 
 		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.WorkshopWorkshop})
 	}
 
-	source, err = iface.hostSource(user.HomeDir, plug, slot)
+	source, err = iface.hostSource(spec.User.HomeDir, plug, slot)
 	if err == nil {
 		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.HostWorkshop})
 	}

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -20,7 +20,6 @@
 package builtin_test
 
 import (
-	"os/user"
 	"path/filepath"
 	"testing"
 
@@ -174,28 +173,13 @@ slots:
  mount:
 `, s.projectId, "ws", "producer", "mount")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
 
-	homeDir := c.MkDir()
-	usr, err := user.Current()
-	c.Assert(err, check.IsNil)
-
-	restore := testutil.FakeFunc(func(name string) (*user.User, error) {
-		u := &user.User{
-			Name:     usr.Name,
-			Username: usr.Name,
-			Uid:      usr.Uid,
-			Gid:      usr.Gid,
-			HomeDir:  homeDir,
-		}
-		return u, nil
-	}, &workshop.LookupUsername)
-	defer restore()
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 
 	// Validate the mount specification.
-	sourceDir := filepath.Join(homeDir, "/.local/share/workshop/project/42424242/mount/ws_consumer_mount.sdk")
+	sourceDir := filepath.Join(testuser.HomeDir, ".local/share/workshop/project/42424242/mount/ws_consumer_mount.sdk")
 	expectedMnt := workshop.Mount{Name: plug.Name, What: sourceDir, Where: "/project/training", Type: workshop.HostWorkshop}
 	c.Assert(deviceSpec.Profile.Mounts, check.DeepEquals, map[string]workshop.Mount{plug.Name: expectedMnt})
 }

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -174,7 +174,7 @@ slots:
 `, s.projectId, "ws", "producer", "mount")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -85,8 +85,8 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 		return err
 	}
 
-	sock, ok := env["SSH_AUTH_SOCK"]
-	if !ok {
+	sock := env["SSH_AUTH_SOCK"]
+	if sock == "" {
 		return fmt.Errorf(`cannot access ssh-agent for user %q: environment variable "SSH_AUTH_SOCK" not found`, spec.User())
 	}
 

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -55,7 +55,7 @@ const sshAgentDeclarationPlugs = `
       plug-names:
         - $INTERFACE
     allow-connection: true
-    allow-auto-connection: false
+    deny-auto-connection: true
 `
 
 type sshAgentInterface struct{}

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -90,7 +90,7 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 	fromSocket := sock
 	toSocket := filepath.Join(dirs.WorkshopRunDir, name+".ssh")
 
-	return spec.SetSshAgent(workshop.SshAgent{Name: name, Connect: fromSocket, Listen: toSocket})
+	return spec.SetSshAgent(workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: name, Connect: fromSocket, Listen: toSocket}})
 }
 
 func init() {

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -75,19 +75,14 @@ func (iface *sshAgentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotIn
 }
 
 func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	user, err := workshop.LookupUsername(spec.User())
-	if err != nil {
-		return err
-	}
-
-	env, err := systemd.UserEnvironment(user.Username)
+	env, err := systemd.UserEnvironment(spec.User)
 	if err != nil {
 		return err
 	}
 
 	sock := env["SSH_AUTH_SOCK"]
 	if sock == "" {
-		return fmt.Errorf(`cannot access ssh-agent for user %q: environment variable "SSH_AUTH_SOCK" not found`, spec.User())
+		return fmt.Errorf(`cannot access ssh-agent for user %q: environment variable "SSH_AUTH_SOCK" not found`, spec.User.Username)
 	}
 
 	name := plug.Sdk().Name + "-" + plug.Name()

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -75,12 +75,12 @@ func (iface *sshAgentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotIn
 }
 
 func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	usr, err := workshop.LookupUsername(spec.User())
+	user, err := workshop.LookupUsername(spec.User())
 	if err != nil {
 		return err
 	}
 
-	env, err := systemd.UserEnvironment(usr)
+	env, err := systemd.UserEnvironment(user.Username)
 	if err != nil {
 		return err
 	}

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -21,16 +21,13 @@ package builtin
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
-	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -78,37 +75,19 @@ func (iface *sshAgentInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotIn
 }
 
 func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	user, err := workshop.LookupUsername(spec.User())
+	usr, err := workshop.LookupUsername(spec.User())
 	if err != nil {
 		return err
 	}
 
-	uid, _, err := osutil.UidGid(user)
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command("sudo", "-E", "-u", spec.User(), "systemctl", "--user", "show-environment")
-	// XDG_RUNTIME_DIR may not be set if a command invoked by sudo or
-	// systemd-run; set it here to the default location. It is required for the
-	// systemctl to work with --user. See:
-	// https://unix.stackexchange.com/questions/346841/why-does-sudo-i-not-set-xdg-runtime-dir-for-the-target-user
-	defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, strconv.FormatUint(uint64(uid), 10))
-	cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+defaultXdg)
-	out, errOut, err := osutil.RunCmd(cmd)
-	if err != nil {
-		return fmt.Errorf(string(errOut))
-	}
-
-	rawEnv := strings.FieldsFunc(string(out), func(r rune) bool { return r == '\n' })
-	env, err := osutil.ParseEnvironment(rawEnv)
+	env, err := systemd.UserEnvironment(usr)
 	if err != nil {
 		return err
 	}
 
 	sock, ok := env["SSH_AUTH_SOCK"]
 	if !ok {
-		return fmt.Errorf(`cannot access ssh-agent for user %q: environment variable "SSH_AUTH_SOCK" not found`, user.Username)
+		return fmt.Errorf(`cannot access ssh-agent for user %q: environment variable "SSH_AUTH_SOCK" not found`, spec.User())
 	}
 
 	name := plug.Sdk().Name + "-" + plug.Name()

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -65,7 +65,7 @@ slots:
   ssh-agent:
 `, s.projectId, "ws", "producer", "ssh-agent")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "SSH_AUTH_SOCK=/tmp/dir/ssh"
@@ -92,7 +92,7 @@ slots:
   ssh-agent:
 `, s.projectId, "ws", "producer", "ssh-agent")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 >&2 echo -n "No medium found"

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -73,7 +73,7 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedProxy := &workshop.SshAgent{Name: "consumer-" + plug.Name, Connect: "/tmp/dir/ssh", Listen: "/var/lib/workshop/run/consumer-ssh-agent.ssh"}
+	expectedProxy := &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: "consumer-" + plug.Name, Connect: "/tmp/dir/ssh", Listen: "/var/lib/workshop/run/consumer-ssh-agent.ssh"}}
 	c.Assert(deviceSpec.Profile.Agent, check.DeepEquals, expectedProxy)
 }
 

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -65,7 +65,7 @@ slots:
   ssh-agent:
 `, s.projectId, "ws", "producer", "ssh-agent")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 echo "SSH_AUTH_SOCK=/tmp/dir/ssh"
@@ -92,7 +92,7 @@ slots:
   ssh-agent:
 `, s.projectId, "ws", "producer", "ssh-agent")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec := lxd_device.NewSpecification("testuser", s.projectId, "consumer")
+	deviceSpec := lxd_device.NewSpecification(&testuser, s.projectId, "consumer")
 
 	fake := testutil.FakeCommand(c, "sudo", `
 >&2 echo -n "No medium found"

--- a/internal/interfaces/ifacetest/backend.go
+++ b/internal/interfaces/ifacetest/backend.go
@@ -21,6 +21,7 @@ package ifacetest
 
 import (
 	"context"
+	"os/user"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/sdk"
@@ -75,7 +76,7 @@ func (b *TestSecurityBackend) Remove(context context.Context, workshop, sdkName 
 	return b.RemoveCallback(sdkName)
 }
 
-func (b *TestSecurityBackend) NewSpecification(user, pid, sdk string) interfaces.Specification {
+func (b *TestSecurityBackend) NewSpecification(user *user.User, pid, sdk string) interfaces.Specification {
 	return &Specification{user: user, pid: pid, sdk: sdk}
 }
 

--- a/internal/interfaces/ifacetest/spec.go
+++ b/internal/interfaces/ifacetest/spec.go
@@ -20,6 +20,8 @@
 package ifacetest
 
 import (
+	"os/user"
+
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/sdk"
 )
@@ -28,7 +30,7 @@ import (
 type Specification struct {
 	Snippets []string
 
-	user string
+	user *user.User
 	pid  string
 	sdk  string
 }

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -15,12 +15,15 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/x-go/randutil"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
+	"github.com/canonical/workshop/internal/wsutil"
 )
 
 const (
@@ -111,7 +114,7 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 		// configuration which is not acceptable.
 		// The dir is being dynamically created (no source attribute
 		// provided by the slot).
-		if !osutil.IsDir(dev.What) {
+		if _, err := os.Stat(dev.What); err != nil {
 			uid, gid, err := osutil.UidGid(user)
 			if err != nil {
 				return false, err
@@ -226,33 +229,73 @@ func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) error {
 	return fs.Remove(filepath.Join("/etc/profile.d", dev.Name+".sh"))
 }
 
-func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, workshop string) error {
-	envVars := map[string]string{
-		"WAYLAND_DISPLAY":              strings.TrimPrefix(dev.Listen, "/run/user/1000/"),
-		"QT_QPA_PLATFORM":              "wayland-egl",
-		"XDG_SESSION_TYPE":             "wayland",
-		"ELECTRON_OZONE_PLATFORM_HINT": "auto",
+func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, usr string, ws string) error {
+	user, err := workshop.LookupUsername(usr)
+	if err != nil {
+		return err
 	}
 
-	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
+	env, err := systemd.UserEnvironment(user)
 	if err != nil {
-		return fmt.Errorf("cannot configure required environment for %q: %w", workshop, err)
+		return err
 	}
-	defer env.Close()
+
+	backend := env["XDG_BACKEND"]
+
+	var envVars map[string]string
+	// Use Wayland as the default backend in the case where it's unset
+	if (backend == "wayland" || backend == "") && dev.Wayland.Name != "" {
+		envVars = map[string]string{
+			"QT_QPA_PLATFORM":  "wayland-egl",
+			"XDG_SESSION_TYPE": "wayland",
+			"XDG_BACKEND":      "wayland",
+		}
+	} else {
+		envVars = map[string]string{
+			"QT_QPA_PLATFORM":  "xcb",
+			"XDG_SESSION_TYPE": "x11",
+			"XDG_BACKEND":      "x11",
+		}
+	}
+
+	if dev.Wayland.Name != "" {
+		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen, "/run/user/1000/")
+	}
+
+	if dev.X11.Name != "" {
+		envVars["DISPLAY"] = ":" + strings.TrimPrefix(dev.X11.Listen, "/tmp/.X11-unix/X")
+	}
+
+	xauth := env["XAUTHORITY"]
+	if xauth != "" {
+		envVars["XAUTHORITY"] = filepath.Join(dirs.WorkshopRunDir, ".Xauthority")
+		err := wsutil.CopyXauthority(usr)
+		if err != nil {
+			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+		}
+	}
+
+	envVars["ELECTRON_OZONE_PLATFORM_HINT"] = "auto"
+
+	envFile, err := fs.Create(filepath.Join("/etc/profile.d", "desktop"+".sh"))
+	if err != nil {
+		return fmt.Errorf("cannot configure required environment for %q: %w", ws, err)
+	}
+	defer envFile.Close()
 
 	for key, val := range envVars {
-		_, err = env.WriteString("export " + key + "=" + val + "\n")
+		_, err = envFile.WriteString("export " + key + "=" + val + "\n")
 		if err != nil {
 
-			return fmt.Errorf("cannot set %q for %q: %w", key, workshop, err)
+			return fmt.Errorf("cannot set %q for %q: %w", key, ws, err)
 		}
 	}
 
 	return nil
 }
 
-func removeDesktop(fs workshop.WorkshopFs, dev workshop.Desktop) error {
-	return fs.Remove(filepath.Join("/etc/profile.d", dev.Name+".sh"))
+func removeDesktop(fs workshop.WorkshopFs) error {
+	return fs.Remove(filepath.Join("/etc/profile.d", "desktop"+".sh"))
 }
 
 func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error) {
@@ -320,7 +363,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 	}
 
 	if spec.Profile.Desktop != nil {
-		err = installDesktop(fs, *spec.Profile.Desktop, sdkInfo.Workshop)
+		err = installDesktop(fs, *spec.Profile.Desktop, spec.user, sdkInfo.Workshop)
 		if err != nil {
 			return err
 		}
@@ -348,7 +391,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		}
 		if prevp.Desktop != nil {
 			if spec.Profile.Desktop == nil || *prevp.Desktop != *spec.Profile.Desktop {
-				if err = removeDesktop(fs, *prevp.Desktop); err != nil {
+				if err = removeDesktop(fs); err != nil {
 					return err
 				}
 			}
@@ -424,7 +467,7 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 	}
 
 	if prof.Desktop != nil {
-		if err = removeDesktop(fs, *prof.Desktop); err != nil {
+		if err = removeDesktop(fs); err != nil {
 			return err
 		}
 	}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -14,6 +14,7 @@ import (
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/x-go/randutil"
+	"github.com/spf13/afero"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
@@ -264,11 +265,7 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	}
 
 	if dev.X11.Name != "" {
-		envVars["DISPLAY"] = ":" + strings.TrimPrefix(dev.X11.Listen, filepath.Join(dirs.WorkshopRunDir, "X"))
-		err := setupX11(fs, dev.X11.Listen)
-		if err != nil {
-			logger.Noticef("cannot symlink X11 socket, X11 applications will not work: %v", err)
-		}
+		envVars["DISPLAY"] = ":" + strings.TrimPrefix(filepath.Base(dev.X11.Listen), "X")
 	}
 
 	// The .Xauthority cookie contains a 128bit key used to authenticate consumers
@@ -302,17 +299,10 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 }
 
 func removeDesktop(fs workshop.WorkshopFs) error {
-	x11Service := "/etc/systemd/system/symlinkX11.service"
-	_, err := fs.Stat(x11Service)
-	if err == nil {
-		if err := fs.Remove(x11Service); err != nil {
+	if err := fs.Remove("/etc/profile.d/desktop.sh"); err != nil {
+		if !errors.Is(err, afero.ErrFileNotFound) {
 			return err
 		}
-	}
-	envFile := filepath.Join("/etc/profile.d", "desktop"+".sh")
-	_, err = fs.Stat(envFile)
-	if err == nil {
-		return fs.Remove(envFile)
 	}
 	return nil
 }
@@ -518,63 +508,4 @@ func MockWorkshopFs(f func(conn lxd.InstanceServer, pid, w string) (workshop.Wor
 	return func() {
 		workshopFs = old
 	}
-}
-
-// Creates a systemd service to symlink the X11 socket into /tmp/.X11-unix/ on
-// each boot. Symlinks the created service to the multi-user.target directory
-// and the X11 socket to /tmp/.X11-unix for the current boot
-func setupX11(fs workshop.WorkshopFs, listen string) error {
-	// LXD has a race condition wherein it may wipe the /tmp directory after
-	// creating the proxy devices. Because of this, we proxy the X11 socket
-	// into the workshop runtime directory, then create a script to symlink it
-	// into the /tmp/.X11-unix directory after boot.
-	systemdDefaultDir := "/etc/systemd/system"
-	symlinkTarget := "/tmp/.X11-unix" + strings.TrimPrefix(listen, dirs.WorkshopRunDir)
-
-	if err := fs.MkdirAll(systemdDefaultDir, 755); err != nil {
-		return err
-	}
-
-	f, err := fs.Create(filepath.Join(systemdDefaultDir, "symlinkX11.service"))
-	if err != nil {
-		return err
-	}
-
-	_, err = f.WriteString(`
-[Unit]
-Description=X11 symlink service
-After=multi-user.target
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-User=workshop
-ExecStartPre=/bin/bash -c "mkdir -p /tmp/.X11-unix"
-`)
-	if err != nil {
-		return err
-	}
-
-	_, err = f.WriteString(fmt.Sprintf("ExecStart=/bin/bash -c \"ln -sf %s %s\"", listen, symlinkTarget))
-	if err != nil {
-		return err
-	}
-
-	_, err = f.WriteString(`
-
-[Install]
-WantedBy=multi-user.target`)
-	if err != nil {
-		return err
-	}
-
-	if err = fs.Symlink(filepath.Join(systemdDefaultDir, "symlinkX11.service"), filepath.Join(systemdDefaultDir, "multi-user.target.wants", "symlinkX11.service")); err != nil {
-		return err
-	}
-
-	if err = fs.MkdirAll(filepath.Dir(symlinkTarget), 777); err != nil {
-		return err
-	}
-
-	return fs.Symlink(listen, symlinkTarget)
 }

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -23,7 +23,7 @@ import (
 	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
-	"github.com/canonical/workshop/internal/workshoputil"
+	"github.com/canonical/workshop/internal/x11"
 )
 
 const (
@@ -229,8 +229,8 @@ func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) error {
 	return fs.Remove(filepath.Join("/etc/profile.d", dev.Name+".sh"))
 }
 
-func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, usr string, ws string) error {
-	env, err := systemd.UserEnvironment(usr)
+func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.User, ws string) error {
+	env, err := systemd.UserEnvironment(user)
 	if err != nil {
 		return err
 	}
@@ -270,8 +270,8 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, usr string, ws
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
 		envVars["XAUTHORITY"] = filepath.Join(dirs.WorkshopRunDir, ".Xauthority")
-		if err := workshoputil.CopyXauthority(usr); err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", usr, err)
+		if err := x11.MigrateXauthority(user, xauth); err != nil {
+			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user.Username, err)
 		}
 	}
 
@@ -363,7 +363,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 	}
 
 	if spec.Profile.Desktop != nil {
-		err = installDesktop(fs, *spec.Profile.Desktop, spec.user, sdkInfo.Workshop)
+		err = installDesktop(fs, *spec.Profile.Desktop, spec.User, sdkInfo.Workshop)
 		if err != nil {
 			return err
 		}
@@ -489,7 +489,7 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 }
 
 // NewSpecification returns a new mount specification.
-func (b *Backend) NewSpecification(user, pid, sdk string) interfaces.Specification {
+func (b *Backend) NewSpecification(user *user.User, pid, sdk string) interfaces.Specification {
 	return NewSpecification(user, pid, sdk)
 }
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -238,6 +238,12 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	backend := env["XDG_BACKEND"]
 
 	var envVars map[string]string
+	envFile, err := fs.Create(filepath.Join("/etc/profile.d", "desktop"+".sh"))
+	if err != nil {
+		return fmt.Errorf("cannot configure required environment for %q: %w", ws, err)
+	}
+	defer envFile.Close()
+
 	// Use Wayland as the default backend in the case where it's unset
 	if (backend == "wayland" || backend == "") && dev.Wayland.Name != "" {
 		envVars = map[string]string{
@@ -258,7 +264,11 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	}
 
 	if dev.X11.Name != "" {
-		envVars["DISPLAY"] = ":" + strings.TrimPrefix(dev.X11.Listen, "/tmp/.X11-unix/X")
+		envVars["DISPLAY"] = ":" + strings.TrimPrefix(dev.X11.Listen, filepath.Join(dirs.WorkshopRunDir, "X"))
+		err := setupX11(fs, dev.X11.Listen)
+		if err != nil {
+			logger.Noticef("cannot symlink X11 socket, X11 applications will not work: %v", err)
+		}
 	}
 
 	// The .Xauthority cookie contains a 128bit key used to authenticate consumers
@@ -280,12 +290,6 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 
 	envVars["ELECTRON_OZONE_PLATFORM_HINT"] = "auto"
 
-	envFile, err := fs.Create(filepath.Join("/etc/profile.d", "desktop"+".sh"))
-	if err != nil {
-		return fmt.Errorf("cannot configure required environment for %q: %w", ws, err)
-	}
-	defer envFile.Close()
-
 	for key, val := range envVars {
 		_, err = envFile.WriteString("export " + key + "=" + val + "\n")
 		if err != nil {
@@ -298,7 +302,19 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 }
 
 func removeDesktop(fs workshop.WorkshopFs) error {
-	return fs.Remove(filepath.Join("/etc/profile.d", "desktop"+".sh"))
+	x11Service := "/etc/systemd/system/symlinkX11.service"
+	_, err := fs.Stat(x11Service)
+	if err == nil {
+		if err := fs.Remove(x11Service); err != nil {
+			return err
+		}
+	}
+	envFile := filepath.Join("/etc/profile.d", "desktop"+".sh")
+	_, err = fs.Stat(envFile)
+	if err == nil {
+		return fs.Remove(envFile)
+	}
+	return nil
 }
 
 func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error) {
@@ -502,4 +518,63 @@ func MockWorkshopFs(f func(conn lxd.InstanceServer, pid, w string) (workshop.Wor
 	return func() {
 		workshopFs = old
 	}
+}
+
+// Creates a systemd service to symlink the X11 socket into /tmp/.X11-unix/ on
+// each boot. Symlinks the created service to the multi-user.target directory
+// and the X11 socket to /tmp/.X11-unix for the current boot
+func setupX11(fs workshop.WorkshopFs, listen string) error {
+	// LXD has a race condition wherein it may wipe the /tmp directory after
+	// creating the proxy devices. Because of this, we proxy the X11 socket
+	// into the workshop runtime directory, then create a script to symlink it
+	// into the /tmp/.X11-unix directory after boot.
+	systemdDefaultDir := "/etc/systemd/system"
+	symlinkTarget := "/tmp/.X11-unix" + strings.TrimPrefix(listen, dirs.WorkshopRunDir)
+
+	if err := fs.MkdirAll(systemdDefaultDir, 755); err != nil {
+		return err
+	}
+
+	f, err := fs.Create(filepath.Join(systemdDefaultDir, "symlinkX11.service"))
+	if err != nil {
+		return err
+	}
+
+	_, err = f.WriteString(`
+[Unit]
+Description=X11 symlink service
+After=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=workshop
+ExecStartPre=/bin/bash -c "mkdir -p /tmp/.X11-unix"
+`)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.WriteString(fmt.Sprintf("ExecStart=/bin/bash -c \"ln -sf %s %s\"", listen, symlinkTarget))
+	if err != nil {
+		return err
+	}
+
+	_, err = f.WriteString(`
+
+[Install]
+WantedBy=multi-user.target`)
+	if err != nil {
+		return err
+	}
+
+	if err = fs.Symlink(filepath.Join(systemdDefaultDir, "symlinkX11.service"), filepath.Join(systemdDefaultDir, "multi-user.target.wants", "symlinkX11.service")); err != nil {
+		return err
+	}
+
+	if err = fs.MkdirAll(filepath.Dir(symlinkTarget), 777); err != nil {
+		return err
+	}
+
+	return fs.Symlink(listen, symlinkTarget)
 }

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -281,7 +281,7 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	if xauth != "" {
 		envVars["XAUTHORITY"] = filepath.Join(dirs.WorkshopRunDir, "Xauthority", ".Xauthority")
 		if err := x11.MigrateXauthority(user, xauth); err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user.Username, err)
+			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work: %v", user.Username, err)
 		}
 	}
 
@@ -290,8 +290,7 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	for key, val := range envVars {
 		_, err = envFile.WriteString("export " + key + "=" + val + "\n")
 		if err != nil {
-
-			return fmt.Errorf("cannot set %q for %q: %w", key, ws, err)
+			return fmt.Errorf("cannot set %s for %q: %w", key, ws, err)
 		}
 	}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -16,7 +16,6 @@ import (
 	"github.com/canonical/x-go/randutil"
 	"github.com/spf13/afero"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
@@ -287,9 +286,9 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	// is the responsibility of the interface manager.
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
-		envVars["XAUTHORITY"] = filepath.Join(dirs.WorkshopRunDir, "Xauthority", ".Xauthority")
+		envVars["XAUTHORITY"] = "/tmp/.Xauthority"
 		if err := x11.MigrateXauthority(user, xauth); err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work: %v", user.Username, err)
+			logger.Noticef("cannot migrate Xauthority file for user %s, X11 applications may not work: %v", user.Username, err)
 		}
 	}
 
@@ -307,6 +306,12 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 
 func removeDesktop(fs workshop.WorkshopFs) error {
 	if err := fs.Remove("/etc/profile.d/desktop.sh"); err != nil {
+		if !errors.Is(err, afero.ErrFileNotFound) {
+			return err
+		}
+	}
+
+	if err := fs.Remove("/tmp/.Xauthority"); err != nil {
 		if !errors.Is(err, afero.ErrFileNotFound) {
 			return err
 		}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -236,14 +236,14 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, workshop strin
 
 	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
 	if err != nil {
-		return fmt.Errorf("failed to setup the environment for desktop in profile.d for %q: %w", workshop, err)
+		return fmt.Errorf("failed to configure the environment for interface: desktop in workshop: %q (%w)", workshop, err)
 	}
 	defer env.Close()
 
 	for _, envVar := range envVars {
 		_, err = env.WriteString("export " + envVar + "\n")
 		if err != nil {
-			return fmt.Errorf("failed to setup the environment for desktop in profile.d for %q: %w", workshop, err)
+			return fmt.Errorf("failed to configure the environment for interface: desktop in workshop: %q (%w)", workshop, err)
 		}
 	}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -272,7 +272,7 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	// is the responsibility of the interface manager.
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
-		envVars["XAUTHORITY"] = filepath.Join(dirs.WorkshopRunDir, ".Xauthority")
+		envVars["XAUTHORITY"] = filepath.Join(dirs.WorkshopRunDir, "Xauthority", ".Xauthority")
 		if err := x11.MigrateXauthority(user, xauth); err != nil {
 			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user.Username, err)
 		}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -92,20 +92,6 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 	}
 
 	if dev.Type == workshop.HostWorkshop {
-		// confirm the target path exists
-		if info, err := fs.Stat(dev.Where); err != nil {
-			if !osutil.IsDirNotExist(err) {
-				return false, err
-			}
-			// FIXME: workaround LXD empty directory issue (which, if the
-			// connection was disconnected earlier, was removed by LXD).
-			if err = fs.Mkdir(dev.Where, os.ModePerm); err != nil {
-				return false, err
-			}
-		} else if !info.IsDir() {
-			return false, fmt.Errorf(`%q is not a directory`, dev.Where)
-		}
-
 		// Ensure that the source path exists here. LXD allows to
 		// require the source attribute when updating an instance
 		// configuration but it would fail and still save changes to the
@@ -115,13 +101,35 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 		// configuration which is not acceptable.
 		// The dir is being dynamically created (no source attribute
 		// provided by the slot).
-		if _, err := os.Stat(dev.What); err != nil {
+		sourceExists, sourceIsDir, err := osutil.ExistsIsDir(dev.What)
+		if err != nil {
+			return false, err
+		}
+
+		// We cannot infer what the user intended to mount if the source doesn't
+		// exist. In this case - inline with the above - we create a directory.
+		if !sourceExists {
 			uid, gid, err := osutil.UidGid(user)
 			if err != nil {
 				return false, err
 			}
 
 			if err = osutil.MkdirAllChown(dev.What, 0755, uid, gid); err != nil {
+				return false, err
+			}
+		}
+
+		if !sourceIsDir {
+			return false, nil
+		}
+
+		_, err = fs.Stat(dev.Where)
+		if !osutil.IsDirNotExist(err) {
+			return false, err
+		} else {
+			// FIXME: workaround LXD empty directory issue (which, if the
+			// connection was disconnected earlier, was removed by LXD).
+			if err = fs.MkdirAll(dev.Where, os.ModePerm); err != nil {
 				return false, err
 			}
 		}
@@ -246,7 +254,7 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	defer envFile.Close()
 
 	// Use Wayland as the default backend in the case where it's unset
-	if (backend == "wayland" || backend == "") && dev.Wayland.Name != "" {
+	if (backend == "wayland" || backend == "") && dev.Wayland != nil {
 		envVars = map[string]string{
 			"QT_QPA_PLATFORM":  "wayland-egl",
 			"XDG_SESSION_TYPE": "wayland",
@@ -260,11 +268,11 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 		}
 	}
 
-	if dev.Wayland.Name != "" {
+	if dev.Wayland != nil {
 		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen, "/run/user/1000/")
 	}
 
-	if dev.X11.Name != "" {
+	if dev.X11 != nil {
 		envVars["DISPLAY"] = ":" + strings.TrimPrefix(filepath.Base(dev.X11.Listen), "X")
 	}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -226,6 +226,34 @@ func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) error {
 	return fs.Remove(filepath.Join("/etc/profile.d", dev.Name+".sh"))
 }
 
+func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, workshop string) error {
+	envVars := []string{
+		"WAYLAND_DISPLAY=" + strings.TrimPrefix(dev.Listen, "/run/user/1000/"),
+		"QT_QPA_PLATFORM=wayland-egl",
+		"XDG_SESSION_TYPE=wayland",
+		"ELECTRON_OZONE_PLATFORM_HINT=auto",
+	}
+
+	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
+	if err != nil {
+		return fmt.Errorf("failed to setup the environment for desktop in profile.d for %q: %w", workshop, err)
+	}
+	defer env.Close()
+
+	for _, envVar := range envVars {
+		_, err = env.WriteString("export " + envVar + "\n")
+		if err != nil {
+			return fmt.Errorf("failed to setup the environment for desktop in profile.d for %q: %w", workshop, err)
+		}
+	}
+
+	return nil
+}
+
+func removeDesktop(fs workshop.WorkshopFs, dev workshop.Desktop) error {
+	return fs.Remove(filepath.Join("/etc/profile.d", dev.Name+".sh"))
+}
+
 func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error) {
 	sftp, err := conn.GetInstanceFileSFTP(lxdbackend.InstanceName(w, pid))
 	if err != nil {
@@ -290,6 +318,13 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		}
 	}
 
+	if spec.Profile.Desktop != nil {
+		err = installDesktop(fs, *spec.Profile.Desktop, sdkInfo.Workshop)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Either create or update an existing LXD profile for the SDK so that later
 	// it can be assigned to the required workshop.
 	prevp, err := lxdbackend.Profile(conn, sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Sdk)
@@ -306,6 +341,13 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		if prevp.Agent != nil {
 			if spec.Profile.Agent == nil || *prevp.Agent != *spec.Profile.Agent {
 				if err = removeSshAgent(fs, *prevp.Agent); err != nil {
+					return err
+				}
+			}
+		}
+		if prevp.Desktop != nil {
+			if spec.Profile.Desktop == nil || *prevp.Desktop != *spec.Profile.Desktop {
+				if err = removeDesktop(fs, *prevp.Desktop); err != nil {
 					return err
 				}
 			}
@@ -376,6 +418,12 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 
 	if prof.Agent != nil {
 		if err = removeSshAgent(fs, *prof.Agent); err != nil {
+			return err
+		}
+	}
+
+	if prof.Desktop != nil {
+		if err = removeDesktop(fs, *prof.Desktop); err != nil {
 			return err
 		}
 	}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -264,9 +264,12 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	// The .Xauthority cookie contains a 128bit key used to authenticate consumers
 	// of the X11 socket. It is generated on each boot with a random suffix,
 	// because of this we need to ensure there exists a consistently-named copy
-	// of the cookie for the LXC profile. We handle it here for the connect,
-	// presence of the copied cookie after reboot is the responsibility of the
-	// interface manager.
+	// of the cookie for the LXC profile. There are two cases where we need to
+	// copy the cookie, one is on workshopd startup as we iterate through the
+	// list of projects, the other is on connect because this could be the first
+	// workshop launched, in which case the user would not have had a project. We
+	// handle it here for the connect, presence of the copied cookie after reboot
+	// is the responsibility of the interface manager.
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
 		envVars["XAUTHORITY"] = filepath.Join(dirs.WorkshopRunDir, ".Xauthority")
@@ -490,7 +493,7 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 
 // NewSpecification returns a new mount specification.
 func (b *Backend) NewSpecification(user *user.User, pid, sdk string) interfaces.Specification {
-	return NewSpecification(user, pid, sdk)
+	return NewSpecification(user, sdk)
 }
 
 func MockWorkshopFs(f func(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error)) func() {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -227,23 +227,24 @@ func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) error {
 }
 
 func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, workshop string) error {
-	envVars := []string{
-		"WAYLAND_DISPLAY=" + strings.TrimPrefix(dev.Listen, "/run/user/1000/"),
-		"QT_QPA_PLATFORM=wayland-egl",
-		"XDG_SESSION_TYPE=wayland",
-		"ELECTRON_OZONE_PLATFORM_HINT=auto",
+	envVars := map[string]string{
+		"WAYLAND_DISPLAY":              strings.TrimPrefix(dev.Listen, "/run/user/1000/"),
+		"QT_QPA_PLATFORM":              "wayland-egl",
+		"XDG_SESSION_TYPE":             "wayland",
+		"ELECTRON_OZONE_PLATFORM_HINT": "auto",
 	}
 
 	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
 	if err != nil {
-		return fmt.Errorf("failed to configure the environment for interface: desktop in workshop: %q (%w)", workshop, err)
+		return fmt.Errorf("cannot configure required environment for %q: %w", workshop, err)
 	}
 	defer env.Close()
 
-	for _, envVar := range envVars {
-		_, err = env.WriteString("export " + envVar + "\n")
+	for key, val := range envVars {
+		_, err = env.WriteString("export " + key + "=" + val + "\n")
 		if err != nil {
-			return fmt.Errorf("failed to configure the environment for interface: desktop in workshop: %q (%w)", workshop, err)
+
+			return fmt.Errorf("cannot set %q for %q: %w", key, workshop, err)
 		}
 	}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -23,7 +23,7 @@ import (
 	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
-	"github.com/canonical/workshop/internal/wsutil"
+	"github.com/canonical/workshop/internal/workshoputil"
 )
 
 const (
@@ -230,12 +230,7 @@ func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) error {
 }
 
 func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, usr string, ws string) error {
-	user, err := workshop.LookupUsername(usr)
-	if err != nil {
-		return err
-	}
-
-	env, err := systemd.UserEnvironment(user)
+	env, err := systemd.UserEnvironment(usr)
 	if err != nil {
 		return err
 	}
@@ -266,12 +261,17 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, usr string, ws
 		envVars["DISPLAY"] = ":" + strings.TrimPrefix(dev.X11.Listen, "/tmp/.X11-unix/X")
 	}
 
+	// The .Xauthority cookie contains a 128bit key used to authenticate consumers
+	// of the X11 socket. It is generated on each boot with a random suffix,
+	// because of this we need to ensure there exists a consistently-named copy
+	// of the cookie for the LXC profile. We handle it here for the connect,
+	// presence of the copied cookie after reboot is the responsibility of the
+	// interface manager.
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
 		envVars["XAUTHORITY"] = filepath.Join(dirs.WorkshopRunDir, ".Xauthority")
-		err := wsutil.CopyXauthority(usr)
-		if err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+		if err := workshoputil.CopyXauthority(usr); err != nil {
+			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", usr, err)
 		}
 	}
 

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -100,31 +100,21 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 
 func (s *Specification) SetSshAgent(agent workshop.SshAgent) error {
 	s.Profile.Agent = &agent
-
-	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, agent.Name)] = "ssh-agent"
-	s.devices[agent.Name] = map[string]string{
-		"type":    "proxy",
-		"connect": "unix:" + agent.Connect,
-		"listen":  "unix:" + agent.Listen,
-		"uid":     "1000",
-		"gid":     "1000",
-		"bind":    "instance",
-	}
+	addProxyEntry(s, (*workshop.ProxyEntry)(&agent), "ssh-agent")
 	return nil
 }
 
-func (s *Specification) SetDesktop(desktop workshop.Desktop) error {
-	s.Profile.Desktop = &desktop
+func (s *Specification) SetDesktop(desktop *workshop.Desktop) error {
+	s.Profile.Desktop = desktop
 
-	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, desktop.Name)] = "desktop"
-	s.devices[desktop.Name] = map[string]string{
-		"type":    "proxy",
-		"connect": "unix:" + desktop.Connect,
-		"listen":  "unix:" + desktop.Listen,
-		"uid":     "1000",
-		"gid":     "1000",
-		"bind":    "instance",
+	if desktop.Wayland.Name != "" {
+		addProxyEntry(s, &desktop.Wayland, "desktop-wayland")
 	}
+
+	if desktop.X11.Name != "" {
+		addProxyEntry(s, &desktop.X11, "desktop-x11")
+	}
+
 	return nil
 }
 
@@ -184,4 +174,16 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 	}
 
 	return nil
+}
+
+func addProxyEntry(s *Specification, entry *workshop.ProxyEntry, configKey string) {
+	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, entry.Name)] = configKey
+	s.devices[entry.Name] = map[string]string{
+		"type":    "proxy",
+		"connect": "unix:" + entry.Connect,
+		"listen":  "unix:" + entry.Listen,
+		"uid":     "1000",
+		"gid":     "1000",
+		"bind":    "instance",
+	}
 }

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -92,19 +92,19 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 
 func (s *Specification) SetSshAgent(agent workshop.SshAgent) error {
 	s.Profile.Agent = &agent
-	addProxyEntry(s, (*workshop.ProxyEntry)(&agent), "ssh-agent")
+	s.addProxyEntry(&agent.ProxyEntry, "ssh-agent")
 	return nil
 }
 
-func (s *Specification) SetDesktop(desktop *workshop.Desktop) error {
-	s.Profile.Desktop = desktop
+func (s *Specification) SetDesktop(desktop workshop.Desktop) error {
+	s.Profile.Desktop = &desktop
 
-	if desktop.Wayland.Name != "" {
-		addProxyEntry(s, &desktop.Wayland, "desktop-wayland")
+	if desktop.Wayland != nil {
+		s.addProxyEntry(desktop.Wayland, "desktop-wayland")
 	}
 
-	if desktop.X11.Name != "" {
-		addProxyEntry(s, &desktop.X11, "desktop-x11")
+	if desktop.X11 != nil {
+		s.addProxyEntry(desktop.X11, "desktop-x11")
 	}
 
 	return nil
@@ -168,7 +168,7 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 	return nil
 }
 
-func addProxyEntry(s *Specification, entry *workshop.ProxyEntry, configKey string) {
+func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey string) {
 	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, entry.Name)] = configKey
 	s.devices[entry.Name] = map[string]string{
 		"type":    "proxy",

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -92,16 +92,39 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 	return nil
 }
 
+// Ssh Agent and Desktop are both of the lxc 'proxy' type
+// These are network protocol proxy devices and open a port on the host or in a workhop.
+// 'from', 'to' are the source and destination addresses (paths in the case of unix sockets),
+// see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
+// bind denotes where the port is open (can be: instance, host)
+
 func (s *Specification) SetSshAgent(agent workshop.SshAgent) error {
-	// A network protocol proxy device, opens a port on the host or in a workhop.
-	// from, to are the source and destination addresses (paths in the case of unix sockets),
-	// see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
-	// bind denotes where the port is open (can be: instance, host)
 	s.Profile.Agent = &agent
 
 	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, agent.Name)] = "ssh-agent"
-	s.devices[agent.Name] = map[string]string{"type": "proxy", "connect": "unix:" + agent.Connect, "listen": "unix:" + agent.Listen, "uid": "1000", "gid": "1000", "bind": "instance"}
+	s.devices[agent.Name] = map[string]string{
+		"type":    "proxy",
+		"connect": "unix:" + agent.Connect,
+		"listen":  "unix:" + agent.Listen,
+		"uid":     "1000",
+		"gid":     "1000",
+		"bind":    "instance",
+	}
+	return nil
+}
 
+func (s *Specification) SetDesktop(desktop workshop.Desktop) error {
+	s.Profile.Desktop = &desktop
+
+	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, desktop.Name)] = "desktop"
+	s.devices[desktop.Name] = map[string]string{
+		"type":    "proxy",
+		"connect": "unix:" + desktop.Connect,
+		"listen":  "unix:" + desktop.Listen,
+		"uid":     "1000",
+		"gid":     "1000",
+		"bind":    "instance",
+	}
 	return nil
 }
 

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -93,7 +93,7 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 }
 
 // Ssh Agent and Desktop are both of the lxc 'proxy' type
-// These are network protocol proxy devices and open a port on the host or in a workhop.
+// These are network protocol proxy devices that open a port on the host or in a workhop.
 // 'from', 'to' are the source and destination addresses (paths in the case of unix sockets),
 // see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
 // bind denotes where the port is open (can be: instance, host)

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -11,13 +11,12 @@ import (
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
 
-func NewSpecification(user *user.User, pid, sdk string) *Specification {
+func NewSpecification(user *user.User, sdk string) *Specification {
 	return &Specification{
 		devices: make(map[string]map[string]string),
 		config:  make(map[string]string),
 		Profile: workshop.NewSdkProfile(sdk),
 		User:    user,
-		pid:     pid,
 	}
 }
 
@@ -29,10 +28,6 @@ type Specification struct {
 
 	User *user.User
 	pid  string
-}
-
-func (s *Specification) ProjectId() string {
-	return s.pid
 }
 
 // AddPermanentSlot records side-effects of having a slot.

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -3,6 +3,7 @@ package lxd_device
 import (
 	"encoding/json"
 	"fmt"
+	"os/user"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/sdk"
@@ -10,12 +11,12 @@ import (
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
 
-func NewSpecification(user, pid, sdk string) *Specification {
+func NewSpecification(user *user.User, pid, sdk string) *Specification {
 	return &Specification{
 		devices: make(map[string]map[string]string),
 		config:  make(map[string]string),
 		Profile: workshop.NewSdkProfile(sdk),
-		user:    user,
+		User:    user,
 		pid:     pid,
 	}
 }
@@ -26,12 +27,8 @@ type Specification struct {
 	devices map[string]map[string]string
 	config  map[string]string
 
-	user string
+	User *user.User
 	pid  string
-}
-
-func (s *Specification) User() string {
-	return s.user
 }
 
 func (s *Specification) ProjectId() string {

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -789,12 +789,17 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 		return nil, fmt.Errorf("internal error: context key %s not found", workshop.ContextUser)
 	}
 
+	usr, err := workshop.LookupUsername(user)
+	if err != nil {
+		return nil, err
+	}
+
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return nil, fmt.Errorf("context key project-id not found")
 	}
 
-	spec := backend.NewSpecification(user, projectId, sdkInfo.Sdk)
+	spec := backend.NewSpecification(usr, projectId, sdkInfo.Sdk)
 
 	key := plugOrSlotKey(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Sdk)
 

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -22,6 +22,7 @@ package interfaces_test
 import (
 	"context"
 	"fmt"
+	"os/user"
 
 	. "gopkg.in/check.v1"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 type RepositorySuite struct {
@@ -43,6 +45,7 @@ type RepositorySuite struct {
 	testRepo  *Repository
 	context   context.Context
 	projectId string
+	restore   func()
 }
 
 var _ = Suite(&RepositorySuite{
@@ -91,10 +94,25 @@ func (s *RepositorySuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.projectId = "42424242"
 	s.context = ifacetest.CreateTestContext("user", s.projectId)
+
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	homeDir := c.MkDir()
+	s.restore = testutil.FakeFunc(func(name string) (*user.User, error) {
+		u := &user.User{
+			Name:     usr.Name,
+			Username: usr.Name,
+			Uid:      usr.Uid,
+			Gid:      usr.Gid,
+			HomeDir:  homeDir,
+		}
+		return u, nil
+	}, &workshop.LookupUsername)
 }
 
 func (s *RepositorySuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
+	s.restore()
 }
 
 type instanceNameAndYaml struct {
@@ -1655,7 +1673,7 @@ plugs:
 	s2 := sdk.MockInfo(c, `
 name: s2
 base: ubuntu@22.04
-slots: 
+slots:
   i1:
   i3:
 `, s.projectId, "ws")

--- a/internal/osutil/cp.go
+++ b/internal/osutil/cp.go
@@ -1,0 +1,171 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// CopyFlag is used to tweak the behaviour of CopyFile
+type CopyFlag uint8
+
+const (
+	// CopyFlagDefault is the default behaviour
+	CopyFlagDefault CopyFlag = 0
+	// CopyFlagSync does a sync after copying the files
+	CopyFlagSync CopyFlag = 1 << iota
+	// CopyFlagOverwrite overwrites the target if it exists
+	CopyFlagOverwrite
+	// CopyFlagPreserveAll preserves mode,owner,time attributes
+	CopyFlagPreserveAll
+)
+
+var (
+	openfile = doOpenFile
+	copyfile = doCopyFile
+)
+
+type fileish interface {
+	Close() error
+	Sync() error
+	Fd() uintptr
+	Stat() (os.FileInfo, error)
+	Read([]byte) (int, error)
+	Write([]byte) (int, error)
+}
+
+func doOpenFile(name string, flag int, perm os.FileMode) (fileish, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+// CopyFile copies src to dst
+func CopyFile(src, dst string, flags CopyFlag) (err error) {
+	if flags&CopyFlagPreserveAll != 0 {
+		// Our native copy code does not preserve all attributes
+		// (yet). If the user needs this functionality we just
+		// fallback to use the system's "cp" binary to do the copy.
+		if err := runCpPreserveAll(src, dst, "copy all"); err != nil {
+			return err
+		}
+		if flags&CopyFlagSync != 0 {
+			return runSync()
+		}
+		return nil
+	}
+
+	fin, err := openfile(src, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("unable to open %s: %w", src, err)
+	}
+	defer func() {
+		if cerr := fin.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("when closing %s: %w", src, cerr)
+		}
+	}()
+
+	fi, err := fin.Stat()
+	if err != nil {
+		return fmt.Errorf("unable to stat %s: %w", src, err)
+	}
+
+	outflags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	if flags&CopyFlagOverwrite == 0 {
+		outflags |= os.O_EXCL
+	}
+
+	fout, err := openfile(dst, outflags, fi.Mode())
+	if err != nil {
+		return fmt.Errorf("unable to create %s: %w", dst, err)
+	}
+	defer func() {
+		if cerr := fout.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("when closing %s: %w", dst, cerr)
+		}
+	}()
+
+	if err := copyfile(fin, fout, fi); err != nil {
+		return fmt.Errorf("unable to copy %s to %s: %w", src, dst, err)
+	}
+
+	if flags&CopyFlagSync != 0 {
+		if err = fout.Sync(); err != nil {
+			return fmt.Errorf("unable to sync %s: %w", dst, err)
+		}
+	}
+
+	return nil
+}
+
+func runCmd(cmd *exec.Cmd, errdesc string) error {
+	if output, err := cmd.CombinedOutput(); err != nil {
+		output = bytes.TrimSpace(output)
+		if exitCode, err := ExitCode(err); err == nil {
+			return &CopySpecialFileError{
+				desc:     errdesc,
+				exitCode: exitCode,
+				output:   output,
+			}
+		}
+		return &CopySpecialFileError{
+			desc:   errdesc,
+			err:    err,
+			output: output,
+		}
+	}
+
+	return nil
+}
+
+func runSync(args ...string) error {
+	return runCmd(exec.Command("sync", args...), "sync")
+}
+
+func runCpPreserveAll(path, dest, errdesc string) error {
+	return runCmd(exec.Command("cp", "-av", path, dest), errdesc)
+}
+
+// CopySpecialFile is used to copy all the things that are not files
+// (like device nodes, named pipes etc)
+func CopySpecialFile(path, dest string) error {
+	if err := runCpPreserveAll(path, dest, "copy device node"); err != nil {
+		return err
+	}
+	return runSync(filepath.Dir(dest))
+}
+
+// CopySpecialFileError is returned if a special file copy fails
+type CopySpecialFileError struct {
+	desc     string
+	exitCode int
+	output   []byte
+	err      error
+}
+
+func (e CopySpecialFileError) Error() string {
+	if e.err == nil {
+		return fmt.Sprintf("failed to %s: %q (%v)", e.desc, e.output, e.exitCode)
+	}
+
+	return fmt.Sprintf("failed to %s: %q (%v)", e.desc, e.output, e.err)
+}

--- a/internal/osutil/cp_linux.go
+++ b/internal/osutil/cp_linux.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"os"
+	"syscall"
+)
+
+const maxint = int64(^uint(0) >> 1)
+
+var maxcp = maxint // overridden in testing
+
+func doCopyFile(fin, fout fileish, fi os.FileInfo) error {
+	size := fi.Size()
+	var offset int64
+	for offset < size {
+		// sendfile is funny; it only copies up to maxint
+		// bytes at a time, but takes an int64 offset.
+		count := size - offset
+		if count > maxcp {
+			count = maxcp
+		}
+
+		if _, err := syscall.Sendfile(int(fout.Fd()), int(fin.Fd()), &offset, int(count)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/osutil/cp_linux_test.go
+++ b/internal/osutil/cp_linux_test.go
@@ -1,0 +1,54 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+func (s *cpSuite) TestCpMulti(c *C) {
+	r := osutil.MockMaxCp(2)
+	defer r()
+
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagDefault), IsNil)
+	c.Check(s.f2, testutil.FileEquals, s.data)
+}
+
+func (s *cpSuite) TestDoCpErr(c *C) {
+	c.Assert(os.WriteFile(s.f2, nil, 0444), IsNil)
+
+	src, err := os.Open(s.f1)
+	c.Assert(err, IsNil)
+	defer src.Close()
+
+	roFd, err := os.Open(s.f2)
+	c.Assert(err, IsNil)
+	defer roFd.Close()
+
+	// force an error by asking it to write to a readonly stream
+	st, err := src.Stat()
+	c.Assert(err, IsNil)
+	c.Check(osutil.DoCopyFile(src, roFd, st), NotNil)
+}

--- a/internal/osutil/cp_test.go
+++ b/internal/osutil/cp_test.go
@@ -1,0 +1,298 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+type cpSuite struct {
+	testutil.BaseTest
+
+	dir  string
+	f1   string
+	f2   string
+	data []byte
+	log  []string
+	errs []error
+}
+
+var _ = Suite(&cpSuite{})
+
+func (s *cpSuite) mockCopyFile(fin, fout osutil.Fileish, fi os.FileInfo) error {
+	return s.µ("copyfile")
+}
+
+func (s *cpSuite) mockOpenFile(name string, flag int, perm os.FileMode) (osutil.Fileish, error) {
+	return &mockfile{s}, s.µ("open")
+}
+
+func (s *cpSuite) µ(msg string) (err error) {
+	s.log = append(s.log, msg)
+	if len(s.errs) > 0 {
+		err = s.errs[0]
+		if len(s.errs) > 1 {
+			s.errs = s.errs[1:]
+		}
+	}
+
+	return err
+}
+
+func (s *cpSuite) SetUpTest(c *C) {
+	s.errs = nil
+	s.log = nil
+	s.dir = c.MkDir()
+	s.f1 = filepath.Join(s.dir, "f1")
+	s.f2 = filepath.Join(s.dir, "f2")
+	s.data = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	c.Assert(os.WriteFile(s.f1, s.data, 0644), IsNil)
+}
+
+func (s *cpSuite) mock() {
+	s.AddCleanup(osutil.MockCopyFile(s.mockCopyFile))
+	s.AddCleanup(osutil.MockOpenFile(s.mockOpenFile))
+}
+
+func (s *cpSuite) TestCp(c *C) {
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagDefault), IsNil)
+	c.Check(s.f2, testutil.FileEquals, s.data)
+}
+
+func (s *cpSuite) TestCpNoOverwrite(c *C) {
+	_, err := os.Create(s.f2)
+	c.Assert(err, IsNil)
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagDefault), NotNil)
+}
+
+func (s *cpSuite) TestCpOverwrite(c *C) {
+	_, err := os.Create(s.f2)
+	c.Assert(err, IsNil)
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagOverwrite), IsNil)
+	c.Check(s.f2, testutil.FileEquals, s.data)
+}
+
+func (s *cpSuite) TestCpOverwriteTruncates(c *C) {
+	c.Assert(os.WriteFile(s.f2, []byte("xxxxxxxxxxxxxxxx"), 0644), IsNil)
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagOverwrite), IsNil)
+	c.Check(s.f2, testutil.FileEquals, s.data)
+}
+
+func (s *cpSuite) TestCpSync(c *C) {
+	s.mock()
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagDefault), IsNil)
+	c.Check(strings.Join(s.log, ":"), Not(Matches), `.*:sync(:.*)?`)
+
+	s.log = nil
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagSync), IsNil)
+	c.Check(strings.Join(s.log, ":"), Matches, `(.*:)?sync(:.*)?`)
+}
+
+func (s *cpSuite) TestCpCantOpen(c *C) {
+	s.mock()
+	s.errs = []error{errors.New("xyzzy"), nil}
+
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagSync), ErrorMatches, `unable to open \S+/f1: xyzzy`)
+}
+
+func (s *cpSuite) TestCpCantStat(c *C) {
+	s.mock()
+	s.errs = []error{nil, errors.New("xyzzy"), nil}
+
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagSync), ErrorMatches, `unable to stat \S+/f1: xyzzy`)
+}
+
+func (s *cpSuite) TestCpCantCreate(c *C) {
+	s.mock()
+	s.errs = []error{nil, nil, errors.New("xyzzy"), nil}
+
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagSync), ErrorMatches, `unable to create \S+/f2: xyzzy`)
+}
+
+func (s *cpSuite) TestCpCantCopy(c *C) {
+	s.mock()
+	s.errs = []error{nil, nil, nil, errors.New("xyzzy"), nil}
+
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagSync), ErrorMatches, `unable to copy \S+/f1 to \S+/f2: xyzzy`)
+}
+
+func (s *cpSuite) TestCpCantSync(c *C) {
+	s.mock()
+	s.errs = []error{nil, nil, nil, nil, errors.New("xyzzy"), nil}
+
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagSync), ErrorMatches, `unable to sync \S+/f2: xyzzy`)
+}
+
+func (s *cpSuite) TestCpCantStop2(c *C) {
+	s.mock()
+	s.errs = []error{nil, nil, nil, nil, nil, errors.New("xyzzy"), nil}
+
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagSync), ErrorMatches, `when closing \S+/f2: xyzzy`)
+}
+
+func (s *cpSuite) TestCpCantStop1(c *C) {
+	s.mock()
+	s.errs = []error{nil, nil, nil, nil, nil, nil, errors.New("xyzzy"), nil}
+
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagSync), ErrorMatches, `when closing \S+/f1: xyzzy`)
+}
+
+type mockfile struct {
+	s *cpSuite
+}
+
+var mockst = mockstat{}
+
+func (f *mockfile) Close() error               { return f.s.µ("close") }
+func (f *mockfile) Sync() error                { return f.s.µ("sync") }
+func (f *mockfile) Fd() uintptr                { f.s.µ("fd"); return 42 }
+func (f *mockfile) Read([]byte) (int, error)   { return 0, f.s.µ("read") }
+func (f *mockfile) Write([]byte) (int, error)  { return 0, f.s.µ("write") }
+func (f *mockfile) Stat() (os.FileInfo, error) { return mockst, f.s.µ("stat") }
+
+type mockstat struct{}
+
+func (mockstat) Name() string       { return "mockstat" }
+func (mockstat) Size() int64        { return 42 }
+func (mockstat) Mode() os.FileMode  { return 0644 }
+func (mockstat) ModTime() time.Time { return time.Now() }
+func (mockstat) IsDir() bool        { return false }
+func (mockstat) Sys() interface{}   { return nil }
+
+func (s *cpSuite) TestCopySpecialFileSimple(c *C) {
+	sync := testutil.FakeCommand(c, "sync", "")
+	defer sync.Restore()
+
+	src := filepath.Join(c.MkDir(), "fifo")
+	err := syscall.Mkfifo(src, 0644)
+	c.Assert(err, IsNil)
+	dir := c.MkDir()
+	dst := filepath.Join(dir, "copied-fifo")
+
+	err = osutil.CopySpecialFile(src, dst)
+	c.Assert(err, IsNil)
+
+	st, err := os.Stat(dst)
+	c.Assert(err, IsNil)
+	c.Check((st.Mode() & os.ModeNamedPipe), Equals, os.ModeNamedPipe)
+	c.Check(sync.Calls(), DeepEquals, [][]string{{"sync", dir}})
+}
+
+func (s *cpSuite) TestCopySpecialFileErrors(c *C) {
+	err := osutil.CopySpecialFile("no-such-file", "no-such-target")
+	c.Assert(err, ErrorMatches, "failed to copy device node:.*cp:.*stat.*no-such-file.*")
+}
+
+func (s *cpSuite) TestCopyPreserveAll(c *C) {
+	src := filepath.Join(c.MkDir(), "meep")
+	dst := filepath.Join(c.MkDir(), "copied-meep")
+
+	err := os.WriteFile(src, []byte(nil), 0644)
+	c.Assert(err, IsNil)
+
+	// Give the file a different mtime to ensure CopyFlagPreserveAll
+	// really works.
+	//
+	// You wonder why "touch" is used? And want to me about
+	// syscall.Utime()? Well, syscall not implemented on armhf
+	// Aha, syscall.Utimes() then? No, not implemented on arm64
+	// Really, this is a just a test, touch is good enough!
+	err = exec.Command("touch", src, "-d", "2007-08-23 08:21:42").Run()
+	c.Assert(err, IsNil)
+
+	err = osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll)
+	c.Assert(err, IsNil)
+
+	// ensure that the mtime got preserved
+	st1, err := os.Stat(src)
+	c.Assert(err, IsNil)
+	st2, err := os.Stat(dst)
+	c.Assert(err, IsNil)
+	c.Assert(st1.ModTime(), Equals, st2.ModTime())
+}
+
+func (s *cpSuite) TestCopyPreserveAllSync(c *C) {
+	dir := c.MkDir()
+	mocked := testutil.FakeCommand(c, "cp", "").Also("sync", "")
+	defer mocked.Restore()
+
+	src := filepath.Join(dir, "meep")
+	dst := filepath.Join(dir, "copied-meep")
+
+	err := os.WriteFile(src, []byte(nil), 0644)
+	c.Assert(err, IsNil)
+
+	err = osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
+	c.Assert(err, IsNil)
+
+	c.Check(mocked.Calls(), DeepEquals, [][]string{
+		{"cp", "-av", src, dst},
+		{"sync"},
+	})
+}
+
+func (s *cpSuite) TestCopyPreserveAllSyncCpFailure(c *C) {
+	dir := c.MkDir()
+	mocked := testutil.FakeCommand(c, "cp", "echo OUCH: cp failed.;exit 42").Also("sync", "")
+	defer mocked.Restore()
+
+	src := filepath.Join(dir, "meep")
+	dst := filepath.Join(dir, "copied-meep")
+
+	err := os.WriteFile(src, []byte(nil), 0644)
+	c.Assert(err, IsNil)
+
+	err = osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
+	c.Assert(err, ErrorMatches, `failed to copy all: "OUCH: cp failed." \(42\)`)
+	c.Check(mocked.Calls(), DeepEquals, [][]string{
+		{"cp", "-av", src, dst},
+	})
+}
+
+func (s *cpSuite) TestCopyPreserveAllSyncSyncFailure(c *C) {
+	dir := c.MkDir()
+	mocked := testutil.FakeCommand(c, "cp", "").Also("sync", "echo OUCH: sync failed.;exit 42")
+	defer mocked.Restore()
+
+	src := filepath.Join(dir, "meep")
+	dst := filepath.Join(dir, "copied-meep")
+
+	err := os.WriteFile(src, []byte(nil), 0644)
+	c.Assert(err, IsNil)
+
+	err = osutil.CopyFile(src, dst, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
+	c.Assert(err, ErrorMatches, `failed to sync: "OUCH: sync failed." \(42\)`)
+
+	c.Check(mocked.Calls(), DeepEquals, [][]string{
+		{"cp", "-av", src, dst},
+		{"sync"},
+	})
+}

--- a/internal/osutil/export_test.go
+++ b/internal/osutil/export_test.go
@@ -28,7 +28,10 @@ import (
 	"github.com/canonical/workshop/internal/osutil/sys"
 )
 
-var ParseRawEnvironment = parseRawEnvironment
+var (
+	ParseRawEnvironment = parseRawEnvironment
+	DoCopyFile          = doCopyFile
+)
 
 // ParseRawExpandableEnv returns a new expandable environment parsed from key=value strings.
 func ParseRawExpandableEnv(entries []string) (ExpandableEnv, error) {
@@ -128,5 +131,31 @@ func FakeSyscallGetpgid(f func(int) (int, error)) (restore func()) {
 	syscallGetpgid = f
 	return func() {
 		syscallGetpgid = oldSyscallGetpgid
+	}
+}
+
+func MockCopyFile(new func(fileish, fileish, os.FileInfo) error) (restore func()) {
+	old := copyfile
+	copyfile = new
+	return func() {
+		copyfile = old
+	}
+}
+
+func MockOpenFile(new func(string, int, os.FileMode) (fileish, error)) (restore func()) {
+	old := openfile
+	openfile = new
+	return func() {
+		openfile = old
+	}
+}
+
+type Fileish = fileish
+
+func MockMaxCp(new int64) (restore func()) {
+	old := maxcp
+	maxcp = new
+	return func() {
+		maxcp = old
 	}
 }

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/wsutil"
 )
 
 type InterfaceManager struct {
@@ -137,6 +138,12 @@ func (m *InterfaceManager) StartUp() error {
 	}
 
 	for user, projects := range allprojects {
+		// We want to run this once for each user
+		err := wsutil.CopyXauthority(user)
+		if err != nil {
+			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+		}
+
 		ctx := context.WithValue(context.Background(), workshop.ContextUser, user)
 		for _, project := range projects {
 			pctx := context.WithValue(ctx, workshop.ContextProjectId, project.ProjectId)

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -14,8 +14,9 @@ import (
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
-	"github.com/canonical/workshop/internal/workshoputil"
+	"github.com/canonical/workshop/internal/x11"
 )
 
 type InterfaceManager struct {
@@ -138,11 +139,6 @@ func (m *InterfaceManager) StartUp() error {
 	}
 
 	for user, projects := range allprojects {
-		// We want to run this once for each user
-		err := workshoputil.CopyXauthority(user)
-		if err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
-		}
 
 		ctx := context.WithValue(context.Background(), workshop.ContextUser, user)
 		for _, project := range projects {
@@ -182,6 +178,20 @@ func (m *InterfaceManager) StartUp() error {
 				}
 			}
 		}
+		usr, err := workshop.LookupUsername(user)
+		if err != nil {
+			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+			continue
+		}
+		env, err := systemd.UserEnvironment(usr)
+		if err != nil {
+			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+		}
+		err = x11.MigrateXauthority(usr, env["XAUTHORITY"])
+		if err != nil {
+			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+		}
+
 	}
 
 	if _, err := m.reloadConnections("", "", ""); err != nil {

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -15,7 +15,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
-	"github.com/canonical/workshop/internal/wsutil"
+	"github.com/canonical/workshop/internal/workshoputil"
 )
 
 type InterfaceManager struct {
@@ -139,7 +139,7 @@ func (m *InterfaceManager) StartUp() error {
 
 	for user, projects := range allprojects {
 		// We want to run this once for each user
-		err := wsutil.CopyXauthority(user)
+		err := workshoputil.CopyXauthority(user)
 		if err != nil {
 			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
 		}

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -178,6 +178,12 @@ func (m *InterfaceManager) StartUp() error {
 				}
 			}
 		}
+
+		// The .Xauthority cookie contains a 128bit key used to authenticate
+		// consumers of the X11 socket. It is generated on each boot with a random
+		// suffix, because of this we need to ensure there exists a
+		// consistently-named copy of the cookie for the LXC profile. We handle
+		// this consistency across reboots here.
 		usr, err := workshop.LookupUsername(user)
 		if err != nil {
 			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
@@ -187,11 +193,9 @@ func (m *InterfaceManager) StartUp() error {
 		if err != nil {
 			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
 		}
-		err = x11.MigrateXauthority(usr, env["XAUTHORITY"])
-		if err != nil {
+		if err = x11.MigrateXauthority(usr, env["XAUTHORITY"]); err != nil {
 			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
 		}
-
 	}
 
 	if _, err := m.reloadConnections("", "", ""); err != nil {

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -186,15 +186,17 @@ func (m *InterfaceManager) StartUp() error {
 		// this consistency across reboots here.
 		usr, err := workshop.LookupUsername(user)
 		if err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+			logger.Noticef("cannot copy Xauthority file for user %q, X11 applications may not work: %v", user, err)
 			continue
 		}
 		env, err := systemd.UserEnvironment(usr)
 		if err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+			logger.Noticef("cannot copy Xauthority file for user %q, X11 applications may not work: %v", user, err)
+			continue
 		}
 		if err = x11.MigrateXauthority(usr, env["XAUTHORITY"]); err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %s, X11 applications may not work, %v", user, err)
+			logger.Noticef("cannot copy Xauthority file for user %q, X11 applications may not work: %v", user, err)
+			continue
 		}
 	}
 

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -178,32 +178,19 @@ func (m *InterfaceManager) StartUp() error {
 				}
 			}
 		}
-
 		// The .Xauthority cookie contains a 128bit key used to authenticate
 		// consumers of the X11 socket. It is generated on each boot with a random
 		// suffix, because of this we need to ensure there exists a
-		// consistently-named copy of the cookie for the LXC profile. We handle
-		// this consistency across reboots here.
-		usr, err := workshop.LookupUsername(user)
+		// consistently-named copy of the cookie for the LXC profile.
+		// this consistency across reboots here.}
+		err = updateXauthority(user)
 		if err != nil {
 			logger.Noticef("cannot copy Xauthority file for user %q, X11 applications may not work: %v", user, err)
-			continue
-		}
-		env, err := systemd.UserEnvironment(usr)
-		if err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %q, X11 applications may not work: %v", user, err)
-			continue
-		}
-		if err = x11.MigrateXauthority(usr, env["XAUTHORITY"]); err != nil {
-			logger.Noticef("cannot copy Xauthority file for user %q, X11 applications may not work: %v", user, err)
-			continue
 		}
 	}
-
 	if _, err := m.reloadConnections("", "", ""); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -498,4 +485,24 @@ func MockSecurityBackends(be []interfaces.SecurityBackend) func() {
 	old := securityBackendsOverride
 	securityBackendsOverride = be
 	return func() { securityBackendsOverride = old }
+}
+
+// updateXauthority determines user and environment information, then calls
+// MigrateXauthority
+func updateXauthority(user string) error {
+	usr, err := workshop.LookupUsername(user)
+	if err != nil {
+		return err
+	}
+
+	env, err := systemd.UserEnvironment(usr)
+	if err != nil {
+		return err
+	}
+
+	if err = x11.MigrateXauthority(usr, env["XAUTHORITY"]); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/sdk/system.go
+++ b/internal/sdk/system.go
@@ -1,0 +1,25 @@
+package sdk
+
+import (
+	"fmt"
+)
+
+var systemSdkYaml = `name: system
+base: %s
+type: system
+slots:
+  camera:
+    interface: camera
+  mount:
+    interface: mount
+  gpu:
+    interface: gpu
+  ssh-agent:
+    interface: ssh-agent
+  desktop:
+    interface: desktop
+`
+
+func SystemSdkMeta(base string) string {
+	return fmt.Sprintf(systemSdkYaml, base)
+}

--- a/internal/sdk/system/meta/sdk.yaml
+++ b/internal/sdk/system/meta/sdk.yaml
@@ -9,3 +9,5 @@ slots:
     interface: ssh-agent
   camera:
     interface: camera
+  desktop:
+    interface: desktop

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -12,7 +12,14 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 )
 
-func UserEnvironment(user *user.User) (map[string]string, error) {
+var userLookup = user.Lookup
+
+func UserEnvironment(usr string) (map[string]string, error) {
+	user, err := userLookup(usr)
+	if err != nil {
+		return nil, err
+	}
+
 	uid, _, err := osutil.UidGid(user)
 	if err != nil {
 		return nil, err
@@ -34,9 +41,5 @@ func UserEnvironment(user *user.User) (map[string]string, error) {
 	}
 
 	rawEnv := strings.FieldsFunc(string(out), func(r rune) bool { return r == '\n' })
-	env, err := osutil.ParseEnvironment(rawEnv)
-	if err != nil {
-		return nil, err
-	}
-	return env, nil
+	return osutil.ParseEnvironment(rawEnv)
 }

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -5,35 +5,21 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 )
 
-var userLookup = user.Lookup
-
-func UserEnvironment(usr string) (map[string]string, error) {
-	user, err := userLookup(usr)
-	if err != nil {
-		return nil, err
-	}
-
-	uid, _, err := osutil.UidGid(user)
-	if err != nil {
-		return nil, err
-	}
-
-	// Systemd is responsible for generating many environment
-	// variables. Because of this we must parse the environment as it's set by
-	// systemd.
+// Returns the environment for the user as set by systemd.
+// This is the equivalent of running 'systemctl --user show-environment'
+func UserEnvironment(user *user.User) (map[string]string, error) {
 	cmd := exec.Command("sudo", "-E", "-u", user.Username, "systemctl", "--user", "show-environment")
 	// XDG_RUNTIME_DIR may not be set if a command invoked by sudo or
 	// systemd-run; set it here to the default location. It is required for the
 	// systemctl to work with --user. See:
 	// https://unix.stackexchange.com/questions/346841/why-does-sudo-i-not-set-xdg-runtime-dir-for-the-target-user
-	defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, strconv.FormatUint(uint64(uid), 10))
+	defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
 	cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+defaultXdg)
 	out, errOut, err := osutil.RunCmd(cmd)
 	if err != nil {

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -1,0 +1,42 @@
+package systemd
+
+import (
+	"fmt"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/osutil"
+)
+
+func UserEnvironment(user *user.User) (map[string]string, error) {
+	uid, _, err := osutil.UidGid(user)
+	if err != nil {
+		return nil, err
+	}
+
+	// Systemd is responsible for generating many environment
+	// variables. Because of this we must parse the environment as it's set by
+	// systemd.
+	cmd := exec.Command("sudo", "-E", "-u", user.Username, "systemctl", "--user", "show-environment")
+	// XDG_RUNTIME_DIR may not be set if a command invoked by sudo or
+	// systemd-run; set it here to the default location. It is required for the
+	// systemctl to work with --user. See:
+	// https://unix.stackexchange.com/questions/346841/why-does-sudo-i-not-set-xdg-runtime-dir-for-the-target-user
+	defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, strconv.FormatUint(uint64(uid), 10))
+	cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+defaultXdg)
+	out, errOut, err := osutil.RunCmd(cmd)
+	if err != nil {
+		return nil, fmt.Errorf(string(errOut))
+	}
+
+	rawEnv := strings.FieldsFunc(string(out), func(r rune) bool { return r == '\n' })
+	env, err := osutil.ParseEnvironment(rawEnv)
+	if err != nil {
+		return nil, err
+	}
+	return env, nil
+}

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -25,11 +25,13 @@ type Mount struct {
 	Type  MountType `json:"type"`
 }
 
-type SshAgent ProxyEntry
+type SshAgent struct {
+	ProxyEntry
+}
 
 type Desktop struct {
-	Wayland ProxyEntry
-	X11     ProxyEntry
+	Wayland *ProxyEntry
+	X11     *ProxyEntry
 }
 
 type Gpu struct {

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -25,6 +25,12 @@ type SshAgent struct {
 	Listen  string
 }
 
+type Desktop struct {
+	Name    string
+	Connect string
+	Listen  string
+}
+
 type Gpu struct {
 	Name string
 }
@@ -32,10 +38,11 @@ type Gpu struct {
 type SdkProfile struct {
 	Sdk string
 
-	Camera *Camera
-	Mounts map[string]Mount
-	Agent  *SshAgent
-	Gpu    *Gpu
+	Camera  *Camera
+	Mounts  map[string]Mount
+	Agent   *SshAgent
+	Gpu     *Gpu
+	Desktop *Desktop
 }
 
 func NewSdkProfile(sdkName string) SdkProfile {

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -8,6 +8,12 @@ const (
 	Volume
 )
 
+type ProxyEntry struct {
+	Name    string
+	Connect string
+	Listen  string
+}
+
 type Camera struct {
 	Name string `json:"name"`
 }
@@ -19,16 +25,11 @@ type Mount struct {
 	Type  MountType `json:"type"`
 }
 
-type SshAgent struct {
-	Name    string
-	Connect string
-	Listen  string
-}
+type SshAgent ProxyEntry
 
 type Desktop struct {
-	Name    string
-	Connect string
-	Listen  string
+	Wayland ProxyEntry
+	X11     ProxyEntry
 }
 
 type Gpu struct {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -721,6 +721,7 @@ users:
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,
 		"user.workshop.file":       string(f),
+		"raw.lxc":                  "lxc.mount.entry = tmpfs tmp tmpfs defaults",
 	}
 
 	nvidiaRuntime, err := checkNvidiaRuntime()

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -702,9 +702,18 @@ func checkNvidia() (bool, error) {
 // The following 'write-files' and 'runcmd' sections are for the desktop
 // interface. These create a systemd path/service unit pair to copy the
 // Xauthority cookie to /tmp when we mount it in the workshop. This is done to
-// work around file mount ordering complications with lxc. Although these will
-// be present within every workshop, path units utilise inotify and as such add
-// effectively zero overhead to a workshop launch/start.
+// work around file mount ordering complications with lxc and the requirements
+// on the Xauthority cookie for snapd, namely:
+//  1. Snapd requires the Xauth cookie to be in a directory visible to snaps,
+//     however there is a special case for /tmp in which snapd will migrate
+//     the cookie for us, guaranteeing it's visibility.
+//  2. Snapd explicitly checks the provided cookie for symlinks, this means
+//     that we can only make a copy of the cookie
+//  2. Mounts in dynamic filesystems (ie. /tmp) are genreally advised against
+//     for LXD
+//
+// Although these will be present within every workshop, path units utilise
+// inotify and as such add effectively zero overhead to a workshop launch/start.
 func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File) (map[string]string, error) {
 	cloudInitConfig := `#cloud-config
 users:
@@ -759,7 +768,8 @@ runcmd:
 		// LXC appears to have a race condition wherein a proxy device mounted in
 		// a dynamically created directory has the potential to be 'masked' by this
 		// directory. We create an explicit mount for /tmp here (one such dymanic
-		// directory) to allow us to mount X11 sockets reliably
+		// directory) to allow us to mount X11 sockets reliably.
+		// See: https://github.com/lxc/lxc/issues/434
 		"raw.lxc": "lxc.mount.entry = tmpfs tmp tmpfs defaults",
 	}
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -721,7 +721,11 @@ users:
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,
 		"user.workshop.file":       string(f),
-		"raw.lxc":                  "lxc.mount.entry = tmpfs tmp tmpfs defaults",
+		// LXC appears to have a race condition wherein a proxy device mounted in
+		// a dynamically created directory has the potential to be 'masked' by this
+		// directory. We create an explicit mount for /tmp here (one such dymanic
+		// directory) to allow us to mount X11 sockets reliably
+		"raw.lxc": "lxc.mount.entry = tmpfs tmp tmpfs defaults",
 	}
 
 	nvidiaRuntime, err := checkNvidiaRuntime()

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -699,6 +699,12 @@ func checkNvidia() (bool, error) {
 	return nvidiaRuntime, nil
 }
 
+// The following 'write-files' and 'runcmd' sections are for the desktop
+// interface. These create a systemd path/service unit pair to copy the
+// Xauthority cookie to /tmp when we mount it in the workshop. This is done to
+// work around file mount ordering complications with lxc. Although these will
+// be present within every workshop, path units utilise inotify and as such add
+// effectively zero overhead to a workshop launch/start.
 func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File) (map[string]string, error) {
 	cloudInitConfig := `#cloud-config
 users:
@@ -708,6 +714,35 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
     groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video,render
     shell: /bin/bash
+write_files:
+- content: |
+    # Managed by workshop, do not remove
+    [Unit]
+    Description=Required for x11 support
+
+    [Path]
+    PathChanged=/var/lib/workshop/run/
+    Unit=xauth-copy.service
+
+    [Install]
+    WantedBy=multi-user.target
+  path: /etc/systemd/system/xauth-watch.path
+- content: |
+    # Managed by workshop, do not remove
+    [Unit]
+    Description=Required for x11 support; copies Xauthority to /tmp
+
+    [Service]
+    Type=simple
+    ExecStart=/bin/bash -c 'if [ -f /var/lib/workshop/run/Xauthority/.Xauthority ]; then cp -f /var/lib/workshop/run/Xauthority/.Xauthority /tmp/.Xauthority && chown workshop:workshop /tmp/.Xauthority; fi'
+
+    [Install]
+    WantedBy=multi-user.target
+  path: /etc/systemd/system/xauth-copy.service
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable xauth-copy.service
+  - systemctl enable --now xauth-watch.path
 `
 
 	f, err := yaml.Marshal(file)

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -48,12 +48,14 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			pr.Gpu = &workshop.Gpu{Name: name}
 		case "proxy":
 			devtype := config[DeviceTypeConfigKey(profile, name)]
-			if devtype == "ssh-agent" {
+			switch devtype {
+			case "ssh-agent":
 				pr.Agent = &workshop.SshAgent{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
-				continue
+			case "desktop":
+				pr.Desktop = &workshop.Desktop{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
+			default:
+				logger.Noticef("On reading %q SDK profile: unknown device type: %q", profile, devtype)
 			}
-
-			logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
 		case "unix-char":
 			devtype := config[DeviceTypeConfigKey(profile, name)]
 			if devtype == "camera" {

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -51,8 +51,10 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			switch devtype {
 			case "ssh-agent":
 				pr.Agent = &workshop.SshAgent{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
-			case "desktop":
-				pr.Desktop = &workshop.Desktop{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
+			case "desktop-wayland":
+				parseDesktop(name, dev, &pr, "wayland")
+			case "desktop-x11":
+				parseDesktop(name, dev, &pr, "x11")
 			default:
 				logger.Noticef("On reading %q SDK profile: unknown device type: %q", profile, devtype)
 			}
@@ -92,4 +94,26 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 		}
 	}
 	return pr, nil
+}
+
+func parseDesktop(name string, dev map[string]string, pr *workshop.SdkProfile, backend string) {
+	if pr.Desktop == nil {
+		pr.Desktop = &workshop.Desktop{}
+	}
+	switch backend {
+	case "wayland":
+		{
+			w := &pr.Desktop.Wayland
+			w.Name = name
+			w.Connect = dev["connect"]
+			w.Listen = dev["listen"]
+		}
+	case "x11":
+		{
+			x := &pr.Desktop.X11
+			x.Name = name
+			x.Connect = dev["connect"]
+			x.Listen = dev["listen"]
+		}
+	}
 }

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -50,11 +50,17 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			devtype := config[DeviceTypeConfigKey(profile, name)]
 			switch devtype {
 			case "ssh-agent":
-				pr.Agent = &workshop.SshAgent{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
+				pr.Agent = &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: name, Connect: dev["connect"], Listen: dev["listen"]}}
 			case "desktop-wayland":
-				parseDesktop(name, dev, &pr, "wayland")
+				if pr.Desktop == nil {
+					pr.Desktop = &workshop.Desktop{}
+				}
+				pr.Desktop.Wayland = &workshop.ProxyEntry{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
 			case "desktop-x11":
-				parseDesktop(name, dev, &pr, "x11")
+				if pr.Desktop == nil {
+					pr.Desktop = &workshop.Desktop{}
+				}
+				pr.Desktop.X11 = &workshop.ProxyEntry{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
 			default:
 				logger.Noticef("On reading %q SDK profile: unknown device type: %q", profile, devtype)
 			}
@@ -94,26 +100,4 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 		}
 	}
 	return pr, nil
-}
-
-func parseDesktop(name string, dev map[string]string, pr *workshop.SdkProfile, backend string) {
-	if pr.Desktop == nil {
-		pr.Desktop = &workshop.Desktop{}
-	}
-	switch backend {
-	case "wayland":
-		{
-			w := &pr.Desktop.Wayland
-			w.Name = name
-			w.Connect = dev["connect"]
-			w.Listen = dev["listen"]
-		}
-	case "x11":
-		{
-			x := &pr.Desktop.X11
-			x.Name = name
-			x.Connect = dev["connect"]
-			x.Listen = dev["listen"]
-		}
-	}
 }

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -19,6 +19,7 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Gpu: &workshop.Gpu{Name: "gpu"}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"userdisk": {Name: "userdisk", What: "/home", Where: "/opt", Type: workshop.HostWorkshop}}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}},
+		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Desktop: &workshop.Desktop{Name: "desktop", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"plug": {Name: "plug", What: "/var", Where: "/etc", Type: workshop.WorkshopWorkshop}}},
 	}
 
@@ -31,11 +32,13 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		{"sdk", map[string]map[string]string{"gpu": {"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"}}, map[string]string{}},
 		{"sdk", map[string]map[string]string{"userdisk": {"type": "disk", "source": "/home", "path": "/opt"}}, map[string]string{}},
 		{"sdk", map[string]map[string]string{"ssh-agent": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{"user.workshop.sdk.ssh-agent.type": "ssh-agent"}},
+		{"sdk", map[string]map[string]string{"desktop": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{"user.workshop.sdk.desktop.type": "desktop"}},
 		{"sdk", map[string]map[string]string{"plug": {"type": "none"}}, map[string]string{"user.workshop.sdk.plug": `{"name": "plug", "what": "/var", "where": "/etc", "type": 1}`, "user.workshop.sdk.plug.type": "mount"}},
 	} {
 		res, err := lxdbackend.LxdToSdkProfile(t.name, t.devs, t.cfg)
 		c.Assert(err, check.IsNil)
 		c.Assert(res.Agent, check.DeepEquals, expected[i].Agent)
+		c.Assert(res.Desktop, check.DeepEquals, expected[i].Desktop)
 		c.Assert(res.Camera, check.DeepEquals, expected[i].Camera)
 		c.Assert(res.Gpu, check.DeepEquals, expected[i].Gpu)
 		c.Assert(res.Mounts, testutil.DeepUnsortedMatches, expected[i].Mounts)

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -18,8 +18,8 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		{Sdk: "sdk", Camera: &workshop.Camera{Name: "camera"}, Mounts: map[string]workshop.Mount{}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Gpu: &workshop.Gpu{Name: "gpu"}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"userdisk": {Name: "userdisk", What: "/home", Where: "/opt", Type: workshop.HostWorkshop}}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Desktop: &workshop.Desktop{Wayland: workshop.ProxyEntry{Name: "desktop", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}}},
+		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}}},
+		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Desktop: &workshop.Desktop{Wayland: &workshop.ProxyEntry{Name: "desktop", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"plug": {Name: "plug", What: "/var", Where: "/etc", Type: workshop.WorkshopWorkshop}}},
 	}
 

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -19,7 +19,7 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Gpu: &workshop.Gpu{Name: "gpu"}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"userdisk": {Name: "userdisk", What: "/home", Where: "/opt", Type: workshop.HostWorkshop}}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Desktop: &workshop.Desktop{Name: "desktop", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}},
+		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Desktop: &workshop.Desktop{Wayland: workshop.ProxyEntry{Name: "desktop", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"plug": {Name: "plug", What: "/var", Where: "/etc", Type: workshop.WorkshopWorkshop}}},
 	}
 
@@ -32,7 +32,7 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		{"sdk", map[string]map[string]string{"gpu": {"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"}}, map[string]string{}},
 		{"sdk", map[string]map[string]string{"userdisk": {"type": "disk", "source": "/home", "path": "/opt"}}, map[string]string{}},
 		{"sdk", map[string]map[string]string{"ssh-agent": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{"user.workshop.sdk.ssh-agent.type": "ssh-agent"}},
-		{"sdk", map[string]map[string]string{"desktop": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{"user.workshop.sdk.desktop.type": "desktop"}},
+		{"sdk", map[string]map[string]string{"desktop": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{"user.workshop.sdk.desktop.type": "desktop-wayland"}},
 		{"sdk", map[string]map[string]string{"plug": {"type": "none"}}, map[string]string{"user.workshop.sdk.plug": `{"name": "plug", "what": "/var", "where": "/etc", "type": 1}`, "user.workshop.sdk.plug.type": "mount"}},
 	} {
 		res, err := lxdbackend.LxdToSdkProfile(t.name, t.devs, t.cfg)

--- a/internal/workshop/lxd/start_command.sh
+++ b/internal/workshop/lxd/start_command.sh
@@ -10,3 +10,36 @@ done
 # sets $XDG_RUNTIME_DIR and more. Interfaces such as desktop rely on both of these to be present.
 # This does not introduce any additional modification beyond what a login session would normally create.
 loginctl enable-linger workshop
+# There is currently an assumption made in snapd that the $XAUTHORITY cookie is
+# visible to confined snaps provided it's not located in /tmp. If it's present
+# in /tmp, snapd will migrate the cookie to a directory that the snap can use.
+# We cannot mount directly into /tmp via lxc to trigger this behavior, so we
+# make a copy on startup instead
+if [ -f /var/lib/workshop/run/Xauthority/.Xauthority ]; then
+  /bin/cp -rf /var/lib/workshop/run/Xauthority/.Xauthority /tmp/.Xauthority
+  chown workshop:workshop /tmp/.Xauthority
+fi
+
+wait_for_xauth() {
+# This is a proof-of-concept hack.
+# Installing on workshop launch is not ideal, especially as we have to perform
+# an apt update call.
+# One option would be to implement as part of the daemon, otherwise find a
+# neater (and more thought out) way to implement via bash.
+sudo apt update
+sudo apt install -y inotify-tools
+while true; do
+inotifywait /var/lib/workshop/run
+# There is currently an assumption made in snapd that the $XAUTHORITY cookie is
+# visible to confined snaps provided it's not located in /tmp. If it's present
+# in /tmp, snapd will migrate the cookie to a directory that the snap can use.
+# We cannot mount directly into /tmp via lxc to trigger this behavior, so we
+# make a copy on startup instead
+if [ -f /var/lib/workshop/run/Xauthority/.Xauthority ]; then
+  /bin/cp -rf /var/lib/workshop/run/Xauthority/.Xauthority /tmp/.Xauthority
+  chown workshop:workshop /tmp/.Xauthority
+fi
+done
+}
+export -f wait_for_xauth
+nohup bash -c wait_for_xauth &

--- a/internal/workshop/lxd/start_command.sh
+++ b/internal/workshop/lxd/start_command.sh
@@ -10,36 +10,3 @@ done
 # sets $XDG_RUNTIME_DIR and more. Interfaces such as desktop rely on both of these to be present.
 # This does not introduce any additional modification beyond what a login session would normally create.
 loginctl enable-linger workshop
-# There is currently an assumption made in snapd that the $XAUTHORITY cookie is
-# visible to confined snaps provided it's not located in /tmp. If it's present
-# in /tmp, snapd will migrate the cookie to a directory that the snap can use.
-# We cannot mount directly into /tmp via lxc to trigger this behavior, so we
-# make a copy on startup instead
-if [ -f /var/lib/workshop/run/Xauthority/.Xauthority ]; then
-  /bin/cp -rf /var/lib/workshop/run/Xauthority/.Xauthority /tmp/.Xauthority
-  chown workshop:workshop /tmp/.Xauthority
-fi
-
-wait_for_xauth() {
-# This is a proof-of-concept hack.
-# Installing on workshop launch is not ideal, especially as we have to perform
-# an apt update call.
-# One option would be to implement as part of the daemon, otherwise find a
-# neater (and more thought out) way to implement via bash.
-sudo apt update
-sudo apt install -y inotify-tools
-while true; do
-inotifywait /var/lib/workshop/run
-# There is currently an assumption made in snapd that the $XAUTHORITY cookie is
-# visible to confined snaps provided it's not located in /tmp. If it's present
-# in /tmp, snapd will migrate the cookie to a directory that the snap can use.
-# We cannot mount directly into /tmp via lxc to trigger this behavior, so we
-# make a copy on startup instead
-if [ -f /var/lib/workshop/run/Xauthority/.Xauthority ]; then
-  /bin/cp -rf /var/lib/workshop/run/Xauthority/.Xauthority /tmp/.Xauthority
-  chown workshop:workshop /tmp/.Xauthority
-fi
-done
-}
-export -f wait_for_xauth
-nohup bash -c wait_for_xauth &

--- a/internal/workshoputil/x11.go
+++ b/internal/workshoputil/x11.go
@@ -1,38 +1,42 @@
-package wsutil
+package workshoputil
 
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"syscall"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/systemd"
-	"github.com/canonical/workshop/internal/workshop"
 )
+
+var userLookup = user.Lookup
 
 // Copies the user's $XAUTHORITY file to the Workshop run directory.
 // This is used by interfaces that require an X11 socket.
 func CopyXauthority(user string) error {
-	usr, err := workshop.LookupUsername(user)
+	usr, err := userLookup(user)
 	if err != nil {
 		return err
 	}
 
-	env, err := systemd.UserEnvironment(usr)
+	env, err := systemd.UserEnvironment(user)
 	if err != nil {
 		return err
 	}
 
-	xauth, _ := env["XAUTHORITY"]
+	xauth := env["XAUTHORITY"]
 	if xauth == "" {
 		return err
 	}
 
 	destDir := filepath.Join(dirs.WorkshopdRunDir, usr.Uid)
 	if !osutil.IsDir(destDir) {
-		os.MkdirAll(destDir, 0744)
+		if err := os.MkdirAll(destDir, 0755); err != nil {
+			return err
+		}
 	}
 
 	// Make sure the target file doesn't exist as a directory.
@@ -44,12 +48,19 @@ func CopyXauthority(user string) error {
 	// There's no advantage to comparing the files, destroy and copy every
 	// time
 	destFile := filepath.Join(destDir, ".Xauthority")
-	os.RemoveAll(destFile)
+	if err = os.RemoveAll(destFile); err != nil {
+		return err
+	}
 
-	// Make sure the user owns the file.
-	// Important to make sure that the user cannot steal another user's
-	// Xauthority file
-	// See migrateXauthority function inside of snapd for more info
+	// We are performing a Stat() here to ensure that the user can't steal
+	// another user's Xauthority file. Note that while Stat() uses fstat() on the
+	// file descriptor created during Open(), the file might have change
+	// ownership between the Open() and the Stat(). That's ok because we aren't
+	// trying to block access that the user already has: if the user has the
+	// privileges to chown another user's Xauthority file, we won't block that
+	// since the user can just steal it without having to use workshop. This code
+	// is just to ensure that a user who doesn't have those privileges can't
+	// steal the file via 'workshop connect'
 	f, err := os.Stat(xauth)
 	if err != nil {
 		return err
@@ -58,6 +69,9 @@ func CopyXauthority(user string) error {
 	if sys == nil {
 		return fmt.Errorf("cannot validate owner of file %s", f.Name())
 	}
+	// cheap comparison as the current uid is only available as a string
+	// but it is better to convert the uid from the stat result to a
+	// string than a string into a number.
 	if fmt.Sprintf("%d", sys.(*syscall.Stat_t).Uid) != usr.Uid {
 		return fmt.Errorf("Xauthority file isn't owned by the current user %s", usr.Uid)
 	}

--- a/internal/workshoputil/x11_test.go
+++ b/internal/workshoputil/x11_test.go
@@ -1,0 +1,69 @@
+package workshoputil_test
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshoputil"
+)
+
+var userCurrent = user.Current
+
+func Test(t *testing.T) { TestingT(t) }
+
+type X11TestSuit struct{}
+
+var _ = Suite(&X11TestSuit{})
+
+func (x *X11TestSuit) SetUpTest(c *C) {
+}
+
+func (x *X11TestSuit) TearDownTest(c *C) {
+}
+
+func restoreWorkshopdRunDir(runDir string) {
+	dirs.WorkshopdRunDir = runDir
+}
+
+func (x *X11TestSuit) TestCopyXAuthority(c *C) {
+	user, err := userCurrent()
+	c.Assert(err, IsNil)
+
+	defer restoreWorkshopdRunDir(dirs.WorkshopdRunDir)
+	dirs.WorkshopdRunDir = c.MkDir()
+
+	xf, err := os.Create(filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
+	defer xf.Close()
+	c.Assert(err, IsNil)
+
+	fake := testutil.FakeCommand(c, "sudo", fmt.Sprintf("echo XDG_RUNTIME_DIR=\"/tmp\"\necho XAUTHORITY=\"%s/.workshop-Xauthority\"\nexit 0", dirs.WorkshopdRunDir))
+	defer fake.Restore()
+
+	err = workshoputil.CopyXauthority(user.Username)
+	c.Assert(err, IsNil)
+	_, err = os.Stat(filepath.Join(dirs.WorkshopdRunDir, user.Uid, ".Xauthority"))
+	c.Assert(err, IsNil)
+}
+
+func (x *X11TestSuit) TestCopyXAuthorityOwnershipFail(c *C) {
+	defer restoreWorkshopdRunDir(dirs.WorkshopdRunDir)
+	dirs.WorkshopdRunDir = c.MkDir()
+
+	xf, err := os.Create(filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
+	defer xf.Close()
+	c.Assert(err, IsNil)
+
+	fake := testutil.FakeCommand(c, "sudo", fmt.Sprintf("echo XDG_RUNTIME_DIR=\"/tmp\"\necho XAUTHORITY=\"%s/.workshop-Xauthority\"\nexit 0", dirs.WorkshopdRunDir))
+	defer fake.Restore()
+
+	err = workshoputil.CopyXauthority("root")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), testutil.Contains, "Xauthority file isn't owned")
+}

--- a/internal/wsutil/x11.go
+++ b/internal/wsutil/x11.go
@@ -1,0 +1,71 @@
+package wsutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/systemd"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+// Copies the user's $XAUTHORITY file to the Workshop run directory.
+// This is used by interfaces that require an X11 socket.
+func CopyXauthority(user string) error {
+	usr, err := workshop.LookupUsername(user)
+	if err != nil {
+		return err
+	}
+
+	env, err := systemd.UserEnvironment(usr)
+	if err != nil {
+		return err
+	}
+
+	xauth, _ := env["XAUTHORITY"]
+	if xauth == "" {
+		return err
+	}
+
+	destDir := filepath.Join(dirs.WorkshopdRunDir, usr.Uid)
+	if !osutil.IsDir(destDir) {
+		os.MkdirAll(destDir, 0744)
+	}
+
+	// Make sure the target file doesn't exist as a directory.
+	// We do this because if the file doesn't exist and the desktop interface is
+	// mounted, workshopd will create an empty directory as part of the mount
+	// interface.
+	// This then breaks any 'normal' file operations
+	//
+	// There's no advantage to comparing the files, destroy and copy every
+	// time
+	destFile := filepath.Join(destDir, ".Xauthority")
+	os.RemoveAll(destFile)
+
+	// Make sure the user owns the file.
+	// Important to make sure that the user cannot steal another user's
+	// Xauthority file
+	// See migrateXauthority function inside of snapd for more info
+	f, err := os.Stat(xauth)
+	if err != nil {
+		return err
+	}
+	sys := f.Sys()
+	if sys == nil {
+		return fmt.Errorf("cannot validate owner of file %s", f.Name())
+	}
+	if fmt.Sprintf("%d", sys.(*syscall.Stat_t).Uid) != usr.Uid {
+		return fmt.Errorf("Xauthority file isn't owned by the current user %s", usr.Uid)
+	}
+
+	err = osutil.CopyFile(xauth, destFile, osutil.CopyFlagOverwrite)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/x11/x11.go
+++ b/internal/x11/x11.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/osutil/sys"
 )
 
 var userLookup = user.Lookup
@@ -38,19 +39,29 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 	if err != nil {
 		return err
 	}
-	sys := f.Sys()
-	if sys == nil {
+	fsys := f.Sys()
+	if fsys == nil {
 		return fmt.Errorf("cannot validate owner of file %s", f.Name())
 	}
 	// cheap comparison as the current uid is only available as a string
 	// but it is better to convert the uid from the stat result to a
 	// string than a string into a number.
-	if fmt.Sprintf("%d", sys.(*syscall.Stat_t).Uid) != user.Uid {
+	if fmt.Sprintf("%d", fsys.(*syscall.Stat_t).Uid) != user.Uid {
 		return fmt.Errorf("Xauthority file isn't owned by the current user %s", user.Uid)
 	}
 
+	destFile := filepath.Join(destDir, ".Xauthority")
 	err = osutil.CopyFile(xauth, filepath.Join(destDir, ".Xauthority"), osutil.CopyFlagOverwrite)
 	if err != nil {
+		return err
+	}
+
+	uid, gid, err := osutil.UidGid(user)
+	if err != nil {
+		return err
+	}
+
+	if err = sys.ChownPath(destFile, uid, gid); err != nil {
 		return err
 	}
 

--- a/internal/x11/x11.go
+++ b/internal/x11/x11.go
@@ -1,7 +1,6 @@
 package x11
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -18,7 +17,7 @@ var userLookup = user.Lookup
 // Copies the user's $XAUTHORITY file to the Workshopd run directory.
 func MigrateXauthority(user *user.User, xauth string) (err error) {
 	if xauth == "" {
-		return errors.New("xauth cannot be empty")
+		return fmt.Errorf("xauth cannot be empty")
 	}
 
 	destDir := filepath.Join(dirs.WorkshopdRunDir, user.Uid, "Xauthority")

--- a/internal/x11/x11.go
+++ b/internal/x11/x11.go
@@ -21,10 +21,8 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 	}
 
 	destDir := filepath.Join(dirs.WorkshopdRunDir, user.Uid)
-	if !osutil.IsDir(destDir) {
-		if err := os.MkdirAll(destDir, 0755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return err
 	}
 
 	// Make sure the target file doesn't exist as a directory.
@@ -42,7 +40,7 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 
 	// We are performing a Stat() here to ensure that the user can't steal
 	// another user's Xauthority file. Note that while Stat() uses fstat() on the
-	// file descriptor created during Open(), the file might have change
+	// file descriptor created during Open(), the file might have changed
 	// ownership between the Open() and the Stat(). That's ok because we aren't
 	// trying to block access that the user already has: if the user has the
 	// privileges to chown another user's Xauthority file, we won't block that

--- a/internal/x11/x11.go
+++ b/internal/x11/x11.go
@@ -1,6 +1,7 @@
-package workshoputil
+package x11
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -9,30 +10,17 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
-	"github.com/canonical/workshop/internal/systemd"
 )
 
 var userLookup = user.Lookup
 
-// Copies the user's $XAUTHORITY file to the Workshop run directory.
-// This is used by interfaces that require an X11 socket.
-func CopyXauthority(user string) error {
-	usr, err := userLookup(user)
-	if err != nil {
-		return err
-	}
-
-	env, err := systemd.UserEnvironment(user)
-	if err != nil {
-		return err
-	}
-
-	xauth := env["XAUTHORITY"]
+// Copies the user's $XAUTHORITY file to the Workshopd run directory.
+func MigrateXauthority(user *user.User, xauth string) (err error) {
 	if xauth == "" {
-		return err
+		return errors.New("xauth cannot be empty")
 	}
 
-	destDir := filepath.Join(dirs.WorkshopdRunDir, usr.Uid)
+	destDir := filepath.Join(dirs.WorkshopdRunDir, user.Uid)
 	if !osutil.IsDir(destDir) {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return err
@@ -72,8 +60,8 @@ func CopyXauthority(user string) error {
 	// cheap comparison as the current uid is only available as a string
 	// but it is better to convert the uid from the stat result to a
 	// string than a string into a number.
-	if fmt.Sprintf("%d", sys.(*syscall.Stat_t).Uid) != usr.Uid {
-		return fmt.Errorf("Xauthority file isn't owned by the current user %s", usr.Uid)
+	if fmt.Sprintf("%d", sys.(*syscall.Stat_t).Uid) != user.Uid {
+		return fmt.Errorf("Xauthority file isn't owned by the current user %s", user.Uid)
 	}
 
 	err = osutil.CopyFile(xauth, destFile, osutil.CopyFlagOverwrite)

--- a/internal/x11/x11.go
+++ b/internal/x11/x11.go
@@ -20,6 +20,10 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 		return fmt.Errorf("xauth cannot be empty")
 	}
 
+	// We place the Xauthority inside a parent folder to ensure that the mounted
+	// cookie is updated when the host cookie changes (ie. reboot). This entire
+	// parent folder is mounted inside the workshop.
+	// https://discuss.linuxcontainers.org/t/mount-single-file/17975
 	destDir := filepath.Join(dirs.WorkshopdRunDir, user.Uid, "Xauthority")
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return err

--- a/internal/x11/x11.go
+++ b/internal/x11/x11.go
@@ -20,21 +20,8 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 		return errors.New("xauth cannot be empty")
 	}
 
-	destDir := filepath.Join(dirs.WorkshopdRunDir, user.Uid)
+	destDir := filepath.Join(dirs.WorkshopdRunDir, user.Uid, "Xauthority")
 	if err := os.MkdirAll(destDir, 0755); err != nil {
-		return err
-	}
-
-	// Make sure the target file doesn't exist as a directory.
-	// We do this because if the file doesn't exist and the desktop interface is
-	// mounted, workshopd will create an empty directory as part of the mount
-	// interface.
-	// This then breaks any 'normal' file operations
-	//
-	// There's no advantage to comparing the files, destroy and copy every
-	// time
-	destFile := filepath.Join(destDir, ".Xauthority")
-	if err = os.RemoveAll(destFile); err != nil {
 		return err
 	}
 
@@ -62,7 +49,7 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 		return fmt.Errorf("Xauthority file isn't owned by the current user %s", user.Uid)
 	}
 
-	err = osutil.CopyFile(xauth, destFile, osutil.CopyFlagOverwrite)
+	err = osutil.CopyFile(xauth, filepath.Join(destDir, ".Xauthority"), osutil.CopyFlagOverwrite)
 	if err != nil {
 		return err
 	}

--- a/internal/x11/x11_test.go
+++ b/internal/x11/x11_test.go
@@ -1,7 +1,6 @@
-package workshoputil_test
+package x11_test
 
 import (
-	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -11,10 +10,11 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/testutil"
-	"github.com/canonical/workshop/internal/workshoputil"
+	"github.com/canonical/workshop/internal/x11"
 )
 
 var userCurrent = user.Current
+var userLookup = user.Lookup
 
 func Test(t *testing.T) { TestingT(t) }
 
@@ -43,16 +43,16 @@ func (x *X11TestSuit) TestCopyXAuthority(c *C) {
 	defer xf.Close()
 	c.Assert(err, IsNil)
 
-	fake := testutil.FakeCommand(c, "sudo", fmt.Sprintf("echo XDG_RUNTIME_DIR=\"/tmp\"\necho XAUTHORITY=\"%s/.workshop-Xauthority\"\nexit 0", dirs.WorkshopdRunDir))
-	defer fake.Restore()
-
-	err = workshoputil.CopyXauthority(user.Username)
+	err = x11.MigrateXauthority(user, filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
 	c.Assert(err, IsNil)
 	_, err = os.Stat(filepath.Join(dirs.WorkshopdRunDir, user.Uid, ".Xauthority"))
 	c.Assert(err, IsNil)
 }
 
 func (x *X11TestSuit) TestCopyXAuthorityOwnershipFail(c *C) {
+	user, err := userLookup("root")
+	c.Assert(err, IsNil)
+
 	defer restoreWorkshopdRunDir(dirs.WorkshopdRunDir)
 	dirs.WorkshopdRunDir = c.MkDir()
 
@@ -60,10 +60,7 @@ func (x *X11TestSuit) TestCopyXAuthorityOwnershipFail(c *C) {
 	defer xf.Close()
 	c.Assert(err, IsNil)
 
-	fake := testutil.FakeCommand(c, "sudo", fmt.Sprintf("echo XDG_RUNTIME_DIR=\"/tmp\"\necho XAUTHORITY=\"%s/.workshop-Xauthority\"\nexit 0", dirs.WorkshopdRunDir))
-	defer fake.Restore()
-
-	err = workshoputil.CopyXauthority("root")
+	err = x11.MigrateXauthority(user, filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), testutil.Contains, "Xauthority file isn't owned")
 }

--- a/internal/x11/x11_test.go
+++ b/internal/x11/x11_test.go
@@ -6,61 +6,60 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/x11"
 )
 
-var userCurrent = user.Current
-var userLookup = user.Lookup
+func Test(t *testing.T) { check.TestingT(t) }
 
-func Test(t *testing.T) { TestingT(t) }
-
-type X11TestSuit struct{}
-
-var _ = Suite(&X11TestSuit{})
-
-func (x *X11TestSuit) SetUpTest(c *C) {
+type X11TestSuit struct {
+	restore func()
 }
 
-func (x *X11TestSuit) TearDownTest(c *C) {
+var _ = check.Suite(&X11TestSuit{})
+
+func FakeWorkshopdRunDir(dir string) func() {
+	old := dirs.WorkshopdRunDir
+	dirs.WorkshopdRunDir = dir
+	return func() {
+		dirs.WorkshopdRunDir = old
+	}
 }
 
-func restoreWorkshopdRunDir(runDir string) {
-	dirs.WorkshopdRunDir = runDir
+func (x *X11TestSuit) SetUpTest(c *check.C) {
+	x.restore = FakeWorkshopdRunDir(c.MkDir())
 }
 
-func (x *X11TestSuit) TestCopyXAuthority(c *C) {
-	user, err := userCurrent()
-	c.Assert(err, IsNil)
+func (x *X11TestSuit) TearDownTest(c *check.C) {
+	x.restore()
+}
 
-	defer restoreWorkshopdRunDir(dirs.WorkshopdRunDir)
-	dirs.WorkshopdRunDir = c.MkDir()
+func (x *X11TestSuit) TestMigrateXAuthoritySuccess(c *check.C) {
+	user, err := user.Current()
+	c.Assert(err, check.IsNil)
 
 	xf, err := os.Create(filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
 	defer xf.Close()
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	err = x11.MigrateXauthority(user, filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
-	c.Assert(err, IsNil)
-	_, err = os.Stat(filepath.Join(dirs.WorkshopdRunDir, user.Uid, ".Xauthority"))
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(filepath.Join(dirs.WorkshopdRunDir, user.Uid, ".Xauthority"), testutil.FilePresent)
 }
 
-func (x *X11TestSuit) TestCopyXAuthorityOwnershipFail(c *C) {
-	user, err := userLookup("root")
-	c.Assert(err, IsNil)
-
-	defer restoreWorkshopdRunDir(dirs.WorkshopdRunDir)
-	dirs.WorkshopdRunDir = c.MkDir()
+func (x *X11TestSuit) TestMigrateXAuthorityOwnershipFail(c *check.C) {
+	user, err := user.Lookup("root")
+	c.Assert(err, check.IsNil)
 
 	xf, err := os.Create(filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
 	defer xf.Close()
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	err = x11.MigrateXauthority(user, filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), testutil.Contains, "Xauthority file isn't owned")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "Xauthority file isn't owned by the current user "+user.Uid)
 }

--- a/internal/x11/x11_test.go
+++ b/internal/x11/x11_test.go
@@ -48,7 +48,7 @@ func (x *X11TestSuit) TestMigrateXAuthoritySuccess(c *check.C) {
 	err = x11.MigrateXauthority(user, filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
 	c.Assert(err, check.IsNil)
 
-	c.Assert(filepath.Join(dirs.WorkshopdRunDir, user.Uid, ".Xauthority"), testutil.FilePresent)
+	c.Assert(filepath.Join(dirs.WorkshopdRunDir, user.Uid, "Xauthority", ".Xauthority"), testutil.FilePresent)
 }
 
 func (x *X11TestSuit) TestMigrateXAuthorityOwnershipFail(c *check.C) {

--- a/tests/lib/sdk/test-sdk-desktop/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-desktop/meta/sdk.yaml
@@ -1,0 +1,10 @@
+name: test-sdk-desktop
+title: test-sdk-desktop
+base: ubuntu@22.04
+
+summary: test-sdk-desktop SDK
+description: |
+  test-sdk-desktop SDK
+plugs:
+  desktop:
+    interface: desktop

--- a/tests/lib/sdk/test-sdk-desktop/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-desktop/sdk/hooks/setup-base
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+exit 0

--- a/tests/lib/sdk/test-sdk-desktop/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-desktop/sdk/hooks/setup-base
@@ -1,3 +1,1 @@
-#!/usr/bin/bash
-
 exit 0

--- a/tests/main/interface-desktop/.workshop/workshop.ws-desktop-empty.yaml
+++ b/tests/main/interface-desktop/.workshop/workshop.ws-desktop-empty.yaml
@@ -1,0 +1,2 @@
+name: ws-desktop
+base: ubuntu@22.04

--- a/tests/main/interface-desktop/.workshop/workshop.ws-desktop-fail.yaml
+++ b/tests/main/interface-desktop/.workshop/workshop.ws-desktop-fail.yaml
@@ -1,0 +1,9 @@
+name: ws-desktop-fail
+base: ubuntu@22.04
+sdks:
+  system:
+    slots:
+      user-desktop:
+        interface: desktop
+  test-sdk-desktop:
+    channel: latest/stable

--- a/tests/main/interface-desktop/.workshop/workshop.ws-desktop.yaml
+++ b/tests/main/interface-desktop/.workshop/workshop.ws-desktop.yaml
@@ -1,0 +1,8 @@
+name: ws-desktop
+base: ubuntu@22.04
+sdks:
+  test-sdk-desktop:
+    channel: latest/stable
+connections:
+  - plug: test-sdk-desktop:desktop
+    slot: system:desktop

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -1,4 +1,4 @@
-summary: Check desktop-agent interface scenarios
+summary: Check desktop interface scenarios
 prepare: |
   . "$TESTSLIB"/utils.sh
   # required to keep /lib/systemd/systemd --user running for a regular user
@@ -24,14 +24,22 @@ execute: |
   sudo -u ubuntu /bin/bash -c 'workshop connect ws-desktop/test-sdk-desktop:desktop :desktop'
 
   echo "Check that the expected environment is configured inside the workshop"
-  workshop_exec exec ws-desktop -- sudo -H -i -u workshop \
-    echo '$WAYLAND_DISPLAY, $QT_QPA_PLATFORM, $XDG_SESSION_TYPE, $ELECTRON_OZONE_PLATFORM_HINT' | \
-      MATCH ".*wayland-1.*wayland-egl.*wayland.*auto.*"
+  workshop_exec exec ws-desktop -- sudo -H -i -u workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -n "$WAYLAND_DISPLAY" ]
+      [ -n "$QT_QPA_PLATFORM" ]
+      [ -n "$XDG_SESSION_TYPE" ]
+      [ -n "$ELECTRON_OZONE_PLATFORM_HINT" ]
+  EOF
 
   echo "Disconnect the desktop interface"
   workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
 
   echo "Check that the environment is removed from the workshop"
-  workshop_exec exec ws-desktop -- sudo -H -i -u workshop \
-    echo '$WAYLAND_DISPLAY, $QT_QPA_PLATFORM, $XDG_SESSION_TYPE, $ELECTRON_OZONE_PLATFORM_HINT' | \
-      MATCH ", , unspecified,"
+  workshop_exec exec ws-desktop -- sudo -H -i -u workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -z "$WAYLAND_DISPLAY" ]
+      [ -z "$QT_QPA_PLATFORM" ]
+      [ "$XDG_SESSION_TYPE" == "unspecified" ]
+      [ -z "$ELECTRON_OZONE_PLATFORM_HINT" ]
+  EOF

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -5,6 +5,8 @@ prepare: |
   # which is used by the interface to get info about the desktop socket path
   loginctl enable-linger ubuntu
   workshop_exec launch ws-desktop
+  mkdir /var/snap/workshop/current/run/workshopd/1000
+  touch /var/snap/workshop/current/run/workshopd/1000/.Xauthority
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-desktop
@@ -19,12 +21,12 @@ execute: |
   workshop_exec launch ws-desktop-fail > launch.log || true
   MATCH ".*installation not allowed by \"user-desktop\" slot rule of interface \"desktop\"" < launch.log
 
-  echo "Connect the desktop interface"
+  echo "Connect the desktop interface for a wayland session"
   sudo -u ubuntu /bin/bash -c 'XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment WAYLAND_DISPLAY=wayland-1'
   sudo -u ubuntu /bin/bash -c 'workshop connect ws-desktop/test-sdk-desktop:desktop :desktop'
 
   echo "Check that the expected environment is configured inside the workshop"
-  workshop_exec exec ws-desktop -- sudo -H -i -u workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -n "$WAYLAND_DISPLAY" ]
       [ -n "$QT_QPA_PLATFORM" ]
@@ -32,14 +34,56 @@ execute: |
       [ -n "$ELECTRON_OZONE_PLATFORM_HINT" ]
   EOF
 
+  echo "Check that the required mounts are configured inside the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -S "/run/user/1000/${WAYLAND_DISPLAY}" ]
+  EOF
+
   echo "Disconnect the desktop interface"
   workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
 
   echo "Check that the environment is removed from the workshop"
-  workshop_exec exec ws-desktop -- sudo -H -i -u workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -z "$WAYLAND_DISPLAY" ]
       [ -z "$QT_QPA_PLATFORM" ]
       [ "$XDG_SESSION_TYPE" == "unspecified" ]
       [ -z "$ELECTRON_OZONE_PLATFORM_HINT" ]
+  EOF
+
+  echo "Connect the desktop interface for an x11 session"
+  sudo -u ubuntu /bin/bash -c 'touch /tmp/.Xauthority'
+  sudo -u ubuntu /bin/bash -c 'XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment DISPLAY=:0 XAUTHORITY=/tmp/.Xauthority'
+  sudo -u ubuntu /bin/bash -c 'workshop connect ws-desktop/test-sdk-desktop:desktop :desktop'
+
+  echo "Check that the expected environment is configured inside the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -n "$DISPLAY" ]
+      [ -n "$XAUTHORITY" ]
+  EOF
+
+  echo "Check that the required mounts are configured inside the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
+      [ -f "${XAUTHORITY}" ]
+  EOF
+
+  echo "Disconnect the desktop interface"
+  workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
+
+  echo "Check that the expected environment is removed from the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -z "$DISPLAY" ]
+      [ -z "$XAUTHORITY" ]
+  EOF
+
+  echo "Check that the required mounts are removed from the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ ! -f "${XAUTHORITY}" ]
+      [ ! -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
   EOF

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -5,8 +5,6 @@ prepare: |
   # which is used by the interface to get info about the desktop socket path
   loginctl enable-linger ubuntu
   workshop_exec launch ws-desktop
-  mkdir /var/snap/workshop/current/run/workshopd/1000
-  touch /var/snap/workshop/current/run/workshopd/1000/.Xauthority
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-desktop
@@ -22,8 +20,8 @@ execute: |
   MATCH ".*installation not allowed by \"user-desktop\" slot rule of interface \"desktop\"" < launch.log
 
   echo "Connect the desktop interface for a wayland session"
-  sudo -u ubuntu /bin/bash -c 'XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment WAYLAND_DISPLAY=wayland-1'
-  sudo -u ubuntu /bin/bash -c 'workshop connect ws-desktop/test-sdk-desktop:desktop :desktop'
+  sudo -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment WAYLAND_DISPLAY=wayland-1
+  workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
 
   echo "Check that the expected environment is configured inside the workshop"
   workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
@@ -53,9 +51,9 @@ execute: |
   EOF
 
   echo "Connect the desktop interface for an x11 session"
-  sudo -u ubuntu /bin/bash -c 'touch /tmp/.Xauthority'
-  sudo -u ubuntu /bin/bash -c 'XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment DISPLAY=:0 XAUTHORITY=/tmp/.Xauthority'
-  sudo -u ubuntu /bin/bash -c 'workshop connect ws-desktop/test-sdk-desktop:desktop :desktop'
+  sudo -u ubuntu touch /tmp/.Xauthority
+  sudo -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment DISPLAY=:0 XAUTHORITY=/tmp/.Xauthority
+  workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
 
   echo "Check that the expected environment is configured inside the workshop"
   workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -69,6 +69,15 @@ execute: |
       [ -f "${XAUTHORITY}" ]
   EOF
 
+  echo "Check that the required mounts are present after restart"
+  workshop_exec stop ws-desktop
+  workshop_exec start ws-desktop
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
+      [ -f "${XAUTHORITY}" ]
+  EOF
+
   echo "Disconnect the desktop interface"
   workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
 

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -1,0 +1,37 @@
+summary: Check desktop-agent interface scenarios
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  # required to keep /lib/systemd/systemd --user running for a regular user
+  # which is used by the interface to get info about the desktop socket path
+  loginctl enable-linger ubuntu
+  workshop_exec launch ws-desktop
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove ws-desktop
+  loginctl disable-linger ubuntu
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check that the desktop interface plug cannot be auto-connected"
+  workshop_exec connections ws-desktop | MATCH "^desktop.+ws-desktop/test-sdk-desktop:desktop.+\-.+\-$"
+
+  echo "Check that a user cannot install a desktop slot (violates slot declaration)"
+  workshop_exec launch ws-desktop-fail > launch.log || true
+  MATCH ".*installation not allowed by \"user-desktop\" slot rule of interface \"desktop\"" < launch.log
+
+  echo "Connect the desktop interface"
+  sudo -u ubuntu /bin/bash -c 'XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment WAYLAND_DISPLAY=wayland-1'
+  sudo -u ubuntu /bin/bash -c 'workshop connect ws-desktop/test-sdk-desktop:desktop :desktop'
+
+  echo "Check that the expected environment is configured inside the workshop"
+  workshop_exec exec ws-desktop -- sudo -H -i -u workshop \
+    echo '$WAYLAND_DISPLAY, $QT_QPA_PLATFORM, $XDG_SESSION_TYPE, $ELECTRON_OZONE_PLATFORM_HINT' | \
+      MATCH ".*wayland-1.*wayland-egl.*wayland.*auto.*"
+
+  echo "Disconnect the desktop interface"
+  workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
+
+  echo "Check that the environment is removed from the workshop"
+  workshop_exec exec ws-desktop -- sudo -H -i -u workshop \
+    echo '$WAYLAND_DISPLAY, $QT_QPA_PLATFORM, $XDG_SESSION_TYPE, $ELECTRON_OZONE_PLATFORM_HINT' | \
+      MATCH ", , unspecified,"

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -91,6 +91,24 @@ execute: |
   echo "Check that the required mounts are removed from the workshop"
   workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
-      [ ! -f "${XAUTHORITY}" ]
       [ ! -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
+      [ ! -f "${XAUTHORITY}" ]
+  EOF
+
+  echo "Reconnect the desktop interface with a different socket name"
+  sudo -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment DISPLAY=:1
+  workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
+
+  echo "Check that the expected environment is configured inside the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ "$DISPLAY" == ":1" ]
+      [ -n "$XAUTHORITY" ]
+  EOF
+
+  echo "Check that the required mounts are configured inside the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
+      [ -f "${XAUTHORITY}" ]
   EOF

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -112,3 +112,26 @@ execute: |
       [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
       [ -f "${XAUTHORITY}" ]
   EOF
+
+  echo "Check refreshing to an empty workshop definition"
+  rm .workshop/workshop.ws-desktop.yaml
+  mv .workshop/workshop.ws-desktop-empty.yaml .workshop/workshop.ws-desktop.yaml
+  workshop_exec refresh ws-desktop
+
+  echo "Check that the desktop plug is removed from the workshop"
+  set -e
+  [ -z "$(workshop_exec connections --all)" ]
+
+  echo "Check that the expected environment is removed from the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ -z "$DISPLAY" ]
+      [ -z "$XAUTHORITY" ]
+  EOF
+
+  echo "Check that the required mounts are removed from the workshop"
+  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+      set -e
+      [ ! -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
+      [ ! -f "${XAUTHORITY}" ]
+  EOF


### PR DESCRIPTION
# Description
The desktop interface provides a method for a workshop to access the Wayland and/or X11 sockets of the host, enabling GUI-based applications and development.

Additionally, the desktop interface can be paired with the GPU interface to enable hardware-accelerated graphical applications

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
