### PR TITLE
Remove apt cache in separate lane

### DIFF
--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -765,6 +765,15 @@ func remove(st *state.State, w *workshop.Workshop, project *workshop.Project) (*
 	removeAptCache := st.NewTask("remove-apt-cache", fmt.Sprintf("Remove apt cache for %q", w.Name))
 	removeAptCache.WaitFor(remove)
 
+	// The apt cache cannot be removed until the workshop has stopped,
+	// which currently happens as part of remove-workshop.
+	// Since there is no way to undo remove-workshop,
+	// we run remove-apt-cache in a separate lane.
+	// If an error occurs when removing the cache,
+	// it will not affect the other tasks.
+	cleanupLane := st.NewLane()
+	removeAptCache.JoinLane(cleanupLane)
+
 	removeSet.AddAll(disconnectSet)
 	removeSet.AddTask(discard)
 	removeSet.AddTask(remove)


### PR DESCRIPTION
# Description

Removing the apt cache can fail if the workshop was created by an earlier version, or the user manually removed the LXD volume for some reason. This task should be in a separate lane, so the error doesn't cause workshopd to try to undo the previous tasks (there's no way to undo removing a workshop anyway).

I don't see an easy way to test this, but I did some smoke testing after launching a workshop without an apt cache:
```console
$ workshop remove ws
error: cannot perform the following tasks:
- Remove apt cache for "ws" (Storage pool volume not found)
$ workshop changes
ID   Status  Spawn                Ready                Summary
...
219  Error   today at 12:01 NZDT  today at 12:01 NZDT  Remove "ws" workshop
$ workshop tasks 219
ID    Status  Spawn                Ready                Summary
2841  Done    today at 12:01 NZDT  today at 12:01 NZDT  Disconnect interfaces of "system" SDK
2842  Done    today at 12:01 NZDT  today at 12:01 NZDT  Discard "ws" undesired connections
2843  Done    today at 12:01 NZDT  today at 12:01 NZDT  Remove "ws" workshop
2844  Error   today at 12:01 NZDT  today at 12:01 NZDT  Remove apt cache for "ws"
2845  Done    today at 12:01 NZDT  today at 12:01 NZDT  Remove "system" SDK profile

......................................................................
Remove apt cache for "ws"

2024-11-20T12:01:29+13:00 ERROR Storage pool volume not found
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.