### PR TITLE
Add 'workshop sketches' command

### DIFF
--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -47,6 +47,7 @@ func (c *CmdRoot) Command(cwd string) *cobra.Command {
 	cmd.AddCommand((&CmdWarnings{root: c}).Command())
 	cmd.AddCommand((&CmdOkay{root: c}).Command())
 	cmd.AddCommand((&CmdSketch{root: c}).Command())
+	cmd.AddCommand((&CmdSketches{root: c}).Command())
 	cmd.AddCommand((&CmdDocs{root: c}).Command())
 
 	cmd.PersistentFlags().StringVarP(&c.project, "project", "p", cwd, "Specify the project's directory path.")

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -5,7 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
 
 	"github.com/canonical/lxd/shared"
 	"github.com/spf13/cobra"
@@ -159,11 +163,7 @@ func restoreSketch(sketchdir, stashdir string) error {
 		return fmt.Errorf(`cannot restore: the 'sketch' SDK exists; run 'workshop sketch-sdk --remove' to remove it from the workshop`)
 	}
 
-	if err := os.MkdirAll(sketchdir, 0755); err != nil {
-		return err
-	}
-
-	if err = osutil.Exchange(sketchdir, stashdir); err != nil {
+	if err = osutil.Rename(stashdir, sketchdir); err != nil {
 		return err
 	}
 	return nil
@@ -343,4 +343,99 @@ func writeSketchSdk(sketchdir string, content []byte) error {
 
 	r.Success()
 	return nil
+}
+
+type CmdSketches struct {
+	root *CmdRoot
+}
+
+func (c *CmdSketches) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "sketches",
+		Args:  cobra.ExactArgs(0),
+		Short: "List sketches",
+		Long: `
+This command enumerates all sketches in the project, printing a compact list:
+
+- Project:  absolute pathname of the project
+
+- Workshop: workshop name, as set in its definition
+
+- Rev:      sketch SDK revision, if present
+
+- Notes:    current, stashed, or both
+`,
+		Example: `
+List the sketches in the current project directory:
+$ workshop sketches`,
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
+	cli, err := c.root.client()
+	if err != nil {
+		return err
+	}
+
+	w := tabWriter()
+	var header sync.Once
+	printHeader := func() {
+		fmt.Fprintf(w, "Project\tWorkshop\tRev\tNotes\n")
+	}
+
+	p, err := cli.Project(c.root.project)
+	if err != nil {
+		return err
+	}
+
+	wps, _, err := cli.List(&client.ListOptions{ProjectId: p.Id})
+	if err != nil {
+		return err
+	}
+
+	user, err := osutil.UserMaybeSudoUser()
+	if err != nil {
+		return err
+	}
+
+	for _, wp := range wps {
+		entry := stashEntry(user, wp, p)
+		if entry != nil {
+			header.Do(printHeader)
+			fmt.Fprintln(w, strings.Join(entry, "\t"))
+		}
+	}
+
+	w.Flush()
+
+	return nil
+}
+
+func stashEntry(usr *user.User, w *client.WorkshopInfo, p *client.Project) []string {
+	rev := "-"
+	notes := ""
+	exists := false
+	idx := slices.IndexFunc(w.Content, func(s *client.Sdk) bool { return s.Name == sdk.Sketch })
+	if idx != -1 {
+		info := w.Content[idx]
+		rev = info.Revision
+		notes = "current"
+		exists = true
+	}
+
+	stashdir := sdk.WorkshopSketchSdkStash(usr.HomeDir, p.Id, w.Name)
+	if osutil.IsDir(stashdir) {
+		if len(notes) > 0 {
+			notes += ","
+		}
+		notes += "stashed"
+		exists = true
+	}
+	if !exists {
+		return nil
+	}
+	return []string{contractHomeDirectory(p.Path), w.Name, rev, notes}
 }

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -23,6 +23,8 @@ type workshopSketch struct {
 
 var _ = check.Suite(&workshopSketch{})
 
+var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready","content":[{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}]},{"name":"nosketch","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"},{"name":"both","base":"ubuntu@22.04","project-id":"42424242","status":"Ready","content":[{"name":"sketch","channel":"","revision":"x3","install-time":"2017-03-22T09:01:00.0Z"}]},{"name":"none","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"}]},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
+
 var simpleSketchMeta = `name: sketch
 base: ubuntu@22.04
 `
@@ -43,12 +45,12 @@ func (m *workshopSketch) TearDownTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (m *workshopSketch) mockMinimalSketchSdk(c *check.C, current bool, meta []byte) (metapath string, hookspath string) {
+func (m *workshopSketch) mockMinimalSketchSdk(c *check.C, ws string, current bool, meta []byte) (metapath string, hookspath string) {
 	var rootdir string
 	if current {
-		rootdir = sdk.WorkshopSketchSdkCurrent(m.user.HomeDir, m.prjId, "ws")
+		rootdir = sdk.WorkshopSketchSdkCurrent(m.user.HomeDir, m.prjId, ws)
 	} else {
-		rootdir = sdk.WorkshopSketchSdkStash(m.user.HomeDir, m.prjId, "ws")
+		rootdir = sdk.WorkshopSketchSdkStash(m.user.HomeDir, m.prjId, ws)
 	}
 
 	err := writeSketchSdk(rootdir, meta)
@@ -88,6 +90,27 @@ func (m *workshopSketch) mockSketchHappyRefreshPath(c *check.C, refreshname stri
 			fmt.Fprintln(w, mockReadyChangeJSON)
 		default:
 			c.Errorf("expected 5 calls, now on %d", n)
+		}
+	})
+}
+
+func (m *workshopSketch) mockSketchesHappyPath(c *check.C, resp string) {
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			res := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, res)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects/"+m.prjId+"/workshops")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, resp)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
 		}
 	})
 }
@@ -140,7 +163,7 @@ func (m *workshopSketch) TestSketchSdkUpdateHooks(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}}
 	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
 
-	meta, hooks := m.mockMinimalSketchSdk(c, true, []byte(`name: sketch
+	meta, hooks := m.mockMinimalSketchSdk(c, "ws", true, []byte(`name: sketch
 base: ubuntu@22.04
 
 hooks:
@@ -207,7 +230,7 @@ func (m *workshopSketch) TestSketchSdkStashOK(c *check.C) {
 	c.Assert(filepath.Join(restore, "meta", "sdk.yaml"), testutil.FileAbsent)
 
 	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
-	metadir, _ := m.mockMinimalSketchSdk(c, true, []byte(simpleSketchMeta))
+	metadir, _ := m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.IsNil)
@@ -219,7 +242,7 @@ func (m *workshopSketch) TestSketchSdkStashOK(c *check.C) {
 func (m *workshopSketch) TestSketchSdkOverwritesExistingStash(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
 	stash := sdk.WorkshopSketchSdkStash(m.user.HomeDir, m.prjId, "ws")
-	_, stashedhooks := m.mockMinimalSketchSdk(c, false, []byte(`name: sketch
+	_, stashedhooks := m.mockMinimalSketchSdk(c, "ws", false, []byte(`name: sketch
 base: ubuntu@18.04
 hooks:
     setup-base: |
@@ -229,7 +252,7 @@ hooks:
 `))
 
 	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
-	metadir, _ := m.mockMinimalSketchSdk(c, true, []byte(simpleSketchMeta))
+	metadir, _ := m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.IsNil)
@@ -274,7 +297,7 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 		}
 	})
 
-	metadir, _ := m.mockMinimalSketchSdk(c, true, []byte(simpleSketchMeta))
+	metadir, _ := m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
 	err := cmd.Run(nil, nil)
 	c.Assert(err, check.NotNil)
@@ -291,7 +314,7 @@ func (m *workshopSketch) TestSketchSdkRestoreOK(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, restore: true}
 
 	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
-	m.mockMinimalSketchSdk(c, false, []byte(simpleSketchMeta))
+	m.mockMinimalSketchSdk(c, "ws", false, []byte(simpleSketchMeta))
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.IsNil)
@@ -320,9 +343,9 @@ plugs:
     interface: gpu
 `
 	// current
-	m.mockMinimalSketchSdk(c, true, []byte(simpleSketchMeta))
+	m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 	// stored
-	m.mockMinimalSketchSdk(c, false, []byte(stored))
+	m.mockMinimalSketchSdk(c, "ws", false, []byte(stored))
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.ErrorMatches, `cannot restore: the 'sketch' SDK exists; run 'workshop sketch-sdk --remove' to remove it from the workshop`)
@@ -383,7 +406,7 @@ func (m *workshopSketch) TestSketchSdkRemoveOK(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, remove: true}
 
 	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
-	m.mockMinimalSketchSdk(c, true, []byte(simpleSketchMeta))
+	m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.IsNil)
@@ -399,4 +422,33 @@ func (m *workshopSketch) TestSketchSdkRemoveCurrentNotExist(c *check.C) {
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.ErrorMatches, `cannot remove: the 'sketch' SDK doesn't exist`)
+}
+
+func (m *workshopSketch) TestSketchesOK(c *check.C) {
+	cmd := &CmdSketches{root: &CmdRoot{}}
+
+	m.mockSketchesHappyPath(c, mockWorkshopsListWithSketch)
+	m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
+	m.mockMinimalSketchSdk(c, "nosketch", false, []byte(simpleSketchMeta))
+	m.mockMinimalSketchSdk(c, "both", false, []byte(simpleSketchMeta))
+
+	err := cmd.Run(nil, nil)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`Project                   Workshop  Rev  Notes
+%s  ws        x1   current
+%s  nosketch  -    stashed
+%s  both      x3   current,stashed
+`, m.prjDir, m.prjDir, m.prjDir))
+}
+
+func (m *workshopSketch) TestSketchesEmpty(c *check.C) {
+	cmd := &CmdSketches{root: &CmdRoot{}}
+
+	m.mockSketchesHappyPath(c, mockWorkshopList)
+
+	err := cmd.Run(nil, nil)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(m.stdout.String(), check.Matches, "")
 }


### PR DESCRIPTION
# Description

The command lists all sketches in the project, both current and stashed.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
