### PR TITLE
Don't propogate a non-zero exit code to the host when running 'shell'

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -158,7 +158,7 @@ func maybeNameAndCommand(cmd *cobra.Command, av []string) error {
 func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
 	// Infer workshop name if first positional argument is --
 	if cmd.ArgsLenAtDash() == 0 {
-		return c.runExec("", true, av)
+		return c.runExec("", true, false, av)
 	}
 
 	// Remove first -- if cobra didn't see it
@@ -168,7 +168,7 @@ func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
 		}
 	}
 
-	return c.runExec(av[0], false, av[1:])
+	return c.runExec(av[0], false, false, av[1:])
 }
 
 func (c *CmdShellAlias) Command() *cobra.Command {
@@ -196,10 +196,10 @@ func (c *CmdShellAlias) Run(cmd *cobra.Command, av []string) error {
 		workshop = av[0]
 	}
 	command := []string{"sudo", "-i", "-u", "workshop", "bash", "-c", "cd /project; exec bash"}
-	return c.execCommand.runExec(workshop, len(av) == 0, command)
+	return c.execCommand.runExec(workshop, len(av) == 0, true, command)
 }
 
-func (c *CmdExec) runExec(workshop string, inferName bool, command []string) error {
+func (c *CmdExec) runExec(workshop string, inferName bool, shell bool, command []string) error {
 	if c.Interactive && c.NonInteractive {
 		return errors.New("'-i' incompatible with '-I'")
 	}
@@ -324,9 +324,16 @@ func (c *CmdExec) runExec(workshop string, inferName bool, command []string) err
 		case nil:
 			return nil
 		case *client.ExitError:
+			// Wrap the exit-code for a shell session
+			if shell {
+				return nil
+			}
 			logger.Debugf("Process exited with code %d", e.ExitCode())
 			return err
 		default:
+			if shell {
+				return nil
+			}
 			return err
 		}
 	case <-sighup:


### PR DESCRIPTION
# Description
Small PR that stops the propagation of exit codes to the host when running the `shell` command.

As a shell is inherently interactive (and therefore surfaces all errors during a session to the end-user), there is no need to re-alert the user that a command they attempted to run failed.   

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
