### PR TITLE
Add code coverage action

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -1,0 +1,118 @@
+name: Automatic tests
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 */2 * *"
+  workflow_dispatch:
+
+# Cancel currently-running builds when pushing new commits to a PR or branch
+# https://stackoverflow.com/a/72408109
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # Call spread and unit tests as reusable workflows. This is the most
+  # dependable method by which to share the artifacts
+  spread:
+    uses: ./.github/workflows/spread.yaml
+  unit-tests:
+    uses: ./.github/workflows/unit-tests.yaml
+
+  code-coverage:
+    needs: [spread, unit-tests]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Checkout Wiki
+        if: github.ref == 'refs/heads/main'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: ./.github/wiki
+
+      - name: Download Coverage
+        uses: actions/download-artifact@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Merge Coverage
+        run: |
+          mkdir -p .github/wiki/coverage
+          COVERDIRS=$(find -mindepth 2 -type d -name cover | tr '\n' ',' | sed 's/.$//')
+          mkdir .cover
+          go tool covdata merge -i=$COVERDIRS -o .cover
+          go tool covdata textfmt -i=$PWD/.cover -o cover.out
+          go tool cover -html=cover.out -o .github/wiki/coverage/coverage.html
+
+      - name: Upload Coverage
+        id: upload-coverage
+        if: github.ref != 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-html
+          path: .github/wiki/coverage/coverage.html
+
+      - name: Generate Badge
+        id: generate-badge
+        run: |
+          COVERPERCENT=$(go tool cover -func=cover.out | tail -1 | grep -Eo '[0-9]{2}')
+
+          if (( $COVERPERCENT >= 80 )); then
+            COLOR=green
+          elif (( $COVERPERCENT >= 60 )); then
+            COLOR=yellow
+          else
+            COLOR=red
+          fi
+
+          curl -s 'https://img.shields.io/badge/Coverage-"$COVERPERCENT"%25-"$COLOR"' > .github/wiki/coverage/coverage.svg
+
+          echo svg_url=https://img.shields.io/badge/Coverage-"$COVERPERCENT"%25-"$COLOR" >> $GITHUB_OUTPUT
+
+      - name: Find Comment
+        if: github.ref != 'refs/heads/main'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Code Coverage
+
+      - name: Create or Update Comment
+        if: github.ref != 'refs/heads/main'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Code Coverage Report
+            ![Coverage](${{ steps.generate-badge.outputs.svg_url }})
+
+            [HTML Coverage Map](${{ steps.upload-coverage.outputs.artifact-url }})
+          edit-mode: replace
+
+      # Upload code coverage to wiki. Takes inspiration from https://github.com/ncruces/go-coverage-report
+      - name: Add Coverage to Wiki
+        if: github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          cd .github/wiki
+
+          git add --all
+          git diff-index --quiet HEAD && exit
+
+          # https://github.com/orgs/community/discussions/26560
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          git commit --amend --no-edit
+          git push --force-with-lease

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -1,18 +1,5 @@
 name: Spread
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-  schedule:
-    - cron: "0 0 */2 * *"
-  workflow_dispatch:
-
-# Cancel currently-running builds when pushing new commits to a PR or branch
-# https://stackoverflow.com/a/72408109
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+on: [workflow_dispatch, workflow_call]
 
 jobs:
   build-snap:
@@ -40,7 +27,7 @@ jobs:
       - name: Install LXD
         uses: canonical/setup-lxd@main
         with:
-            channel: 5.21/stable
+          channel: 5.21/stable
       - name: Cleanup job workspace
         run: |
           rm -rf "${{ github.workspace }}"
@@ -52,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: "1.23"
           cache: false
       - uses: actions/download-artifact@master
         with:
@@ -66,5 +53,12 @@ jobs:
           go install ./...
           popd
       - name: Run spread
-        run: |  
-          spread tests/${{matrix.suite}}/
+        run: |
+          mkdir ${{ github.workspace }}.cover
+          spread -artifacts=${{ github.workspace }}.cover tests/${{matrix.suite}}/
+      - name: Upload Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-${{matrix.suite}}
+          path: ${{ github.workspace }}.cover/lxd:ubuntu-24.04:tests/
+          if-no-files-found: ignore

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,22 +1,26 @@
 name: Unit Tests
-on:
-  pull_request:
-  push:
-    branches: [main]
+on: [workflow_dispatch, workflow_call]
 
 jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.23'
+      - name: Setup
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: mkdir -p ${{ github.workspace }}.cover/unit/cover && go test -cover ./... -args -test.gocoverdir=${{ github.workspace }}.cover/unit/cover
+
+      - name: Upload Coverage
+        id: upload-coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-unit
+          path: ${{ github.workspace }}.cover/

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,3 +1,4 @@
+artifacts
 AUTH
 backend
 basename
@@ -5,6 +6,7 @@ Charmcraft
 CLIs
 colcon
 cooldown
+coverprofile
 cuda
 customisable
 cwd
@@ -26,6 +28,7 @@ gopkg
 GPG
 GPUs
 GUIs
+html
 http
 https
 IDEs

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -37,10 +37,10 @@ Environment setup
       workshopd run --create-dirs
 
    The client can connect using the daemon's Unix domain socket:
-   
+
    .. code-block:: console
 
-      
+
       export WORKSHOP=~/workshop
       workshop list
 
@@ -214,6 +214,39 @@ of ``Spread``:
 .. code-block:: console
 
    spread tests/<TestPathName>
+
+
+To check code coverage:
+
+.. code-block:: console
+
+  go test --coverpkg=<./...|package> covermode=<set|count|atomic> -coverprofile=<OutputFile> <./...|package>
+
+  // For example to measure coverage using all tests:
+  go test covermode=count -coverprofile=cover.out ./...
+
+
+To generate a html representation:
+
+.. code-block:: console
+
+  go tool cover -html=<OutputFile> -o <OutputHTML>
+
+  // For example:
+  go tool cover -html=cover.out -o cover.html
+
+  // The output flag can be omitted to open in the default browser:
+  go tool cover -html=cover.out
+
+
+The above will work for unit and integration tests instrumented directly with
+`go test`. Integration tests run using spread will create the coverprofile
+automatically, however the artifacts will need to be collected from the VM.
+This can be accomplished by using the `-artifacts` flag when running spread.
+
+.. code-block:: console
+
+  spread -artifacts=<path-to-dest> tests/integration/
 
 
 How to run a local SDK Store

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -220,33 +220,33 @@ To check code coverage:
 
 .. code-block:: console
 
-  go test --coverpkg=<./...|package> covermode=<set|count|atomic> -coverprofile=<OutputFile> <./...|package>
+   go test --coverpkg=<./...|package> covermode=<set|count|atomic> -coverprofile=<OutputFile> <./...|package>
 
-  // For example to measure coverage using all tests:
-  go test covermode=count -coverprofile=cover.out ./...
+   // For example to measure coverage using all tests:
+   go test covermode=count -coverprofile=cover.out ./...
 
 
-To generate a html representation:
+To generate an HTML representation:
 
 .. code-block:: console
 
-  go tool cover -html=<OutputFile> -o <OutputHTML>
+   go tool cover -html=<OutputFile> -o <OutputHTML>
 
-  // For example:
-  go tool cover -html=cover.out -o cover.html
+   // For example:
+   go tool cover -html=cover.out -o cover.html
 
-  // The output flag can be omitted to open in the default browser:
-  go tool cover -html=cover.out
+   // The output flag can be omitted to open in the default browser:
+   go tool cover -html=cover.out
 
 
 The above will work for unit and integration tests instrumented directly with
-`go test`. Integration tests run using spread will create the coverprofile
+`go test`. Integration tests run using `spread` will create the coverprofile
 automatically, however the artifacts will need to be collected from the VM.
-This can be accomplished by using the `-artifacts` flag when running spread.
+This can be accomplished by using the `-artifacts` flag when running `spread`.
 
 .. code-block:: console
 
-  spread -artifacts=<path-to-dest> tests/integration/
+   spread -artifacts=<path-to-dest> tests/integration/
 
 
 How to run a local SDK Store

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,3 +1,9 @@
+|Coverage badge|
+
+.. |Coverage badge| image:: https://github.com/canonical/workshop/wiki/coverage/coverage.svg
+   :target: https://github.com/canonical/workshop/wiki/coverage/coverage.html
+
+
 Workshop
 ========
 

--- a/tests/integration/fake-store/task.yaml
+++ b/tests/integration/fake-store/task.yaml
@@ -8,4 +8,10 @@ restore: |
   . "$TESTSLIB"/utils.sh
   stop_sdk_store
 execute: |
-  go test "$SPREAD_PATH"/internal/fakestore/ -timeout=30m -tags=integration -check.v -check.f storeIntegration
+  rm -rf cover
+  mkdir cover
+
+  go test -cover "$SPREAD_PATH"/internal/fakestore/ -timeout=30m -tags=integration -check.v -check.f storeIntegration -coverpkg=github.com/canonical/workshop/internal/fakestore -args -test.gocoverdir="$PWD"/cover
+
+artifacts:
+  - cover

--- a/tests/integration/profile/task.yaml
+++ b/tests/integration/profile/task.yaml
@@ -1,4 +1,9 @@
 summary: Run LXD integration tests for SDK profiles
 
 execute: |
-  go test "$SPREAD_PATH"/internal/interfaces/lxd_device/tests/integration -timeout=30m -tags=integration -check.v -check.f backendDeviceSuite
+  rm -rf cover
+  mkdir cover
+
+  go test -cover "$SPREAD_PATH"/internal/interfaces/lxd_device/tests/integration -timeout=30m -tags=integration -check.v -check.f backendDeviceSuite -coverpkg=github.com/canonical/workshop/internal/interfaces/lxd_device -args -test.gocoverdir="$PWD"/cover
+artifacts:
+  - cover

--- a/tests/integration/project-tracking/task.yaml
+++ b/tests/integration/project-tracking/task.yaml
@@ -1,4 +1,10 @@
 summary: Run LXD integration tests for project tracking
 
 execute: |
-  go test "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsProject
+  rm -rf cover
+  mkdir cover
+
+  go test -cover "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsProject -coverpkg=github.com/canonical/workshop/internal/workshop/lxd -args -test.gocoverdir="$PWD"/cover
+
+artifacts:
+  - cover

--- a/tests/integration/workshop-exec/task.yaml
+++ b/tests/integration/workshop-exec/task.yaml
@@ -10,4 +10,10 @@ restore: |
   rm -rf "${WORKSHOP}"
 
 execute: |
-  sudo --preserve-env=WORKSHOP -u ubuntu 2>&1 -- go test "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsExec
+  rm -rf cover
+  mkdir -m 777 cover
+
+  sudo --preserve-env=WORKSHOP -u ubuntu 2>&1 -- go test -cover "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsExec -coverpkg=github.com/canonical/workshop/internal/workshop/lxd -args -test.gocoverdir="$PWD"/cover
+
+artifacts:
+  - cover

--- a/tests/integration/workshop-ops/task.yaml
+++ b/tests/integration/workshop-ops/task.yaml
@@ -1,4 +1,10 @@
 summary: Run LXD integration tests for workshop operations (launch, delete, attach storage, etc.)
 
 execute: |
-  go test "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsOps
+  rm -rf cover
+  mkdir cover
+
+  go test -cover "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f wsOps -coverpkg=github.com/canonical/workshop/internal/workshop/lxd -args -test.gocoverdir="$PWD"/cover
+
+artifacts:
+  - cover


### PR DESCRIPTION
# Description
This PR adds go cover profile generation to unit and spread tests, surfacing this information in the readme (for main) and in an automatically-updating comment for PRs. 

Two outputs are generated:
- A traditional 'badge' showing coverage as an overall %
- The go cover html representation 

For a pull-request, these will appear as a comment created in the PR which includes the badge inline and a link to the html output. Subsequent commits will update this comment. Note, due to limitations with the upload-artifact action, this will download as a zip. 

For the main branch, the badge will appear at the top of the README. Clicking the badge will link to the raw HTML output. 

## Notes on coloring
Currently this matches the default coloring of [codecov](https://docs.codecov.com/docs/coverage-configuration). 
That is values below 60% are red, values over 80% are green, and values between these are yellow. 

# Breaking Changes
- Spread and unit tests now run as a callee of the coverage checks. This is done to make sharing artifacts between the (previously separate) workflows as stable as possible. There were alternatives, however most interacted directly with the GH cli and as such felt quite brittle. 
- The wiki is used to store artifacts used by the README. As we host out docs via RTD, it was felt that this shouldn't be an issue. If at a later date we wish to incorporate the wiki, alternative hosting for the artifacts will need to be found (it is also likely this would coincide the the project being released, at which point we could use codecov or something similar)

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
