### PR TITLE
Remove volumes after images when uninstalling snap

### DIFF
--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -23,18 +23,19 @@ for p in $(echo "$projects" | xargs -L1 echo); do
     fi
   done
   
-  volumes=$(lxc storage volume list default -c n -f compact --project "$p" | awk 'NR>1 {printf "%s ", $1}')
-  echo "Removing storage volumes: $volumes"
-  for volume in $(echo "$volumes" | xargs -L1 echo); do
-    lxc storage volume delete default "$volume" --project "$p"
-  done
-  
   images=$(lxc image list -f compact --project "$p"| awk 'NR>1 {printf "%s ", $1}')
   if [ -n "$images" ]; then
     echo "Removing images: $images"
     # shellcheck disable=SC2086
     lxc image delete $images --project "$p"
   fi
+
+  lxc storage volume list default --project "$p"
+  volumes=$(lxc storage volume list default -c n -f compact --project "$p" | awk 'NR>1 {printf "%s ", $1}')
+  echo "Removing storage volumes: $volumes"
+  for volume in $(echo "$volumes" | xargs -L1 echo); do
+    lxc storage volume delete default "$volume" --project "$p"
+  done
 
   lxc project delete "$p" 
 done 

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
-# The workshop services are stopped by the moment the configure 
+# The workshop services are stopped by the moment the remove 
 # hook is called. Therefore, for now, we walk the LXD projects created 
-# by the workshop and remove all instances/profiles/images.
+# by the workshop and remove all instances/profiles/images/volumes.
 projects=$(lxc project list -f compact | awk '$1 ~ /^workshop\..*/ {print $1}')
 
 for p in $(echo "$projects" | xargs -L1 echo); do

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -31,7 +31,7 @@ for p in $(echo "$projects" | xargs -L1 echo); do
   fi
 
   lxc storage volume list default --project "$p"
-  volumes=$(lxc storage volume list default -c n -f compact --project "$p" | awk 'NR>1 {printf "%s ", $1}')
+  volumes=$(lxc storage volume list default type=custom -c n -f compact --project "$p" | awk 'NR>1 {printf "%s ", $1}')
   echo "Removing storage volumes: $volumes"
   for volume in $(echo "$volumes" | xargs -L1 echo); do
     lxc storage volume delete default "$volume" --project "$p"


### PR DESCRIPTION
# Description

Occasionally I get spread errors in remove-snap, which seems to be caused by LXD refusing to remove certain storage volumes. It seems to be caused by volumes of type 'image' so I'm hoping removing the images first will fix it.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
