### PR TITLE
Show full output for system plugs and slots

### DIFF
--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -59,9 +59,6 @@ func isDefaultSystemSlot(slot client.Slot) bool {
 }
 
 func endpoint(workshop, sdkName, name string) string {
-	if isSystemSdk(sdkName) {
-		return ":" + name
-	}
 	return workshop + "/" + sdkName + ":" + name
 }
 

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -369,10 +369,10 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 	err := cmd.Run(cmd.Command(), []string{})
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
-		"Interface  Plug                              Slot                                 Notes\n" +
-		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led  -\n" +
-		"leds       keyboard-lights/lights:numlock    :numlock-led                         manual\n" +
-		"leds       keyboard-lights/lights:scrollock  :scrollock-led                       -\n"
+		"Interface  Plug                              Slot                                  Notes\n" +
+		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led   -\n" +
+		"leds       keyboard-lights/lights:numlock    keyboard-lights/system:numlock-led    manual\n" +
+		"leds       keyboard-lights/lights:scrollock  keyboard-lights/system:scrollock-led  -\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
@@ -508,10 +508,10 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 	err := cmd.Run(cmd.Command(), []string{})
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
-		"Interface  Plug                              Slot                                 Notes\n" +
-		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led  -\n" +
-		"leds       keyboard-lights/lights:numlock    :numlock-led                         manual,bind.3\n" +
-		"leds       keyboard-lights/lights:scrollock  :scrollock-led                       manual,bind.3\n"
+		"Interface  Plug                              Slot                                  Notes\n" +
+		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led   -\n" +
+		"leds       keyboard-lights/lights:numlock    keyboard-lights/system:numlock-led    manual,bind.3\n" +
+		"leds       keyboard-lights/lights:scrollock  keyboard-lights/system:scrollock-led  manual,bind.3\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
@@ -647,12 +647,12 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                          Notes\n" +
-		"leds       -                                 :capslock-led                                 -\n" +
-		"leds       -                                 :numlock-led                                  -\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
+		"leds       -                                 keyboard-lights/system:numlock-led            -\n" +
+		"leds       -                                 leds-provider/system:capslock-led             -\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
 		"leds       keyboard-lights/lights:numlock    -                                             -\n" +
-		"leds       keyboard-lights/lights:scrollock  :scrollock-led                                -\n"
+		"leds       keyboard-lights/lights:scrollock  keyboard-lights/system:scrollock-led          -\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }
@@ -778,9 +778,9 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                          Notes\n" +
-		"leds       -                                 :numlock-led                                  -\n" +
-		"leds       -                                 :scrollock-led                                -\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
+		"leds       -                                 keyboard-lights/system:numlock-led            -\n" +
+		"leds       -                                 keyboard-lights/system:scrollock-led          -\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
 		"leds       keyboard-lights/lights:numlock    -                                             bind.6\n" +
 		"leds       keyboard-lights/lights:scrollock  -                                             bind.6\n"
@@ -1126,16 +1126,16 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 	c.Assert(err, IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                         Slot                           Notes\n" +
-		"desktop    abc/foo:desktop-plug         :desktop                       -\n" +
+		"desktop    abc/foo:desktop-plug         abc/system:desktop             -\n" +
 		"leds       -                            abc/leds-provider:numlock-led  -\n" +
 		"leds       abc/keyboard-lights:numlock  -                              -\n" +
 		"mount      -                            abc/c-content-provider:data    -\n" +
 		"mount      abc/a-foo:plug               abc/a-content-provider:data    -\n" +
 		"mount      abc/foo:plug                 abc/a-content-provider:data    -\n" +
 		"mount      abc/foo:plug                 abc/b-content-provider:data    -\n" +
-		"x11        abc/foo:x11-plug             :x11                           -\n" +
-		"x11        def/foo:a-x11-plug           :x11                           -\n" +
-		"x11        def/keyboard-app:x11         :x11                           manual\n"
+		"x11        abc/foo:x11-plug             abc/system:x11                 -\n" +
+		"x11        def/foo:a-x11-plug           def/system:x11                 -\n" +
+		"x11        def/keyboard-app:x11         def/system:x11                 manual\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/docs/explanation/interfaces/camera-interface.rst
+++ b/docs/explanation/interfaces/camera-interface.rst
@@ -73,7 +73,7 @@ To check if the interface is connected:
 
      Interface  Plug              Slot     Notes
      ...
-     camera     ws/camera:camera  :camera  manual
+     camera     ws/camera:camera  ws/system:camera  manual
 
 
 This means the host's cameras are available inside the workshop:

--- a/docs/explanation/interfaces/desktop-interface.rst
+++ b/docs/explanation/interfaces/desktop-interface.rst
@@ -65,9 +65,9 @@ To check if the interface is connected:
 
    $ workshop connections --all
 
-     Interface  Plug                   Slot       Notes
+     Interface  Plug                   Slot                Notes
      ...
-     desktop    ws/desktop-sdk:desktop :desktop   manual
+     desktop    ws/desktop-sdk:desktop ws/system:desktop   manual
 
 
 This means the host's display socket (Wayland, X11 or both) is available inside the workshop:

--- a/docs/explanation/interfaces/gpu-interface.rst
+++ b/docs/explanation/interfaces/gpu-interface.rst
@@ -68,9 +68,9 @@ To check if the interface is connected:
 
    $ workshop connections --all
 
-     Interface  Plug            Slot  Notes
+     Interface  Plug            Slot           Notes
      ...
-     gpu        ws/gpu-sdk:gpu  :gpu  -
+     gpu        ws/gpu-sdk:gpu  ws/system:gpu  -
 
 
 This means the host's GPUs are directly available inside the workshop:

--- a/docs/explanation/interfaces/ssh-interface.rst
+++ b/docs/explanation/interfaces/ssh-interface.rst
@@ -73,9 +73,9 @@ To check if the interface is connected:
 
    $ workshop connections --all
 
-     Interface  Plug                  Slot        Notes
+     Interface  Plug                  Slot                 Notes
      ...
-     ssh-agent  ws/ssh-sdk:ssh-agent  :ssh-agent  manual
+     ssh-agent  ws/ssh-sdk:ssh-agent  ws/system:ssh-agent  manual
 
 
 So the host's SSH identities and configuration

--- a/docs/explanation/workshops/workshops.rst
+++ b/docs/explanation/workshops/workshops.rst
@@ -197,9 +197,9 @@ along with the line number of the target plug:
 
    $ workshop connections digits
 
-     Interface  Plug                        Slot    Notes
-     mount      digits/pytorch:datasets     :mount  bind.2
-     mount      digits/tensorflow:datasets  :mount  bind.2
+     Interface  Plug                        Slot                 Notes
+     mount      digits/pytorch:datasets     digits/system:mount  bind.2
+     mount      digits/tensorflow:datasets  digits/system:mount  bind.2
 
 
 Here, both plugs are listed as :samp:`bind.2`,

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -532,7 +532,7 @@ use :ref:`connections <ref_workshop_connections>`:
    $ workshop connections
 
      Interface  Plug                 Slot    Notes
-     mount      golang/go:mod-cache  :mount  -
+     mount      golang/go:mod-cache  golang/system:mount  -
 
 
 This lists a :ref:`mount interface <exp_mount_interface>` plug

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -1,13 +1,13 @@
 summary: Check plug binding
 execute: |
   . "$TESTSLIB"/utils.sh
-     
+
   function check_original_binding() {
     MATCH "mount      -                                          ws-bind/test-sdk-mount:jobs  -" < conns.log
-    MATCH "mount      ws-bind/test-sdk-mount:one                 :mount                       bind.2" < conns.log
-    MATCH "mount      ws-bind/test-sdk-mount:two                 :mount                       bind.4" < conns.log
-    MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      :mount                       bind.4" < conns.log
-    MATCH "mount      ws-bind/test-sdk-multiple-plugs:data       :mount                       bind.2" < conns.log
+    MATCH "mount      ws-bind/test-sdk-mount:one                 ws-bind/system:mount         bind.2" < conns.log
+    MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         bind.4" < conns.log
+    MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      ws-bind/system:mount         bind.4" < conns.log
+    MATCH "mount      ws-bind/test-sdk-multiple-plugs:data       ws-bind/system:mount         bind.2" < conns.log
     MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -                            bind.6" < conns.log
     MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -                            bind.6" < conns.log
   }
@@ -18,10 +18,10 @@ execute: |
   workshop_exec connections ws-bind > conns.log
   check_original_binding
 
-  echo "Check bound content plugs use host directories of the plug they are bound to"  
+  echo "Check bound content plugs use host directories of the plug they are bound to"
   workshop_exec info | grep -v notes > mounts.log
-  yq '.content["test-sdk-multiple-plugs"].mounts["data"]' < mounts.log | MATCH "^host-source:.*ws-bind_test-sdk-mount_one.sdk" 
-  yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*ws-bind_test-sdk-multiple-plugs_cache.sdk" 
+  yq '.content["test-sdk-multiple-plugs"].mounts["data"]' < mounts.log | MATCH "^host-source:.*ws-bind_test-sdk-mount_one.sdk"
+  yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*ws-bind_test-sdk-multiple-plugs_cache.sdk"
 
   echo "Check disconnect affects all bound plugs"
   workshop_exec disconnect ws-bind/test-sdk-multiple-plugs:cache
@@ -32,15 +32,15 @@ execute: |
   echo "Check connect affects all bound plugs"
   workshop_exec connect ws-bind/test-sdk-multiple-plugs:cache :mount
   workshop_exec connections ws-bind > conns.log
-  MATCH "mount      ws-bind/test-sdk-mount:two                 :mount                       manual,bind.4" < conns.log
-  MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      :mount                       manual,bind.4" < conns.log
+  MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         manual,bind.4" < conns.log
+  MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      ws-bind/system:mount         manual,bind.4" < conns.log
 
   echo "Check remount affects all bound plugs"
   new_source="/home/ubuntu/remount-bound-test"
   workshop_exec remount ws-bind/test-sdk-mount:two "$new_source"
   workshop_exec info | grep -v notes > mounts.log
-  yq '.content["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host-source:.*$new_source" 
-  yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*$new_source" 
+  yq '.content["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host-source:.*$new_source"
+  yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*$new_source"
 
   echo "Check refresh respects binding"
   workshop_exec refresh
@@ -51,8 +51,8 @@ execute: |
   cat workshop.yaml | yq '.sdks["test-sdk-mount"].plugs = ~' | sponge workshop.yaml
   workshop_exec refresh
   workshop_exec connections ws-bind > conns.log
-  MATCH "mount      ws-bind/test-sdk-mount:two                 :mount                       -" < conns.log
-  MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      :mount                       -" < conns.log  
+  MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         -" < conns.log
+  MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      ws-bind/system:mount         -" < conns.log
   workshop_exec info | grep -v notes > mounts.log
-  yq '.content["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host-source:.*$new_source" 
+  yq '.content["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host-source:.*$new_source"
   yq '.content["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*ws-bind_test-sdk-mount_two.sdk"


### PR DESCRIPTION
# Description
Changes `workshop connections` output to display the full output for system plugs and slots. For example:

```
Interface  Plug                  Slot        Notes
ssh-agent  ws/sketch:ssh-agent   :ssh-agent  manual
```

Becomes

```
Interface  Plug                  Slot                  Notes
ssh-agent  ws/sketch:ssh-agent   ws/system:ssh-agent   manual
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
