### PR TITLE
Improve CLI reference structure

### DIFF
--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -39,7 +39,7 @@ Notes:
 
 - Only successful changes display values in the *Ready* column
 
-- To investigate the details of a specific change, use 'workshop tasks' instead
+- To investigate the details of a specific change, use **workshop tasks** instead
 `,
 		Example: `
 # List changes for all workshops in the current project directory

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -45,7 +45,7 @@ that is specified as the second argument or deduced from the context.
 
 - Multiple plugs can be connected to the same slot, but not vice versa
 
-- The 'workshop connections' output will list the connection as 'manual'
+- The **workshop connections** output will list the connection as *manual*
 `,
 		Example: `
 # Connect the 'mod-cache' mount interface plug of the 'go' SDK

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -31,9 +31,9 @@ additional notes, including specific plug bindings, are provided as needed.
 
 Notes:
 
-- The output lists connections created with 'workshop connect' as 'manual'
+- The output lists connections created with **workshop connect** as *manual*
 
-- The '--all' option needn't be used with an argument;
+- The **--all** option needn't be used with an argument;
   if a workshop is supplied, disconnected plugs are also listed
 `,
 		Example: `

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -36,8 +36,8 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
   Notes:
 
 - After an auto-connected plug is thus disconnected,
-  it is reconnected during 'workshop refresh'
-  only if the '--forget' option was used with 'workshop disconnect'
+  it is reconnected during **workshop refresh**
+  only if the **--forget** option was used with **workshop disconnect**
 `,
 		Example: `
 # Disconnect the 'mod-cache' mount interface plug of the 'go' SDK
@@ -56,7 +56,7 @@ workshop disconnect nimble/system:mount`,
 
 	cmd.PersistentFlags().BoolVar(&c.forget, "forget",
 		false,
-		"Reconnect the plugs at 'workshop refresh' if auto-connected initially")
+		"Reconnect the plugs at **workshop refresh** if auto-connected initially")
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
 		false,

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -47,10 +47,10 @@ type CmdShellAlias struct {
 
 var shortExecHelp = "Run a command and wait for it to complete"
 var longExecHelp = `
-The 'exec' subcommand runs an arbitrary command in the specified workshop,
+The **exec** subcommand runs an arbitrary command in the specified workshop,
 waiting for it to complete. If a timeout elapses before that, it's terminated.
 
-To accept an 'exec' command, the workshop must be *Ready* or *Pending*.
+To accept an **exec** command, the workshop must be *Ready* or *Pending*.
 A command can run in two modes that determine how it handles standard streams:
 
 - Interactively (for shell sessions)
@@ -58,23 +58,23 @@ A command can run in two modes that determine how it handles standard streams:
 - Non-interactively (for scripts)
 
 
-To set the mode explicitly, use '-i' or '-I'. If neither is supplied,
-'exec' deduces the mode based on the nature of its own streams:
+To set the mode explicitly, use **-i** or **-I**. If neither is supplied,
+**exec** deduces the mode based on the nature of its own streams:
 
 - If stdin and stdout are terminals, the mode is interactive
 
 - Otherwise, it's non-interactive
 
 
-To separate the 'exec' subcommand from the command itself,
-use shell syntax such as '--':
+To separate the **exec** subcommand from the command itself,
+use shell syntax such as *--*:
 
   $ workshop exec nimble -- echo -n foo bar
 
 
 Notes:
 
-- To start a workshop before running commands in it, use 'workshop start'
+- To start a workshop before running commands in it, use **workshop start**
 
 - You can set the working directory, environment variables, user and group ID
   for running the command in the workshop; reasonable defaults are provided
@@ -82,18 +82,18 @@ Notes:
 
 var shortShellHelp = "Start an interactive terminal session for the workshop"
 var longShellHelp = `
-The 'shell' subcommand runs an interactive terminal session
+The **shell** subcommand runs an interactive terminal session
 in the specified workshop.
 
-To accept a 'shell' command, the workshop must be *Ready* or *Pending*.
+To accept a **shell** command, the workshop must be *Ready* or *Pending*.
 
 
 Notes:
 
-- To start a workshop before running a terminal session, use 'workshop start'
+- To start a workshop before running a terminal session, use **workshop start**
 
-- The subcommand is a shorthand for 'workshop exec';
-  it launches the login shell for 'workshop',
+- The subcommand is a shorthand for **workshop exec**;
+  it launches the login shell for *workshop*,
   the default non-privileged user in a workshop
 `
 
@@ -124,7 +124,7 @@ workshop exec nimble --uid 0 id`,
 	cmd.Flags().StringArrayVar(&c.Env, "env", []string{}, "Set an environment variable, e.g. 'FOO=bar'; if only the name is provided, the value is inherited from the CLI environment.")
 	cmd.Flags().IntVar(&c.UserId, "uid", 1000, "Run as a specific workshop user")
 	cmd.Flags().IntVar(&c.GroupId, "gid", 1000, "Run as a member of a specific workshop group")
-	cmd.Flags().DurationVar(&c.Timeout, "timeout", 0, "Set a timeout; valid units are 'ns', 'us'/'µs', 'ms', 's', 'm', 'h'")
+	cmd.Flags().DurationVar(&c.Timeout, "timeout", 0, "Set a timeout; valid units are ns, us or µs, ms, s, m, h")
 	cmd.Flags().BoolVarP(&c.Interactive, "interactive", "i", false, "Force interactive mode")
 	cmd.Flags().BoolVarP(&c.NonInteractive, "non-interactive", "I", false, "Force non-interactive mode")
 

--- a/cmd/workshop/gendocs/cli.tmpl
+++ b/cmd/workshop/gendocs/cli.tmpl
@@ -1,5 +1,3 @@
-:hide-toc:
-
 .. _ref_cli:
 
 CLI commands
@@ -20,17 +18,17 @@ Shell completion
 ----------------
 
 To configure shell completion,
-follow the instructions offered by :command:`workshop completion`:
+follow the instructions offered by **workshop completion**:
 
 .. code-block:: console
 
-   $ workshop completion -h
+   workshop completion -h
 
 For example, in your :file:`~/.bashrc` file:
 
 .. code-block:: console
 
-   $ source <(workshop completion bash)
+   source <(workshop completion bash)
 
 
 See also

--- a/cmd/workshop/gendocs/command.tmpl
+++ b/cmd/workshop/gendocs/command.tmpl
@@ -3,36 +3,34 @@
 {{ .CommandName }}
 {{ .Heading }}
 
-{{ .Short }}
+{{ .Short }}.
 
-Synopsis
-~~~~~~~~
-
-{{ .Long }}
+.. rubric:: Synopsis
 
 .. code-block:: console
 
    {{ .Synopsis }}
 
-{{- if .Examples }}
+.. rubric:: Description
 
-Examples
-~~~~~~~~
-
-.. code-block:: console
-
-{{ .Examples | indent 3 }}
-{{- end }}
+{{ .Long }}
 
 {{- if .Flags }}
 
-Options
-~~~~~~~
+.. rubric:: Options
 
-{{- range .Flags }}
+{{ range .Flags }}
 --{{ .Name }}
 
 {{ .Usage | indent 3 }}
 
 {{ end }}
+{{- end }}
+
+{{- if .Examples }}
+
+.. rubric:: Examples
+
+.. code-block:: console
+{{ .Examples | indent 3 }}
 {{- end }}

--- a/cmd/workshop/hack.go
+++ b/cmd/workshop/hack.go
@@ -26,7 +26,7 @@ func (c *CmdHack) Command() *cobra.Command {
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Edit the hack SDK and graft it onto the workshop",
 		Long: `
-This command opens the default text editor to configure the 'hack' SDK
+This command opens the default text editor to configure the **hack** SDK
 and immediately installs it in the specified workshop,
 enabling rapid experiments and tweaks at the SDK level.
 
@@ -40,22 +40,22 @@ Setting the <HOOK> value opens the respective hook file:
 
 
 Saving and exiting causes a refresh,
-which installs the updated 'hack' SDK in the workshop.
+which installs the updated **hack** SDK in the workshop.
 
-The '--drop' and '--restore' options stash the 'hack' SDK,
+The **--drop** and **--restore** options stash the **hack** SDK,
 reversing the changes, and quickly restore it to the workshop.
 
 
 Notes:
 
-- The 'hack' SDK doesn't appear in the workshop definition
+- The **hack** SDK doesn't appear in the workshop definition
   and cannot include build-time data such as parts
 
-- In addition to hooks, the 'hack' SDK can use interfaces,
+- In addition to hooks, the **hack** SDK can use interfaces,
   define plugs, slots, connections and bindings
 
-- You can partially refresh the workshop, targeting the 'hack' SDK
-  with the 'workshop refresh <WORKSHOP>/hack' command
+- You can partially refresh the workshop, targeting the **hack** SDK
+  with the **workshop refresh <WORKSHOP>/hack** command
 `,
 		Example: `
 # Edit the hack SDK definition for the 'nimble' workshop

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -38,7 +38,7 @@ Notes:
 
 - Names listed as arguments must match respective 'name:' values in definitions
 
-- To update an existing workshop, use 'workshop refresh' instead
+- To update an existing workshop, use **workshop refresh** instead
 
 - SDKs are installed in alphabetical order
 `,

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -37,13 +37,13 @@ This command enumerates all workshops in the project, printing a compact list:
 - Notes:    internal remarks on the overall state of the workshop
 
 
-The '--global' option lists all workshops from *all* projects in the system;
+The **--global** option lists all workshops from *all* projects in the system;
 however, it doesn't include any that are *Off*.
 
 
 Notes:
 
-- For details of a single workshop, use 'workshop info' instead
+- For details of a single workshop, use **workshop info** instead
 `,
 		Example: `
 # List the workshops in the current project directory

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -47,7 +47,7 @@ Notes:
 
 - The workshop must be *Ready* to be refreshed
 
-- To construct a newly defined workshop, use 'workshop launch' instead
+- To construct a newly defined workshop, use **workshop launch** instead
 
 - Throughout the refresh, all affected workshops remain *Pending*
 
@@ -56,11 +56,11 @@ Notes:
 - Updated and newly added SDKs are installed in alphabetical order
 
 - For content interface plugs, mounts the last source
-  set by 'workshop remount', if any
+  set by **workshop remount**, if any
 
 - If the optional <SDK> is supplied,
   the operation is limited to this SDK;
-  currently, it can only be 'hack'
+  currently, it can only be **hack**
 `,
 		Example: `
 # Refresh the 'nimble' and 'jazzy' workshops in the current project directory
@@ -83,7 +83,7 @@ workshop refresh nimble/hack`,
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",
 		false,
-		"Pause the operation on error; to resume, use '--continue' or '--abort'.")
+		"Pause the operation on error; to resume, use **--continue** or **--abort**.")
 	cmd.PersistentFlags().BoolVar(&c.Continue, "continue",
 		false,
 		"Continue the previously paused operation.")

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -33,13 +33,13 @@ Specifically, it does the following:
 
 Notes:
 
-- To stop the workshop, use 'workshop stop'
+- To stop the workshop, use **workshop stop**
 
-- 'workshop info' lists any mounted content interface plugs for the workshop
+- **workshop info** lists any mounted content interface plugs for the workshop
 
-- 'workshop refresh' mounts the last source set by 'workshop remount', if any
+- **workshop refresh** mounts the last source set by **workshop remount**, if any
 
-- During 'workshop remove', non-default sources set by 'workshop remount'
+- During **workshop remove**, non-default sources set by **workshop remount**
   aren't removed
 `,
 		Example: `

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -30,8 +30,8 @@ This command removes the workshops listed as arguments. For each workshop, it:
 Notes:
 
 - If any listed workshop is *Off* or *Pending*, none are removed
-- To rebuild a removed workshop from scratch, use 'workshop launch'
-- For content interface plugs, non-default sources set by 'workshop remount'
+- To rebuild a removed workshop from scratch, use **workshop launch**
+- For content interface plugs, non-default sources set by **workshop remount**
   aren't removed
 `,
 		Example: `

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -35,7 +35,7 @@ Notes:
 
 - When interrupted, the command attempts to gracefully revert its actions
 
-- To stop a started workshop, use 'workshop stop'
+- To stop a started workshop, use **workshop stop**
 `,
 		Example: `
 # Start the 'nimble' and 'jazzy' workshops in the current project directory

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -35,7 +35,7 @@ Notes:
 
 - When interrupted, the command attempts to gracefully revert its actions
 
-- To start a stopped workshop, use 'workshop start'
+- To start a stopped workshop, use **workshop start**
 `,
 		Example: `
 # Stop the nimble and jazzy workshops in the current project directory

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -37,7 +37,7 @@ Notes:
 
 - The command may print additional log details for tasks that store them
 
-- To investigate recent changes in a project, use 'workshop changes' instead
+- To investigate recent changes in a project, use **workshop changes** instead
 `,
 		Example: `
 # List the tasks under change ID 42

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -60,11 +60,11 @@ func (c *CmdWarnings) Command() *cobra.Command {
 		Long: `
 This command lists the warnings that were reported to the system.
 
-All warnings listed by 'workshop warnings'
-can be acknowledged with the 'workshop okay' command.
-Acknowledged warnings aren't listed by 'workshop warnings'
+All warnings listed by **workshop warnings**
+can be acknowledged with the **workshop okay** command.
+Acknowledged warnings aren't listed by **workshop warnings**
 unless they occur again after their cooldown period has elapsed
-or the '--all' option is used.
+or the **--all** option is used.
 
 Also, warnings expire automatically; expired warnings are not listed.
 `,
@@ -102,11 +102,11 @@ func (c *CmdOkay) Command() *cobra.Command {
 		Short: "Acknowledge listed warnings",
 		Long: `
 This command acknowledges all warnings
-listed previously by the 'workshop warnings' command.
+listed previously by the **workshop warnings** command.
 `,
 		Example: `
 # Acknowledge the globally registered warnings across all workshops
-# (must run after 'workshop warnings')
+# (must run after **workshop warnings**)
 workshop okay`,
 		RunE: c.Run,
 	}

--- a/docs/reference/cli/index.rst
+++ b/docs/reference/cli/index.rst
@@ -1,5 +1,3 @@
-:hide-toc:
-
 .. _ref_cli:
 
 CLI commands
@@ -71,17 +69,17 @@ Shell completion
 ----------------
 
 To configure shell completion,
-follow the instructions offered by :command:`workshop completion`:
+follow the instructions offered by **workshop completion**:
 
 .. code-block:: console
 
-   $ workshop completion -h
+   workshop completion -h
 
 For example, in your :file:`~/.bashrc` file:
 
 .. code-block:: console
 
-   $ source <(workshop completion bash)
+   source <(workshop completion bash)
 
 
 See also

--- a/docs/reference/cli/workshop-changes.rst
+++ b/docs/reference/cli/workshop-changes.rst
@@ -3,10 +3,15 @@
 workshop changes
 ----------------
 
-List recent changes to the workshops in a project
+List recent changes to the workshops in a project.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop changes [flags]
+
+.. rubric:: Description
 
 
 Any substantial operation on a workshop is a *change* that consists of *tasks*;
@@ -28,9 +33,12 @@ Notes:
 
 - Only successful changes display values in the *Ready* column
 
-- To investigate the details of a specific change, use 'workshop tasks' instead
+- To investigate the details of a specific change, use **workshop tasks** instead
 
+
+.. rubric:: Examples
 
 .. code-block:: console
-
-   workshop changes [flags]
+   
+   # List changes for all workshops in the current project directory
+   workshop changes

--- a/docs/reference/cli/workshop-connect.rst
+++ b/docs/reference/cli/workshop-connect.rst
@@ -3,10 +3,15 @@
 workshop connect
 ----------------
 
-Connect a plug to a slot
+Connect a plug to a slot.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop connect <WORKSHOP>/<SDK>:<PLUG> [<WORKSHOP>/<SDK>][:<SLOT>] [flags]
+
+.. rubric:: Description
 
 
 This command connects a plug to a target slot
@@ -34,17 +39,25 @@ that is specified as the second argument or deduced from the context.
 
 - Multiple plugs can be connected to the same slot, but not vice versa
 
-- The 'workshop connections' output will list the connection as 'manual'
+- The **workshop connections** output will list the connection as *manual*
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop connect <WORKSHOP>/<SDK>:<PLUG> [<WORKSHOP>/<SDK>][:<SLOT>] [flags]
 
-Options
-~~~~~~~
 --no-wait
 
    Return the change ID, don't wait for the operation to finish
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Connect the 'mod-cache' mount interface plug of the 'go' SDK
+   # under the 'nimble' workshop in the current project directory
+   workshop connect nimble/go:mod-cache :mount
+   
+   # A full version of the command that also lists the target SDK ('system')
+   workshop connect nimble/go:mod-cache nimble/system:mount

--- a/docs/reference/cli/workshop-connections.rst
+++ b/docs/reference/cli/workshop-connections.rst
@@ -3,10 +3,15 @@
 workshop connections
 --------------------
 
-List interface connections
+List interface connections.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop connections [<WORKSHOP>] [flags]
+
+.. rubric:: Description
 
 
 This command lists the connections between interface plugs and slots
@@ -17,20 +22,27 @@ additional notes, including specific plug bindings, are provided as needed.
 
 Notes:
 
-- The output lists connections created with 'workshop connect' as 'manual'
+- The output lists connections created with **workshop connect** as *manual*
 
-- The '--all' option needn't be used with an argument;
+- The **--all** option needn't be used with an argument;
   if a workshop is supplied, disconnected plugs are also listed
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop connections [<WORKSHOP>] [flags]
 
-Options
-~~~~~~~
 --all
 
    Include disconnected plugs in the output.
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # List connections for the workshop 'nimble' in the current project directory
+   workshop connections nimble
+   
+   # List connections for all workshops in the current project directory:
+   workshop connections

--- a/docs/reference/cli/workshop-disconnect.rst
+++ b/docs/reference/cli/workshop-disconnect.rst
@@ -3,10 +3,15 @@
 workshop disconnect
 -------------------
 
-Disconnect a plug or a slot
+Disconnect a plug or a slot.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop disconnect <WORKSHOP>/<SDK>:<PLUG OR SLOT> [<WORKSHOP>/<SDK>]:[<SLOT>] [flags]
+
+.. rubric:: Description
 
 
 This command disconnects a plug from its slot, or a slot from all its plugs.
@@ -25,19 +30,16 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
   Notes:
 
 - After an auto-connected plug is thus disconnected,
-  it is reconnected during 'workshop refresh'
-  only if the '--forget' option was used with 'workshop disconnect'
+  it is reconnected during **workshop refresh**
+  only if the **--forget** option was used with **workshop disconnect**
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop disconnect <WORKSHOP>/<SDK>:<PLUG OR SLOT> [<WORKSHOP>/<SDK>]:[<SLOT>] [flags]
 
-Options
-~~~~~~~
 --forget
 
-   Reconnect the plugs at 'workshop refresh' if auto-connected initially
+   Reconnect the plugs at **workshop refresh** if auto-connected initially
 
 
 --no-wait
@@ -45,3 +47,19 @@ Options
    Return the change ID, don't wait for the operation to finish
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Disconnect the 'mod-cache' mount interface plug of the 'go' SDK
+   # under the 'nimble' workshop in the current project directory
+   workshop disconnect nimble/go:mod-cache
+   
+   # A full version of the same command
+   # that lists the target SDK ('system') and slot ('mount')
+   workshop disconnect nimble/go:mod-cache nimble/system:mount
+   
+   # Disconnect all plugs connected to the 'mount' slot of the 'system' SDK
+   # under the 'nimble' workshop in the current project directory
+   workshop disconnect nimble/system:mount

--- a/docs/reference/cli/workshop-exec.rst
+++ b/docs/reference/cli/workshop-exec.rst
@@ -3,16 +3,21 @@
 workshop exec
 -------------
 
-Run a command and wait for it to complete
+Run a command and wait for it to complete.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop exec <WORKSHOP> [flags]
+
+.. rubric:: Description
 
 
-The 'exec' subcommand runs an arbitrary command in the specified workshop,
+The **exec** subcommand runs an arbitrary command in the specified workshop,
 waiting for it to complete. If a timeout elapses before that, it's terminated.
 
-To accept an 'exec' command, the workshop must be *Ready* or *Pending*.
+To accept an **exec** command, the workshop must be *Ready* or *Pending*.
 A command can run in two modes that determine how it handles standard streams:
 
 - Interactively (for shell sessions)
@@ -20,34 +25,31 @@ A command can run in two modes that determine how it handles standard streams:
 - Non-interactively (for scripts)
 
 
-To set the mode explicitly, use '-i' or '-I'. If neither is supplied,
-'exec' deduces the mode based on the nature of its own streams:
+To set the mode explicitly, use **-i** or **-I**. If neither is supplied,
+**exec** deduces the mode based on the nature of its own streams:
 
 - If stdin and stdout are terminals, the mode is interactive
 
 - Otherwise, it's non-interactive
 
 
-To separate the 'exec' subcommand from the command itself,
-use shell syntax such as '--':
+To separate the **exec** subcommand from the command itself,
+use shell syntax such as *--*:
 
   $ workshop exec nimble -- echo -n foo bar
 
 
 Notes:
 
-- To start a workshop before running commands in it, use 'workshop start'
+- To start a workshop before running commands in it, use **workshop start**
 
 - You can set the working directory, environment variables, user and group ID
   for running the command in the workshop; reasonable defaults are provided
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop exec <WORKSHOP> [flags]
 
-Options
-~~~~~~~
 --cwd
 
    Set the working directory in the workshop
@@ -70,7 +72,7 @@ Options
 
 --timeout
 
-   Set a timeout; valid units are 'ns', 'us'/'µs', 'ms', 's', 'm', 'h'
+   Set a timeout; valid units are ns, us or µs, ms, s, m, h
 
 
 --interactive
@@ -83,3 +85,20 @@ Options
    Force non-interactive mode
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Run the 'go build main.go' command under the 'nimble' workshop
+   # in the current project directory
+   workshop exec nimble go build main.go
+   
+   # A similar command that sets an environment variable and the working directory
+   workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
+   
+   # Run a custom interactive shell
+   workshop exec nimble -I sh
+   
+   # Run a command as root (the default is 'workshop')
+   workshop exec nimble --uid 0 id

--- a/docs/reference/cli/workshop-hack.rst
+++ b/docs/reference/cli/workshop-hack.rst
@@ -3,13 +3,18 @@
 workshop hack
 -------------
 
-Edit the hack SDK and graft it onto the workshop
+Edit the hack SDK and graft it onto the workshop.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop hack [--drop|--restore] <WORKSHOP> [setup-base|save-save|restore-state|check-health] [flags]
+
+.. rubric:: Description
 
 
-This command opens the default text editor to configure the 'hack' SDK
+This command opens the default text editor to configure the **hack** SDK
 and immediately installs it in the specified workshop,
 enabling rapid experiments and tweaks at the SDK level.
 
@@ -23,30 +28,27 @@ Setting the <HOOK> value opens the respective hook file:
 
 
 Saving and exiting causes a refresh,
-which installs the updated 'hack' SDK in the workshop.
+which installs the updated **hack** SDK in the workshop.
 
-The '--drop' and '--restore' options stash the 'hack' SDK,
+The **--drop** and **--restore** options stash the **hack** SDK,
 reversing the changes, and quickly restore it to the workshop.
 
 
 Notes:
 
-- The 'hack' SDK doesn't appear in the workshop definition
+- The **hack** SDK doesn't appear in the workshop definition
   and cannot include build-time data such as parts
 
-- In addition to hooks, the 'hack' SDK can use interfaces,
+- In addition to hooks, the **hack** SDK can use interfaces,
   define plugs, slots, connections and bindings
 
-- You can partially refresh the workshop, targeting the 'hack' SDK
-  with the 'workshop refresh <WORKSHOP>/hack' command
+- You can partially refresh the workshop, targeting the **hack** SDK
+  with the **workshop refresh <WORKSHOP>/hack** command
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop hack [--drop|--restore] <WORKSHOP> [setup-base|save-save|restore-state|check-health] [flags]
 
-Options
-~~~~~~~
 --drop
 
    Drop the hack SDK from the workshop.
@@ -57,3 +59,18 @@ Options
    Return the previously dropped SDK to the workshop.
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Edit the hack SDK definition for the 'nimble' workshop
+   # and apply it after saving by automatically refreshing the workshop
+   workshop hack nimble
+   
+   # Edit the 'check-health' hook for the hack SDK
+   # and apply it after saving by automatically refreshing the workshop
+   workshop hack nimble check-health
+   
+   # Stash the hack SDK, temporarily reverting the changes in the workshop
+   workshop hack nimble --drop

--- a/docs/reference/cli/workshop-info.rst
+++ b/docs/reference/cli/workshop-info.rst
@@ -3,10 +3,15 @@
 workshop info
 -------------
 
-Print the current status and details of a workshop as YAML
+Print the current status and details of a workshop as YAML.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop info <WORKSHOP> [flags]
+
+.. rubric:: Description
 
 
 This command outputs the basic settings, current status and individual SDK
@@ -26,6 +31,9 @@ Notes:
 - Avoid assumptions based on SDK channels: 'latest/stable' may be neither
 
 
-.. code-block:: console
+.. rubric:: Examples
 
-   workshop info <WORKSHOP> [flags]
+.. code-block:: console
+   
+   # List details for the 'nimble' workshop in the current project directory
+   workshop info nimble

--- a/docs/reference/cli/workshop-launch.rst
+++ b/docs/reference/cli/workshop-launch.rst
@@ -3,10 +3,15 @@
 workshop launch
 ---------------
 
-Construct one or many workshops using their definitions
+Construct one or many workshops using their definitions.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop launch <WORKSHOP>... [flags]
+
+.. rubric:: Description
 
 
 This command constructs the workshops listed as arguments by going over their
@@ -29,19 +34,23 @@ Notes:
 
 - Names listed as arguments must match respective 'name:' values in definitions
 
-- To update an existing workshop, use 'workshop refresh' instead
+- To update an existing workshop, use **workshop refresh** instead
 
 - SDKs are installed in alphabetical order
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop launch <WORKSHOP>... [flags]
 
-Options
-~~~~~~~
 --no-wait
 
    Return the change ID, don't wait for the operation to finish
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Launch the 'nimble' and 'jazzy' workshops in the current project directory
+   workshop launch nimble jazzy

--- a/docs/reference/cli/workshop-list.rst
+++ b/docs/reference/cli/workshop-list.rst
@@ -3,10 +3,15 @@
 workshop list
 -------------
 
-List project workshops
+List project workshops.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop list [flags]
+
+.. rubric:: Description
 
 
 This command enumerates all workshops in the project, printing a compact list:
@@ -20,23 +25,30 @@ This command enumerates all workshops in the project, printing a compact list:
 - Notes:    internal remarks on the overall state of the workshop
 
 
-The '--global' option lists all workshops from *all* projects in the system;
+The **--global** option lists all workshops from *all* projects in the system;
 however, it doesn't include any that are *Off*.
 
 
 Notes:
 
-- For details of a single workshop, use 'workshop info' instead
+- For details of a single workshop, use **workshop info** instead
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop list [flags]
 
-Options
-~~~~~~~
 --global
 
    List workshops from all projects in the system
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # List the workshops in the current project directory
+   workshop list
+   
+   # List the globally registered workshops
+   workshop list --global

--- a/docs/reference/cli/workshop-okay.rst
+++ b/docs/reference/cli/workshop-okay.rst
@@ -3,16 +3,25 @@
 workshop okay
 -------------
 
-Acknowledge listed warnings
+Acknowledge listed warnings.
 
-Synopsis
-~~~~~~~~
-
-
-This command acknowledges all warnings
-listed previously by the 'workshop warnings' command.
-
+.. rubric:: Synopsis
 
 .. code-block:: console
 
    workshop okay [flags]
+
+.. rubric:: Description
+
+
+This command acknowledges all warnings
+listed previously by the **workshop warnings** command.
+
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Acknowledge the globally registered warnings across all workshops
+   # (must run after **workshop warnings**)
+   workshop okay

--- a/docs/reference/cli/workshop-refresh.rst
+++ b/docs/reference/cli/workshop-refresh.rst
@@ -3,10 +3,15 @@
 workshop refresh
 ----------------
 
-Update workshops according to their definitions
+Update workshops according to their definitions.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop refresh [--abort|--continue|--wait-on-error] <WORKSHOP>[/<SDK>]... [flags]
+
+.. rubric:: Description
 
 
 This command updates the workshops listed as arguments by going over their
@@ -34,7 +39,7 @@ Notes:
 
 - The workshop must be *Ready* to be refreshed
 
-- To construct a newly defined workshop, use 'workshop launch' instead
+- To construct a newly defined workshop, use **workshop launch** instead
 
 - Throughout the refresh, all affected workshops remain *Pending*
 
@@ -43,19 +48,16 @@ Notes:
 - Updated and newly added SDKs are installed in alphabetical order
 
 - For content interface plugs, mounts the last source
-  set by 'workshop remount', if any
+  set by **workshop remount**, if any
 
 - If the optional <SDK> is supplied,
   the operation is limited to this SDK;
-  currently, it can only be 'hack'
+  currently, it can only be **hack**
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop refresh [--abort|--continue|--wait-on-error] <WORKSHOP>[/<SDK>]... [flags]
 
-Options
-~~~~~~~
 --abort
 
    Abort the previously paused operation, reverting any changes.
@@ -68,6 +70,26 @@ Options
 
 --wait-on-error
 
-   Pause the operation on error; to resume, use '--continue' or '--abort'.
+   Pause the operation on error; to resume, use **--continue** or **--abort**.
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Refresh the 'nimble' and 'jazzy' workshops in the current project directory
+   workshop refresh nimble jazzy
+   
+   # Refresh 'nimble', but stop on any errors (won’t accept multiple workshops)
+   workshop refresh nimble --wait-on-error
+   
+   # After 'nimble' refresh stopped on error, abort the operation
+   workshop refresh nimble --abort
+   
+   # After 'nimble' refresh stopped on error and the workshop was fixed,
+   # continue the operation
+   workshop refresh nimble --continue
+   
+   # Refresh the hack SDK under 'nimble'
+   workshop refresh nimble/hack

--- a/docs/reference/cli/workshop-remount.rst
+++ b/docs/reference/cli/workshop-remount.rst
@@ -3,10 +3,15 @@
 workshop remount
 ----------------
 
-Mount a new source location to the content interface plug's target
+Mount a new source location to the content interface plug's target.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop remount <WORKSHOP>/<SDK>:<PLUG> <SOURCE> [flags]
+
+.. rubric:: Description
 
 
 This command mounts a new source location on the host to the target directory
@@ -23,24 +28,30 @@ Specifically, it does the following:
 
 Notes:
 
-- To stop the workshop, use 'workshop stop'
+- To stop the workshop, use **workshop stop**
 
-- 'workshop info' lists any mounted content interface plugs for the workshop
+- **workshop info** lists any mounted content interface plugs for the workshop
 
-- 'workshop refresh' mounts the last source set by 'workshop remount', if any
+- **workshop refresh** mounts the last source set by **workshop remount**, if any
 
-- During 'workshop remove', non-default sources set by 'workshop remount'
+- During **workshop remove**, non-default sources set by **workshop remount**
   aren't removed
 
 
-.. code-block:: console
+.. rubric:: Options
 
-   workshop remount <WORKSHOP>/<SDK>:<PLUG> <SOURCE> [flags]
 
-Options
-~~~~~~~
 --no-wait
 
    Return the change ID, don't wait for the operation to finish
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Remount the 'mod-cache' mount interface plug of the 'go' SDK
+   # under the 'nimble' workshop in the current project directory
+   # to '~/new-cache-mount/' on the host:
+   workshop remount nimble/go:mod-cache ~/new-cache-mount

--- a/docs/reference/cli/workshop-remove.rst
+++ b/docs/reference/cli/workshop-remove.rst
@@ -3,10 +3,15 @@
 workshop remove
 ---------------
 
-Remove one or many workshops
+Remove one or many workshops.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop remove <WORKSHOP>... [flags]
+
+.. rubric:: Description
 
 
 This command removes the workshops listed as arguments. For each workshop, it:
@@ -18,11 +23,14 @@ This command removes the workshops listed as arguments. For each workshop, it:
 Notes:
 
 - If any listed workshop is *Off* or *Pending*, none are removed
-- To rebuild a removed workshop from scratch, use 'workshop launch'
-- For content interface plugs, non-default sources set by 'workshop remount'
+- To rebuild a removed workshop from scratch, use **workshop launch**
+- For content interface plugs, non-default sources set by **workshop remount**
   aren't removed
 
 
-.. code-block:: console
+.. rubric:: Examples
 
-   workshop remove <WORKSHOP>... [flags]
+.. code-block:: console
+   
+   # Remove the 'nimble' and 'jazzy' workshops in the current project directory
+   workshop remove nimble jazzy

--- a/docs/reference/cli/workshop-shell.rst
+++ b/docs/reference/cli/workshop-shell.rst
@@ -3,27 +3,36 @@
 workshop shell
 --------------
 
-Start an interactive terminal session for the workshop
+Start an interactive terminal session for the workshop.
 
-Synopsis
-~~~~~~~~
-
-
-The 'shell' subcommand runs an interactive terminal session
-in the specified workshop.
-
-To accept a 'shell' command, the workshop must be *Ready* or *Pending*.
-
-
-Notes:
-
-- To start a workshop before running a terminal session, use 'workshop start'
-
-- The subcommand is a shorthand for 'workshop exec';
-  it launches the login shell for 'workshop',
-  the default non-privileged user in a workshop
-
+.. rubric:: Synopsis
 
 .. code-block:: console
 
    workshop shell <WORKSHOP> [flags]
+
+.. rubric:: Description
+
+
+The **shell** subcommand runs an interactive terminal session
+in the specified workshop.
+
+To accept a **shell** command, the workshop must be *Ready* or *Pending*.
+
+
+Notes:
+
+- To start a workshop before running a terminal session, use **workshop start**
+
+- The subcommand is a shorthand for **workshop exec**;
+  it launches the login shell for *workshop*,
+  the default non-privileged user in a workshop
+
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # Open the default login shell of the 'workshop' user into the 'nimble' workshop
+   # in the current project directory
+   workshop shell nimble

--- a/docs/reference/cli/workshop-start.rst
+++ b/docs/reference/cli/workshop-start.rst
@@ -3,10 +3,15 @@
 workshop start
 --------------
 
-Start one or many workshops
+Start one or many workshops.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop start <WORKSHOP>... [flags]
+
+.. rubric:: Description
 
 
 This command activates the workshops listed as arguments. For each one, it:
@@ -26,9 +31,12 @@ Notes:
 
 - When interrupted, the command attempts to gracefully revert its actions
 
-- To stop a started workshop, use 'workshop stop'
+- To stop a started workshop, use **workshop stop**
 
+
+.. rubric:: Examples
 
 .. code-block:: console
-
-   workshop start <WORKSHOP>... [flags]
+   
+   # Start the 'nimble' and 'jazzy' workshops in the current project directory
+   workshop start nimble jazzy

--- a/docs/reference/cli/workshop-stop.rst
+++ b/docs/reference/cli/workshop-stop.rst
@@ -3,10 +3,15 @@
 workshop stop
 -------------
 
-Stop one or many workshops
+Stop one or many workshops.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop stop <WORKSHOP>... [flags]
+
+.. rubric:: Description
 
 
 This command deactivates the workshops listed as arguments. For each one, it:
@@ -26,9 +31,12 @@ Notes:
 
 - When interrupted, the command attempts to gracefully revert its actions
 
-- To start a stopped workshop, use 'workshop start'
+- To start a stopped workshop, use **workshop start**
 
+
+.. rubric:: Examples
 
 .. code-block:: console
-
-   workshop stop <WORKSHOP>... [flags]
+   
+   # Stop the nimble and jazzy workshops in the current project directory
+   workshop stop nimble jazzy

--- a/docs/reference/cli/workshop-tasks.rst
+++ b/docs/reference/cli/workshop-tasks.rst
@@ -3,10 +3,15 @@
 workshop tasks
 --------------
 
-List tasks for a specific change
+List tasks for a specific change.
 
-Synopsis
-~~~~~~~~
+.. rubric:: Synopsis
+
+.. code-block:: console
+
+   workshop tasks <CHANGE ID> [flags]
+
+.. rubric:: Description
 
 
 Any substantial operation on a workshop is a *change* that consists of *tasks*;
@@ -24,9 +29,12 @@ Notes:
 
 - The command may print additional log details for tasks that store them
 
-- To investigate recent changes in a project, use 'workshop changes' instead
+- To investigate recent changes in a project, use **workshop changes** instead
 
+
+.. rubric:: Examples
 
 .. code-block:: console
-
-   workshop tasks <CHANGE ID> [flags]
+   
+   # List the tasks under change ID 42
+   workshop tasks 42

--- a/docs/reference/cli/workshop-warnings.rst
+++ b/docs/reference/cli/workshop-warnings.rst
@@ -3,29 +3,31 @@
 workshop warnings
 -----------------
 
-List warnings
+List warnings.
 
-Synopsis
-~~~~~~~~
-
-
-This command lists the warnings that were reported to the system.
-
-All warnings listed by 'workshop warnings'
-can be acknowledged with the 'workshop okay' command.
-Acknowledged warnings aren't listed by 'workshop warnings'
-unless they occur again after their cooldown period has elapsed
-or the '--all' option is used.
-
-Also, warnings expire automatically; expired warnings are not listed.
-
+.. rubric:: Synopsis
 
 .. code-block:: console
 
    workshop warnings [OPTIONS] [flags]
 
-Options
-~~~~~~~
+.. rubric:: Description
+
+
+This command lists the warnings that were reported to the system.
+
+All warnings listed by **workshop warnings**
+can be acknowledged with the **workshop okay** command.
+Acknowledged warnings aren't listed by **workshop warnings**
+unless they occur again after their cooldown period has elapsed
+or the **--all** option is used.
+
+Also, warnings expire automatically; expired warnings are not listed.
+
+
+.. rubric:: Options
+
+
 --abs-time
 
    Use absolute times in RFC 3339 format.
@@ -48,3 +50,10 @@ Options
    Show more information per each warning.
 
 
+
+.. rubric:: Examples
+
+.. code-block:: console
+   
+   # List the globally registered warnings across all workshops
+   workshop warnings


### PR DESCRIPTION
# Description

This finally brings the generated CLI reference to a production-ready level.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [x] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.
