### PR TITLE
Check for workshop definitions before considering parent directories

### DIFF
--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -202,7 +202,8 @@ func ancestorProject(child string) (string, error) {
 			return "", err
 		}
 		if ok && isDir {
-			if _, err := readProjectId(path); err == nil {
+			_, err := readProjectId(path)
+			if err == nil || isProject(path) {
 				return filepath.Clean(path), nil
 			}
 		}

--- a/internal/workshop/project_test.go
+++ b/internal/workshop/project_test.go
@@ -209,6 +209,25 @@ func (p *projectSuite) TestTrackProjectSubDirectory(c *check.C) {
 	}
 }
 
+func (p *projectSuite) TestTrackNestedProjects(c *check.C) {
+	outer := c.MkDir()
+	_, err := os.Create(filepath.Join(outer, "workshop.yaml"))
+	c.Assert(err, check.IsNil)
+	project := &workshop.Project{Path: outer, ProjectId: "42424242"}
+	c.Assert(workshop.UpdateLock(project), check.IsNil)
+
+	inner := filepath.Join(outer, "vendor", "product")
+	c.Assert(os.MkdirAll(inner, os.ModePerm), check.IsNil)
+	_, err = os.Create(filepath.Join(inner, "workshop.yaml"))
+	c.Assert(err, check.IsNil)
+
+	tracker := workshop.ProjectTracker{}
+	project, result, err := tracker.Track(inner)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectAdded)
+	c.Check(project.Path, check.Equals, inner)
+}
+
 func (p *projectSuite) TestTrackExistingProject(c *check.C) {
 	d := c.MkDir()
 	original := filepath.Join(d, "original")

--- a/tests/main/list/task.yaml
+++ b/tests/main/list/task.yaml
@@ -55,6 +55,11 @@ execute: |
   workshop_exec --project "$PROJECT"-copy list | MATCH "^$PROJECT-copy[[:space:]]+ws-list[[:space:]]+Off[[:space:]]+-$"
   workshop_exec --project "$PROJECT"-copy launch
   workshop_exec --project "$PROJECT"-copy list | MATCH "^${PROJECT}-copy[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
+
+  echo "List should create nested project even if parent is known"
+  mkdir -p "$PROJECT"-copy/subprj/.workshop
+  touch "$PROJECT"-copy/subprj/.workshop/nested.yaml
+  workshop_exec --project "$PROJECT"-copy/subprj list | MATCH "^$PROJECT-copy/subprj[[:space:]]+nested[[:space:]]+Off[[:space:]]+-$"
   workshop_exec --project "$PROJECT"-copy remove
 
   # TODO:


### PR DESCRIPTION
# Description

Consider a directory tree like this:
```
/home/user/p/
  .workshop.lock
  .workshop.yaml
  q/
    workshop.yaml
```
Most commands will ignore `q` in favour of `p`. For example:
```console
$ workshop list --project /home/user/p/q
Project  Workshop  Status  Notes
~/p      ws        Off     -
```
After this change `q` will be preferred.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
