### PR TITLE
Tidy code coverage for readme

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -74,9 +74,9 @@ jobs:
             COLOR=red
           fi
 
-          curl -s 'https://img.shields.io/badge/Coverage-"$COVERPERCENT"%25-"$COLOR"' > .github/wiki/coverage/coverage.svg
+          curl -s https://img.shields.io/badge/coverage-"$COVERPERCENT"%25-"$COLOR" > .github/wiki/coverage/coverage.svg
 
-          echo svg_url=https://img.shields.io/badge/Coverage-"$COVERPERCENT"%25-"$COLOR" >> $GITHUB_OUTPUT
+          echo svg_url=https://img.shields.io/badge/coverage-"$COVERPERCENT"%25-"$COLOR" >> $GITHUB_OUTPUT
 
       - name: Find Comment
         if: github.ref != 'refs/heads/main'

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,14 +1,13 @@
 Workshop
 ========
-|docs badge| |coverage badge|
-
-.. |docs badge| image:: https://readthedocs.com/projects/canonical-workshop/badge/?version=latest&token=a8c81a46da98f75a366a1eef905457dadfa50c23cf3a1c1929a81af05ffea85d
-   :target: https://canonical-workshop.readthedocs-hosted.com/en/latest/?badge=latest
-   :alt: Documentation Status
+|coverage badge|\ |docs badge|
 
 .. |coverage badge| image:: https://github.com/canonical/workshop/wiki/coverage/coverage.svg
    :target: https://github.com/canonical/workshop/wiki/coverage/coverage.html
 
+.. |docs badge| image:: https://readthedocs.com/projects/canonical-workshop/badge/?version=latest&token=a8c81a46da98f75a366a1eef905457dadfa50c23cf3a1c1929a81af05ffea85d
+   :target: https://canonical-workshop.readthedocs-hosted.com/en/latest/?badge=latest
+   :alt: Documentation Status
 
 **A tool for defining and handling ephemeral development environments**.
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,15 +1,14 @@
-|Coverage badge|
-
-.. |Coverage badge| image:: https://github.com/canonical/workshop/wiki/coverage/coverage.svg
-   :target: https://github.com/canonical/workshop/wiki/coverage/coverage.html
-
-
 Workshop
 ========
+|docs badge| |coverage badge|
 
-.. image:: https://readthedocs.com/projects/canonical-workshop/badge/?version=latest&token=a8c81a46da98f75a366a1eef905457dadfa50c23cf3a1c1929a81af05ffea85d
+.. |docs badge| image:: https://readthedocs.com/projects/canonical-workshop/badge/?version=latest&token=a8c81a46da98f75a366a1eef905457dadfa50c23cf3a1c1929a81af05ffea85d
    :target: https://canonical-workshop.readthedocs-hosted.com/en/latest/?badge=latest
    :alt: Documentation Status
+
+.. |coverage badge| image:: https://github.com/canonical/workshop/wiki/coverage/coverage.svg
+   :target: https://github.com/canonical/workshop/wiki/coverage/coverage.html
+
 
 **A tool for defining and handling ephemeral development environments**.
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,9 +1,10 @@
 Workshop
 ========
-|coverage badge|\ |docs badge|
+|coverage badge| |docs badge|
 
-.. |coverage badge| image:: https://github.com/canonical/workshop/wiki/coverage/coverage.svg
+.. |coverage badge| image:: https://github.com/canonical/workshop/wiki/coverage/coverage.svg?
    :target: https://github.com/canonical/workshop/wiki/coverage/coverage.html
+   :alt: Code Status
 
 .. |docs badge| image:: https://readthedocs.com/projects/canonical-workshop/badge/?version=latest&token=a8c81a46da98f75a366a1eef905457dadfa50c23cf3a1c1929a81af05ffea85d
    :target: https://canonical-workshop.readthedocs-hosted.com/en/latest/?badge=latest


### PR DESCRIPTION
# Description
Fixes `"$COVERPERCENT"` and changes badge text to lowercase in order to match the `docs` badge

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
