### PR TITLE
Doc: Improve CLI formatting

### DIFF
--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -42,8 +42,9 @@ Notes:
 - To investigate the details of a specific change, use **workshop tasks** instead
 `,
 		Example: `
-# List changes for all workshops in the current project directory
-workshop changes`,
+List changes for all workshops in the current project directory:
+
+  $ workshop changes`,
 
 		RunE: c.Run,
 	}

--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -43,8 +43,7 @@ Notes:
 `,
 		Example: `
 List changes for all workshops in the current project directory:
-
-  $ workshop changes`,
+$ workshop changes`,
 
 		RunE: c.Run,
 	}

--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -20,7 +20,7 @@ func (c *CmdChanges) Command() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "List recent changes to the workshops in a project",
 		Long: `
-Any substantial operation on a workshop is a *change* that consists of *tasks*;
+Any substantial operation on a workshop is a change that consists of tasks;
 the command lists details of recent changes for all workshops within a project.
 For each change, it prints the following details:
 
@@ -30,16 +30,16 @@ For each change, it prints the following details:
 
 - Spawn:   tells when the change was started
 
-- Ready:   tells when the change was *successfully* finished, if at all
+- Ready:   tells when the change was successfully finished, if at all
 
 - Summary: lists actions, affected workshops, other information
 
 
 Notes:
 
-- Only successful changes display values in the *Ready* column
+- Only successful changes display values in the 'Ready' column
 
-- To investigate the details of a specific change, use **workshop tasks** instead
+- To investigate the details of a specific change, use 'workshop tasks' instead
 `,
 		Example: `
 List changes for all workshops in the current project directory:

--- a/cmd/workshop/color.go
+++ b/cmd/workshop/color.go
@@ -55,7 +55,7 @@ func (ux unicodeMixin) addUnicodeChars(esc *escapes) {
 	} else {
 		esc.dash = "--" // two dashes keeps yaml happy also
 		esc.uparrow = "^"
-		esc.tick = "**"
+		esc.tick = "'"
 		esc.star = "*"
 	}
 }

--- a/cmd/workshop/color.go
+++ b/cmd/workshop/color.go
@@ -55,7 +55,7 @@ func (ux unicodeMixin) addUnicodeChars(esc *escapes) {
 	} else {
 		esc.dash = "--" // two dashes keeps yaml happy also
 		esc.uparrow = "^"
-		esc.tick = "'"
+		esc.tick = "**"
 		esc.star = "*"
 	}
 }

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -45,7 +45,7 @@ that is specified as the second argument or deduced from the context.
 
 - Multiple plugs can be connected to the same slot, but not vice versa
 
-- The **workshop connections** output will list the connection as *manual*
+- The 'workshop connections' output will list the connection as 'manual'
 `,
 		Example: `
 Connect the 'mod-cache' mount interface plug of the 'go' SDK

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -50,13 +50,10 @@ that is specified as the second argument or deduced from the context.
 		Example: `
 Connect the 'mod-cache' mount interface plug of the 'go' SDK
 under the 'nimble' workshop in the current project directory:
-
-  $ workshop connect nimble/go:mod-cache :mount
-
+$ workshop connect nimble/go:mod-cache :mount
 
 A full version of the command that also lists the target SDK ('system'):
-
-  $ workshop connect nimble/go:mod-cache nimble/system:mount`,
+$ workshop connect nimble/go:mod-cache nimble/system:mount`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -48,12 +48,15 @@ that is specified as the second argument or deduced from the context.
 - The **workshop connections** output will list the connection as *manual*
 `,
 		Example: `
-# Connect the 'mod-cache' mount interface plug of the 'go' SDK
-# under the 'nimble' workshop in the current project directory
-workshop connect nimble/go:mod-cache :mount
+Connect the 'mod-cache' mount interface plug of the 'go' SDK
+under the 'nimble' workshop in the current project directory:
 
-# A full version of the command that also lists the target SDK ('system')
-workshop connect nimble/go:mod-cache nimble/system:mount`,
+  $ workshop connect nimble/go:mod-cache :mount
+
+
+A full version of the command that also lists the target SDK ('system'):
+
+  $ workshop connect nimble/go:mod-cache nimble/system:mount`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -38,13 +38,10 @@ Notes:
 `,
 		Example: `
 List connections for the workshop 'nimble' in the current project directory:
-
-  $ workshop connections nimble
-
+$ workshop connections nimble
 
 List connections for all workshops in the current project directory:
-
-  $ workshop connections`,
+$ workshop connections`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -31,9 +31,9 @@ additional notes, including specific plug bindings, are provided as needed.
 
 Notes:
 
-- The output lists connections created with **workshop connect** as *manual*
+- The output lists connections created with 'workshop connect' as 'manual'
 
-- The **--all** option needn't be used with an argument;
+- The '--all' option needn't be used with an argument;
   if a workshop is supplied, disconnected plugs are also listed
 `,
 		Example: `

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -37,11 +37,14 @@ Notes:
   if a workshop is supplied, disconnected plugs are also listed
 `,
 		Example: `
-# List connections for the workshop 'nimble' in the current project directory
-workshop connections nimble
+List connections for the workshop 'nimble' in the current project directory:
 
-# List connections for all workshops in the current project directory:
-workshop connections`,
+  $ workshop connections nimble
+
+
+List connections for all workshops in the current project directory:
+
+  $ workshop connections`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -40,17 +40,22 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
   only if the **--forget** option was used with **workshop disconnect**
 `,
 		Example: `
-# Disconnect the 'mod-cache' mount interface plug of the 'go' SDK
-# under the 'nimble' workshop in the current project directory
-workshop disconnect nimble/go:mod-cache
+Disconnect the 'mod-cache' mount interface plug of the 'go' SDK
+under the 'nimble' workshop in the current project directory:
 
-# A full version of the same command
-# that lists the target SDK ('system') and slot ('mount')
-workshop disconnect nimble/go:mod-cache nimble/system:mount
+  $ workshop disconnect nimble/go:mod-cache
 
-# Disconnect all plugs connected to the 'mount' slot of the 'system' SDK
-# under the 'nimble' workshop in the current project directory
-workshop disconnect nimble/system:mount`,
+
+A full version of the same command
+that lists the target SDK ('system') and slot ('mount'):
+
+  $ workshop disconnect nimble/go:mod-cache nimble/system:mount
+
+
+Disconnect all plugs connected to the 'mount' slot of the 'system' SDK
+under the 'nimble' workshop in the current project directory:
+
+  $ workshop disconnect nimble/system:mount`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -42,20 +42,15 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
 		Example: `
 Disconnect the 'mod-cache' mount interface plug of the 'go' SDK
 under the 'nimble' workshop in the current project directory:
-
-  $ workshop disconnect nimble/go:mod-cache
-
+$ workshop disconnect nimble/go:mod-cache
 
 A full version of the same command
 that lists the target SDK ('system') and slot ('mount'):
-
-  $ workshop disconnect nimble/go:mod-cache nimble/system:mount
-
+$ workshop disconnect nimble/go:mod-cache nimble/system:mount
 
 Disconnect all plugs connected to the 'mount' slot of the 'system' SDK
 under the 'nimble' workshop in the current project directory:
-
-  $ workshop disconnect nimble/system:mount`,
+$ workshop disconnect nimble/system:mount`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -36,8 +36,8 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
   Notes:
 
 - After an auto-connected plug is thus disconnected,
-  it is reconnected during **workshop refresh**
-  only if the **--forget** option was used with **workshop disconnect**
+  it is reconnected during 'workshop refresh'
+  only if the '--forget' option was used with 'workshop disconnect'
 `,
 		Example: `
 Disconnect the 'mod-cache' mount interface plug of the 'go' SDK
@@ -61,7 +61,7 @@ under the 'nimble' workshop in the current project directory:
 
 	cmd.PersistentFlags().BoolVar(&c.forget, "forget",
 		false,
-		"Reconnect the plugs at **workshop refresh** if auto-connected initially")
+		"Reconnect the plugs at 'workshop refresh' if auto-connected initially")
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
 		false,

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -69,7 +69,7 @@ To set the mode explicitly, use '-i' or '-I'. If neither is supplied,
 To separate the 'exec' subcommand from the command itself,
 use shell syntax such as *--*:
 
-  $ workshop exec nimble -- echo -n foo bar
+$ workshop exec nimble -- echo -n foo bar
 
 
 Notes:
@@ -106,23 +106,16 @@ func (c *CmdExec) Command() *cobra.Command {
 		Example: `
 Run the 'go build main.go' command under the 'nimble' workshop
 in the current project directory:
-
-  $ workshop exec nimble go build main.go
-
+$ workshop exec nimble go build main.go
 
 A similar command that sets an environment variable and the working directory:
-
-  $ workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
-
+$ workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
 
 Run a custom interactive shell:
-
-  $ workshop exec nimble -I sh
-
+$ workshop exec nimble -I sh
 
 Run a command as root (the default is 'workshop'):
-
-  $ workshop exec nimble --uid 0 id`,
+$ workshop exec nimble --uid 0 id`,
 		RunE: c.Run,
 	}
 
@@ -147,8 +140,7 @@ func (c *CmdShellAlias) Command() *cobra.Command {
 		Example: `
 Open the default login shell of the 'workshop' user into the 'nimble' workshop
 in the current project directory:
-
-  $ workshop shell nimble`,
+$ workshop shell nimble`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -47,10 +47,10 @@ type CmdShellAlias struct {
 
 var shortExecHelp = "Run a command and wait for it to complete"
 var longExecHelp = `
-The **exec** subcommand runs an arbitrary command in the specified workshop,
+The 'exec' subcommand runs an arbitrary command in the specified workshop,
 waiting for it to complete. If a timeout elapses before that, it's terminated.
 
-To accept an **exec** command, the workshop must be *Ready* or *Pending*.
+To accept an 'exec' command, the workshop must be 'Ready' or 'Pending'.
 A command can run in two modes that determine how it handles standard streams:
 
 - Interactively (for shell sessions)
@@ -58,15 +58,15 @@ A command can run in two modes that determine how it handles standard streams:
 - Non-interactively (for scripts)
 
 
-To set the mode explicitly, use **-i** or **-I**. If neither is supplied,
-**exec** deduces the mode based on the nature of its own streams:
+To set the mode explicitly, use '-i' or '-I'. If neither is supplied,
+'exec' deduces the mode based on the nature of its own streams:
 
 - If stdin and stdout are terminals, the mode is interactive
 
 - Otherwise, it's non-interactive
 
 
-To separate the **exec** subcommand from the command itself,
+To separate the 'exec' subcommand from the command itself,
 use shell syntax such as *--*:
 
   $ workshop exec nimble -- echo -n foo bar
@@ -74,7 +74,7 @@ use shell syntax such as *--*:
 
 Notes:
 
-- To start a workshop before running commands in it, use **workshop start**
+- To start a workshop before running commands in it, use 'workshop start'
 
 - You can set the working directory, environment variables, user and group ID
   for running the command in the workshop; reasonable defaults are provided
@@ -82,18 +82,18 @@ Notes:
 
 var shortShellHelp = "Start an interactive terminal session for the workshop"
 var longShellHelp = `
-The **shell** subcommand runs an interactive terminal session
+The 'shell' subcommand runs an interactive terminal session
 in the specified workshop.
 
-To accept a **shell** command, the workshop must be *Ready* or *Pending*.
+To accept a 'shell' command, the workshop must be 'Ready' or 'Pending'.
 
 
 Notes:
 
-- To start a workshop before running a terminal session, use **workshop start**
+- To start a workshop before running a terminal session, use 'workshop start'
 
-- The subcommand is a shorthand for **workshop exec**;
-  it launches the login shell for *workshop*,
+- The subcommand is a shorthand for 'workshop exec';
+  it launches the login shell for 'workshop',
   the default non-privileged user in a workshop
 `
 

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -104,18 +104,25 @@ func (c *CmdExec) Command() *cobra.Command {
 		Short: shortExecHelp,
 		Long:  longExecHelp,
 		Example: `
-# Run the 'go build main.go' command under the 'nimble' workshop
-# in the current project directory
-workshop exec nimble go build main.go
+Run the 'go build main.go' command under the 'nimble' workshop
+in the current project directory:
 
-# A similar command that sets an environment variable and the working directory
-workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
+  $ workshop exec nimble go build main.go
 
-# Run a custom interactive shell
-workshop exec nimble -I sh
 
-# Run a command as root (the default is 'workshop')
-workshop exec nimble --uid 0 id`,
+A similar command that sets an environment variable and the working directory:
+
+  $ workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
+
+
+Run a custom interactive shell:
+
+  $ workshop exec nimble -I sh
+
+
+Run a command as root (the default is 'workshop'):
+
+  $ workshop exec nimble --uid 0 id`,
 		RunE: c.Run,
 	}
 
@@ -138,9 +145,10 @@ func (c *CmdShellAlias) Command() *cobra.Command {
 		Short: shortShellHelp,
 		Long:  longShellHelp,
 		Example: `
-# Open the default login shell of the 'workshop' user into the 'nimble' workshop
-# in the current project directory
-workshop shell nimble`,
+Open the default login shell of the 'workshop' user into the 'nimble' workshop
+in the current project directory:
+
+  $ workshop shell nimble`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/gendocs/command.tmpl
+++ b/cmd/workshop/gendocs/command.tmpl
@@ -1,7 +1,7 @@
 .. _{{ .Ref }}:
 
 {{ .CommandName }}
-{{ .Heading }}
+{{ repeat "-" .HeadingLen }}
 
 {{ .Short }}.
 
@@ -9,7 +9,7 @@
 
 .. code-block:: console
 
-   {{ .Synopsis }}
+   $ {{ .Synopsis }}
 
 .. rubric:: Description
 
@@ -31,6 +31,12 @@
 
 .. rubric:: Examples
 
+{{ range .Examples }}
+{{ .Info }}
+
 .. code-block:: console
-{{ .Examples | indent 3 }}
+
+{{ .Usage | indent 3 }}
+
+{{ end }}
 {{- end }}

--- a/cmd/workshop/gendocs/rest.go
+++ b/cmd/workshop/gendocs/rest.go
@@ -38,6 +38,11 @@ type FlagDetail struct {
 	DefaultValue string
 }
 
+type ExampleDetail struct {
+	Info  string
+	Usage string
+}
+
 // GenReSTCustom creates custom reStructured Text output with the specified formatting.
 func GenReSTCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string, string) string) error {
 	cmd.InitDefaultHelpCmd()
@@ -54,7 +59,33 @@ func GenReSTCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string, str
 	ref := "ref_" + strings.ReplaceAll(name, " ", "_")
 
 	// Compute the heading separator
-	heading := strings.Repeat("-", len(name))
+	headinglen := len(name)
+
+	// Break down examples for further formatting
+	entries := strings.Split(cmd.Example, "\n\n")
+	var structuredExamples []ExampleDetail
+
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		lines := strings.Split(entry, "\n")
+		var infoLines, usageLines []string
+
+		for i, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "$") {
+				infoLines = lines[:i]
+				usageLines = lines[i:]
+				break
+			}
+		}
+
+		if len(infoLines) > 0 && len(usageLines) > 0 {
+			structuredExamples = append(structuredExamples, ExampleDetail{
+				Info:  strings.Join(infoLines, "\n"),
+				Usage: strings.Join(usageLines, "\n"),
+			})
+		}
+	}
 
 	// Collect flag details
 	flags := cmd.NonInheritedFlags()
@@ -74,21 +105,21 @@ func GenReSTCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string, str
 		Short       string
 		Long        string
 		Synopsis    string
-		Examples    string
+		Examples    []ExampleDetail
 		Flags       []FlagDetail
-		Heading     string
+		HeadingLen  int
 	}{
 		Ref:         ref,
 		CommandName: name,
 		Short:       short,
 		Long:        long,
 		Synopsis:    cmd.UseLine(),
-		Examples:    cmd.Example,
+		Examples:    structuredExamples,
 		Flags:       flagDetails,
-		Heading:     heading,
+		HeadingLen:  headinglen,
 	}
 
-	// Define the indent helper function
+	// Define the helper functions
 	funcMap := template.FuncMap{
 		"indent": func(spaces int, ss ...string) string {
 			padding := strings.Repeat(" ", spaces)
@@ -98,6 +129,7 @@ func GenReSTCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string, str
 			}
 			return strings.Join(indentedStrings, "\n")
 		},
+		"repeat": strings.Repeat,
 	}
 
 	// Read and parse the template

--- a/cmd/workshop/hack.go
+++ b/cmd/workshop/hack.go
@@ -26,7 +26,7 @@ func (c *CmdHack) Command() *cobra.Command {
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Edit the hack SDK and graft it onto the workshop",
 		Long: `
-This command opens the default text editor to configure the **hack** SDK
+This command opens the default text editor to configure the 'hack' SDK
 and immediately installs it in the specified workshop,
 enabling rapid experiments and tweaks at the SDK level.
 
@@ -40,22 +40,22 @@ Setting the <HOOK> value opens the respective hook file:
 
 
 Saving and exiting causes a refresh,
-which installs the updated **hack** SDK in the workshop.
+which installs the updated 'hack' SDK in the workshop.
 
-The **--drop** and **--restore** options stash the **hack** SDK,
+The '--drop' and '--restore' options stash the 'hack' SDK,
 reversing the changes, and quickly restore it to the workshop.
 
 
 Notes:
 
-- The **hack** SDK doesn't appear in the workshop definition
+- The 'hack' SDK doesn't appear in the workshop definition
   and cannot include build-time data such as parts
 
-- In addition to hooks, the **hack** SDK can use interfaces,
+- In addition to hooks, the 'hack' SDK can use interfaces,
   define plugs, slots, connections and bindings
 
-- You can partially refresh the workshop, targeting the **hack** SDK
-  with the **workshop refresh <WORKSHOP>/hack** command
+- You can partially refresh the workshop, targeting the 'hack' SDK
+  with the 'workshop refresh <WORKSHOP>/hack' command
 `,
 		Example: `
 Edit the hack SDK definition for the 'nimble' workshop

--- a/cmd/workshop/hack.go
+++ b/cmd/workshop/hack.go
@@ -58,16 +58,21 @@ Notes:
   with the **workshop refresh <WORKSHOP>/hack** command
 `,
 		Example: `
-# Edit the hack SDK definition for the 'nimble' workshop
-# and apply it after saving by automatically refreshing the workshop
-workshop hack nimble
+Edit the hack SDK definition for the 'nimble' workshop
+and apply it after saving by automatically refreshing the workshop:
 
-# Edit the 'check-health' hook for the hack SDK
-# and apply it after saving by automatically refreshing the workshop
-workshop hack nimble check-health
+  $ workshop hack nimble
 
-# Stash the hack SDK, temporarily reverting the changes in the workshop
-workshop hack nimble --drop`,
+
+Edit the 'check-health' hook for the hack SDK
+and apply it after saving by automatically refreshing the workshop:
+
+  $ workshop hack nimble check-health
+
+
+Stash the hack SDK, temporarily reverting the changes in the workshop:
+
+  $ workshop hack nimble --drop`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/hack.go
+++ b/cmd/workshop/hack.go
@@ -60,19 +60,14 @@ Notes:
 		Example: `
 Edit the hack SDK definition for the 'nimble' workshop
 and apply it after saving by automatically refreshing the workshop:
-
-  $ workshop hack nimble
-
+$ workshop hack nimble
 
 Edit the 'check-health' hook for the hack SDK
 and apply it after saving by automatically refreshing the workshop:
-
-  $ workshop hack nimble check-health
-
+$ workshop hack nimble check-health
 
 Stash the hack SDK, temporarily reverting the changes in the workshop:
-
-  $ workshop hack nimble --drop`,
+$ workshop hack nimble --drop`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -42,8 +42,7 @@ Notes:
 `,
 		Example: `
 List details for the 'nimble' workshop in the current project directory:
-
-  $ workshop info nimble`,
+$ workshop info nimble`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -29,7 +29,7 @@ details for a workshop, formatting them as YAML. Specifically, it prints:
 
 - Essential workshop attributes, such as name, base and project directory
 
-- Current status (e.g. *Ready*, *Pending*, *Off*) and notes for the workshop
+- Current status (e.g. 'Ready', 'Pending', 'Off') and notes for the workshop
 
 - Individual SDK details, such as name, channel, installation date and revision
 

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -41,8 +41,9 @@ Notes:
 - Avoid assumptions based on SDK channels: 'latest/stable' may be neither
 `,
 		Example: `
-# List details for the 'nimble' workshop in the current project directory
-workshop info nimble`,
+List details for the 'nimble' workshop in the current project directory:
+
+  $ workshop info nimble`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -43,8 +43,9 @@ Notes:
 - SDKs are installed in alphabetical order
 `,
 		Example: `
-# Launch the 'nimble' and 'jazzy' workshops in the current project directory
-workshop launch nimble jazzy`,
+Launch the 'nimble' and 'jazzy' workshops in the current project directory:
+
+  $ workshop launch nimble jazzy`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -44,8 +44,7 @@ Notes:
 `,
 		Example: `
 Launch the 'nimble' and 'jazzy' workshops in the current project directory:
-
-  $ workshop launch nimble jazzy`,
+$ workshop launch nimble jazzy`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -38,7 +38,7 @@ Notes:
 
 - Names listed as arguments must match respective 'name:' values in definitions
 
-- To update an existing workshop, use **workshop refresh** instead
+- To update an existing workshop, use 'workshop refresh' instead
 
 - SDKs are installed in alphabetical order
 `,

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -32,18 +32,18 @@ This command enumerates all workshops in the project, printing a compact list:
 
 - Workshop: workshop name, as set by its definition
 
-- Status:   workshop status, such as *Off*, *Ready*, *Pending* and so on
+- Status:   workshop status, such as 'Off', 'Ready', 'Pending' and so on
 
 - Notes:    internal remarks on the overall state of the workshop
 
 
-The **--global** option lists all workshops from *all* projects in the system;
-however, it doesn't include any that are *Off*.
+The '--global' option lists all workshops from all projects in the system;
+however, it doesn't include any that are 'Off'.
 
 
 Notes:
 
-- For details of a single workshop, use **workshop info** instead
+- For details of a single workshop, use 'workshop info' instead
 `,
 		Example: `
 List the workshops in the current project directory:

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -46,11 +46,14 @@ Notes:
 - For details of a single workshop, use **workshop info** instead
 `,
 		Example: `
-# List the workshops in the current project directory
-workshop list
+List the workshops in the current project directory:
 
-# List the globally registered workshops
-workshop list --global`,
+  $ workshop list
+
+
+List the globally registered workshops:
+
+  $ workshop list --global`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -47,13 +47,10 @@ Notes:
 `,
 		Example: `
 List the workshops in the current project directory:
-
-  $ workshop list
-
+$ workshop list
 
 List the globally registered workshops:
-
-  $ workshop list --global`,
+$ workshop list --global`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -40,27 +40,27 @@ The '--wait-on-error' option pauses the refresh if an error occurs.
 Thus, you can fix the error and resume the operation or abort and revert it.
 This option can only be used with a single workshop.
 If multiple workshops are listed and an error occurs,
-the operation is aborted and reverted for *all* of them.
+the operation is aborted and reverted for all of them.
 
 
 Notes:
 
-- The workshop must be *Ready* to be refreshed
+- The workshop must be 'Ready' to be refreshed
 
-- To construct a newly defined workshop, use **workshop launch** instead
+- To construct a newly defined workshop, use 'workshop launch' instead
 
-- Throughout the refresh, all affected workshops remain *Pending*
+- Throughout the refresh, all affected workshops remain 'Pending'
 
 - If the refresh removes an SDK from the workshop, the SDK state isn't saved
 
 - Updated and newly added SDKs are installed in alphabetical order
 
 - For content interface plugs, mounts the last source
-  set by **workshop remount**, if any
+  set by 'workshop remount', if any
 
 - If the optional <SDK> is supplied,
   the operation is limited to this SDK;
-  currently, it can only be **hack**
+  currently, it can only be 'hack'
 `,
 		Example: `
 Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
@@ -91,7 +91,7 @@ Refresh the hack SDK under 'nimble':
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",
 		false,
-		"Pause the operation on error; to resume, use **--continue** or **--abort**.")
+		"Pause the operation on error; to resume, use '--continue' or '--abort'.")
 	cmd.PersistentFlags().BoolVar(&c.Continue, "continue",
 		false,
 		"Continue the previously paused operation.")

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -63,21 +63,29 @@ Notes:
   currently, it can only be **hack**
 `,
 		Example: `
-# Refresh the 'nimble' and 'jazzy' workshops in the current project directory
-workshop refresh nimble jazzy
+Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
 
-# Refresh 'nimble', but stop on any errors (won’t accept multiple workshops)
-workshop refresh nimble --wait-on-error
+  $ workshop refresh nimble jazzy
 
-# After 'nimble' refresh stopped on error, abort the operation
-workshop refresh nimble --abort
 
-# After 'nimble' refresh stopped on error and the workshop was fixed,
-# continue the operation
-workshop refresh nimble --continue
+Refresh 'nimble', but stop on any errors (won’t accept multiple workshops):
 
-# Refresh the hack SDK under 'nimble'
-workshop refresh nimble/hack`,
+  $ workshop refresh nimble --wait-on-error
+
+
+After 'nimble' refresh stopped on error, abort the operation:
+
+  $ workshop refresh nimble --abort
+
+
+After 'nimble' refresh stopped on error and the workshop was fixed,
+continue the operation:
+
+  $ workshop refresh nimble --continue
+
+Refresh the hack SDK under 'nimble':
+
+  $ workshop refresh nimble/hack`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -64,28 +64,20 @@ Notes:
 `,
 		Example: `
 Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
-
-  $ workshop refresh nimble jazzy
-
+$ workshop refresh nimble jazzy
 
 Refresh 'nimble', but stop on any errors (won’t accept multiple workshops):
-
-  $ workshop refresh nimble --wait-on-error
-
+$ workshop refresh nimble --wait-on-error
 
 After 'nimble' refresh stopped on error, abort the operation:
-
-  $ workshop refresh nimble --abort
-
+$ workshop refresh nimble --abort
 
 After 'nimble' refresh stopped on error and the workshop was fixed,
 continue the operation:
-
-  $ workshop refresh nimble --continue
+$ workshop refresh nimble --continue
 
 Refresh the hack SDK under 'nimble':
-
-  $ workshop refresh nimble/hack`,
+$ workshop refresh nimble/hack`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -46,8 +46,7 @@ Notes:
 Remount the 'mod-cache' mount interface plug of the 'go' SDK
 under the 'nimble' workshop in the current project directory
 to '~/new-cache-mount/' on the host:
-
-  $ workshop remount nimble/go:mod-cache ~/new-cache-mount`,
+$ workshop remount nimble/go:mod-cache ~/new-cache-mount`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -27,19 +27,19 @@ Specifically, it does the following:
   this normally succeeds if the new source is either a non-existing directory
   or an empty directory on the same file system as the current source
 
-- Otherwise, performs the mount operation only if the workshop is *Stopped*
+- Otherwise, performs the mount operation only if the workshop is 'Stopped'
   to prevent data corruption
 
 
 Notes:
 
-- To stop the workshop, use **workshop stop**
+- To stop the workshop, use 'workshop stop'
 
-- **workshop info** lists any mounted content interface plugs for the workshop
+- 'workshop info' lists any mounted content interface plugs for the workshop
 
-- **workshop refresh** mounts the last source set by **workshop remount**, if any
+- 'workshop refresh' mounts the last source set by 'workshop remount', if any
 
-- During **workshop remove**, non-default sources set by **workshop remount**
+- During 'workshop remove', non-default sources set by 'workshop remount'
   aren't removed
 `,
 		Example: `

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -43,10 +43,11 @@ Notes:
   aren't removed
 `,
 		Example: `
-# Remount the 'mod-cache' mount interface plug of the 'go' SDK
-# under the 'nimble' workshop in the current project directory
-# to '~/new-cache-mount/' on the host:
-workshop remount nimble/go:mod-cache ~/new-cache-mount`,
+Remount the 'mod-cache' mount interface plug of the 'go' SDK
+under the 'nimble' workshop in the current project directory
+to '~/new-cache-mount/' on the host:
+
+  $ workshop remount nimble/go:mod-cache ~/new-cache-mount`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -36,8 +36,7 @@ Notes:
 `,
 		Example: `
 Remove the 'nimble' and 'jazzy' workshops in the current project directory:
-
-  $ workshop remove nimble jazzy`,
+$ workshop remove nimble jazzy`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -23,15 +23,15 @@ func (c *CmdRemove) Command() *cobra.Command {
 		Long: `
 This command removes the workshops listed as arguments. For each workshop, it:
 
-- Checks that the workshop isn't *Off* or *Pending*
-- Stops the workshop if it's not already *Stopped*
+- Checks that the workshop isn't 'Off' or 'Pending'
+- Stops the workshop if it's not already 'Stopped'
 - Deletes the workshop but preserves its definition
 
 Notes:
 
-- If any listed workshop is *Off* or *Pending*, none are removed
-- To rebuild a removed workshop from scratch, use **workshop launch**
-- For content interface plugs, non-default sources set by **workshop remount**
+- If any listed workshop is 'Off' or 'Pending', none are removed
+- To rebuild a removed workshop from scratch, use 'workshop launch'
+- For content interface plugs, non-default sources set by 'workshop remount'
   aren't removed
 `,
 		Example: `

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -35,8 +35,9 @@ Notes:
   aren't removed
 `,
 		Example: `
-# Remove the 'nimble' and 'jazzy' workshops in the current project directory
-workshop remove nimble jazzy`,
+Remove the 'nimble' and 'jazzy' workshops in the current project directory:
+
+  $ workshop remove nimble jazzy`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -22,7 +22,7 @@ This command activates the workshops listed as arguments. For each one, it:
 
 - Makes sure the workshop was actually launched
 
-- Activates the workshop for use and sets it to *Ready*
+- Activates the workshop for use and sets it to 'Ready'
 
 
 If multiple workshops are listed and an error occurs,
@@ -35,7 +35,7 @@ Notes:
 
 - When interrupted, the command attempts to gracefully revert its actions
 
-- To stop a started workshop, use **workshop stop**
+- To stop a started workshop, use 'workshop stop'
 `,
 		Example: `
 Start the 'nimble' and 'jazzy' workshops in the current project directory:

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -38,8 +38,9 @@ Notes:
 - To stop a started workshop, use **workshop stop**
 `,
 		Example: `
-# Start the 'nimble' and 'jazzy' workshops in the current project directory
-workshop start nimble jazzy`,
+Start the 'nimble' and 'jazzy' workshops in the current project directory:
+
+  $ workshop start nimble jazzy`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -39,8 +39,7 @@ Notes:
 `,
 		Example: `
 Start the 'nimble' and 'jazzy' workshops in the current project directory:
-
-  $ workshop start nimble jazzy`,
+$ workshop start nimble jazzy`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -22,7 +22,7 @@ This command deactivates the workshops listed as arguments. For each one, it:
 
 - Makes sure the workshop was actually started or is already stopped
 
-- Deactivates the workshop and sets it to *Stopped*
+- Deactivates the workshop and sets it to 'Stopped'
 
 
 If multiple workshops are listed and an error occurs,
@@ -35,7 +35,7 @@ Notes:
 
 - When interrupted, the command attempts to gracefully revert its actions
 
-- To start a stopped workshop, use **workshop start**
+- To start a stopped workshop, use 'workshop start'
 `,
 		Example: `
 Stop the nimble and jazzy workshops in the current project directory:

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -38,7 +38,8 @@ Notes:
 - To start a stopped workshop, use **workshop start**
 `,
 		Example: `
-# Stop the nimble and jazzy workshops in the current project directory
+Stop the nimble and jazzy workshops in the current project directory:
+
 workshop stop nimble jazzy`,
 		RunE: c.Run,
 	}

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -40,8 +40,9 @@ Notes:
 - To investigate recent changes in a project, use **workshop changes** instead
 `,
 		Example: `
-# List the tasks under change ID 42
-workshop tasks 42`,
+List the tasks under change ID 42:
+
+  $ workshop tasks 42`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -41,8 +41,7 @@ Notes:
 `,
 		Example: `
 List the tasks under change ID 42:
-
-  $ workshop tasks 42`,
+$ workshop tasks 42`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -22,7 +22,7 @@ func (c *CmdTasks) Command() *cobra.Command {
 		Args:  cobra.RangeArgs(1, 1),
 		Short: "List tasks for a specific change",
 		Long: `
-Any substantial operation on a workshop is a *change* that consists of *tasks*;
+Any substantial operation on a workshop is a change that consists of tasks;
 the command lists individual tasks that comprise a specific change.
 For each task, it prints the following details:
 
@@ -37,7 +37,7 @@ Notes:
 
 - The command may print additional log details for tasks that store them
 
-- To investigate recent changes in a project, use **workshop changes** instead
+- To investigate recent changes in a project, use 'workshop changes' instead
 `,
 		Example: `
 List the tasks under change ID 42:

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -70,8 +70,7 @@ Also, warnings expire automatically; expired warnings are not listed.
 `,
 		Example: `
 List the globally registered warnings across all workshops:
-
-  $ workshop warnings`,
+$ workshop warnings`,
 		RunE: c.Run,
 	}
 
@@ -108,8 +107,7 @@ listed previously by the 'workshop warnings' command.
 		Example: `
 Acknowledge the globally registered warnings across all workshops
 (must run after 'workshop warnings'):
-
-  $ workshop okay`,
+$ workshop okay`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -69,8 +69,9 @@ or the **--all** option is used.
 Also, warnings expire automatically; expired warnings are not listed.
 `,
 		Example: `
-# List the globally registered warnings across all workshops
-workshop warnings`,
+List the globally registered warnings across all workshops:
+
+  $ workshop warnings`,
 		RunE: c.Run,
 	}
 
@@ -105,9 +106,10 @@ This command acknowledges all warnings
 listed previously by the **workshop warnings** command.
 `,
 		Example: `
-# Acknowledge the globally registered warnings across all workshops
-# (must run after **workshop warnings**)
-workshop okay`,
+Acknowledge the globally registered warnings across all workshops
+(must run after **workshop warnings**):
+
+  $ workshop okay`,
 		RunE: c.Run,
 	}
 

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -60,11 +60,11 @@ func (c *CmdWarnings) Command() *cobra.Command {
 		Long: `
 This command lists the warnings that were reported to the system.
 
-All warnings listed by **workshop warnings**
-can be acknowledged with the **workshop okay** command.
-Acknowledged warnings aren't listed by **workshop warnings**
+All warnings listed by 'workshop warnings'
+can be acknowledged with the 'workshop okay' command.
+Acknowledged warnings aren't listed by 'workshop warnings'
 unless they occur again after their cooldown period has elapsed
-or the **--all** option is used.
+or the '--all' option is used.
 
 Also, warnings expire automatically; expired warnings are not listed.
 `,
@@ -103,11 +103,11 @@ func (c *CmdOkay) Command() *cobra.Command {
 		Short: "Acknowledge listed warnings",
 		Long: `
 This command acknowledges all warnings
-listed previously by the **workshop warnings** command.
+listed previously by the 'workshop warnings' command.
 `,
 		Example: `
 Acknowledge the globally registered warnings across all workshops
-(must run after **workshop warnings**):
+(must run after 'workshop warnings'):
 
   $ workshop okay`,
 		RunE: c.Run,

--- a/docs/reference/cli/workshop-changes.rst
+++ b/docs/reference/cli/workshop-changes.rst
@@ -9,12 +9,12 @@ List recent changes to the workshops in a project.
 
 .. code-block:: console
 
-   workshop changes [flags]
+   $ workshop changes [flags]
 
 .. rubric:: Description
 
 
-Any substantial operation on a workshop is a *change* that consists of *tasks*;
+Any substantial operation on a workshop is a change that consists of tasks;
 the command lists details of recent changes for all workshops within a project.
 For each change, it prints the following details:
 
@@ -24,21 +24,25 @@ For each change, it prints the following details:
 
 - Spawn:   tells when the change was started
 
-- Ready:   tells when the change was *successfully* finished, if at all
+- Ready:   tells when the change was successfully finished, if at all
 
 - Summary: lists actions, affected workshops, other information
 
 
 Notes:
 
-- Only successful changes display values in the *Ready* column
+- Only successful changes display values in the 'Ready' column
 
-- To investigate the details of a specific change, use **workshop tasks** instead
+- To investigate the details of a specific change, use 'workshop tasks' instead
 
 
 .. rubric:: Examples
 
+
+List changes for all workshops in the current project directory:
+
 .. code-block:: console
-   
-   # List changes for all workshops in the current project directory
-   workshop changes
+
+   $ workshop changes
+
+

--- a/docs/reference/cli/workshop-connect.rst
+++ b/docs/reference/cli/workshop-connect.rst
@@ -9,7 +9,7 @@ Connect a plug to a slot.
 
 .. code-block:: console
 
-   workshop connect <WORKSHOP>/<SDK>:<PLUG> [<WORKSHOP>/<SDK>][:<SLOT>] [flags]
+   $ workshop connect <WORKSHOP>/<SDK>:<PLUG> [<WORKSHOP>/<SDK>][:<SLOT>] [flags]
 
 .. rubric:: Description
 
@@ -39,7 +39,7 @@ that is specified as the second argument or deduced from the context.
 
 - Multiple plugs can be connected to the same slot, but not vice versa
 
-- The **workshop connections** output will list the connection as *manual*
+- The 'workshop connections' output will list the connection as 'manual'
 
 
 .. rubric:: Options
@@ -53,11 +53,19 @@ that is specified as the second argument or deduced from the context.
 
 .. rubric:: Examples
 
+
+Connect the 'mod-cache' mount interface plug of the 'go' SDK
+under the 'nimble' workshop in the current project directory:
+
 .. code-block:: console
-   
-   # Connect the 'mod-cache' mount interface plug of the 'go' SDK
-   # under the 'nimble' workshop in the current project directory
-   workshop connect nimble/go:mod-cache :mount
-   
-   # A full version of the command that also lists the target SDK ('system')
-   workshop connect nimble/go:mod-cache nimble/system:mount
+
+   $ workshop connect nimble/go:mod-cache :mount
+
+
+A full version of the command that also lists the target SDK ('system'):
+
+.. code-block:: console
+
+   $ workshop connect nimble/go:mod-cache nimble/system:mount
+
+

--- a/docs/reference/cli/workshop-connections.rst
+++ b/docs/reference/cli/workshop-connections.rst
@@ -9,7 +9,7 @@ List interface connections.
 
 .. code-block:: console
 
-   workshop connections [<WORKSHOP>] [flags]
+   $ workshop connections [<WORKSHOP>] [flags]
 
 .. rubric:: Description
 
@@ -22,9 +22,9 @@ additional notes, including specific plug bindings, are provided as needed.
 
 Notes:
 
-- The output lists connections created with **workshop connect** as *manual*
+- The output lists connections created with 'workshop connect' as 'manual'
 
-- The **--all** option needn't be used with an argument;
+- The '--all' option needn't be used with an argument;
   if a workshop is supplied, disconnected plugs are also listed
 
 
@@ -39,10 +39,18 @@ Notes:
 
 .. rubric:: Examples
 
+
+List connections for the workshop 'nimble' in the current project directory:
+
 .. code-block:: console
-   
-   # List connections for the workshop 'nimble' in the current project directory
-   workshop connections nimble
-   
-   # List connections for all workshops in the current project directory:
-   workshop connections
+
+   $ workshop connections nimble
+
+
+List connections for all workshops in the current project directory:
+
+.. code-block:: console
+
+   $ workshop connections
+
+

--- a/docs/reference/cli/workshop-disconnect.rst
+++ b/docs/reference/cli/workshop-disconnect.rst
@@ -9,7 +9,7 @@ Disconnect a plug or a slot.
 
 .. code-block:: console
 
-   workshop disconnect <WORKSHOP>/<SDK>:<PLUG OR SLOT> [<WORKSHOP>/<SDK>]:[<SLOT>] [flags]
+   $ workshop disconnect <WORKSHOP>/<SDK>:<PLUG OR SLOT> [<WORKSHOP>/<SDK>]:[<SLOT>] [flags]
 
 .. rubric:: Description
 
@@ -30,8 +30,8 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
   Notes:
 
 - After an auto-connected plug is thus disconnected,
-  it is reconnected during **workshop refresh**
-  only if the **--forget** option was used with **workshop disconnect**
+  it is reconnected during 'workshop refresh'
+  only if the '--forget' option was used with 'workshop disconnect'
 
 
 .. rubric:: Options
@@ -39,7 +39,7 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
 
 --forget
 
-   Reconnect the plugs at **workshop refresh** if auto-connected initially
+   Reconnect the plugs at 'workshop refresh' if auto-connected initially
 
 
 --no-wait
@@ -50,16 +50,28 @@ This command disconnects a plug from its slot, or a slot from all its plugs.
 
 .. rubric:: Examples
 
+
+Disconnect the 'mod-cache' mount interface plug of the 'go' SDK
+under the 'nimble' workshop in the current project directory:
+
 .. code-block:: console
-   
-   # Disconnect the 'mod-cache' mount interface plug of the 'go' SDK
-   # under the 'nimble' workshop in the current project directory
-   workshop disconnect nimble/go:mod-cache
-   
-   # A full version of the same command
-   # that lists the target SDK ('system') and slot ('mount')
-   workshop disconnect nimble/go:mod-cache nimble/system:mount
-   
-   # Disconnect all plugs connected to the 'mount' slot of the 'system' SDK
-   # under the 'nimble' workshop in the current project directory
-   workshop disconnect nimble/system:mount
+
+   $ workshop disconnect nimble/go:mod-cache
+
+
+A full version of the same command
+that lists the target SDK ('system') and slot ('mount'):
+
+.. code-block:: console
+
+   $ workshop disconnect nimble/go:mod-cache nimble/system:mount
+
+
+Disconnect all plugs connected to the 'mount' slot of the 'system' SDK
+under the 'nimble' workshop in the current project directory:
+
+.. code-block:: console
+
+   $ workshop disconnect nimble/system:mount
+
+

--- a/docs/reference/cli/workshop-exec.rst
+++ b/docs/reference/cli/workshop-exec.rst
@@ -9,15 +9,15 @@ Run a command and wait for it to complete.
 
 .. code-block:: console
 
-   workshop exec <WORKSHOP> [flags]
+   $ workshop exec <WORKSHOP> [flags]
 
 .. rubric:: Description
 
 
-The **exec** subcommand runs an arbitrary command in the specified workshop,
+The 'exec' subcommand runs an arbitrary command in the specified workshop,
 waiting for it to complete. If a timeout elapses before that, it's terminated.
 
-To accept an **exec** command, the workshop must be *Ready* or *Pending*.
+To accept an 'exec' command, the workshop must be 'Ready' or 'Pending'.
 A command can run in two modes that determine how it handles standard streams:
 
 - Interactively (for shell sessions)
@@ -25,23 +25,23 @@ A command can run in two modes that determine how it handles standard streams:
 - Non-interactively (for scripts)
 
 
-To set the mode explicitly, use **-i** or **-I**. If neither is supplied,
-**exec** deduces the mode based on the nature of its own streams:
+To set the mode explicitly, use '-i' or '-I'. If neither is supplied,
+'exec' deduces the mode based on the nature of its own streams:
 
 - If stdin and stdout are terminals, the mode is interactive
 
 - Otherwise, it's non-interactive
 
 
-To separate the **exec** subcommand from the command itself,
+To separate the 'exec' subcommand from the command itself,
 use shell syntax such as *--*:
 
-  $ workshop exec nimble -- echo -n foo bar
+$ workshop exec nimble -- echo -n foo bar
 
 
 Notes:
 
-- To start a workshop before running commands in it, use **workshop start**
+- To start a workshop before running commands in it, use 'workshop start'
 
 - You can set the working directory, environment variables, user and group ID
   for running the command in the workshop; reasonable defaults are provided
@@ -88,17 +88,33 @@ Notes:
 
 .. rubric:: Examples
 
+
+Run the 'go build main.go' command under the 'nimble' workshop
+in the current project directory:
+
 .. code-block:: console
-   
-   # Run the 'go build main.go' command under the 'nimble' workshop
-   # in the current project directory
-   workshop exec nimble go build main.go
-   
-   # A similar command that sets an environment variable and the working directory
-   workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
-   
-   # Run a custom interactive shell
-   workshop exec nimble -I sh
-   
-   # Run a command as root (the default is 'workshop')
-   workshop exec nimble --uid 0 id
+
+   $ workshop exec nimble go build main.go
+
+
+A similar command that sets an environment variable and the working directory:
+
+.. code-block:: console
+
+   $ workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
+
+
+Run a custom interactive shell:
+
+.. code-block:: console
+
+   $ workshop exec nimble -I sh
+
+
+Run a command as root (the default is 'workshop'):
+
+.. code-block:: console
+
+   $ workshop exec nimble --uid 0 id
+
+

--- a/docs/reference/cli/workshop-hack.rst
+++ b/docs/reference/cli/workshop-hack.rst
@@ -9,12 +9,12 @@ Edit the hack SDK and graft it onto the workshop.
 
 .. code-block:: console
 
-   workshop hack [--drop|--restore] <WORKSHOP> [setup-base|save-save|restore-state|check-health] [flags]
+   $ workshop hack [--drop|--restore] <WORKSHOP> [setup-base|save-save|restore-state|check-health] [flags]
 
 .. rubric:: Description
 
 
-This command opens the default text editor to configure the **hack** SDK
+This command opens the default text editor to configure the 'hack' SDK
 and immediately installs it in the specified workshop,
 enabling rapid experiments and tweaks at the SDK level.
 
@@ -28,22 +28,22 @@ Setting the <HOOK> value opens the respective hook file:
 
 
 Saving and exiting causes a refresh,
-which installs the updated **hack** SDK in the workshop.
+which installs the updated 'hack' SDK in the workshop.
 
-The **--drop** and **--restore** options stash the **hack** SDK,
+The '--drop' and '--restore' options stash the 'hack' SDK,
 reversing the changes, and quickly restore it to the workshop.
 
 
 Notes:
 
-- The **hack** SDK doesn't appear in the workshop definition
+- The 'hack' SDK doesn't appear in the workshop definition
   and cannot include build-time data such as parts
 
-- In addition to hooks, the **hack** SDK can use interfaces,
+- In addition to hooks, the 'hack' SDK can use interfaces,
   define plugs, slots, connections and bindings
 
-- You can partially refresh the workshop, targeting the **hack** SDK
-  with the **workshop refresh <WORKSHOP>/hack** command
+- You can partially refresh the workshop, targeting the 'hack' SDK
+  with the 'workshop refresh <WORKSHOP>/hack' command
 
 
 .. rubric:: Options
@@ -62,15 +62,27 @@ Notes:
 
 .. rubric:: Examples
 
+
+Edit the hack SDK definition for the 'nimble' workshop
+and apply it after saving by automatically refreshing the workshop:
+
 .. code-block:: console
-   
-   # Edit the hack SDK definition for the 'nimble' workshop
-   # and apply it after saving by automatically refreshing the workshop
-   workshop hack nimble
-   
-   # Edit the 'check-health' hook for the hack SDK
-   # and apply it after saving by automatically refreshing the workshop
-   workshop hack nimble check-health
-   
-   # Stash the hack SDK, temporarily reverting the changes in the workshop
-   workshop hack nimble --drop
+
+   $ workshop hack nimble
+
+
+Edit the 'check-health' hook for the hack SDK
+and apply it after saving by automatically refreshing the workshop:
+
+.. code-block:: console
+
+   $ workshop hack nimble check-health
+
+
+Stash the hack SDK, temporarily reverting the changes in the workshop:
+
+.. code-block:: console
+
+   $ workshop hack nimble --drop
+
+

--- a/docs/reference/cli/workshop-info.rst
+++ b/docs/reference/cli/workshop-info.rst
@@ -9,7 +9,7 @@ Print the current status and details of a workshop as YAML.
 
 .. code-block:: console
 
-   workshop info <WORKSHOP> [flags]
+   $ workshop info <WORKSHOP> [flags]
 
 .. rubric:: Description
 
@@ -19,7 +19,7 @@ details for a workshop, formatting them as YAML. Specifically, it prints:
 
 - Essential workshop attributes, such as name, base and project directory
 
-- Current status (e.g. *Ready*, *Pending*, *Off*) and notes for the workshop
+- Current status (e.g. 'Ready', 'Pending', 'Off') and notes for the workshop
 
 - Individual SDK details, such as name, channel, installation date and revision
 
@@ -33,7 +33,11 @@ Notes:
 
 .. rubric:: Examples
 
+
+List details for the 'nimble' workshop in the current project directory:
+
 .. code-block:: console
-   
-   # List details for the 'nimble' workshop in the current project directory
-   workshop info nimble
+
+   $ workshop info nimble
+
+

--- a/docs/reference/cli/workshop-launch.rst
+++ b/docs/reference/cli/workshop-launch.rst
@@ -9,7 +9,7 @@ Construct one or many workshops using their definitions.
 
 .. code-block:: console
 
-   workshop launch <WORKSHOP>... [flags]
+   $ workshop launch <WORKSHOP>... [flags]
 
 .. rubric:: Description
 
@@ -34,7 +34,7 @@ Notes:
 
 - Names listed as arguments must match respective 'name:' values in definitions
 
-- To update an existing workshop, use **workshop refresh** instead
+- To update an existing workshop, use 'workshop refresh' instead
 
 - SDKs are installed in alphabetical order
 
@@ -50,7 +50,11 @@ Notes:
 
 .. rubric:: Examples
 
+
+Launch the 'nimble' and 'jazzy' workshops in the current project directory:
+
 .. code-block:: console
-   
-   # Launch the 'nimble' and 'jazzy' workshops in the current project directory
-   workshop launch nimble jazzy
+
+   $ workshop launch nimble jazzy
+
+

--- a/docs/reference/cli/workshop-list.rst
+++ b/docs/reference/cli/workshop-list.rst
@@ -9,7 +9,7 @@ List project workshops.
 
 .. code-block:: console
 
-   workshop list [flags]
+   $ workshop list [flags]
 
 .. rubric:: Description
 
@@ -20,18 +20,18 @@ This command enumerates all workshops in the project, printing a compact list:
 
 - Workshop: workshop name, as set by its definition
 
-- Status:   workshop status, such as *Off*, *Ready*, *Pending* and so on
+- Status:   workshop status, such as 'Off', 'Ready', 'Pending' and so on
 
 - Notes:    internal remarks on the overall state of the workshop
 
 
-The **--global** option lists all workshops from *all* projects in the system;
-however, it doesn't include any that are *Off*.
+The '--global' option lists all workshops from all projects in the system;
+however, it doesn't include any that are 'Off'.
 
 
 Notes:
 
-- For details of a single workshop, use **workshop info** instead
+- For details of a single workshop, use 'workshop info' instead
 
 
 .. rubric:: Options
@@ -45,10 +45,18 @@ Notes:
 
 .. rubric:: Examples
 
+
+List the workshops in the current project directory:
+
 .. code-block:: console
-   
-   # List the workshops in the current project directory
-   workshop list
-   
-   # List the globally registered workshops
-   workshop list --global
+
+   $ workshop list
+
+
+List the globally registered workshops:
+
+.. code-block:: console
+
+   $ workshop list --global
+
+

--- a/docs/reference/cli/workshop-okay.rst
+++ b/docs/reference/cli/workshop-okay.rst
@@ -9,19 +9,23 @@ Acknowledge listed warnings.
 
 .. code-block:: console
 
-   workshop okay [flags]
+   $ workshop okay [flags]
 
 .. rubric:: Description
 
 
 This command acknowledges all warnings
-listed previously by the **workshop warnings** command.
+listed previously by the 'workshop warnings' command.
 
 
 .. rubric:: Examples
 
+
+Acknowledge the globally registered warnings across all workshops
+(must run after 'workshop warnings'):
+
 .. code-block:: console
-   
-   # Acknowledge the globally registered warnings across all workshops
-   # (must run after **workshop warnings**)
-   workshop okay
+
+   $ workshop okay
+
+

--- a/docs/reference/cli/workshop-refresh.rst
+++ b/docs/reference/cli/workshop-refresh.rst
@@ -9,7 +9,7 @@ Update workshops according to their definitions.
 
 .. code-block:: console
 
-   workshop refresh [--abort|--continue|--wait-on-error] <WORKSHOP>[/<SDK>]... [flags]
+   $ workshop refresh [--abort|--continue|--wait-on-error] <WORKSHOP>[/<SDK>]... [flags]
 
 .. rubric:: Description
 
@@ -32,27 +32,27 @@ The '--wait-on-error' option pauses the refresh if an error occurs.
 Thus, you can fix the error and resume the operation or abort and revert it.
 This option can only be used with a single workshop.
 If multiple workshops are listed and an error occurs,
-the operation is aborted and reverted for *all* of them.
+the operation is aborted and reverted for all of them.
 
 
 Notes:
 
-- The workshop must be *Ready* to be refreshed
+- The workshop must be 'Ready' to be refreshed
 
-- To construct a newly defined workshop, use **workshop launch** instead
+- To construct a newly defined workshop, use 'workshop launch' instead
 
-- Throughout the refresh, all affected workshops remain *Pending*
+- Throughout the refresh, all affected workshops remain 'Pending'
 
 - If the refresh removes an SDK from the workshop, the SDK state isn't saved
 
 - Updated and newly added SDKs are installed in alphabetical order
 
 - For content interface plugs, mounts the last source
-  set by **workshop remount**, if any
+  set by 'workshop remount', if any
 
 - If the optional <SDK> is supplied,
   the operation is limited to this SDK;
-  currently, it can only be **hack**
+  currently, it can only be 'hack'
 
 
 .. rubric:: Options
@@ -70,26 +70,46 @@ Notes:
 
 --wait-on-error
 
-   Pause the operation on error; to resume, use **--continue** or **--abort**.
+   Pause the operation on error; to resume, use '--continue' or '--abort'.
 
 
 
 .. rubric:: Examples
 
+
+Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
+
 .. code-block:: console
-   
-   # Refresh the 'nimble' and 'jazzy' workshops in the current project directory
-   workshop refresh nimble jazzy
-   
-   # Refresh 'nimble', but stop on any errors (won’t accept multiple workshops)
-   workshop refresh nimble --wait-on-error
-   
-   # After 'nimble' refresh stopped on error, abort the operation
-   workshop refresh nimble --abort
-   
-   # After 'nimble' refresh stopped on error and the workshop was fixed,
-   # continue the operation
-   workshop refresh nimble --continue
-   
-   # Refresh the hack SDK under 'nimble'
-   workshop refresh nimble/hack
+
+   $ workshop refresh nimble jazzy
+
+
+Refresh 'nimble', but stop on any errors (won’t accept multiple workshops):
+
+.. code-block:: console
+
+   $ workshop refresh nimble --wait-on-error
+
+
+After 'nimble' refresh stopped on error, abort the operation:
+
+.. code-block:: console
+
+   $ workshop refresh nimble --abort
+
+
+After 'nimble' refresh stopped on error and the workshop was fixed,
+continue the operation:
+
+.. code-block:: console
+
+   $ workshop refresh nimble --continue
+
+
+Refresh the hack SDK under 'nimble':
+
+.. code-block:: console
+
+   $ workshop refresh nimble/hack
+
+

--- a/docs/reference/cli/workshop-remount.rst
+++ b/docs/reference/cli/workshop-remount.rst
@@ -9,7 +9,7 @@ Mount a new source location to the content interface plug's target.
 
 .. code-block:: console
 
-   workshop remount <WORKSHOP>/<SDK>:<PLUG> <SOURCE> [flags]
+   $ workshop remount <WORKSHOP>/<SDK>:<PLUG> <SOURCE> [flags]
 
 .. rubric:: Description
 
@@ -22,19 +22,19 @@ Specifically, it does the following:
   this normally succeeds if the new source is either a non-existing directory
   or an empty directory on the same file system as the current source
 
-- Otherwise, performs the mount operation only if the workshop is *Stopped*
+- Otherwise, performs the mount operation only if the workshop is 'Stopped'
   to prevent data corruption
 
 
 Notes:
 
-- To stop the workshop, use **workshop stop**
+- To stop the workshop, use 'workshop stop'
 
-- **workshop info** lists any mounted content interface plugs for the workshop
+- 'workshop info' lists any mounted content interface plugs for the workshop
 
-- **workshop refresh** mounts the last source set by **workshop remount**, if any
+- 'workshop refresh' mounts the last source set by 'workshop remount', if any
 
-- During **workshop remove**, non-default sources set by **workshop remount**
+- During 'workshop remove', non-default sources set by 'workshop remount'
   aren't removed
 
 
@@ -49,9 +49,13 @@ Notes:
 
 .. rubric:: Examples
 
+
+Remount the 'mod-cache' mount interface plug of the 'go' SDK
+under the 'nimble' workshop in the current project directory
+to '~/new-cache-mount/' on the host:
+
 .. code-block:: console
-   
-   # Remount the 'mod-cache' mount interface plug of the 'go' SDK
-   # under the 'nimble' workshop in the current project directory
-   # to '~/new-cache-mount/' on the host:
-   workshop remount nimble/go:mod-cache ~/new-cache-mount
+
+   $ workshop remount nimble/go:mod-cache ~/new-cache-mount
+
+

--- a/docs/reference/cli/workshop-remove.rst
+++ b/docs/reference/cli/workshop-remove.rst
@@ -9,28 +9,32 @@ Remove one or many workshops.
 
 .. code-block:: console
 
-   workshop remove <WORKSHOP>... [flags]
+   $ workshop remove <WORKSHOP>... [flags]
 
 .. rubric:: Description
 
 
 This command removes the workshops listed as arguments. For each workshop, it:
 
-- Checks that the workshop isn't *Off* or *Pending*
-- Stops the workshop if it's not already *Stopped*
+- Checks that the workshop isn't 'Off' or 'Pending'
+- Stops the workshop if it's not already 'Stopped'
 - Deletes the workshop but preserves its definition
 
 Notes:
 
-- If any listed workshop is *Off* or *Pending*, none are removed
-- To rebuild a removed workshop from scratch, use **workshop launch**
-- For content interface plugs, non-default sources set by **workshop remount**
+- If any listed workshop is 'Off' or 'Pending', none are removed
+- To rebuild a removed workshop from scratch, use 'workshop launch'
+- For content interface plugs, non-default sources set by 'workshop remount'
   aren't removed
 
 
 .. rubric:: Examples
 
+
+Remove the 'nimble' and 'jazzy' workshops in the current project directory:
+
 .. code-block:: console
-   
-   # Remove the 'nimble' and 'jazzy' workshops in the current project directory
-   workshop remove nimble jazzy
+
+   $ workshop remove nimble jazzy
+
+

--- a/docs/reference/cli/workshop-shell.rst
+++ b/docs/reference/cli/workshop-shell.rst
@@ -9,30 +9,34 @@ Start an interactive terminal session for the workshop.
 
 .. code-block:: console
 
-   workshop shell <WORKSHOP> [flags]
+   $ workshop shell <WORKSHOP> [flags]
 
 .. rubric:: Description
 
 
-The **shell** subcommand runs an interactive terminal session
+The 'shell' subcommand runs an interactive terminal session
 in the specified workshop.
 
-To accept a **shell** command, the workshop must be *Ready* or *Pending*.
+To accept a 'shell' command, the workshop must be 'Ready' or 'Pending'.
 
 
 Notes:
 
-- To start a workshop before running a terminal session, use **workshop start**
+- To start a workshop before running a terminal session, use 'workshop start'
 
-- The subcommand is a shorthand for **workshop exec**;
-  it launches the login shell for *workshop*,
+- The subcommand is a shorthand for 'workshop exec';
+  it launches the login shell for 'workshop',
   the default non-privileged user in a workshop
 
 
 .. rubric:: Examples
 
+
+Open the default login shell of the 'workshop' user into the 'nimble' workshop
+in the current project directory:
+
 .. code-block:: console
-   
-   # Open the default login shell of the 'workshop' user into the 'nimble' workshop
-   # in the current project directory
-   workshop shell nimble
+
+   $ workshop shell nimble
+
+

--- a/docs/reference/cli/workshop-start.rst
+++ b/docs/reference/cli/workshop-start.rst
@@ -9,7 +9,7 @@ Start one or many workshops.
 
 .. code-block:: console
 
-   workshop start <WORKSHOP>... [flags]
+   $ workshop start <WORKSHOP>... [flags]
 
 .. rubric:: Description
 
@@ -18,7 +18,7 @@ This command activates the workshops listed as arguments. For each one, it:
 
 - Makes sure the workshop was actually launched
 
-- Activates the workshop for use and sets it to *Ready*
+- Activates the workshop for use and sets it to 'Ready'
 
 
 If multiple workshops are listed and an error occurs,
@@ -31,12 +31,16 @@ Notes:
 
 - When interrupted, the command attempts to gracefully revert its actions
 
-- To stop a started workshop, use **workshop stop**
+- To stop a started workshop, use 'workshop stop'
 
 
 .. rubric:: Examples
 
+
+Start the 'nimble' and 'jazzy' workshops in the current project directory:
+
 .. code-block:: console
-   
-   # Start the 'nimble' and 'jazzy' workshops in the current project directory
-   workshop start nimble jazzy
+
+   $ workshop start nimble jazzy
+
+

--- a/docs/reference/cli/workshop-stop.rst
+++ b/docs/reference/cli/workshop-stop.rst
@@ -9,7 +9,7 @@ Stop one or many workshops.
 
 .. code-block:: console
 
-   workshop stop <WORKSHOP>... [flags]
+   $ workshop stop <WORKSHOP>... [flags]
 
 .. rubric:: Description
 
@@ -18,7 +18,7 @@ This command deactivates the workshops listed as arguments. For each one, it:
 
 - Makes sure the workshop was actually started or is already stopped
 
-- Deactivates the workshop and sets it to *Stopped*
+- Deactivates the workshop and sets it to 'Stopped'
 
 
 If multiple workshops are listed and an error occurs,
@@ -31,12 +31,5 @@ Notes:
 
 - When interrupted, the command attempts to gracefully revert its actions
 
-- To start a stopped workshop, use **workshop start**
+- To start a stopped workshop, use 'workshop start'
 
-
-.. rubric:: Examples
-
-.. code-block:: console
-   
-   # Stop the nimble and jazzy workshops in the current project directory
-   workshop stop nimble jazzy

--- a/docs/reference/cli/workshop-tasks.rst
+++ b/docs/reference/cli/workshop-tasks.rst
@@ -9,12 +9,12 @@ List tasks for a specific change.
 
 .. code-block:: console
 
-   workshop tasks <CHANGE ID> [flags]
+   $ workshop tasks <CHANGE ID> [flags]
 
 .. rubric:: Description
 
 
-Any substantial operation on a workshop is a *change* that consists of *tasks*;
+Any substantial operation on a workshop is a change that consists of tasks;
 the command lists individual tasks that comprise a specific change.
 For each task, it prints the following details:
 
@@ -29,12 +29,16 @@ Notes:
 
 - The command may print additional log details for tasks that store them
 
-- To investigate recent changes in a project, use **workshop changes** instead
+- To investigate recent changes in a project, use 'workshop changes' instead
 
 
 .. rubric:: Examples
 
+
+List the tasks under change ID 42:
+
 .. code-block:: console
-   
-   # List the tasks under change ID 42
-   workshop tasks 42
+
+   $ workshop tasks 42
+
+

--- a/docs/reference/cli/workshop-warnings.rst
+++ b/docs/reference/cli/workshop-warnings.rst
@@ -9,18 +9,18 @@ List warnings.
 
 .. code-block:: console
 
-   workshop warnings [OPTIONS] [flags]
+   $ workshop warnings [OPTIONS] [flags]
 
 .. rubric:: Description
 
 
 This command lists the warnings that were reported to the system.
 
-All warnings listed by **workshop warnings**
-can be acknowledged with the **workshop okay** command.
-Acknowledged warnings aren't listed by **workshop warnings**
+All warnings listed by 'workshop warnings'
+can be acknowledged with the 'workshop okay' command.
+Acknowledged warnings aren't listed by 'workshop warnings'
 unless they occur again after their cooldown period has elapsed
-or the **--all** option is used.
+or the '--all' option is used.
 
 Also, warnings expire automatically; expired warnings are not listed.
 
@@ -53,7 +53,11 @@ Also, warnings expire automatically; expired warnings are not listed.
 
 .. rubric:: Examples
 
+
+List the globally registered warnings across all workshops:
+
 .. code-block:: console
-   
-   # List the globally registered warnings across all workshops
-   workshop warnings
+
+   $ workshop warnings
+
+


### PR DESCRIPTION
# Description

This improves CLI help rendering at runtime and better divides the logic between the code and the templates.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [x] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.
