### PR TITLE
Make error messages more consistent and understandable

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@
  * [ ] Put variable declaration and initialisation together.
  * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
  * [ ] Put a blank line between two logically different chunks of code.
+ * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for newly introduced error messages.
 
 ## Docs
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -101,17 +101,17 @@ type DisconnectOptions struct {
 }
 
 func ParseShortPlugRef(plug string) (*PlugRef, error) {
-	// the expected format of the plug ref is <workshop>[/<sdk>]:<plug>
+	// the expected format of the plug ref is <workshop>/<sdk>:<plug>
 	var plugRef PlugRef
 
 	parts := strings.Split(plug, ":")
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("unknown plug or slot reference %q", plug)
+		return nil, fmt.Errorf("invalid plug or slot reference %q (expected <WORKSHOP>/<SDK>:<PLUG>)", plug)
 	}
 
 	wssdk := strings.Split(parts[0], "/")
 	if len(wssdk) != 2 {
-		return nil, fmt.Errorf("unknown plug or slot reference %q", plug)
+		return nil, fmt.Errorf("invalid SDK reference %q (expected <WORKSHOP>/<SDK>)", parts[0])
 	}
 
 	plugRef.Workshop = wssdk[0]
@@ -137,7 +137,7 @@ func ParseSlotSdkRef(slot string) (*SlotRef, error) {
 	var slotRef SlotRef
 	parts := strings.Split(slot, "/")
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("unknown plug or slot reference %q", slot)
+		return nil, fmt.Errorf("invalid SDK reference %q (expected <WORKSHOP>/<SDK>)", slot)
 	}
 	slotRef.Workshop = parts[0]
 	slotRef.Sdk = parts[1]

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -100,27 +100,6 @@ type DisconnectOptions struct {
 	Forget bool
 }
 
-func ParseFullPlugRef(plug string) (*PlugRef, error) {
-	// the expected format of the plug ref is <workshop>[/<sdk>]:<plug>
-	var plugRef PlugRef
-
-	parts := strings.Split(plug, ":")
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("unknown plug or slot reference %q", plug)
-	}
-
-	wssdk := strings.Split(parts[0], "/")
-	if len(wssdk) != 3 {
-		return nil, fmt.Errorf("unknown plug or slot reference %q", plug)
-	}
-
-	plugRef.ProjectId = wssdk[0]
-	plugRef.Workshop = wssdk[1]
-	plugRef.Sdk = wssdk[2]
-	plugRef.Name = parts[1]
-	return &plugRef, nil
-}
-
 func ParseShortPlugRef(plug string) (*PlugRef, error) {
 	// the expected format of the plug ref is <workshop>[/<sdk>]:<plug>
 	var plugRef PlugRef

--- a/cmd/workshop/connect_test.go
+++ b/cmd/workshop/connect_test.go
@@ -21,6 +21,27 @@ func (m *connectSuite) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
+func (m *connectSuite) TestConnectAcrossWorkshops(c *check.C) {
+	cmd := &CmdConnect{root: &CmdRoot{}}
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		default:
+			c.Errorf("expected 1 call, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"ws/sdk:plug", "ws2/sdk:slot"})
+	c.Assert(err, check.ErrorMatches, "cannot connect plugs and slots across different workshops")
+}
+
 func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 	cmd := &CmdConnect{root: &CmdRoot{}}
 	body := map[string]interface{}{

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -25,6 +26,7 @@ func (c *CmdRoot) Command(cwd string) *cobra.Command {
 		SilenceUsage:     true,
 		TraverseChildren: true,
 
+		PersistentPreRunE: c.preRun,
 		PersistentPostRun: c.postRun,
 	}
 
@@ -66,6 +68,15 @@ func (c *CmdRoot) client() (*client.Client, error) {
 	}
 
 	return cli, err
+}
+
+func (c *CmdRoot) preRun(cmd *cobra.Command, args []string) error {
+	project, err := filepath.Abs(c.project)
+	if err != nil {
+		return err
+	}
+	c.project = project
+	return nil
 }
 
 func (c *CmdRoot) postRun(cmd *cobra.Command, args []string) {

--- a/cmd/workshop/remount_test.go
+++ b/cmd/workshop/remount_test.go
@@ -64,5 +64,5 @@ func (m *remountSuite) TestRemountSuccess(c *check.C) {
 func (m *remountSuite) TestRemountBrokenReference(c *check.C) {
 	cmd := &CmdRemount{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"ws:sdk:plug", "/new/source"})
-	c.Assert(err, check.ErrorMatches, `unknown plug or slot reference "ws:sdk:plug"`)
+	c.Assert(err, check.ErrorMatches, `invalid plug or slot reference "ws:sdk:plug" \(expected <WORKSHOP>/<SDK>:<PLUG>\)`)
 }

--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -153,7 +153,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	var checkTicker <-chan time.Time
 	var tic *time.Ticker
 	if err := sanityCheck(); err != nil {
-		degradedErr := fmt.Errorf("system is not healthy: %s", err)
+		degradedErr := fmt.Errorf("system is not healthy: %w", err)
 		logger.Noticef("%s", degradedErr)
 		d.SetDegradedMode(degradedErr)
 		tic = time.NewTicker(checkRunningConditionsRetryDelay)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -157,18 +157,18 @@ Error messages
 - **Be consistent**:
   Try to match the style of existing error messages.
   Most of these can be found by searching for ``fmt.Errorf`` and ``errors.New``.
-  Paths and other identifiers should be quoted if possible.
+  Paths and other identifiers should be double-quoted if possible.
 
 - **Consider the user experience**:
-  Error messages should be clear, and when possible, actionable.
+  Error messages should be clear and actionable.
 
 - **Be specific**:
-  For example, if a file was not found, the error message should include the path.
+  For example, if a file was not found, the error message should include its path.
 
-- **Think about nesting**:
-  Start with lowercase letters and avoid trailing punctuation.
-  Try to avoid excessively long or repetitive error chains.
-  A common template is ``what was attempted: why it went wrong``.
+- **Mind the nesting**:
+  Start in lowercase and avoid trailing punctuation.
+  Avoid excessively long or repetitive error chains.
+  A common template is: ``what was attempted: why it went wrong``.
 
 
 Code structure

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -151,6 +151,26 @@ follow a consistent pattern:
    }
 
 
+Error messages
+~~~~~~~~~~~~~~
+
+- **Be consistent**:
+  Try to match the style of existing error messages.
+  Most of these can be found by searching for ``fmt.Errorf`` and ``errors.New``.
+  Paths and other identifiers should be quoted if possible.
+
+- **Consider the user experience**:
+  Error messages should be clear, and when possible, actionable.
+
+- **Be specific**:
+  For example, if a file was not found, the error message should include the path.
+
+- **Think about nesting**:
+  Start with lowercase letters and avoid trailing punctuation.
+  Try to avoid excessively long or repetitive error chains.
+  A common template is ``what was attempted: why it went wrong``.
+
+
 Code structure
 ~~~~~~~~~~~~~~
 

--- a/docs/reference/workshop-definition.rst
+++ b/docs/reference/workshop-definition.rst
@@ -48,7 +48,7 @@ and includes a number of mandatory and optional keys:
        It can be :samp:`ubuntu@20.04`, :samp:`ubuntu@22.04`
        or :samp:`ubuntu@24.04`.
 
-   * - :samp:`sdks` (required)
+   * - :samp:`sdks`
      - object
      - List of individual SDKs
        from the SDK Store to include in the workshop.
@@ -65,7 +65,7 @@ and includes a number of mandatory and optional keys:
        :samp:`slot` from the SDKs listed under :samp:`sdks` (the system SDK is
        always implicitly included). Both must be strings that reference a plug
        and a slot with the same interface in different SDKs, using the
-       :samp:`<SDK>/<PLUG>` format.
+       :samp:`<SDK>:<PLUG>` format.
 
 
 Any entry in :samp:`sdks` must be named after an existing SDK
@@ -101,7 +101,7 @@ Each SDK is described with the following keys:
        - A plug binding must name an existing plug in the SDK
          and set a single :samp:`bind` attribute
          that references a plug of the same interface in a different SDK
-         using the :samp:`<SDK>/<PLUG>` format.
+         using the :samp:`<SDK>:<PLUG>` format.
 
        - A plug definition must specify the :samp:`interface`
          and the relevant attributes.

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -261,7 +261,7 @@ func v1GetConnections(c *Command, r *http.Request, _ *userState) Response {
 
 	if workshop != "" {
 		if err := checkWorkshopExists(r.Context(), c.d.overlord.WorkshopManager(), projectId, workshop); err != nil {
-			return statusNotFound("cannot access workshop: %v", err)
+			return statusNotFound("cannot access workshop %q: %v", workshop, err)
 		}
 	}
 

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -236,7 +236,7 @@ func (s *apiSuite) TestConnectionsNotFound(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": `cannot access workshop: workshop not found`,
+			"message": `cannot access workshop "not-found": workshop has not been launched`,
 		},
 		"status":      "Not Found",
 		"status-code": 404.0,
@@ -1682,7 +1682,7 @@ func (s *apiSuite) testDisconnectFailureNoWorkshop(c *check.C, installedWorkshop
 	if producer {
 		c.Check(body, check.DeepEquals, map[string]interface{}{
 			"result": map[string]interface{}{
-				"message": `cannot access workshop "consumer-ws": workshop not found`,
+				"message": `cannot access workshop "consumer-ws": workshop has not been launched`,
 			},
 			"status":      "Not Found",
 			"status-code": 404.0,
@@ -1691,7 +1691,7 @@ func (s *apiSuite) testDisconnectFailureNoWorkshop(c *check.C, installedWorkshop
 	} else {
 		c.Check(body, check.DeepEquals, map[string]interface{}{
 			"result": map[string]interface{}{
-				"message": `cannot access workshop "producer-ws": workshop not found`,
+				"message": `cannot access workshop "producer-ws": workshop has not been launched`,
 			},
 			"status":      "Not Found",
 			"status-code": 404.0,

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1237,7 +1237,7 @@ slots:
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": "cannot connect consumer-ws/consumer:plug (\"test\" interface) to producer-ws/producer:slot (\"different\" interface)",
+			"message": `cannot connect "consumer-ws/consumer:plug" ("test" interface) to "producer-ws/producer:slot" ("different" interface)`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1276,7 +1276,7 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": "SDK \"consumer-ws/consumer\" has no plug named \"missingplug\"",
+			"message": `SDK "consumer-ws/consumer" has no plug named "missingplug"`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1315,7 +1315,7 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": "SDK producer-ws/producer has no slot named \"missingslot\"",
+			"message": `SDK "producer-ws/producer" has no slot named "missingslot"`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1635,7 +1635,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": `sdk "consumer" has no plug named "missingplug"`,
+			"message": `SDK "consumer-ws/consumer" has no plug named "missingplug"`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1772,7 +1772,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": "cannot disconnect consumer-ws/consumer:plug from producer-ws/producer:slot, it is not connected",
+			"message": `cannot disconnect "consumer-ws/consumer:plug" from "producer-ws/producer:slot": they are not connected`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1809,7 +1809,7 @@ func (s *apiSuite) TestDisconnectForgetPlugFailureNotConnected(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": "cannot forget connection consumer-ws/consumer:plug from producer-ws/producer:slot, it was not connected",
+			"message": `cannot disconnect "consumer-ws/consumer:plug" from "producer-ws/producer:slot": they are not connected`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -62,6 +62,10 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	reqData.Plug.Workshop = w
 	reqData.Plug.ProjectId = projectId
 
+	if err := checkWorkshopExists(r.Context(), o.WorkshopManager(), projectId, w); err != nil {
+		return statusNotFound("cannot access workshop %q: %v", w, err)
+	}
+
 	change := newMountChange(st, user, &reqData)
 	defer func() {
 		if len(change.Tasks()) == 0 {

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -80,7 +80,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	if len(connRef) == 0 {
-		return statusBadRequest(`"%s/%s:%s" must be connected for remount`, reqData.Plug.Workshop, reqData.Plug.Sdk, reqData.Plug.Name)
+		return statusBadRequest("cannot remount %q: plug is disconnected", reqData.Plug.ShortRef())
 	}
 
 	conn, err := repo.Connection(connRef[0])
@@ -89,7 +89,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	if conn.Plug.Interface() != "mount" {
-		return statusBadRequest("remount requires a content interface plug (provided plug is of %q interface)", conn.Plug.Interface())
+		return statusBadRequest(`cannot remount %q: interface type should be "mount" (now: %q)`, reqData.Plug.ShortRef(), conn.Plug.Interface())
 	}
 
 	taskset, err := o.WorkshopManager().Remount(r.Context(), st, reqData.Plug, reqData.HostSource, projectId)

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -161,7 +161,7 @@ func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `"manysdks/test-sdk:data" must be connected for remount`,
+			Message: `cannot remount "manysdks/test-sdk:data": plug is disconnected`,
 		},
 	}
 
@@ -213,7 +213,7 @@ func (s *apiSuite) TestWorkshopRemountInvalidInterface(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `remount requires a content interface plug (provided plug is of "gpu" interface)`,
+			Message: `cannot remount "manysdks/test-sdk-2:gpu": interface type should be "mount" (now: "gpu")`,
 		},
 	}
 
@@ -238,7 +238,7 @@ func (s *apiSuite) TestWorkshopRemountStaticSlotSourceFails(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "remount",
 			Summary:   `Remount workshopconns/test-sdk:data`,
-			ChangeErr: `(?s).*sdk "system" does not have attribute "host-source" for interface "mount".*`,
+			ChangeErr: `(?s).*SDK "system" does not have attribute "host-source" for interface "mount".*`,
 		},
 	}
 

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -121,6 +121,27 @@ func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
 	c.Assert(conn.Slot.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"host-source": src})
 }
 
+func (s *apiSuite) TestWorkshopRemountNoWorkshop(c *check.C) {
+	// Setup
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"host-source":"/srv/data"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusNotFound,
+			Message: `cannot access workshop "missing": workshop has not been launched`,
+		},
+	}
+
+	s.runMountTest(c, "missing", requests, expected)
+}
+
 func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
 	// Setup
 	s.daemon(c)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -185,7 +185,8 @@ func newWorkshopChange(st *state.State, kind string, user, projectId, action str
 }
 
 func newWorkshopSdkChange(st *state.State, kind string, user, projectId, action string, wp, sk string) *state.Change {
-	summary := fmt.Sprintf(`%s "%s/%s" SDK`, cases.Title(language.BritishEnglish).String(action), wp, sk)
+	sdkRef := sdk.Ref{ProjectId: projectId, Workshop: wp, Sdk: sk}
+	summary := fmt.Sprintf(`%s %q SDK`, cases.Title(language.BritishEnglish).String(action), sdkRef.ShortRef())
 	change := st.NewChange(kind, summary)
 	change.Set("user", user)
 	change.Set("project-id", projectId)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -28,6 +28,10 @@ var (
 base: ubuntu@22.04
 `
 
+	basic_invalid = `name: [basic]
+base: ubuntu@22.04
+`
+
 	basic_refreshed = `name: basic
 base: ubuntu@22.04
 sdks:
@@ -661,13 +665,17 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "basic", basic)
+	s.createWFile(c, "basic-invalid", basic_invalid)
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic", "basic", "basic"],"action":"launch"}`),
 		bytes.NewBufferString(`{"names":[],"action":"launch"}`),
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["missing"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic-invalid"],"action":"launch"}`),
 	}
 
+	missingFile := workshop.Filepath(s.project.Path, "missing")
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
@@ -682,8 +690,19 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 		},
 		{
 			Type:    ResponseTypeError,
-			Message: `cannot launch: "basic" already exists`,
 			Status:  http.StatusBadRequest,
+			Message: `cannot launch "basic": workshop already exists`,
+		},
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: fmt.Sprintf(`cannot launch "missing": workshop definition %q not found`, missingFile),
+		},
+		{
+			Type:   ResponseTypeError,
+			Status: http.StatusBadRequest,
+			Message: `cannot launch "basic-invalid": workshop definition YAML:
+line 1: cannot unmarshal !!seq into string`,
 		},
 	}
 
@@ -1240,7 +1259,7 @@ func (s *apiSuite) TestRefreshWorkshopIncorrectInput(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot continue, no refresh in progress",
+			Message: "cannot continue: no refresh in progress",
 		}, {
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
@@ -1344,12 +1363,12 @@ func (s *apiSuite) TestRefreshWorkshopNoRefreshInProgress(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot continue, no refresh in progress",
+			Message: "cannot continue: no refresh in progress",
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot abort, no refresh in progress",
+			Message: "cannot abort: no refresh in progress",
 		},
 	}
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -839,7 +839,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "launch",
 			Summary:   `Launch "masterunknown" workshop`,
-			ChangeErr: `(?s).*SDK masterunknown/test-sdk has no "unknown-data" plug.*`,
+			ChangeErr: `(?s).*SDK "masterunknown/test-sdk" has no plug named "unknown-data".*`,
 		},
 	}
 
@@ -864,7 +864,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "launch",
 			Summary:   `Launch "slaveunknown" workshop`,
-			ChangeErr: `(?s).*SDK slaveunknown/test-sdk has no "unknown" plug.*`,
+			ChangeErr: `(?s).*SDK "slaveunknown/test-sdk" has no plug named "unknown".*`,
 		},
 	}
 
@@ -889,7 +889,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "launch",
 			Summary:   `Launch "bindincompatible" workshop`,
-			ChangeErr: `(?s).*cannot bind bindincompatible/test-sdk:data \("mount" interface\) to bindincompatible/test-sdk-2:gpu \("gpu" interface\).*`,
+			ChangeErr: `(?s).*cannot bind "bindincompatible/test-sdk:data" \("mount" interface\) to "bindincompatible/test-sdk-2:gpu" \("gpu" interface\).*`,
 		},
 	}
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -177,15 +177,6 @@ connections:
     slot: system:training
 `
 
-	workshopconns_refreshed = `name: workshopconns
-base: ubuntu@22.04
-sdks:
-  test-sdk:
-    channel: latest/stable
-  test-sdk-2:
-    channel: latest/stable
-`
-
 	workshopbrokenconn = `name: workshopbrokenconn
 base: ubuntu@22.04
 sdks:

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -772,7 +772,7 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	s.runActionTest(c, requests, expected)
 
 	_, err := s.b.Workshop(s.ctx, "manysdks")
-	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
+	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
 
 	repo := s.d.overlord.InterfaceManager().Repository()
 	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", sdk.System.String()), check.HasLen, 0)
@@ -1647,6 +1647,6 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 	s.runActionTest(c, requests, expected)
 
 	_, err := s.b.Workshop(s.ctx, "workshopconns")
-	c.Check(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
+	c.Check(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
 	c.Check(s.secBackend.RemoveCalls, check.HasLen, 3)
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1541,7 +1541,7 @@ base: ubuntu@22.04
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot refresh: "manysdks" status is "Pending", must be one of: "Ready"`,
+			Message: `cannot refresh "manysdks": refresh waiting on error`,
 			Summary: `Refresh "manysdks" workshop`,
 		},
 	}
@@ -1588,7 +1588,7 @@ func (s *apiSuite) TestStartWorkshop(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot start: "basic" status is "Ready", must be one of: "Stopped"`,
+			Message: `cannot start "basic": workshop already running`,
 		},
 	}
 

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -73,7 +73,7 @@ func (f *storeIntegration) TestStoreDownloadCleanupPrevious(c *check.C) {
 	err = s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(setup.Filename(), testutil.FilePresent)
-	c.Assert(prev, check.Not(testutil.FilePresent))
+	c.Assert(prev, testutil.FileAbsent)
 	c.Assert(os.Remove(setup.Filename()), check.IsNil)
 }
 
@@ -82,7 +82,7 @@ func (f *storeIntegration) TestStoreDownloadNotfound(c *check.C) {
 	setup := sdk.Setup{Name: "test-sdk-unknown", Channel: "latest/stable"}
 	err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.ErrorMatches, `SDK not found in "latest/stable"`)
-	c.Assert(setup.Filename(), check.Not(testutil.FilePresent))
+	c.Assert(setup.Filename(), testutil.FileAbsent)
 }
 
 func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.C) {
@@ -134,7 +134,7 @@ func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 55}}
 	err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(setup.Filename(), check.Not(testutil.FilePresent))
+	c.Assert(setup.Filename(), testutil.FileAbsent)
 }
 
 func (s *storeIntegration) TestSdkActionInstallStoreError(c *check.C) {

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -103,7 +103,7 @@ func lookupAttr(staticAttrs map[string]interface{}, dynamicAttrs map[string]inte
 func getAttribute(sdkName string, ifaceName string, staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string, val interface{}) error {
 	v, ok := lookupAttr(staticAttrs, dynamicAttrs, path)
 	if !ok {
-		err := fmt.Errorf("sdk %q does not have attribute %q for interface %q", sdkName, path, ifaceName)
+		err := fmt.Errorf("SDK %q does not have attribute %q for interface %q", sdkName, path, ifaceName)
 		return sdk.AttributeNotFoundError{Err: err}
 	}
 
@@ -184,7 +184,7 @@ func (plug *ConnectedPlug) Lookup(path string) (interface{}, bool) {
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
 func (plug *ConnectedPlug) SetAttr(key string, value interface{}) error {
 	if _, ok := plug.staticAttrs[key]; ok {
-		return fmt.Errorf("cannot change attribute %q as it was statically specified in the %q sdk details", key, plug.plugInfo.Sdk.Name)
+		return fmt.Errorf("cannot change attribute %q as it was statically specified in the %q SDK details", key, plug.plugInfo.Sdk.Name)
 	}
 	if plug.dynamicAttrs == nil {
 		plug.dynamicAttrs = make(map[string]interface{})
@@ -242,7 +242,7 @@ func (slot *ConnectedSlot) Lookup(path string) (interface{}, bool) {
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
 func (slot *ConnectedSlot) SetAttr(key string, value interface{}) error {
 	if _, ok := slot.staticAttrs[key]; ok {
-		return fmt.Errorf("cannot change attribute %q as it was statically specified in the %q sdk details", key, slot.slotInfo.Sdk.Name)
+		return fmt.Errorf("cannot change attribute %q as it was statically specified in the %q SDK details", key, slot.slotInfo.Sdk.Name)
 	}
 	if slot.dynamicAttrs == nil {
 		slot.dynamicAttrs = make(map[string]interface{})

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -84,7 +84,7 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 
 	var val string
 	var intVal int
-	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `sdk "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `SDK "producer" does not have attribute "unknown" for interface "interface"`)
 
 	attrs := slot.StaticAttrs()
 	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
@@ -95,8 +95,8 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 	slot.StaticAttr("attr", &val)
 	c.Assert(val, check.Equals, "value")
 
-	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `sdk "producer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(slot.StaticAttr("attr", &intVal), check.ErrorMatches, `sdk "producer" has interface "interface" with invalid value type string for "attr" attribute: \*int`)
+	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `SDK "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(slot.StaticAttr("attr", &intVal), check.ErrorMatches, `SDK "producer" has interface "interface" with invalid value type "string" for "attr" attribute: \*int`)
 	c.Check(slot.StaticAttr("attr", val), check.ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
 
 	// static attributes passed via args take precedence over slot.Attrs
@@ -123,7 +123,7 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 
 	var val string
 	var intVal int
-	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `sdk "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `SDK "consumer" does not have attribute "unknown" for interface "interface"`)
 
 	attrs := plug.StaticAttrs()
 	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
@@ -133,8 +133,8 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 	plug.StaticAttr("attr", &val)
 	c.Assert(val, check.Equals, "value")
 
-	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `sdk "consumer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(plug.StaticAttr("attr", &intVal), check.ErrorMatches, `sdk "consumer" has interface "interface" with invalid value type string for "attr" attribute: \*int`)
+	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `SDK "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(plug.StaticAttr("attr", &intVal), check.ErrorMatches, `SDK "consumer" has interface "interface" with invalid value type "string" for "attr" attribute: \*int`)
 	c.Check(plug.StaticAttr("attr", val), check.ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
 
 	// static attributes passed via args take precedence over plug.Attrs
@@ -170,8 +170,8 @@ func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
 	num := mapVal["number-two"]
 	c.Assert(num, check.Equals, int64(222))
 
-	c.Check(slot.Attr("unknown", &strVal), check.ErrorMatches, `sdk "producer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(slot.Attr("foo", &intVal), check.ErrorMatches, `sdk "producer" has interface "interface" with invalid value type string for "foo" attribute: \*int64`)
+	c.Check(slot.Attr("unknown", &strVal), check.ErrorMatches, `SDK "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(slot.Attr("foo", &intVal), check.ErrorMatches, `SDK "producer" has interface "interface" with invalid value type "string" for "foo" attribute: \*int64`)
 	c.Check(slot.Attr("number", intVal), check.ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
 }
 
@@ -292,8 +292,8 @@ func (s *connSuite) TestDynamicPlugAttrs(c *check.C) {
 	num := mapVal["number-two"]
 	c.Assert(num, check.Equals, int64(222))
 
-	c.Check(plug.Attr("unknown", &strVal), check.ErrorMatches, `sdk "consumer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(plug.Attr("foo", &intVal), check.ErrorMatches, `sdk "consumer" has interface "interface" with invalid value type string for "foo" attribute: \*int64`)
+	c.Check(plug.Attr("unknown", &strVal), check.ErrorMatches, `SDK "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Check(plug.Attr("foo", &intVal), check.ErrorMatches, `SDK "consumer" has interface "interface" with invalid value type "string" for "foo" attribute: \*int64`)
 	c.Check(plug.Attr("number", intVal), check.ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
 }
 
@@ -307,11 +307,11 @@ func (s *connSuite) TestOverwriteStaticAttrError(c *check.C) {
 
 	err := plug.SetAttr("attr", "overwrite")
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the "consumer" sdk details`)
+	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the "consumer" SDK details`)
 
 	err = slot.SetAttr("attr", "overwrite")
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the "producer" sdk details`)
+	c.Assert(err, check.ErrorMatches, `cannot change attribute "attr" as it was statically specified in the "producer" SDK details`)
 }
 
 func (s *connSuite) TestCopyAttributes(c *check.C) {
@@ -363,7 +363,7 @@ func (s *connSuite) TestGetAttributeUnhappy(c *check.C) {
 	var stringVal string
 	err := interfaces.GetAttribute("sdk0", "iface0", attrs, attrs, "non-existent", &stringVal)
 	c.Check(stringVal, check.Equals, "")
-	c.Check(err, check.ErrorMatches, `sdk "sdk0" does not have attribute "non-existent" for interface "iface0"`)
+	c.Check(err, check.ErrorMatches, `SDK "sdk0" does not have attribute "non-existent" for interface "iface0"`)
 	c.Check(errors.Is(err, sdk.AttributeNotFoundError{}), check.Equals, true)
 }
 

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -70,14 +70,18 @@ func NewPlugRef(info *sdk.PlugInfo) PlugRef {
 	return PlugRef{ProjectId: info.Sdk.ProjectId, Workshop: info.Sdk.Workshop, Sdk: info.Sdk.Name, Name: info.Name}
 }
 
-// String returns the "project-id/workshop/sdk:plug" representation of a plug reference.
-func (ref PlugRef) String() string {
-	return fmt.Sprintf("%s/%s/%s:%s", ref.ProjectId, ref.Workshop, ref.Sdk, ref.Name)
+func (ref PlugRef) SdkRef() sdk.Ref {
+	return sdk.Ref{ProjectId: ref.ProjectId, Workshop: ref.Workshop, Sdk: ref.Sdk}
 }
 
-// String returns the "workshop/sdk:plug" representation of a plug reference (human-friendly).
+// String returns the "project-id/workshop/sdk:plug" representation of a plug reference.
+func (ref PlugRef) String() string {
+	return fmt.Sprintf("%s:%s", ref.SdkRef().String(), ref.Name)
+}
+
+// ShortRef returns the "workshop/sdk:plug" representation of a plug reference (human-friendly).
 func (ref PlugRef) ShortRef() string {
-	return fmt.Sprintf("%s/%s:%s", ref.Workshop, ref.Sdk, ref.Name)
+	return fmt.Sprintf("%s:%s", ref.SdkRef().ShortRef(), ref.Name)
 }
 
 // SortsBefore returns true when plug should be sorted before the other
@@ -116,14 +120,18 @@ func NewSlotRef(info *sdk.SlotInfo) SlotRef {
 	return SlotRef{ProjectId: info.Sdk.ProjectId, Workshop: info.Sdk.Workshop, Sdk: info.Sdk.Name, Name: info.Name}
 }
 
-// String returns the "project-id/workshop/sdk:slot" representation of a slot reference.
-func (ref SlotRef) String() string {
-	return fmt.Sprintf("%s/%s/%s:%s", ref.ProjectId, ref.Workshop, ref.Sdk, ref.Name)
+func (ref SlotRef) SdkRef() sdk.Ref {
+	return sdk.Ref{ProjectId: ref.ProjectId, Workshop: ref.Workshop, Sdk: ref.Sdk}
 }
 
-// String returns the "workshop/sdk:slot" representation of a slot reference (human-friendly).
+// String returns the "project-id/workshop/sdk:slot" representation of a slot reference.
+func (ref SlotRef) String() string {
+	return fmt.Sprintf("%s:%s", ref.SdkRef().String(), ref.Name)
+}
+
+// ShortRef returns the "workshop/sdk:slot" representation of a slot reference (human-friendly).
 func (ref SlotRef) ShortRef() string {
-	return fmt.Sprintf("%s/%s:%s", ref.Workshop, ref.Sdk, ref.Name)
+	return fmt.Sprintf("%s:%s", ref.SdkRef().ShortRef(), ref.Name)
 }
 
 // SortsBefore returns true when slot should be sorted before the other

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -99,7 +99,7 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 				return false, err
 			}
 		} else if !info.IsDir() {
-			return false, fmt.Errorf(`%s is not a directory`, dev.Where)
+			return false, fmt.Errorf(`%q is not a directory`, dev.Where)
 		}
 
 		// Ensure that the source path exists here. LXD allows to

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -238,7 +238,7 @@ func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error)
 func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(ctx, b.Name(), sdkInfo)
 	if err != nil {
-		return fmt.Errorf("cannot obtain device snippets for workshop %q: %s", sdkInfo.Workshop, err)
+		return fmt.Errorf("cannot obtain device snippets for workshop %q: %w", sdkInfo.Workshop, err)
 	}
 	spec := s.(*Specification)
 

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -279,23 +279,22 @@ func (r *Repository) Connection(connRef *ConnRef) (*Connection, error) {
 	plug := r.plugs[plugkey][connRef.PlugRef.Name]
 	if plug == nil {
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("sdk %q has no plug named %q",
-				connRef.PlugRef.Sdk, connRef.PlugRef.Name)}
+			message: fmt.Sprintf("SDK %q has no plug named %q",
+				connRef.PlugRef.SdkRef().ShortRef(), connRef.PlugRef.Name)}
 	}
 	// Ensure that such slot exists
 	slot := r.slots[slotkey][connRef.SlotRef.Name]
 	if slot == nil {
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("sdk %q has no slot named %q",
-				connRef.SlotRef.Sdk, connRef.SlotRef.Name)}
+			message: fmt.Sprintf("SDK %q has no slot named %q",
+				connRef.SlotRef.SdkRef().ShortRef(), connRef.SlotRef.Name)}
 	}
 	// Ensure that slot and plug are connected
 	conn, ok := r.slotPlugs[slot][plug]
 	if !ok {
 		return nil, &NotConnectedError{
-			message: fmt.Sprintf("no connection from %s:%s to %s:%s",
-				connRef.PlugRef.Sdk, connRef.PlugRef.Name,
-				connRef.SlotRef.Sdk, connRef.SlotRef.Name)}
+			message: fmt.Sprintf("no connection from %q to %q",
+				connRef.PlugRef.ShortRef(), connRef.SlotRef.ShortRef())}
 	}
 
 	return conn, nil
@@ -485,20 +484,18 @@ func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, sl
 	plug := r.plugs[plugKey][plugName]
 	if plug == nil {
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("cannot connect plug %q from sdk %q: no such plug",
-				plugName, plugSdkName)}
+			message: fmt.Sprintf("cannot connect plug %q: plug not found", ref.PlugRef.ShortRef())}
 	}
 	// Ensure that such slot exists
 	slot := r.slots[slotKey][slotName]
 	if slot == nil {
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("cannot connect slot %q from sdk %q: no such slot",
-				slotName, slotSdkName)}
+			message: fmt.Sprintf("cannot connect slot %q: slot not found", ref.SlotRef.ShortRef())}
 	}
 	// Ensure that plug and slot are compatible
 	if slot.Interface != plug.Interface {
-		return nil, fmt.Errorf(`cannot connect plug "%s:%s" (interface %q) to "%s:%s" (interface %q)`,
-			plugSdkName, plugName, plug.Interface, slotSdkName, slotName, slot.Interface)
+		return nil, fmt.Errorf(`cannot connect plug %q (%q interface) to %q (%q interface)`,
+			ref.PlugRef.ShortRef(), plug.Interface, ref.SlotRef.ShortRef(), slot.Interface)
 	}
 
 	iface, ok := r.ifaces[plug.Interface]
@@ -513,12 +510,12 @@ func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, sl
 	if policyCheck != nil {
 		if i, ok := iface.(plugValidator); ok {
 			if err := i.BeforeConnectPlug(cplug); err != nil {
-				return nil, fmt.Errorf("cannot connect plug %q of sdk %q: %s", plug.Name, plug.Sdk.Name, err)
+				return nil, fmt.Errorf("cannot connect plug %q: %w", ref.PlugRef.ShortRef(), err)
 			}
 		}
 		if i, ok := iface.(slotValidator); ok {
 			if err := i.BeforeConnectSlot(cslot); err != nil {
-				return nil, fmt.Errorf("cannot connect slot %q of sdk %q: %s", slot.Name, slot.Sdk.Name, err)
+				return nil, fmt.Errorf("cannot connect slot %q: %w", ref.SlotRef.ShortRef(), err)
 			}
 		}
 
@@ -574,13 +571,13 @@ func (r *Repository) Disconnect(plugProjectId, plugWorkshop, plugSdkName, plugNa
 
 	// Validity check
 	if plugSdkName == "" {
-		return fmt.Errorf("cannot disconnect, plug sdk name is empty")
+		return fmt.Errorf("cannot disconnect, plug SDK name is empty")
 	}
 	if plugName == "" {
 		return fmt.Errorf("cannot disconnect, plug name is empty")
 	}
 	if slotSdkName == "" {
-		return fmt.Errorf("cannot disconnect, slot sdk name is empty")
+		return fmt.Errorf("cannot disconnect, slot SDK name is empty")
 	}
 	if slotName == "" {
 		return fmt.Errorf("cannot disconnect, slot name is empty")
@@ -592,24 +589,24 @@ func (r *Repository) Disconnect(plugProjectId, plugWorkshop, plugSdkName, plugNa
 	// Ensure that such plug exists
 	plug := r.plugs[plugKey][plugName]
 	if plug == nil {
+		sdkRef := sdk.Ref{ProjectId: plugProjectId, Workshop: plugWorkshop, Sdk: plugSdkName}
 		return &NoPlugOrSlotError{
-			message: fmt.Sprintf("sdk %q has no plug named %q",
-				plugSdkName, plugName),
+			message: fmt.Sprintf("SDK %q has no plug named %q", sdkRef.ShortRef(), plugName),
 		}
 	}
 	// Ensure that such slot exists
 	slot := r.slots[slotKey][slotName]
 	if slot == nil {
+		sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
 		return &NoPlugOrSlotError{
-			message: fmt.Sprintf("sdk %q has no slot named %q",
-				slotSdkName, slotName),
+			message: fmt.Sprintf("SDK %q has no slot named %q", sdkRef.ShortRef(), slotName),
 		}
 	}
 	// Ensure that slot and plug are connected
 	if r.slotPlugs[slot][plug] == nil {
 		return &NotConnectedError{
-			message: fmt.Sprintf("cannot disconnect %s:%s from %s:%s, it is not connected",
-				plugSdkName, plugName, slotSdkName, slotName),
+			message: fmt.Sprintf("cannot disconnect %q from %q: they are not connected",
+				NewPlugRef(plug).ShortRef(), NewSlotRef(slot).ShortRef()),
 		}
 	}
 	r.disconnect(plug, slot)
@@ -654,16 +651,16 @@ func (r *Repository) Connected(projectId, workshop, sdkName, plugOrSlotName stri
 	return r.connected(projectId, workshop, sdkName, plugOrSlotName)
 }
 
-func (r *Repository) connected(projectId, workshop, sdk, plugOrSlotName string) ([]*ConnRef, error) {
+func (r *Repository) connected(projectId, workshop, sk, plugOrSlotName string) ([]*ConnRef, error) {
 	if workshop == "" {
 		return nil, fmt.Errorf("internal error: cannot obtain workshop name while computing connections")
 	}
 
-	if sdk == "" {
-		return nil, fmt.Errorf("internal error: cannot obtain sdk name while computing connections")
+	if sk == "" {
+		return nil, fmt.Errorf("internal error: cannot obtain SDK name while computing connections")
 	}
 
-	key := plugOrSlotKey(projectId, workshop, sdk)
+	key := plugOrSlotKey(projectId, workshop, sk)
 
 	var conns []*ConnRef
 	if plugOrSlotName == "" {
@@ -671,9 +668,10 @@ func (r *Repository) connected(projectId, workshop, sdk, plugOrSlotName string) 
 	}
 	// Check if plugOrSlotName actually maps to anything
 	if r.plugs[key][plugOrSlotName] == nil && r.slots[key][plugOrSlotName] == nil {
+		sdkRef := sdk.Ref{ProjectId: projectId, Workshop: workshop, Sdk: sk}
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("sdk %q has no plug or slot named %q",
-				sdk, plugOrSlotName)}
+			message: fmt.Sprintf("SDK %q has no plug or slot named %q",
+				sdkRef.ShortRef(), plugOrSlotName)}
 	}
 	// Collect all the relevant connections
 
@@ -909,14 +907,14 @@ func (r *Repository) RemoveSdk(projectId, workshop, sdkName string) error {
 
 	key := plugOrSlotKey(projectId, workshop, sdkName)
 
-	for plugName, plug := range r.plugs[key] {
+	for _, plug := range r.plugs[key] {
 		if len(r.plugSlots[plug]) > 0 {
-			return fmt.Errorf("cannot remove connected plug %s.%s", sdkName, plugName)
+			return fmt.Errorf("cannot remove connected plug %q", NewPlugRef(plug).ShortRef())
 		}
 	}
-	for slotName, slot := range r.slots[key] {
+	for _, slot := range r.slots[key] {
 		if len(r.slotPlugs[slot]) > 0 {
-			return fmt.Errorf("cannot remove connected slot %s.%s", sdkName, slotName)
+			return fmt.Errorf("cannot remove connected slot %q", NewSlotRef(slot).ShortRef())
 		}
 	}
 
@@ -1064,9 +1062,10 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 	// Ensure that such plug exists
 	plug := r.plugs[plugKey][plugName]
 	if plug == nil {
+		sdkRef := sdk.Ref{ProjectId: plugProjectId, Workshop: plugWorkshop, Sdk: plugSdkName}
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf(`SDK "%s/%s" has no plug named %q`,
-				plugWorkshop, plugSdkName, plugName),
+			message: fmt.Sprintf(`SDK %q has no plug named %q`,
+				sdkRef.ShortRef(), plugName),
 		}
 	}
 
@@ -1090,26 +1089,30 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 		}
 		switch len(candidates) {
 		case 0:
-			return nil, fmt.Errorf(`SDK %s/%s has no %q interface slots`, slotWorkshop, slotSdkName, plug.Interface)
+			sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
+			return nil, fmt.Errorf(`SDK %q has no %q interface slots`, sdkRef.ShortRef(), plug.Interface)
 		case 1:
 			slotName = candidates[0]
 		default:
 			sort.Strings(candidates)
-			return nil, fmt.Errorf("SDK %s/%s has multiple %q interface slots: %s", slotWorkshop, slotSdkName, plug.Interface, strings.Join(candidates, ", "))
+			sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
+			return nil, fmt.Errorf("SDK %q has multiple %q interface slots: %s",
+				sdkRef.ShortRef(), plug.Interface, strings.Join(candidates, ", "))
 		}
 	}
 
 	// Ensure that such slot exists
 	slot := r.slots[slotKey][slotName]
 	if slot == nil {
+		sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("SDK %s/%s has no slot named %q", slotWorkshop, slotSdkName, slotName),
+			message: fmt.Sprintf("SDK %q has no slot named %q", sdkRef.ShortRef(), slotName),
 		}
 	}
 	// Ensure that plug and slot are compatible
 	if slot.Interface != plug.Interface {
-		return nil, fmt.Errorf("cannot connect %s/%s:%s (%q interface) to %s/%s:%s (%q interface)",
-			plugWorkshop, plugSdkName, plugName, plug.Interface, slotWorkshop, slotSdkName, slotName, slot.Interface)
+		return nil, fmt.Errorf("cannot connect %q (%q interface) to %q (%q interface)",
+			NewPlugRef(plug).ShortRef(), plug.Interface, NewSlotRef(slot).ShortRef(), slot.Interface)
 	}
 	return NewConnRef(plug, slot), nil
 }

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -684,7 +684,7 @@ func (s *RepositorySuite) TestConnectFailsWhenPlugDoesNotExist(c *C) {
 	// Connecting an unknown plug returns an appropriate error
 	connRef := NewConnRef(s.plug, s.slot)
 	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
-	c.Assert(err, ErrorMatches, `cannot connect plug "plug" from sdk "consumer": no such plug`)
+	c.Assert(err, ErrorMatches, `cannot connect plug "ws/consumer:plug": plug not found`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -695,7 +695,7 @@ func (s *RepositorySuite) TestConnectFailsWhenSlotDoesNotExist(c *C) {
 	// Connecting to an unknown slot returns an error
 	connRef := NewConnRef(s.plug, s.slot)
 	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
-	c.Assert(err, ErrorMatches, `cannot connect slot "slot" from sdk "producer": no such slot`)
+	c.Assert(err, ErrorMatches, `cannot connect slot "ws/producer:slot": slot not found`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -743,7 +743,7 @@ func (s *RepositorySuite) TestConnectFailsWhenSlotAndPlugAreIncompatible(c *C) {
 	// Connecting a plug to an incompatible slot fails with an appropriate error
 	connRef := NewConnRef(s.plug, s.slot)
 	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
-	c.Assert(err, ErrorMatches, `cannot connect plug "consumer:plug" \(interface "other-interface"\) to "producer:slot" \(interface "interface"\)`)
+	c.Assert(err, ErrorMatches, `cannot connect plug "ws/consumer:plug" \("other-interface" interface\) to "ws/producer:slot" \("interface" interface\)`)
 }
 
 func (s *RepositorySuite) TestConnectSucceeds(c *C) {
@@ -766,16 +766,16 @@ func (s *RepositorySuite) TestDisconnectFailsOnEmptyArgs(c *C) {
 	err3 := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, "", s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	err4 := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, "", s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err1, ErrorMatches, `cannot disconnect, slot name is empty`)
-	c.Assert(err2, ErrorMatches, `cannot disconnect, slot sdk name is empty`)
+	c.Assert(err2, ErrorMatches, `cannot disconnect, slot SDK name is empty`)
 	c.Assert(err3, ErrorMatches, `cannot disconnect, plug name is empty`)
-	c.Assert(err4, ErrorMatches, `cannot disconnect, plug sdk name is empty`)
+	c.Assert(err4, ErrorMatches, `cannot disconnect, plug SDK name is empty`)
 }
 
 // Disconnect fails if plug doesn't exist
 func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
 	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `sdk "consumer" has no plug named "plug"`)
+	c.Assert(err, ErrorMatches, `SDK "ws/consumer" has no plug named "plug"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -784,7 +784,7 @@ func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
 func (s *RepositorySuite) TestDisconnectFailsWithutSlot(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `sdk "producer" has no slot named "slot"`)
+	c.Assert(err, ErrorMatches, `SDK "ws/producer" has no slot named "slot"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -794,7 +794,7 @@ func (s *RepositorySuite) TestDisconnectFailsWhenNotConnected(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
 	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `cannot disconnect consumer:plug from producer:slot, it is not connected`)
+	c.Assert(err, ErrorMatches, `cannot disconnect "ws/consumer:plug" from "ws/producer:slot": they are not connected`)
 	e, _ := err.(*NotConnectedError)
 	c.Check(e, NotNil)
 }
@@ -820,7 +820,7 @@ func (s *RepositorySuite) TestDisconnectSucceeds(c *C) {
 // Connected fails if sdk name is empty
 func (s *RepositorySuite) TestConnectedFailsWithEmptyWorkshopName(c *C) {
 	_, err := s.testRepo.Connected(s.projectId, "ws", "", s.plug.Name)
-	c.Check(err, ErrorMatches, "internal error: cannot obtain sdk name while computing connections")
+	c.Check(err, ErrorMatches, "internal error: cannot obtain SDK name while computing connections")
 }
 
 func (s *RepositorySuite) TestConnectedFailsWithEmptySdkName(c *C) {
@@ -838,10 +838,10 @@ func (s *RepositorySuite) TestConnectedFailsWithEmptyPlugSlotName(c *C) {
 func (s *RepositorySuite) TestConnectedFailsWithoutPlugOrSlot(c *C) {
 	_, err1 := s.testRepo.Connected(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
 	_, err2 := s.testRepo.Connected(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Check(err1, ErrorMatches, `sdk "consumer" has no plug or slot named "plug"`)
+	c.Check(err1, ErrorMatches, `SDK "ws/consumer" has no plug or slot named "plug"`)
 	e, _ := err1.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
-	c.Check(err2, ErrorMatches, `sdk "producer" has no plug or slot named "slot"`)
+	c.Check(err2, ErrorMatches, `SDK "ws/producer" has no plug or slot named "slot"`)
 	e, _ = err1.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -1548,7 +1548,7 @@ func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
 		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
 		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `cannot connect plug "consumer" of sdk "s1": invalid plug`)
+	c.Assert(err, ErrorMatches, `cannot connect plug "ws-s1/s1:consumer": invalid plug`)
 	c.Assert(conn, IsNil)
 }
 
@@ -1587,7 +1587,7 @@ func (s *RepositorySuite) TestConnection(c *C) {
 	connRef := NewConnRef(s.plug, s.slot)
 
 	_, err := s.testRepo.Connection(connRef)
-	c.Assert(err, ErrorMatches, `no connection from consumer:plug to producer:slot`)
+	c.Assert(err, ErrorMatches, `no connection from "ws/consumer:plug" to "ws/producer:slot"`)
 
 	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
@@ -1600,14 +1600,14 @@ func (s *RepositorySuite) TestConnection(c *C) {
 	_, err = s.testRepo.Connection(&ConnRef{
 		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"},
 		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"}})
-	c.Assert(err, ErrorMatches, `sdk "a" has no plug named "b"`)
+	c.Assert(err, ErrorMatches, `SDK "ws/a" has no plug named "b"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 
 	_, err = s.testRepo.Connection(&ConnRef{
 		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
 		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"}})
-	c.Assert(err, ErrorMatches, `sdk "a" has no slot named "b"`)
+	c.Assert(err, ErrorMatches, `SDK "ws/a" has no slot named "b"`)
 	e, _ = err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }

--- a/internal/metautil/type_conversions.go
+++ b/internal/metautil/type_conversions.go
@@ -80,7 +80,7 @@ type AttributeNotCompatibleError struct {
 }
 
 func (e AttributeNotCompatibleError) Error() string {
-	return fmt.Sprintf("sdk %q has interface %q with invalid value type %s for %q attribute: %s", e.SdkName, e.InterfaceName, e.AttributeType, e.AttributeName, e.ExpectedType)
+	return fmt.Sprintf("SDK %q has interface %q with invalid value type %q for %q attribute: %s", e.SdkName, e.InterfaceName, e.AttributeType, e.AttributeName, e.ExpectedType)
 }
 
 func (e AttributeNotCompatibleError) Is(target error) bool {

--- a/internal/metautil/type_conversions_test.go
+++ b/internal/metautil/type_conversions_test.go
@@ -133,7 +133,7 @@ func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 			"attr2",
 			"input value",
 			&outputBool,
-			`sdk "sdk2" has interface "iface2" with invalid value type string for "attr2" attribute: \*bool`,
+			`SDK "sdk2" has interface "iface2" with invalid value type "string" for "attr2" attribute: \*bool`,
 		},
 	}
 

--- a/internal/osutil/exec.go
+++ b/internal/osutil/exec.go
@@ -109,7 +109,7 @@ func RunAndWait(argv []string, env []string, timeout time.Duration, tomb *tomb.T
 	// was reached. Kill the command and wait for command.Wait()
 	// to clean it up (but limit the wait with the cmdWaitTimer)
 	if err := KillProcessGroup(command); err != nil {
-		return nil, fmt.Errorf("cannot abort: %s", err)
+		return nil, fmt.Errorf("cannot abort: %w", err)
 	}
 	select {
 	case <-time.After(cmdWaitTimeout):

--- a/internal/osutil/export_test.go
+++ b/internal/osutil/export_test.go
@@ -78,10 +78,10 @@ func FakeMountInfo(text string) (restore func()) {
 	old := procSelfMountInfo
 	f, err := os.CreateTemp("", "mountinfo")
 	if err != nil {
-		panic(fmt.Errorf("cannot open temporary file: %s", err))
+		panic(fmt.Errorf("cannot open temporary file: %w", err))
 	}
 	if err := os.WriteFile(f.Name(), []byte(text), 0644); err != nil {
-		panic(fmt.Errorf("cannot write mock mountinfo file: %s", err))
+		panic(fmt.Errorf("cannot write mock mountinfo file: %w", err))
 	}
 	procSelfMountInfo = f.Name()
 	return func() {

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -72,11 +72,11 @@ func UidGid(u *user.User) (sys.UserID, sys.GroupID, error) {
 	// XXX this will be wrong for high uids on 32-bit arches (for now)
 	uid, err := strconv.Atoi(u.Uid)
 	if err != nil {
-		return sys.FlagID, sys.FlagID, fmt.Errorf("cannot parse user id %s: %s", u.Uid, err)
+		return sys.FlagID, sys.FlagID, fmt.Errorf("cannot parse user id %q: %w", u.Uid, err)
 	}
 	gid, err := strconv.Atoi(u.Gid)
 	if err != nil {
-		return sys.FlagID, sys.FlagID, fmt.Errorf("cannot parse group id %s: %s", u.Gid, err)
+		return sys.FlagID, sys.FlagID, fmt.Errorf("cannot parse group id %q: %w", u.Gid, err)
 	}
 
 	return sys.UserID(uid), sys.GroupID(gid), nil

--- a/internal/osutil/user_test.go
+++ b/internal/osutil/user_test.go
@@ -84,8 +84,8 @@ func (s *userSuite) TestUidGid(c *check.C) {
 		Err  string
 	}{
 		"happy":   {&user.User{Uid: "10", Gid: "10"}, 10, 10, ""},
-		"bad uid": {&user.User{Uid: "x", Gid: "10"}, sys.FlagID, sys.FlagID, "cannot parse user id x"},
-		"bad gid": {&user.User{Uid: "10", Gid: "x"}, sys.FlagID, sys.FlagID, "cannot parse group id x"},
+		"bad uid": {&user.User{Uid: "x", Gid: "10"}, sys.FlagID, sys.FlagID, `cannot parse user id "x"`},
+		"bad gid": {&user.User{Uid: "10", Gid: "x"}, sys.FlagID, sys.FlagID, `cannot parse group id "x"`},
 	} {
 		uid, gid, err := osutil.UidGid(t.User)
 		c.Check(uid, check.Equals, t.Uid, check.Commentf(k))

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -151,15 +151,15 @@ func ResumeRefresh(st *state.State,
 		}
 	}
 	if chg == nil {
-		return nil, fmt.Errorf("cannot %s, no refresh in progress", mode)
+		return nil, fmt.Errorf("cannot %s: no refresh in progress", mode)
 	}
 
 	if chg.Kind() != "refresh" {
-		return nil, fmt.Errorf("cannot resume, no refresh in progress (%q is in progress)", chg.Kind())
+		return nil, fmt.Errorf("cannot resume: no refresh in progress (%s is in progress)", chg.Kind())
 	}
 
 	if chg.Status() != state.WaitStatus {
-		return nil, fmt.Errorf("cannot resume, no refresh is waiting on error")
+		return nil, fmt.Errorf("cannot resume: no refresh is waiting on error")
 	}
 
 	for _, tsk := range chg.Tasks() {

--- a/internal/overlord/conflict/conflict_test.go
+++ b/internal/overlord/conflict/conflict_test.go
@@ -137,7 +137,7 @@ func (s *conflictSuite) TestResumeRefreshWrongChangeKindInProgress(c *check.C) {
 	_ = s.newChange("launch")
 
 	_, err := conflict.ResumeRefresh(s.state, "ws", s.project.ProjectId, conflict.RefreshContinue)
-	c.Check(err, check.ErrorMatches, `.* no refresh in progress \("launch" is in progress\)`)
+	c.Check(err, check.ErrorMatches, `.* no refresh in progress \(launch is in progress\)`)
 }
 
 func (s *conflictSuite) TestResumeRefreshNoWaitingOnError(c *check.C) {

--- a/internal/overlord/hookstate/context.go
+++ b/internal/overlord/hookstate/context.go
@@ -208,7 +208,7 @@ func (c *Context) Get(key string, value interface{}) error {
 
 	err := jsonutil.DecodeWithNumber(bytes.NewReader(*raw), &value)
 	if err != nil {
-		return fmt.Errorf("cannot unmarshal context value for %q: %s", key, err)
+		return fmt.Errorf("cannot unmarshal context value for %q: %w", key, err)
 	}
 
 	return nil

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -42,7 +42,7 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 
 		defer func() {
 			if err := h.backend.DetachVolume(ctx, w, volume); err != nil {
-				logger.Noticef("RunHook on Do: Cannot detach SDK state storage volume %s", volume)
+				logger.Noticef("RunHook on Do: Cannot detach SDK state storage volume %q", volume)
 			}
 		}()
 	}

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -161,7 +161,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, proj
 	hookLog, _ := afero.ReadFile(memFs, out.Name())
 	if len(hookLog) > 0 {
 		st.Lock()
-		task.Logf(string(hookLog))
+		task.Logf("%s", string(hookLog))
 		st.Unlock()
 	}
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -117,7 +117,7 @@ func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sd
 	connectTs := state.NewTaskSet()
 	var affected = map[sdk.Ref]bool{}
 	for _, ref := range refs {
-		connect := m.state.NewTask("connect", fmt.Sprintf("Connect %s to %s", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
+		connect := m.state.NewTask("connect", fmt.Sprintf("Connect %q to %q", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
 
 		connect.Set("plug", ref.PlugRef)
 		connect.Set("slot", ref.SlotRef)
@@ -247,12 +247,12 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 
 				slaveInfo := m.repo.Plug(slave.ProjectId, slave.Workshop, slave.Sdk, slave.Name)
 				if slaveInfo == nil {
-					return fmt.Errorf("SDK %s/%s has no %q plug", slave.Workshop, slave.Sdk, slave.Name)
+					return fmt.Errorf("SDK %q has no plug named %q", slave.SdkRef().ShortRef(), slave.Name)
 				}
 
 				if slaveInfo.Interface != plug.Interface {
-					return fmt.Errorf("cannot bind %s/%s:%s (%q interface) to %s/%s:%s (%q interface)",
-						slave.Workshop, slave.Sdk, slave.Name, slaveInfo.Interface, master.Workshop, master.Sdk, master.Name, plug.Interface)
+					return fmt.Errorf("cannot bind %q (%q interface) to %q (%q interface)",
+						slave.ShortRef(), slaveInfo.Interface, master.ShortRef(), plug.Interface)
 				}
 
 				if _, ok := conns[slref.ID()]; !ok {
@@ -294,7 +294,7 @@ func (m *InterfaceManager) batchDisconnectTasks(p *workshop.Project, workshop, s
 	var prev *state.Task
 	for _, ref := range refs {
 		task := m.state.NewTask("disconnect",
-			fmt.Sprintf("Disconnnect %s from %s", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
+			fmt.Sprintf("Disconnnect %q from %q", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
 		task.Set("plug", ref.PlugRef)
 		task.Set("slot", ref.SlotRef)
 		if conn := conns[ref.ID()]; conn != nil && conn.Undesired {
@@ -448,12 +448,12 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 
 	plug := m.repo.Plug(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name)
 	if plug == nil {
-		return fmt.Errorf("SDK %q has no %q plug", plugRef.Sdk, plugRef.Name)
+		return fmt.Errorf("SDK %q has no plug named %q", plugRef.SdkRef().ShortRef(), plugRef.Name)
 	}
 
 	slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
 	if slot == nil {
-		return fmt.Errorf("SDK %q has no %q slot", slotRef.Sdk, slotRef.Name)
+		return fmt.Errorf("SDK %q has no slot named %q", slotRef.SdkRef().ShortRef(), slotRef.Name)
 	}
 
 	var plugDynamicAttrs, slotDynamicAttrs map[string]interface{}
@@ -562,12 +562,12 @@ func (m *InterfaceManager) undoConnect(task *state.Task, tomb *tomb.Tomb) error 
 
 	plug := m.repo.Plug(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name)
 	if plug == nil {
-		return fmt.Errorf("SDK %q has no %q plug", plugRef.Sdk, plugRef.Name)
+		return fmt.Errorf("SDK %q has no plug named %q", plugRef.SdkRef().ShortRef(), plugRef.Name)
 	}
 
 	slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
 	if slot == nil {
-		return fmt.Errorf("SDK %q has no %q slot", slotRef.Sdk, slotRef.Name)
+		return fmt.Errorf("SDK %q has no slot named %q", slotRef.SdkRef().ShortRef(), slotRef.Name)
 	}
 
 	if err = m.repo.Disconnect(plugRef.ProjectId, plugRef.Workshop,
@@ -729,10 +729,10 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 		return nil
 	}
 	if plug == nil {
-		return fmt.Errorf("SDK %q has no %q plug", cref.PlugRef.Sdk, cref.PlugRef.Name)
+		return fmt.Errorf("SDK %q has no plug named %q", cref.PlugRef.SdkRef().ShortRef(), cref.PlugRef.Name)
 	}
 	if slot == nil {
-		return fmt.Errorf("SDK %q has no %q slot", cref.SlotRef.Sdk, cref.SlotRef.Name)
+		return fmt.Errorf("SDK %q has no slot named %q", cref.SlotRef.SdkRef().ShortRef(), cref.SlotRef.Name)
 	}
 
 	c, err := m.repo.Connect(&cref, oldconn.StaticPlugAttrs, oldconn.DynamicPlugAttrs,
@@ -844,7 +844,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 			backend := backend
 			rev.Add(func() {
 				if err1 := backend.Remove(ctx, ref.Workshop, ref.Sdk); err1 != nil {
-					logger.Noticef(`On doSetupProfiles: Failed to clean up "%s/%s" SDK backend setup`, ref.Workshop, ref.Sdk)
+					logger.Noticef(`On doSetupProfiles: Failed to clean up %q SDK backend setup`, ref.ShortRef())
 				}
 			})
 		}
@@ -1045,7 +1045,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 
 	_, err = os.Stat(oldSource)
 	if osutil.IsDirNotExist(err) {
-		task.State().Warnf("%s/%s:%s's source at %q does not exist; will attempt to recreate", plug.Workshop, plug.Sdk, plug.Name, oldSource)
+		task.State().Warnf("cannot find source %q for %q; will attempt to recreate", oldSource, plug.ShortRef())
 	} else if err != nil {
 		return err
 	} else {
@@ -1053,10 +1053,10 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 			if errno, ok := err.(syscall.Errno); ok {
 				if workshopRunning {
 					if errno == syscall.ENOTEMPTY {
-						return fmt.Errorf("new source is not empty; workshop must be stopped to remount safely")
+						return fmt.Errorf("source %q is not empty; workshop must be stopped to remount safely", source)
 					}
 					if errno == syscall.EXDEV {
-						return fmt.Errorf("current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely")
+						return fmt.Errorf("sources %q and %q are not on the same mounted filesystem; workshop must be stopped to remount safely", oldSource, source)
 					}
 					return err
 				} else {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -619,7 +619,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 
 	var forget bool
 	if err := task.Get("forget", &forget); err != nil && !errors.Is(err, state.ErrNoState) {
-		return fmt.Errorf("internal error: cannot read 'forget' flag: %s", err)
+		return fmt.Errorf("internal error: cannot read 'forget' flag: %w", err)
 	}
 
 	conn, ok := conns[cref.ID()]
@@ -705,7 +705,7 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 
 	var forget bool
 	if err := task.Get("forget", &forget); err != nil && !errors.Is(err, state.ErrNoState) {
-		return fmt.Errorf("internal error: cannot read 'forget' flag: %s", err)
+		return fmt.Errorf("internal error: cannot read 'forget' flag: %w", err)
 	}
 	var oldconn schema.ConnState
 	if err = task.Get("old-conn", &oldconn); err != nil {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -1072,7 +1072,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 		} else {
 			revert.Add(func() {
 				if err := os.Rename(source, oldSource); err != nil {
-					logger.Debugf("On doRemount: Cannot rename %s to %s on a failed remount", source, oldSource)
+					logger.Debugf("On doRemount: Cannot rename %q to %q on a failed remount", source, oldSource)
 				}
 			})
 		}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -1058,6 +1058,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 					if errno == syscall.EXDEV {
 						return fmt.Errorf("current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely")
 					}
+					return err
 				} else {
 					// if the workshop is stopped, we can perform a remount safely
 					// (other fs or non-empty dir), otherwise, return the error

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -3,6 +3,7 @@ package ifacestate_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -303,7 +304,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindMasterPlugNotFound(c *check.
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Check(chg.Err(), check.ErrorMatches, `(?s).*SDK "consumer" has no "no-such-plug2" plug.*`)
+	c.Check(chg.Err(), check.ErrorMatches, `(?s).*SDK "ws/consumer" has no plug named "no-such-plug2".*`)
 
 	// Validate
 	pconns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
@@ -394,7 +395,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingContentTargets
 	defer s.state.Unlock()
 
 	// Validate
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target /home/workshop is also mounted by.*`)
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target "/home/workshop" is also mounted by.*`)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.C) {
@@ -641,7 +642,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *chec
 	// Validate
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Check(change.Err(), check.ErrorMatches, "(?s).*\\(new source is not empty; workshop must be stopped to remount safely\\)")
+	c.Check(change.Err(), check.ErrorMatches, fmt.Sprintf(`(?s).*\(source %q is not empty; workshop must be stopped to remount safely\)`, newSource))
 	c.Assert(change.Status(), check.Equals, state.ErrorStatus)
 
 	repo := s.mgr.Repository()
@@ -751,6 +752,10 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C)
 	s.state.Lock()
 	defer s.state.Unlock()
 	c.Assert(change.Status(), check.Equals, state.DoneStatus)
+
+	warnings := s.state.AllWarnings()
+	c.Check(warnings, check.HasLen, 1)
+	c.Check(warnings[0].String(), check.Equals, `cannot find source "/does/not/exist" for "ws-consumer/consumer:plug"; will attempt to recreate`)
 
 	repo := s.mgr.Repository()
 	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -563,7 +563,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	c.Assert(connection.Slot.Attr("host-source", &remountSource), check.IsNil)
 	c.Assert(remountSource, check.Equals, newSource)
 
-	c.Assert(oldSource, check.Not(testutil.FilePresent))
+	c.Assert(oldSource, testutil.FileAbsent)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 
 	// ensure the global conns state was updated correctly
@@ -607,7 +607,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	c.Assert(connection.Slot.Attr("host-source", &remountSource), check.IsNil)
 	c.Assert(remountSource, check.Equals, newSource)
 
-	c.Assert(oldSource, check.Not(testutil.FilePresent))
+	c.Assert(oldSource, testutil.FileAbsent)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 	c.Assert(s.secBackend.SetupCalls[0].SdkInfo.Sdk, check.Equals, "consumer")
 	c.Assert(s.secBackend.SetupCalls[0].SdkInfo.Workshop, check.Equals, "ws-consumer")
@@ -766,7 +766,7 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(src, check.Equals, oldSource)
 
 	c.Assert(oldSource, testutil.FilePresent)
-	c.Assert(newSource, check.Not(testutil.FilePresent))
+	c.Assert(newSource, testutil.FileAbsent)
 	// 2 calls for the autoconnect, no calls for the remount
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 }

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
-	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/ifacestate/schema"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -564,7 +563,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	c.Assert(connection.Slot.Attr("host-source", &remountSource), check.IsNil)
 	c.Assert(remountSource, check.Equals, newSource)
 
-	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
+	c.Assert(oldSource, check.Not(testutil.FilePresent))
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 
 	// ensure the global conns state was updated correctly
@@ -608,7 +607,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	c.Assert(connection.Slot.Attr("host-source", &remountSource), check.IsNil)
 	c.Assert(remountSource, check.Equals, newSource)
 
-	c.Assert(osutil.FileExists(oldSource), check.Equals, false)
+	c.Assert(oldSource, check.Not(testutil.FilePresent))
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 	c.Assert(s.secBackend.SetupCalls[0].SdkInfo.Sdk, check.Equals, "consumer")
 	c.Assert(s.secBackend.SetupCalls[0].SdkInfo.Workshop, check.Equals, "ws-consumer")
@@ -656,8 +655,8 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *chec
 	c.Assert(connection.Slot.Attr("host-source", &src), check.IsNil)
 	c.Assert(src, check.Equals, oldSource)
 
-	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
-	c.Assert(osutil.FileExists(newSource), check.Equals, true)
+	c.Assert(oldSource, testutil.FilePresent)
+	c.Assert(newSource, testutil.FilePresent)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 }
 
@@ -694,8 +693,8 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 	c.Assert(connection.Slot.Attr("host-source", &src), check.IsNil)
 	c.Assert(src, check.Equals, newSource)
 
-	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
-	c.Assert(osutil.FileExists(newSource), check.Equals, true)
+	c.Assert(oldSource, testutil.FilePresent)
+	c.Assert(newSource, testutil.FilePresent)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 }
 
@@ -728,8 +727,8 @@ func (s *interfaceHandlersSuite) TestRemountRenameUnexpectedError(c *check.C) {
 	c.Assert(connection.Slot.Attr("host-source", &src), check.IsNil)
 	c.Assert(src, check.Equals, oldSource)
 
-	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
-	c.Assert(osutil.FileExists(newSource), check.Equals, true)
+	c.Assert(oldSource, testutil.FilePresent)
+	c.Assert(newSource, testutil.FilePresent)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 }
 
@@ -766,8 +765,8 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(connection.Slot.Attr("host-source", &src), check.IsNil)
 	c.Assert(src, check.Equals, oldSource)
 
-	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
-	c.Assert(osutil.FileExists(newSource), check.Equals, false)
+	c.Assert(oldSource, testutil.FilePresent)
+	c.Assert(newSource, check.Not(testutil.FilePresent))
 	// 2 calls for the autoconnect, no calls for the remount
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 }
@@ -802,7 +801,7 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C)
 	c.Assert(connection.Slot.Attr("host-source", &src), check.IsNil)
 	c.Assert(src, check.Equals, newSource)
 
-	c.Assert(osutil.FileExists(newSource), check.Equals, true)
+	c.Assert(newSource, testutil.FilePresent)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 }
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -699,6 +699,40 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 }
 
+func (s *interfaceHandlersSuite) TestRemountRenameUnexpectedError(c *check.C) {
+	// Setup
+	oldSource := c.MkDir()
+	newSource := filepath.Join(c.MkDir(), "new-source")
+	_, err := os.Create(newSource)
+	c.Check(err, check.IsNil)
+	s.launchRemountWorkshop(c, oldSource)
+	change := s.newRemountChange(newSource)
+
+	// Execute
+	s.settle(c)
+
+	// Validate
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(change.Err(), check.ErrorMatches, `(?s).*\(not a directory\)`)
+	c.Assert(change.Status(), check.Equals, state.ErrorStatus)
+
+	repo := s.mgr.Repository()
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	connection, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	var src string
+	c.Assert(connection.Slot.Attr("host-source", &src), check.IsNil)
+	c.Assert(src, check.Equals, oldSource)
+
+	c.Assert(osutil.FileExists(oldSource), check.Equals, true)
+	c.Assert(osutil.FileExists(newSource), check.Equals, true)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
+}
+
 func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.C) {
 	// Setup
 	oldSource := c.MkDir()

--- a/internal/overlord/ifacestate/helpers.go
+++ b/internal/overlord/ifacestate/helpers.go
@@ -84,12 +84,12 @@ func getConns(st *state.State) (conns map[string]*schema.ConnState, err error) {
 	var raw *json.RawMessage
 	err = st.Get("conns", &raw)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
-		return nil, fmt.Errorf("cannot obtain raw data about existing connections: %s", err)
+		return nil, fmt.Errorf("cannot obtain raw data about existing connections: %w", err)
 	}
 	if raw != nil {
 		err = jsonutil.DecodeWithNumber(bytes.NewReader(*raw), &conns)
 		if err != nil {
-			return nil, fmt.Errorf("cannot decode data about existing connections: %s", err)
+			return nil, fmt.Errorf("cannot decode data about existing connections: %w", err)
 		}
 	}
 	if conns == nil {

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -260,19 +260,13 @@ func (m *InterfaceManager) ResolveDisconnect(
 		if err != nil {
 			return nil, err
 		}
+		plugRef := interfaces.PlugRef{ProjectId: plugProject, Workshop: plugWorkshop, Sdk: plugSdk, Name: plugName}
+		slotRef := interfaces.SlotRef{ProjectId: slotProject, Workshop: slotWorkshop, Sdk: slotSdk, Name: slotName}
 		if !isConnected {
-			if forget {
-				return nil, fmt.Errorf("cannot forget connection %s/%s:%s from %s/%s:%s, it was not connected",
-					plugWorkshop, plugSdk, plugName, slotWorkshop, slotSdk, slotName)
-			}
-			return nil, fmt.Errorf("cannot disconnect %s/%s:%s from %s/%s:%s, it is not connected",
-				plugWorkshop, plugSdk, plugName, slotWorkshop, slotSdk, slotName)
+			return nil, fmt.Errorf("cannot disconnect %q from %q: they are not connected",
+				plugRef.ShortRef(), slotRef.ShortRef())
 		}
-		return []*interfaces.ConnRef{
-			{
-				PlugRef: interfaces.PlugRef{ProjectId: plugProject, Workshop: plugWorkshop, Sdk: plugSdk, Name: plugName},
-				SlotRef: interfaces.SlotRef{ProjectId: slotProject, Workshop: slotWorkshop, Sdk: slotSdk, Name: slotName},
-			}}, nil
+		return []*interfaces.ConnRef{{PlugRef: plugRef, SlotRef: slotRef}}, nil
 	// 2: <workshop>/<sdk>:<plug or slot> (through 1st pair)
 	// Return a list of connections involving specified plug or slot.
 	case plugWorkshop != "" && plugName != "" && slotWorkshop == "" && slotName == "":
@@ -406,7 +400,8 @@ func (m *InterfaceManager) resolveWorkshopBindings(w *workshop.Workshop) error {
 			if plug.Bind != nil {
 				master := m.repo.Plug(w.Project.ProjectId, w.Name, plug.Bind.Sdk, plug.Bind.Name)
 				if master == nil {
-					return fmt.Errorf("SDK %q has no %q plug", plug.Bind.Sdk, plug.Bind.Name)
+					sdkRef := sdk.Ref{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: plug.Bind.Sdk}
+					return fmt.Errorf("SDK %q has no plug named %q", sdkRef.ShortRef(), plug.Bind.Name)
 				}
 			}
 		}
@@ -447,8 +442,9 @@ func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
 			return target == candidateTarget
 		})
 		if idx != -1 {
-			return fmt.Errorf(`cannot connect "%s/%s:%s": target %s is also mounted by %s/%s:%s`, plug.Sdk.Workshop, plug.Sdk.Name, plug.Name, candidateTarget,
-				allPlugs[idx].Sdk.Workshop, allPlugs[idx].Sdk.Name, allPlugs[idx].Name)
+			return fmt.Errorf(`cannot connect %q: target %q is also mounted by %q`,
+				interfaces.NewPlugRef(plug).ShortRef(), candidateTarget,
+				interfaces.NewPlugRef(allPlugs[idx]).ShortRef())
 		}
 	}
 	return nil

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -142,7 +142,7 @@ func (m *InterfaceManager) StartUp() error {
 			pctx := context.WithValue(ctx, workshop.ContextProjectId, project.ProjectId)
 			_, workshops, err := m.backend.ProjectWorkshops(pctx)
 			if err != nil {
-				logger.Noticef("Cannot load workshops from %s: %v", project.Path, err)
+				logger.Noticef("Cannot load workshops from %q: %v", project.Path, err)
 				continue
 			}
 			for _, workshop := range workshops {

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -42,7 +42,7 @@ func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.Conn
 	}
 
 	master, affected := MaybeBound(plugW, connRef.PlugRef)
-	masterTask := st.NewTask("connect", fmt.Sprintf("Connect %s to %s", master.ShortRef(), connRef.SlotRef.ShortRef()))
+	masterTask := st.NewTask("connect", fmt.Sprintf("Connect %q to %q", master.ShortRef(), connRef.SlotRef.ShortRef()))
 
 	masterTask.Set("slot", connRef.SlotRef)
 	masterTask.Set("plug", master)
@@ -55,7 +55,7 @@ func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.Conn
 	ts := state.NewTaskSet(masterTask)
 	prev := masterTask
 	for _, p := range affected {
-		slave := st.NewTask("connect", fmt.Sprintf("Connect %s to %s", p.ShortRef(), connRef.SlotRef.ShortRef()))
+		slave := st.NewTask("connect", fmt.Sprintf("Connect %q to %q", p.ShortRef(), connRef.SlotRef.ShortRef()))
 		slave.Set("slot", connRef.SlotRef)
 		slave.Set("plug", p)
 		slave.Set("delayed-setup-profile", true)
@@ -75,7 +75,7 @@ func maybeAddDisconnect(st *state.State, ts *state.TaskSet, conn interfaces.Conn
 		return nil
 	}
 
-	dtask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %s from %s", conn.PlugRef.ShortRef(), conn.SlotRef.ShortRef()))
+	dtask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %q from %q", conn.PlugRef.ShortRef(), conn.SlotRef.ShortRef()))
 	dtask.Set("plug", conn.PlugRef)
 	dtask.Set("slot", conn.SlotRef)
 	dtask.Set("forget", forget)

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -181,7 +181,7 @@ func (se *Overlord) StartUp() error {
 	se.startOfOperationTime, err = se.StartOfOperationTime()
 	st.Unlock()
 	if err != nil {
-		return fmt.Errorf("cannot get start of operation time: %s", err)
+		return fmt.Errorf("cannot get start of operation time: %w", err)
 	}
 	return se.stateEng.StartUp()
 }
@@ -290,7 +290,7 @@ func (o *Overlord) loadState(statePath string, restartHandler restart.Handler, b
 
 	r, err := os.Open(statePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read the state file: %s", err)
+		return nil, fmt.Errorf("cannot read the state file: %w", err)
 	}
 	defer r.Close()
 

--- a/internal/overlord/state/copy.go
+++ b/internal/overlord/state/copy.go
@@ -109,7 +109,7 @@ func CopyState(srcStatePath, dstStatePath string, dataEntries []string) error {
 
 	f, err := os.Open(srcStatePath)
 	if err != nil {
-		return fmt.Errorf("cannot open state: %s", err)
+		return fmt.Errorf("cannot open state: %w", err)
 	}
 	defer f.Close()
 

--- a/internal/overlord/state/state.go
+++ b/internal/overlord/state/state.go
@@ -495,7 +495,7 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 	d := json.NewDecoder(r)
 	err := d.Decode(&s)
 	if err != nil {
-		return nil, fmt.Errorf("cannot read state: %s", err)
+		return nil, fmt.Errorf("cannot read state: %w", err)
 	}
 	s.backend = backend
 	s.modified = false

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -227,7 +227,7 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
 	ws, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(ws, check.IsNil)
-	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
+	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
 
 	exist, _, _ := osutil.ExistsIsDir(filepath.Join(projectContent, plugs[0]))
 	c.Assert(exist, check.Equals, false)

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -127,7 +127,7 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshop.Workshop) healthstate.Heal
 
 	// Check the project directory exists.
 	if !ws.Project.Exists() {
-		w.state.Warnf("%q project directory %q does not exist", ws.Name, ws.Project.Path)
+		w.state.Warnf("cannot find project directory %q for workshop %q", ws.Project.Path, ws.Name)
 
 		healthState.Status = healthstate.ErrorStatus
 		healthState.Code = "missing-project"
@@ -139,7 +139,7 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshop.Workshop) healthstate.Heal
 	// with the workshop instance or has any errors) is not checked.
 	path := ws.Filepath()
 	if !osutil.FileExists(path) {
-		w.state.Warnf("%q workshop definition %q does not exist", ws.Name, path)
+		w.state.Warnf("cannot find definition %q for workshop %q", path, ws.Name)
 
 		healthState.Status = healthstate.ErrorStatus
 		healthState.Code = "missing-file"

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/canonical/x-go/strutil"
 	"golang.org/x/exp/slices"
 
 	"github.com/canonical/workshop/internal/osutil"
@@ -55,21 +54,31 @@ func (w *WorkshopManager) Ensure() error {
 	return nil
 }
 
-// Checks all of the provided list of workshops are in the required health status.
-func (w *WorkshopManager) CheckStatus(ctx context.Context, names []string, pId string, allowedStatuses []healthstate.Status) error {
-	for _, name := range names {
-		workshop, err := w.Workshop(ctx, name, pId)
-		if err != nil {
-			return fmt.Errorf("status check for %q failed (%v)", name, err)
-		}
+// Checks the provided workshop has one of the allowed health statuses.
+func (w *WorkshopManager) CheckStatus(ctx context.Context, name, pId string, allowedStatuses []healthstate.Status) error {
+	wp, err := w.Workshop(ctx, name, pId)
+	if err != nil {
+		return err
+	}
 
-		health := w.WorkshopHealth(workshop)
-		allowed := []string{}
-		for _, s := range allowedStatuses {
-			allowed = append(allowed, s.String())
-		}
-		if slices.Index(allowedStatuses, health.Status) == -1 {
-			return fmt.Errorf("%q status is %q, must be one of: %s", name, health.Status.String(), strutil.Quoted(allowed))
+	health := w.WorkshopHealth(wp)
+	if slices.Index(allowedStatuses, health.Status) == -1 {
+		switch health.Status {
+		case healthstate.ReadyStatus:
+			return fmt.Errorf("workshop already running")
+		case healthstate.PendingStatus:
+			if health.Code == "wait-on-error" {
+				return fmt.Errorf("refresh waiting on error")
+			}
+			return fmt.Errorf("other changes in progress")
+		case healthstate.ErrorStatus:
+			return fmt.Errorf("workshop is unhealthy")
+		case healthstate.StoppedStatus:
+			return fmt.Errorf("workshop is not running")
+		case healthstate.OffStatus:
+			return workshop.ErrWorkshopNotLaunched
+		default:
+			return fmt.Errorf("workshop health is unknown")
 		}
 	}
 	return nil

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -62,7 +62,7 @@ func (w *WorkshopManager) CheckStatus(ctx context.Context, name, pId string, all
 	}
 
 	health := w.WorkshopHealth(wp)
-	if slices.Index(allowedStatuses, health.Status) == -1 {
+	if !slices.Contains(allowedStatuses, health.Status) {
 		switch health.Status {
 		case healthstate.ReadyStatus:
 			return fmt.Errorf("workshop already running")

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -148,7 +148,7 @@ func (s *managerSuite) TestWorkshopHealthMissingProject(c *check.C) {
 
 	warnings := s.state.AllWarnings()
 	c.Check(warnings, check.HasLen, 1)
-	warning := fmt.Sprintf("%q project directory %q does not exist", workshop.Name, s.project.Path)
+	warning := fmt.Sprintf(`cannot find project directory %q for workshop "test"`, s.project.Path)
 	c.Check(warnings[0].String(), check.Equals, warning)
 }
 
@@ -167,7 +167,7 @@ func (s *managerSuite) TestWorkshopHealthMissingFile(c *check.C) {
 
 	warnings := s.state.AllWarnings()
 	c.Check(warnings, check.HasLen, 1)
-	warning := fmt.Sprintf("%q workshop definition %q does not exist", testWorkshop.Name, testWorkshop.Filepath())
+	warning := fmt.Sprintf(`cannot find definition %q for workshop "test"`, testWorkshop.Filepath())
 	c.Check(warnings[0].String(), check.Equals, warning)
 }
 

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -256,7 +256,7 @@ func (s *managerSuite) TestRefreshRequireStatusReady(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	_, err = s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId)
-	c.Assert(err, check.ErrorMatches, `cannot refresh: "test-2" status is "Stopped", must be one of: "Ready"`)
+	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop is not running`)
 }
 
 func (s *managerSuite) TestRefreshRequireWorkshopExistence(c *check.C) {
@@ -265,5 +265,5 @@ func (s *managerSuite) TestRefreshRequireWorkshopExistence(c *check.C) {
 	s.launchWorkshopWithSDKs(c, "test-1", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 
 	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId)
-	c.Assert(err, check.ErrorMatches, `cannot refresh: status check for "test-2" failed \(workshop has not been launched\)`)
+	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop has not been launched`)
 }

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -259,11 +259,11 @@ func (s *managerSuite) TestRefreshRequireStatusReady(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `cannot refresh: "test-2" status is "Stopped", must be one of: "Ready"`)
 }
 
-func (s *managerSuite) TestRefreshRequireWorkshopExistance(c *check.C) {
+func (s *managerSuite) TestRefreshRequireWorkshopExistence(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.launchWorkshopWithSDKs(c, "test-1", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 
 	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId)
-	c.Assert(err, check.ErrorMatches, `cannot refresh: status check for "test-2" failed \(workshop not found\)`)
+	c.Assert(err, check.ErrorMatches, `cannot refresh: status check for "test-2" failed \(workshop has not been launched\)`)
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -272,13 +272,15 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, names []string, proje
 		return nil, err
 	}
 
-	err = w.CheckStatus(
-		ctx,
-		names,
-		projectId,
-		[]healthstate.Status{healthstate.ReadyStatus})
-	if err != nil {
-		return nil, fmt.Errorf("cannot refresh: %v", err)
+	for _, name := range names {
+		err = w.CheckStatus(
+			ctx,
+			name,
+			projectId,
+			[]healthstate.Status{healthstate.ReadyStatus})
+		if err != nil {
+			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+		}
 	}
 
 	_, workshops, err := w.Workshops(ctx, projectId)
@@ -330,11 +332,11 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, names []string, proje
 func (w *WorkshopManager) RefreshLocalSdk(ctx context.Context, pid string, wpn string, sdkn string) ([]*state.TaskSet, error) {
 	err := w.CheckStatus(
 		ctx,
-		[]string{wpn},
+		wpn,
 		pid,
 		[]healthstate.Status{healthstate.ReadyStatus})
 	if err != nil {
-		return nil, fmt.Errorf("cannot refresh: %v", err)
+		return nil, fmt.Errorf("cannot refresh %q: %w", wpn, err)
 	}
 
 	var taskset []*state.TaskSet
@@ -592,13 +594,15 @@ func createStateHooks(st *state.State, w string, content []sdk.Setup, newContent
 
 func (w *WorkshopManager) StartMany(ctx context.Context, names []string, projectId string, opChangeId string) ([]*state.TaskSet, error) {
 	// check if all the workshops are stopped
-	err := w.CheckStatus(
-		ctx,
-		names,
-		projectId,
-		[]healthstate.Status{healthstate.StoppedStatus})
-	if err != nil {
-		return nil, fmt.Errorf("cannot start: %w", err)
+	for _, name := range names {
+		err := w.CheckStatus(
+			ctx,
+			name,
+			projectId,
+			[]healthstate.Status{healthstate.StoppedStatus})
+		if err != nil {
+			return nil, fmt.Errorf("cannot start %q: %w", name, err)
+		}
 	}
 
 	project, err := w.loadProject(ctx, projectId)
@@ -627,13 +631,15 @@ func startMany(st *state.State, names []string, project *workshop.Project) ([]*s
 }
 
 func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectId string, opChangeId string) ([]*state.TaskSet, error) {
-	err := w.CheckStatus(
-		ctx,
-		names,
-		projectId,
-		[]healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus})
-	if err != nil {
-		return nil, fmt.Errorf("cannot stop: %w", err)
+	for _, name := range names {
+		err := w.CheckStatus(
+			ctx,
+			name,
+			projectId,
+			[]healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus})
+		if err != nil {
+			return nil, fmt.Errorf("cannot stop %q: %w", name, err)
+		}
 	}
 
 	project, err := w.loadProject(ctx, projectId)
@@ -670,11 +676,11 @@ type ExecMeta struct {
 func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args *workshop.ExecArgs) (*state.Task, error) {
 	err := w.CheckStatus(
 		ctx,
-		[]string{name},
+		name,
 		projectId,
 		[]healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus})
 	if err != nil {
-		return nil, fmt.Errorf("cannot exec: %w", err)
+		return nil, fmt.Errorf("cannot exec command in %q: %w", name, err)
 	}
 
 	project, err := w.loadProject(ctx, projectId)
@@ -707,13 +713,15 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 }
 
 func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projectId string, opChangeId string) ([]*state.TaskSet, error) {
-	err := w.CheckStatus(
-		ctx,
-		names,
-		projectId,
-		[]healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus})
-	if err != nil {
-		return nil, fmt.Errorf("cannot remove: %w", err)
+	for _, name := range names {
+		err := w.CheckStatus(
+			ctx,
+			name,
+			projectId,
+			[]healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus})
+		if err != nil {
+			return nil, fmt.Errorf("cannot remove %q: %w", name, err)
+		}
 	}
 
 	project, err := w.loadProject(ctx, projectId)
@@ -786,11 +794,11 @@ func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug int
 
 	err := w.CheckStatus(
 		ctx,
-		[]string{plug.Workshop},
+		plug.Workshop,
 		projectId,
 		[]healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus})
 	if err != nil {
-		return nil, fmt.Errorf("cannot remount: %w", err)
+		return nil, fmt.Errorf("cannot remount %q: %w", plug.ShortRef(), err)
 	}
 
 	project, err := w.loadProject(ctx, projectId)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -92,7 +92,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 
 		_, err = w.Workshop(ctx, name, projectId)
 		if err == nil {
-			return nil, fmt.Errorf("cannot launch: %q already exists", name)
+			return nil, fmt.Errorf("cannot launch %q: workshop already exists", name)
 		}
 		if !errors.Is(err, workshop.ErrWorkshopNotLaunched) {
 			return nil, err
@@ -691,10 +691,10 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 
 	info, err := wrkspc.Stat(args.WorkDir)
 	if err != nil {
-		return nil, fmt.Errorf("%s does not exist", args.WorkDir)
+		return nil, fmt.Errorf("cannot exec command in %q: working directory %q not found", name, args.WorkDir)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("%s is not a directory", args.WorkDir)
+		return nil, fmt.Errorf("cannot exec command in %q: %q is not a directory", name, args.WorkDir)
 	}
 
 	exec := w.state.NewTask("exec", fmt.Sprintf("Exec command %q", args.Command[0]))

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -805,7 +805,7 @@ func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug int
 
 	master, _ := ifacestate.MaybeBound(wp, plug)
 
-	remount := st.NewTask("remount", fmt.Sprintf(`Remount %s`, plug.ShortRef()))
+	remount := st.NewTask("remount", fmt.Sprintf(`Remount %q`, plug.ShortRef()))
 	remount.Set("workshop", plug.Workshop)
 	remount.Set("project", project)
 	remount.Set("plug", master)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -94,7 +94,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		if err == nil {
 			return nil, fmt.Errorf("cannot launch: %q already exists", name)
 		}
-		if !errors.Is(err, workshop.ErrWorkshopNotFound) {
+		if !errors.Is(err, workshop.ErrWorkshopNotLaunched) {
 			return nil, err
 		}
 
@@ -291,11 +291,11 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, names []string, proje
 	for _, ws := range names {
 		idx := slices.IndexFunc(workshops, func(w *workshop.Workshop) bool { return w.Name == ws })
 		if idx == -1 {
-			return nil, fmt.Errorf("cannot refresh: workshop %q not found", ws)
+			return nil, fmt.Errorf("cannot refresh %q: %w", ws, workshop.ErrWorkshopNotLaunched)
 		}
-		file, err := project.Workshop(workshops[idx].Name)
+		file, err := project.Workshop(ws)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot refresh %q: %w", ws, err)
 		}
 		files = append(files, file)
 
@@ -420,7 +420,7 @@ func refreshMany(st *state.State, files []*workshop.File, installed [][]sdk.Setu
 	for i, file := range files {
 		tasks, err := refresh(st, file, installed[i], toInstall[i], project)
 		if err != nil {
-			return nil, fmt.Errorf("cannot refresh \"%s\" workshop: %w", file, err)
+			return nil, fmt.Errorf("cannot refresh %q: %w", file.Name, err)
 		}
 		taskset = append(taskset, tasks)
 	}

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -741,7 +741,7 @@ func (s *requestSuite) TestRemountSuccess(c *check.C) {
 	task := ts.Tasks()[0]
 	c.Assert(task.Get("workshop", &w), check.IsNil)
 	c.Assert(task.Get("project", &p), check.IsNil)
-	c.Assert(task.Summary(), check.Equals, `Remount ws-1/sdk-1:plug`)
+	c.Assert(task.Summary(), check.Equals, `Remount "ws-1/sdk-1:plug"`)
 	c.Assert(w, check.Equals, "ws-1")
 	c.Assert(p, check.DeepEquals, *s.project)
 

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -772,5 +772,5 @@ func (s *requestSuite) TestRemountWorkshopNotReady(c *check.C) {
 	change.Set("project-id", s.project.ProjectId)
 
 	_, err := s.mgr.Remount(s.ctx, s.state, plug, c.MkDir(), s.project.ProjectId)
-	c.Assert(err, check.ErrorMatches, `cannot remount: "ws-1" status is "Pending", must be one of: "Ready", "Stopped"`)
+	c.Assert(err, check.ErrorMatches, `cannot remount "ws-1/sdk-1:plug": other changes in progress`)
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -84,7 +84,7 @@ func (i *Info) SetupPlugBinds(binds map[string]*PlugBind) error {
 			// all plugs from all SDKs are in the repository already.
 			i.PlugBinds[name] = plug
 		} else {
-			return fmt.Errorf("plug binding failed: SDK %s/%s has no %q plug", i.Workshop, i.Name, name)
+			return fmt.Errorf("plug binding failed: SDK %q has no plug named %q", i.Ref().ShortRef(), name)
 		}
 	}
 	return nil
@@ -142,8 +142,12 @@ type Ref struct {
 	Sdk       string
 }
 
-func (r *Ref) ID() string {
-	return fmt.Sprintf("%s/%s:%s", r.ProjectId, r.Workshop, r.Sdk)
+func (r Ref) String() string {
+	return fmt.Sprintf("%s/%s/%s", r.ProjectId, r.Workshop, r.Sdk)
+}
+
+func (r Ref) ShortRef() string {
+	return fmt.Sprintf("%s/%s", r.Workshop, r.Sdk)
 }
 
 var SanitizePlugsSlots = func(snapInfo *Info) {
@@ -316,7 +320,7 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 func getAttribute(sdkName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := lookupAttr(attrs, key)
 	if !ok {
-		return AttributeNotFoundError{fmt.Errorf("sdk %q does not have attribute %q for interface %q", sdkName, key, ifaceName)}
+		return AttributeNotFoundError{fmt.Errorf("SDK %q does not have attribute %q for interface %q", sdkName, key, ifaceName)}
 	}
 
 	return metautil.SetValueFromAttribute(sdkName, ifaceName, key, v, val)

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -707,7 +707,7 @@ func (s *systemd) RemoveMountUnitFile(mountedDir string) error {
 	if s.rootDir != "" {
 		rel, err := filepath.Rel(s.rootDir, mountedDir)
 		if err != nil || strings.HasPrefix(rel, "..") {
-			return fmt.Errorf("mount unit file not inside root dir: %s", mountedDir)
+			return fmt.Errorf("mount unit file not inside root dir %q", mountedDir)
 		}
 		unitNamePath = "/" + rel
 	}

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	ErrWorkshopNotFound    = errors.New("workshop not found")
+	ErrWorkshopNotLaunched = errors.New("workshop has not been launched")
 	ErrVolumeAlreadyExists = errors.New("storage volume already exists")
 	ErrSdkProfileNotFound  = errors.New("sdk profile not found")
 

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -172,7 +172,7 @@ func (f *FakeWorkshopBackend) RemoveWorkshop(ctx context.Context, name string) e
 	prj := f.project(user, projectId)
 
 	if _, ok := f.Workshops[prj.ProjectId][name]; !ok {
-		return workshop.ErrWorkshopNotFound
+		return workshop.ErrWorkshopNotLaunched
 	}
 
 	delete(f.Workshops[prj.ProjectId], name)
@@ -249,7 +249,7 @@ func (f *FakeWorkshopBackend) Workshop(ctx context.Context, name string) (*works
 	}
 	wp := f.Workshops[projectId][name]
 	if wp == nil {
-		return nil, workshop.ErrWorkshopNotFound
+		return nil, workshop.ErrWorkshopNotLaunched
 	}
 
 	var c map[string]sdk.Setup
@@ -328,7 +328,7 @@ func (s *FakeWorkshopBackend) UnstashWorkshop(ctx context.Context, name string) 
 
 	wp := s.StashedWorkshops[projectId][workshop.StashNamePrefix+name]
 	if wp == nil {
-		return workshop.ErrWorkshopNotFound
+		return fmt.Errorf("stashed workshop %q not found", name)
 	}
 	delete(s.StashedWorkshops[projectId], workshop.StashNamePrefix+name)
 	wp.Name = name
@@ -344,7 +344,7 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 
 	wp := s.Workshops[projectId][name]
 	if wp == nil {
-		return workshop.ErrWorkshopNotFound
+		return workshop.ErrWorkshopNotLaunched
 	}
 
 	if s.StashedWorkshops[projectId] == nil {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -421,7 +421,7 @@ func (s *Backend) Workshop(ctx context.Context, name string) (*workshop.Workshop
 	inst, _, err := conn.GetInstance(InstanceName(name, projectId))
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return nil, workshop.ErrWorkshopNotFound
+			return nil, workshop.ErrWorkshopNotLaunched
 		}
 		return nil, err
 	}

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -53,18 +53,18 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 				continue
 			}
 
-			logger.Noticef("On reading %q SDK profile: unknown device type: %s", profile, devtype)
+			logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
 		case "unix-char":
 			devtype := config[DeviceTypeConfigKey(profile, name)]
 			if devtype == "camera" {
 				continue
 			}
 
-			logger.Noticef("On reading %q SDK profile: unknown device type: %s", profile, devtype)
+			logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
 		case "none":
 			cfg, exist := config[DeviceConfigKey(profile, name)]
 			if !exist {
-				logger.Noticef("On reading %q SDK profile: unknown device: %s", profile, name)
+				logger.Noticef("On reading %q SDK profile: unknown device %q", profile, name)
 				continue
 			}
 
@@ -83,10 +83,10 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 				}
 				pr.Mounts[name] = mnt
 			default:
-				logger.Noticef("On reading %q SDK profile: unknown device type: %s", profile, devtype)
+				logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
 			}
 		default:
-			logger.Noticef("On reading %q SDK profile: unknown device type: %s", profile, dev["type"])
+			logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, dev["type"])
 		}
 	}
 	return pr, nil

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -110,7 +110,7 @@ func (s *Backend) moveInstanceAndProfiles(conn lxd.InstanceServer, instanceFrom,
 	_, _, err := conn.GetInstance(instanceFrom)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return workshop.ErrWorkshopNotFound
+			return workshop.ErrWorkshopNotLaunched
 		}
 		return err
 	}

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -150,7 +150,7 @@ func (f *wsExec) TestLxdBackendExecWorkingDirectoryDoesNotExist(c *check.C) {
 	_, _, err := f.exec(c, "", "test", f.project.ProjectId, opts)
 
 	// Validate
-	c.Assert(err, check.ErrorMatches, ".*/no/such/dir does not exist")
+	c.Assert(err, check.ErrorMatches, `cannot exec command in "test": working directory "/no/such/dir" not found`)
 }
 
 func (f *wsExec) TestLxdBackendExecDefaultUserGroup(c *check.C) {

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -102,7 +102,7 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 	// Validate
 	c.Assert(err, check.IsNil)
 	_, err = f.bd.Workshop(f.ctx, "test")
-	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
+	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
 
 	// Execute
 	err = f.bd.RemoveWorkshopStash(f.ctx, "test")
@@ -110,7 +110,7 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 
 	// Validate
 	err = f.bd.UnstashWorkshop(f.ctx, "test")
-	c.Assert(err, check.ErrorMatches, "workshop not found")
+	c.Assert(err, check.ErrorMatches, "workshop has not been launched")
 }
 
 func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
@@ -139,7 +139,7 @@ func (f *wsOps) TestLxdBackendDeleteWorkshop(c *check.C) {
 	err := f.bd.RemoveWorkshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 	_, err = f.bd.Workshop(f.ctx, "test")
-	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotFound)
+	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
 }
 
 func (f *wsOps) image(c *check.C, alias string) (string, error) {

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -49,6 +49,9 @@ func (w *Project) Workshop(workshop string) (*File, error) {
 
 	buf, err := os.ReadFile(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("workshop definition %q not found", path)
+		}
 		return nil, err
 	}
 
@@ -59,7 +62,7 @@ func (w *Project) Workshop(workshop string) (*File, error) {
 
 	fname := filepath.Base(path)
 	if Filename(file.Name) != fname {
-		return nil, fmt.Errorf("%q workshop file must be named as %q (now: %s)", file.Name, Filename(file.Name), fname)
+		return nil, fmt.Errorf("%q workshop file must be named %q (now: %q)", file.Name, Filename(file.Name), fname)
 	}
 	return file, nil
 }

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -144,6 +144,11 @@ func readWorkshop(buf []byte) (*File, error) {
 	var file File
 
 	if err = yaml.Unmarshal(buf, &file); err != nil {
+		te, ok := err.(*yaml.TypeError)
+		if ok {
+			errs := strings.Join(te.Errors, "\n")
+			return nil, fmt.Errorf("workshop definition YAML:\n%s", errs)
+		}
 		return nil, err
 	}
 

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -156,7 +156,7 @@ func readWorkshop(buf []byte) (*File, error) {
 	}
 
 	if !slices.Contains(SupportedBases, file.Base) {
-		return nil, fmt.Errorf("unsupported base: %s", file.Base)
+		return nil, fmt.Errorf("unsupported base %q", file.Base)
 	}
 
 	if err = validateSdks(file.Sdks); err != nil {
@@ -186,7 +186,7 @@ func validateSdks(sdks SdkList) error {
 			continue
 		}
 		if matches := channel.FindStringSubmatch(s.Channel); matches == nil {
-			return fmt.Errorf("unsupported channel %s for \"%s\"", s.Channel, s.Name)
+			return fmt.Errorf("unsupported channel %q for %q SDK", s.Channel, s.Name)
 		}
 		// A plug must either be bound or declared/extended with dynamic
 		// attributes.
@@ -216,10 +216,10 @@ func validateBinding(sdks SdkList) error {
 			slaves[sl] = mr
 
 			if p.Bind.Sdk != sdk.System.String() && !slices.ContainsFunc(sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }) {
-				return fmt.Errorf("%q tries to bind to a plug from a non-existing SDK", fmt.Sprintf("%s:%s", p.Bind.Sdk, p.Bind.Name))
+				return fmt.Errorf("cannot bind plug %q: SDK %q not found", p.Bind.String(), p.Bind.Sdk)
 			}
 			if p.Bind.Sdk == s.Name && p.Bind.Name == name {
-				return fmt.Errorf(`cannot bind plug "%s:%s" to itself`, s.Name, name)
+				return fmt.Errorf(`cannot bind plug %q to itself`, p.Bind.String())
 			}
 		}
 	}
@@ -236,7 +236,7 @@ func validateBinding(sdks SdkList) error {
 	for _, sl := range slaveKeysOrdered {
 		m := slaves[sl]
 		if _, ok := masters[sl]; ok {
-			return fmt.Errorf(`invalid binding %s:%s to %s:%s; plug "%s:%s" must not be bound to`, sl.Sdk, sl.Name, m.Sdk, m.Name, sl.Sdk, sl.Name)
+			return fmt.Errorf(`cannot bind %q to %q: plug %q is already bound`, sl.String(), m.String(), sl.String())
 		}
 	}
 	return nil
@@ -260,20 +260,17 @@ func isBound(plug PlugRef, wf *File) bool {
 func validateConnections(wfile *File) error {
 	for _, conn := range wfile.Connections {
 		if isBound(conn.PlugRef, wfile) {
-			return fmt.Errorf(`cannot connect plug "%s:%s" to slot "%s:%s": plug is bound`,
-				conn.PlugRef.Sdk, conn.PlugRef.Name, conn.SlotRef.Sdk,
-				conn.SlotRef.Name)
+			return fmt.Errorf(`cannot connect plug %q to slot %q: plug is bound`,
+				conn.PlugRef.String(), conn.SlotRef.String())
 		}
 
 		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.PlugRef.Sdk || conn.PlugRef.Sdk == sdk.System.String() }) {
-			return fmt.Errorf(`cannot connect plug "%s:%s" to slot "%s:%s": %q SDK is not found in %q workshop`,
-				conn.PlugRef.Sdk, conn.PlugRef.Name, conn.SlotRef.Sdk,
-				conn.SlotRef.Name, conn.PlugRef.Sdk, wfile.Name)
+			return fmt.Errorf(`cannot connect plug %q to slot %q: workshop %q has no SDK named %q`,
+				conn.PlugRef.String(), conn.SlotRef.String(), wfile.Name, conn.PlugRef.Sdk)
 		}
 		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.SlotRef.Sdk || conn.SlotRef.Sdk == sdk.System.String() }) {
-			return fmt.Errorf(`cannot connect plug "%s:%s" to slot "%s:%s": %q SDK is not found in %q workshop`,
-				conn.PlugRef.Sdk, conn.PlugRef.Name,
-				conn.SlotRef.Sdk, conn.SlotRef.Name, conn.SlotRef.Sdk, wfile.Name)
+			return fmt.Errorf(`cannot connect plug %q to slot %q: workshop %q has no SDK named %q`,
+				conn.PlugRef.String(), conn.SlotRef.String(), wfile.Name, conn.SlotRef.Sdk)
 		}
 	}
 	return nil

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -157,7 +157,7 @@ func readWorkshop(buf []byte) (*File, error) {
 	})
 
 	if !workshopName.MatchString(file.Name) {
-		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) include only lower case alpha-numeric or an underscore symbol(s)")
+		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) include only lowercase alphanumeric characters or underscore(s)")
 	}
 
 	if !slices.Contains(SupportedBases, file.Base) {

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	SupportedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
-	sdkBlacklist   = []string{"agent"}
+	sdkBlocklist   = []string{"agent"}
 
 	workshopName = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
 	channel      = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
@@ -176,7 +176,7 @@ func readWorkshop(buf []byte) (*File, error) {
 
 func validateSdks(sdks SdkList) error {
 	for _, s := range sdks {
-		if slices.Contains(sdkBlacklist, s.Name) {
+		if slices.Contains(sdkBlocklist, s.Name) {
 			return fmt.Errorf("%q is a reserved SDK name", s.Name)
 		}
 

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -161,7 +161,7 @@ func readWorkshop(buf []byte) (*File, error) {
 	}
 
 	if !slices.Contains(SupportedBases, file.Base) {
-		return nil, fmt.Errorf("unsupported base %q", file.Base)
+		return nil, fmt.Errorf("base %q not supported", file.Base)
 	}
 
 	if err = validateSdks(file.Sdks); err != nil {

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -110,7 +110,17 @@ base: ubuntu@20.04
 	f.createWFile(c, "xbert", yaml)
 	file, err := f.project.Workshop("xbert")
 	c.Assert(file, check.IsNil)
-	c.Assert(err, check.ErrorMatches, `"xbert-gpu" workshop file must be named as "workshop.xbert-gpu.yaml" \(now: workshop.xbert.yaml\)`)
+	c.Assert(err, check.ErrorMatches, `"xbert-gpu" workshop file must be named "workshop.xbert-gpu.yaml" \(now: "workshop.xbert.yaml"\)`)
+}
+
+func (f *workshopFile) TestWorkshopInvalidName(c *check.C) {
+	yaml := `name: 99-xbert
+base: ubuntu@20.04
+`
+	f.createWFile(c, "99-xbert", yaml)
+	file, err := f.project.Workshop("99-xbert")
+	c.Assert(file, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `a workshop's name must: \(1\) start with a letter, \(2\) include only lower case alpha-numeric or an underscore symbol\(s\)`)
 }
 
 func (f *workshopFile) TestWorkshopUnsupportedBase(c *check.C) {

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -120,7 +120,7 @@ base: ubuntu@20.04
 	f.createWFile(c, "99-xbert", yaml)
 	file, err := f.project.Workshop("99-xbert")
 	c.Assert(file, check.IsNil)
-	c.Assert(err, check.ErrorMatches, `a workshop's name must: \(1\) start with a letter, \(2\) include only lower case alpha-numeric or an underscore symbol\(s\)`)
+	c.Assert(err, check.ErrorMatches, `a workshop's name must: \(1\) start with a letter, \(2\) include only lowercase alphanumeric characters or underscore\(s\)`)
 }
 
 func (f *workshopFile) TestWorkshopUnsupportedBase(c *check.C) {

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -113,6 +113,16 @@ base: ubuntu@20.04
 	c.Assert(err, check.ErrorMatches, `"xbert-gpu" workshop file must be named as "workshop.xbert-gpu.yaml" \(now: workshop.xbert.yaml\)`)
 }
 
+func (f *workshopFile) TestWorkshopUnsupportedBase(c *check.C) {
+	yaml := `name: xbert-gpu
+base: foo@20.04
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	file, err := f.project.Workshop("xbert-gpu")
+	c.Assert(file, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `unsupported base "foo@20.04"`)
+}
+
 func (f *workshopFile) TestWorkshopFileDuplicateSdks(c *check.C) {
 	yaml := `name: xbert-gpu
 base: ubuntu@20.04
@@ -139,6 +149,19 @@ sdks:
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
 	c.Assert(file, check.IsNil)
+}
+
+func (f *workshopFile) TestWorkshopUnsupportedChannel(c *check.C) {
+	yaml := `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  cuda:
+    channel: latest/foo
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	file, err := f.project.Workshop("xbert-gpu")
+	c.Assert(file, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `unsupported channel "latest/foo" for "cuda" SDK`)
 }
 
 func (f *workshopFile) TestBindPlug(c *check.C) {
@@ -224,7 +247,44 @@ sdks:
 `
 	f.createWFile(c, "xbert-gpu", yaml)
 	_, err := f.project.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `"no-sdk:cache" tries to bind to a plug from a non-existing SDK`)
+	c.Assert(err, check.ErrorMatches, `cannot bind plug "no-sdk:cache": SDK "no-sdk" not found`)
+}
+
+func (f *workshopFile) TestBindPlugToItself(c *check.C) {
+	yaml := `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  data-sdk:
+    channel: latest/stable
+    plugs:
+      cache:
+        bind: data-sdk:cache
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	_, err := f.project.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `cannot bind plug "data-sdk:cache" to itself`)
+}
+
+func (f *workshopFile) TestBindPlugToBoundPlug(c *check.C) {
+	yaml := `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  one:
+    channel: latest/stable
+  two:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: one:data
+  three:
+    channel: latest/stable
+    plugs:
+      data:
+        bind: two:data
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	_, err := f.project.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `cannot bind "two:data" to "one:data": plug "two:data" is already bound`)
 }
 
 func (f *workshopFile) TestBindPlugInvalidPlugRef(c *check.C) {
@@ -273,7 +333,7 @@ sdks:
 `
 	f.createWFile(c, "xbert-gpu", yaml)
 	_, err := f.project.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `invalid binding etl-sdk:cache to etl-sdk:data; plug "etl-sdk:cache" must not be bound to`)
+	c.Assert(err, check.ErrorMatches, `cannot bind "etl-sdk:cache" to "etl-sdk:data": plug "etl-sdk:cache" is already bound`)
 }
 
 func (f *workshopFile) TestIndirectBindToAlreadyBoundPlug(c *check.C) {
@@ -295,7 +355,7 @@ sdks:
 `
 	f.createWFile(c, "xbert-gpu", yaml)
 	_, err := f.project.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `invalid binding data-sdk:aux to etl-sdk:cache; plug "data-sdk:aux" must not be bound to`)
+	c.Assert(err, check.ErrorMatches, `cannot bind "data-sdk:aux" to "etl-sdk:cache": plug "data-sdk:aux" is already bound`)
 }
 
 func (f *workshopFile) TestHostSdkSlot(c *check.C) {
@@ -370,7 +430,7 @@ connections:
 `
 	f.createWFile(c, "xbert-gpu", yaml)
 	_, err := f.project.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `cannot connect plug "data-sdk:data" to slot "lost-sdk:mount": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
+	c.Assert(err, check.ErrorMatches, `cannot connect plug "data-sdk:data" to slot "lost-sdk:mount": workshop "xbert-gpu" has no SDK named "lost-sdk"`)
 }
 
 func (f *workshopFile) TestWorkshopConnectionsPlugSdkNotInTheList(c *check.C) {
@@ -387,7 +447,7 @@ connections:
 `
 	f.createWFile(c, "xbert-gpu", yaml)
 	_, err := f.project.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `cannot connect plug "lost-sdk:data" to slot "data-sdk:mount": "lost-sdk" SDK is not found in "xbert-gpu" workshop`)
+	c.Assert(err, check.ErrorMatches, `cannot connect plug "lost-sdk:data" to slot "data-sdk:mount": workshop "xbert-gpu" has no SDK named "lost-sdk"`)
 }
 
 func (f *workshopFile) TestWorkshopConnectionsImplicitHostSdkPlugSlot(c *check.C) {

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -130,7 +130,7 @@ base: foo@20.04
 	f.createWFile(c, "xbert-gpu", yaml)
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(file, check.IsNil)
-	c.Assert(err, check.ErrorMatches, `unsupported base "foo@20.04"`)
+	c.Assert(err, check.ErrorMatches, `base "foo@20.04" not supported`)
 }
 
 func (f *workshopFile) TestWorkshopFileDuplicateSdks(c *check.C) {

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -45,4 +45,4 @@ execute: |
 
   echo "Check stopped workshop"
   workshop_exec stop ws-exec
-  workshop_exec exec ws-exec pwd | MATCH '.*"ws-exec" status is "Stopped", must be one of: "Ready", "Pending"$'
+  workshop_exec exec ws-exec pwd | MATCH '.*cannot exec command in "ws-exec": workshop is not running$'

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -26,7 +26,7 @@ execute: |
   workshop_exec warnings |
     tr -d '\n' | # remove newlines
     sed -e 's,\s\+, ,g' | # rename any extra spaces
-    MATCH '"ws" workshop definition ".*/project/.workshop/workshop.ws.yaml" does not exist'
+    MATCH 'cannot find definition ".*/project/.workshop/workshop.ws.yaml" for workshop "ws"'
   workshop_exec --project "$PROJECT" list | NOMATCH 'new warning'
 
   echo "Check report a workshop state as Error if there is no workshop file"

--- a/tests/main/list/task.yaml
+++ b/tests/main/list/task.yaml
@@ -22,7 +22,12 @@ execute: |
   echo "workshop list from a nested directory must work similarly as if ran from a project directory"
   pushd ./; mkdir "$PROJECT"/nested; cd "$PROJECT"/nested
   workshop_exec list | MATCH "^.+[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
-  rm -rf "$PROJECT"/nested; popd
+  popd; rmdir "$PROJECT"/nested
+
+  echo "workshop --project should accept a relative directory"
+  mkdir relative
+  workshop_exec list --project relative | MATCH "^.+[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
+  rmdir relative
 
   echo "Listing outside of a project directory should trigger an error"
   workshop_exec --project /home/ubuntu list | MATCH "^error: not a project \(no workshop files found\)$"

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -21,7 +21,7 @@ execute: |
   workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
 
   echo "Remount: the new source is not empty"  
-  workshop_exec remount ws-remount/test-sdk-mount:one /home/ubuntu  | MATCH ".*(new source is not empty; workshop must be stopped to remount safely)"
+  workshop_exec remount ws-remount/test-sdk-mount:one /home/ubuntu  | MATCH '.*(source "/home/ubuntu" is not empty; workshop must be stopped to remount safely)'
 
   echo "Remount: workshop stopped"
   new_source="/home/ubuntu/two"
@@ -38,7 +38,7 @@ execute: |
   mkdir -p /home/ubuntu/other-fs
   mount --bind "$otherfs" /home/ubuntu/other-fs
   mkdir "$otherfs_path"
-  workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path" | MATCH ".*(current and new sources are not on the same mounted filesystem; workshop must be stopped to remount safely)"
+  workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path" | MATCH '.*(sources "/home/ubuntu/two" and "/home/ubuntu/other-fs/new" are not on the same mounted filesystem; workshop must be stopped to remount safely)'
   workshop_exec stop ws-remount
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path"
   workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$otherfs_path"
@@ -53,12 +53,12 @@ execute: |
   workshop_exec warnings |
     tr -d '\n' | # remove newlines
     sed -e 's,\s\+, ,g' | # rename any extra spaces
-    MATCH "ws-remount/test-sdk-mount:two's source at \"${new_source}\\.1\" does not exist; will attempt to recreate"
+    MATCH 'cannot find source "/home/ubuntu/two\.1" for "ws-remount/test-sdk-mount:two"; will attempt to recreate'
   workshop_exec list | NOMATCH "new warning"
   workshop_exec warnings |
     tr -d '\n' | # remove newlines
     sed -e 's,\s\+, ,g' | # rename any extra spaces
-    MATCH "ws-remount/test-sdk-mount:two's source at \"${new_source}\\.2\" does not exist; will attempt to recreate"
+    MATCH 'cannot find source "/home/ubuntu/two\.2" for "ws-remount/test-sdk-mount:two"; will attempt to recreate'
   workshop_exec okay
   workshop_exec warnings | MATCH '^No further warnings.$'
 


### PR DESCRIPTION
# Description

Existing errors should be more consistent and easier to understand now. Going forward we will attempt to maintain this by following a basic style guide (see checklist).

There are a couple changes I wanted to highlight:
- 6d866be1b998b7ff872507407918d2ebd126795c makes remount fail if an unexpected error occurs. I think this was a bug previously, but I could be mistaken.
- In 7be586fadb517b5e3ee9e7007b31064083239d66 I removed the difference in error messages between `workshop disconnect` and `workshop disconnect --forget`, because I think of `disconnect` as the main task and `forget` just modifies it slightly. Again this might be because I'm not understanding something.
- I adjusted the style guide link below to point to this branch instead of `main`. Once we have a public docs URL we could potentially use that instead.

Feel free to suggest changes to the wording!

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/refactor/consistent-errors/docs/contributing.rst#error-messages) for newly introduced error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.

Closes #206.