### PR TITLE
Make workshop name optional for some commands

### DIFF
--- a/client/projects.go
+++ b/client/projects.go
@@ -21,8 +21,8 @@ type WorkshopActionSetup struct {
 	Options *WorkshopActionOptions
 }
 
-func (client *Client) Projects() ([]*Project, error) {
-	var projects []*Project
+func (client *Client) Projects() ([]Project, error) {
+	var projects []Project
 	_, err := client.doSync("GET", "/v1/projects", nil, nil, nil, &projects)
 	if err != nil {
 		return nil, err

--- a/client/projects_test.go
+++ b/client/projects_test.go
@@ -14,7 +14,7 @@ func (cs *clientSuite) TestClientProjects(c *check.C) {
 			"path": "/home/francua/test"}]}`
 	prjs, err := cs.cli.Projects()
 	c.Assert(err, check.IsNil)
-	c.Assert(prjs, check.DeepEquals, []*client.Project{{"42ws42ws", "/home/francua/workshop"}, {"34hg34gh", "/home/francua/test"}})
+	c.Assert(prjs, check.DeepEquals, []client.Project{{"42ws42ws", "/home/francua/workshop"}, {"34hg34gh", "/home/francua/test"}})
 	c.Check(cs.req.Method, check.Equals, "GET")
 }
 

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 )
 
@@ -65,8 +66,10 @@ type Remount struct {
 }
 
 func (client *Client) List(opts *ListOptions) ([]*WorkshopInfo, []*WorkshopFile, error) {
+	query := url.Values{}
+	query.Set("state", "available")
 	var info Workshops
-	_, err := client.doSync("GET", "/v1/projects/"+opts.ProjectId+"/workshops", nil, nil, nil, &info)
+	_, err := client.doSync("GET", "/v1/projects/"+opts.ProjectId+"/workshops", query, nil, nil, &info)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot list workshops: %w", err)
 	}

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -67,7 +68,7 @@ func (client *Client) List(opts *ListOptions) ([]*WorkshopInfo, []*WorkshopFile,
 	var info Workshops
 	_, err := client.doSync("GET", "/v1/projects/"+opts.ProjectId+"/workshops", nil, nil, nil, &info)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("cannot list workshops: %w", err)
 	}
 	return info.Workshops, info.Files, nil
 }

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"slices"
@@ -87,11 +88,42 @@ func (client *Client) Workshop(projectId, name string) (*Workshop, error) {
 	return &workshop, nil
 }
 
+func (client *Client) SingleWorkshopName(project *Project) (string, error) {
+	info, file, err := client.singleWorkshopOrFile(project)
+	if err != nil {
+		return "", fmt.Errorf("cannot infer workshop name: %w", err)
+	}
+
+	if info != nil {
+		return info.Name, nil
+	}
+	if file != nil {
+		return file.Name, nil
+	}
+	return "", errors.New("internal error: singleWorkshopOrFile returned nothing")
+}
+
 func (client *Client) SingleWorkshop(project *Project) (*Workshop, error) {
+	info, file, err := client.singleWorkshopOrFile(project)
+	if err != nil {
+		return nil, fmt.Errorf("cannot infer workshop name: %w", err)
+	}
+
+	if info == nil {
+		return nil, errors.New("workshop not launched")
+	}
+	workshop := Workshop{WorkshopInfo: *info}
+	if file != nil {
+		workshop.Path = file.Path
+	}
+	return &workshop, nil
+}
+
+func (client *Client) singleWorkshopOrFile(project *Project) (*WorkshopInfo, *WorkshopFile, error) {
 	var info Workshops
 	_, err := client.doSync("GET", "/v1/projects/"+project.Id+"/workshops", nil, nil, nil, &info)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var names []string
@@ -105,26 +137,25 @@ func (client *Client) SingleWorkshop(project *Project) (*Workshop, error) {
 	}
 
 	if len(names) < 1 {
-		return nil, fmt.Errorf("no workshops found in %q", project.Path)
+		return nil, nil, fmt.Errorf("no workshops found in %q", project.Path)
 	}
 	if len(names) > 1 {
 		var quoted []string
 		for _, name := range names {
 			quoted = append(quoted, fmt.Sprintf("%q", name))
 		}
-		return nil, fmt.Errorf("multiple workshops found: %s", strings.Join(quoted, ", "))
+		return nil, nil, fmt.Errorf("multiple workshops found: %s", strings.Join(quoted, ", "))
 	}
 
-	var workshop Workshop
-	if len(info.Files) > 0 {
-		workshop.ProjectId = info.Files[0].ProjectId
-		workshop.Name = info.Files[0].Name
-		workshop.Path = info.Files[0].Path
-	}
+	var workshop *WorkshopInfo
 	if len(info.Workshops) > 0 {
-		workshop.WorkshopInfo = *info.Workshops[0]
+		workshop = info.Workshops[0]
 	}
-	return &workshop, nil
+	var file *WorkshopFile
+	if len(info.Files) > 0 {
+		file = info.Files[0]
+	}
+	return workshop, file, nil
 }
 
 func (client *Client) Remount(plug *PlugRef, source string) (changeId string, err error) {

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -35,11 +35,6 @@ type Workshops struct {
 	Files     []*WorkshopFile `json:"files"`
 }
 
-type Workshop struct {
-	Workshop *WorkshopInfo `json:"workshop"`
-	File     *WorkshopFile `json:"file"`
-}
-
 type WorkshopInfo struct {
 	ProjectId string   `json:"project-id"`
 	Name      string   `json:"name"`
@@ -53,6 +48,11 @@ type WorkshopFile struct {
 	ProjectId string `json:"project-id"`
 	Name      string `json:"name"`
 	Path      string `json:"path"`
+}
+
+type Workshop struct {
+	WorkshopInfo
+	Path string `json:"path"`
 }
 
 type ListOptions struct {
@@ -76,13 +76,13 @@ func (client *Client) List(opts *ListOptions) ([]*WorkshopInfo, []*WorkshopFile,
 	return info.Workshops, info.Files, nil
 }
 
-func (client *Client) Workshop(projectId, name string) (*WorkshopInfo, *WorkshopFile, error) {
+func (client *Client) Workshop(projectId, name string) (*Workshop, error) {
 	var workshop Workshop
 	_, err := client.doSync("GET", "/v1/projects/"+projectId+"/workshops/"+name, nil, nil, nil, &workshop)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return workshop.Workshop, workshop.File, nil
+	return &workshop, nil
 }
 
 func (client *Client) Remount(plug *PlugRef, source string) (changeId string, err error) {

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
+	"strings"
 	"time"
 )
 
@@ -81,6 +83,46 @@ func (client *Client) Workshop(projectId, name string) (*Workshop, error) {
 	_, err := client.doSync("GET", "/v1/projects/"+projectId+"/workshops/"+name, nil, nil, nil, &workshop)
 	if err != nil {
 		return nil, err
+	}
+	return &workshop, nil
+}
+
+func (client *Client) SingleWorkshop(project *Project) (*Workshop, error) {
+	var info Workshops
+	_, err := client.doSync("GET", "/v1/projects/"+project.Id+"/workshops", nil, nil, nil, &info)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, workshop := range info.Workshops {
+		names = append(names, workshop.Name)
+	}
+	for _, file := range info.Files {
+		if !slices.Contains(names, file.Name) {
+			names = append(names, file.Name)
+		}
+	}
+
+	if len(names) < 1 {
+		return nil, fmt.Errorf("no workshops found in %q", project.Path)
+	}
+	if len(names) > 1 {
+		var quoted []string
+		for _, name := range names {
+			quoted = append(quoted, fmt.Sprintf("%q", name))
+		}
+		return nil, fmt.Errorf("multiple workshops found: %s", strings.Join(quoted, ", "))
+	}
+
+	var workshop Workshop
+	if len(info.Files) > 0 {
+		workshop.ProjectId = info.Files[0].ProjectId
+		workshop.Name = info.Files[0].Name
+		workshop.Path = info.Files[0].Path
+	}
+	if len(info.Workshops) > 0 {
+		workshop.WorkshopInfo = *info.Workshops[0]
 	}
 	return &workshop, nil
 }

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"net/url"
 	"slices"
-	"strings"
 	"time"
+
+	"github.com/canonical/x-go/strutil"
 )
 
 type HealthCheck struct {
@@ -140,11 +141,7 @@ func (client *Client) singleWorkshopOrFile(project *Project) (*WorkshopInfo, *Wo
 		return nil, nil, fmt.Errorf("no workshops found in %q", project.Path)
 	}
 	if len(names) > 1 {
-		var quoted []string
-		for _, name := range names {
-			quoted = append(quoted, fmt.Sprintf("%q", name))
-		}
-		return nil, nil, fmt.Errorf("multiple workshops found: %s", strings.Join(quoted, ", "))
+		return nil, nil, fmt.Errorf("multiple workshops found: %s", strutil.Quoted(names))
 	}
 
 	var workshop *WorkshopInfo

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -46,6 +46,7 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 }
 
 func (cs *clientSuite) TestClientSingleWorkshop(c *check.C) {
+	project := &client.Project{Id: "42ws42ws", Path: "/home/user/project"}
 	expectedInfo := client.WorkshopInfo{
 		ProjectId: "42ws42ws",
 		Name:      "workshop",
@@ -57,32 +58,41 @@ func (cs *clientSuite) TestClientSingleWorkshop(c *check.C) {
 
 	// Workshop only
 	cs.rsp = `{"type": "sync", "result": {"workshops":[{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]}]}}`
-	workshop, err := cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	workshop, err := cs.cli.SingleWorkshop(project)
 	c.Assert(err, check.IsNil)
 	c.Assert(workshop, check.DeepEquals, &client.Workshop{WorkshopInfo: expectedInfo})
 	c.Check(cs.req.Method, check.Equals, "GET")
 
+	name, err := cs.cli.SingleWorkshopName(project)
+	c.Assert(err, check.IsNil)
+	c.Assert(name, check.Equals, expectedInfo.Name)
+	c.Check(cs.req.Method, check.Equals, "GET")
+
 	// File only
 	cs.rsp = `{"type": "sync", "result": {"files":[{"name":"workshop","project-id":"42ws42ws","path":"/home/user/project/workshop.yaml"}]}}`
-	workshop, err = cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	workshop, err = cs.cli.SingleWorkshop(project)
+	c.Assert(workshop, check.IsNil)
+	c.Assert(err, check.ErrorMatches, "workshop not launched")
+	c.Check(cs.req.Method, check.Equals, "GET")
+
+	name, err = cs.cli.SingleWorkshopName(project)
 	c.Assert(err, check.IsNil)
-	c.Assert(workshop, check.DeepEquals, &client.Workshop{
-		WorkshopInfo: client.WorkshopInfo{
-			ProjectId: "42ws42ws",
-			Name:      "workshop",
-		},
-		Path: "/home/user/project/workshop.yaml",
-	})
+	c.Assert(name, check.Equals, expectedInfo.Name)
 	c.Check(cs.req.Method, check.Equals, "GET")
 
 	// Workshop and file
 	cs.rsp = `{"type": "sync", "result": {"workshops":[{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]}], "files":[{"name":"workshop","project-id":"42ws42ws","path":"/home/user/project/workshop.yaml"}]}}`
-	workshop, err = cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	workshop, err = cs.cli.SingleWorkshop(project)
 	c.Assert(err, check.IsNil)
 	c.Assert(workshop, check.DeepEquals, &client.Workshop{
 		WorkshopInfo: expectedInfo,
 		Path:         "/home/user/project/workshop.yaml",
 	})
+	c.Check(cs.req.Method, check.Equals, "GET")
+
+	name, err = cs.cli.SingleWorkshopName(project)
+	c.Assert(err, check.IsNil)
+	c.Assert(name, check.Equals, expectedInfo.Name)
 	c.Check(cs.req.Method, check.Equals, "GET")
 }
 
@@ -90,30 +100,32 @@ func (cs *clientSuite) TestClientNoWorkshops(c *check.C) {
 	cs.rsp = `{"type": "sync", "result": {}}`
 	workshop, err := cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
 	c.Assert(workshop, check.IsNil)
-	c.Assert(err, check.ErrorMatches, `no workshops found in "/home/user/project"`)
+	c.Assert(err, check.ErrorMatches, `cannot infer workshop name: no workshops found in "/home/user/project"`)
 	c.Check(cs.req.Method, check.Equals, "GET")
 }
 
 func (cs *clientSuite) TestClientMultipleWorkshops(c *check.C) {
+	project := &client.Project{Id: "42ws42ws", Path: "/home/user/project"}
+
 	// Two workshops
 	cs.rsp = `{"type": "sync", "result": {"workshops":[{"name":"ci","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]},{"name":"dev","base":"ubuntu@24.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]}]}}`
-	workshop, err := cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	workshop, err := cs.cli.SingleWorkshop(project)
 	c.Assert(workshop, check.IsNil)
-	c.Assert(err, check.ErrorMatches, `multiple workshops found: "ci", "dev"`)
+	c.Assert(err, check.ErrorMatches, `cannot infer workshop name: multiple workshops found: "ci", "dev"`)
 	c.Check(cs.req.Method, check.Equals, "GET")
 
 	// Workshop and file
 	cs.rsp = `{"type": "sync", "result": {"workshops":[{"name":"ci","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]}],"files":[{"name":"dev","project-id":"42ws42ws","path":"/home/user/project/.workshop/dev.yaml"}]}}`
-	workshop, err = cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	workshop, err = cs.cli.SingleWorkshop(project)
 	c.Assert(workshop, check.IsNil)
-	c.Assert(err, check.ErrorMatches, `multiple workshops found: "ci", "dev"`)
+	c.Assert(err, check.ErrorMatches, `cannot infer workshop name: multiple workshops found: "ci", "dev"`)
 	c.Check(cs.req.Method, check.Equals, "GET")
 
 	// Two files
 	cs.rsp = `{"type": "sync", "result": {"files":[{"name":"ci","project-id":"42ws42ws","path":"/home/user/project/.workshop/ci.yaml"},{"name":"dev","project-id":"42ws42ws","path":"/home/user/project/.workshop/dev.yaml"}]}}`
-	workshop, err = cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
-	c.Assert(workshop, check.IsNil)
-	c.Assert(err, check.ErrorMatches, `multiple workshops found: "ci", "dev"`)
+	name, err := cs.cli.SingleWorkshopName(project)
+	c.Assert(name, check.Equals, "")
+	c.Assert(err, check.ErrorMatches, `cannot infer workshop name: multiple workshops found: "ci", "dev"`)
 	c.Check(cs.req.Method, check.Equals, "GET")
 }
 

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -45,7 +45,7 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "GET")
 }
 func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
-	cs.rsp = `{"type": "sync", "result": {"workshop":{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready",
+	cs.rsp = `{"type": "sync", "result": {"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready",
 	"content":[
 		{"name":"go",
 		"channel":"latest/stable",
@@ -53,36 +53,34 @@ func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
 		"install-time":"2023-04-25T01:02:03Z", 
 		"health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"},
 		"mounts":[{"host-source":"/home/user/src","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}},{"workshop-source":"/home","workshop-target":"/mnt", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name-2"}}]
-	}]}, "file":{"name":"workshop","project-id":"2","path":"/home/projects/.workshop/workshop.yaml"}}}`
-	wp, file, err := cs.cli.Workshop("42ws42ws", "workshop")
+	}],"path":"/home/projects/.workshop/workshop.yaml"}}`
+	wp, err := cs.cli.Workshop("42ws42ws", "workshop")
 	c.Assert(err, check.IsNil)
-	c.Assert(wp, check.DeepEquals, &client.WorkshopInfo{
-		ProjectId: "42ws42ws",
-		Name:      "workshop",
-		Base:      "ubuntu@20.04",
-		Status:    "Ready",
-		Content: []*client.Sdk{
-			{
-				Name:        "go",
-				Channel:     "latest/stable",
-				Revision:    "453",
-				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
-				Health: &client.HealthCheck{
-					Timestamp: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
-					Message:   "hello from health-check",
-					Code:      "check-waiting",
-				},
-				Mounts: []*client.Mount{
-					{HostSource: "/home/user/src", WorkshopTarget: "/home/workshop/target", Plug: client.PlugRef{ProjectId: "42ws42ws", Workshop: "workshop", Sdk: "go", Name: "plug-name"}},
-					{WorkshopSource: "/home", WorkshopTarget: "/mnt", Plug: client.PlugRef{ProjectId: "42ws42ws", Workshop: "workshop", Sdk: "go", Name: "plug-name-2"}},
+	c.Assert(wp, check.DeepEquals, &client.Workshop{
+		WorkshopInfo: client.WorkshopInfo{
+			ProjectId: "42ws42ws",
+			Name:      "workshop",
+			Base:      "ubuntu@20.04",
+			Status:    "Ready",
+			Content: []*client.Sdk{
+				{
+					Name:        "go",
+					Channel:     "latest/stable",
+					Revision:    "453",
+					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+					Health: &client.HealthCheck{
+						Timestamp: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+						Message:   "hello from health-check",
+						Code:      "check-waiting",
+					},
+					Mounts: []*client.Mount{
+						{HostSource: "/home/user/src", WorkshopTarget: "/home/workshop/target", Plug: client.PlugRef{ProjectId: "42ws42ws", Workshop: "workshop", Sdk: "go", Name: "plug-name"}},
+						{WorkshopSource: "/home", WorkshopTarget: "/mnt", Plug: client.PlugRef{ProjectId: "42ws42ws", Workshop: "workshop", Sdk: "go", Name: "plug-name-2"}},
+					},
 				},
 			},
 		},
-	})
-	c.Assert(file, check.DeepEquals, &client.WorkshopFile{
-		ProjectId: "2",
-		Name:      "workshop",
-		Path:      "/home/projects/.workshop/workshop.yaml",
+		Path: "/home/projects/.workshop/workshop.yaml",
 	})
 	c.Check(cs.req.Method, check.Equals, "GET")
 }

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -44,6 +44,79 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 	})
 	c.Check(cs.req.Method, check.Equals, "GET")
 }
+
+func (cs *clientSuite) TestClientSingleWorkshop(c *check.C) {
+	expectedInfo := client.WorkshopInfo{
+		ProjectId: "42ws42ws",
+		Name:      "workshop",
+		Base:      "ubuntu@20.04",
+		Status:    "Ready",
+		Content:   []*client.Sdk{},
+		Notes:     []string{},
+	}
+
+	// Workshop only
+	cs.rsp = `{"type": "sync", "result": {"workshops":[{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]}]}}`
+	workshop, err := cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	c.Assert(err, check.IsNil)
+	c.Assert(workshop, check.DeepEquals, &client.Workshop{WorkshopInfo: expectedInfo})
+	c.Check(cs.req.Method, check.Equals, "GET")
+
+	// File only
+	cs.rsp = `{"type": "sync", "result": {"files":[{"name":"workshop","project-id":"42ws42ws","path":"/home/user/project/workshop.yaml"}]}}`
+	workshop, err = cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	c.Assert(err, check.IsNil)
+	c.Assert(workshop, check.DeepEquals, &client.Workshop{
+		WorkshopInfo: client.WorkshopInfo{
+			ProjectId: "42ws42ws",
+			Name:      "workshop",
+		},
+		Path: "/home/user/project/workshop.yaml",
+	})
+	c.Check(cs.req.Method, check.Equals, "GET")
+
+	// Workshop and file
+	cs.rsp = `{"type": "sync", "result": {"workshops":[{"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]}], "files":[{"name":"workshop","project-id":"42ws42ws","path":"/home/user/project/workshop.yaml"}]}}`
+	workshop, err = cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	c.Assert(err, check.IsNil)
+	c.Assert(workshop, check.DeepEquals, &client.Workshop{
+		WorkshopInfo: expectedInfo,
+		Path:         "/home/user/project/workshop.yaml",
+	})
+	c.Check(cs.req.Method, check.Equals, "GET")
+}
+
+func (cs *clientSuite) TestClientNoWorkshops(c *check.C) {
+	cs.rsp = `{"type": "sync", "result": {}}`
+	workshop, err := cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	c.Assert(workshop, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `no workshops found in "/home/user/project"`)
+	c.Check(cs.req.Method, check.Equals, "GET")
+}
+
+func (cs *clientSuite) TestClientMultipleWorkshops(c *check.C) {
+	// Two workshops
+	cs.rsp = `{"type": "sync", "result": {"workshops":[{"name":"ci","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]},{"name":"dev","base":"ubuntu@24.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]}]}}`
+	workshop, err := cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	c.Assert(workshop, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `multiple workshops found: "ci", "dev"`)
+	c.Check(cs.req.Method, check.Equals, "GET")
+
+	// Workshop and file
+	cs.rsp = `{"type": "sync", "result": {"workshops":[{"name":"ci","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready","notes":[],"content":[]}],"files":[{"name":"dev","project-id":"42ws42ws","path":"/home/user/project/.workshop/dev.yaml"}]}}`
+	workshop, err = cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	c.Assert(workshop, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `multiple workshops found: "ci", "dev"`)
+	c.Check(cs.req.Method, check.Equals, "GET")
+
+	// Two files
+	cs.rsp = `{"type": "sync", "result": {"files":[{"name":"ci","project-id":"42ws42ws","path":"/home/user/project/.workshop/ci.yaml"},{"name":"dev","project-id":"42ws42ws","path":"/home/user/project/.workshop/dev.yaml"}]}}`
+	workshop, err = cs.cli.SingleWorkshop(&client.Project{Id: "42ws42ws", Path: "/home/user/project"})
+	c.Assert(workshop, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `multiple workshops found: "ci", "dev"`)
+	c.Check(cs.req.Method, check.Equals, "GET")
+}
+
 func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
 	cs.rsp = `{"type": "sync", "result": {"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready",
 	"content":[

--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -17,7 +17,7 @@ type CmdChanges struct {
 func (c *CmdChanges) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "changes",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(0),
 		Short: "List recent changes to the workshops in a project",
 		Long: `
 Any substantial operation on a workshop is a change that consists of tasks;

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -215,11 +215,10 @@ func (c *CmdExec) runExec(workshop string, inferName bool, command []string) err
 	}
 
 	if inferName {
-		wp, err := cli.SingleWorkshop(project)
+		workshop, err = cli.SingleWorkshopName(project)
 		if err != nil {
-			return fmt.Errorf("cannot infer workshop name: %w", err)
+			return err
 		}
-		workshop = wp.Name
 	}
 
 	logger.Debugf("Running %q", command)

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -116,7 +116,7 @@ $ workshop exec --env GO111MODULE=off -w /project nimble go build -x
 Run a custom interactive shell:
 $ workshop exec -I nimble sh
 
-The name is optional if the project only has one workshop
+The name is optional if the project has only one workshop
 and a separator is provided:
 $ workshop exec -I -- sh
 
@@ -182,7 +182,7 @@ Open the default login shell of the 'workshop' user into the 'nimble' workshop
 in the current project directory:
 $ workshop shell nimble
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 $ workshop shell`,
 		RunE: c.Run,
 	}

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"time"
 
@@ -99,8 +100,8 @@ Notes:
 
 func (c *CmdExec) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "exec <WORKSHOP>",
-		Args:  cobra.MinimumNArgs(1),
+		Use:   "exec [flags] <WORKSHOP> [--] <COMMAND>...",
+		Args:  nameAndCommand,
 		Short: shortExecHelp,
 		Long:  longExecHelp,
 		Example: `
@@ -109,17 +110,18 @@ in the current project directory:
 $ workshop exec nimble go build main.go
 
 A similar command that sets an environment variable and the working directory:
-$ workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
+$ workshop exec --env GO111MODULE=off -w /project nimble go build -x
 
 Run a custom interactive shell:
-$ workshop exec nimble -I sh
+$ workshop exec -I nimble sh
 
 Run a command as root (the default is 'workshop'):
-$ workshop exec nimble --uid 0 id`,
+$ workshop exec --uid 0 nimble id`,
 		RunE: c.Run,
 	}
 
 	cmd.Flags().SortFlags = false
+	cmd.Flags().SetInterspersed(false)
 	cmd.Flags().StringVarP(&c.WorkingDir, "cwd", "w", "/project", "Set the working directory in the workshop")
 	cmd.Flags().StringArrayVar(&c.Env, "env", []string{}, "Set an environment variable, e.g. 'FOO=bar'; if only the name is provided, the value is inherited from the CLI environment.")
 	cmd.Flags().IntVar(&c.UserId, "uid", 1000, "Run as a specific workshop user")
@@ -129,6 +131,18 @@ $ workshop exec nimble --uid 0 id`,
 	cmd.Flags().BoolVarP(&c.NonInteractive, "non-interactive", "I", false, "Force non-interactive mode")
 
 	return cmd
+}
+
+func nameAndCommand(cmd *cobra.Command, av []string) error {
+	argCount := len(av)
+	if cmd.ArgsLenAtDash() < 0 && slices.Contains(av, "--") {
+		argCount--
+	}
+
+	if argCount < 2 {
+		return fmt.Errorf("requires at least 2 arg(s), only received %d", argCount)
+	}
+	return nil
 }
 
 func (c *CmdShellAlias) Command() *cobra.Command {
@@ -164,6 +178,13 @@ func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
 	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
+	}
+
+	// Remove first -- if cobra didn't see it
+	if cmd.ArgsLenAtDash() < 0 {
+		if i := slices.Index(av, "--"); i >= 0 {
+			av = slices.Delete(slices.Clone(av), i, i+1)
+		}
 	}
 
 	command := av[1:]

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -72,6 +72,7 @@ use shell syntax such as *--*:
 
 $ workshop exec nimble -- echo -n foo bar
 
+This syntax is required if the workshop name is omitted.
 
 Notes:
 
@@ -100,8 +101,8 @@ Notes:
 
 func (c *CmdExec) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "exec [flags] <WORKSHOP> [--] <COMMAND>...",
-		Args:  nameAndCommand,
+		Use:   "exec [flags] [<WORKSHOP>] [--] <COMMAND>...",
+		Args:  maybeNameAndCommand,
 		Short: shortExecHelp,
 		Long:  longExecHelp,
 		Example: `
@@ -114,6 +115,10 @@ $ workshop exec --env GO111MODULE=off -w /project nimble go build -x
 
 Run a custom interactive shell:
 $ workshop exec -I nimble sh
+
+The name is optional if the project only has one workshop
+and a separator is provided:
+$ workshop exec -I -- sh
 
 Run a command as root (the default is 'workshop'):
 $ workshop exec --uid 0 nimble id`,
@@ -133,7 +138,12 @@ $ workshop exec --uid 0 nimble id`,
 	return cmd
 }
 
-func nameAndCommand(cmd *cobra.Command, av []string) error {
+func maybeNameAndCommand(cmd *cobra.Command, av []string) error {
+	if cmd.ArgsLenAtDash() == 0 {
+		// Workshop name is implicit if -- precedes all positional arguments
+		return cobra.MinimumNArgs(1)(cmd, av)
+	}
+
 	argCount := len(av)
 	if cmd.ArgsLenAtDash() < 0 && slices.Contains(av, "--") {
 		argCount--
@@ -145,16 +155,35 @@ func nameAndCommand(cmd *cobra.Command, av []string) error {
 	return nil
 }
 
+func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
+	// Infer workshop name if first positional argument is --
+	if cmd.ArgsLenAtDash() == 0 {
+		return c.runExec("", true, av)
+	}
+
+	// Remove first -- if cobra didn't see it
+	if cmd.ArgsLenAtDash() < 0 {
+		if i := slices.Index(av, "--"); i >= 0 {
+			av = slices.Delete(slices.Clone(av), i, i+1)
+		}
+	}
+
+	return c.runExec(av[0], false, av[1:])
+}
+
 func (c *CmdShellAlias) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "shell <WORKSHOP>",
-		Args:  cobra.ExactArgs(1),
+		Use:   "shell [<WORKSHOP>]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: shortShellHelp,
 		Long:  longShellHelp,
 		Example: `
 Open the default login shell of the 'workshop' user into the 'nimble' workshop
 in the current project directory:
-$ workshop shell nimble`,
+$ workshop shell nimble
+
+The name is optional if the project only has one workshop:
+$ workshop shell`,
 		RunE: c.Run,
 	}
 
@@ -162,10 +191,15 @@ $ workshop shell nimble`,
 }
 
 func (c *CmdShellAlias) Run(cmd *cobra.Command, av []string) error {
-	return c.execCommand.Run(cmd, []string{av[0], "sudo", "-u", "workshop", "bash", "-l"})
+	var workshop string
+	if len(av) > 0 {
+		workshop = av[0]
+	}
+	command := []string{"sudo", "-u", "workshop", "bash", "-l"}
+	return c.execCommand.runExec(workshop, len(av) == 0, command)
 }
 
-func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
+func (c *CmdExec) runExec(workshop string, inferName bool, command []string) error {
 	if c.Interactive && c.NonInteractive {
 		return errors.New("'-i' incompatible with '-I'")
 	}
@@ -180,14 +214,14 @@ func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	// Remove first -- if cobra didn't see it
-	if cmd.ArgsLenAtDash() < 0 {
-		if i := slices.Index(av, "--"); i >= 0 {
-			av = slices.Delete(slices.Clone(av), i, i+1)
+	if inferName {
+		wp, err := cli.SingleWorkshop(project)
+		if err != nil {
+			return fmt.Errorf("cannot infer workshop name: %w", err)
 		}
+		workshop = wp.Name
 	}
 
-	command := av[1:]
 	logger.Debugf("Running %q", command)
 
 	// Set up environment variables.
@@ -268,7 +302,7 @@ func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	// Start the command.
-	process, err := cli.Exec(opts, av[0], project.Id)
+	process, err := cli.Exec(opts, workshop, project.Id)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/gendocs.go
+++ b/cmd/workshop/gendocs.go
@@ -18,7 +18,7 @@ type CmdDocs struct {
 func (c *CmdDocs) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:    "generate-docs",
-		Args:   cobra.RangeArgs(0, 1),
+		Args:   cobra.MaximumNArgs(1),
 		Short:  "Generate workshop reference docs",
 		Hidden: true,
 		RunE:   c.Run,
@@ -37,8 +37,8 @@ func linkHandler(name, ref string) string {
 
 func (c *CmdDocs) Run(cmd *cobra.Command, av []string) error {
 	docDir := "docs-gendocs"
-	if len(av) > 1 {
-		docDir = av[1]
+	if len(av) > 0 {
+		docDir = av[0]
 	}
 
 	err := os.MkdirAll(docDir, os.ModePerm)

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -44,7 +44,7 @@ Notes:
 List details for the 'nimble' workshop in the current project directory:
 $ workshop info nimble
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 $ workshop info`,
 		RunE: c.Run,
 	}

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -20,8 +20,8 @@ type CmdInfo struct {
 
 func (c *CmdInfo) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "info <WORKSHOP>",
-		Args:  cobra.RangeArgs(1, 1),
+		Use:   "info [<WORKSHOP>]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Print the current status and details of a workshop as YAML",
 		Long: `
 This command outputs the basic settings, current status and individual SDK
@@ -42,7 +42,10 @@ Notes:
 `,
 		Example: `
 List details for the 'nimble' workshop in the current project directory:
-$ workshop info nimble`,
+$ workshop info nimble
+
+The name is optional if the project only has one workshop:
+$ workshop info`,
 		RunE: c.Run,
 	}
 
@@ -76,6 +79,14 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
+	}
+
+	if len(av) == 0 {
+		workshop, err := cli.SingleWorkshop(project)
+		if err != nil {
+			return fmt.Errorf("cannot infer workshop name: %w", err)
+		}
+		av = []string{workshop.Name}
 	}
 
 	workshop, err := cli.Workshop(project.Id, av[0])

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -82,11 +82,11 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	if len(av) == 0 {
-		workshop, err := cli.SingleWorkshop(project)
+		name, err := cli.SingleWorkshopName(project)
 		if err != nil {
-			return fmt.Errorf("cannot infer workshop name: %w", err)
+			return err
 		}
-		av = []string{workshop.Name}
+		av = []string{name}
 	}
 
 	workshop, err := cli.Workshop(project.Id, av[0])

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -78,7 +78,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	workshop, _, err := cli.Workshop(project.Id, av[0])
+	workshop, err := cli.Workshop(project.Id, av[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -22,7 +22,7 @@ func (m *workshopInfo) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
-var mockWorkshopWithContent = `{"type":"sync","status-code":200,"status":"OK","result":{"workshop":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"]},"file":{"name":"ws","path":"/home/project/.workshop/ws.yaml","project-id":"42424242"}},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
+var mockWorkshopWithContent = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"],"path":"/home/project/.workshop/ws.yaml"},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
 
 func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}
@@ -62,7 +62,7 @@ content:
 	c.Check(n, check.Equals, 2)
 }
 
-var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{"workshop":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Pending","notes":["workshop-note"],"content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z","health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}}]}}}`
+var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Pending","notes":["workshop-note"],"content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z","health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}}]}}`
 
 func (m *workshopInfo) TestWorkshopInfoWithSdkHealthReport(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}
@@ -101,12 +101,12 @@ content:
 	c.Check(n, check.Equals, 2)
 }
 
-var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","result":{"workshop":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready",
+var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready",
 "content":[
 	{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z",
 	"mounts":[{"host-source":"/home/user/src","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}},
 	{"host-source":"%s/.local/share/workshop/project/17942561/mount/ws_go_mod-cache.sdk","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-default"}}]
-}]}}}`
+}]}}`
 
 func (m *workshopInfo) TestWorkshopInfoWithSdkMounts(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -22,6 +22,8 @@ func (m *workshopInfo) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
+var mockSingleWorkshop = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","notes":["missing-project"]}]},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
+
 var mockWorkshopWithContent = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"],"path":"/home/project/.workshop/ws.yaml"},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
 
 func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
@@ -38,15 +40,20 @@ func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
 			fmt.Fprintln(w, r)
 		case 2:
 			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockSingleWorkshop)
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
 			fmt.Fprintln(w, mockWorkshopWithContent)
 		default:
-			c.Errorf("expected 2 calls, now on %d", n)
+			c.Errorf("expected 3 calls, now on %d", n)
 		}
 	})
 
-	err := cmd.Run(cmd.Command(), []string{workshop})
+	err := cmd.Run(cmd.Command(), nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`name:     ws
 base:     ubuntu@22.04
@@ -59,7 +66,7 @@ content:
   sketch:
     channel:  ~   2017-03-22  \(x1\)
 `, m.prjDir))
-	c.Check(n, check.Equals, 2)
+	c.Check(n, check.Equals, 3)
 }
 
 var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Pending","notes":["workshop-note"],"content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z","health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}}]}}`

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -45,7 +45,7 @@ Notes:
 Launch the 'nimble' and 'jazzy' workshops in the current project directory:
 $ workshop launch nimble jazzy
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 $ workshop launch`,
 		RunE: c.Run,
 	}

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -71,11 +71,11 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	if len(av) == 0 {
-		workshop, err := cli.SingleWorkshop(project)
+		name, err := cli.SingleWorkshopName(project)
 		if err != nil {
-			return fmt.Errorf("cannot infer workshop name: %w", err)
+			return err
 		}
-		av = []string{workshop.Name}
+		av = []string{name}
 	}
 
 	changeId, err := cli.Launch(project.Id, av)

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -15,7 +15,6 @@ type CmdLaunch struct {
 func (c *CmdLaunch) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "launch <WORKSHOP>...",
-		Args:  cobra.MinimumNArgs(1),
 		Short: "Construct one or many workshops using their definitions",
 		Long: `
 This command constructs the workshops listed as arguments by going over their
@@ -44,7 +43,10 @@ Notes:
 `,
 		Example: `
 Launch the 'nimble' and 'jazzy' workshops in the current project directory:
-$ workshop launch nimble jazzy`,
+$ workshop launch nimble jazzy
+
+The name is optional if the project only has one workshop:
+$ workshop launch`,
 		RunE: c.Run,
 	}
 
@@ -66,6 +68,14 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
+	}
+
+	if len(av) == 0 {
+		workshop, err := cli.SingleWorkshop(project)
+		if err != nil {
+			return fmt.Errorf("cannot infer workshop name: %w", err)
+		}
+		av = []string{workshop.Name}
 	}
 
 	changeId, err := cli.Launch(project.Id, av)

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -23,7 +23,7 @@ type CmdList struct {
 func (c *CmdList) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "list",
-		Args:  cobra.MaximumNArgs(0),
+		Args:  cobra.ExactArgs(0),
 		Short: "List project workshops",
 		Long: `
 This command enumerates all workshops in the project, printing a compact list:

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -93,7 +93,7 @@ func (c *CmdList) runList() error {
 		/* List all workshops for the current project */
 		if len(workshops) != 0 || len(files) != 0 {
 			header.Do(printHeader)
-			print(w, workshops, files, project)
+			print(w, workshops, files, *project)
 		}
 	} else {
 		projects, err := cli.Projects()
@@ -127,7 +127,7 @@ func sorter[T *client.WorkshopInfo | *client.WorkshopFile](extract func(T) strin
 	}
 }
 
-func print(w *tabwriter.Writer, workshops []*client.WorkshopInfo, files []*client.WorkshopFile, prj *client.Project) {
+func print(w *tabwriter.Writer, workshops []*client.WorkshopInfo, files []*client.WorkshopFile, prj client.Project) {
 	slices.SortFunc(workshops, sorter(func(w *client.WorkshopInfo) string { return w.Name }))
 	for _, wp := range workshops {
 		line := workshopEntry(wp, prj)
@@ -146,7 +146,7 @@ func print(w *tabwriter.Writer, workshops []*client.WorkshopInfo, files []*clien
 	}
 }
 
-func fileEntry(w *client.WorkshopFile, p *client.Project) []string {
+func fileEntry(w *client.WorkshopFile, p client.Project) []string {
 	line := []string{
 		contractHomeDirectory(p.Path),
 		w.Name,
@@ -156,7 +156,7 @@ func fileEntry(w *client.WorkshopFile, p *client.Project) []string {
 	return line
 }
 
-func workshopEntry(w *client.WorkshopInfo, p *client.Project) []string {
+func workshopEntry(w *client.WorkshopInfo, p client.Project) []string {
 	comment := "-"
 	if len(w.Notes) > 0 {
 		comment = strings.Join(w.Notes, ",")

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -135,11 +135,11 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	if len(av) == 0 {
-		workshop, err := cli.SingleWorkshop(project)
+		name, err := cli.SingleWorkshopName(project)
 		if err != nil {
-			return fmt.Errorf("cannot infer workshop name: %w", err)
+			return err
 		}
-		av = []string{workshop.Name}
+		av = []string{name}
 	}
 
 	mode := "transactional"

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -19,7 +19,6 @@ type CmdRefresh struct {
 func (c *CmdRefresh) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "refresh [--abort|--continue|--wait-on-error] <WORKSHOP>[/<SDK>]...",
-		Args:  cobra.MinimumNArgs(1),
 		Short: "Update workshops according to their definitions",
 		Long: `
 This command updates the workshops listed as arguments by going over their
@@ -66,18 +65,21 @@ Notes:
 Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
 $ workshop refresh nimble jazzy
 
-Refresh 'nimble', but stop on any errors (won’t accept multiple workshops):
-$ workshop refresh nimble --wait-on-error
+The name is optional if the project only has one workshop:
+$ workshop refresh
 
-After 'nimble' refresh stopped on error, abort the operation:
-$ workshop refresh nimble --abort
+Refresh workshop, but stop on any errors (won’t accept multiple workshops):
+$ workshop refresh --wait-on-error
 
-After 'nimble' refresh stopped on error and the workshop was fixed,
+After refresh stopped on error, abort the operation:
+$ workshop refresh --abort
+
+After refresh stopped on error and the workshop was fixed,
 continue the operation:
-$ workshop refresh nimble --continue
+$ workshop refresh --continue
 
-Refresh the hack SDK under 'nimble':
-$ workshop refresh nimble/hack`,
+Refresh the sketch SDK in the 'nimble' workshop:
+$ workshop refresh nimble/sketch`,
 		RunE: c.Run,
 	}
 
@@ -130,6 +132,14 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
+	}
+
+	if len(av) == 0 {
+		workshop, err := cli.SingleWorkshop(project)
+		if err != nil {
+			return fmt.Errorf("cannot infer workshop name: %w", err)
+		}
+		av = []string{workshop.Name}
 	}
 
 	mode := "transactional"

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -65,7 +65,7 @@ Notes:
 Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
 $ workshop refresh nimble jazzy
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 $ workshop refresh
 
 Refresh workshop, but stop on any errors (won’t accept multiple workshops):

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -15,6 +15,8 @@ type workshopRefresh struct {
 
 var _ = check.Suite(&workshopRefresh{})
 
+var mockSingleWorkshopJSON = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"}]}}`
+
 var mockReadyChangeJSON = `{"type": "sync", "result":{
     "id":   "four",
     "kind": "refresh",
@@ -94,6 +96,7 @@ func (m *workshopRefresh) TestRefreshTransactionalSuccess(c *check.C) {
 	err := cmd.Run(cmd.Command(), []string{"ws", "ws"})
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, `"ws" refreshed\n`)
+	c.Check(n, check.Equals, 3)
 }
 
 func (m *workshopRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
@@ -124,6 +127,7 @@ func (m *workshopRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
 	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, `(?s).*"ws", "ws-1" refresh aborted`)
+	c.Check(n, check.Equals, 3)
 }
 
 func (m *workshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
@@ -140,24 +144,29 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
 			fmt.Fprintln(w, r)
 		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			fmt.Fprintln(w, mockSingleWorkshopJSON)
+		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
 				"names": []interface{}{"ws"}, "options": map[string]interface{}{"refresh-mode": "wait-on-error"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
-		case 3:
+		case 4:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
 			fmt.Fprintln(w, mockWaitChangeJSON)
 		default:
-			c.Errorf("expected 3 calls, now on %d", n)
+			c.Errorf("expected 4 calls, now on %d", n)
 		}
 	})
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(nil, nil)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, `cannot refresh; fix the errors reported,\nthen run "workshop refresh --continue ws".\nTo abort and revert, run "workshop refresh --abort ws"`)
+	c.Check(n, check.Equals, 4)
 }
 
 func (m *workshopRefresh) TestRefreshWaitOnErrorAbortedSuccessfully(c *check.C) {
@@ -192,6 +201,7 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorAbortedSuccessfully(c *check.C) 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, `"ws" refresh aborted\n`)
+	c.Check(n, check.Equals, 3)
 }
 
 func (m *workshopRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C) {
@@ -226,6 +236,7 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, `"ws" refreshed\n`)
+	c.Check(n, check.Equals, 3)
 }
 
 func (m *workshopRefresh) TestRefreshIncompatibleOptions(c *check.C) {

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -62,11 +62,11 @@ func (c *CmdRemove) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	if len(av) == 0 {
-		workshop, err := cli.SingleWorkshop(project)
+		name, err := cli.SingleWorkshopName(project)
 		if err != nil {
-			return fmt.Errorf("cannot infer workshop name: %w", err)
+			return err
 		}
-		av = []string{workshop.Name}
+		av = []string{name}
 	}
 
 	changeId, err := cli.Remove(project.Id, av)

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -19,7 +19,6 @@ type CmdRemove struct {
 func (c *CmdRemove) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "remove <WORKSHOP>...",
-		Args:  cobra.MinimumNArgs(1),
 		Short: "Remove one or many workshops",
 		Long: `
 This command removes the workshops listed as arguments. For each workshop, it:
@@ -37,7 +36,10 @@ Notes:
 `,
 		Example: `
 Remove the 'nimble' and 'jazzy' workshops in the current project directory:
-$ workshop remove nimble jazzy`,
+$ workshop remove nimble jazzy
+
+The name is optional if the project only has one workshop:
+$ workshop remove`,
 		RunE: c.Run,
 	}
 
@@ -57,6 +59,14 @@ func (c *CmdRemove) Run(cmd *cobra.Command, av []string) error {
 	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
+	}
+
+	if len(av) == 0 {
+		workshop, err := cli.SingleWorkshop(project)
+		if err != nil {
+			return fmt.Errorf("cannot infer workshop name: %w", err)
+		}
+		av = []string{workshop.Name}
 	}
 
 	changeId, err := cli.Remove(project.Id, av)

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -38,7 +38,7 @@ Notes:
 Remove the 'nimble' and 'jazzy' workshops in the current project directory:
 $ workshop remove nimble jazzy
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 $ workshop remove`,
 		RunE: c.Run,
 	}

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -57,7 +57,7 @@ Edit the sketch SDK definition for the 'nimble' workshop
 and apply it after saving by automatically refreshing the workshop:
 $ workshop sketch-sdk nimble
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 $ workshop sketch-sdk
 
 Stash the sketch SDK, temporarily reverting the changes in the workshop:

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -201,10 +201,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	} else {
 		wp, err = cli.SingleWorkshop(p)
 		if err != nil {
-			return fmt.Errorf("cannot infer workshop name: %w", err)
-		}
-		if wp.Base == "" {
-			return workshop.ErrWorkshopNotLaunched
+			return err
 		}
 	}
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -188,7 +188,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	wp, file, err := cli.Workshop(p.Id, av[0])
+	wp, err := cli.Workshop(p.Id, av[0])
 	if err != nil {
 		return err
 	}
@@ -249,11 +249,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	metafile := filepath.Join(sketchdir, "meta", "sdk.yaml")
 
 	// Format sketch SDK template header.
-	wpath := ""
-	if file != nil {
-		wpath = file.Path
-	}
-	boilerplate := fmt.Sprintf(sketchTemplate, wpath, wp.Base)
+	boilerplate := fmt.Sprintf(sketchTemplate, wp.Path, wp.Base)
 
 	if osutil.FileExists(metafile) {
 		old, err := os.ReadFile(metafile)

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
@@ -26,8 +27,8 @@ type CmdSketch struct {
 
 func (c *CmdSketch) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "sketch-sdk [--stash|--restore|--remove] <WORKSHOP>",
-		Args:  cobra.ExactArgs(1),
+		Use:   "sketch-sdk [--stash|--restore|--remove] [<WORKSHOP>]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Edit the sketch SDK and graft it onto the workshop",
 		Long: `
 This opens the 'sketch' SDK definition in the default text editor,
@@ -52,11 +53,14 @@ Notes:
   with the 'workshop refresh <WORKSHOP>/sketch' command
 `,
 		Example: `
-Edit the hack SDK definition for the 'nimble' workshop
+Edit the sketch SDK definition for the 'nimble' workshop
 and apply it after saving by automatically refreshing the workshop:
 $ workshop sketch-sdk nimble
 
-Stash the hack SDK, temporarily reverting the changes in the workshop:
+The name is optional if the project only has one workshop:
+$ workshop sketch-sdk
+
+Stash the sketch SDK, temporarily reverting the changes in the workshop:
 $ workshop sketch-sdk nimble --stash`,
 		RunE: c.Run,
 	}
@@ -188,9 +192,20 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	wp, err := cli.Workshop(p.Id, av[0])
-	if err != nil {
-		return err
+	var wp *client.Workshop
+	if len(av) > 0 {
+		wp, err = cli.Workshop(p.Id, av[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		wp, err = cli.SingleWorkshop(p)
+		if err != nil {
+			return fmt.Errorf("cannot infer workshop name: %w", err)
+		}
+		if wp.Base == "" {
+			return workshop.ErrWorkshopNotLaunched
+		}
 	}
 
 	user, err := osutil.UserMaybeSudoUser()
@@ -209,7 +224,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		defer reverter.Fail()
 
 		cmdrefresh := &CmdRefresh{root: c.root}
-		if err = cmdrefresh.Run(cmd, av[0:1]); err != nil {
+		if err = cmdrefresh.Run(cmd, []string{wp.Name}); err != nil {
 			// Refresh failed, revert the stash operation so a possible subsequent
 			// "workshop refresh <WORKSHOP>/sketch" won't fail due to the lack of
 			// sketch SDK definition.
@@ -234,7 +249,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		// and with --wait-on-error. Hence, there is always a possibility to
 		// workshop refresh --abort and workshop sketch-sdk --restore to restore the
 		// original sketch content.
-		return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", av[0])})
+		return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", wp.Name)})
 	}
 
 	if c.remove {
@@ -243,7 +258,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		}
 
 		cmdrefresh := &CmdRefresh{root: c.root}
-		return cmdrefresh.Run(cmd, av[0:1])
+		return cmdrefresh.Run(cmd, []string{wp.Name})
 	}
 
 	metafile := filepath.Join(sketchdir, "meta", "sdk.yaml")
@@ -283,7 +298,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	cmdrefresh := &CmdRefresh{root: c.root}
 	cmdrefresh.WaitOnError = true
 
-	return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", av[0])})
+	return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", wp.Name)})
 }
 
 func writeSketchSdk(sketchdir string, content []byte) error {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -255,9 +255,9 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 			fmt.Fprintln(w, r)
 		case 2:
 			c.Check(r.Method, check.Equals, "GET")
-			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockWorkshopWithContent)
+			fmt.Fprintln(w, mockSingleWorkshop)
 		case 4:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
@@ -276,7 +276,7 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 
 	metadir, _ := m.mockMinimalSketchSdk(c, true, []byte(simpleSketchMeta))
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(nil, nil)
 	c.Assert(err, check.NotNil)
 	c.Assert(n, check.Equals, 5)
 

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -352,23 +352,28 @@ func (m *workshopSketch) TestRemoveRemovesSketch(c *check.C) {
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
 			fmt.Fprintln(w, r)
 		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			fmt.Fprintln(w, mockSingleWorkshop)
+		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
-		case 3:
+		case 4:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
 			fmt.Fprintln(w, mockReadyChangeJSON)
 		default:
-			c.Errorf("expected 3 calls, now on %d", n)
+			c.Errorf("expected 4 calls, now on %d", n)
 		}
 	})
 
 	m.ResetStdStreams()
-	err = cmdremove.Run(nil, []string{"ws"})
+	err = cmdremove.Run(nil, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, `"ws" removed\n`)
+	c.Check(n, check.Equals, 4)
 
 	sketchroot := sdk.WorkshopSketchSdk(m.user.HomeDir, m.prjId, "ws")
 	c.Assert(sketchroot, testutil.FileAbsent)

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -64,11 +64,11 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	if len(av) == 0 {
-		workshop, err := cli.SingleWorkshop(project)
+		name, err := cli.SingleWorkshopName(project)
 		if err != nil {
-			return fmt.Errorf("cannot infer workshop name: %w", err)
+			return err
 		}
-		av = []string{workshop.Name}
+		av = []string{name}
 	}
 
 	changeId, err := cli.Start(project.Id, av)

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -40,7 +40,7 @@ Notes:
 Start the 'nimble' and 'jazzy' workshops in the current project directory:
 $ workshop start nimble jazzy
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 $ workshop start`,
 		RunE: c.Run,
 	}

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -15,7 +15,6 @@ type CmdStart struct {
 func (c *CmdStart) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "start <WORKSHOP>...",
-		Args:  cobra.MinimumNArgs(1),
 		Short: "Start one or many workshops",
 		Long: `
 This command activates the workshops listed as arguments. For each one, it:
@@ -39,7 +38,10 @@ Notes:
 `,
 		Example: `
 Start the 'nimble' and 'jazzy' workshops in the current project directory:
-$ workshop start nimble jazzy`,
+$ workshop start nimble jazzy
+
+The name is optional if the project only has one workshop:
+$ workshop start`,
 		RunE: c.Run,
 	}
 
@@ -59,6 +61,14 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
+	}
+
+	if len(av) == 0 {
+		workshop, err := cli.SingleWorkshop(project)
+		if err != nil {
+			return fmt.Errorf("cannot infer workshop name: %w", err)
+		}
+		av = []string{workshop.Name}
 	}
 
 	changeId, err := cli.Start(project.Id, av)

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -15,7 +15,6 @@ type CmdStop struct {
 func (c *CmdStop) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "stop <WORKSHOP>...",
-		Args:  cobra.MinimumNArgs(1),
 		Short: "Stop one or many workshops",
 		Long: `
 This command deactivates the workshops listed as arguments. For each one, it:
@@ -39,8 +38,10 @@ Notes:
 `,
 		Example: `
 Stop the nimble and jazzy workshops in the current project directory:
+$ workshop stop nimble jazzy
 
-workshop stop nimble jazzy`,
+The name is optional if the project only has one workshop:
+$ workshop stop`,
 		RunE: c.Run,
 	}
 
@@ -60,6 +61,14 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	project, err := cli.Project(c.root.project)
 	if err != nil {
 		return err
+	}
+
+	if len(av) == 0 {
+		workshop, err := cli.SingleWorkshop(project)
+		if err != nil {
+			return fmt.Errorf("cannot infer workshop name: %w", err)
+		}
+		av = []string{workshop.Name}
 	}
 
 	changeId, err := cli.Stop(project.Id, av)

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -40,7 +40,7 @@ Notes:
 Stop the nimble and jazzy workshops in the current project directory:
 $ workshop stop nimble jazzy
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 $ workshop stop`,
 		RunE: c.Run,
 	}

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -64,11 +64,11 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	if len(av) == 0 {
-		workshop, err := cli.SingleWorkshop(project)
+		name, err := cli.SingleWorkshopName(project)
 		if err != nil {
-			return fmt.Errorf("cannot infer workshop name: %w", err)
+			return err
 		}
-		av = []string{workshop.Name}
+		av = []string{name}
 	}
 
 	changeId, err := cli.Stop(project.Id, av)

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -19,7 +19,7 @@ type CmdTasks struct {
 func (c *CmdTasks) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "tasks <CHANGE ID>",
-		Args:  cobra.RangeArgs(1, 1),
+		Args:  cobra.ExactArgs(1),
 		Short: "List tasks for a specific change",
 		Long: `
 Any substantial operation on a workshop is a change that consists of tasks;

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -55,7 +55,7 @@ type CmdOkay struct {
 func (c *CmdWarnings) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "warnings [OPTIONS]",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(0),
 		Short: "List warnings",
 		Long: `
 This command lists the warnings that were reported to the system.
@@ -98,7 +98,7 @@ By default, Unicode is used only if the output supports it.`)
 func (c *CmdOkay) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "okay",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(0),
 		Short: "Acknowledge listed warnings",
 		Long: `
 This command acknowledges all warnings

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -54,7 +54,7 @@ type CmdOkay struct {
 
 func (c *CmdWarnings) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "warnings [OPTIONS]",
+		Use:   "warnings",
 		Args:  cobra.ExactArgs(0),
 		Short: "List warnings",
 		Long: `

--- a/docs/how-to/ros2/ros2-create-workshop.rst
+++ b/docs/how-to/ros2/ros2-create-workshop.rst
@@ -74,7 +74,7 @@ All set, so launch the workshop:
 
 .. code-block:: console
 
-   $ workshop launch ros2-humble
+   $ workshop launch
 
 
 .. note::

--- a/docs/how-to/ros2/ros2-create-workshop.rst
+++ b/docs/how-to/ros2/ros2-create-workshop.rst
@@ -95,7 +95,7 @@ so open a shell and go there:
 
 .. code-block:: console
 
-   $ workshop shell ros2-humble
+   $ workshop shell
    workshop@ros2-humble-8584e57d$ cd /project/
    workshop@ros2-humble-8584e57d$ ls
 
@@ -136,7 +136,7 @@ Try this for yourself:
 
    workshop@ros2-humble-8584e57d$ exit
    $ workshop refresh
-   $ workshop shell ros2-humble
+   $ workshop shell
    workshop@ros2-humble-8584e57d$ cd /project/
    workshop@ros2-humble-8584e57d$ colcon build
 
@@ -173,7 +173,7 @@ from the project directory:
 
 .. code-block:: console
 
-   $ workshop shell ros2-humble
+   $ workshop shell
    workshop@ros2-humble-8584e57d$ cd /project/
    workshop@ros2-humble-8584e57d$ colcon test
    workshop@ros2-humble-8584e57d$ colcon test-result --all

--- a/docs/how-to/ros2/ros2-create-workshop.rst
+++ b/docs/how-to/ros2/ros2-create-workshop.rst
@@ -135,7 +135,7 @@ Try this for yourself:
 .. code-block:: console
 
    workshop@ros2-humble-8584e57d$ exit
-   $ workshop refresh ros2-humble
+   $ workshop refresh
    $ workshop shell ros2-humble
    workshop@ros2-humble-8584e57d$ cd /project/
    workshop@ros2-humble-8584e57d$ colcon build

--- a/docs/how-to/use-workshops/debug-workshop-issues.rst
+++ b/docs/how-to/use-workshops/debug-workshop-issues.rst
@@ -30,7 +30,7 @@ Suppose something goes wrong during :command:`workshop refresh`:
 
 .. code-block:: console
 
-   $ workshop refresh golang-volatile
+   $ workshop refresh
 
      Error: cannot perform the following tasks:
      - Run hook "setup-base" for "go" SDK (command failed with an error code (1))
@@ -89,7 +89,7 @@ instead of reverting the workshop to its previous state,
 
 .. code-block:: console
 
-   $ workshop refresh --wait-on-error golang-volatile
+   $ workshop refresh --wait-on-error
 
      Error: cannot perform the following tasks:
      - Run hook "setup-base" for "go" SDK (command failed with an error code (1))
@@ -107,14 +107,14 @@ On success, you can resume the refresh process:
 
 .. code-block:: console
 
-   $ workshop refresh --continue golang-volatile
+   $ workshop refresh --continue
 
 
 Otherwise, undo the changes with the :option:`!--abort` option:
 
 .. code-block:: console
 
-   $ workshop refresh --abort golang-volatile
+   $ workshop refresh --abort
 
 
 The effect will be the same as if you hadn't used :option:`!--wait-on-error`:

--- a/docs/how-to/use-workshops/debug-workshop-issues.rst
+++ b/docs/how-to/use-workshops/debug-workshop-issues.rst
@@ -100,7 +100,7 @@ Next, you can shell into the workshop to debug and possibly fix it:
 
 .. code-block:: console
 
-   $ workshop shell golang-volatile
+   $ workshop shell
 
 
 On success, you can resume the refresh process:

--- a/docs/how-to/use-workshops/git-workshop.rst
+++ b/docs/how-to/use-workshops/git-workshop.rst
@@ -74,7 +74,7 @@ They stay there even if you remove the workshop:
 
 .. code-block:: console
 
-   $ workshop remove golang
+   $ workshop remove
    $ ./main
 
      hello, Workshop
@@ -171,7 +171,7 @@ before running :samp:`git worktree remove`:
 
 .. code-block:: console
 
-   $ workshop remove golang --project /home/user/resolved/
+   $ workshop remove --project ../resolved/
    $ git worktree remove ../resolved/
 
 

--- a/docs/how-to/use-workshops/git-workshop.rst
+++ b/docs/how-to/use-workshops/git-workshop.rst
@@ -36,7 +36,7 @@ and start working on your code:
 
 .. code-block:: console
 
-   $ workshop launch golang
+   $ workshop launch
 
 
 .. code-block:: go
@@ -87,7 +87,7 @@ They stay there even if you remove the workshop:
 
    .. code-block:: console
 
-      $ workshop launch golang
+      $ workshop launch
 
 From here, you can do whatever you like with your repo,
 because |ws_markup| handles
@@ -143,7 +143,7 @@ Next, launch the redefined workshop to work on the problem:
 
 .. code-block:: console
 
-   $ workshop launch golang
+   $ workshop launch
    $ # Hacking away until the problem is solved
    $ git commit -m "solve problem with hotfix"
    $ cd ../original/

--- a/docs/how-to/use-workshops/git-workshop.rst
+++ b/docs/how-to/use-workshops/git-workshop.rst
@@ -58,7 +58,7 @@ should now occur inside the workshop:
 .. code-block:: console
 
    $ git add . && git commit -m "initial commit"
-   $ workshop exec golang -- go build -x main.go
+   $ workshop exec golang go build -x main.go
 
 
 However, the resulting artefacts are exposed in the project directory:

--- a/docs/how-to/use-workshops/moving-projects.rst
+++ b/docs/how-to/use-workshops/moving-projects.rst
@@ -28,7 +28,7 @@ Things change *after* you run :command:`workshop launch`:
 
 .. code-block:: console
 
-   $ workshop launch golang --project /home/user/old/
+   $ workshop launch --project /home/user/old/
 
 
 Moving a project
@@ -99,7 +99,7 @@ but what happens if you do it yourself?
 
 .. code-block:: console
 
-   $ workshop launch golang --project /home/user/new/
+   $ workshop launch --project /home/user/new/
    $ workshop list --global
 
      Project                 Workshop  Status  Notes

--- a/docs/how-to/use-workshops/moving-projects.rst
+++ b/docs/how-to/use-workshops/moving-projects.rst
@@ -123,7 +123,7 @@ before deleting the project directory:
 
 .. code-block:: console
 
-   $ workshop remove golang --project /home/user/old/
+   $ workshop remove --project /home/user/old/
    $ rm -rf /home/user/old/
 
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -60,7 +60,7 @@ In the ``.workshop`` directory of the project
 that you want to use with Workshop,
 create a workshop definition file named ``workshop.yaml``
 to list your project's prerequisites,
-then run ``workshop launch <NAME>``:
+then run ``workshop launch``:
 
 .. code-block:: console
 
@@ -74,7 +74,7 @@ then run ``workshop launch <NAME>``:
        channel: latest/stable
    EOF
 
-   workshop launch golang
+   workshop launch
 
 
 Workshop downloads and installs the SDKs your definition lists;

--- a/docs/reference/cli/workshop-exec.rst
+++ b/docs/reference/cli/workshop-exec.rst
@@ -9,7 +9,7 @@ Run a command and wait for it to complete.
 
 .. code-block:: console
 
-   $ workshop exec [flags] <WORKSHOP> [--] <COMMAND>...
+   $ workshop exec [flags] [<WORKSHOP>] [--] <COMMAND>...
 
 .. rubric:: Description
 
@@ -38,6 +38,7 @@ use shell syntax such as *--*:
 
 $ workshop exec nimble -- echo -n foo bar
 
+This syntax is required if the workshop name is omitted.
 
 Notes:
 
@@ -109,6 +110,14 @@ Run a custom interactive shell:
 .. code-block:: console
 
    $ workshop exec -I nimble sh
+
+
+The name is optional if the project only has one workshop
+and a separator is provided:
+
+.. code-block:: console
+
+   $ workshop exec -I -- sh
 
 
 Run a command as root (the default is 'workshop'):

--- a/docs/reference/cli/workshop-exec.rst
+++ b/docs/reference/cli/workshop-exec.rst
@@ -112,7 +112,7 @@ Run a custom interactive shell:
    $ workshop exec -I nimble sh
 
 
-The name is optional if the project only has one workshop
+The name is optional if the project has only one workshop
 and a separator is provided:
 
 .. code-block:: console

--- a/docs/reference/cli/workshop-exec.rst
+++ b/docs/reference/cli/workshop-exec.rst
@@ -9,7 +9,7 @@ Run a command and wait for it to complete.
 
 .. code-block:: console
 
-   $ workshop exec <WORKSHOP> [flags]
+   $ workshop exec [flags] <WORKSHOP> [--] <COMMAND>...
 
 .. rubric:: Description
 
@@ -101,20 +101,20 @@ A similar command that sets an environment variable and the working directory:
 
 .. code-block:: console
 
-   $ workshop exec nimble --env GO111MODULE=off -w /project -- go build -x
+   $ workshop exec --env GO111MODULE=off -w /project nimble go build -x
 
 
 Run a custom interactive shell:
 
 .. code-block:: console
 
-   $ workshop exec nimble -I sh
+   $ workshop exec -I nimble sh
 
 
 Run a command as root (the default is 'workshop'):
 
 .. code-block:: console
 
-   $ workshop exec nimble --uid 0 id
+   $ workshop exec --uid 0 nimble id
 
 

--- a/docs/reference/cli/workshop-info.rst
+++ b/docs/reference/cli/workshop-info.rst
@@ -9,7 +9,7 @@ Print the current status and details of a workshop as YAML.
 
 .. code-block:: console
 
-   $ workshop info <WORKSHOP> [flags]
+   $ workshop info [<WORKSHOP>] [flags]
 
 .. rubric:: Description
 
@@ -39,5 +39,12 @@ List details for the 'nimble' workshop in the current project directory:
 .. code-block:: console
 
    $ workshop info nimble
+
+
+The name is optional if the project only has one workshop:
+
+.. code-block:: console
+
+   $ workshop info
 
 

--- a/docs/reference/cli/workshop-info.rst
+++ b/docs/reference/cli/workshop-info.rst
@@ -41,7 +41,7 @@ List details for the 'nimble' workshop in the current project directory:
    $ workshop info nimble
 
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-launch.rst
+++ b/docs/reference/cli/workshop-launch.rst
@@ -58,3 +58,10 @@ Launch the 'nimble' and 'jazzy' workshops in the current project directory:
    $ workshop launch nimble jazzy
 
 
+The name is optional if the project only has one workshop:
+
+.. code-block:: console
+
+   $ workshop launch
+
+

--- a/docs/reference/cli/workshop-launch.rst
+++ b/docs/reference/cli/workshop-launch.rst
@@ -58,7 +58,7 @@ Launch the 'nimble' and 'jazzy' workshops in the current project directory:
    $ workshop launch nimble jazzy
 
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-refresh.rst
+++ b/docs/reference/cli/workshop-refresh.rst
@@ -84,32 +84,39 @@ Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
    $ workshop refresh nimble jazzy
 
 
-Refresh 'nimble', but stop on any errors (won’t accept multiple workshops):
+The name is optional if the project only has one workshop:
 
 .. code-block:: console
 
-   $ workshop refresh nimble --wait-on-error
+   $ workshop refresh
 
 
-After 'nimble' refresh stopped on error, abort the operation:
+Refresh workshop, but stop on any errors (won’t accept multiple workshops):
 
 .. code-block:: console
 
-   $ workshop refresh nimble --abort
+   $ workshop refresh --wait-on-error
 
 
-After 'nimble' refresh stopped on error and the workshop was fixed,
+After refresh stopped on error, abort the operation:
+
+.. code-block:: console
+
+   $ workshop refresh --abort
+
+
+After refresh stopped on error and the workshop was fixed,
 continue the operation:
 
 .. code-block:: console
 
-   $ workshop refresh nimble --continue
+   $ workshop refresh --continue
 
 
-Refresh the hack SDK under 'nimble':
+Refresh the sketch SDK in the 'nimble' workshop:
 
 .. code-block:: console
 
-   $ workshop refresh nimble/hack
+   $ workshop refresh nimble/sketch
 
 

--- a/docs/reference/cli/workshop-refresh.rst
+++ b/docs/reference/cli/workshop-refresh.rst
@@ -84,7 +84,7 @@ Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
    $ workshop refresh nimble jazzy
 
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-remove.rst
+++ b/docs/reference/cli/workshop-remove.rst
@@ -38,7 +38,7 @@ Remove the 'nimble' and 'jazzy' workshops in the current project directory:
    $ workshop remove nimble jazzy
 
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-remove.rst
+++ b/docs/reference/cli/workshop-remove.rst
@@ -38,3 +38,10 @@ Remove the 'nimble' and 'jazzy' workshops in the current project directory:
    $ workshop remove nimble jazzy
 
 
+The name is optional if the project only has one workshop:
+
+.. code-block:: console
+
+   $ workshop remove
+
+

--- a/docs/reference/cli/workshop-shell.rst
+++ b/docs/reference/cli/workshop-shell.rst
@@ -9,7 +9,7 @@ Start an interactive terminal session for the workshop.
 
 .. code-block:: console
 
-   $ workshop shell <WORKSHOP> [flags]
+   $ workshop shell [<WORKSHOP>] [flags]
 
 .. rubric:: Description
 
@@ -38,5 +38,12 @@ in the current project directory:
 .. code-block:: console
 
    $ workshop shell nimble
+
+
+The name is optional if the project only has one workshop:
+
+.. code-block:: console
+
+   $ workshop shell
 
 

--- a/docs/reference/cli/workshop-shell.rst
+++ b/docs/reference/cli/workshop-shell.rst
@@ -40,7 +40,7 @@ in the current project directory:
    $ workshop shell nimble
 
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-sketch-sdk.rst
+++ b/docs/reference/cli/workshop-sketch-sdk.rst
@@ -9,7 +9,7 @@ Edit the sketch SDK and graft it onto the workshop.
 
 .. code-block:: console
 
-   $ workshop sketch-sdk [--stash|--restore|--remove] <WORKSHOP> [flags]
+   $ workshop sketch-sdk [--stash|--restore|--remove] [<WORKSHOP>] [flags]
 
 .. rubric:: Description
 
@@ -58,7 +58,7 @@ Notes:
 .. rubric:: Examples
 
 
-Edit the hack SDK definition for the 'nimble' workshop
+Edit the sketch SDK definition for the 'nimble' workshop
 and apply it after saving by automatically refreshing the workshop:
 
 .. code-block:: console
@@ -66,7 +66,14 @@ and apply it after saving by automatically refreshing the workshop:
    $ workshop sketch-sdk nimble
 
 
-Stash the hack SDK, temporarily reverting the changes in the workshop:
+The name is optional if the project only has one workshop:
+
+.. code-block:: console
+
+   $ workshop sketch-sdk
+
+
+Stash the sketch SDK, temporarily reverting the changes in the workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-sketch-sdk.rst
+++ b/docs/reference/cli/workshop-sketch-sdk.rst
@@ -66,7 +66,7 @@ and apply it after saving by automatically refreshing the workshop:
    $ workshop sketch-sdk nimble
 
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-start.rst
+++ b/docs/reference/cli/workshop-start.rst
@@ -44,7 +44,7 @@ Start the 'nimble' and 'jazzy' workshops in the current project directory:
    $ workshop start nimble jazzy
 
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-start.rst
+++ b/docs/reference/cli/workshop-start.rst
@@ -44,3 +44,10 @@ Start the 'nimble' and 'jazzy' workshops in the current project directory:
    $ workshop start nimble jazzy
 
 
+The name is optional if the project only has one workshop:
+
+.. code-block:: console
+
+   $ workshop start
+
+

--- a/docs/reference/cli/workshop-stop.rst
+++ b/docs/reference/cli/workshop-stop.rst
@@ -44,7 +44,7 @@ Stop the nimble and jazzy workshops in the current project directory:
    $ workshop stop nimble jazzy
 
 
-The name is optional if the project only has one workshop:
+The name is optional if the project has only one workshop:
 
 .. code-block:: console
 

--- a/docs/reference/cli/workshop-stop.rst
+++ b/docs/reference/cli/workshop-stop.rst
@@ -33,3 +33,21 @@ Notes:
 
 - To start a stopped workshop, use 'workshop start'
 
+
+.. rubric:: Examples
+
+
+Stop the nimble and jazzy workshops in the current project directory:
+
+.. code-block:: console
+
+   $ workshop stop nimble jazzy
+
+
+The name is optional if the project only has one workshop:
+
+.. code-block:: console
+
+   $ workshop stop
+
+

--- a/docs/reference/cli/workshop-warnings.rst
+++ b/docs/reference/cli/workshop-warnings.rst
@@ -9,7 +9,7 @@ List warnings.
 
 .. code-block:: console
 
-   $ workshop warnings [OPTIONS] [flags]
+   $ workshop warnings [flags]
 
 .. rubric:: Description
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -694,7 +694,7 @@ If you no longer need your workshop,
 
 .. code-block:: console
 
-   $ workshop remove golang
+   $ workshop remove
 
 
 This doesn't affect the files in the project directory,

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -345,7 +345,7 @@ To make it *Ready* again, :ref:`start <ref_workshop_start>` the workshop:
 
 .. code-block:: console
 
-   $ workshop start golang
+   $ workshop start
 
 
 Both commands work gracefully,

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -251,7 +251,7 @@ to see what went into your workshop:
 
 .. code-block:: console
 
-   $ workshop info golang
+   $ workshop info
 
      name:     golang
      base:     ubuntu@22.04
@@ -549,7 +549,7 @@ to a new location on the host:
    :emphasize-lines: 14
 
    $ workshop remount golang/go:mod-cache ~/mod/
-   $ workshop info golang
+   $ workshop info
 
      name:     golang
      base:     ubuntu@20.04

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -441,7 +441,7 @@ Next, build it *inside the workshop* using :ref:`exec <ref_workshop_exec>`:
 .. tip::
 
    Since :samp:`golang` is the only workshop in the project,
-   it can be omitted from most :samp:`workshop` commands.
+   it can be omitted from most :command:`workshop` commands.
    For :ref:`exec <ref_workshop_exec>`,
    a name or a separator (:samp:`--`) is required to avoid ambiguity.
    The above command can also be written as:

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -596,7 +596,7 @@ opens an :ref:`SDK definition <exp_sdk_definition>`:
 
 .. code-block:: console
 
-   $ workshop hack golang
+   $ workshop hack
 
 
 Initially, the editor shows a very basic setup
@@ -676,14 +676,14 @@ When you're done experimenting, you can just drop the hack SDK:
 
 .. code-block:: console
 
-   $ workshop hack golang --drop
+   $ workshop hack --drop
 
 
 If you drop a hack SDK by mistake, restoring it is quite simple:
 
 .. code-block:: console
 
-   $ workshop hack golang --restore
+   $ workshop hack --restore
 
 
 While the entire process for :ref:`building a complete SDK <how_use_sdkcraft>`

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -438,6 +438,18 @@ Next, build it *inside the workshop* using :ref:`exec <ref_workshop_exec>`:
 
    $ workshop exec golang go build main.go
 
+.. tip::
+
+   Since :samp:`golang` is the only workshop in the project,
+   it can be omitted from most :samp:`workshop` commands.
+   For :ref:`exec <ref_workshop_exec>`,
+   a name or a separator (:samp:`--`) is required to avoid ambiguity.
+   The above command can also be written as:
+
+   .. code-block:: console
+
+      $ workshop exec -- go build main.go
+
 
 This uses the Go version installed by the :samp:`go` SDK.
 
@@ -472,7 +484,7 @@ who's also named :samp:`workshop`:
 
 .. code-block:: console
 
-   $ workshop shell golang
+   $ workshop shell
    workshop@golang-6b79e889:~$ pwd
 
      /home/workshop
@@ -492,8 +504,8 @@ are visible in the project directory, and vice versa:
 .. code-block:: console
 
    $ touch created_outside.txt
-   $ workshop exec golang ls /project/
-   $ workshop exec golang touch /project/created_inside.txt
+   $ workshop exec -- ls /project/
+   $ workshop exec -- touch /project/created_inside.txt
    $ ls
 
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -234,7 +234,7 @@ To get a workshop ready for use, you :ref:`launch <ref_workshop_launch>` it:
 
 .. code-block:: console
 
-   $ workshop launch golang
+   $ workshop launch
 
 
 Now, the workshop is *Ready*;

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -337,7 +337,7 @@ so you :ref:`stop <ref_workshop_stop>` the workshop:
 
 .. code-block:: console
 
-   $ workshop stop golang
+   $ workshop stop
 
 This changes the status of the workshop to *Stopped*.
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -446,7 +446,7 @@ or separate it from :command:`workshop exec` options for clarity:
 
 .. code-block:: console
 
-   $ workshop exec golang --env GO111MODULE=off -- go build -x
+   $ workshop exec --env GO111MODULE=off golang -- go build -x
 
 The binary, built within the workshop environment,
 is now available in the project directory.
@@ -492,8 +492,8 @@ are visible in the project directory, and vice versa:
 .. code-block:: console
 
    $ touch created_outside.txt
-   $ workshop exec golang -- ls /project/
-   $ workshop exec golang -- touch /project/created_inside.txt
+   $ workshop exec golang ls /project/
+   $ workshop exec golang touch /project/created_inside.txt
    $ ls
 
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -395,7 +395,7 @@ and refresh the workshop:
 
 .. code-block:: console
 
-   $ workshop refresh golang
+   $ workshop refresh
 
 
 Running :command:`workshop refresh` is similar to a :ref:`launch <tut_launch>`.

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -18,7 +18,7 @@ func v1GetProjects(c *Command, r *http.Request, _ *userState) Response {
 		return statusInternalError("cannot get projects list: %v", err)
 	}
 
-	result := make([]*workshop.Project, 0)
+	result := make([]workshop.Project, 0)
 	for _, val := range projects {
 		result = append(result, val...)
 	}

--- a/internal/daemon/api_projects_test.go
+++ b/internal/daemon/api_projects_test.go
@@ -35,7 +35,7 @@ func (s *apiSuite) TestProjectsGetProjects(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
-	c.Check(rsp.Result, testutil.DeepUnsortedMatches, []*workshop.Project{
+	c.Check(rsp.Result, testutil.DeepUnsortedMatches, []workshop.Project{
 		{Path: s.project.Path, ProjectId: s.project.ProjectId},
 	})
 }

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -46,7 +46,7 @@ type apiSuite struct {
 	username    string
 	userhome    string
 	installTime time.Time
-	project     *workshop.Project
+	project     workshop.Project
 	ctx         context.Context
 
 	vars map[string]string
@@ -74,7 +74,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 		return &user.User{Name: s.username, HomeDir: s.userhome, Uid: cur.Uid, Gid: cur.Gid}, nil
 	})
 
-	s.project = &workshop.Project{
+	s.project = workshop.Project{
 		Path:      s.workshopDir,
 		ProjectId: "b8639dea",
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -215,8 +215,16 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 
 	query := r.URL.Query()
 	wstate := query.Get("state")
-	if wstate == "" {
-		wstate = "all"
+	status := healthstate.UnknownStatus
+	ignoreStatus := false
+	var err error
+	if wstate == "" || wstate == "all" || wstate == "available" {
+		ignoreStatus = true
+	} else {
+		status, err = healthstate.StatusLookup(wstate)
+		if err != nil {
+			return statusBadRequest(`%v, "all", "available"`, err)
+		}
 	}
 
 	wrkmgr := c.d.overlord.WorkshopManager()
@@ -229,12 +237,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	info.Workshops = make([]*WorkshopInfo, 0, len(workshops))
 	for _, w := range workshops {
 		health := wrkmgr.WorkshopHealth(w)
-		switch wstate {
-		case "all":
-			fallthrough
-		case "available":
-			fallthrough
-		case strings.ToLower(health.Status.String()):
+		if ignoreStatus || health.Status == status {
 			wi := workshopToInfo(w, health, nil)
 			info.Workshops = append(info.Workshops, wi)
 		}
@@ -245,7 +248,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	// Some of these may only exist as files, not instances.
 	// The "available" query is a best-effort version of "all":
 	// if something is wrong with the files we still return the instances.
-	if wstate == "all" || wstate == "available" {
+	if ignoreStatus {
 		files, err := wrkmgr.WorkshopFiles(r.Context(), projectId)
 		var fileErr *workshopstate.WorkshopFileError
 		if wstate == "available" && errors.As(err, &fileErr) {

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -321,7 +321,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	var change *state.Change
-	var taskset = []*state.TaskSet{}
+	var taskset []*state.TaskSet
 	var err error
 
 	switch reqData.Action {

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -56,11 +56,6 @@ type Mount struct {
 	WorkshopTarget string             `json:"workshop-target,omitempty"`
 }
 
-type Workshop struct {
-	Workshop *WorkshopInfo     `json:"workshop"`
-	File     *WorkshopFileInfo `json:"file"`
-}
-
 type Workshops struct {
 	Workshops []*WorkshopInfo     `json:"workshops"`
 	Files     []*WorkshopFileInfo `json:"files"`
@@ -79,6 +74,11 @@ type WorkshopFileInfo struct {
 	ProjectId string `json:"project-id"`
 	Name      string `json:"name"`
 	Path      string `json:"path"`
+}
+
+type Workshop struct {
+	WorkshopInfo
+	Path string `json:"path"`
 }
 
 var ensureStateSoon = stateEnsureBefore
@@ -411,11 +411,9 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest(err.Error())
 	}
 
-	file := files[w.Name]
-
 	rsp := Workshop{
-		Workshop: workshopToInfo(w, health, ms),
-		File:     workshopFileToInfo(projectId, w.Name, file),
+		WorkshopInfo: *workshopToInfo(w, health, ms),
+		Path:         files[w.Name],
 	}
 
 	return SyncResponse(rsp, http.StatusOK)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -229,20 +229,26 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	info.Workshops = make([]*WorkshopInfo, 0, len(workshops))
 	for _, w := range workshops {
 		health := wrkmgr.WorkshopHealth(w)
-		if wstate != "all" && strings.ToLower(health.Status.String()) != wstate {
-			continue
+		switch wstate {
+		case "all":
+			fallthrough
+		case "available":
+			fallthrough
+		case strings.ToLower(health.Status.String()):
+			wi := workshopToInfo(w, health, nil)
+			info.Workshops = append(info.Workshops, wi)
 		}
-		wi := workshopToInfo(w, health, nil)
-		info.Workshops = append(info.Workshops, wi)
 	}
 
 	// If the client queried everything available,
 	// we add workshop files to the response.
 	// Some of these may only exist as files, not instances.
-	if wstate == "all" {
+	// The "available" query is a best-effort version of "all":
+	// if something is wrong with the files we still return the instances.
+	if wstate == "all" || wstate == "available" {
 		files, err := wrkmgr.WorkshopFiles(r.Context(), projectId)
 		var fileErr *workshopstate.WorkshopFileError
-		if errors.As(err, &fileErr) {
+		if wstate == "available" && errors.As(err, &fileErr) {
 			state.Warnf("%v", err)
 		} else if err != nil {
 			return statusInternalError("%v", err)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -221,7 +222,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	wrkmgr := c.d.overlord.WorkshopManager()
 	workshops, err := wrkmgr.Workshops(r.Context(), projectId)
 	if err != nil {
-		return statusInternalError("cannot list workshops: %v", err)
+		return statusInternalError("%v", err)
 	}
 
 	info := Workshops{}
@@ -235,13 +236,22 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 		info.Workshops = append(info.Workshops, wi)
 	}
 
-	info.Files = make([]*WorkshopFileInfo, 0, len(workshops))
-	files, err := wrkmgr.WorkshopFiles(r.Context(), projectId)
-	if err != nil {
-		state.Warnf("%v", err)
-	}
-	for name, path := range files {
-		info.Files = append(info.Files, workshopFileToInfo(projectId, name, path))
+	// If the client queried everything available,
+	// we add workshop files to the response.
+	// Some of these may only exist as files, not instances.
+	if wstate == "all" {
+		files, err := wrkmgr.WorkshopFiles(r.Context(), projectId)
+		var fileErr *workshopstate.WorkshopFileError
+		if errors.As(err, &fileErr) {
+			state.Warnf("%v", err)
+		} else if err != nil {
+			return statusInternalError("%v", err)
+		} else {
+			info.Files = make([]*WorkshopFileInfo, 0, len(files))
+			for name, path := range files {
+				info.Files = append(info.Files, workshopFileToInfo(projectId, name, path))
+			}
+		}
 	}
 
 	return SyncResponse(info, http.StatusOK)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -384,7 +384,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 	// for DeepEqual to work correctly
 	t1, t2 := s.installTime, s.installTime
 	c.Check(rsp.Result, check.DeepEquals, Workshop{
-		Workshop: &WorkshopInfo{
+		WorkshopInfo: WorkshopInfo{
 			Name:      "manysdks",
 			Base:      "ubuntu@22.04",
 			ProjectId: s.project.ProjectId,
@@ -439,7 +439,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 				},
 			},
 		},
-		File: &WorkshopFileInfo{ProjectId: "b8639dea", Name: "manysdks", Path: workshop.Filepath(s.project.Path, "manysdks")}})
+		Path: workshop.Filepath(s.project.Path, "manysdks")})
 }
 
 func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
@@ -477,7 +477,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 	// for DeepEqual to work correctly
 	t1, t2 := s.installTime, s.installTime
 	c.Check(rsp.Result, check.DeepEquals, Workshop{
-		Workshop: &WorkshopInfo{
+		WorkshopInfo: WorkshopInfo{
 			Name:      "somebound",
 			Base:      "ubuntu@22.04",
 			ProjectId: s.project.ProjectId,
@@ -522,7 +522,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 				},
 			},
 		},
-		File: &WorkshopFileInfo{ProjectId: "b8639dea", Name: "somebound", Path: workshop.Filepath(s.project.Path, "somebound")}})
+		Path: workshop.Filepath(s.project.Path, "somebound")})
 }
 
 type expectedResp struct {

--- a/internal/overlord/conflict/conflict_test.go
+++ b/internal/overlord/conflict/conflict_test.go
@@ -13,7 +13,7 @@ import (
 
 type conflictSuite struct {
 	state   *state.State
-	project *workshop.Project
+	project workshop.Project
 }
 
 var _ = check.Suite(&conflictSuite{})
@@ -41,7 +41,7 @@ func (s *conflictSuite) newChangeDisconnect(kind string) *state.Change {
 
 func (s *conflictSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
-	s.project = &workshop.Project{Path: c.MkDir(), ProjectId: "42ws42ws"}
+	s.project = workshop.Project{Path: c.MkDir(), ProjectId: "42ws42ws"}
 }
 
 func (s *conflictSuite) TestCheckChangeConflictNotFound(c *check.C) {

--- a/internal/overlord/handlersetup/handler_setup_test.go
+++ b/internal/overlord/handlersetup/handler_setup_test.go
@@ -16,7 +16,7 @@ import (
 
 type CommonStateFuncs struct {
 	state   *state.State
-	project *workshop.Project
+	project workshop.Project
 }
 
 var _ = check.Suite(&CommonStateFuncs{})
@@ -32,14 +32,14 @@ func (s *CommonStateFuncs) setupTask() *state.Task {
 
 	t := s.state.NewTask("task", "...")
 	t.Set("workshop", "ws")
-	t.Set("project", *s.project)
+	t.Set("project", s.project)
 	chg.AddTask(t)
 	return t
 }
 
 func (s *CommonStateFuncs) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
-	s.project = &workshop.Project{Path: c.MkDir(), ProjectId: "42ws42ws"}
+	s.project = workshop.Project{Path: c.MkDir(), ProjectId: "42ws42ws"}
 }
 
 func (s *CommonStateFuncs) TestRefreshWaitOnError(c *check.C) {

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -24,12 +24,33 @@ const (
 	OffStatus
 )
 
+var knownStatuses = []string{"Unknown", "Ready", "Pending", "Error", "Stopped", "Off"}
+
+func StatusLookup(str string) (Status, error) {
+	switch str {
+	case "unknown":
+		return UnknownStatus, nil
+	case "ready":
+		return ReadyStatus, nil
+	case "pending":
+		return PendingStatus, nil
+	case "error":
+		return ErrorStatus, nil
+	case "stopped":
+		return StoppedStatus, nil
+	case "off":
+		return OffStatus, nil
+	}
+
+	return -1, fmt.Errorf("invalid status %q, must be one of %s",
+		str, strutil.Quoted(knownStatuses))
+}
+
 func (s Status) String() string {
-	statuses := [...]string{"Unknown", "Ready", "Pending", "Error", "Stopped", "Off"}
-	if s < 0 || int(s) >= len(statuses) {
+	if s < 0 || int(s) >= len(knownStatuses) {
 		return fmt.Sprintf("invalid (%d)", s)
 	}
-	return statuses[s]
+	return knownStatuses[s]
 }
 
 type HealthCheckResult int

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -44,7 +44,7 @@ type healthSuite struct {
 	runner  *state.TaskRunner
 	backend *fakebackend.FakeWorkshopBackend
 	hookMgr *hookstate.HookManager
-	project *workshop.Project
+	project workshop.Project
 	ctx     context.Context
 }
 
@@ -63,8 +63,9 @@ func (s *healthSuite) SetUpTest(c *check.C) {
 	workshop.ReplaceBackend(s.state, s.backend)
 
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
-	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())
+	project, _, err := s.backend.CreateOrLoadProject(ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
+	s.project = *project
 	s.ctx = context.WithValue(ctx, workshop.ContextProjectId, s.project.ProjectId)
 
 	s.hookMgr = hookstate.New(s.state, s.runner)
@@ -86,10 +87,10 @@ func (s *healthSuite) TearDownTest(c *check.C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
+func setWorkshopProject(w string, p workshop.Project, tasks ...*state.Task) {
 	for _, task := range tasks {
 		task.Set("workshop", w)
-		task.Set("project", *p)
+		task.Set("project", p)
 	}
 }
 

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -28,7 +28,7 @@ type hookSuite struct {
 	se          *overlord.StateEngine
 	hookmgr     *hookstate.HookManager
 	ctx         context.Context
-	project     *workshop.Project
+	project     workshop.Project
 	mockHandler *hooktest.MockHandler
 }
 
@@ -40,10 +40,10 @@ func fakeHandler(task *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
+func setWorkshopProject(w string, p workshop.Project, tasks ...*state.Task) {
 	for _, i := range tasks {
 		i.Set("workshop", w)
-		i.Set("project", *p)
+		i.Set("project", p)
 	}
 }
 
@@ -52,8 +52,9 @@ func (s *hookSuite) SetUpTest(c *check.C) {
 	s.backend, err = fakebackend.New(c.MkDir())
 
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
-	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())
+	project, _, err := s.backend.CreateOrLoadProject(ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
+	s.project = *project
 	s.ctx = context.WithValue(ctx, workshop.ContextProjectId, s.project.ProjectId)
 
 	s.state = state.New(nil)

--- a/internal/overlord/hookstate/request_test.go
+++ b/internal/overlord/hookstate/request_test.go
@@ -8,19 +8,16 @@ import (
 
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/workshop"
 )
 
 type S struct {
-	state   *state.State
-	project *workshop.Project
+	state *state.State
 }
 
 var _ = check.Suite(&S{})
 
 func (s *S) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
-	s.project = &workshop.Project{Path: "/home/testuser", ProjectId: "42ws42ws"}
 }
 
 func (s *S) TestCreateHook(c *check.C) {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -287,7 +287,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 	return nil
 }
 
-func (m *InterfaceManager) batchDisconnectTasks(p *workshop.Project, workshop, sdkName string,
+func (m *InterfaceManager) batchDisconnectTasks(p workshop.Project, workshop, sdkName string,
 	conns map[string]*schema.ConnState, refs []*interfaces.ConnRef) *state.TaskSet {
 	ts := state.NewTaskSet()
 
@@ -366,7 +366,7 @@ func (m *InterfaceManager) doDisconnectInterfaces(task *state.Task, tomb *tomb.T
 		return err
 	}
 
-	ts := m.batchDisconnectTasks(project, w, s, conns, connections)
+	ts := m.batchDisconnectTasks(*project, w, s, conns, connections)
 
 	handlersetup.InjectTasks(task, ts)
 	m.state.EnsureBefore(0)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -145,10 +145,10 @@ func (s *interfaceHandlersSuite) settle(c *check.C) {
 	c.Check(err, check.IsNil)
 }
 
-func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
+func setWorkshopProject(w string, p workshop.Project, tasks ...*state.Task) {
 	for _, i := range tasks {
 		i.Set("workshop", w)
-		i.Set("project", *p)
+		i.Set("project", p)
 	}
 }
 

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -31,7 +31,7 @@ type interfaceManagerSuite struct {
 	runner     *state.TaskRunner
 	ctx        context.Context
 	wsbackend  workshop.Backend
-	prj        *workshop.Project
+	prj        workshop.Project
 	secBackend *ifacetest.TestSecurityBackend
 
 	restoreProjectId func()
@@ -56,8 +56,9 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 	workshop.ReplaceBackend(s.state, s.wsbackend)
 
 	s.ctx = context.WithValue(context.Background(), workshop.ContextUser, "testuser")
-	s.prj, _, err = s.wsbackend.CreateOrLoadProject(s.ctx, c.MkDir())
+	prj, _, err := s.wsbackend.CreateOrLoadProject(s.ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
+	s.prj = *prj
 	s.ctx = context.WithValue(s.ctx, workshop.ContextProjectId, s.prj.ProjectId)
 
 	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -37,7 +37,7 @@ type sdkStateSuite struct {
 	sdkmgr      *sdkstate.SdkManager
 	repo        *interfaces.Repository
 	ctx         context.Context
-	project     *workshop.Project
+	project     workshop.Project
 	installTime time.Time
 
 	restoreProjectId   func()
@@ -52,7 +52,7 @@ func fakeHandler(task *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
+func setWorkshopProject(w string, p workshop.Project, tasks ...*state.Task) {
 	for _, i := range tasks {
 		i.Set("workshop", w)
 		i.Set("project", p)
@@ -110,7 +110,7 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	s.backend, err = fakebackend.New(c.MkDir())
 	c.Check(err, check.IsNil)
 
-	s.project = &workshop.Project{
+	s.project = workshop.Project{
 		Path:      c.MkDir(),
 		ProjectId: "projectId",
 	}

--- a/internal/overlord/workshopstate/export_test.go
+++ b/internal/overlord/workshopstate/export_test.go
@@ -8,7 +8,5 @@ var (
 	RestoreStateHooks  = restoreStateHooks
 	StartManyImpl      = startMany
 	StopManyImpl       = stopMany
-	RemoveManyImpl     = removeMany
-	Launch             = launch
 	CheckHealthTimeout = checkHealthTimeout
 )

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -39,7 +39,7 @@ type workshopHandlers struct {
 	se                *overlord.StateEngine
 	wrkmgr            *workshopstate.WorkshopManager
 	ctx               context.Context
-	project           *workshop.Project
+	project           workshop.Project
 	homeDir           string
 	lookupUserRestore func()
 }
@@ -50,10 +50,10 @@ func fakeHandler(task *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func setWorkshopProject(w string, p *workshop.Project, tasks ...*state.Task) {
+func setWorkshopProject(w string, p workshop.Project, tasks ...*state.Task) {
 	for _, i := range tasks {
 		i.Set("workshop", w)
-		i.Set("project", *p)
+		i.Set("project", p)
 	}
 }
 
@@ -77,8 +77,9 @@ func (s *workshopHandlers) SetUpTest(c *check.C) {
 	s.backend, err = fakebackend.New(c.MkDir())
 	c.Assert(err, check.IsNil)
 
-	s.project, _, err = s.backend.CreateOrLoadProject(ctx, c.MkDir())
+	project, _, err := s.backend.CreateOrLoadProject(ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
+	s.project = *project
 	s.ctx = context.WithValue(ctx, workshop.ContextProjectId, s.project.ProjectId)
 	s.homeDir = c.MkDir()
 	s.lookupUserRestore = testutil.FakeFunc(func(name string) (*user.User, error) {

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -105,17 +105,16 @@ func (w *WorkshopManager) WorkshopFiles(ctx context.Context, pId string) (map[st
 		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
 	}
 
-	var p *workshop.Project
 	projects, err := w.backend.Projects(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	idx := slices.IndexFunc(projects[user], func(p *workshop.Project) bool { return p.ProjectId == pId })
+	idx := slices.IndexFunc(projects[user], func(p workshop.Project) bool { return p.ProjectId == pId })
 	if idx == -1 {
 		return nil, fmt.Errorf("project %q not found", pId)
 	}
-	p = projects[user][idx]
+	p := projects[user][idx]
 
 	files, err := p.ReadWorkshops()
 	if err != nil {

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -117,7 +117,24 @@ func (w *WorkshopManager) WorkshopFiles(ctx context.Context, pId string) (map[st
 	}
 	p = projects[user][idx]
 
-	return p.ReadWorkshops()
+	files, err := p.ReadWorkshops()
+	if err != nil {
+		return files, &WorkshopFileError{err}
+	}
+	return files, nil
+}
+
+// WorkshopFileError wraps errors related to invalid workshop definitions or file locations.
+type WorkshopFileError struct {
+	err error
+}
+
+func (e *WorkshopFileError) Error() string {
+	return e.err.Error()
+}
+
+func (e *WorkshopFileError) Unwrap() error {
+	return e.err
 }
 
 // Returns all existing workshops for a project, the state must be

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -26,7 +26,7 @@ type managerSuite struct {
 	runner  *state.TaskRunner
 	manager *workshopstate.WorkshopManager
 	ctx     context.Context
-	project *workshop.Project
+	project workshop.Project
 
 	lookupUserRestore func()
 }
@@ -52,7 +52,9 @@ func (s *managerSuite) SetUpTest(c *check.C) {
 		}
 		return u, nil
 	}, &workshop.LookupUsername)
-	s.project, _, _ = s.backend.CreateOrLoadProject(ctx, c.MkDir())
+	project, _, err := s.backend.CreateOrLoadProject(ctx, c.MkDir())
+	c.Assert(err, check.IsNil)
+	s.project = *project
 	s.ctx = context.WithValue(ctx, workshop.ContextProjectId, s.project.ProjectId)
 	sdk.ReplaceStore(s.state, sdk.NewFakeStore())
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -46,11 +46,11 @@ func (w *WorkshopManager) loadProject(ctx context.Context, id string) (*workshop
 		return nil, err
 	}
 
-	idx := slices.IndexFunc(projects[username], func(p *workshop.Project) bool { return p.ProjectId == id })
+	idx := slices.IndexFunc(projects[username], func(p workshop.Project) bool { return p.ProjectId == id })
 	if idx == -1 {
 		return nil, fmt.Errorf("no project found with \"id\" %v", id)
 	}
-	return projects[username][idx], nil
+	return &projects[username][idx], nil
 }
 
 func maybeSketch(ctx context.Context, pid, wp string) (bool, error) {
@@ -108,7 +108,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			sets = append(sets, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 		}
 
-		tasks := launch(w.state, file, sets, project)
+		tasks := launch(w.state, file, sets, *project)
 		taskset = append(taskset, tasks)
 	}
 	return taskset, nil
@@ -212,7 +212,7 @@ func checkHealthHooks(st *state.State, file *workshop.File) *state.TaskSet {
 	return checkHealth
 }
 
-func constructWorkshop(st *state.State, file *workshop.File, project *workshop.Project) *state.TaskSet {
+func constructWorkshop(st *state.State, file *workshop.File, project workshop.Project) *state.TaskSet {
 	base := st.NewTask("download-base", fmt.Sprintf("Download %q base image", file.Base))
 	base.Set("workshop-base", file.Base)
 
@@ -231,7 +231,7 @@ func constructWorkshop(st *state.State, file *workshop.File, project *workshop.P
 	return state.NewTaskSet(base, create, mountProject, mountAptCache, start)
 }
 
-func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project *workshop.Project) *state.TaskSet {
+func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project workshop.Project) *state.TaskSet {
 	// check and download all the required SDKs
 	retrieve := retrieveSdks(st, sdks)
 
@@ -322,7 +322,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, names []string, proje
 		installed = append(installed, maps.Values(workshops[idx].Content))
 	}
 
-	fullrefresh, err := refreshMany(w.state, files, installed, toinstall, project)
+	fullrefresh, err := refreshMany(w.state, files, installed, toinstall, *project)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func (w *WorkshopManager) refreshLocalSdk(wp *workshop.Workshop, sdkn string) (*
 }
 
 func refreshMany(st *state.State, files []*workshop.File, installed [][]sdk.Setup,
-	toInstall [][]sdk.Setup, project *workshop.Project) ([]*state.TaskSet, error) {
+	toInstall [][]sdk.Setup, project workshop.Project) ([]*state.TaskSet, error) {
 	taskset := make([]*state.TaskSet, 0, len(files))
 
 	for i, file := range files {
@@ -455,7 +455,7 @@ func refreshMany(st *state.State, files []*workshop.File, installed [][]sdk.Setu
 	return taskset, nil
 }
 
-func refresh(st *state.State, file *workshop.File, installed []sdk.Setup, toInstall []sdk.Setup, p *workshop.Project) (*state.TaskSet, error) {
+func refresh(st *state.State, file *workshop.File, installed []sdk.Setup, toInstall []sdk.Setup, p workshop.Project) (*state.TaskSet, error) {
 	// 1. Save previous state
 	// 2. Stop previous workshop
 	// 3. Put to stash
@@ -544,7 +544,7 @@ func refresh(st *state.State, file *workshop.File, installed []sdk.Setup, toInst
 
 	for _, task := range refresh.Tasks() {
 		task.Set("workshop", file.Name)
-		task.Set("project", *p)
+		task.Set("project", p)
 	}
 
 	return refresh, nil
@@ -609,20 +609,20 @@ func (w *WorkshopManager) StartMany(ctx context.Context, names []string, project
 	if err != nil {
 		return nil, err
 	}
-	taskset, err := startMany(w.state, names, project)
+	taskset, err := startMany(w.state, names, *project)
 	if err != nil {
 		return nil, err
 	}
 	return taskset, nil
 }
 
-func startMany(st *state.State, names []string, project *workshop.Project) ([]*state.TaskSet, error) {
+func startMany(st *state.State, names []string, project workshop.Project) ([]*state.TaskSet, error) {
 	taskset := []*state.TaskSet{}
 
 	for _, name := range names {
 		start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", name))
 		start.Set("workshop", name)
-		start.Set("project", *project)
+		start.Set("project", project)
 
 		taskset = append(taskset, state.NewTaskSet(start))
 	}
@@ -646,21 +646,21 @@ func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectI
 	if err != nil {
 		return nil, err
 	}
-	taskset, err := stopMany(w.state, names, project)
+	taskset, err := stopMany(w.state, names, *project)
 	if err != nil {
 		return nil, err
 	}
 	return taskset, nil
 }
 
-func stopMany(st *state.State, names []string, project *workshop.Project) ([]*state.TaskSet, error) {
+func stopMany(st *state.State, names []string, project workshop.Project) ([]*state.TaskSet, error) {
 	taskset := []*state.TaskSet{}
 
 	for _, name := range names {
 		stop := st.NewTask("stop-workshop", fmt.Sprintf("Stop %q workshop", name))
 		stop.Set("force", false)
 		stop.Set("workshop", name)
-		stop.Set("project", *project)
+		stop.Set("project", project)
 
 		taskset = append(taskset, state.NewTaskSet(stop))
 	}
@@ -740,14 +740,14 @@ func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projec
 		}
 	}
 
-	taskset, err := removeMany(w.state, workshops, project)
+	taskset, err := removeMany(w.state, workshops, *project)
 	if err != nil {
 		return nil, err
 	}
 	return taskset, nil
 }
 
-func removeMany(st *state.State, workshops []*workshop.Workshop, project *workshop.Project) ([]*state.TaskSet, error) {
+func removeMany(st *state.State, workshops []*workshop.Workshop, project workshop.Project) ([]*state.TaskSet, error) {
 	taskset := []*state.TaskSet{}
 	for _, name := range workshops {
 		remove, err := remove(st, name, project)
@@ -759,7 +759,7 @@ func removeMany(st *state.State, workshops []*workshop.Workshop, project *worksh
 	return taskset, nil
 }
 
-func remove(st *state.State, w *workshop.Workshop, project *workshop.Project) (*state.TaskSet, error) {
+func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*state.TaskSet, error) {
 	removeSet := state.NewTaskSet()
 	disconnectSet := disconnectSdks(maps.Values(w.Content), st)
 

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -26,7 +26,7 @@ import (
 
 type requestSuite struct {
 	state   *state.State
-	project *workshop.Project
+	project workshop.Project
 	backend workshop.Backend
 	mgr     *workshopstate.WorkshopManager
 	ctx     context.Context
@@ -45,7 +45,9 @@ func (s *requestSuite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	workshop.ReplaceBackend(s.state, s.backend)
 	s.mgr = workshopstate.New(s.state, state.NewTaskRunner(s.state))
-	s.project, _, _ = s.backend.CreateOrLoadProject(s.ctx, c.MkDir())
+	project, _, err := s.backend.CreateOrLoadProject(s.ctx, c.MkDir())
+	c.Assert(err, check.IsNil)
+	s.project = *project
 	s.ctx = context.WithValue(s.ctx, workshop.ContextProjectId, s.project.ProjectId)
 }
 
@@ -107,7 +109,7 @@ func (s *requestSuite) ensureTaskHasWorkshopAndProjectKeys(c *check.C, w string,
 		var prj workshop.Project
 		err := i.Get("project", &prj)
 		c.Assert(err, check.IsNil)
-		c.Assert(&prj, check.DeepEquals, s.project)
+		c.Assert(prj, check.DeepEquals, s.project)
 
 		var workshop string
 		err = i.Get("workshop", &workshop)
@@ -743,7 +745,7 @@ func (s *requestSuite) TestRemountSuccess(c *check.C) {
 	c.Assert(task.Get("project", &p), check.IsNil)
 	c.Assert(task.Summary(), check.Equals, `Remount "ws-1/sdk-1:plug"`)
 	c.Assert(w, check.Equals, "ws-1")
-	c.Assert(p, check.DeepEquals, *s.project)
+	c.Assert(p, check.DeepEquals, s.project)
 
 	var plugRef interfaces.PlugRef
 	var src string

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -132,7 +132,7 @@ type Backend interface {
 
 	// Returns a list of projects known to the backend. The returned map
 	// has a username key that the corresponding projects belong to.
-	Projects(ctx context.Context) (map[string][]*Project, error)
+	Projects(ctx context.Context) (map[string][]Project, error)
 
 	// Loads a workshop instance.
 	Workshop(ctx context.Context, name string) (*Workshop, error)

--- a/internal/workshop/export_test.go
+++ b/internal/workshop/export_test.go
@@ -3,4 +3,5 @@ package workshop
 var (
 	ReadWorkshop = readWorkshop
 	Filename     = filename
+	UpdateLock   = (*Project).updateLock
 )

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -54,7 +54,7 @@ type FakeWorkshopBackend struct {
 	WorkshopVolumeContents    map[string]map[string]bool
 	WorkshopVolumeMountPoints map[string]string
 	// the key is a username
-	projects map[string][]*workshop.Project
+	projects map[string][]workshop.Project
 
 	ExecCallback ExecFunc
 	ExecCalls    []*ExecCall
@@ -75,7 +75,7 @@ func New(baseDir string) (*FakeWorkshopBackend, error) {
 	be.WorkshopVolumes = make(map[string]bool)
 	be.WorkshopVolumeContents = make(map[string]map[string]bool)
 	be.WorkshopVolumeMountPoints = make(map[string]string)
-	be.projects = make(map[string][]*workshop.Project)
+	be.projects = make(map[string][]workshop.Project)
 
 	be.ExecCallback = DoExecDefault
 	be.BaseDir = baseDir
@@ -89,26 +89,26 @@ func (s *FakeWorkshopBackend) CreateOrLoadProject(ctx context.Context, path stri
 		return nil, false, errors.New("user not found")
 	}
 	if val, ok := s.projects[username]; ok {
-		idx := slices.IndexFunc(val, func(p *workshop.Project) bool { return p.Path == path })
+		idx := slices.IndexFunc(val, func(p workshop.Project) bool { return p.Path == path })
 		if idx != -1 {
-			return val[idx], false, nil
+			return &val[idx], false, nil
 		}
 	} else {
-		s.projects[username] = make([]*workshop.Project, 0)
+		s.projects[username] = make([]workshop.Project, 0)
 	}
 
 	prjId, _ := workshop.NewProjectId()
-	newPrj := &workshop.Project{ProjectId: prjId, Path: path}
+	newPrj := workshop.Project{ProjectId: prjId, Path: path}
 	s.projects[username] = append(s.projects[username], newPrj)
-	return newPrj, true, nil
+	return &newPrj, true, nil
 }
 
-func (f *FakeWorkshopBackend) Projects(ctx context.Context) (map[string][]*workshop.Project, error) {
+func (f *FakeWorkshopBackend) Projects(ctx context.Context) (map[string][]workshop.Project, error) {
 	userName, ok := ctx.Value(workshop.ContextUser).(string)
 	if ok {
-		return map[string][]*workshop.Project{userName: f.projects[userName]}, nil
+		return map[string][]workshop.Project{userName: f.projects[userName]}, nil
 	}
-	all := map[string][]*workshop.Project{}
+	all := map[string][]workshop.Project{}
 	for name, prjs := range f.projects {
 		all[name] = prjs
 	}
@@ -117,9 +117,9 @@ func (f *FakeWorkshopBackend) Projects(ctx context.Context) (map[string][]*works
 
 func (f *FakeWorkshopBackend) project(user, id string) *workshop.Project {
 	prjs := f.projects[user]
-	idx := slices.IndexFunc(prjs, func(p *workshop.Project) bool { return p.ProjectId == id })
+	idx := slices.IndexFunc(prjs, func(p workshop.Project) bool { return p.ProjectId == id })
 	if idx != -1 {
-		return prjs[idx]
+		return &prjs[idx]
 	}
 	return nil
 }
@@ -147,7 +147,7 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *workshop
 	ws.Workshop = &workshop.Workshop{Backend: f,
 		Name:    file.Name,
 		Running: false,
-		Project: prj,
+		Project: *prj,
 		Base:    file.Base,
 		File:    file,
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -400,7 +400,6 @@ func (s *Backend) Workshop(ctx context.Context, name string) (*workshop.Workshop
 		return nil, fmt.Errorf("context key project-id not found")
 	}
 
-	var p *workshop.Project
 	projects, err := s.Projects(ctx)
 	if err != nil {
 		return nil, err
@@ -411,11 +410,11 @@ func (s *Backend) Workshop(ctx context.Context, name string) (*workshop.Workshop
 		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
 	}
 
-	idx := slices.IndexFunc(projects[user], func(p *workshop.Project) bool { return p.ProjectId == projectId })
+	idx := slices.IndexFunc(projects[user], func(p workshop.Project) bool { return p.ProjectId == projectId })
 	if idx == -1 {
 		return nil, fmt.Errorf("project %q not found", projectId)
 	}
-	p = projects[user][idx]
+	p := projects[user][idx]
 
 	inst, _, err := conn.GetInstance(InstanceName(name, projectId))
 	if err != nil {
@@ -443,7 +442,7 @@ func workshopFile(lxdConfig map[string]string) (*workshop.File, error) {
 	return &f, nil
 }
 
-func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p *workshop.Project) (*workshop.Workshop, error) {
+func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p workshop.Project) (*workshop.Workshop, error) {
 	f, err := workshopFile(inst.Config)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load workshop: %v", err)
@@ -514,17 +513,16 @@ func (s *Backend) ProjectWorkshops(ctx context.Context) ([]*workshop.Workshop, e
 	}
 	defer conn.Disconnect()
 
-	var p *workshop.Project
 	projects, err := s.Projects(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	idx := slices.IndexFunc(projects[user], func(p *workshop.Project) bool { return p.ProjectId == projectId })
+	idx := slices.IndexFunc(projects[user], func(p workshop.Project) bool { return p.ProjectId == projectId })
 	if idx == -1 {
 		return nil, fmt.Errorf("project %q not found", projectId)
 	}
-	p = projects[user][idx]
+	p := projects[user][idx]
 
 	// Get all the running workshops for this project.
 	instances, err := conn.GetInstances(api.InstanceTypeContainer)

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -3,11 +3,8 @@ package lxdbackend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
-	"os"
-	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -75,188 +72,51 @@ func createOrLoadLxdProject(conn lxd.InstanceServer, projectName string) error {
 }
 
 func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*workshop.Project, bool, error) {
-	var err error
-
-	if !filepath.IsAbs(path) {
-		return nil, false, workshop.ErrNoRelativePathsAllowed
-	}
-
-	projectDir, err := ProjectPath(path)
-	if err != nil {
-		return nil, false, err
-	}
-
 	client, err := s.LxdClient(ctx)
 	if err != nil {
 		return nil, false, err
 	}
 	defer client.Disconnect()
 
-	// see if we have this project already existing
-	if existingProject, err := s.loadProjectFromPath(client, ctx, projectDir); err == nil {
-		// the tracked path and the requested path must be the same
-		// otherwise it means that the project directory was moved or copied
-		// If that is the case, we must update the project's configuration
-		// in the LXD user.* key (i.e. track the project path with the existing id)
-		if existingProject.Path != projectDir {
-			// Was the project directory moved or copied?
-			_, err := os.Stat(existingProject.Path)
-			copied := true
-			if err != nil && !errors.Is(err, os.ErrNotExist) {
-				return nil, false, err
-			} else if errors.Is(err, os.ErrNotExist) {
-				copied = false
-			}
-
-			if !copied {
-				// the directory was moved, so we:
-				// 1. Update the new path to the actual and track it
-				// 2. Update all the workshops to the new project mount
-				existingProject.Path = projectDir
-				err := s.trackProject(client, ctx, existingProject)
-				if err != nil {
-					return nil, false, err
-				}
-				// also, update configuration of all the project's workshops
-				return existingProject, false, s.updateProjectMounts(client, ctx, existingProject)
-			} else {
-				// the directory was copied, so we:
-				// 1. Generate a new project id for the actual path and update .lock file
-				// 2. Start tracking the actual path as a new project
-				id, err := workshop.NewProjectId()
-				if err != nil {
-					return nil, false, err
-				}
-				var newPrj = workshop.Project{Path: projectDir, ProjectId: id}
-
-				// rewrite the existing lock file with the new project id.
-				if err = newPrj.UpdateProjectLock(); err != nil {
-					return nil, false, err
-				}
-				if err := s.trackProject(client, ctx, &newPrj); err != nil {
-					return nil, false, err
-				}
-				return &newPrj, true, nil
-			}
-		}
-		return existingProject, false, nil
-	} else if !errors.Is(err, workshop.ErrProjectNotFound) {
-		// if there is some error that is unrelated to the
-		// project loadOrCreate logic (e.g. failed to connect to LXD)
-		// then return the error immediately
-		return nil, false, err
-	}
-
-	// No project found. If there is at least one workshop definition,
-	// we consider the path as a project and create or load its project id.
-	if !workshop.IsProject(projectDir) {
-		return nil, false, workshop.ErrNotProject
-	}
-
-	project := workshop.Project{Path: projectDir}
-	project.ProjectId, err = workshop.ProjectId(projectDir)
-	if errors.Is(err, os.ErrNotExist) {
-		// No .workshop.lock in the project dir yet,
-		project.ProjectId, err = workshop.NewProjectId()
-		if err != nil {
-			return nil, false, err
-		}
-
-		// if we allocated a new project ID successfully,
-		// store it in the lock file immediately.
-		if err = project.CreateProjectLock(); err != nil {
-			return nil, false, err
-		}
-	} else if err != nil {
-		return nil, false, err
-	}
-
-	// Now, add the project ID to the tracking map
-	// stored in a custom user.* key of the LXD project for this user
-	if err = s.trackProject(client, ctx, &project); err != nil {
-		return nil, false, err
-	}
-
-	return &project, true, nil
-}
-
-// projectPath returns a project path for the cwd provided
-// if cwd is a sub-directory of the project. Otherwise, cwd
-// is returned unchanged
-func ProjectPath(cwd string) (string, error) {
-	path, err := filepath.EvalSymlinks(cwd)
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		var err error
-		var ok, isDir bool
-		if ok, isDir, err = osutil.ExistsIsDir(path); err == nil && ok && isDir {
-			if _, err := workshop.ProjectId(path); err == nil {
-				return filepath.Clean(path), nil
-			}
-		}
-		if err != nil {
-			return "", err
-		}
-
-		if path == string(os.PathSeparator) {
-			break
-		}
-		path = filepath.Join(path, "..", string(os.PathSeparator))
-	}
-
-	if cwd, err = filepath.EvalSymlinks(cwd); err != nil {
-		return "", err
-	}
-	return cwd, nil
-}
-
-func (s *Backend) loadProjectFromPath(client lxd.InstanceServer, ctx context.Context, path string) (*workshop.Project, error) {
 	user, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
-		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
+		return nil, false, fmt.Errorf("context key %s not found", workshop.ContextUser)
 	}
 
-	pId, err := workshop.ProjectId(path)
-	lockNotFound := false
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, err
-	} else if errors.Is(err, os.ErrNotExist) {
-		lockNotFound = true
-	}
-
-	lxdPrj, _, err := client.GetProject(LxdProjectName(user))
+	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	// did we find a .workshop.lock in the path?
-	if lockNotFound {
-		// try to recover .workshop.lock file for this project
-		// if it existed before and was accidentally removed
-		for _, i := range projects {
-			if i.Path == path {
-				// save the lock file in the project's location
-				if err = i.CreateProjectLock(); err != nil {
-					return nil, err
-				}
-				return i, nil
-			}
-		}
-	} else {
-		idx := slices.IndexFunc(projects, func(p *workshop.Project) bool { return p.ProjectId == pId })
-		if idx != -1 {
-			return projects[idx], nil
+	tracker := workshop.ProjectTracker{Projects: projects}
+	project, result, err := tracker.Track(path)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if result == workshop.ProjectMoved {
+		if err = s.updateProjectMounts(client, ctx, project); err != nil {
+			return nil, false, err
 		}
 	}
-	return nil, workshop.ErrProjectNotFound
+
+	if result != workshop.ProjectFound {
+		projectsJson, err := saveProjects(tracker.Projects)
+		if err != nil {
+			return nil, false, err
+		}
+		lxdPrj.Config["user.workshop.projects"] = projectsJson
+		if err = client.UpdateProject(lxdPrj.Name, lxdPrj.Writable(), etag); err != nil {
+			return nil, false, err
+		}
+	}
+
+	return project, result == workshop.ProjectAdded, nil
 }
 
 func (s *Backend) Projects(ctx context.Context) (map[string][]*workshop.Project, error) {

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -74,256 +74,6 @@ func createOrLoadLxdProject(conn lxd.InstanceServer, projectName string) error {
 	return nil
 }
 
-func (s *Backend) loadProjectFromId(client lxd.InstanceServer, ctx context.Context, id string) (*workshop.Project, error) {
-	user, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
-	}
-
-	lxdPrj, _, err := client.GetProject(LxdProjectName(user))
-	if err != nil {
-		return nil, err
-	}
-
-	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
-	if err != nil {
-		return nil, err
-	}
-
-	idx := slices.IndexFunc(projects, func(p *workshop.Project) bool { return p.ProjectId == id })
-	if idx == -1 {
-		return nil, workshop.ErrProjectNotFound
-	}
-	return projects[idx], nil
-}
-
-func (s *Backend) loadProjectFromPath(client lxd.InstanceServer, ctx context.Context, path string) (*workshop.Project, error) {
-	user, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
-	}
-
-	pId, err := workshop.ProjectId(path)
-	lockNotFound := false
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, err
-	} else if errors.Is(err, os.ErrNotExist) {
-		lockNotFound = true
-	}
-
-	lxdPrj, _, err := client.GetProject(LxdProjectName(user))
-	if err != nil {
-		return nil, err
-	}
-
-	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
-	if err != nil {
-		return nil, err
-	}
-
-	// did we find a .workshop.lock in the path?
-	if lockNotFound {
-		// try to recover .workshop.lock file for this project
-		// if it existed before and was accidentally removed
-		for _, i := range projects {
-			if i.Path == path {
-				// save the lock file in the project's location
-				if err = i.CreateProjectLock(); err != nil {
-					return nil, err
-				}
-				return i, nil
-			}
-		}
-	} else {
-		idx := slices.IndexFunc(projects, func(p *workshop.Project) bool { return p.ProjectId == pId })
-		if idx != -1 {
-			return projects[idx], nil
-		}
-	}
-	return nil, workshop.ErrProjectNotFound
-}
-
-func (s *Backend) trackProject(client lxd.InstanceServer, ctx context.Context, prj *workshop.Project) error {
-	user, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return fmt.Errorf("context key %s not found", workshop.ContextUser)
-	}
-
-	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
-	if err != nil {
-		return err
-	}
-
-	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
-	if err != nil {
-		return err
-	}
-
-	idx := slices.IndexFunc(projects, func(p *workshop.Project) bool { return p.ProjectId == prj.ProjectId })
-	if idx == -1 {
-		projects = append(projects, prj)
-	} else {
-		projects[idx] = prj
-	}
-
-	projectsJson, err := saveProjects(projects)
-	if err != nil {
-		return err
-	}
-	lxdPrj.Config["user.workshop.projects"] = projectsJson
-
-	return client.UpdateProject(LxdProjectName(user), lxdPrj.Writable(), etag)
-}
-
-func (s *Backend) updateWorkshopsProjectPath(conn lxd.InstanceServer, ctx context.Context, existingProject *workshop.Project) error {
-	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, existingProject.ProjectId))
-	if err != nil {
-		return err
-	}
-
-	for _, i := range workshops {
-		project := workshop.Mount{Name: workshop.ConfigProjectPathDevice, What: existingProject.Path, Where: workshop.WorkshopProjectPath}
-		err = s.AddWorkshopMount(ctx, workshop.WorkshopName(i.Name), project)
-		if err != nil {
-			return fmt.Errorf("cannot update workshop \"%v\" project directory", i.Name)
-		}
-	}
-	return nil
-}
-
-func (s *Backend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx context.Context, p *workshop.Project) (path string, err error) {
-	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, p.ProjectId))
-	if err != nil {
-		return "", err
-	}
-
-	/* memFs to story temporary results of the commands execution output */
-	memFs := afero.NewMemMapFs()
-	for _, i := range workshops {
-		// attempt to execute the command only in a running instance
-		if i.StatusCode != api.Ready && i.StatusCode != api.Running {
-			continue
-		}
-
-		/* Take the first instance from the group, we need any running
-		and ready to execute commands to validate the project directory */
-		out, err := memFs.Create(i.Name)
-		if err != nil {
-			return "", err
-		}
-		defer out.Close()
-
-		/* Get the mount point device/directory from findmnt and extract the path without a device
-		using awk */
-		args := workshop.Execution{
-			ExecArgs: workshop.ExecArgs{
-				UserId:  0,
-				GroupId: 0,
-				Command: []string{"bash", "-c",
-					"findmnt --mountpoint /project -o source -n | awk -F\"[][]\" '{printf $2}'"},
-				WorkDir: "/",
-			},
-			ExecControls: workshop.ExecControls{
-				Stdin:  nil,
-				Stdout: out,
-				Stderr: out,
-			},
-		}
-
-		execCtx := context.WithValue(ctx, workshop.ContextProjectId, p.ProjectId)
-		meta, err := s.execCommand(conn, execCtx, workshop.WorkshopName(i.Name), &args)
-		if err == nil {
-			err = meta.WaitExecution(ctx)
-			if err != nil {
-				outbuf, _ := afero.ReadFile(memFs, out.Name())
-				logger.Debugf("cannot check %q bind-mounts: %v, findmnt output: %s", i.Name, err, string(outbuf))
-				continue
-			}
-		} else {
-			logger.Debugf("cannot check %q bind-mounts: %v", i.Name, err)
-			continue
-		}
-
-		/* Process the findmnt results */
-		if currentPath, err := afero.ReadFile(memFs, i.Name); err == nil {
-			/* check if the path is not //deleted, i.e. the project directory still exists on the host */
-			if ok, isDir, err := osutil.ExistsIsDir(string(currentPath)); ok && isDir {
-				return string(currentPath), nil
-			} else if err != nil && !osutil.IsDirNotExist(err) {
-				return "", nil
-			}
-		}
-	}
-	return "", nil
-}
-
-// Ensures that every project has a valid existing path. If not, tries to
-// recover the path from the actual bind mount of the '/project'. If recovery
-// went unsuccessful, removes the project from the list.
-func (s *Backend) maybeRecoverProjectPaths(client lxd.InstanceServer, ctx context.Context, projects []*workshop.Project) []*workshop.Project {
-	return slices.DeleteFunc(projects, func(prj *workshop.Project) bool {
-		if !prj.Exists() {
-			var err error
-			// If got here then there is no project directory for the projectId
-			// anymore. It can mean moving or deletion happened in the past. Try
-			// to recover the new project path
-			newPath, _ := s.findProjectPathFromBindMounts(client, ctx, prj)
-			if newPath != "" {
-				// start tracking this project under a new path
-				prj.Path = newPath
-				if err = s.trackProject(client, ctx, prj); err == nil {
-					// update the workshops configuration with the new path
-					_ = s.updateWorkshopsProjectPath(client, ctx, prj)
-				}
-				return false
-			}
-			// Could not recover the directory, reconcile the project from the
-			// list of projects that we track (only if there are no remaining
-			// workshops for this project)
-			inst, err := s.filterLxdInstancesByConfig(client, func(config map[string]string) bool {
-				return config["user.workshop.project-id"] == prj.ProjectId
-			})
-			if err == nil && len(inst) == 0 {
-				return true
-			}
-		}
-		return false
-	})
-}
-
-// projectPath returns a project path for the cwd provided
-// if cwd is a sub-directory of the project. Otherwise, cwd
-// is returned unchanged
-func ProjectPath(cwd string) (string, error) {
-	path, err := filepath.EvalSymlinks(cwd)
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		var err error
-		var ok, isDir bool
-		if ok, isDir, err = osutil.ExistsIsDir(path); err == nil && ok && isDir {
-			if _, err := workshop.ProjectId(path); err == nil {
-				return filepath.Clean(path), nil
-			}
-		}
-		if err != nil {
-			return "", err
-		}
-
-		if path == string(os.PathSeparator) {
-			break
-		}
-		path = filepath.Join(path, "..", string(os.PathSeparator))
-	}
-
-	if cwd, err = filepath.EvalSymlinks(cwd); err != nil {
-		return "", err
-	}
-	return cwd, nil
-}
-
 func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*workshop.Project, bool, error) {
 	var err error
 
@@ -431,14 +181,54 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 	return &project, true, nil
 }
 
-func (s *Backend) loadUserProjects(ctx context.Context, user string) ([]*workshop.Project, error) {
-	client, err := s.LxdClient(ctx)
+// projectPath returns a project path for the cwd provided
+// if cwd is a sub-directory of the project. Otherwise, cwd
+// is returned unchanged
+func ProjectPath(cwd string) (string, error) {
+	path, err := filepath.EvalSymlinks(cwd)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	defer client.Disconnect()
 
-	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
+	for {
+		var err error
+		var ok, isDir bool
+		if ok, isDir, err = osutil.ExistsIsDir(path); err == nil && ok && isDir {
+			if _, err := workshop.ProjectId(path); err == nil {
+				return filepath.Clean(path), nil
+			}
+		}
+		if err != nil {
+			return "", err
+		}
+
+		if path == string(os.PathSeparator) {
+			break
+		}
+		path = filepath.Join(path, "..", string(os.PathSeparator))
+	}
+
+	if cwd, err = filepath.EvalSymlinks(cwd); err != nil {
+		return "", err
+	}
+	return cwd, nil
+}
+
+func (s *Backend) loadProjectFromPath(client lxd.InstanceServer, ctx context.Context, path string) (*workshop.Project, error) {
+	user, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
+	}
+
+	pId, err := workshop.ProjectId(path)
+	lockNotFound := false
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	} else if errors.Is(err, os.ErrNotExist) {
+		lockNotFound = true
+	}
+
+	lxdPrj, _, err := client.GetProject(LxdProjectName(user))
 	if err != nil {
 		return nil, err
 	}
@@ -448,19 +238,26 @@ func (s *Backend) loadUserProjects(ctx context.Context, user string) ([]*worksho
 		return nil, err
 	}
 
-	checked := s.maybeRecoverProjectPaths(client, ctx, projects)
-
-	if !reflect.DeepEqual(projects, checked) {
-		projectsJson, err := saveProjects(checked)
-		if err != nil {
-			return nil, err
+	// did we find a .workshop.lock in the path?
+	if lockNotFound {
+		// try to recover .workshop.lock file for this project
+		// if it existed before and was accidentally removed
+		for _, i := range projects {
+			if i.Path == path {
+				// save the lock file in the project's location
+				if err = i.CreateProjectLock(); err != nil {
+					return nil, err
+				}
+				return i, nil
+			}
 		}
-		lxdPrj.Config["user.workshop.projects"] = projectsJson
-		if err = client.UpdateProject(LxdProjectName(user), lxdPrj.Writable(), etag); err != nil {
-			return nil, err
+	} else {
+		idx := slices.IndexFunc(projects, func(p *workshop.Project) bool { return p.ProjectId == pId })
+		if idx != -1 {
+			return projects[idx], nil
 		}
 	}
-	return checked, nil
+	return nil, workshop.ErrProjectNotFound
 }
 
 func (s *Backend) Projects(ctx context.Context) (map[string][]*workshop.Project, error) {
@@ -506,6 +303,138 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]*workshop.Project,
 	}
 }
 
+func (s *Backend) loadUserProjects(ctx context.Context, user string) ([]*workshop.Project, error) {
+	client, err := s.LxdClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Disconnect()
+
+	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
+	if err != nil {
+		return nil, err
+	}
+
+	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
+	if err != nil {
+		return nil, err
+	}
+
+	checked := s.maybeRecoverProjectPaths(client, ctx, projects)
+
+	if !reflect.DeepEqual(projects, checked) {
+		projectsJson, err := saveProjects(checked)
+		if err != nil {
+			return nil, err
+		}
+		lxdPrj.Config["user.workshop.projects"] = projectsJson
+		if err = client.UpdateProject(LxdProjectName(user), lxdPrj.Writable(), etag); err != nil {
+			return nil, err
+		}
+	}
+	return checked, nil
+}
+
+// Ensures that every project has a valid existing path. If not, tries to
+// recover the path from the actual bind mount of the '/project'. If recovery
+// went unsuccessful, removes the project from the list.
+func (s *Backend) maybeRecoverProjectPaths(client lxd.InstanceServer, ctx context.Context, projects []*workshop.Project) []*workshop.Project {
+	return slices.DeleteFunc(projects, func(prj *workshop.Project) bool {
+		if !prj.Exists() {
+			var err error
+			// If got here then there is no project directory for the projectId
+			// anymore. It can mean moving or deletion happened in the past. Try
+			// to recover the new project path
+			newPath, _ := s.findProjectPathFromBindMounts(client, ctx, prj)
+			if newPath != "" {
+				// start tracking this project under a new path
+				prj.Path = newPath
+				if err = s.trackProject(client, ctx, prj); err == nil {
+					// update the workshops configuration with the new path
+					_ = s.updateWorkshopsProjectPath(client, ctx, prj)
+				}
+				return false
+			}
+			// Could not recover the directory, reconcile the project from the
+			// list of projects that we track (only if there are no remaining
+			// workshops for this project)
+			inst, err := s.filterLxdInstancesByConfig(client, func(config map[string]string) bool {
+				return config["user.workshop.project-id"] == prj.ProjectId
+			})
+			if err == nil && len(inst) == 0 {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (s *Backend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx context.Context, p *workshop.Project) (path string, err error) {
+	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, p.ProjectId))
+	if err != nil {
+		return "", err
+	}
+
+	/* memFs to story temporary results of the commands execution output */
+	memFs := afero.NewMemMapFs()
+	for _, i := range workshops {
+		// attempt to execute the command only in a running instance
+		if i.StatusCode != api.Ready && i.StatusCode != api.Running {
+			continue
+		}
+
+		/* Take the first instance from the group, we need any running
+		and ready to execute commands to validate the project directory */
+		out, err := memFs.Create(i.Name)
+		if err != nil {
+			return "", err
+		}
+		defer out.Close()
+
+		/* Get the mount point device/directory from findmnt and extract the path without a device
+		using awk */
+		args := workshop.Execution{
+			ExecArgs: workshop.ExecArgs{
+				UserId:  0,
+				GroupId: 0,
+				Command: []string{"bash", "-c",
+					"findmnt --mountpoint /project -o source -n | awk -F\"[][]\" '{printf $2}'"},
+				WorkDir: "/",
+			},
+			ExecControls: workshop.ExecControls{
+				Stdin:  nil,
+				Stdout: out,
+				Stderr: out,
+			},
+		}
+
+		execCtx := context.WithValue(ctx, workshop.ContextProjectId, p.ProjectId)
+		meta, err := s.execCommand(conn, execCtx, workshop.WorkshopName(i.Name), &args)
+		if err == nil {
+			err = meta.WaitExecution(ctx)
+			if err != nil {
+				outbuf, _ := afero.ReadFile(memFs, out.Name())
+				logger.Debugf("cannot check %q bind-mounts: %v, findmnt output: %s", i.Name, err, string(outbuf))
+				continue
+			}
+		} else {
+			logger.Debugf("cannot check %q bind-mounts: %v", i.Name, err)
+			continue
+		}
+
+		/* Process the findmnt results */
+		if currentPath, err := afero.ReadFile(memFs, i.Name); err == nil {
+			/* check if the path is not //deleted, i.e. the project directory still exists on the host */
+			if ok, isDir, err := osutil.ExistsIsDir(string(currentPath)); ok && isDir {
+				return string(currentPath), nil
+			} else if err != nil && !osutil.IsDirNotExist(err) {
+				return "", nil
+			}
+		}
+	}
+	return "", nil
+}
+
 func readProjects(jsonData []byte) ([]*workshop.Project, error) {
 	var projects = make([]*workshop.Project, 0)
 	if len(jsonData) == 0 {
@@ -523,4 +452,52 @@ func saveProjects(projects []*workshop.Project) (string, error) {
 		return "", err
 	}
 	return string(buf), nil
+}
+
+func (s *Backend) trackProject(client lxd.InstanceServer, ctx context.Context, prj *workshop.Project) error {
+	user, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return fmt.Errorf("context key %s not found", workshop.ContextUser)
+	}
+
+	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
+	if err != nil {
+		return err
+	}
+
+	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
+	if err != nil {
+		return err
+	}
+
+	idx := slices.IndexFunc(projects, func(p *workshop.Project) bool { return p.ProjectId == prj.ProjectId })
+	if idx == -1 {
+		projects = append(projects, prj)
+	} else {
+		projects[idx] = prj
+	}
+
+	projectsJson, err := saveProjects(projects)
+	if err != nil {
+		return err
+	}
+	lxdPrj.Config["user.workshop.projects"] = projectsJson
+
+	return client.UpdateProject(LxdProjectName(user), lxdPrj.Writable(), etag)
+}
+
+func (s *Backend) updateWorkshopsProjectPath(conn lxd.InstanceServer, ctx context.Context, existingProject *workshop.Project) error {
+	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, existingProject.ProjectId))
+	if err != nil {
+		return err
+	}
+
+	for _, i := range workshops {
+		project := workshop.Mount{Name: workshop.ConfigProjectPathDevice, What: existingProject.Path, Where: workshop.WorkshopProjectPath}
+		err = s.AddWorkshopMount(ctx, workshop.WorkshopName(i.Name), project)
+		if err != nil {
+			return fmt.Errorf("cannot update workshop \"%v\" project directory", i.Name)
+		}
+	}
+	return nil
 }

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -1,6 +1,7 @@
 package lxdbackend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/spf13/afero"
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
@@ -204,7 +204,7 @@ func (s *Backend) maybeRecoverProjectPaths(client lxd.InstanceServer, ctx contex
 			// If got here then there is no project directory for the projectId
 			// anymore. It can mean moving or deletion happened in the past. Try
 			// to recover the new project path
-			newPath, _ := s.findProjectPathFromBindMounts(client, ctx, prj)
+			newPath, _ := s.projectFsRoot(client, ctx, prj.ProjectId)
 			if newPath != "" {
 				// start tracking this project under a new path
 				prj.Path = newPath
@@ -228,67 +228,66 @@ func (s *Backend) maybeRecoverProjectPaths(client lxd.InstanceServer, ctx contex
 	})
 }
 
-func (s *Backend) findProjectPathFromBindMounts(conn lxd.InstanceServer, ctx context.Context, p *workshop.Project) (path string, err error) {
-	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, p.ProjectId))
+func (s *Backend) projectFsRoot(conn lxd.InstanceServer, ctx context.Context, projectId string) (path string, err error) {
+	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, projectId))
 	if err != nil {
 		return "", err
 	}
 
-	/* memFs to story temporary results of the commands execution output */
-	memFs := afero.NewMemMapFs()
 	for _, i := range workshops {
 		// attempt to execute the command only in a running instance
 		if i.StatusCode != api.Ready && i.StatusCode != api.Running {
 			continue
 		}
 
-		/* Take the first instance from the group, we need any running
-		and ready to execute commands to validate the project directory */
-		out, err := memFs.Create(i.Name)
-		if err != nil {
-			return "", err
-		}
-		defer out.Close()
+		var outbuf bytes.Buffer
+		var errbuf strings.Builder
 
-		/* Get the mount point device/directory from findmnt and extract the path without a device
-		using awk */
+		/* Get the mount point directory from findmnt */
 		args := workshop.Execution{
 			ExecArgs: workshop.ExecArgs{
 				UserId:  0,
 				GroupId: 0,
-				Command: []string{"bash", "-c",
-					"findmnt --mountpoint /project -o source -n | awk -F\"[][]\" '{printf $2}'"},
+				Command: []string{"findmnt", "--json", "--mountpoint", "/project", "--output", "fsroot"},
 				WorkDir: "/",
 			},
 			ExecControls: workshop.ExecControls{
 				Stdin:  nil,
-				Stdout: out,
-				Stderr: out,
+				Stdout: &outbuf,
+				Stderr: &errbuf,
 			},
 		}
 
-		execCtx := context.WithValue(ctx, workshop.ContextProjectId, p.ProjectId)
+		execCtx := context.WithValue(ctx, workshop.ContextProjectId, projectId)
 		meta, err := s.execCommand(conn, execCtx, workshop.WorkshopName(i.Name), &args)
-		if err == nil {
-			err = meta.WaitExecution(ctx)
-			if err != nil {
-				outbuf, _ := afero.ReadFile(memFs, out.Name())
-				logger.Debugf("cannot check %q bind-mounts: %v, findmnt output: %s", i.Name, err, string(outbuf))
-				continue
-			}
-		} else {
+		if err != nil {
 			logger.Debugf("cannot check %q bind-mounts: %v", i.Name, err)
 			continue
 		}
+		if err = meta.WaitExecution(ctx); err != nil {
+			logger.Debugf("cannot check %q bind-mounts: %v, findmnt output: %s", i.Name, err, errbuf.String())
+			continue
+		}
 
-		/* Process the findmnt results */
-		if currentPath, err := afero.ReadFile(memFs, i.Name); err == nil {
-			/* check if the path is not //deleted, i.e. the project directory still exists on the host */
-			if ok, isDir, err := osutil.ExistsIsDir(string(currentPath)); ok && isDir {
-				return string(currentPath), nil
-			} else if err != nil && !osutil.IsDirNotExist(err) {
-				return "", nil
-			}
+		output := struct {
+			Filesystems []struct {
+				Fsroot string `json:"fsroot"`
+			} `json:"filesystems"`
+		}{}
+		if err = json.Unmarshal(outbuf.Bytes(), &output); err != nil {
+			return "", err
+		}
+		if len(output.Filesystems) != 1 {
+			logger.Debugf("cannot check %q bind-mounts: exactly one source required", i.Name)
+			continue
+		}
+		currentPath := output.Filesystems[0].Fsroot
+
+		/* check if the path is not deleted, i.e. the project directory still exists on the host */
+		if ok, isDir, err := osutil.ExistsIsDir(currentPath); ok && isDir {
+			return currentPath, nil
+		} else if err != nil && !osutil.IsDirNotExist(err) {
+			return "", err
 		}
 	}
 	return "", nil

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -118,8 +118,7 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 					return nil, false, err
 				}
 				// also, update configuration of all the project's workshops
-				projectCtx := context.WithValue(ctx, workshop.ContextProjectId, existingProject.ProjectId)
-				return existingProject, false, s.updateWorkshopsProjectPath(client, projectCtx, existingProject)
+				return existingProject, false, s.updateProjectMounts(client, ctx, existingProject)
 			} else {
 				// the directory was copied, so we:
 				// 1. Generate a new project id for the actual path and update .lock file
@@ -351,7 +350,7 @@ func (s *Backend) maybeRecoverProjectPaths(client lxd.InstanceServer, ctx contex
 				prj.Path = newPath
 				if err = s.trackProject(client, ctx, prj); err == nil {
 					// update the workshops configuration with the new path
-					_ = s.updateWorkshopsProjectPath(client, ctx, prj)
+					_ = s.updateProjectMounts(client, ctx, prj)
 				}
 				return false
 			}
@@ -486,17 +485,19 @@ func (s *Backend) trackProject(client lxd.InstanceServer, ctx context.Context, p
 	return client.UpdateProject(LxdProjectName(user), lxdPrj.Writable(), etag)
 }
 
-func (s *Backend) updateWorkshopsProjectPath(conn lxd.InstanceServer, ctx context.Context, existingProject *workshop.Project) error {
-	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, existingProject.ProjectId))
+func (s *Backend) updateProjectMounts(conn lxd.InstanceServer, ctx context.Context, project *workshop.Project) error {
+	projectCtx := context.WithValue(ctx, workshop.ContextProjectId, project.ProjectId)
+
+	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, project.ProjectId))
 	if err != nil {
 		return err
 	}
 
 	for _, i := range workshops {
-		project := workshop.Mount{Name: workshop.ConfigProjectPathDevice, What: existingProject.Path, Where: workshop.WorkshopProjectPath}
-		err = s.AddWorkshopMount(ctx, workshop.WorkshopName(i.Name), project)
+		mount := workshop.Mount{Name: workshop.ConfigProjectPathDevice, What: project.Path, Where: workshop.WorkshopProjectPath}
+		err = s.AddWorkshopMount(projectCtx, workshop.WorkshopName(i.Name), mount)
 		if err != nil {
-			return fmt.Errorf("cannot update workshop \"%v\" project directory", i.Name)
+			return fmt.Errorf("cannot update workshop %q project directory: %w", i.Name, err)
 		}
 	}
 	return nil

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -28,12 +28,11 @@ func LxdProjectName(user string) string {
 	return "workshop." + user
 }
 
-func LxdProjectUser(project string) string {
-	parts := strings.Split(project, ".")
-	if len(parts) != 2 {
-		return ""
+func lxdProjectUser(project string) string {
+	if strings.HasPrefix(project, "workshop.") {
+		return strings.TrimPrefix(project, "workshop.")
 	}
-	return parts[1]
+	return ""
 }
 
 func LxdSystemProjectName(user string) string {
@@ -121,48 +120,53 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 
 func (s *Backend) Projects(ctx context.Context) (map[string][]*workshop.Project, error) {
 	if user, ok := ctx.Value(workshop.ContextUser).(string); ok {
-		projects, err := s.loadUserProjects(ctx, user)
+		projects, err := s.userProjects(ctx, user)
 		if err != nil {
 			return nil, err
 		}
 		return map[string][]*workshop.Project{user: projects}, nil
-	} else {
-		// get a default connection without preseting the LXD project as we are
-		// going over all the LXD projects to filter the ones managed by
-		// workshop and reload every interface connection for every SDK of
-		// every workshop
-		client, err := lxd.ConnectLXDUnixWithContext(ctx, LxdSock, nil)
-		if err != nil {
-			return nil, err
-		}
-		// list all projects for all users if the user is not provided
-		lxdProjects, err := client.GetProjects()
-		if err != nil {
-			return nil, err
-		}
-		allProjects := make(map[string][]*workshop.Project)
-		for _, lxdProject := range lxdProjects {
-			username := LxdProjectUser(lxdProject.Name)
-			if _, err = workshop.LookupUsername(username); err != nil {
-				continue
-			}
-			// if the project is created by workshop, the key must be present
-			if _, ok := lxdProject.Config["user.workshop.projects"]; ok {
-				prjctx := context.WithValue(ctx, workshop.ContextUser, username)
-
-				projects, err := s.loadUserProjects(prjctx, username)
-				if err != nil {
-					return nil, err
-				}
-
-				allProjects[username] = projects
-			}
-		}
-		return allProjects, nil
 	}
+
+	// get a default connection without preseting the LXD project as we are
+	// going over all the LXD projects to filter the ones managed by
+	// workshop and reload every interface connection for every SDK of
+	// every workshop
+	client, err := lxd.ConnectLXDUnixWithContext(ctx, LxdSock, nil)
+	if err != nil {
+		return nil, err
+	}
+	// list all projects for all users if the user is not provided
+	lxdProjects, err := client.GetProjects()
+	if err != nil {
+		return nil, err
+	}
+	allProjects := make(map[string][]*workshop.Project)
+	for _, lxdProject := range lxdProjects {
+		// if the project is created by workshop, the key must be present
+		if _, ok := lxdProject.Config["user.workshop.projects"]; !ok {
+			continue
+		}
+		username := lxdProjectUser(lxdProject.Name)
+		if username == "" {
+			continue
+		}
+		if _, err = workshop.LookupUsername(username); err != nil {
+			logger.Noticef("cannot find user %q: %v", username, err)
+			continue
+		}
+
+		prjctx := context.WithValue(ctx, workshop.ContextUser, username)
+		projects, err := s.userProjects(prjctx, username)
+		if err != nil {
+			return nil, err
+		}
+
+		allProjects[username] = projects
+	}
+	return allProjects, nil
 }
 
-func (s *Backend) loadUserProjects(ctx context.Context, user string) ([]*workshop.Project, error) {
+func (s *Backend) userProjects(ctx context.Context, user string) ([]*workshop.Project, error) {
 	client, err := s.LxdClient(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -97,7 +97,7 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 	}
 
 	if result == workshop.ProjectMoved {
-		if err = s.updateProjectMounts(client, ctx, project); err != nil {
+		if err = s.updateProjectMounts(client, ctx, *project); err != nil {
 			return nil, false, err
 		}
 	}
@@ -116,13 +116,13 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 	return project, result == workshop.ProjectAdded, nil
 }
 
-func (s *Backend) Projects(ctx context.Context) (map[string][]*workshop.Project, error) {
+func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, error) {
 	if user, ok := ctx.Value(workshop.ContextUser).(string); ok {
 		projects, err := s.userProjects(ctx, user)
 		if err != nil {
 			return nil, err
 		}
-		return map[string][]*workshop.Project{user: projects}, nil
+		return map[string][]workshop.Project{user: projects}, nil
 	}
 
 	// get a default connection without preseting the LXD project as we are
@@ -138,7 +138,7 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]*workshop.Project,
 	if err != nil {
 		return nil, err
 	}
-	allProjects := make(map[string][]*workshop.Project)
+	allProjects := make(map[string][]workshop.Project)
 	for _, lxdProject := range lxdProjects {
 		// if the project is created by workshop, the key must be present
 		if _, ok := lxdProject.Config["user.workshop.projects"]; !ok {
@@ -164,7 +164,7 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]*workshop.Project,
 	return allProjects, nil
 }
 
-func (s *Backend) userProjects(ctx context.Context, user string) ([]*workshop.Project, error) {
+func (s *Backend) userProjects(ctx context.Context, user string) ([]workshop.Project, error) {
 	client, err := s.LxdClient(ctx)
 	if err != nil {
 		return nil, err
@@ -203,8 +203,8 @@ func (s *Backend) userProjects(ctx context.Context, user string) ([]*workshop.Pr
 // If a path does not exist, recover it from the actual bind mount of the '/project'.
 // If recovery fails and no workshops exist for the project,
 // remove the project from the list.
-func (s *Backend) pruneProjects(client lxd.InstanceServer, ctx context.Context, projects []*workshop.Project) ([]*workshop.Project, bool, error) {
-	pruned := make([]*workshop.Project, 0, len(projects))
+func (s *Backend) pruneProjects(client lxd.InstanceServer, ctx context.Context, projects []workshop.Project) ([]workshop.Project, bool, error) {
+	pruned := make([]workshop.Project, 0, len(projects))
 	modified := false
 
 	for _, prj := range projects {
@@ -221,7 +221,7 @@ func (s *Backend) pruneProjects(client lxd.InstanceServer, ctx context.Context, 
 			return nil, false, err
 		}
 		if path != "" {
-			prj = &workshop.Project{Path: path, ProjectId: prj.ProjectId}
+			prj.Path = path
 			if err = s.updateProjectMounts(client, ctx, prj); err != nil {
 				return nil, false, err
 			}
@@ -312,8 +312,8 @@ func (s *Backend) projectFsRoot(conn lxd.InstanceServer, ctx context.Context, pr
 	return "", nil
 }
 
-func readProjects(jsonData []byte) ([]*workshop.Project, error) {
-	var projects = make([]*workshop.Project, 0)
+func readProjects(jsonData []byte) ([]workshop.Project, error) {
+	var projects = make([]workshop.Project, 0)
 	if len(jsonData) == 0 {
 		return projects, nil
 	}
@@ -323,7 +323,7 @@ func readProjects(jsonData []byte) ([]*workshop.Project, error) {
 	return projects, nil
 }
 
-func saveProjects(projects []*workshop.Project) (string, error) {
+func saveProjects(projects []workshop.Project) (string, error) {
 	buf, err := json.Marshal(projects)
 	if err != nil {
 		return "", err
@@ -331,7 +331,7 @@ func saveProjects(projects []*workshop.Project) (string, error) {
 	return string(buf), nil
 }
 
-func (s *Backend) updateProjectMounts(conn lxd.InstanceServer, ctx context.Context, project *workshop.Project) error {
+func (s *Backend) updateProjectMounts(conn lxd.InstanceServer, ctx context.Context, project workshop.Project) error {
 	projectCtx := context.WithValue(ctx, workshop.ContextProjectId, project.ProjectId)
 
 	workshops, err := s.filterLxdInstancesByConfig(conn, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, project.ProjectId))

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
-	"slices"
 	"strings"
 
 	lxd "github.com/canonical/lxd/client"
@@ -183,53 +181,70 @@ func (s *Backend) userProjects(ctx context.Context, user string) ([]*workshop.Pr
 		return nil, err
 	}
 
-	checked := s.maybeRecoverProjectPaths(client, ctx, projects)
-
-	if !reflect.DeepEqual(projects, checked) {
-		projectsJson, err := saveProjects(checked)
+	projects, modified, err := s.pruneProjects(client, ctx, projects)
+	if err != nil {
+		return nil, err
+	}
+	if modified {
+		projectsJson, err := saveProjects(projects)
 		if err != nil {
 			return nil, err
 		}
 		lxdPrj.Config["user.workshop.projects"] = projectsJson
-		if err = client.UpdateProject(LxdProjectName(user), lxdPrj.Writable(), etag); err != nil {
+		if err = client.UpdateProject(lxdPrj.Name, lxdPrj.Writable(), etag); err != nil {
 			return nil, err
 		}
 	}
-	return checked, nil
+
+	return projects, nil
 }
 
-// Ensures that every project has a valid existing path. If not, tries to
-// recover the path from the actual bind mount of the '/project'. If recovery
-// went unsuccessful, removes the project from the list.
-func (s *Backend) maybeRecoverProjectPaths(client lxd.InstanceServer, ctx context.Context, projects []*workshop.Project) []*workshop.Project {
-	return slices.DeleteFunc(projects, func(prj *workshop.Project) bool {
-		if !prj.Exists() {
-			var err error
-			// If got here then there is no project directory for the projectId
-			// anymore. It can mean moving or deletion happened in the past. Try
-			// to recover the new project path
-			newPath, _ := s.projectFsRoot(client, ctx, prj.ProjectId)
-			if newPath != "" {
-				// start tracking this project under a new path
-				prj.Path = newPath
-				if err = s.trackProject(client, ctx, prj); err == nil {
-					// update the workshops configuration with the new path
-					_ = s.updateProjectMounts(client, ctx, prj)
-				}
-				return false
-			}
-			// Could not recover the directory, reconcile the project from the
-			// list of projects that we track (only if there are no remaining
-			// workshops for this project)
-			inst, err := s.filterLxdInstancesByConfig(client, func(config map[string]string) bool {
-				return config["user.workshop.project-id"] == prj.ProjectId
-			})
-			if err == nil && len(inst) == 0 {
-				return true
-			}
+// Attempts to ensure that every project has a valid existing path.
+// If a path does not exist, recover it from the actual bind mount of the '/project'.
+// If recovery fails and no workshops exist for the project,
+// remove the project from the list.
+func (s *Backend) pruneProjects(client lxd.InstanceServer, ctx context.Context, projects []*workshop.Project) ([]*workshop.Project, bool, error) {
+	pruned := make([]*workshop.Project, 0, len(projects))
+	modified := false
+
+	for _, prj := range projects {
+		if prj.Exists() {
+			pruned = append(pruned, prj)
+			continue
 		}
-		return false
-	})
+
+		// If got here then there is no project directory for the projectId
+		// anymore. It can mean moving or deletion happened in the past. Try
+		// to recover the new project path.
+		path, err := s.projectFsRoot(client, ctx, prj.ProjectId)
+		if err != nil {
+			return nil, false, err
+		}
+		if path != "" {
+			prj = &workshop.Project{Path: path, ProjectId: prj.ProjectId}
+			if err = s.updateProjectMounts(client, ctx, prj); err != nil {
+				return nil, false, err
+			}
+			pruned = append(pruned, prj)
+			modified = true
+			continue
+		}
+
+		// Could not recover the directory, reconcile the project from the
+		// list of projects that we track (only if there are no remaining
+		// workshops for this project)
+		workshops, err := s.filterLxdInstancesByConfig(client, workshop.NewWorkshopConfigFilter(workshop.ConfigProjectId, prj.ProjectId))
+		if err != nil {
+			return nil, false, err
+		}
+		if len(workshops) > 0 {
+			pruned = append(pruned, prj)
+		} else {
+			modified = true
+		}
+	}
+
+	return pruned, modified, nil
 }
 
 func (s *Backend) projectFsRoot(conn lxd.InstanceServer, ctx context.Context, projectId string) (path string, err error) {
@@ -314,38 +329,6 @@ func saveProjects(projects []*workshop.Project) (string, error) {
 		return "", err
 	}
 	return string(buf), nil
-}
-
-func (s *Backend) trackProject(client lxd.InstanceServer, ctx context.Context, prj *workshop.Project) error {
-	user, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return fmt.Errorf("context key %s not found", workshop.ContextUser)
-	}
-
-	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
-	if err != nil {
-		return err
-	}
-
-	projects, err := readProjects([]byte(lxdPrj.Config["user.workshop.projects"]))
-	if err != nil {
-		return err
-	}
-
-	idx := slices.IndexFunc(projects, func(p *workshop.Project) bool { return p.ProjectId == prj.ProjectId })
-	if idx == -1 {
-		projects = append(projects, prj)
-	} else {
-		projects[idx] = prj
-	}
-
-	projectsJson, err := saveProjects(projects)
-	if err != nil {
-		return err
-	}
-	lxdPrj.Config["user.workshop.projects"] = projectsJson
-
-	return client.UpdateProject(LxdProjectName(user), lxdPrj.Writable(), etag)
 }
 
 func (s *Backend) updateProjectMounts(conn lxd.InstanceServer, ctx context.Context, project *workshop.Project) error {

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -297,7 +297,7 @@ func (s *Backend) maybeRecoverProjectPaths(client lxd.InstanceServer, ctx contex
 func ProjectPath(cwd string) (string, error) {
 	path, err := filepath.EvalSymlinks(cwd)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	for {

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type LxdBeTests struct {
-	project *workshop.Project
+	project workshop.Project
 }
 
 var _ = check.Suite(&LxdBeTests{})
@@ -20,7 +20,7 @@ func TestLxdBackendSuite(t *testing.T) { check.TestingT(t) }
 
 func (s *LxdBeTests) SetUpTest(c *check.C) {
 	dir := c.MkDir()
-	s.project = &workshop.Project{ProjectId: "42ws42ws", Path: dir}
+	s.project = workshop.Project{ProjectId: "42ws42ws", Path: dir}
 }
 
 func (f *LxdBeTests) TestReadProjectsSuccess(c *check.C) {
@@ -28,7 +28,7 @@ func (f *LxdBeTests) TestReadProjectsSuccess(c *check.C) {
 
 	projects, err := lxdbackend.ReadProjects([]byte(configData))
 	c.Assert(err, check.IsNil)
-	c.Assert(projects, testutil.DeepUnsortedMatches, []*workshop.Project{
+	c.Assert(projects, testutil.DeepUnsortedMatches, []workshop.Project{
 		{
 			Path:      "/home/dmitry/Work/ros-tutorials",
 			ProjectId: "01ac7c0e",

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -1,9 +1,6 @@
 package lxdbackend_test
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -24,69 +21,6 @@ func TestLxdBackendSuite(t *testing.T) { check.TestingT(t) }
 func (s *LxdBeTests) SetUpTest(c *check.C) {
 	dir := c.MkDir()
 	s.project = &workshop.Project{ProjectId: "42ws42ws", Path: dir}
-}
-
-func (f *LxdBeTests) TestProjectSubDirectoryProvideAsPath(c *check.C) {
-	root := c.MkDir()
-	cases := []struct {
-		project   string
-		lockFile  bool
-		cwd       string
-		isSymlink bool
-		expected  string
-		err       error
-	}{
-		// nested directory
-		{"/home/user", true, "/home/user/nested", false, "/home/user", nil},
-
-		// nested directory
-		{"/home/user", true, "/home/user/test/very/deeply", false, "/home/user", nil},
-
-		// same level
-		{"/home/user/same", true, "/home/user/same", false, "/home/user/same", nil},
-		// same level, symlink
-		{"/home/user/same", true, "/home/user/samelink", true, "/home/user/same", nil},
-
-		// different cwd
-		{"/home/user/different", true, "/home", false, "/home", nil},
-
-		// project is in root
-		{"/", true, "/home/user/notroot", false, "", nil},
-
-		// .lock does not exist
-		{"/home/user/nolock", false, "/home/user/test/nolock", false, "/home/user/test/nolock", nil},
-
-		// path is unclean (lock exists)
-		{"/home/user/unclean", true, "/home/user/unclean/", false, "/home/user/unclean", nil},
-
-		// path is unclean (no lock)
-		{"/home/user/unclean", false, "/home/user/unclean/", false, "/home/user/unclean", nil},
-
-		// path is unclean (no lock, symlink)
-		{"/home/user/projectdir", false, "/home/user/symlinktest/", true, "/home/user/projectdir", nil},
-	}
-
-	for _, i := range cases {
-		os.MkdirAll(filepath.Join(root, i.project), 0755)
-		if i.lockFile == true {
-			os.Create(workshop.LockPath(filepath.Join(root, i.project)))
-		}
-		if i.isSymlink == true {
-			err := os.Symlink(filepath.Join(root, i.project), filepath.Join(root, i.cwd))
-			c.Assert(err, check.IsNil)
-		} else {
-			os.MkdirAll(filepath.Join(root, i.cwd), 0755)
-		}
-		// note: no filepath.join here as it calls Clean on exist for the path
-		// the data must come unclean for the ProjectPath input and the test
-		// must ensure it returns a clean one on every condition
-		path, err := lxdbackend.ProjectPath(fmt.Sprintf("%s%s", root, i.cwd))
-
-		c.Assert(path, check.Equals, fmt.Sprintf("%s%s", root, i.expected))
-		c.Assert(err, check.Equals, i.err)
-		os.RemoveAll(filepath.Join(root, i.project))
-		os.RemoveAll(filepath.Join(root, i.cwd))
-	}
 }
 
 func (f *LxdBeTests) TestReadProjectsSuccess(c *check.C) {

--- a/internal/workshop/lxd/tests/integration/project_test.go
+++ b/internal/workshop/lxd/tests/integration/project_test.go
@@ -250,7 +250,7 @@ func (f *wsProject) TestLxdBackendListAvailableProjects(c *check.C) {
 
 	// Validate
 	c.Assert(err, check.IsNil)
-	c.Assert(projects, check.DeepEquals, map[string][]*workshop.Project{
+	c.Assert(projects, check.DeepEquals, map[string][]workshop.Project{
 		f.username: {
 			{ProjectId: "b8639dea", Path: projectDir},
 			{ProjectId: "d4352dea", Path: projectDir2},
@@ -308,7 +308,7 @@ func (f *wsProject) TestLxdBackendLoadProjectsAllUsers(c *check.C) {
 
 	// Validate
 	c.Assert(err, check.IsNil)
-	c.Assert(projects, testutil.DeepUnsortedMatches, map[string][]*workshop.Project{
+	c.Assert(projects, testutil.DeepUnsortedMatches, map[string][]workshop.Project{
 		f.username: {{ProjectId: "b8639dea", Path: projectDir}},
 	})
 }

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -28,7 +28,7 @@ type wsExec struct {
 	username            string
 	client              *client.Client
 	daemon              *daemon.Daemon
-	project             *workshop.Project
+	project             workshop.Project
 	lookupUserRestore   func()
 	lookupUserIdRestore func()
 	newProjectidRestore func()
@@ -70,7 +70,7 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	f.project = &workshop.Project{
+	f.project = workshop.Project{
 		ProjectId: "42424242",
 		Path:      c.MkDir(),
 	}

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -21,7 +21,7 @@ type wsOps struct {
 	bd                 *lxdbackend.Backend
 	ctx                context.Context
 	username           string
-	project            *workshop.Project
+	project            workshop.Project
 	restoreLookupUsr   func()
 	restoreNewId       func()
 	restoreDevices     func()
@@ -37,7 +37,7 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	f.username = "testuser"
-	f.project = &workshop.Project{
+	f.project = workshop.Project{
 		ProjectId: "42424242",
 		Path:      c.MkDir(),
 	}

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -146,7 +146,7 @@ func (w *Project) maybeSingleWorkshop() (string, error) {
 }
 
 type ProjectTracker struct {
-	Projects []*Project
+	Projects []Project
 }
 
 type TrackResult int
@@ -229,12 +229,12 @@ func readProjectId(projectDir string) (string, error) {
 func (t *ProjectTracker) writeProjectId(path string) (*Project, TrackResult, error) {
 	// Try to recover .lock file for this project
 	// if it existed before and was accidentally removed.
-	idx := slices.IndexFunc(t.Projects, func(p *Project) bool { return p.Path == path })
+	idx := slices.IndexFunc(t.Projects, func(p Project) bool { return p.Path == path })
 	if idx >= 0 {
 		if err := t.Projects[idx].updateLock(); err != nil {
 			return nil, ProjectError, err
 		}
-		return t.Projects[idx], ProjectFound, nil
+		return &t.Projects[idx], ProjectFound, nil
 	}
 
 	// No project found. If there is at least one workshop definition,
@@ -246,12 +246,12 @@ func (t *ProjectTracker) writeProjectId(path string) (*Project, TrackResult, err
 }
 
 func (t *ProjectTracker) maybeFindProject(path, id string) (*Project, TrackResult, error) {
-	idx := slices.IndexFunc(t.Projects, func(p *Project) bool { return p.ProjectId == id })
+	idx := slices.IndexFunc(t.Projects, func(p Project) bool { return p.ProjectId == id })
 	if idx < 0 {
 		return nil, ProjectError, nil
 	}
 	if t.Projects[idx].Path == path {
-		return t.Projects[idx], ProjectFound, nil
+		return &t.Projects[idx], ProjectFound, nil
 	}
 
 	// Existing project was moved or copied.
@@ -260,7 +260,7 @@ func (t *ProjectTracker) maybeFindProject(path, id string) (*Project, TrackResul
 		if errors.Is(err, os.ErrNotExist) {
 			// Moved: keep ID but update path.
 			t.Projects[idx].Path = path
-			return t.Projects[idx], ProjectMoved, nil
+			return &t.Projects[idx], ProjectMoved, nil
 		}
 		return nil, ProjectError, err
 	}
@@ -275,13 +275,13 @@ func (t *ProjectTracker) createProject(path string) (*Project, TrackResult, erro
 		return nil, ProjectError, err
 	}
 
-	project := &Project{Path: path, ProjectId: id}
+	project := Project{Path: path, ProjectId: id}
 	if err = project.updateLock(); err != nil {
 		return nil, ProjectError, err
 	}
 
 	t.Projects = append(t.Projects, project)
-	return project, ProjectAdded, nil
+	return &project, ProjectAdded, nil
 }
 
 func (t *ProjectTracker) createProjectWithId(path, id string) (*Project, TrackResult, error) {
@@ -291,9 +291,9 @@ func (t *ProjectTracker) createProjectWithId(path, id string) (*Project, TrackRe
 		return nil, ProjectError, ErrNotProject
 	}
 
-	project := &Project{ProjectId: id, Path: path}
+	project := Project{ProjectId: id, Path: path}
 	t.Projects = append(t.Projects, project)
-	return project, ProjectAdded, nil
+	return &project, ProjectAdded, nil
 }
 
 // A directory is a project if it has at least one workshop definition.

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -15,7 +16,6 @@ import (
 )
 
 var (
-	ErrProjectNotFound        = errors.New("project not found")
 	ErrProjectLockNotFound    = errors.New("project lock file not found")
 	ErrProjectAlreadyExists   = errors.New("project already exists")
 	ErrNotProject             = errors.New("not a project (no workshop files found)")
@@ -145,8 +145,159 @@ func (w *Project) maybeSingleWorkshop() (string, error) {
 	return path, nil
 }
 
+type ProjectTracker struct {
+	Projects []*Project
+}
+
+type TrackResult int
+
+const (
+	ProjectError TrackResult = iota
+	ProjectFound
+	ProjectMoved
+	ProjectAdded
+)
+
+// Track attempts to locate a known project that contains the given path.
+// If unsuccessful, it creates a new project and begins tracking it.
+// Moved projects will be updated with the new path,
+// whereas copied projects will receive a new project ID.
+func (t *ProjectTracker) Track(path string) (*Project, TrackResult, error) {
+	if !filepath.IsAbs(path) {
+		return nil, ProjectError, ErrNoRelativePathsAllowed
+	}
+
+	path, err := ancestorProject(path)
+	if err != nil {
+		return nil, ProjectError, err
+	}
+
+	id, err := readProjectId(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return t.writeProjectId(path)
+		}
+		return nil, ProjectError, err
+	}
+
+	project, result, err := t.maybeFindProject(path, id)
+	if err == nil && project == nil {
+		return t.createProjectWithId(path, id)
+	}
+	return project, result, err
+}
+
+// ancestorProject returns an existing project which contains the given path,
+// or the path itself if there is no such project.
+func ancestorProject(child string) (string, error) {
+	child, err := filepath.EvalSymlinks(child)
+	if err != nil {
+		return "", err
+	}
+
+	path := child
+	for {
+		ok, isDir, err := osutil.ExistsIsDir(path)
+		if err != nil {
+			return "", err
+		}
+		if ok && isDir {
+			if _, err := readProjectId(path); err == nil {
+				return filepath.Clean(path), nil
+			}
+		}
+
+		parent := filepath.Dir(path)
+		if parent == path {
+			break
+		}
+		path = parent
+	}
+
+	return child, nil
+}
+
+// Read a project id from projectDir (.workshop.lock)
+func readProjectId(projectDir string) (string, error) {
+	buf, err := os.ReadFile(LockPath(projectDir))
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func (t *ProjectTracker) writeProjectId(path string) (*Project, TrackResult, error) {
+	// Try to recover .lock file for this project
+	// if it existed before and was accidentally removed.
+	idx := slices.IndexFunc(t.Projects, func(p *Project) bool { return p.Path == path })
+	if idx >= 0 {
+		if err := t.Projects[idx].updateLock(); err != nil {
+			return nil, ProjectError, err
+		}
+		return t.Projects[idx], ProjectFound, nil
+	}
+
+	// No project found. If there is at least one workshop definition,
+	// we consider the path as a project and create a project ID.
+	if !isProject(path) {
+		return nil, ProjectError, ErrNotProject
+	}
+	return t.createProject(path)
+}
+
+func (t *ProjectTracker) maybeFindProject(path, id string) (*Project, TrackResult, error) {
+	idx := slices.IndexFunc(t.Projects, func(p *Project) bool { return p.ProjectId == id })
+	if idx < 0 {
+		return nil, ProjectError, nil
+	}
+	if t.Projects[idx].Path == path {
+		return t.Projects[idx], ProjectFound, nil
+	}
+
+	// Existing project was moved or copied.
+	_, err := os.Stat(t.Projects[idx].Path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Moved: keep ID but update path.
+			t.Projects[idx].Path = path
+			return t.Projects[idx], ProjectMoved, nil
+		}
+		return nil, ProjectError, err
+	}
+
+	// Copied: generate a new project ID and overwrite the copied .lock file.
+	return t.createProject(path)
+}
+
+func (t *ProjectTracker) createProject(path string) (*Project, TrackResult, error) {
+	id, err := NewProjectId()
+	if err != nil {
+		return nil, ProjectError, err
+	}
+
+	project := &Project{Path: path, ProjectId: id}
+	if err = project.updateLock(); err != nil {
+		return nil, ProjectError, err
+	}
+
+	t.Projects = append(t.Projects, project)
+	return project, ProjectAdded, nil
+}
+
+func (t *ProjectTracker) createProjectWithId(path, id string) (*Project, TrackResult, error) {
+	// If there is at least one workshop definition,
+	// we consider the path as a project and use the given ID.
+	if !isProject(path) {
+		return nil, ProjectError, ErrNotProject
+	}
+
+	project := &Project{ProjectId: id, Path: path}
+	t.Projects = append(t.Projects, project)
+	return project, ProjectAdded, nil
+}
+
 // A directory is a project if it has at least one workshop definition.
-func IsProject(dir string) bool {
+func isProject(dir string) bool {
 	files, err := filepath.Glob(filepath.Join(dir, Directory, "*.yaml"))
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
@@ -171,18 +322,7 @@ func IsProject(dir string) bool {
 	return false
 }
 
-func (w *Project) UpdateProjectLock() error {
-	return w.createLock()
-}
-
-func (w *Project) CreateProjectLock() error {
-	if osutil.FileExists(LockPath(w.Path)) {
-		return ErrProjectAlreadyExists
-	}
-	return w.createLock()
-}
-
-func (w *Project) createLock() error {
+func (w *Project) updateLock() error {
 	lock, err := os.Create(LockPath(w.Path))
 	if err != nil {
 		return err
@@ -211,15 +351,6 @@ func (w *Project) createLock() error {
 	}
 
 	return nil
-}
-
-// Read a project id from projectDir (.workshop.lock)
-func ProjectId(projectDir string) (string, error) {
-	buf, err := os.ReadFile(LockPath(projectDir))
-	if err != nil {
-		return "", err
-	}
-	return string(buf), nil
 }
 
 func allocateProjectId() (string, error) {

--- a/internal/workshop/project_test.go
+++ b/internal/workshop/project_test.go
@@ -77,29 +77,210 @@ func (p *projectSuite) TestSingleWorkshopFileBroken(c *check.C) {
 	c.Assert(err, check.NotNil)
 }
 
-func (p *projectSuite) TestIsProject(c *check.C) {
+func (p *projectSuite) TestTrackRelativePath(c *check.C) {
+	tracker := workshop.ProjectTracker{}
+	_, _, err := tracker.Track("relative/path")
+	c.Assert(err, check.ErrorMatches, "absolute project path must be used")
+}
+
+func (p *projectSuite) TestTrackNewProject(c *check.C) {
+	tracker := workshop.ProjectTracker{}
+
+	// Single-workshop project
 	d := c.MkDir()
-	c.Assert(workshop.IsProject(d), check.Equals, false)
-
-	d = c.MkDir()
-	_, err := os.Create(filepath.Join(d, "workshop.yaml"))
+	_, err := os.Create(filepath.Join(d, ".workshop.yaml"))
 	c.Assert(err, check.IsNil)
-	c.Assert(workshop.IsProject(d), check.Equals, true)
 
-	d = c.MkDir()
-	_, err = os.Create(filepath.Join(d, ".workshop.yaml"))
-	c.Assert(os.Mkdir(filepath.Join(d, ".workshop"), os.ModePerm), check.IsNil)
+	project, result, err := tracker.Track(d)
 	c.Assert(err, check.IsNil)
-	c.Assert(workshop.IsProject(d), check.Equals, true)
+	c.Check(result, check.Equals, workshop.ProjectAdded)
+	c.Check(project.Path, check.Equals, d)
+	c.Check(project.ProjectId, check.Not(check.Equals), "")
+	c.Check(tracker.Projects, check.HasLen, 1)
+	c.Assert(workshop.LockPath(d), testutil.FilePresent)
 
+	// Multi-workshop project
 	d = c.MkDir()
 	c.Assert(os.Mkdir(filepath.Join(d, ".workshop"), os.ModePerm), check.IsNil)
 	_, err = os.Create(filepath.Join(d, ".workshop", "dev.yaml"))
 	c.Assert(err, check.IsNil)
-	c.Assert(workshop.IsProject(d), check.Equals, true)
+	_, err = os.Create(filepath.Join(d, ".workshop", "prod.yaml"))
+	c.Assert(err, check.IsNil)
 
+	project, result, err = tracker.Track(d)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectAdded)
+	c.Check(project.Path, check.Equals, d)
+	c.Check(project.ProjectId, check.Not(check.Equals), "")
+	c.Check(tracker.Projects, check.HasLen, 2)
+	c.Assert(workshop.LockPath(d), testutil.FilePresent)
+
+	// Mixed convention project
+	d = c.MkDir()
+	_, err = os.Create(filepath.Join(d, ".workshop.yaml"))
+	c.Assert(err, check.IsNil)
+	c.Assert(os.Mkdir(filepath.Join(d, ".workshop"), os.ModePerm), check.IsNil)
+	_, err = os.Create(filepath.Join(d, ".workshop", "dev.yaml"))
+	c.Assert(err, check.IsNil)
+
+	project, result, err = tracker.Track(d)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectAdded)
+	c.Check(project.Path, check.Equals, d)
+	c.Check(project.ProjectId, check.Not(check.Equals), "")
+	c.Check(tracker.Projects, check.HasLen, 3)
+	c.Assert(workshop.LockPath(d), testutil.FilePresent)
+
+	// Invalid project
 	d = c.MkDir()
 	path := filepath.Join(d, ".workshop", "prod.yaml")
 	c.Assert(os.MkdirAll(path, os.ModePerm), check.IsNil)
-	c.Assert(workshop.IsProject(d), check.Equals, false)
+
+	_, _, err = tracker.Track(d)
+	c.Assert(err, check.ErrorMatches, `not a project \(no workshop files found\)`)
+	c.Assert(tracker.Projects, check.HasLen, 3)
+}
+
+func (p *projectSuite) TestTrackProjectSubDirectory(c *check.C) {
+	root := c.MkDir()
+	cases := []struct {
+		project   string
+		lockFile  bool
+		cwd       string
+		isSymlink bool
+		expected  string
+	}{
+		// nested directory
+		{"/home/user", true, "/home/user/nested", false, "/home/user"},
+
+		// nested directory
+		{"/home/user", true, "/home/user/test/very/deeply", false, "/home/user"},
+
+		// same level
+		{"/home/user/same", true, "/home/user/same", false, "/home/user/same"},
+		// same level, symlink
+		{"/home/user/same", true, "/home/user/samelink", true, "/home/user/same"},
+
+		// different cwd
+		{"/home/user/different", true, "/home", false, "/home"},
+
+		// project is in root
+		{"/", true, "/home/user/notroot", false, ""},
+
+		// .lock does not exist
+		{"/home/user/nolock", false, "/home/user/test/nolock", false, "/home/user/test/nolock"},
+
+		// path is unclean (lock exists)
+		{"/home/user/unclean", true, "/home/user/unclean/", false, "/home/user/unclean"},
+
+		// path is unclean (no lock)
+		{"/home/user/unclean", false, "/home/user/unclean/", false, "/home/user/unclean"},
+
+		// path is unclean (no lock, symlink)
+		{"/home/user/projectdir", false, "/home/user/symlinktest/", true, "/home/user/projectdir"},
+	}
+
+	for _, i := range cases {
+		c.Assert(os.MkdirAll(filepath.Join(root, i.project), 0755), check.IsNil)
+		if i.lockFile == true {
+			project := &workshop.Project{Path: filepath.Join(root, i.project), ProjectId: "42424242"}
+			c.Assert(workshop.UpdateLock(project), check.IsNil)
+		}
+		if i.isSymlink == true {
+			err := os.Symlink(filepath.Join(root, i.project), filepath.Join(root, i.cwd))
+			c.Assert(err, check.IsNil)
+		} else {
+			c.Assert(os.MkdirAll(filepath.Join(root, i.cwd), 0755), check.IsNil)
+		}
+		_, err := os.Create(filepath.Join(root, i.expected, "workshop.yaml"))
+		c.Assert(err, check.IsNil)
+
+		tracker := workshop.ProjectTracker{}
+		// note: no filepath.join here as it calls Clean on exist for the path
+		// the data must come unclean for the Track input and the test
+		// must ensure it returns a clean one on every condition
+		project, result, err := tracker.Track(fmt.Sprintf("%s%s", root, i.cwd))
+		c.Assert(err, check.IsNil)
+		c.Check(result, check.Equals, workshop.ProjectAdded)
+		c.Check(project.Path, check.Equals, fmt.Sprintf("%s%s", root, i.expected))
+
+		os.RemoveAll(filepath.Join(root, i.project))
+		os.RemoveAll(filepath.Join(root, i.cwd))
+	}
+}
+
+func (p *projectSuite) TestTrackExistingProject(c *check.C) {
+	d := c.MkDir()
+	original := filepath.Join(d, "original")
+	c.Assert(os.Mkdir(original, os.ModePerm), check.IsNil)
+
+	first := &workshop.Project{Path: original, ProjectId: "42424242"}
+	c.Assert(workshop.UpdateLock(first), check.IsNil)
+
+	projects := []*workshop.Project{{Path: original, ProjectId: "42424242"}}
+	tracker := workshop.ProjectTracker{Projects: projects}
+
+	// Existing project with .lock file.
+	project, result, err := tracker.Track(original)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectFound)
+	c.Check(project, check.DeepEquals, first)
+	c.Check(tracker.Projects, check.DeepEquals, []*workshop.Project{first})
+
+	// Copy of existing project with .lock file.
+	copied := filepath.Join(d, "copied")
+	c.Assert(os.CopyFS(copied, os.DirFS(original)), check.IsNil)
+
+	project, result, err = tracker.Track(copied)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectAdded)
+	c.Check(project.Path, check.Equals, copied)
+	c.Check(project.ProjectId, check.Not(check.Equals), "")
+	c.Check(project.ProjectId, check.Not(check.Equals), first.ProjectId)
+	second := &workshop.Project{Path: copied, ProjectId: project.ProjectId}
+	c.Check(tracker.Projects, testutil.DeepUnsortedMatches, []*workshop.Project{first, second})
+
+	// Relocation of existing project with .lock file.
+	moved := filepath.Join(d, "moved")
+	c.Assert(os.Rename(original, moved), check.IsNil)
+	first.Path = moved
+
+	project, result, err = tracker.Track(moved)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectMoved)
+	c.Check(project, check.DeepEquals, first)
+	c.Check(tracker.Projects, testutil.DeepUnsortedMatches, []*workshop.Project{first, second})
+}
+
+func (p *projectSuite) TestTrackRecoversProjectIds(c *check.C) {
+	d := c.MkDir()
+	expected := &workshop.Project{Path: d, ProjectId: "42424242"}
+
+	projects := []*workshop.Project{{Path: d, ProjectId: "42424242"}}
+	tracker := workshop.ProjectTracker{Projects: projects}
+
+	// Existing project without .lock file.
+	project, result, err := tracker.Track(d)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectFound)
+	c.Check(project, check.DeepEquals, expected)
+	c.Check(tracker.Projects, check.DeepEquals, []*workshop.Project{expected})
+	c.Assert(workshop.LockPath(d), testutil.FilePresent)
+
+	// Unknown directory with .lock file.
+	tracker = workshop.ProjectTracker{}
+
+	_, _, err = tracker.Track(d)
+	c.Assert(err, check.ErrorMatches, `not a project \(no workshop files found\)`)
+	c.Assert(tracker.Projects, check.HasLen, 0)
+
+	// Unknown project with .lock file.
+	_, err = os.Create(filepath.Join(d, "workshop.yaml"))
+	c.Assert(err, check.IsNil)
+
+	project, result, err = tracker.Track(d)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectAdded)
+	c.Check(project, check.DeepEquals, expected)
+	c.Check(tracker.Projects, check.DeepEquals, []*workshop.Project{expected})
 }

--- a/internal/workshop/project_test.go
+++ b/internal/workshop/project_test.go
@@ -214,18 +214,18 @@ func (p *projectSuite) TestTrackExistingProject(c *check.C) {
 	original := filepath.Join(d, "original")
 	c.Assert(os.Mkdir(original, os.ModePerm), check.IsNil)
 
-	first := &workshop.Project{Path: original, ProjectId: "42424242"}
-	c.Assert(workshop.UpdateLock(first), check.IsNil)
+	first := workshop.Project{Path: original, ProjectId: "42424242"}
+	c.Assert(workshop.UpdateLock(&first), check.IsNil)
 
-	projects := []*workshop.Project{{Path: original, ProjectId: "42424242"}}
+	projects := []workshop.Project{{Path: original, ProjectId: "42424242"}}
 	tracker := workshop.ProjectTracker{Projects: projects}
 
 	// Existing project with .lock file.
 	project, result, err := tracker.Track(original)
 	c.Assert(err, check.IsNil)
 	c.Check(result, check.Equals, workshop.ProjectFound)
-	c.Check(project, check.DeepEquals, first)
-	c.Check(tracker.Projects, check.DeepEquals, []*workshop.Project{first})
+	c.Check(project, check.DeepEquals, &first)
+	c.Check(tracker.Projects, check.DeepEquals, []workshop.Project{first})
 
 	// Copy of existing project with .lock file.
 	copied := filepath.Join(d, "copied")
@@ -237,8 +237,8 @@ func (p *projectSuite) TestTrackExistingProject(c *check.C) {
 	c.Check(project.Path, check.Equals, copied)
 	c.Check(project.ProjectId, check.Not(check.Equals), "")
 	c.Check(project.ProjectId, check.Not(check.Equals), first.ProjectId)
-	second := &workshop.Project{Path: copied, ProjectId: project.ProjectId}
-	c.Check(tracker.Projects, testutil.DeepUnsortedMatches, []*workshop.Project{first, second})
+	second := workshop.Project{Path: copied, ProjectId: project.ProjectId}
+	c.Check(tracker.Projects, testutil.DeepUnsortedMatches, []workshop.Project{first, second})
 
 	// Relocation of existing project with .lock file.
 	moved := filepath.Join(d, "moved")
@@ -248,23 +248,23 @@ func (p *projectSuite) TestTrackExistingProject(c *check.C) {
 	project, result, err = tracker.Track(moved)
 	c.Assert(err, check.IsNil)
 	c.Check(result, check.Equals, workshop.ProjectMoved)
-	c.Check(project, check.DeepEquals, first)
-	c.Check(tracker.Projects, testutil.DeepUnsortedMatches, []*workshop.Project{first, second})
+	c.Check(project, check.DeepEquals, &first)
+	c.Check(tracker.Projects, testutil.DeepUnsortedMatches, []workshop.Project{first, second})
 }
 
 func (p *projectSuite) TestTrackRecoversProjectIds(c *check.C) {
 	d := c.MkDir()
-	expected := &workshop.Project{Path: d, ProjectId: "42424242"}
+	expected := workshop.Project{Path: d, ProjectId: "42424242"}
 
-	projects := []*workshop.Project{{Path: d, ProjectId: "42424242"}}
+	projects := []workshop.Project{{Path: d, ProjectId: "42424242"}}
 	tracker := workshop.ProjectTracker{Projects: projects}
 
 	// Existing project without .lock file.
 	project, result, err := tracker.Track(d)
 	c.Assert(err, check.IsNil)
 	c.Check(result, check.Equals, workshop.ProjectFound)
-	c.Check(project, check.DeepEquals, expected)
-	c.Check(tracker.Projects, check.DeepEquals, []*workshop.Project{expected})
+	c.Check(project, check.DeepEquals, &expected)
+	c.Check(tracker.Projects, check.DeepEquals, []workshop.Project{expected})
 	c.Assert(workshop.LockPath(d), testutil.FilePresent)
 
 	// Unknown directory with .lock file.
@@ -281,6 +281,6 @@ func (p *projectSuite) TestTrackRecoversProjectIds(c *check.C) {
 	project, result, err = tracker.Track(d)
 	c.Assert(err, check.IsNil)
 	c.Check(result, check.Equals, workshop.ProjectAdded)
-	c.Check(project, check.DeepEquals, expected)
-	c.Check(tracker.Projects, check.DeepEquals, []*workshop.Project{expected})
+	c.Check(project, check.DeepEquals, &expected)
+	c.Check(tracker.Projects, check.DeepEquals, []workshop.Project{expected})
 }

--- a/internal/workshop/project_test.go
+++ b/internal/workshop/project_test.go
@@ -31,9 +31,9 @@ func createWorkshop(dir, name string) error {
 	return os.WriteFile(filepath.Join(dir, workshop.Filename(name)), []byte(fmt.Sprintf(w, name)), 0644)
 }
 
-func (f *workshopFile) TestSomeWorkshopFilesBroken(c *check.C) {
+func (p *projectSuite) TestSomeWorkshopFilesBroken(c *check.C) {
 	d := c.MkDir()
-	p := &workshop.Project{Path: d, ProjectId: "42424242"}
+	project := &workshop.Project{Path: d, ProjectId: "42424242"}
 
 	w := filepath.Join(d, workshop.Directory)
 	c.Assert(os.MkdirAll(w, os.ModePerm), check.IsNil)
@@ -45,39 +45,39 @@ func (f *workshopFile) TestSomeWorkshopFilesBroken(c *check.C) {
 	c.Assert(os.WriteFile(filepath.Join(w, "wb.yaml"), []byte(wb), 0644), check.IsNil)
 	// no match with the filename pattern
 	c.Assert(os.WriteFile(filepath.Join(w, "test-file.yml"), []byte{}, 0644), check.IsNil)
-	fls, err := p.ReadWorkshops()
+	fls, err := project.ReadWorkshops()
 	c.Assert(err, check.IsNil)
 	c.Assert(fls, check.HasLen, 3)
 	c.Assert(fls, testutil.DeepUnsortedMatches, map[string]string{"w1": filepath.Join(w, "w1.yaml"), "w2": filepath.Join(w, "w2.yaml"), "wb": filepath.Join(w, "wb.yaml")})
 }
 
-func (f *workshopFile) TestMixedWorkshopFileConventions(c *check.C) {
+func (p *projectSuite) TestMixedWorkshopFileConventions(c *check.C) {
 	d := c.MkDir()
-	p := &workshop.Project{Path: d, ProjectId: "42424242"}
+	project := &workshop.Project{Path: d, ProjectId: "42424242"}
 
 	w := filepath.Join(d, workshop.Directory)
 	c.Assert(os.MkdirAll(w, os.ModePerm), check.IsNil)
 
 	c.Assert(createWorkshop(w, "ws"), check.IsNil)
 	c.Assert(createWorkshop(d, "workshop"), check.IsNil)
-	fls, err := p.ReadWorkshops()
+	fls, err := project.ReadWorkshops()
 	c.Assert(fls, check.IsNil)
 	path := filepath.Join(d, "workshop.yaml")
 	message := fmt.Sprintf(`multiple workshops found, but %q not in ".workshop" subdirectory`, path)
 	c.Assert(err, check.ErrorMatches, message)
 }
 
-func (f *workshopFile) TestSingleWorkshopFileBroken(c *check.C) {
+func (p *projectSuite) TestSingleWorkshopFileBroken(c *check.C) {
 	d := c.MkDir()
-	p := &workshop.Project{Path: d, ProjectId: "42424242"}
+	project := &workshop.Project{Path: d, ProjectId: "42424242"}
 
 	c.Assert(os.WriteFile(filepath.Join(d, ".workshop.yaml"), []byte(wb), 0644), check.IsNil)
-	fls, err := p.ReadWorkshops()
+	fls, err := project.ReadWorkshops()
 	c.Assert(fls, check.IsNil)
 	c.Assert(err, check.NotNil)
 }
 
-func (f *workshopFile) TestIsProject(c *check.C) {
+func (p *projectSuite) TestIsProject(c *check.C) {
 	d := c.MkDir()
 	c.Assert(workshop.IsProject(d), check.Equals, false)
 

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -29,7 +29,7 @@ var InstallTimeNow = time.Now
 
 type Workshop struct {
 	Backend Backend
-	Project *Project
+	Project Project
 	// Workshop file that was used to launch it; it may be out of sync with the
 	// file in the project directory due to user's edits, etc.
 	File    *File

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -19,7 +19,7 @@ import (
 
 type workshopFile struct {
 	fs      afero.Fs
-	project *workshop.Project
+	project workshop.Project
 }
 
 var _ = check.Suite(&workshopFile{})
@@ -29,7 +29,7 @@ func TestWorkshop(t *testing.T) { check.TestingT(t) }
 func (f *workshopFile) SetUpTest(c *check.C) {
 	f.fs = afero.NewMemMapFs()
 
-	f.project = &workshop.Project{
+	f.project = workshop.Project{
 		Path:      c.MkDir(),
 		ProjectId: "b8639dea",
 	}

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -18,7 +18,7 @@ import (
 type workshopSuite struct {
 	bend *fakebackend.FakeWorkshopBackend
 	ctx  context.Context
-	p    *workshop.Project
+	p    workshop.Project
 
 	restoreUserLookup func()
 }
@@ -47,8 +47,9 @@ func (f *workshopSuite) SetUpTest(c *check.C) {
 
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 
-	f.p, _, err = f.bend.CreateOrLoadProject(ctx, c.MkDir())
+	p, _, err := f.bend.CreateOrLoadProject(ctx, c.MkDir())
 	c.Assert(err, check.IsNil)
+	f.p = *p
 
 	f.ctx = createTestContext("testuser", f.p.ProjectId)
 }

--- a/tests/documentation/how-to-debug-issues/task.yaml
+++ b/tests/documentation/how-to-debug-issues/task.yaml
@@ -5,10 +5,10 @@ execute: |
   echo "Expecting launch to fail..."
   workshop_exec launch || true
   echo "Expecting refresh to fail..."
-  workshop_exec refresh golang-volatile || true
-  workshop_exec refresh --wait-on-error golang-volatile || true
+  workshop_exec refresh || true
+  workshop_exec refresh --wait-on-error || true
   echo "Skipping interactive exercises with --wait-on-error..."
-  workshop_exec refresh --continue golang-volatile || true
-  workshop_exec refresh --abort golang-volatile || true
+  workshop_exec refresh --continue || true
+  workshop_exec refresh --abort || true
   workshop_exec changes
   workshop_exec tasks $(workshop changes | awk 'END{print $1}')

--- a/tests/documentation/how-to-debug-issues/task.yaml
+++ b/tests/documentation/how-to-debug-issues/task.yaml
@@ -3,7 +3,7 @@ execute: |
   . "$TESTSLIB"/utils.sh
   
   echo "Expecting launch to fail..."
-  workshop_exec launch golang-volatile || true
+  workshop_exec launch || true
   echo "Expecting refresh to fail..."
   workshop_exec refresh golang-volatile || true
   workshop_exec refresh --wait-on-error golang-volatile || true

--- a/tests/documentation/how-to-git-worktree/task.yaml
+++ b/tests/documentation/how-to-git-worktree/task.yaml
@@ -11,7 +11,7 @@ execute: |
   workshop_exec --project "$PROJECT/original" launch golang
   git add . && git commit -m "initial commit"
   chown -R ubuntu:ubuntu $PROJECT/original
-  workshop_exec --project "$PROJECT/original" exec golang -- go build -x main.go
+  workshop_exec --project "$PROJECT/original" exec golang go build -x main.go
   workshop_exec --project "$PROJECT/original" remove golang
   ./main
   workshop_exec --project "$PROJECT/original" launch golang

--- a/tests/documentation/how-to-git-worktree/task.yaml
+++ b/tests/documentation/how-to-git-worktree/task.yaml
@@ -12,7 +12,7 @@ execute: |
   git add . && git commit -m "initial commit"
   chown -R ubuntu:ubuntu $PROJECT/original
   workshop_exec --project "$PROJECT/original" exec golang go build -x main.go
-  workshop_exec --project "$PROJECT/original" remove golang
+  workshop_exec --project "$PROJECT/original" remove
   ./main
   workshop_exec --project "$PROJECT/original" launch
   git config --global --add safe.directory "$PROJECT/original"
@@ -26,5 +26,5 @@ execute: |
   git merge hotfix
   git worktree move $PROJECT/hotfix/ $PROJECT/resolved/
   workshop_exec list --global
-  workshop_exec --project "$PROJECT/resolved" remove golang
+  workshop_exec --project "$PROJECT/resolved" remove
   git worktree remove $PROJECT/resolved/

--- a/tests/documentation/how-to-git-worktree/task.yaml
+++ b/tests/documentation/how-to-git-worktree/task.yaml
@@ -8,18 +8,18 @@ execute: |
   git init original
   mv main.go workshop.yaml original/
   cd original/
-  workshop_exec --project "$PROJECT/original" launch golang
+  workshop_exec --project "$PROJECT/original" launch
   git add . && git commit -m "initial commit"
   chown -R ubuntu:ubuntu $PROJECT/original
   workshop_exec --project "$PROJECT/original" exec golang go build -x main.go
   workshop_exec --project "$PROJECT/original" remove golang
   ./main
-  workshop_exec --project "$PROJECT/original" launch golang
+  workshop_exec --project "$PROJECT/original" launch
   git config --global --add safe.directory "$PROJECT/original"
   git worktree add $PROJECT/hotfix
   cd $PROJECT/hotfix/
   sed -i "s/22\.04/20.04/g" workshop.yaml
-  workshop_exec --project "$PROJECT/hotfix" launch golang
+  workshop_exec --project "$PROJECT/hotfix" launch
   sleep 1
   git commit -am "solve problem with hotfix"
   cd $PROJECT/original/

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -15,7 +15,7 @@ execute: |
   workshop_exec --help
 
   # Launch
-  workshop_exec launch nimble
+  workshop_exec launch
 
   # Changes
   workshop_exec changes

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -40,7 +40,7 @@ execute: |
   workshop_exec stop nimble
 
   # Start
-  workshop_exec start nimble
+  workshop_exec start
 
   # Refresh (TODO)
   sed -i "s/22.04/24.04/g" .workshop/nimble.yaml

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -49,8 +49,8 @@ execute: |
 
   # Exec
   workshop_exec exec nimble go build main.go
-  workshop_exec exec nimble --env GO111MODULE=off -w /project/ -- go build -x
-  workshop_exec exec nimble --uid 0 id
+  workshop_exec exec --env GO111MODULE=off -w /project/ nimble go build -x
+  workshop_exec exec --uid 0 nimble id
 
   # Shell (TODO)
   workshop_exec shell nimble

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -53,7 +53,7 @@ execute: |
   workshop_exec exec --uid 0 nimble id
 
   # Shell (TODO)
-  workshop_exec shell nimble
+  workshop_exec shell
 
   # Connections
   workshop_exec connections nimble

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -37,7 +37,7 @@ execute: |
   workshop_exec okay || true
 
   # Stop
-  workshop_exec stop nimble
+  workshop_exec stop
 
   # Start
   workshop_exec start

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -28,7 +28,7 @@ execute: |
   workshop_exec list --global
 
   # Info
-  workshop_exec info nimble
+  workshop_exec info
 
   # Warnings
   workshop_exec warnings

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -71,4 +71,4 @@ execute: |
   workshop_exec remount nimble/test-sdk-go:mod-cache ~/new-cache-mount/
 
   # Remove
-  workshop_exec remove nimble
+  workshop_exec remove

--- a/tests/documentation/ref-workshop-cli/task.yaml
+++ b/tests/documentation/ref-workshop-cli/task.yaml
@@ -44,8 +44,8 @@ execute: |
 
   # Refresh (TODO)
   sed -i "s/22.04/24.04/g" .workshop/nimble.yaml
-  workshop_exec refresh nimble --wait-on-error
-  workshop_exec refresh nimble --abort || workshop_exec refresh nimble --continue || true
+  workshop_exec refresh --wait-on-error
+  workshop_exec refresh --abort || workshop_exec refresh --continue || true
 
   # Exec
   workshop_exec exec nimble go build main.go

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -54,4 +54,4 @@ execute: |
   workshop_exec info
 
   # Remove
-  workshop_exec remove nimble
+  workshop_exec remove

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -21,7 +21,7 @@ execute: |
   workshop_exec tasks $(workshop_exec changes | awk 'END{print $1}')
 
   # Start and stop
-  workshop_exec stop nimble
+  workshop_exec stop
   workshop_exec start
 
   # Refresh

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -28,7 +28,7 @@ execute: |
 
   # Change base
   sed -i "s/22/20/g" workshop.yaml
-  workshop_exec refresh nimble
+  workshop_exec refresh
 
   # Execute commands
   workshop_exec exec nimble go build main.go

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -13,7 +13,7 @@ execute: |
   workshop_exec list
 
   # Launch
-  workshop_exec launch nimble
+  workshop_exec launch
   workshop_exec info nimble
 
   # Changes and tasks after launch

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -32,6 +32,7 @@ execute: |
 
   # Execute commands
   workshop_exec exec nimble go build main.go
+  workshop_exec exec -- go build main.go
 
   # Variable injection
   workshop_exec exec --env GO111MODULE=off nimble -- go build -x

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -22,7 +22,7 @@ execute: |
 
   # Start and stop
   workshop_exec stop nimble
-  workshop_exec start nimble
+  workshop_exec start
 
   # Refresh
 

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -34,16 +34,16 @@ execute: |
   workshop_exec exec nimble go build main.go
 
   # Variable injection
-  workshop_exec exec nimble --env GO111MODULE=off -- go build -x
+  workshop_exec exec --env GO111MODULE=off nimble -- go build -x
 
   # Interactive shell needs a tweak in testing
-  workshop_exec exec nimble -- bash -c "pwd"
-  workshop_exec exec nimble -- bash -c "uname -a"
+  workshop_exec exec nimble bash -c "pwd"
+  workshop_exec exec nimble bash -c "uname -a"
 
   # Changes in project directory
   touch created_outside.txt
-  workshop_exec exec nimble -- [ -f "/project/created_outside.txt" ]
-  workshop_exec exec nimble -- touch /project/created_inside.txt
+  workshop_exec exec nimble [ -f "/project/created_outside.txt" ]
+  workshop_exec exec nimble touch /project/created_inside.txt
   [ -f "created_inside.txt" ]
 
   # Interfaces

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -14,7 +14,7 @@ execute: |
 
   # Launch
   workshop_exec launch
-  workshop_exec info nimble
+  workshop_exec info
 
   # Changes and tasks after launch
   workshop_exec changes
@@ -51,7 +51,7 @@ execute: |
   workshop_exec disconnect nimble/test-sdk-go:mod-cache
   workshop_exec connect nimble/test-sdk-go:mod-cache :mount
   workshop_exec remount nimble/test-sdk-go:mod-cache ~/mod
-  workshop_exec info nimble
+  workshop_exec info
 
   # Remove
   workshop_exec remove nimble

--- a/tests/main/changes/task.yaml
+++ b/tests/main/changes/task.yaml
@@ -7,4 +7,4 @@ execute: |
   echo "The launch change must present in the list"
   workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-changes\" workshop$"
   
-  workshop_exec remove ws-changes
+  workshop_exec remove

--- a/tests/main/changes/task.yaml
+++ b/tests/main/changes/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure the changes command output correctness
 execute: |
   . "$TESTSLIB"/utils.sh
     
-  workshop_exec launch ws-changes
+  workshop_exec launch
 
   echo "The launch change must present in the list"
   workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-changes\" workshop$"

--- a/tests/main/connect/task.yaml
+++ b/tests/main/connect/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-conn
+  workshop_exec remove
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/main/connect/task.yaml
+++ b/tests/main/connect/task.yaml
@@ -24,9 +24,9 @@ execute: |
   workshop_exec connections ws-conn | MATCH "^gpu.+ws-conn/test-sdk-gpu:gpu.+:gpu.+manual$"
 
   echo "Check workshop refresh does not reconnect undesired connections"
-  workshop_exec refresh ws-conn
+  workshop_exec refresh
   workshop_exec disconnect ws-conn/test-sdk-gpu:gpu
-  workshop_exec refresh ws-conn
+  workshop_exec refresh
   workshop_exec connections ws-conn > output.log
   MATCH "^mount.+ws-conn/test-sdk-mount:one.+:mount.+$" < output.log
   MATCH "^mount.+ws-conn/test-sdk-mount:two.+:mount.+$" < output.log

--- a/tests/main/connect/task.yaml
+++ b/tests/main/connect/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that "workshop connect" works as expected
 prepare: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-conn
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-conn

--- a/tests/main/disconnect/task.yaml
+++ b/tests/main/disconnect/task.yaml
@@ -29,5 +29,5 @@ execute: |
 
   echo "Check disconnect --forget (reconnects after refresh)"
   workshop_exec disconnect ws-disconn/test-sdk-mount:one --forget
-  workshop_exec refresh ws-disconn
+  workshop_exec refresh
   workshop_exec connections ws-disconn | MATCH "^mount.+ws-disconn/test-sdk-mount:one.+:mount.+\-$"

--- a/tests/main/disconnect/task.yaml
+++ b/tests/main/disconnect/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that "workshop disconnect" works as expected
 prepare: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-disconn
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-disconn
@@ -18,7 +18,7 @@ execute: |
 
   echo "Check 'workshop remove' does not leave the undesired connections for the workshop (the automatic connections will exist after remove-launch)"
   workshop_exec remove ws-disconn
-  workshop_exec launch ws-disconn
+  workshop_exec launch
   workshop_exec connections ws-disconn | MATCH "^mount.+ws-disconn/test-sdk-mount:one.+:mount.+\-$"
   workshop_exec connections ws-disconn | MATCH "^mount.+ws-disconn/test-sdk-mount:two.+:mount.+\-$"  
 

--- a/tests/main/disconnect/task.yaml
+++ b/tests/main/disconnect/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-disconn
+  workshop_exec remove
 execute: |
   . "$TESTSLIB"/utils.sh
 
@@ -17,7 +17,7 @@ execute: |
   workshop_exec connections ws-disconn | MATCH "^mount.+ws-disconn/test-sdk-mount:two.+-.+\-$"
 
   echo "Check 'workshop remove' does not leave the undesired connections for the workshop (the automatic connections will exist after remove-launch)"
-  workshop_exec remove ws-disconn
+  workshop_exec remove
   workshop_exec launch
   workshop_exec connections ws-disconn | MATCH "^mount.+ws-disconn/test-sdk-mount:one.+:mount.+\-$"
   workshop_exec connections ws-disconn | MATCH "^mount.+ws-disconn/test-sdk-mount:two.+:mount.+\-$"  

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -51,5 +51,5 @@ execute: |
   workshop_exec exec -I ws-exec bash -c '>&2 echo -n stderr' | MATCH stderr
 
   echo "Check stopped workshop"
-  workshop_exec stop ws-exec
+  workshop_exec stop
   workshop_exec exec ws-exec pwd | MATCH '.*cannot exec command in "ws-exec": workshop not running$'

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -10,9 +10,10 @@ execute: |
 
   echo "Check that one -- prevents further argument parsing"
   workshop_exec exec ws-exec echo -e '\x66oo' | MATCH foo
-  workshop_exec exec -- ws-exec echo -e '\x66oo' | MATCH foo
+  workshop_exec exec -- echo -e '\x66oo' | MATCH foo
   workshop_exec exec ws-exec -- echo -e '\x66oo' | MATCH foo
   workshop_exec exec ws-exec echo -- -e '\x66oo' | MATCH foo
+  workshop_exec exec -- echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
   workshop_exec exec ws-exec -- echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
 
   echo "Check an environment variable can be set"
@@ -20,16 +21,16 @@ execute: |
 
   echo "Check that environment variables are inherited"
   sudo -u ubuntu 2>&1 -- env Foo=bar workshop exec --env Foo ws-exec bash -c '[ "$Foo" = bar ]'
-  sudo -u ubuntu 2>&1 -- env Foo= workshop exec --env Foo ws-exec bash -c '[ -z "${Foo-x}" ]'
+  sudo -u ubuntu 2>&1 -- env Foo= workshop exec --env Foo -- bash -c '[ -z "${Foo-x}" ]'
   sudo -u ubuntu 2>&1 -- env --unset=Foo workshop exec --env Foo ws-exec bash -c '[ -z "${Foo+x}" ]'
 
   echo "Check default user and group"
-  workshop_exec exec ws-exec bash -c 'id -u -n' | MATCH workshop
+  workshop_exec exec -- bash -c 'id -u -n' | MATCH workshop
   workshop_exec exec ws-exec bash -c 'id -g -n' | MATCH workshop
 
   echo "Check working directory setup"
   workshop_exec exec ws-exec pwd | MATCH '/project'
-  workshop_exec exec -w /home/workshop ws-exec pwd | MATCH '/home/workshop'
+  workshop_exec exec -w /home/workshop -- pwd | MATCH '/home/workshop'
 
   echo "Check enforce non-interactive mode"
   workshop_exec exec -I ws-exec bash -c '[[ -t 1 ]] || echo -n nonterminal' | MATCH nonterminal
@@ -45,7 +46,7 @@ execute: |
   #workshop_exec exec --interactive ws-exec bash -c 'echo -n terminal' | MATCH terminal
 
   echo "Check timeout"
-  workshop_exec exec --timeout 1s ws-exec bash -c 'sleep 5' | MATCH ".*timed out after 1s.*"
+  workshop_exec exec --timeout 1s -- sleep 5 | MATCH ".*timed out after 1s.*"
 
   echo "Check stderr (workshop exec redirects stderr to stdout for MATCH to work)"
   workshop_exec exec -I ws-exec bash -c '>&2 echo -n stderr' | MATCH stderr

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -1,7 +1,7 @@
 summary: Check major workshop exec scenarios
 prepare: |  
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-exec
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-exec

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-exec
+  workshop_exec remove
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -8,24 +8,31 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
+  echo "Check that one -- prevents further argument parsing"
+  workshop_exec exec ws-exec echo -e '\x66oo' | MATCH foo
+  workshop_exec exec -- ws-exec echo -e '\x66oo' | MATCH foo
+  workshop_exec exec ws-exec -- echo -e '\x66oo' | MATCH foo
+  workshop_exec exec ws-exec echo -- -e '\x66oo' | MATCH foo
+  workshop_exec exec ws-exec -- echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
+
   echo "Check an environment variable can be set"
-  workshop_exec exec --env 'Foo=bar'  ws-exec -- bash -c '[ "$Foo" = bar ]'
+  workshop_exec exec --env 'Foo=bar' ws-exec bash -c '[ "$Foo" = bar ]'
 
   echo "Check that environment variables are inherited"
-  sudo -u ubuntu 2>&1 -- env Foo=bar workshop exec --env Foo ws-exec -- bash -c '[ "$Foo" = bar ]'
-  sudo -u ubuntu 2>&1 -- env Foo= workshop exec --env Foo ws-exec -- bash -c '[ -z "${Foo-x}" ]'
-  sudo -u ubuntu 2>&1 -- env --unset=Foo workshop exec --env Foo ws-exec -- bash -c '[ -z "${Foo+x}" ]'
+  sudo -u ubuntu 2>&1 -- env Foo=bar workshop exec --env Foo ws-exec bash -c '[ "$Foo" = bar ]'
+  sudo -u ubuntu 2>&1 -- env Foo= workshop exec --env Foo ws-exec bash -c '[ -z "${Foo-x}" ]'
+  sudo -u ubuntu 2>&1 -- env --unset=Foo workshop exec --env Foo ws-exec bash -c '[ -z "${Foo+x}" ]'
 
   echo "Check default user and group"
-  workshop_exec exec ws-exec -- bash -c 'id -u -n' | MATCH workshop
-  workshop_exec exec ws-exec -- bash -c 'id -g -n' | MATCH workshop
+  workshop_exec exec ws-exec bash -c 'id -u -n' | MATCH workshop
+  workshop_exec exec ws-exec bash -c 'id -g -n' | MATCH workshop
 
   echo "Check working directory setup"
-  workshop_exec exec ws-exec -- pwd | MATCH '/project'
-  workshop_exec exec -w /home/workshop ws-exec -- pwd | MATCH '/home/workshop'
+  workshop_exec exec ws-exec pwd | MATCH '/project'
+  workshop_exec exec -w /home/workshop ws-exec pwd | MATCH '/home/workshop'
 
   echo "Check enforce non-interactive mode"
-  workshop_exec exec -I ws-exec -- bash -c '[[ -t 1 ]] || echo -n nonterminal' | MATCH nonterminal
+  workshop_exec exec -I ws-exec bash -c '[[ -t 1 ]] || echo -n nonterminal' | MATCH nonterminal
 
   #FIXME: this works in a terminal but not under spread This is due to the
   #websocket client implementation that closes the connection when a reader from
@@ -35,13 +42,13 @@ execute: |
   #by the time already (note: it is only relevant for the interactive sessions
   #where one websocket used for in/out)
   #echo "Check enforce interactive mode"
-  #workshop_exec exec --interactive ws-exec -- bash -c 'echo -n terminal' | MATCH terminal
+  #workshop_exec exec --interactive ws-exec bash -c 'echo -n terminal' | MATCH terminal
 
   echo "Check timeout"
-  workshop_exec exec --timeout 1s ws-exec -- bash -c 'sleep 5' | MATCH ".*timed out after 1s.*"
+  workshop_exec exec --timeout 1s ws-exec bash -c 'sleep 5' | MATCH ".*timed out after 1s.*"
 
   echo "Check stderr (workshop exec redirects stderr to stdout for MATCH to work)"
-  workshop_exec exec -I ws-exec -- bash -c '>&2 echo -n stderr' | MATCH stderr
+  workshop_exec exec -I ws-exec bash -c '>&2 echo -n stderr' | MATCH stderr
 
   echo "Check stopped workshop"
   workshop_exec stop ws-exec

--- a/tests/main/info-sdk-health/health.exp
+++ b/tests/main/info-sdk-health/health.exp
@@ -3,7 +3,7 @@
 set success 0 
 
 while {1} {
-    spawn workshop info ws-sdk-health
+    spawn workshop info
     set result [wait]
     expect {
         -re "message:\[ \]*Cannot finish health check" {

--- a/tests/main/info-sdk-health/task.yaml
+++ b/tests/main/info-sdk-health/task.yaml
@@ -8,6 +8,6 @@ restore: |
   apt remove -y expect
 execute: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-sdk-health --no-wait
+  workshop_exec launch --no-wait
   sudo -u ubuntu 2>&1 -- expect -f ./health.exp
   workshop_exec remove ws-sdk-health

--- a/tests/main/info-sdk-health/task.yaml
+++ b/tests/main/info-sdk-health/task.yaml
@@ -10,4 +10,4 @@ execute: |
   . "$TESTSLIB"/utils.sh
   workshop_exec launch --no-wait
   sudo -u ubuntu 2>&1 -- expect -f ./health.exp
-  workshop_exec remove ws-sdk-health
+  workshop_exec remove

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -17,13 +17,13 @@ execute: |
   workshop_exec --project "$PROJECT" list
   test -f "$PROJECT"/.workshop.lock
 
-  workshop_exec remove --project "$PROJECT" ws
+  workshop_exec remove --project "$PROJECT"
   
   echo "Check recreating project dir with the same name does not cause conflicts"
   mkdir -p ./new-project
   cp -r "$PROJECT"/.workshop ./new-project/
   workshop_exec launch --project $(pwd)/new-project
-  workshop_exec remove --project $(pwd)/new-project ws
+  workshop_exec remove --project $(pwd)/new-project
   rm -rf ./new-project
   mkdir -p ./new-project
   cp -r "$PROJECT"/.workshop ./new-project/

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -10,7 +10,7 @@ execute: |
   
   PROJECT=$(pwd)/project
 
-  workshop_exec --project "$PROJECT" launch ws
+  workshop_exec --project "$PROJECT" launch
 
   echo "Check recover .lock file if removed for an existing project"
   rm -f "$PROJECT"/.workshop.lock
@@ -22,12 +22,12 @@ execute: |
   echo "Check recreating project dir with the same name does not cause conflicts"
   mkdir -p ./new-project
   cp -r "$PROJECT"/.workshop ./new-project/
-  workshop_exec launch --project $(pwd)/new-project ws
+  workshop_exec launch --project $(pwd)/new-project
   workshop_exec remove --project $(pwd)/new-project ws
   rm -rf ./new-project
   mkdir -p ./new-project
   cp -r "$PROJECT"/.workshop ./new-project/
-  workshop_exec launch --project $(pwd)/new-project/  ws
+  workshop_exec launch --project $(pwd)/new-project/
   workshop_exec list --project $(pwd)/new-project | MATCH "^$(pwd)/new-project[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
 
   echo "Check for warnings when workshop files conflict"

--- a/tests/main/interface-camera/task.yaml
+++ b/tests/main/interface-camera/task.yaml
@@ -30,26 +30,26 @@ execute: |
     }
     detect_device
 
-    workshop_exec exec ws-camera -- test ! -e "$device_node"
+    workshop_exec exec ws-camera test ! -e "$device_node"
     workshop_exec connect ws-camera/test-sdk-camera:camera
-    workshop_exec exec ws-camera -- test -e "$device_node"
+    workshop_exec exec ws-camera test -e "$device_node"
 
     echo "Ensure video devices can be hotplugged"
     rmmod v4l2loopback
     # this check could fail if another device is immediately plugged in,
     # but within a VM this should be unlikely/impossible
-    workshop_exec exec ws-camera -- test ! -e "$device_node"
+    workshop_exec exec ws-camera test ! -e "$device_node"
 
     modprobe v4l2loopback card_label=v4l2loopback
     detect_device
-    workshop_exec exec ws-camera -- test -e "$device_node"
+    workshop_exec exec ws-camera test -e "$device_node"
 
     echo "Ensure workshop user can access video devices"
-    workshop_exec exec ws-camera -- test -r "$device_node"
-    workshop_exec exec ws-camera -- test -w "$device_node"
+    workshop_exec exec ws-camera test -r "$device_node"
+    workshop_exec exec ws-camera test -w "$device_node"
 
     workshop_exec disconnect ws-camera/test-sdk-camera:camera
-    workshop_exec exec ws-camera -- test ! -e "$device_node"
+    workshop_exec exec ws-camera test ! -e "$device_node"
   fi
 
   echo "Check a user cannot install a camera slot (violates slot declaration)"

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -24,7 +24,7 @@ execute: |
   workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
 
   echo "Check that the expected environment is configured inside the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -n "$WAYLAND_DISPLAY" ]
       [ -n "$QT_QPA_PLATFORM" ]
@@ -33,7 +33,7 @@ execute: |
   EOF
 
   echo "Check that the required mounts are configured inside the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -S "/run/user/1000/${WAYLAND_DISPLAY}" ]
   EOF
@@ -42,7 +42,7 @@ execute: |
   workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
 
   echo "Check that the environment is removed from the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -z "$WAYLAND_DISPLAY" ]
       [ -z "$QT_QPA_PLATFORM" ]
@@ -56,14 +56,14 @@ execute: |
   workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
 
   echo "Check that the expected environment is configured inside the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -n "$DISPLAY" ]
       [ -n "$XAUTHORITY" ]
   EOF
 
   echo "Check that the required mounts are configured inside the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
       [ -f "${XAUTHORITY}" ]
@@ -72,7 +72,7 @@ execute: |
   echo "Check that the required mounts are present after restart"
   workshop_exec stop ws-desktop
   workshop_exec start ws-desktop
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
       [ -f "${XAUTHORITY}" ]
@@ -82,14 +82,14 @@ execute: |
   workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
 
   echo "Check that the expected environment is removed from the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -z "$DISPLAY" ]
       [ -z "$XAUTHORITY" ]
   EOF
 
   echo "Check that the required mounts are removed from the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ ! -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
       [ ! -f "${XAUTHORITY}" ]
@@ -100,14 +100,14 @@ execute: |
   workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
 
   echo "Check that the expected environment is configured inside the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ "$DISPLAY" == ":1" ]
       [ -n "$XAUTHORITY" ]
   EOF
 
   echo "Check that the required mounts are configured inside the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
       [ -f "${XAUTHORITY}" ]
@@ -123,14 +123,14 @@ execute: |
   [ -z "$(workshop_exec connections --all)" ]
 
   echo "Check that the expected environment is removed from the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ -z "$DISPLAY" ]
       [ -z "$XAUTHORITY" ]
   EOF
 
   echo "Check that the required mounts are removed from the workshop"
-  workshop_exec exec ws-desktop -- sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
       [ ! -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
       [ ! -f "${XAUTHORITY}" ]

--- a/tests/main/interface-mount/task.yaml
+++ b/tests/main/interface-mount/task.yaml
@@ -1,6 +1,6 @@
 summary: Check mount interface scenarios
 restore: |
-  workshop_exec remove ws-mount || true
+  workshop_exec remove || true
 execute: |
   . "$TESTSLIB"/utils.sh
     
@@ -43,6 +43,6 @@ execute: |
   workshop_exec exec ws-mount bash -c "! mountpoint -q /etc/cron.weekly && ! test -f /etc/cron.weekly/job.sh"
 
   echo "Check remove will also clean up the default mount interface default locations"
-  workshop_exec remove ws-mount
+  workshop_exec remove
   test ! -d "$source_one"
   test ! -d "$source_two"

--- a/tests/main/interface-mount/task.yaml
+++ b/tests/main/interface-mount/task.yaml
@@ -10,7 +10,7 @@ execute: |
   }
 
   echo "Check the mount interface plug can be installed and auto-connected"
-  workshop_exec launch ws-mount
+  workshop_exec launch
 
   project_id=$(cat .workshop.lock)
   source_one="/home/ubuntu/.local/share/workshop/project/"$project_id"/mount/ws-mount_test-sdk-mount_one.sdk"

--- a/tests/main/interface-mount/task.yaml
+++ b/tests/main/interface-mount/task.yaml
@@ -18,12 +18,12 @@ execute: |
   validate_host_mounts
 
   echo "Check the mount interface plugs auto-reconnected after refresh"
-  workshop_exec refresh ws-mount
+  workshop_exec refresh
   validate_host_mounts
 
   echo "Check the mount interface plugs auto-reconnected if refresh fails"
   sed -i 's/test-sdk-mount/test-sdk-setup-fail/g' workshop.yaml
-  workshop_exec refresh ws-mount || true
+  workshop_exec refresh || true
   sed -i 's/test-sdk-setup-fail/test-sdk-mount/g' workshop.yaml
   validate_host_mounts
 

--- a/tests/main/interface-mount/task.yaml
+++ b/tests/main/interface-mount/task.yaml
@@ -6,7 +6,7 @@ execute: |
     
   function validate_host_mounts() {
     test -d "$source_one" && test -d "$source_two"    
-    workshop_exec exec ws-mount bash -c "mountpoint -q /mnt/one && mountpoint -q /opt/two"
+    workshop_exec exec -- bash -c "mountpoint -q /mnt/one && mountpoint -q /opt/two"
   }
 
   echo "Check the mount interface plug can be installed and auto-connected"
@@ -29,7 +29,7 @@ execute: |
 
   echo "Check manual connect/disconnect works"
   workshop_exec disconnect ws-mount/test-sdk-mount:one
-  workshop_exec exec ws-mount bash -c "! mountpoint -q /mnt/one"
+  workshop_exec exec -- bash -c "! mountpoint -q /mnt/one"
 
   workshop_exec connect ws-mount/test-sdk-mount:one :mount
   workshop_exec connections ws-mount | MATCH "^mount.+ws-mount/test-sdk-mount:one.+:mount.+manual$"
@@ -37,10 +37,10 @@ execute: |
 
   echo "Check workshop to workshop bind mount"
   workshop_exec connections ws-mount | MATCH "^mount.+ws-mount/test-sdk-mount:jobs.+:jobs.+-$"
-  workshop_exec exec ws-mount bash -c "mountpoint -q /etc/cron.weekly && test -f /etc/cron.weekly/job.sh"
+  workshop_exec exec -- bash -c "mountpoint -q /etc/cron.weekly && test -f /etc/cron.weekly/job.sh"
   workshop_exec disconnect ws-mount/test-sdk-mount:jobs
   workshop_exec connections ws-mount | MATCH "^mount.+ws-mount/test-sdk-mount:jobs.+-.+-$"
-  workshop_exec exec ws-mount bash -c "! mountpoint -q /etc/cron.weekly && ! test -f /etc/cron.weekly/job.sh"
+  workshop_exec exec -- bash -c "! mountpoint -q /etc/cron.weekly && ! test -f /etc/cron.weekly/job.sh"
 
   echo "Check remove will also clean up the default mount interface default locations"
   workshop_exec remove

--- a/tests/main/interface-mount/task.yaml
+++ b/tests/main/interface-mount/task.yaml
@@ -6,7 +6,7 @@ execute: |
     
   function validate_host_mounts() {
     test -d "$source_one" && test -d "$source_two"    
-    workshop_exec exec ws-mount -- bash -c "mountpoint -q /mnt/one && mountpoint -q /opt/two"
+    workshop_exec exec ws-mount bash -c "mountpoint -q /mnt/one && mountpoint -q /opt/two"
   }
 
   echo "Check the mount interface plug can be installed and auto-connected"
@@ -29,7 +29,7 @@ execute: |
 
   echo "Check manual connect/disconnect works"
   workshop_exec disconnect ws-mount/test-sdk-mount:one
-  workshop_exec exec ws-mount -- bash -c "! mountpoint -q /mnt/one"
+  workshop_exec exec ws-mount bash -c "! mountpoint -q /mnt/one"
 
   workshop_exec connect ws-mount/test-sdk-mount:one :mount
   workshop_exec connections ws-mount | MATCH "^mount.+ws-mount/test-sdk-mount:one.+:mount.+manual$"
@@ -37,10 +37,10 @@ execute: |
 
   echo "Check workshop to workshop bind mount"
   workshop_exec connections ws-mount | MATCH "^mount.+ws-mount/test-sdk-mount:jobs.+:jobs.+-$"
-  workshop_exec exec ws-mount -- bash -c "mountpoint -q /etc/cron.weekly && test -f /etc/cron.weekly/job.sh"
+  workshop_exec exec ws-mount bash -c "mountpoint -q /etc/cron.weekly && test -f /etc/cron.weekly/job.sh"
   workshop_exec disconnect ws-mount/test-sdk-mount:jobs
   workshop_exec connections ws-mount | MATCH "^mount.+ws-mount/test-sdk-mount:jobs.+-.+-$"
-  workshop_exec exec ws-mount -- bash -c "! mountpoint -q /etc/cron.weekly && ! test -f /etc/cron.weekly/job.sh"
+  workshop_exec exec ws-mount bash -c "! mountpoint -q /etc/cron.weekly && ! test -f /etc/cron.weekly/job.sh"
 
   echo "Check remove will also clean up the default mount interface default locations"
   workshop_exec remove ws-mount

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -12,7 +12,7 @@ execute: |
     MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -                            bind.6" < conns.log
   }
 
-  workshop_exec launch ws-bind
+  workshop_exec launch
 
   echo "Check binding on launch"
   workshop_exec connections ws-bind > conns.log

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -19,7 +19,7 @@ execute: |
   check_original_binding
 
   echo "Check bound content plugs use host directories of the plug they are bound to"  
-  workshop_exec info ws-bind | grep -v notes > mounts.log
+  workshop_exec info | grep -v notes > mounts.log
   yq '.content["test-sdk-multiple-plugs"].mounts["data"]' < mounts.log | MATCH "^host-source:.*ws-bind_test-sdk-mount_one.sdk" 
   yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*ws-bind_test-sdk-multiple-plugs_cache.sdk" 
 
@@ -38,7 +38,7 @@ execute: |
   echo "Check remount affects all bound plugs"
   new_source="/home/ubuntu/remount-bound-test"
   workshop_exec remount ws-bind/test-sdk-mount:two "$new_source"
-  workshop_exec info ws-bind | grep -v notes > mounts.log
+  workshop_exec info | grep -v notes > mounts.log
   yq '.content["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host-source:.*$new_source" 
   yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*$new_source" 
 
@@ -53,6 +53,6 @@ execute: |
   workshop_exec connections ws-bind > conns.log
   MATCH "mount      ws-bind/test-sdk-mount:two                 :mount                       -" < conns.log
   MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      :mount                       -" < conns.log  
-  workshop_exec info ws-bind | grep -v notes > mounts.log
+  workshop_exec info | grep -v notes > mounts.log
   yq '.content["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host-source:.*$new_source" 
   yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*ws-bind_test-sdk-mount_two.sdk"

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -43,13 +43,13 @@ execute: |
   yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*$new_source" 
 
   echo "Check refresh respects binding"
-  workshop_exec refresh ws-bind
+  workshop_exec refresh
   workshop_exec connections ws-bind > conns.log
   check_original_binding
 
   echo "Check a plug maybe unbound"
   cat workshop.yaml | yq '.sdks["test-sdk-mount"].plugs = ~' | sponge workshop.yaml
-  workshop_exec refresh ws-bind
+  workshop_exec refresh
   workshop_exec connections ws-bind > conns.log
   MATCH "mount      ws-bind/test-sdk-mount:two                 :mount                       -" < conns.log
   MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      :mount                       -" < conns.log  

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -7,7 +7,7 @@ execute: |
   workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-basic[[:space:]]*Ready[[:space:]]*-"
   
   # Ensure there is one installed SDK that was provided in the workshop definition
-  workshop_exec info ws-basic | grep -v notes | yq ".content | length == 1"
-  workshop_exec info ws-basic | grep -v notes | yq '.content["test-sdk-basic"].channel' | MATCH "latest/stable"
+  workshop_exec info | grep -v notes | yq ".content | length == 1"
+  workshop_exec info | grep -v notes | yq '.content["test-sdk-basic"].channel' | MATCH "latest/stable"
 
   workshop_exec remove ws-basic

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -10,4 +10,4 @@ execute: |
   workshop_exec info | grep -v notes | yq ".content | length == 1"
   workshop_exec info | grep -v notes | yq '.content["test-sdk-basic"].channel' | MATCH "latest/stable"
 
-  workshop_exec remove ws-basic
+  workshop_exec remove

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -3,7 +3,7 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Check workshop can be launched with a basic SDK"
-  workshop_exec launch ws-basic
+  workshop_exec launch
   workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-basic[[:space:]]*Ready[[:space:]]*-"
   
   # Ensure there is one installed SDK that was provided in the workshop definition

--- a/tests/main/launch/task.yaml
+++ b/tests/main/launch/task.yaml
@@ -8,9 +8,9 @@ execute: |
     workshop_exec launch "$1"
     workshop_exec list | MATCH "$(pwd)[[:space:]]*$1[[:space:]]*Ready[[:space:]]*-"
     # ensure the workshop has a socket for workshopctl
-    workshop_exec exec "$1" -- test -S /var/lib/workshop/run/workshop.socket.untrusted
+    workshop_exec exec "$1" test -S /var/lib/workshop/run/workshop.socket.untrusted
     # ensure the apt cache is mounted
-    workshop_exec exec "$1" -- mountpoint /var/cache/apt/archives
+    workshop_exec exec "$1" mountpoint /var/cache/apt/archives
     workshop_exec remove "$1"
   }
   

--- a/tests/main/list-global/task.yaml
+++ b/tests/main/list-global/task.yaml
@@ -32,5 +32,5 @@ execute: |
   rm -rf project-2-copy
   workshop_exec list --global | MATCH "^$projects/project-2-copy[[:space:]]+ws-global[[:space:]]+Error[[:space:]]+missing-project$"
 
-  workshop_exec --project "$projects"/project-1 remove ws-global
-  workshop_exec --project "$projects"/project-2 remove ws-global
+  workshop_exec --project "$projects"/project-1 remove
+  workshop_exec --project "$projects"/project-2 remove

--- a/tests/main/list-global/task.yaml
+++ b/tests/main/list-global/task.yaml
@@ -13,8 +13,8 @@ execute: |
   
   projects=$(pwd)
   
-  workshop_exec --project "$projects"/project-1 launch ws-global
-  workshop_exec --project "$projects"/project-2 launch ws-global
+  workshop_exec --project "$projects"/project-1 launch
+  workshop_exec --project "$projects"/project-2 launch
   
   echo "(1) make sure every required workshop present in the global list output"
   workshop_exec list --global | MATCH "^$projects/project-1[[:space:]]+ws-global[[:space:]]+Ready[[:space:]]+-$"
@@ -28,7 +28,7 @@ execute: |
   
   echo "(3) delete a directory and validate it has a correct state in the output"
   cp -R project-2 project-2-copy
-  workshop_exec --project $projects/project-2-copy launch ws-global
+  workshop_exec --project $projects/project-2-copy launch
   rm -rf project-2-copy
   workshop_exec list --global | MATCH "^$projects/project-2-copy[[:space:]]+ws-global[[:space:]]+Error[[:space:]]+missing-project$"
 

--- a/tests/main/list/task.yaml
+++ b/tests/main/list/task.yaml
@@ -47,15 +47,15 @@ execute: |
   # launch from a new directory successfully
   workshop_exec --project "$PROJECT"-copy launch
   workshop_exec --project "$PROJECT"-copy list | MATCH "^${PROJECT}-copy[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
-  workshop_exec --project "$PROJECT" remove ws-list
-  workshop_exec --project "$PROJECT"-copy remove ws-list
+  workshop_exec --project "$PROJECT" remove
+  workshop_exec --project "$PROJECT"-copy remove
 
   echo "List should respect project-level workshop definitions"
   mv "$PROJECT"-copy/.workshop/ws-list.yaml "$PROJECT"-copy/workshop.yaml
   workshop_exec --project "$PROJECT"-copy list | MATCH "^$PROJECT-copy[[:space:]]+ws-list[[:space:]]+Off[[:space:]]+-$"
   workshop_exec --project "$PROJECT"-copy launch
   workshop_exec --project "$PROJECT"-copy list | MATCH "^${PROJECT}-copy[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
-  workshop_exec --project "$PROJECT"-copy remove ws-list
+  workshop_exec --project "$PROJECT"-copy remove
 
   # TODO:
   # mv dir dir-1

--- a/tests/main/list/task.yaml
+++ b/tests/main/list/task.yaml
@@ -16,7 +16,7 @@ execute: |
   . "$TESTSLIB"/utils.sh
   PROJECT=$(pwd)
   
-  workshop_exec --project "$PROJECT" launch ws-list
+  workshop_exec --project "$PROJECT" launch
   test -f "$PROJECT"/.workshop.lock
 
   echo "workshop list from a nested directory must work similarly as if ran from a project directory"
@@ -45,7 +45,7 @@ execute: |
 
   mv "$PROJECT"-new "$PROJECT"
   # launch from a new directory successfully
-  workshop_exec --project "$PROJECT"-copy launch ws-list
+  workshop_exec --project "$PROJECT"-copy launch
   workshop_exec --project "$PROJECT"-copy list | MATCH "^${PROJECT}-copy[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
   workshop_exec --project "$PROJECT" remove ws-list
   workshop_exec --project "$PROJECT"-copy remove ws-list
@@ -53,7 +53,7 @@ execute: |
   echo "List should respect project-level workshop definitions"
   mv "$PROJECT"-copy/.workshop/ws-list.yaml "$PROJECT"-copy/workshop.yaml
   workshop_exec --project "$PROJECT"-copy list | MATCH "^$PROJECT-copy[[:space:]]+ws-list[[:space:]]+Off[[:space:]]+-$"
-  workshop_exec --project "$PROJECT"-copy launch ws-list
+  workshop_exec --project "$PROJECT"-copy launch
   workshop_exec --project "$PROJECT"-copy list | MATCH "^${PROJECT}-copy[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
   workshop_exec --project "$PROJECT"-copy remove ws-list
 

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-refresh-abort
+  workshop_exec remove
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -10,12 +10,12 @@ execute: |
 
   echo "Update the workshop file to include a failing SDK"
   sed -i 's/test-sdk-basic/test-sdk-setup-fail/g' workshop.yaml
-  workshop_exec refresh --wait-on-error ws-refresh-abort || true
+  workshop_exec refresh --wait-on-error || true
   sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' workshop.yaml
 
   echo "Check the workshop is in Pending state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-abort[[:space:]]+Pending[[:space:]]+wait-on-error$"
 
   echo "Check the workshop refresh --abort reverts to the previous state"
-  workshop_exec refresh --abort ws-refresh-abort | MATCH "\"ws-refresh-abort\" refresh aborted"
+  workshop_exec refresh --abort | MATCH "\"ws-refresh-abort\" refresh aborted"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-abort[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -1,7 +1,7 @@
 summary: Check a failed non-transactional refresh can be aborted successfully
 prepare: |  
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-refresh-abort
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-refresh-abort

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -10,7 +10,7 @@ execute: |
 
   echo "Update the workshop file to include a failing SDK"
   sed -i 's/test-sdk-basic/test-sdk-setup-fail/g' workshop.yaml
-  workshop_exec refresh --wait-on-error ws-refresh-cont || true
+  workshop_exec refresh --wait-on-error || true
   sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' workshop.yaml
 
   echo "Check the workshop is in Pending state"
@@ -20,7 +20,7 @@ execute: |
   workshop_exec exec --uid 0 --gid 0 ws-refresh-cont sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
 
   echo "Check the workshop refresh --continue reverts to the previous state"
-  workshop_exec refresh --continue ws-refresh-cont | MATCH "\"ws-refresh-cont\" refreshed"
+  workshop_exec refresh --continue | MATCH "\"ws-refresh-cont\" refreshed"
 
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-cont[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -1,7 +1,7 @@
 summary: Check a failed refresh can be fixed and continued successfully
 prepare: |  
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-refresh-cont
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-refresh-cont

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -17,7 +17,7 @@ execute: |
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-cont[[:space:]]+Pending[[:space:]]+wait-on-error$"
 
   echo "\"Fix\" the SDK error by replacing the setup-base hook"
-  workshop_exec exec --uid 0 --gid 0 ws-refresh-cont sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
+  workshop_exec exec --uid 0 --gid 0 -- sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
 
   echo "Check the workshop refresh --continue reverts to the previous state"
   workshop_exec refresh --continue | MATCH "\"ws-refresh-cont\" refreshed"

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -17,7 +17,7 @@ execute: |
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-cont[[:space:]]+Pending[[:space:]]+wait-on-error$"
 
   echo "\"Fix\" the SDK error by replacing the setup-base hook"
-  workshop_exec exec --uid 0 --gid 0 ws-refresh-cont -- sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
+  workshop_exec exec --uid 0 --gid 0 ws-refresh-cont sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
 
   echo "Check the workshop refresh --continue reverts to the previous state"
   workshop_exec refresh --continue ws-refresh-cont | MATCH "\"ws-refresh-cont\" refreshed"

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-refresh-cont
+  workshop_exec remove
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -15,7 +15,7 @@ execute: |
   workshop_exec exec ws-refresh sudo touch /var/cache/apt/archives/sentinel
 
   echo "Check refresh supports project-level workshop definitions"
-  workshop_exec refresh ws-refresh
+  workshop_exec refresh
 
   echo "Check apt cache is preserved across refreshes"
   workshop_exec exec ws-refresh mountpoint /var/cache/apt/archives

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -5,7 +5,7 @@ prepare: |
   workshop_exec launch ws-refresh ws-refresh-sdk --project multi
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-refresh --project single
+  workshop_exec remove --project single
   workshop_exec remove ws-refresh ws-refresh-sdk --project multi
 execute: |
   . "$TESTSLIB"/utils.sh

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -12,14 +12,14 @@ execute: |
 
   echo "Modify apt cache for later"
   cd single
-  workshop_exec exec ws-refresh -- sudo touch /var/cache/apt/archives/sentinel
+  workshop_exec exec ws-refresh sudo touch /var/cache/apt/archives/sentinel
 
   echo "Check refresh supports project-level workshop definitions"
   workshop_exec refresh ws-refresh
 
   echo "Check apt cache is preserved across refreshes"
-  workshop_exec exec ws-refresh -- mountpoint /var/cache/apt/archives
-  workshop_exec exec ws-refresh -- sudo test -f /var/cache/apt/archives/sentinel
+  workshop_exec exec ws-refresh mountpoint /var/cache/apt/archives
+  workshop_exec exec ws-refresh sudo test -f /var/cache/apt/archives/sentinel
 
   echo "Check refresh supports multi-workshop projects"
   cd ../multi

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that basic refresh scenarios work correctly for the transactional mode
 prepare: |  
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-refresh --project single
+  workshop_exec launch --project single
   workshop_exec launch ws-refresh ws-refresh-sdk --project multi
 restore: |
   . "$TESTSLIB"/utils.sh

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -12,14 +12,14 @@ execute: |
 
   echo "Modify apt cache for later"
   cd single
-  workshop_exec exec ws-refresh sudo touch /var/cache/apt/archives/sentinel
+  workshop_exec exec -- sudo touch /var/cache/apt/archives/sentinel
 
   echo "Check refresh supports project-level workshop definitions"
   workshop_exec refresh
 
   echo "Check apt cache is preserved across refreshes"
-  workshop_exec exec ws-refresh mountpoint /var/cache/apt/archives
-  workshop_exec exec ws-refresh sudo test -f /var/cache/apt/archives/sentinel
+  workshop_exec exec -- mountpoint /var/cache/apt/archives
+  workshop_exec exec -- sudo test -f /var/cache/apt/archives/sentinel
 
   echo "Check refresh supports multi-workshop projects"
   cd ../multi

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -28,7 +28,7 @@ execute: |
   workshop_exec stop ws-remount
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source"
   workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
-  workshop_exec start ws-remount
+  workshop_exec start
   workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
   test -d "$new_source"
 

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -63,6 +63,6 @@ execute: |
   workshop_exec warnings | MATCH '^No further warnings.$'
 
   echo "Remount: workshop remove does not delete remounted dirs"
-  workshop_exec remove ws-remount
+  workshop_exec remove
   test -d "/home/ubuntu/one"
   test -d "/home/ubuntu/two"

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -7,7 +7,7 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  workshop_exec launch ws-remount  
+  workshop_exec launch
   echo "Remount: the new source is empty or does not exist"
   new_source="/home/ubuntu/one"
   workshop_exec remount ws-remount/test-sdk-mount:one "$new_source"

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -25,7 +25,7 @@ execute: |
 
   echo "Remount: workshop stopped"
   new_source="/home/ubuntu/two"
-  workshop_exec stop ws-remount
+  workshop_exec stop
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source"
   workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
   workshop_exec start
@@ -39,7 +39,7 @@ execute: |
   mount --bind "$otherfs" /home/ubuntu/other-fs
   mkdir "$otherfs_path"
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path" | MATCH '.*(sources "/home/ubuntu/two" and "/home/ubuntu/other-fs/new" are not on the same mounted filesystem; workshop must be stopped to remount safely)'
-  workshop_exec stop ws-remount
+  workshop_exec stop
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path"
   workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$otherfs_path"
 

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -14,11 +14,11 @@ execute: |
   test -d "$new_source"
 
   echo "Remount: check workshop info output"
-  workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
+  workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
 
   echo "Remount: plugs remount sources are preserved after refresh"
   workshop_exec refresh
-  workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
+  workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
 
   echo "Remount: the new source is not empty"  
   workshop_exec remount ws-remount/test-sdk-mount:one /home/ubuntu  | MATCH '.*(source "/home/ubuntu" is not empty; workshop must be stopped to remount safely)'
@@ -27,9 +27,9 @@ execute: |
   new_source="/home/ubuntu/two"
   workshop_exec stop ws-remount
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source"
-  workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
+  workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
   workshop_exec start ws-remount
-  workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
+  workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
   test -d "$new_source"
 
   echo "Remount: new source is on a different filesystem"
@@ -41,7 +41,7 @@ execute: |
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path" | MATCH '.*(sources "/home/ubuntu/two" and "/home/ubuntu/other-fs/new" are not on the same mounted filesystem; workshop must be stopped to remount safely)'
   workshop_exec stop ws-remount
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path"
-  workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$otherfs_path"
+  workshop_exec info | grep -v notes | yq '.content["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$otherfs_path"
 
   echo "Remount: old source removed"
   workshop_exec remount ws-remount/test-sdk-mount:two "${new_source}.1"

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -17,7 +17,7 @@ execute: |
   workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
 
   echo "Remount: plugs remount sources are preserved after refresh"
-  workshop_exec refresh ws-remount
+  workshop_exec refresh
   workshop_exec info ws-remount | grep -v notes | yq '.content["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
 
   echo "Remount: the new source is not empty"  

--- a/tests/main/remove-snap/task.yaml
+++ b/tests/main/remove-snap/task.yaml
@@ -13,7 +13,7 @@ execute: |
   workshop_exec launch --project $(pwd)/project-2 ws-snap-remove-2 ws-snap-remove-2a
 
   echo "Modify apt cache for later"
-  workshop_exec exec --project $(pwd)/project-1 ws-snap-remove-1 -- sudo touch /var/cache/apt/archives/sentinel
+  workshop_exec exec --project $(pwd)/project-1 ws-snap-remove-1 sudo touch /var/cache/apt/archives/sentinel
 
   echo "Check that workshops will be removed on snap removal"       
   snap remove workshop
@@ -23,4 +23,4 @@ execute: |
 
   echo "Check that cache storage has been removed"
   workshop_exec launch --project $(pwd)/project-1 ws-snap-remove-1
-  workshop_exec exec --project $(pwd)/project-1 ws-snap-remove-1 -- sudo test ! -f /var/cache/apt/archives/sentinel
+  workshop_exec exec --project $(pwd)/project-1 ws-snap-remove-1 sudo test ! -f /var/cache/apt/archives/sentinel

--- a/tests/main/remove/task.yaml
+++ b/tests/main/remove/task.yaml
@@ -11,7 +11,7 @@ execute: |
   workshop_exec launch ws-remove
 
   echo "Modify apt cache for later"
-  workshop_exec exec ws-remove -- sudo touch /var/cache/apt/archives/sentinel
+  workshop_exec exec ws-remove sudo touch /var/cache/apt/archives/sentinel
 
   echo "Check the workshop can be removed if in Ready"
   workshop_exec remove ws-remove
@@ -19,7 +19,7 @@ execute: |
 
   echo "Check the apt cache was removed"
   workshop_exec launch ws-remove
-  workshop_exec exec ws-remove -- sudo test ! -f /var/cache/apt/archives/sentinel
+  workshop_exec exec ws-remove sudo test ! -f /var/cache/apt/archives/sentinel
 
   echo "Check the workshop can be removed if in Stopped"
   workshop_exec stop  ws-remove

--- a/tests/main/remove/task.yaml
+++ b/tests/main/remove/task.yaml
@@ -22,7 +22,7 @@ execute: |
   workshop_exec exec ws-remove sudo test ! -f /var/cache/apt/archives/sentinel
 
   echo "Check the workshop can be removed if in Stopped"
-  workshop_exec stop  ws-remove
+  workshop_exec stop ws-remove
   workshop_exec remove ws-remove
   workshop_exec list | MATCH "^.+[[:space:]]+ws-remove[[:space:]]+Off[[:space:]]+-$"
   

--- a/tests/main/remove/task.yaml
+++ b/tests/main/remove/task.yaml
@@ -27,7 +27,7 @@ execute: |
   workshop_exec list | MATCH "^.+[[:space:]]+ws-remove[[:space:]]+Off[[:space:]]+-$"
   
   echo "Check the workshop can be removed and SDKs disconnected"
-  workshop_exec launch  ws-remove-content
+  workshop_exec launch ws-remove-content
   workshop_exec remove ws-remove-content
   workshop_exec list | MATCH "^.+[[:space:]]+ws-remove-content[[:space:]]+Off[[:space:]]+-$"
 

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -1,7 +1,7 @@
 summary: Check workshop sketch-sdk
 prepare: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-sketch
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-sketch

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -48,4 +48,4 @@ execute: |
 
   workshop_exec info ws-sketch | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x3)"
   workshop_exec connections ws-sketch | MATCH "*.ws-sketch/sketch:sketch-plug.*:mount"
-  workshop_exec exec ws-sketch -- bash -c "test -d /home/workshop/ws-sketch-test"
+  workshop_exec exec ws-sketch test -d /home/workshop/ws-sketch-test

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -13,15 +13,15 @@ execute: |
   wq
   EOF
 
-  workshop_exec info ws-sketch | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x1)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x1)"
 
   echo "Stash current sketch SDK"
   workshop_exec sketch-sdk --stash ws-sketch
-  workshop_exec info ws-sketch | grep -v notes | yq '.content["sketch"].channel' | NOMATCH ".*(x1)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | NOMATCH ".*(x1)"
 
   echo "Restore sketch SDK"
   workshop_exec sketch-sdk --restore ws-sketch
-  workshop_exec info ws-sketch | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x1)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x1)"
 
   echo "Add setup-base"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk ws-sketch <<EOF
@@ -33,7 +33,7 @@ execute: |
   wq
   EOF
 
-  workshop_exec info ws-sketch | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x2)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x2)"
 
   echo "Add a new mount"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk ws-sketch <<EOF
@@ -46,6 +46,6 @@ execute: |
   wq
   EOF
 
-  workshop_exec info ws-sketch | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x3)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x3)"
   workshop_exec connections ws-sketch | MATCH "*.ws-sketch/sketch:sketch-plug.*:mount"
   workshop_exec exec ws-sketch test -d /home/workshop/ws-sketch-test

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -9,22 +9,22 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Install empty sketch SDK"
-  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk ws-sketch <<EOF  
+  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF  
   wq
   EOF
 
   workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x1)"
 
   echo "Stash current sketch SDK"
-  workshop_exec sketch-sdk --stash ws-sketch
+  workshop_exec sketch-sdk --stash
   workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | NOMATCH ".*(x1)"
 
   echo "Restore sketch SDK"
-  workshop_exec sketch-sdk --restore ws-sketch
+  workshop_exec sketch-sdk --restore
   workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x1)"
 
   echo "Add setup-base"
-  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk ws-sketch <<EOF
+  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
   10
   i
     setup-base: |
@@ -36,7 +36,7 @@ execute: |
   workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x2)"
 
   echo "Add a new mount"
-  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk ws-sketch <<EOF
+  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
   $
   a
     sketch-plug:

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -48,4 +48,4 @@ execute: |
 
   workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x3)"
   workshop_exec connections ws-sketch | MATCH "*.ws-sketch/sketch:sketch-plug.*:mount"
-  workshop_exec exec ws-sketch test -d /home/workshop/ws-sketch-test
+  workshop_exec exec -- test -d /home/workshop/ws-sketch-test

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-sketch
+  workshop_exec remove
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -10,8 +10,8 @@ execute: |
 
   function check_linger() {
     echo "Check that linger is enabled for the workshop user"
-    workshop_exec exec ws-start -- test -f /var/lib/systemd/linger/workshop
-    workshop_exec exec ws-start -- test -d /run/user/1000
+    workshop_exec exec ws-start test -f /var/lib/systemd/linger/workshop
+    workshop_exec exec ws-start test -d /run/user/1000
   }
 
   check_linger

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -21,7 +21,7 @@ execute: |
   workshop_exec list | MATCH "^.+[[:space:]]+ws-start[[:space:]]+Stopped[[:space:]]+-$"
 
   echo "Start the workshop"
-  workshop_exec start ws-start
+  workshop_exec start
 
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-start[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -1,7 +1,7 @@
 summary: Check workshop start
 prepare: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-start
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-start

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-start
+  workshop_exec remove
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -10,8 +10,8 @@ execute: |
 
   function check_linger() {
     echo "Check that linger is enabled for the workshop user"
-    workshop_exec exec ws-start test -f /var/lib/systemd/linger/workshop
-    workshop_exec exec ws-start test -d /run/user/1000
+    workshop_exec exec -- test -f /var/lib/systemd/linger/workshop
+    workshop_exec exec -- test -d /run/user/1000
   }
 
   check_linger

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -15,7 +15,7 @@ execute: |
   }
 
   check_linger
-  workshop_exec stop ws-start
+  workshop_exec stop
 
   echo "Check the workshop is in Stopped state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-start[[:space:]]+Stopped[[:space:]]+-$"

--- a/tests/main/stop/task.yaml
+++ b/tests/main/stop/task.yaml
@@ -4,7 +4,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-stop
+  workshop_exec remove
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/main/stop/task.yaml
+++ b/tests/main/stop/task.yaml
@@ -1,7 +1,7 @@
 summary: Check workshop stop
 prepare: |  
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-stop
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-stop

--- a/tests/main/stop/task.yaml
+++ b/tests/main/stop/task.yaml
@@ -9,13 +9,13 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Stop the workshop"
-  workshop_exec stop ws-stop
+  workshop_exec stop
 
   echo "Check the workshop is in Stopped state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-stop[[:space:]]+Stopped[[:space:]]+-$"
 
   echo "Check stopping the Stopped workshop does not result in error"
-  workshop_exec stop ws-stop
+  workshop_exec stop
 
   echo "Check the workshop is in Stopped state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-stop[[:space:]]+Stopped[[:space:]]+-$"

--- a/tests/main/workshop-connections/task.yaml
+++ b/tests/main/workshop-connections/task.yaml
@@ -2,7 +2,7 @@ summary: Check that "workshop connections" works as expected
 prepare: |
   . "$TESTSLIB"/utils.sh
   mkdir user-data user-data-2
-  workshop_exec launch ws-user-conns
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove ws-user-conns

--- a/tests/main/workshop-connections/task.yaml
+++ b/tests/main/workshop-connections/task.yaml
@@ -23,7 +23,7 @@ execute: |
 
   echo "Check refresh that removes a connection"
   mv -f .workshop/ws-user-conns.yaml.new .workshop/ws-user-conns.yaml
-  workshop_exec refresh ws-user-conns
+  workshop_exec refresh
   workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:one.+:mount.+\-$"
   workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:two.+:user-slot-2.+\-$"
 

--- a/tests/main/workshop-connections/task.yaml
+++ b/tests/main/workshop-connections/task.yaml
@@ -16,7 +16,7 @@ execute: |
   workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:wp-plug.+:user-slot-2.+\-$"
 
   echo "Check mounts"
-  workshop_exec info ws-user-conns | grep -v notes > mounts.log
+  workshop_exec info | grep -v notes > mounts.log
   yq '.content["test-sdk-mount"].mounts["one"]' < mounts.log | MATCH "^host-source:.*mount/ws-user-conns_test-sdk-mount_one.sdk" 
   yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^workshop-source:.*/project/user-data-2"
   yq '.content["test-sdk-mount"].mounts["wp-plug"]' < mounts.log | MATCH "^workshop-source:.*/project/user-data-2"
@@ -28,6 +28,6 @@ execute: |
   workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:two.+:user-slot-2.+\-$"
 
   echo "Check mounts"
-  workshop_exec info ws-user-conns | grep -v notes > mounts.log
+  workshop_exec info | grep -v notes > mounts.log
   yq '.content["test-sdk-mount"].mounts["one"]' < mounts.log | MATCH "^host-source:.*ws-user-conns_test-sdk-mount_one.sdk" 
   yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^workshop-source:.*/project/user-data-2"

--- a/tests/main/workshop-connections/task.yaml
+++ b/tests/main/workshop-connections/task.yaml
@@ -5,7 +5,7 @@ prepare: |
   workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-user-conns
+  workshop_exec remove
   rm -rf user-data user-data-2
 execute: |
   . "$TESTSLIB"/utils.sh


### PR DESCRIPTION
# Description

If a project only has one workshop, the `launch`, `refresh`, `info`, `start`, `stop`, `remove`, `exec`, `shell` and `hack` commands no longer require a workshop name. Internally, these commands call `v1GetProjectWorkshops` and, if the result has a single entry, proceed as before.

The `v1GetProjectWorkshops` API has been extended slightly: the `state` query parameter can be `available`, `all`, or an actual state. The new state `available` is similar to `all`. It shows existing workshops and workshop files. If something is wrong with the workshop files, `available` downgrades the error to a warning and lists the existing workshops, whereas `all` returns the error. The actual states work the same as before (since they ignore workshop files).

Now `workshop list` uses `state=available`, but commands without workshop names use `state=all`, which remains the default if no `state` is provided.

The `exec` command is a special case, because in `workshop exec one two` it's unclear if `one` is the workshop name or the start of a command. The ambiguity is resolved by the presence or absence of a separator (`--`): `workshop exec -- one two` will treat `one two` as a command, whereas `workshop exec one two`, `workshop exec one -- two` and `workshop exec one two --` all run the `two` command in the workshop named `one`.

This PR also tells cobra to stop parsing `exec` arguments after the workshop name. We still remove the first `--` by hand if needed. So for example `workshop exec foo bar --project $P` will now run the command `bar --project $P` in the current project, rather than running `bar` in project `$P`. This is not required for the above `exec` changes, but I think it improves ergonomics, and without this I would be inclined to make `--` mandatory.

Where possible I've updated the tests to remove workshop names from commands. I think there's a nice mix of single- and multi-workshop projects so we should have pretty good coverage of both scenarios. Also updated some unit tests but I haven't added new ones just for this.

Following up on [Dmitry's observation](https://github.com/canonical/workshop/pull/226#issuecomment-2529863557), I've refactored the project tracking logic. I hope it's easier to follow now, but it should have the same behaviour as before, except fewer errors are suppressed (23367e8c583847b12c3a98359b556ccad6d424ba, 14edb67887a4e78c6f4b6b0278cdecc6bc07fbb1, 15ad5fd0100cc688640b1fdbb8de70a6ecfd11b1, 218365694d0e0b55be1907127d9e88408356acd5) and some steps have been reordered.

The latency seems to be caused by multiple projects/workshops and missing-project warnings. One step to address this in future might be to add a `Project()` method to the backend, to avoid the overhead of `Projects()` when the project ID is already known.

There also seems to be a bug where an empty `.workshop.lock` can be created, but I haven't been able to reproduce it reliably. Maybe these changes will fix it anyway.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
