### PR TITLE
Add 'read-only' option for mounts

### DIFF
--- a/docs/explanation/interfaces/mount-interface.rst
+++ b/docs/explanation/interfaces/mount-interface.rst
@@ -36,7 +36,8 @@ which is declared in the SDK definition.
 
 A basic structure would include the name of the plug itself,
 the interface (:samp:`mount`)
-and the intended target path inside the workshop (:samp:`workshop-target`).
+the intended target path inside the workshop (:samp:`workshop-target`)
+and, optionally, whether the mount should be read-only (:samp:`read-only`).
 
 Defining the plug in an SDK designates the target directory inside the workshop;
 a directory on the host system that |ws_markup| will create at run-time

--- a/docs/explanation/sdks/data-persistence-sharing.rst
+++ b/docs/explanation/sdks/data-persistence-sharing.rst
@@ -72,6 +72,7 @@ per each directory you want to retain during the workshop's life cycle.
      training-data:
        interface: mount
        workshop-target: /opt/training
+       read-only: true
 
 
 This SDK defines two mount plugs;
@@ -80,6 +81,10 @@ for each,
 Both :samp:`workshop-target` directories inside the workshop
 can be used by the SDK-specific logic
 implemented via :ref:`hooks <exp_sdk_hooks>` and other features.
+
+Additionally, you can mark a directory as `read-only`.
+|ws_markup| will then enforce the immutability of resources in this directory
+when they are accessed from inside the workshop.
 
 Here's a corresponding workshop definition:
 

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -130,8 +130,7 @@ via the GPU pass-through mechanism.
 Mount interface
 ~~~~~~~~~~~~~~~
 
-A mount plug in the definition must specify the plug name, the interface
-and the target directory:
+A mount plug in the definition must specify the plug name, the interface, the target directory and optionally whether to be read-only:
 
 .. code-block:: yaml
    :caption: sdkcraft.yaml
@@ -141,6 +140,7 @@ and the target directory:
       <NAME>:
         interface: mount
         workshop-target: <WORKSHOP DIRECTORY>
+        read-only: <true | false> # optional
 
 
 This mounts a directory automatically created by |ws_markup| on the host
@@ -214,7 +214,7 @@ which can be defined when the SDK's is built using |sdk_markup|:
    * - :samp:`check-health`
      - At :ref:`ref_workshop_launch`:
        after running :samp:`setup-base` hooks for *all* SDKs.
-     
+
        At :ref:`ref_workshop_refresh`:
        after running :samp:`restore-state` hooks for *all* SDKs.
 

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -62,7 +63,7 @@ const mountBaseDeclarationPlugs = `
           auto-explicit: true
 `
 
-var knownPlugAttributes = []string{"workshop-target"}
+var knownPlugAttributes = []string{"workshop-target", "read-only"}
 var knownSlotAttributes = []string{"workshop-source", "host-source"}
 
 // mountInterface allows sharing content between sdks
@@ -98,12 +99,32 @@ func (iface *mountInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 			return fmt.Errorf(`unknown attribute for mount interface plug: %q`, name)
 		}
 	}
+
 	target, ok := plug.Attrs["workshop-target"].(string)
 	if !ok || len(target) == 0 {
 		return fmt.Errorf("mount plug must contain target path")
 	}
+
 	if err := validatePath(target); err != nil {
 		return err
+	}
+
+	ro, ok := plug.Attrs["read-only"]
+	if !ok {
+		ro = false
+	}
+
+	switch ro := ro.(type) {
+	case bool:
+		plug.Attrs["read-only"] = ro
+	case string:
+		roBool, err := strconv.ParseBool(ro)
+		if err != nil {
+			return fmt.Errorf(`unknown value %q in key "read-only" for mount interface plug. Accepted values are 'true' or 'false'. String representations (ie. '"true"') are also permitted.`, ro)
+		}
+		plug.Attrs["read-only"] = roBool
+	default:
+		return fmt.Errorf(`unknown value type %T in key "read-only" for mount interface plug. Accepted types are 'bool' or 'string'.`, ro)
 	}
 	return nil
 }
@@ -141,6 +162,12 @@ func (iface *mountInterface) target(attrs interfaces.Attrer) string {
 		return target
 	}
 	return ""
+}
+
+func (iface *mountInterface) readOnly(attrs interfaces.Attrer) bool {
+	var ro bool
+	attrs.Attr("read-only", &ro)
+	return ro
 }
 
 func (iface *mountInterface) workshopSource(slot *interfaces.ConnectedSlot) (string, error) {
@@ -186,12 +213,12 @@ func (iface *mountInterface) MountConnectedPlug(spec *lxd_device.Specification, 
 		return err
 	}
 	if err == nil {
-		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.WorkshopWorkshop})
+		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.WorkshopWorkshop, ReadOnly: iface.readOnly(plug)})
 	}
 
 	source, err = iface.hostSource(spec.User.HomeDir, plug, slot)
 	if err == nil {
-		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.HostWorkshop})
+		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.HostWorkshop, ReadOnly: iface.readOnly(plug)})
 	}
 
 	return err

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -120,7 +120,7 @@ func (iface *mountInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 	case string:
 		roBool, err := strconv.ParseBool(ro)
 		if err != nil {
-			return fmt.Errorf(`unknown value %q in key "read-only" for mount interface plug. Accepted values are 'true' or 'false'. String representations (ie. '"true"') are also permitted.`, ro)
+			return fmt.Errorf(`unknown value %q in key "read-only" for mount interface plug. Accepted values are 'true' or 'false'. String representations (e.g., '"true"') are also permitted.`, ro)
 		}
 		plug.Attrs["read-only"] = roBool
 	default:

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -183,3 +183,36 @@ slots:
 	expectedMnt := workshop.Mount{Name: plug.Name, What: sourceDir, Where: "/project/training", Type: workshop.HostWorkshop}
 	c.Assert(deviceSpec.Profile.Mounts, check.DeepEquals, map[string]workshop.Mount{plug.Name: expectedMnt})
 }
+
+func (s *mountSuite) TestMountInterfaceReadOnlyBool(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  workshop-target: /project/training
+  read-only: true
+`, s.projectId, "ws", "consumer", "mount")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+}
+
+func (s *mountSuite) TestMountInterfaceReadOnlyString(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  workshop-target: /project/training
+  read-only: "true"
+`, s.projectId, "ws", "consumer", "mount")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+}
+
+func (s *mountSuite) TestMountInterfaceReadOnlyInvalid(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  workshop-target: /project/training
+  read-only: "invalid"
+`, s.projectId, "ws", "consumer", "mount")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "unknown value \"invalid\" in key \"read-only\" for mount interface plug.*")
+}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -72,12 +72,19 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 			return false, err
 		}
 
-		check := func(me osutil.MountEntry) bool { return me.Name == dev.What && me.Dir == dev.Where }
+		check := func(me osutil.MountEntry) bool {
+			return me.Name == dev.What && me.Dir == dev.Where && dev.ReadOnly == slices.Contains(me.Options, "ro")
+		}
 		if slices.ContainsFunc(mounts.Entries, check) {
 			return false, nil
 		}
 
-		entry := osutil.MountEntry{Name: dev.What, Dir: dev.Where, Type: "none", Options: []string{"bind", "x-systemd.requires=/project"}}
+		options := []string{"bind", "x-systemd.requires=/project"}
+		if dev.ReadOnly {
+			options = append(options, "ro")
+		}
+
+		entry := osutil.MountEntry{Name: dev.What, Dir: dev.Where, Type: "none", Options: options}
 		mounts.Entries = append(mounts.Entries, entry)
 		if err = writeMountProfile(fs, mounts); err != nil {
 			return false, err
@@ -169,10 +176,16 @@ func runMountCommand(conn lxd.InstanceServer, pid, w string, cmd []string) error
 	return err
 }
 
+// 'systemd-fstab-generator' is responsible for creating mount entries from
+// fstab. Because of this, we need to first ensure it runs (generating the
+// on-demand unit files) by calling daemon-reload, and then activate the
+// newly-creaed units by restarting a downstream target (ie. local-fs) see:
+// https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html
 func reloadMounts(conn lxd.InstanceServer, pid, w string) error {
 	return runMountCommand(conn, pid, w, []string{
-		"mount",
-		"-a",
+		"/bin/bash",
+		"-c",
+		"systemctl daemon-reload && systemctl restart local-fs.target",
 	})
 }
 
@@ -352,10 +365,16 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 
 	reload := false
 	for _, mnt := range spec.Profile.Mounts {
-		if reload, err = installMount(user, fs, mnt); err != nil {
+		rld, err := installMount(user, fs, mnt)
+		if err != nil {
 			return err
 		}
+
+		if rld {
+			reload = true
+		}
 	}
+
 	if reload {
 		err = reloadMounts(conn, sdkInfo.ProjectId, sdkInfo.Workshop)
 		if err != nil {

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/user"
+	"strconv"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/sdk"
@@ -77,7 +78,7 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 
 	if dev.Type == workshop.HostWorkshop {
 		s.devices[dev.Name] = map[string]string{"type": "disk", "source": dev.What,
-			"path": dev.Where}
+			"path": dev.Where, "readonly": strconv.FormatBool(dev.ReadOnly)}
 	}
 
 	return nil

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -62,10 +62,10 @@ func (f *backendDeviceSuite) setupRepo(c *check.C) {
 func (f *backendDeviceSuite) readWorkshopFile(c *check.C, fname string) string {
 	fs, err := f.be.WorkshopFs(f.ctx, "test")
 	c.Assert(err, check.IsNil)
-	fstab, err := fs.OpenFile(fname, os.O_CREATE|os.O_RDWR, 0744)
+	file, err := fs.OpenFile(fname, os.O_CREATE|os.O_RDWR, 0744)
 	c.Assert(err, check.IsNil)
-	defer fstab.Close()
-	buf, err := io.ReadAll(fstab)
+	defer file.Close()
+	buf, err := io.ReadAll(file)
 	c.Assert(err, check.IsNil)
 	return string(buf)
 }
@@ -198,6 +198,16 @@ func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
 		"/usr/local /opt none bind,x-systemd.requires=/project 0 0",
 		"/home /mnt none bind,x-systemd.requires=/project 0 0",
 	})
+
+	// Check the systemd mount files are generated (ie. reload was called)
+	// Note this will still exist after the connection is removed (it's a tmpfs),
+	// however the unit will be deactivated.
+	fs, err := f.be.WorkshopFs(f.ctx, "test")
+	c.Assert(err, check.IsNil)
+	_, err = fs.Stat("/run/systemd/generator/mnt.mount")
+	c.Assert(err, check.IsNil)
+	_, err = fs.Stat("/run/systemd/generator/opt.mount")
+	c.Assert(err, check.IsNil)
 
 	// Check the LXD profile is removed
 	err = b.Remove(f.ctx, "test", "consumer")

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	lxd "github.com/canonical/lxd/client"
+	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
@@ -70,6 +71,15 @@ func (f *backendDeviceSuite) readWorkshopFile(c *check.C, fname string) string {
 	return string(buf)
 }
 
+func defaultTestDevices() map[string]map[string]string {
+	cwd, _ := os.Getwd()
+	return map[string]map[string]string{
+		"root":             {"type": "disk", "pool": "default", "path": "/"},
+		"project":          {"type": "disk", "source": cwd, "path": "/project"},
+		"workshop.network": {"type": "nic", "network": "lxdbr0", "name": "eth0"},
+	}
+}
+
 func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 	var err error
 	f.username = "testuser"
@@ -95,7 +105,7 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 		return u, nil
 	}, &workshop.LookupUsername)
 
-	defer lxdbackend.FakeDefaultDevices(helper.DefaultTestDevices)()
+	defer lxdbackend.FakeDefaultDevices(defaultTestDevices)()
 	helper.LaunchTestWorkshop(c, f.ctx, f.be, c.MkDir())
 }
 
@@ -194,19 +204,26 @@ func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
 	lines := strings.Split(string(fstab), "\n")
 	c.Check(lines, check.HasLen, 3)
 	c.Check(lines[2], check.Equals, "")
-	c.Check(lines[:2], testutil.DeepUnsortedMatches, []string{
+	c.Check(lines, testutil.DeepUnsortedMatches, []string{
 		"/usr/local /opt none bind,x-systemd.requires=/project 0 0",
 		"/home /mnt none bind,x-systemd.requires=/project 0 0",
+		"",
 	})
 
-	// Check the systemd mount files are generated (ie. reload was called)
-	// Note this will still exist after the connection is removed (it's a tmpfs),
-	// however the unit will be deactivated.
 	fs, err := f.be.WorkshopFs(f.ctx, "test")
 	c.Assert(err, check.IsNil)
-	_, err = fs.Stat("/run/systemd/generator/mnt.mount")
+	// Check that the bind mount is created for /usr/local -> /opt
+	file, err := fs.Create("/opt/tmp")
 	c.Assert(err, check.IsNil)
-	_, err = fs.Stat("/run/systemd/generator/opt.mount")
+	file.Close()
+	_, err = fs.Stat("/usr/local/tmp")
+	c.Assert(err, check.IsNil)
+
+	// Check that the bind mount is created for /home -> /mnt
+	file, err = fs.Create("/home/tmp")
+	c.Assert(err, check.IsNil)
+	file.Close()
+	_, err = fs.Stat("/mnt/tmp")
 	c.Assert(err, check.IsNil)
 
 	// Check the LXD profile is removed
@@ -218,6 +235,14 @@ func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
 	// Check the fstab record was removed
 	fstab = f.readWorkshopFile(c, "/etc/fstab")
 	c.Check(string(fstab), check.Equals, "")
+
+	// Check that the bind mount is removed for /usr/local -> /opt
+	_, err = fs.Stat("/opt/tmp")
+	c.Assert(err, check.Equals, afero.ErrFileNotFound)
+
+	// Check that the bind mount is removed for /home -> /mnt
+	_, err = fs.Stat("/mnt/tmp")
+	c.Assert(err, check.Equals, afero.ErrFileNotFound)
 }
 
 func (f *backendDeviceSuite) TestSetupHostWorkshopMounts(c *check.C) {

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -19,10 +19,11 @@ type Camera struct {
 }
 
 type Mount struct {
-	Name  string    `json:"name"`
-	What  string    `json:"what"`
-	Where string    `json:"where"`
-	Type  MountType `json:"type"`
+	Name     string    `json:"name"`
+	What     string    `json:"what"`
+	Where    string    `json:"where"`
+	Type     MountType `json:"type"`
+	ReadOnly bool      `json:"readonly"`
 }
 
 type SshAgent struct {

--- a/tests/integration/interface-backend/task.yaml
+++ b/tests/integration/interface-backend/task.yaml
@@ -1,4 +1,4 @@
-summary: Run LXD integration tests for SDK profiles
+summary: Test interface system LXD backend
 
 execute: |
   rm -rf cover

--- a/tests/lib/sdk/test-sdk-mount/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-mount/sdk/hooks/setup-base
@@ -2,3 +2,5 @@
 mkdir -p /mnt/one
 mkdir -p /opt/two
 mkdir -p /mnt/wp-plug
+mkdir -p /opt/ro-slot
+mkdir -p /mnt/ro-plug

--- a/tests/main/interface-mount/task.yaml
+++ b/tests/main/interface-mount/task.yaml
@@ -3,9 +3,9 @@ restore: |
   workshop_exec remove || true
 execute: |
   . "$TESTSLIB"/utils.sh
-    
+
   function validate_host_mounts() {
-    test -d "$source_one" && test -d "$source_two"    
+    test -d "$source_one" && test -d "$source_two"
     workshop_exec exec -- bash -c "mountpoint -q /mnt/one && mountpoint -q /opt/two"
   }
 
@@ -41,6 +41,15 @@ execute: |
   workshop_exec disconnect ws-mount/test-sdk-mount:jobs
   workshop_exec connections ws-mount | MATCH "^mount.+ws-mount/test-sdk-mount:jobs.+-.+-$"
   workshop_exec exec -- bash -c "! mountpoint -q /etc/cron.weekly && ! test -f /etc/cron.weekly/job.sh"
+
+  echo "Check mounts specified with 'read-only: true' are read only"
+  workshop_exec exec -- bash -c "sudo touch /test/tmp" && exit 1 || true
+  workshop_exec exec -- bash -c "mountpoint -q /test"
+  echo "Do the same for workshop to workshop bind mounts"
+  workshop_exec exec -- bash -c "sudo touch /mnt/ro-plug" && exit 1 || true
+  workshop_exec exec -- bash -c "sudo touch /opt/ro-slot/tmp"
+  workshop_exec exec -- bash -c "test -f /mnt/ro-plug/tmp"
+
 
   echo "Check remove will also clean up the default mount interface default locations"
   workshop_exec remove

--- a/tests/main/interface-mount/workshop.yaml
+++ b/tests/main/interface-mount/workshop.yaml
@@ -7,6 +7,20 @@ sdks:
       jobs:
         interface: mount
         workshop-target: /etc/cron.weekly
+      ro-workshop:
+        interface: mount
+        workshop-target: /mnt/ro-plug
+        read-only: true
+      ro-host:
+        interface: mount
+        workshop-target: /test
+        read-only: true
+    slots:
+      ro-source:
+        interface: mount
+        workshop-source: /opt/ro-slot
 connections:
   - plug: test-sdk-mount:jobs
     slot: test-sdk-mount:jobs
+  - plug: test-sdk-mount:ro-workshop
+    slot: test-sdk-mount:ro-source


### PR DESCRIPTION
# Description
Adds a 'read-only' parameter for mounts. This enables the enforcement of read-only access to workshop mounts from within a workshop. 

Syntax:
```
plugs:
  example_plug:
    interface: mount
    workshop-target: <target>
    [read-only: <true, false, "true", "false">] 
```

The `read-only` parameter accepts a boolean or any string representation thereof (ie. "true", "false", "TRUE", etc)

SDKcraft validation implemented in https://github.com/canonical/sdkcraft/pull/139

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [x] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
