### PR TITLE
Include version and build time in workshop info

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -27,8 +27,10 @@ type Mount struct {
 
 type Sdk struct {
 	Name        string       `json:"name"`
+	Version     string       `json:"version,omitempty"`
 	Channel     string       `json:"channel"`
 	Revision    string       `json:"revision"`
+	BuildTime   time.Time    `json:"build-time"`
 	InstallTime time.Time    `json:"install-time"`
 	Health      *HealthCheck `json:"health-check,omitempty"`
 	Mounts      []*Mount     `json:"mounts,omitempty"`

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -133,8 +133,10 @@ func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
 	cs.rsp = `{"type": "sync", "result": {"name":"workshop","base":"ubuntu@20.04","project-id":"42ws42ws","status":"Ready",
 	"content":[
 		{"name":"go",
+		"version":"1.20.3",
 		"channel":"latest/stable",
 		"revision":"453",
+		"build-time":"2023-04-06T04:51:36.152964Z", 
 		"install-time":"2023-04-25T01:02:03Z", 
 		"health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"},
 		"mounts":[{"host-source":"/home/user/src","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}},{"workshop-source":"/home","workshop-target":"/mnt", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name-2"}}]
@@ -150,8 +152,10 @@ func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
 			Content: []*client.Sdk{
 				{
 					Name:        "go",
+					Version:     "1.20.3",
 					Channel:     "latest/stable",
 					Revision:    "453",
+					BuildTime:   time.Date(2023, 04, 6, 4, 51, 36, 152964000, time.UTC),
 					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 					Health: &client.HealthCheck{
 						Timestamp: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -128,6 +128,9 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 			fmt.Fprintf(w, "  %s:\n", sk.Name)
 			if sk.Name == sdk.Sketch {
 				sk.Channel = sketchSdkChannel(project.Id, workshop.Name)
+				if sk.BuildTime.IsZero() {
+					sk.BuildTime = sk.InstallTime
+				}
 			} else if sk.Channel == "" {
 				sk.Channel = "~"
 			}
@@ -136,9 +139,6 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 			var buildTime string
 			if !sk.BuildTime.IsZero() {
 				buildTime = "\t" + sk.BuildTime.Format(time.DateOnly)
-			} else if !sk.InstallTime.IsZero() {
-				// TODO: remove this fallback once most SDKs have build times
-				buildTime = "\t" + sk.InstallTime.Format(time.DateOnly)
 			}
 			var version string
 			if sk.Version != "" {

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -123,14 +124,23 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		fmt.Fprintf(w, "content:\n")
 		for _, sdk := range workshop.Content {
 			fmt.Fprintf(w, "  %s:\n", sdk.Name)
-			installTime := sdk.InstallTime.Format("2006-01-02")
-			if sdk.InstallTime.IsZero() {
-				installTime = ""
-			}
 			if sdk.Channel == "" {
 				sdk.Channel = "~"
 			}
-			fmt.Fprintf(w, "    channel:\t%s\t%s\t(%s)\n", sdk.Channel, installTime, sdk.Revision)
+			fmt.Fprintf(w, "    tracking:\t%s\n", sdk.Channel)
+
+			var buildTime string
+			if !sdk.BuildTime.IsZero() {
+				buildTime = "\t" + sdk.BuildTime.Format(time.DateOnly)
+			} else if !sdk.InstallTime.IsZero() {
+				// TODO: remove this fallback once most SDKs have build times
+				buildTime = "\t" + sdk.InstallTime.Format(time.DateOnly)
+			}
+			var version string
+			if sdk.Version != "" {
+				version = "\t" + sdk.Version
+			}
+			fmt.Fprintf(w, "    installed:%s%s\t(%s)\n", version, buildTime, sdk.Revision)
 			if sdk.Health != nil {
 				fmt.Fprintf(w, "    message:\t%s\n", sdk.Health.Message)
 			}

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cmp"
 	"fmt"
+	"os"
 	"os/user"
 	"path/filepath"
 	"slices"
@@ -12,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 type CmdInfo struct {
@@ -122,33 +124,35 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 
 	if len(workshop.Content) > 0 {
 		fmt.Fprintf(w, "content:\n")
-		for _, sdk := range workshop.Content {
-			fmt.Fprintf(w, "  %s:\n", sdk.Name)
-			if sdk.Channel == "" {
-				sdk.Channel = "~"
+		for _, sk := range workshop.Content {
+			fmt.Fprintf(w, "  %s:\n", sk.Name)
+			if sk.Name == sdk.Sketch {
+				sk.Channel = sketchSdkChannel(project.Id, workshop.Name)
+			} else if sk.Channel == "" {
+				sk.Channel = "~"
 			}
-			fmt.Fprintf(w, "    tracking:\t%s\n", sdk.Channel)
+			fmt.Fprintf(w, "    tracking:\t%s\n", sk.Channel)
 
 			var buildTime string
-			if !sdk.BuildTime.IsZero() {
-				buildTime = "\t" + sdk.BuildTime.Format(time.DateOnly)
-			} else if !sdk.InstallTime.IsZero() {
+			if !sk.BuildTime.IsZero() {
+				buildTime = "\t" + sk.BuildTime.Format(time.DateOnly)
+			} else if !sk.InstallTime.IsZero() {
 				// TODO: remove this fallback once most SDKs have build times
-				buildTime = "\t" + sdk.InstallTime.Format(time.DateOnly)
+				buildTime = "\t" + sk.InstallTime.Format(time.DateOnly)
 			}
 			var version string
-			if sdk.Version != "" {
-				version = "\t" + sdk.Version
+			if sk.Version != "" {
+				version = "\t" + sk.Version
 			}
-			fmt.Fprintf(w, "    installed:%s%s\t(%s)\n", version, buildTime, sdk.Revision)
-			if sdk.Health != nil {
-				fmt.Fprintf(w, "    message:\t%s\n", sdk.Health.Message)
+			fmt.Fprintf(w, "    installed:%s%s\t(%s)\n", version, buildTime, sk.Revision)
+			if sk.Health != nil {
+				fmt.Fprintf(w, "    message:\t%s\n", sk.Health.Message)
 			}
 
-			if len(sdk.Mounts) > 0 {
+			if len(sk.Mounts) > 0 {
 				fmt.Fprintf(w, "    mounts:\n")
-				slices.SortFunc(sdk.Mounts, func(a, b *client.Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
-				for _, mount := range sdk.Mounts {
+				slices.SortFunc(sk.Mounts, func(a, b *client.Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
+				for _, mount := range sk.Mounts {
 					if mount.HostSource != "" {
 						fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
 						fmt.Fprintf(w, "        host-source:\t%s\n", shortenDefaulPath(mount.HostSource))
@@ -169,4 +173,14 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	w.Flush()
 
 	return nil
+}
+
+func sketchSdkChannel(projectId, workshop string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "~"
+	}
+
+	path := sdk.WorkshopSketchSdk(home, projectId, workshop)
+	return contractHomeDirectory(path)
 }

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -65,7 +65,7 @@ content:
     tracking:   latest/edge
     installed:  1.8.0  2017-02-19  \(1\)
   sketch:
-    tracking:   ~
+    tracking:   ~/.local/share/workshop/project/42424242/sdk/sketch/ws
     installed:  2017-03-22  \(x1\)
 `, m.prjDir))
 	c.Check(n, check.Equals, 3)

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -24,7 +24,7 @@ func (m *workshopInfo) SetUpTest(c *check.C) {
 
 var mockSingleWorkshop = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","notes":["missing-project"]}]},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
 
-var mockWorkshopWithContent = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"],"path":"/home/project/.workshop/ws.yaml"},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
+var mockWorkshopWithContent = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","content":[{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"],"path":"/home/project/.workshop/ws.yaml"},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
 
 func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}
@@ -62,14 +62,16 @@ status:   error
 notes:    missing-project
 content:
   go:
-    channel:  latest/edge  2017-03-22  \(1\)
+    tracking:   latest/edge
+    installed:  1.8.0  2017-02-19  \(1\)
   sketch:
-    channel:  ~   2017-03-22  \(x1\)
+    tracking:   ~
+    installed:  2017-03-22  \(x1\)
 `, m.prjDir))
 	c.Check(n, check.Equals, 3)
 }
 
-var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Pending","notes":["workshop-note"],"content":[{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z","health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}}]}}`
+var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Pending","notes":["workshop-note"],"content":[{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z","health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}}]}}`
 
 func (m *workshopInfo) TestWorkshopInfoWithSdkHealthReport(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}
@@ -102,15 +104,16 @@ status:   pending
 notes:    workshop-note,try-later
 content:
   go:
-    channel:  latest/edge  2017-03-22  \(1\)
-    message:  Waiting for all required modules to be installed
+    tracking:   latest/edge
+    installed:  1.8.0  2017-02-19  \(1\)
+    message:    Waiting for all required modules to be installed
 `, m.prjDir))
 	c.Check(n, check.Equals, 2)
 }
 
 var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready",
 "content":[
-	{"name":"go","channel":"latest/edge","revision":"1","install-time":"2017-03-22T09:01:00.0Z",
+	{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z",
 	"mounts":[{"host-source":"/home/user/src","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}},
 	{"host-source":"%s/.local/share/workshop/project/17942561/mount/ws_go_mod-cache.sdk","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-default"}}]
 }]}}`
@@ -148,7 +151,8 @@ status:   ready
 notes:    -
 content:
   go:
-    channel:  latest/edge  2017-03-22  \(1\)
+    tracking:   latest/edge
+    installed:  1.8.0  2017-02-19  \(1\)
     mounts:
       plug-default:
         host-source:      .../17942561/mount/ws_go_mod-cache.sdk

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -435,7 +435,7 @@ func (m *workshopSketch) TestSketchesOK(c *check.C) {
 	err := cmd.Run(nil, nil)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`Project                   Workshop  Rev  Notes
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`Project +Workshop  Rev  Notes
 %s  ws        x1   current
 %s  nosketch  -    stashed
 %s  both      x3   current,stashed

--- a/docs/explanation/interfaces/mount-interface.rst
+++ b/docs/explanation/interfaces/mount-interface.rst
@@ -125,7 +125,8 @@ This means a source directory is mounted to the target:
      notes:    -
      content:
        mount-sdk:
-         channel:  latest/edge
+         tracking:   latest/edge
+         installed:  2022-03-04  (1)
          mounts:
            cache:
              host-source:      .../8584e571/mount/ws_mount-sdk_cache.sdk

--- a/docs/explanation/workshops/workshops.rst
+++ b/docs/explanation/workshops/workshops.rst
@@ -171,13 +171,15 @@ because they reference the same entity:
      ...
      sdks:
        pytorch:
-         channel: latest/stable
+         tracking:   latest/stable
+         installed:  2.5.1  2024-11-02  (42)
          mounts:
            datasets:
              host-source:      /new-mount
              workshop-target:  /home/workshop/.cache/torchvision/datasets
        tensorflow:
-         channel: latest/stable
+         tracking:   latest/stable
+         installed:  2.18.0  2024-10-27  (37)
          mounts:
            data:
              host-source:      /new-mount

--- a/docs/reference/cli/workshop-info.rst
+++ b/docs/reference/cli/workshop-info.rst
@@ -21,7 +21,7 @@ details for a workshop, formatting them as YAML. Specifically, it prints:
 
 - Current status (e.g. 'Ready', 'Pending', 'Off') and notes for the workshop
 
-- Individual SDK details, such as name, channel, installation date and revision
+- Individual SDK details, such as name, channel, version, build date and revision
 
 - Currently mounted content interface plugs
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -260,7 +260,8 @@ to see what went into your workshop:
      notes:    -
      content:
        go:
-         channel:  latest/stable
+         tracking:   latest/stable
+         installed:  1.23.0  2024-08-15  (51)
          mounts:
            mod-cache:
              host-source:      .../6b79e889/mount/golang_go_mod-cache.sdk
@@ -570,7 +571,8 @@ to a new location on the host:
      notes:    -
      content:
        go:
-         channel:  latest/stable
+         tracking:   latest/stable
+         installed:  1.23.3  2024-11-09  (54)
          mounts:
            mod-cache:
              host-source:      /home/user/mod
@@ -644,7 +646,8 @@ includes lines similar to the following:
 
    content:
      sketch:
-       channel:  ~   2025-01-08  (x1)
+       tracking:   ~
+       installed:  2024-12-15  (x1)
 
 
 Note that the sketch SDK entry lists the time of last update

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -646,13 +646,14 @@ includes lines similar to the following:
 
    content:
      sketch:
-       tracking:   ~
+       tracking:   ~/.local/share/workshop/project/6b79e889/sdk/sketch/sketch
        installed:  2024-12-15  (x1)
 
 
 Note that the sketch SDK entry lists the time of last update
-and the revision (:samp:`x1`);
-the channel name is given as :samp:`~` because it's a local SDK.
+and the revision (:samp:`x1`).
+Instead of a channel,
+:samp:`tracking` displays the path of the SDK definition.
 If you edit the definition, the revision is incremented.
 
 The next step would be to edit a :ref:`hook <exp_hooks>` under :samp:`hooks`.

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -42,8 +42,10 @@ type HealthCheckInfo struct {
 
 type SdkInfo struct {
 	Name        string           `json:"name"`
+	Version     string           `json:"version,omitempty"`
 	Channel     string           `json:"channel"`
 	Revision    string           `json:"revision"`
+	BuildTime   *time.Time       `json:"build-time,omitempty"`
 	InstallTime *time.Time       `json:"install-time,omitempty"`
 	Health      *HealthCheckInfo `json:"health-check,omitempty"`
 	Mounts      []*Mount         `json:"mounts,omitempty"`
@@ -91,15 +93,20 @@ func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo 
 	return &ws
 }
 
-func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState, mounts map[string][]*Mount) *WorkshopInfo {
+func workshopToInfo(w *workshop.Workshop, content map[string]*sdk.Info, health healthstate.HealthState, mounts map[string][]*Mount) *WorkshopInfo {
 	var info WorkshopInfo
 	info.Name = w.Name
 	info.ProjectId = w.Project.ProjectId
 	info.Base = w.Base
 
-	for _, sdk := range w.Content {
+	for _, sk := range w.Content {
+		sdkInfo := content[sk.Name]
+		if sdkInfo == nil {
+			sdkInfo = &sdk.Info{}
+		}
+
 		var healthInfo *HealthCheckInfo
-		if sdkHealth, ok := health.SdkHealth[sdk.Name]; ok {
+		if sdkHealth, ok := health.SdkHealth[sk.Name]; ok {
 			healthInfo = &HealthCheckInfo{
 				Timestamp: sdkHealth.Timestamp,
 				Message:   sdkHealth.Message,
@@ -107,14 +114,16 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState, mounts
 			}
 		}
 
-		sdkMounts := mounts[sdk.Name]
+		sdkMounts := mounts[sk.Name]
 		slices.SortFunc(sdkMounts, func(a, b *Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
 
 		info.Content = append(info.Content, &SdkInfo{
-			Name:        sdk.Name,
-			Channel:     sdk.Channel,
-			Revision:    sdk.Revision.String(),
-			InstallTime: sdk.InstallTime,
+			Name:        sk.Name,
+			Version:     sdkInfo.Version,
+			Channel:     sk.Channel,
+			Revision:    sk.Revision.String(),
+			BuildTime:   sdkInfo.BuildTime,
+			InstallTime: sk.InstallTime,
 			Health:      healthInfo,
 			Mounts:      sdkMounts,
 		})
@@ -129,13 +138,8 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState, mounts
 	return &info
 }
 
-func mounts(ctx context.Context, w *workshop.Workshop) (map[string][]*Mount, error) {
+func mounts(w *workshop.Workshop, content map[string]*sdk.Info) (map[string][]*Mount, error) {
 	var mnts = map[string][]*Mount{}
-
-	content, err := w.ContentInfo(ctx)
-	if err != nil {
-		return mnts, err
-	}
 
 	masters := map[interfaces.PlugRef][]interfaces.PlugRef{}
 	for _, sk := range content {
@@ -237,7 +241,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	for _, w := range workshops {
 		health := wrkmgr.WorkshopHealth(w)
 		if ignoreStatus || health.Status == status {
-			wi := workshopToInfo(w, health, nil)
+			wi := workshopToInfo(w, nil, health, nil)
 			info.Workshops = append(info.Workshops, wi)
 		}
 	}
@@ -433,7 +437,12 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	health := wrkmgr.WorkshopHealth(w)
 
 	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
-	ms, err := mounts(ctx, w)
+	content, err := w.ContentInfo(ctx)
+	if err != nil {
+		return statusBadRequest(err.Error())
+	}
+
+	ms, err := mounts(w, content)
 	if err != nil {
 		return statusBadRequest(err.Error())
 	}
@@ -444,7 +453,7 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	rsp := Workshop{
-		WorkshopInfo: *workshopToInfo(w, health, ms),
+		WorkshopInfo: *workshopToInfo(w, content, health, ms),
 		Path:         files[w.Name],
 	}
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -82,7 +82,6 @@ type Workshop struct {
 }
 
 var ensureStateSoon = stateEnsureBefore
-var workshopMounts = mounts
 
 func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo {
 	var ws WorkshopFileInfo
@@ -410,8 +409,6 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	return AsyncResponse(nil, change.ID())
 }
 
-var workshopHealth = (*workshopstate.WorkshopManager).WorkshopHealth
-
 func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	projectId := muxVars(r)["id"]
 	name := muxVars(r)["name"]
@@ -433,10 +430,10 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	if err != nil {
 		return statusNotFound("%v", err)
 	}
-	health := workshopHealth(wrkmgr, w)
+	health := wrkmgr.WorkshopHealth(w)
 
 	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
-	ms, err := workshopMounts(ctx, w)
+	ms, err := mounts(ctx, w)
 	if err != nil {
 		return statusBadRequest(err.Error())
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -217,10 +217,12 @@ connections:
 
 	testsdk = `
 name: test-sdk
-base: ubuntu@20.04
 title: title
+base: ubuntu@20.04
+version: '0.1.2'
 summary: summary
 description: SDK
+sdkcraft-started-at: '2020-04-22T19:12:07.903032Z'
 plugs:
   data:
     interface: mount
@@ -231,10 +233,12 @@ plugs:
 
 	testsdk2 = `
 name: test-sdk-2
-base: ubuntu@20.04
 title: title
+base: ubuntu@20.04
+version: '20200401.3f3a63f'
 summary: summary
 description: SDK
+sdkcraft-started-at: '2020-05-03T22:05:35.811829Z'
 plugs:
   photos:
     interface: mount
@@ -297,7 +301,7 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
 	// for DeepEqual to work correctly
-	t1, t2 := s.installTime, s.installTime
+	install1, install2 := s.installTime, s.installTime
 	info := rsp.Result.(Workshops)
 	c.Check(info.Workshops, testutil.DeepUnsortedMatches, []*WorkshopInfo{{
 		Name:      "manysdks",
@@ -309,13 +313,13 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 				Name:        "test-sdk",
 				Channel:     "latest/stable",
 				Revision:    "1",
-				InstallTime: &t1,
+				InstallTime: &install1,
 			},
 			{
 				Name:        "test-sdk-2",
 				Channel:     "latest/stable",
 				Revision:    "1",
-				InstallTime: &t2,
+				InstallTime: &install2,
 			},
 		},
 		Notes: nil,
@@ -383,8 +387,10 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
+	build1 := time.Date(2020, 4, 22, 19, 12, 7, 903032000, time.UTC)
+	build2 := time.Date(2020, 5, 3, 22, 5, 35, 811829000, time.UTC)
 	// for DeepEqual to work correctly
-	t1, t2 := s.installTime, s.installTime
+	install1, install2 := s.installTime, s.installTime
 	c.Check(rsp.Result, check.DeepEquals, Workshop{
 		WorkshopInfo: WorkshopInfo{
 			Name:      "manysdks",
@@ -395,9 +401,11 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 			Content: []*SdkInfo{
 				{
 					Name:        "test-sdk",
+					Version:     "0.1.2",
 					Channel:     "latest/stable",
 					Revision:    "1",
-					InstallTime: &t1,
+					BuildTime:   &build1,
+					InstallTime: &install1,
 					Mounts: []*Mount{
 						{
 							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk", "data"),
@@ -413,9 +421,11 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 				},
 				{
 					Name:        "test-sdk-2",
+					Version:     "20200401.3f3a63f",
 					Channel:     "latest/stable",
 					Revision:    "1",
-					InstallTime: &t2,
+					BuildTime:   &build2,
+					InstallTime: &install2,
 					Mounts: []*Mount{
 						{
 							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk-2", "photos"),
@@ -477,8 +487,10 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
+	build1 := time.Date(2020, 4, 22, 19, 12, 7, 903032000, time.UTC)
+	build2 := time.Date(2020, 5, 3, 22, 5, 35, 811829000, time.UTC)
 	// for DeepEqual to work correctly
-	t1, t2 := s.installTime, s.installTime
+	install1, install2 := s.installTime, s.installTime
 	c.Check(rsp.Result, check.DeepEquals, Workshop{
 		WorkshopInfo: WorkshopInfo{
 			Name:      "somebound",
@@ -489,9 +501,11 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 			Content: []*SdkInfo{
 				{
 					Name:        "test-sdk",
+					Version:     "0.1.2",
 					Channel:     "latest/stable",
 					Revision:    "1",
-					InstallTime: &t1,
+					BuildTime:   &build1,
+					InstallTime: &install1,
 					Mounts: []*Mount{
 						{
 							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
@@ -507,9 +521,11 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 				},
 				{
 					Name:        "test-sdk-2",
+					Version:     "20200401.3f3a63f",
 					Channel:     "latest/stable",
 					Revision:    "1",
-					InstallTime: &t2,
+					BuildTime:   &build2,
+					InstallTime: &install2,
 					Mounts: []*Mount{
 						{
 							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
@@ -744,7 +760,9 @@ line 1: cannot unmarshal !!seq into string`,
 	c.Assert(err, check.IsNil)
 	c.Assert(sdkInfo.Workshop, check.Equals, "basic")
 	c.Assert(sdkInfo.Name, check.Equals, sdk.System.String())
+	c.Assert(sdkInfo.Version, check.Equals, "")
 	c.Assert(sdkInfo.Type, check.Equals, sdk.System)
+	c.Assert(sdkInfo.BuildTime, check.IsNil)
 }
 
 func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {

--- a/internal/daemon/export_test.go
+++ b/internal/daemon/export_test.go
@@ -15,14 +15,10 @@
 package daemon
 
 import (
-	"context"
 	"net/http"
 	"time"
 
-	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/overlord/workshopstate"
-	"github.com/canonical/workshop/internal/workshop"
 )
 
 func FakeMuxVars(f func(*http.Request) map[string]string) (restore func()) {
@@ -38,22 +34,6 @@ func FakeStateEnsureBefore(f func(st *state.State, d time.Duration)) (restore fu
 	stateEnsureBefore = f
 	return func() {
 		stateEnsureBefore = old
-	}
-}
-
-func FakeWorkshopHealth(f func(mgr *workshopstate.WorkshopManager, w *workshop.Workshop) healthstate.HealthState) (restore func()) {
-	old := workshopHealth
-	workshopHealth = f
-	return func() {
-		workshopHealth = old
-	}
-}
-
-func FakeSdkMounts(f func(ctx context.Context, w *workshop.Workshop) (map[string][]*Mount, error)) (restore func()) {
-	old := workshopMounts
-	workshopMounts = f
-	return func() {
-		workshopMounts = old
 	}
 }
 

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -166,7 +166,7 @@ func (m *InterfaceManager) StartUp() error {
 
 				infos, err := workshop.ContentInfo(pctx)
 				if err != nil {
-					logger.Noticef("Cannot obtain the list of installed SDKs for %q workshop: %v", workshop.Name, err)
+					logger.Noticef("Cannot obtain the installed SDKs for %q workshop: %v", workshop.Name, err)
 					continue
 				}
 

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -28,11 +28,13 @@ func (s *Setup) Filename() string {
 }
 
 type sdkYaml struct {
-	Name  string                 `json:"name"`
-	Base  string                 `json:"base"`
-	Type  string                 `json:"type"`
-	Plugs map[string]interface{} `yaml:"plugs,omitempty"`
-	Slots map[string]interface{} `yaml:"slots,omitempty"`
+	Name      string                 `yaml:"name"`
+	Base      string                 `yaml:"base"`
+	Version   string                 `yaml:"version,omitempty"`
+	Type      string                 `yaml:"type"`
+	BuildTime *time.Time             `yaml:"sdkcraft-started-at,omitempty"`
+	Plugs     map[string]interface{} `yaml:"plugs,omitempty"`
+	Slots     map[string]interface{} `yaml:"slots,omitempty"`
 }
 
 type Type string
@@ -53,9 +55,11 @@ type Info struct {
 	Workshop  string
 	Name      string
 	Base      string
+	Version   string
 	Type      Type
 	Revision  Revision
 	Channel   string
+	BuildTime *time.Time
 
 	Plugs     map[string]*PlugInfo
 	PlugBinds map[string]*PlugBind
@@ -170,7 +174,9 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 		Workshop:      workshop,
 		Name:          sdkYaml.Name,
 		Base:          sdkYaml.Base,
+		Version:       sdkYaml.Version,
 		Type:          Type(sdkYaml.Type),
+		BuildTime:     sdkYaml.BuildTime,
 		Plugs:         make(map[string]*PlugInfo),
 		PlugBinds:     make(map[string]*PlugBind),
 		Slots:         make(map[string]*SlotInfo),

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"golang.org/x/exp/slices"
 )
@@ -17,11 +18,15 @@ var (
 
 func Validate(sdk *Info) error {
 	if !sdkName.MatchString(sdk.Name) {
-		return fmt.Errorf("invalid sdk name: %q", sdk.Name)
+		return fmt.Errorf("invalid SDK name %q", sdk.Name)
 	}
 
 	if !slices.Contains(AllowedBases, sdk.Base) {
-		return fmt.Errorf("invalid sdk base: %q; supported bases: %s", sdk.Base, strings.Join(AllowedBases, ", "))
+		return fmt.Errorf("invalid SDK base %q; supported bases: %s", sdk.Base, strings.Join(AllowedBases, ", "))
+	}
+
+	if sdk.BuildTime != nil && sdk.BuildTime.Location() != time.UTC {
+		return fmt.Errorf("invalid SDK build time %q: must be UTC", sdk.BuildTime.Format(time.RFC3339))
 	}
 
 	for plugName, plug := range sdk.Plugs {

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -70,7 +70,7 @@ func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)
-	c.Check(err, check.ErrorMatches, `invalid sdk name: "foo.something"`)
+	c.Check(err, check.ErrorMatches, `invalid SDK name "foo.something"`)
 }
 
 func (s *ValidateSuite) TestIllegalSdkBase(c *check.C) {
@@ -80,7 +80,18 @@ base: ubuntu@21.04
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)
-	c.Check(err, check.ErrorMatches, `invalid sdk base: "ubuntu@21.04"; supported bases: ubuntu@20.04, ubuntu@22.04, ubuntu@24.04`)
+	c.Check(err, check.ErrorMatches, `invalid SDK base "ubuntu@21.04"; supported bases: ubuntu@20.04, ubuntu@22.04, ubuntu@24.04`)
+}
+
+func (s *ValidateSuite) TestSdkBuildTimeNotUTC(c *check.C) {
+	info, err := sdk.ReadSdkInfo([]byte(`name: foo
+base: ubuntu@24.04
+sdkcraft-started-at: '2025-01-09T15:26:13.702403+13:00'
+`), s.projectId, "ws")
+	c.Assert(err, check.IsNil)
+
+	err = sdk.Validate(info)
+	c.Check(err, check.ErrorMatches, `invalid SDK build time "2025-01-09T15:26:13\+13:00": must be UTC`)
 }
 
 func (s *ValidateSuite) TestAcceptableSdkBases(c *check.C) {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -261,16 +261,16 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	return info, nil
 }
 
-// Returns a list of SDK info for installed SDKs. The info includes SDK details
+// Returns a map of SDK info for installed SDKs. The info includes SDK details
 // parsed from its sdk.yaml, such as base, plugs, slots, etc.
-func (w *Workshop) ContentInfo(ctx context.Context) ([]*sdk.Info, error) {
-	var infos = make([]*sdk.Info, 0, len(w.Content))
+func (w *Workshop) ContentInfo(ctx context.Context) (map[string]*sdk.Info, error) {
+	var infos = make(map[string]*sdk.Info, len(w.Content))
 	for _, sdk := range w.Content {
 		info, err := w.SdkInfo(ctx, sdk.Name)
 		if err != nil {
 			return nil, err
 		}
-		infos = append(infos, info)
+		infos[info.Name] = info
 	}
 	return infos, nil
 }

--- a/tests/lib/sdk/test-sdk-basic/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-basic/meta/sdk.yaml
@@ -1,7 +1,10 @@
 name: test-sdk-basic
 title: test-sdk-basic
 base: ubuntu@20.04
+version: '1.0'
 
 summary: test-sdk-basic SDK
 description: |
   test-sdk-basic SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'

--- a/tests/lib/sdk/test-sdk-camera/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-camera/meta/sdk.yaml
@@ -5,6 +5,8 @@ base: ubuntu@20.04
 summary: test-sdk-camera SDK
 description: |
   test-sdk-camera SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
 plugs:
   camera:
     interface: camera

--- a/tests/lib/sdk/test-sdk-content-broken/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-content-broken/meta/sdk.yaml
@@ -5,6 +5,8 @@ base: ubuntu@20.04
 summary: test-sdk-content-broken SDK
 description: |
   test-sdk-content-broken SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
 slots:
   one:
     interface: mount

--- a/tests/lib/sdk/test-sdk-desktop/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-desktop/meta/sdk.yaml
@@ -5,6 +5,8 @@ base: ubuntu@22.04
 summary: test-sdk-desktop SDK
 description: |
   test-sdk-desktop SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
 plugs:
   desktop:
     interface: desktop

--- a/tests/lib/sdk/test-sdk-go/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-go/meta/sdk.yaml
@@ -5,6 +5,8 @@ base: ubuntu@22.04
 summary: test-sdk-go SDK
 description: |
   test-sdk-go SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
 plugs:
   mod-cache:
     interface: mount

--- a/tests/lib/sdk/test-sdk-gpu/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-gpu/meta/sdk.yaml
@@ -5,6 +5,8 @@ base: ubuntu@20.04
 summary: test-sdk-gpu SDK
 description: |
   test-sdk-gpu SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
 plugs:
   gpu:
     interface: gpu

--- a/tests/lib/sdk/test-sdk-health-error/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-error/meta/sdk.yaml
@@ -5,3 +5,5 @@ base: ubuntu@22.04
 summary: test-sdk-health-error SDK
 description: |
   test-sdk-health-error SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'

--- a/tests/lib/sdk/test-sdk-health-ok/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-ok/meta/sdk.yaml
@@ -5,3 +5,5 @@ base: ubuntu@22.04
 summary: test-sdk-health-ok SDK
 description: |
   test-sdk-health-ok SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'

--- a/tests/lib/sdk/test-sdk-health-waiting/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-waiting/meta/sdk.yaml
@@ -5,3 +5,5 @@ base: ubuntu@22.04
 summary: test-sdk-health-waiting SDK
 description: |
   test-sdk-health-waiting SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'

--- a/tests/lib/sdk/test-sdk-mount/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-mount/meta/sdk.yaml
@@ -5,6 +5,8 @@ base: ubuntu@22.04
 summary: test-sdk-mount SDK
 description: |
   test-sdk-mount SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
 plugs:
   one:
     interface: mount

--- a/tests/lib/sdk/test-sdk-multiple-plugs/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-multiple-plugs/meta/sdk.yaml
@@ -5,6 +5,8 @@ base: ubuntu@20.04
 summary: test-sdk-multiple-plugs SDK
 description: |
   test-sdk-multiple-plugs SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
 plugs:
   data:
     interface: mount

--- a/tests/lib/sdk/test-sdk-setup-fail/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-setup-fail/meta/sdk.yaml
@@ -5,3 +5,5 @@ base: ubuntu@20.04
 summary: test-sdk-setup-fail SDK
 description: |
   test-sdk-setup-fail SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'

--- a/tests/lib/sdk/test-sdk-ssh-agent/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-ssh-agent/meta/sdk.yaml
@@ -5,6 +5,8 @@ base: ubuntu@20.04
 summary: test-sdk-ssh-agent SDK
 description: |
   test-sdk-ssh-agent SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
 plugs:
   ssh-agent:
     interface: ssh-agent

--- a/tests/lib/sdk/tf-extended/meta/sdk.yaml
+++ b/tests/lib/sdk/tf-extended/meta/sdk.yaml
@@ -5,3 +5,5 @@ base: ubuntu@24.04
 summary: tf-extended SDK
 description: |
   tf-extended SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -8,6 +8,7 @@ execute: |
   
   # Ensure there is one installed SDK that was provided in the workshop definition
   workshop_exec info | grep -v notes | yq ".content | length == 1"
-  workshop_exec info | grep -v notes | yq '.content["test-sdk-basic"].channel' | MATCH "latest/stable"
+  workshop_exec info | grep -v notes | yq '.content["test-sdk-basic"].tracking' | MATCH "latest/stable"
+  workshop_exec info | grep -v notes | yq '.content["test-sdk-basic"].installed' | MATCH '^1\.0[[:space:]]+2025-04-03[[:space:]]+\([[:digit:]]+\)$'
 
   workshop_exec remove

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -13,15 +13,16 @@ execute: |
   wq
   EOF
 
-  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x1)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].tracking' | MATCH '^~$'
+  workshop_exec info | grep -v notes | yq '.content["sketch"].installed' | MATCH '\(x1\)$'
 
   echo "Stash current sketch SDK"
   workshop_exec sketch-sdk --stash
-  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | NOMATCH ".*(x1)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].installed' | NOMATCH '\(x1\)$'
 
   echo "Restore sketch SDK"
   workshop_exec sketch-sdk --restore
-  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x1)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].installed' | MATCH '\(x1\)$'
 
   echo "Add setup-base"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
@@ -33,7 +34,7 @@ execute: |
   wq
   EOF
 
-  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x2)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].installed' | MATCH '\(x2\)$'
 
   echo "Add a new mount"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
@@ -46,6 +47,6 @@ execute: |
   wq
   EOF
 
-  workshop_exec info | grep -v notes | yq '.content["sketch"].channel' | MATCH ".*(x3)"
+  workshop_exec info | grep -v notes | yq '.content["sketch"].installed' | MATCH '\(x3\)$'
   workshop_exec connections ws-sketch | MATCH "*.ws-sketch/sketch:sketch-plug.*:mount"
   workshop_exec exec -- test -d /home/workshop/ws-sketch-test

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -13,7 +13,7 @@ execute: |
   wq
   EOF
 
-  workshop_exec info | grep -v notes | yq '.content["sketch"].tracking' | MATCH '^~$'
+  workshop_exec info | grep -v notes | yq '.content["sketch"].tracking' | MATCH '^~/.local/share/workshop/project/.*/sdk/sketch/ws-sketch$'
   workshop_exec info | grep -v notes | yq '.content["sketch"].installed' | MATCH '\(x1\)$'
 
   echo "Stash current sketch SDK"


### PR DESCRIPTION
# Description

Splits the existing `channel: <CHANNEL> <INSTALL TIME> (<REVISION>)` line in `workshop info` into:
```
tracking: <CHANNEL>
installed: [<VERSION>] <BUILD TIME> (<REVISION>)
```

The main thing which will be difficult to reverse is the naming for the build time. For consistency with `snap`, the SDK YAML files call it `sdkcraft-started-at`. But the Workshop code and API just call it `BuildTime`, serialised as `build-time`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
