### PR TITLE
Doc: update ros2 SDK to match current revision

### DIFF
--- a/docs/how-to/ros2/design-sdk/sdkcraft.yaml
+++ b/docs/how-to/ros2/design-sdk/sdkcraft.yaml
@@ -1,22 +1,34 @@
 name: ros2
-title: "The ROS\_2 SDK"
+title: The ROS 2 SDK
 base: ubuntu@24.04
-version: '0.1'
-summary: "The strictly necessary ROS\_2 development environment for your project."
-description: "The ROS\_2 SDK creates a minimum viable development environment\nfor your ROS\_2 project.\nIt sets up a bare-bones ROS\_2 workspace\nbefore installing all of the dependencies\nfor the ROS\_2 project mounted by workshop.\n\nA developer can thus connect to the workshop\nto immediately build the project.\n"
+version: "0.1"
+summary: The strictly necessary ROS 2 development environment for your project.
+description: |
+  The ROS 2 SDK creates a minimum viable development environment
+  for your ROS 2 project.
+  It sets up a bare-bones ROS 2 workspace
+  before installing all of the dependencies
+  for the ROS 2 project mounted by workshop.
+
+  A developer can thus connect to the workshop
+  to immediately build the project.
 license: LGPL-2.1
 platforms:
-  amd64: null
-  arm64: null
+  amd64:
+  arm64:
+
 parts:
   ros2-part:
     plugin: nil
+
 plugs:
   ros-cache:
-    interface: content
-    target: /home/workshop/.ros
+    interface: mount
+    workshop-target: /home/workshop/.ros
+
   colcon-artefacts:
-    interface: content
-    target: /home/workshop/colcon
+    interface: mount
+    workshop-target: /home/workshop/colcon
+
   gpu:
     interface: gpu

--- a/docs/how-to/ros2/design-sdk/setup-base
+++ b/docs/how-to/ros2/design-sdk/setup-base
@@ -36,7 +36,7 @@ fi
 
 # Add ROS 2 repository to the sources list
 if [ ! -f "/etc/apt/sources.list.d/ros2.list" ]; then
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" |  tee /etc/apt/sources.list.d/ros2.list > /dev/null
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" |  tee /etc/apt/sources.list.d/ros2.list > /dev/null
 fi
 # [ros2-repo-end]
 
@@ -63,13 +63,13 @@ apt-get -y install ros-${_WORKSHOP_ROS_DISTRO}-ros2run ros-${_WORKSHOP_ROS_DISTR
 # [ros2-workspace-end]
 
 # [bashrc-update-start]
-# Add bashrc setup script
-if ! grep -q "source /opt/ros/${_WORKSHOP_ROS_DISTRO}/setup.bash" "${_WORKSHOP_USER_HOME}/.bashrc"; then
+# Add setup script to .profile so that it is avail for both interactive and non-interactive shell
+if ! grep -q "source /opt/ros/${_WORKSHOP_ROS_DISTRO}/setup.bash" "${_WORKSHOP_USER_HOME}/.profile"; then
   echo "
   # Source ROS 2
   if [ -f /opt/ros/${_WORKSHOP_ROS_DISTRO}/setup.bash ]; then
     source /opt/ros/${_WORKSHOP_ROS_DISTRO}/setup.bash
-  fi" >> "${_WORKSHOP_USER_HOME}/.bashrc"
+  fi" >> "${_WORKSHOP_USER_HOME}/.profile"
 fi
 
 # Add colcon autocompletion to bashrc
@@ -80,7 +80,7 @@ if ! grep -q "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash"
     source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash
   fi" >> "${_WORKSHOP_USER_HOME}/.bashrc"
 fi
-[bashrc-update-end]
+# [bashrc-update-end]
 
 # [colcon-defaults-start]
 # Configure colcon's default dirs
@@ -117,7 +117,7 @@ chown ${_WORKSHOP_USER}:${_WORKSHOP_USER} "${_WORKSHOP_COLCON_CONFIG_BASE_PATH}/
 if [ ! -d "${_WORKSHOP_COLCON_CONFIG_BASE_PATH}/colcon-mixin-repository" ] ; then
   sudo -u ${_WORKSHOP_USER} bash -c "git -C ${_WORKSHOP_COLCON_CONFIG_BASE_PATH} clone https://github.com/colcon/colcon-mixin-repository.git"
 fi
-if [! -f ${_WORKSHOP_COLCON_CONFIG_BASE_PATH}/mixin_repositories.yaml ] || ! grep -q "default:" "${_WORKSHOP_COLCON_CONFIG_BASE_PATH}/mixin_repositories.yaml"; then
+if [ ! -f ${_WORKSHOP_COLCON_CONFIG_BASE_PATH}/mixin_repositories.yaml ] || ! grep -q "default:" "${_WORKSHOP_COLCON_CONFIG_BASE_PATH}/mixin_repositories.yaml"; then
   sudo -u ${_WORKSHOP_USER} bash -c "colcon mixin add default file://${_WORKSHOP_COLCON_CONFIG_BASE_PATH}/colcon-mixin-repository/index.yaml"
 fi
 sudo -u ${_WORKSHOP_USER} bash -c "colcon mixin update default"
@@ -139,5 +139,5 @@ fi
 # [rosdep-dependencies-end]
 
 # Install some useful snaps
-snap install lxd
-snap install snapcraft --classic
+snap install --no-wait lxd
+snap install --no-wait snapcraft --classic

--- a/docs/how-to/ros2/ros2-design-sdk.rst
+++ b/docs/how-to/ros2/ros2-design-sdk.rst
@@ -165,7 +165,7 @@ for running and launching ROS 2 nodes.
 
 
 Update environment for ROS 2 and :program:`colcon`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: design-sdk/setup-base
    :language: shell
@@ -174,7 +174,7 @@ Update environment for ROS 2 and :program:`colcon`
 
 
 Adds lines to the :file:`.profile` and :file:`.bashrc` files
-to setup the ROS 2 environment and auto-completion for :program:`colcon`,
+to set up the ROS 2 environment and auto-completion for :program:`colcon`,
 ensuring they are loaded in every new shell session
 (:program:`Workshop` uses :program:`bash` by default).
 

--- a/docs/how-to/ros2/ros2-design-sdk.rst
+++ b/docs/how-to/ros2/ros2-design-sdk.rst
@@ -164,7 +164,7 @@ Installs minimal workspace packages and tools
 for running and launching ROS 2 nodes.
 
 
-Update :file:`.bashrc` for ROS 2 and :program:`colcon`
+Update environment for ROS 2 and :program:`colcon`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: design-sdk/setup-base
@@ -173,8 +173,8 @@ Update :file:`.bashrc` for ROS 2 and :program:`colcon`
    :end-before: [bashrc-update-end]
 
 
-Adds lines to the :file:`.bashrc` file
-to source ROS 2 and :program:`colcon` auto-completion scripts,
+Adds lines to the :file:`.profile` and :file:`.bashrc` files
+to setup the ROS 2 environment and auto-completion for :program:`colcon`,
 ensuring they are loaded in every new shell session
 (:program:`Workshop` uses :program:`bash` by default).
 


### PR DESCRIPTION
# Description

I fixed a typo in the `ros2` SDK recently and noticed it's still in the docs. This updates everything to match the current SDK. I removed some non-breaking spaces from `sdkcraft.yaml` because they don't currently render correctly, but we can add them back if I manage to get this fixed upstream: https://github.com/pygments/pygments/issues/2827.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
