### PR TITLE
Fix autostart behavior

### DIFF
--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -300,21 +300,11 @@ func (m *InterfaceManager) ResolveDisconnect(
 	}
 }
 
-// Ensure the mounts required by a workshop to function properly were created:
-// workshopctl, socket. These mounts are created at the time of launch but can
-// become invalid on the daemon restart / update. Thus, recreating them upon
-// every daemon restart makes sure they still point to the correct files.
+// Ensure the workshopctl mount (required by a workshop to function properly)
+// is created. This mount is created at the time of launch but can become
+// invalid on the daemon restart / update. Thus, recreating it upon every
+// daemon restart makes sure it still points to the correct files.
 func (m *InterfaceManager) recreateInternalMounts(pctx context.Context, w string) error {
-	hostpath := dirs.SocketPath + ".untrusted"
-	sname := filepath.Base(hostpath)
-	wspath := filepath.Join(dirs.WorkshopRunDir, sname)
-	socket := workshop.Mount{Name: "workshop.socket", What: hostpath, Where: wspath}
-
-	_ = m.backend.RemoveWorkshopMount(pctx, w, socket.Name)
-	if err := m.backend.AddWorkshopMount(pctx, w, socket); err != nil {
-		return err
-	}
-
 	// Recreate workshopctl bind mount, this has to be done if, for example,
 	// workshopctl was updated to a new version and is shown as /deleted in a
 	// workshop.

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -90,7 +90,15 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	if err = m.backend.LaunchWorkshop(ctx, &wf); err != nil {
 		return err
 	}
-	return nil
+
+	// Create workshop base and run directories
+	fs, err := m.backend.WorkshopFs(ctx, wf.Name)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+
+	return fs.MkdirAll(dirs.WorkshopRunDir, 0755)
 }
 
 func (m *WorkshopManager) doCreateAptCache(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -666,7 +666,7 @@ func createDefaultDevices() map[string]map[string]string {
 	return map[string]map[string]string{
 		"root":                 {"type": "disk", "pool": storagePool, "path": "/"},
 		"workshop.network":     {"type": "nic", "network": "lxdbr0", "name": "eth0"},
-		"workshop.socket":      {"type": "disk", "source": shostpath, "path": swspath},
+		"workshop.socket":      {"type": "proxy", "connect": "unix:" + shostpath, "listen": "unix:" + swspath, "bind": "instance", "mode": "0666"},
 		"workshop.workshopctl": {"type": "disk", "source": filepath.Join(dirs.ExecDir, "workshopctl"), "path": "/usr/bin/workshopctl"},
 	}
 }

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -131,10 +131,7 @@ func (s *Backend) LaunchWorkshop(ctx context.Context, file *workshop.File) error
 		return err
 	}
 
-	if err = op.WaitContext(ctx); err != nil {
-		return err
-	}
-	return nil
+	return op.WaitContext(ctx)
 }
 
 func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Context, name, action string, force bool) error {
@@ -175,6 +172,11 @@ func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
 	}
 	defer conn.Disconnect()
 
+	// Workshop started, enable autostart
+	if err = s.addWorkshopConfig(conn, ctx, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "true"}); err != nil {
+		return err
+	}
+
 	if err = s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
 		return err
 	}
@@ -205,6 +207,11 @@ func (s *Backend) StopWorkshop(ctx context.Context, name string, force bool) err
 	}
 	defer conn.Disconnect()
 
+	// Workshop stopped, disable autostart
+	if err = s.addWorkshopConfig(conn, ctx, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "false"}); err != nil {
+		return err
+	}
+
 	return s.updateInstanceState(conn, ctx, name, "stop", force)
 }
 
@@ -215,6 +222,10 @@ func (s *Backend) AddWorkshopConfig(ctx context.Context, name string, item *work
 	}
 	defer conn.Disconnect()
 
+	return s.addWorkshopConfig(conn, ctx, name, item)
+}
+
+func (s *Backend) addWorkshopConfig(conn lxd.InstanceServer, ctx context.Context, name string, item *workshop.WorkshopConfigValue) error {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return fmt.Errorf("context key project-id not found")
@@ -224,6 +235,7 @@ func (s *Backend) AddWorkshopConfig(ctx context.Context, name string, item *work
 	if err != nil {
 		return err
 	}
+
 	inst.Config[item.Name] = item.Value
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
 	if err != nil {

--- a/tests/main/autostart/task.yaml
+++ b/tests/main/autostart/task.yaml
@@ -1,0 +1,24 @@
+summary: Ensure that workshop autostart behavior performs correctly
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-autostart
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove ws-autostart
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Make sure a running workshop automatically starts after reboot"
+  if [ $SPREAD_REBOOT = 0 ]; then
+    REBOOT
+  fi
+  if [ $SPREAD_REBOOT = 1 ]; then
+    workshop_exec list | MATCH 'Ready'
+  fi
+
+  echo "Make sure a stopped workshop remains stopped after reboot"
+  workshop_exec stop ws-autostart
+  if [ $SPREAD_REBOOT = 1 ]; then
+    REBOOT
+  fi
+  workshop_exec list | MATCH 'Stopped'

--- a/tests/main/autostart/task.yaml
+++ b/tests/main/autostart/task.yaml
@@ -1,10 +1,12 @@
 summary: Ensure that workshop autostart behavior performs correctly
 prepare: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec launch ws-autostart
+  workshop_exec launch
 restore: |
   . "$TESTSLIB"/utils.sh
-  workshop_exec remove ws-autostart
+  workshop_exec remove
+  # We need to restart the store after a spread REBOOT for the next task
+  start_sdk_store
 execute: |
   . "$TESTSLIB"/utils.sh
 
@@ -16,9 +18,19 @@ execute: |
     workshop_exec list | MATCH 'Ready'
   fi
 
+  echo "Make sure a workshop can start independently of the workshop daemon"
+  if [ $SPREAD_REBOOT = 1 ]; then
+    snap stop --disable workshop
+    REBOOT
+  fi
+  if [ $SPREAD_REBOOT = 2 ]; then
+    snap start --enable workshop
+    workshop_exec list | MATCH 'Ready'
+  fi
+
   echo "Make sure a stopped workshop remains stopped after reboot"
   workshop_exec stop ws-autostart
-  if [ $SPREAD_REBOOT = 1 ]; then
+  if [ $SPREAD_REBOOT = 2 ]; then
     REBOOT
   fi
   workshop_exec list | MATCH 'Stopped'

--- a/tests/main/autostart/workshop.yaml
+++ b/tests/main/autostart/workshop.yaml
@@ -1,0 +1,2 @@
+name: ws-autostart
+base: ubuntu@20.04


### PR DESCRIPTION
# Description
This PR does two things:

1. Changes the autostart behavior so that if a container was last in the `stopped` state, it won't automatically start it on subsequent boots. 
2. Uses an lxd proxy device in place of a bind mount for the untrusted workshop socket. This fixes an issue where a workshop would be unable to start on boot if the workshop daemon had not started quickly enough. 

# Breaking Changes
Workshops will need to be recreated to use the new proxy device. Workshops using the old mount will still function. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
