### PR TITLE
Prevent connection removal on backend setup failure

### DIFF
--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -652,8 +652,8 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 
 	rev.Add(func() {
 		oldConn := &schema.ConnState{}
-		if err := task.Get("old-conn", oldConn); err != nil {
-			logger.Noticef("On doDisconnect: Cannot recover disconnected %q", cref.ID())
+		if err1 := task.Get("old-conn", oldConn); err1 != nil {
+			err = fmt.Errorf("On Disconnect: %w\nWhen attempting to revert: internal error: previous connection not found in state", err)
 		}
 		conns[cref.ID()] = oldConn
 		setConns(st, conns)
@@ -661,7 +661,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		_, err1 := m.repo.Connect(&cref, conn.StaticPlugAttrs, conn.DynamicPlugAttrs, conn.StaticSlotAttrs,
 			conn.DynamicSlotAttrs, nil)
 		if err1 != nil {
-			logger.Noticef("On doDisconnect: Cannot recover disconnected %q", cref.ID())
+			err = fmt.Errorf("On Disconnect: %w\nWhen attempting to revert: Cannot recover disconnected %q", err, cref.ID())
 		}
 	})
 
@@ -687,7 +687,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
 		defer cancel()
 		for _, backend := range m.repo.Backends() {
-			if err := backend.Setup(ctx, ref, m.repo); err != nil {
+			if err = backend.Setup(ctx, ref, m.repo); err != nil {
 				return err
 			}
 		}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -658,9 +658,10 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		}
 	})
 
-	oldConns := maps.Clone(conns)
+	oldConn := *conn
 	rev.Add(func() {
-		setConns(st, oldConns)
+		conns[cref.ID()] = &oldConn
+		setConns(st, conns)
 	})
 
 	switch {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -651,17 +651,16 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 	defer rev.Fail()
 
 	rev.Add(func() {
+		oldConn := new(schema.ConnState)
+		task.Get("old-conn", oldConn)
+		conns[cref.ID()] = oldConn
+		setConns(st, conns)
+
 		_, err1 := m.repo.Connect(&cref, conn.StaticPlugAttrs, conn.DynamicPlugAttrs, conn.StaticSlotAttrs,
 			conn.DynamicSlotAttrs, nil)
 		if err1 != nil {
 			logger.Noticef("On doDisconnect: Cannot recover disconnected %q", cref.ID())
 		}
-	})
-
-	oldConn := *conn
-	rev.Add(func() {
-		conns[cref.ID()] = &oldConn
-		setConns(st, conns)
 	})
 
 	switch {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -651,8 +651,10 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 	defer rev.Fail()
 
 	rev.Add(func() {
-		oldConn := new(schema.ConnState)
-		task.Get("old-conn", oldConn)
+		oldConn := &schema.ConnState{}
+		if err := task.Get("old-conn", oldConn); err != nil {
+			logger.Noticef("On doDisconnect: Cannot recover disconnected %q", cref.ID())
+		}
 		conns[cref.ID()] = oldConn
 		setConns(st, conns)
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -658,6 +658,11 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		}
 	})
 
+	oldConns := maps.Clone(conns)
+	rev.Add(func() {
+		setConns(st, oldConns)
+	})
+
 	switch {
 	case forget:
 		delete(conns, cref.ID())

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -67,6 +67,7 @@ plugs:
     attribute: three
   plug-ssh:
     interface: mock-ssh-agent
+    attribute: four
 `
 
 var consumer2 = `name: consumer2
@@ -1782,6 +1783,74 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
 	t1 := s.state.NewTask("connect", "")
 	t1.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
 	t1.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	setWorkshopProject("ws", s.prj, t1)
+	c1.AddTask(t1)
+	c1.Set("project-id", s.prj.ProjectId)
+	c1.Set("user", "testuser")
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	oldConns := map[string]*schema.ConnState{}
+	s.state.Get("conns", &oldConns)
+
+	// Force the disconnect to fail
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+		return fmt.Errorf("setup failed")
+	}
+
+	// Disconnect
+	c2 := s.state.NewChange("sample", "")
+	t2 := s.state.NewTask("disconnect", "")
+
+	t2.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	t2.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	setWorkshopProject("ws", s.prj, t2)
+	c2.AddTask(t2)
+	c2.Set("project-id", s.prj.ProjectId)
+	c2.Set("user", "testuser")
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(c2.Err(), check.ErrorMatches, `cannot perform the following tasks:
+-  \(setup failed\)`)
+
+	// Ensure that the connection is not removed from state
+	newConns := map[string]*schema.ConnState{}
+	s.state.Get("conns", &newConns)
+	c.Assert(oldConns, check.DeepEquals, newConns)
+
+	// Ensure the connection is not removed from the repo
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug-ssh")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	ref, err = repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailureAuto(c *check.C) {
+	// Launch
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws", []testSdkSetup{
+		{csetup, consumerManyPlugs},
+		{psetup, strings.Replace(producer, "mock-network", "mock-ssh-agent", 1)},
+	})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, strings.Replace(producer, "mock-network", "mock-ssh-agent", 1), s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Connect
+	s.state.Lock()
+	c1 := s.state.NewChange("sample", "")
+	t1 := s.state.NewTask("connect", "")
+	t1.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	t1.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	t1.Set("auto", true)
 	setWorkshopProject("ws", s.prj, t1)
 	c1.AddTask(t1)
 	c1.Set("project-id", s.prj.ProjectId)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gopkg.in/check.v1"
@@ -65,7 +66,7 @@ plugs:
     interface: mock-network
     attribute: three
   plug-ssh:
-    interface: mock-ssh-agent	
+    interface: mock-ssh-agent
 `
 
 var consumer2 = `name: consumer2
@@ -81,7 +82,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: mount
-    workshop-target: /home/workshop  
+    workshop-target: /home/workshop
 `
 
 var conflictingTarget2 = `name: conflict-2
@@ -89,7 +90,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: mount
-    workshop-target: /home/workshop  
+    workshop-target: /home/workshop
 `
 
 var csetup = sdk.Setup{Name: "consumer", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
@@ -511,7 +512,7 @@ base: ubuntu@22.04
 type: system
 slots:
     slot:
-        interface: mount        
+        interface: mount
 `
 	wm, err := s.launchWorkshop(c, "ws-consumer", []testSdkSetup{{csetup, sdkYaml}})
 	c.Assert(err, check.IsNil)
@@ -1763,4 +1764,71 @@ func (s *interfaceHandlersSuite) TestUndoDiscardConnsSuccess(c *check.C) {
 			Undesired: true,
 		},
 	})
+}
+
+func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
+	// Launch
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws", []testSdkSetup{
+		{csetup, consumerManyPlugs},
+		{psetup, strings.Replace(producer, "mock-network", "mock-ssh-agent", 1)},
+	})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, strings.Replace(producer, "mock-network", "mock-ssh-agent", 1), s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Connect
+	s.state.Lock()
+	c1 := s.state.NewChange("sample", "")
+	t1 := s.state.NewTask("connect", "")
+	t1.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	t1.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	setWorkshopProject("ws", s.prj, t1)
+	c1.AddTask(t1)
+	c1.Set("project-id", s.prj.ProjectId)
+	c1.Set("user", "testuser")
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	oldConns := map[string]*schema.ConnState{}
+	s.state.Get("conns", &oldConns)
+
+	// Force the disconnect to fail
+	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+		return fmt.Errorf("setup failed")
+	}
+
+	// Disconnect
+	c2 := s.state.NewChange("sample", "")
+	t2 := s.state.NewTask("disconnect", "")
+
+	t2.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	t2.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	setWorkshopProject("ws", s.prj, t2)
+	c2.AddTask(t2)
+	c2.Set("project-id", s.prj.ProjectId)
+	c2.Set("user", "testuser")
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(c2.Err(), check.ErrorMatches, `cannot perform the following tasks:
+-  \(setup failed\)`)
+
+	// Ensure that the connection is not removed from state
+	newConns := map[string]*schema.ConnState{}
+	s.state.Get("conns", &newConns)
+	c.Assert(oldConns, check.DeepEquals, newConns)
+
+	// Ensure the connection is not removed from the repo
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug-ssh")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	ref, err = repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
 }

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -1791,9 +1791,16 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
 
 	s.settle(c)
 
+	// Store current connections present in state and repo
 	s.state.Lock()
 	oldConns := map[string]*schema.ConnState{}
 	s.state.Get("conns", &oldConns)
+
+	oldPlugRefs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug-ssh")
+	c.Assert(err, check.IsNil)
+
+	oldSlotRefs, err := repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
+	c.Assert(err, check.IsNil)
 
 	// Force the disconnect to fail
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
@@ -1824,13 +1831,13 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
 	s.state.Get("conns", &newConns)
 	c.Assert(oldConns, check.DeepEquals, newConns)
 
-	// Ensure the connection is not removed from the repo
-	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug-ssh")
-	c.Assert(ref, check.HasLen, 1)
+	// Ensure the connection remains identical in the repo
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug-ssh")
+	c.Assert(refs, check.DeepEquals, oldPlugRefs)
 	c.Assert(err, check.IsNil)
 
-	ref, err = repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
-	c.Assert(ref, check.HasLen, 1)
+	refs, err = repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
+	c.Assert(refs, check.DeepEquals, oldSlotRefs)
 	c.Assert(err, check.IsNil)
 }
 
@@ -1859,9 +1866,16 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailureAuto(c *check.C) {
 
 	s.settle(c)
 
+	// Store current connections present in state and repo
 	s.state.Lock()
 	oldConns := map[string]*schema.ConnState{}
 	s.state.Get("conns", &oldConns)
+
+	oldPlugRefs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug-ssh")
+	c.Assert(err, check.IsNil)
+
+	oldSlotRefs, err := repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
+	c.Assert(err, check.IsNil)
 
 	// Force the disconnect to fail
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
@@ -1887,17 +1901,17 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailureAuto(c *check.C) {
 	c.Assert(c2.Err(), check.ErrorMatches, `cannot perform the following tasks:
 -  \(setup failed\)`)
 
-	// Ensure that the connection is not removed from state
+	// Ensure the connection remains identical in state
 	newConns := map[string]*schema.ConnState{}
 	s.state.Get("conns", &newConns)
 	c.Assert(oldConns, check.DeepEquals, newConns)
 
-	// Ensure the connection is not removed from the repo
-	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug-ssh")
-	c.Assert(ref, check.HasLen, 1)
+	// Ensure the connection remains identical in the repo
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug-ssh")
+	c.Assert(refs, check.DeepEquals, oldPlugRefs)
 	c.Assert(err, check.IsNil)
 
-	ref, err = repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
-	c.Assert(ref, check.HasLen, 1)
+	refs, err = repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
+	c.Assert(refs, check.DeepEquals, oldSlotRefs)
 	c.Assert(err, check.IsNil)
 }


### PR DESCRIPTION
# Description
If an error occurs during the backend setup call within doDisconnect, the connection being disconnected will be left in a partially disconnected state. This error can be either transient (ie. a backend connection issue) or non-transient (ie. a broken workshop missing essential packages).

This PR restores the connection to the workshop state on failure, noting that this will not take any action to revert modifications to the workshop that were run during the disconnect (ie. remove<interface> functions).  

## One-way decisions
It was agreed that it's better to keep a potentially broken connection connected than to disconnect a potentially still-connected connection. Some of the factors going into this decision were the following:

- Transient errors 
  - It's better to let a user try again
- Ramifications for connect 
  - If we disconnect forcibly, it's highly possible we break any subsequent re-connections
- General guarantees
  - We should not allow an action (without making it explicitly clear) to break another action

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
