### PR TITLE
Improve brevity of newly-changed error messages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@
  * [ ] Put variable declaration and initialisation together.
  * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
  * [ ] Put a blank line between two logically different chunks of code.
- * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for newly introduced error messages.
+ * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.
 
 ## Docs
 

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -236,7 +236,7 @@ func (s *apiSuite) TestConnectionsNotFound(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": `cannot access workshop "not-found": workshop has not been launched`,
+			"message": `cannot access workshop "not-found": workshop not launched`,
 		},
 		"status":      "Not Found",
 		"status-code": 404.0,
@@ -1682,7 +1682,7 @@ func (s *apiSuite) testDisconnectFailureNoWorkshop(c *check.C, installedWorkshop
 	if producer {
 		c.Check(body, check.DeepEquals, map[string]interface{}{
 			"result": map[string]interface{}{
-				"message": `cannot access workshop "consumer-ws": workshop has not been launched`,
+				"message": `cannot access workshop "consumer-ws": workshop not launched`,
 			},
 			"status":      "Not Found",
 			"status-code": 404.0,
@@ -1691,7 +1691,7 @@ func (s *apiSuite) testDisconnectFailureNoWorkshop(c *check.C, installedWorkshop
 	} else {
 		c.Check(body, check.DeepEquals, map[string]interface{}{
 			"result": map[string]interface{}{
-				"message": `cannot access workshop "producer-ws": workshop has not been launched`,
+				"message": `cannot access workshop "producer-ws": workshop not launched`,
 			},
 			"status":      "Not Found",
 			"status-code": 404.0,
@@ -1772,7 +1772,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": `cannot disconnect "consumer-ws/consumer:plug" from "producer-ws/producer:slot": they are not connected`,
+			"message": `cannot disconnect "consumer-ws/consumer:plug" from "producer-ws/producer:slot": not connected`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1809,7 +1809,7 @@ func (s *apiSuite) TestDisconnectForgetPlugFailureNotConnected(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": `cannot disconnect "consumer-ws/consumer:plug" from "producer-ws/producer:slot": they are not connected`,
+			"message": `cannot forget connection between "consumer-ws/consumer:plug" and "producer-ws/producer:slot": not connected`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -135,7 +135,7 @@ func (s *apiSuite) TestWorkshopRemountNoWorkshop(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusNotFound,
-			Message: `cannot access workshop "missing": workshop has not been launched`,
+			Message: `cannot access workshop "missing": workshop not launched`,
 		},
 	}
 

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -108,7 +108,7 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 
 	sock, ok := env["SSH_AUTH_SOCK"]
 	if !ok {
-		return fmt.Errorf("user %q does not have SSH_AUTH_SOCK set. ssh-agent is not running?", user.Username)
+		return fmt.Errorf(`cannot access ssh-agent for user %q: environment variable "SSH_AUTH_SOCK" not found`, user.Username)
 	}
 
 	name := plug.Sdk().Name + "-" + plug.Name()

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -605,7 +605,7 @@ func (r *Repository) Disconnect(plugProjectId, plugWorkshop, plugSdkName, plugNa
 	// Ensure that slot and plug are connected
 	if r.slotPlugs[slot][plug] == nil {
 		return &NotConnectedError{
-			message: fmt.Sprintf("cannot disconnect %q from %q: they are not connected",
+			message: fmt.Sprintf("cannot disconnect %q from %q: not connected",
 				NewPlugRef(plug).ShortRef(), NewSlotRef(slot).ShortRef()),
 		}
 	}

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -794,7 +794,7 @@ func (s *RepositorySuite) TestDisconnectFailsWhenNotConnected(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
 	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `cannot disconnect "ws/consumer:plug" from "ws/producer:slot": they are not connected`)
+	c.Assert(err, ErrorMatches, `cannot disconnect "ws/consumer:plug" from "ws/producer:slot": not connected`)
 	e, _ := err.(*NotConnectedError)
 	c.Check(e, NotNil)
 }

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -263,7 +263,11 @@ func (m *InterfaceManager) ResolveDisconnect(
 		plugRef := interfaces.PlugRef{ProjectId: plugProject, Workshop: plugWorkshop, Sdk: plugSdk, Name: plugName}
 		slotRef := interfaces.SlotRef{ProjectId: slotProject, Workshop: slotWorkshop, Sdk: slotSdk, Name: slotName}
 		if !isConnected {
-			return nil, fmt.Errorf("cannot disconnect %q from %q: they are not connected",
+			if forget {
+				return nil, fmt.Errorf("cannot forget connection between %q and %q: not connected",
+					plugRef.ShortRef(), slotRef.ShortRef())
+			}
+			return nil, fmt.Errorf("cannot disconnect %q from %q: not connected",
 				plugRef.ShortRef(), slotRef.ShortRef())
 		}
 		return []*interfaces.ConnRef{{PlugRef: plugRef, SlotRef: slotRef}}, nil

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -74,7 +74,7 @@ func (w *WorkshopManager) CheckStatus(ctx context.Context, name, pId string, all
 		case healthstate.ErrorStatus:
 			return fmt.Errorf("workshop is unhealthy")
 		case healthstate.StoppedStatus:
-			return fmt.Errorf("workshop is not running")
+			return fmt.Errorf("workshop not running")
 		case healthstate.OffStatus:
 			return workshop.ErrWorkshopNotLaunched
 		default:

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -256,7 +256,7 @@ func (s *managerSuite) TestRefreshRequireStatusReady(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	_, err = s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId)
-	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop is not running`)
+	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop not running`)
 }
 
 func (s *managerSuite) TestRefreshRequireWorkshopExistence(c *check.C) {
@@ -265,5 +265,5 @@ func (s *managerSuite) TestRefreshRequireWorkshopExistence(c *check.C) {
 	s.launchWorkshopWithSDKs(c, "test-1", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 
 	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId)
-	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop has not been launched`)
+	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop not launched`)
 }

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	ErrWorkshopNotLaunched = errors.New("workshop has not been launched")
+	ErrWorkshopNotLaunched = errors.New("workshop not launched")
 	ErrVolumeAlreadyExists = errors.New("storage volume already exists")
 	ErrSdkProfileNotFound  = errors.New("sdk profile not found")
 

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -110,7 +110,7 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 
 	// Validate
 	err = f.bd.UnstashWorkshop(f.ctx, "test")
-	c.Assert(err, check.ErrorMatches, "workshop has not been launched")
+	c.Assert(err, check.ErrorMatches, "workshop not launched")
 }
 
 func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -45,4 +45,4 @@ execute: |
 
   echo "Check stopped workshop"
   workshop_exec stop ws-exec
-  workshop_exec exec ws-exec pwd | MATCH '.*cannot exec command in "ws-exec": workshop is not running$'
+  workshop_exec exec ws-exec pwd | MATCH '.*cannot exec command in "ws-exec": workshop not running$'


### PR DESCRIPTION
# Description

Following up on #213. This also restores the difference in errors between `workshop disconnect` and `workshop disconnect --forget`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
