### PR TITLE
Fix the status of an uncomplete task if aborted after a wait

### DIFF
--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -177,6 +177,7 @@ func ResumeAfterWait(st *state.State,
 				tsk.SetStatus(waited)
 				tsk.Logf("Continuing for workshop %q...", workshop)
 			} else if mode == ChangeAbort {
+				tsk.SetStatus(state.DoStatus)
 				tsk.Logf("Aborting for workshop %q...", workshop)
 			}
 		}

--- a/internal/overlord/conflict/conflict_test.go
+++ b/internal/overlord/conflict/conflict_test.go
@@ -180,6 +180,6 @@ func (s *conflictSuite) TestResumeChangeAbort(c *check.C) {
 
 	_, err := conflict.ResumeAfterWait(s.state, "ws", s.project.ProjectId, conflict.ChangeAbort, "refresh")
 	c.Assert(err, check.IsNil)
-	c.Assert(task.Status(), check.Equals, state.AbortStatus)
+	c.Assert(task.Status(), check.Equals, state.HoldStatus)
 	c.Assert(task2.Status(), check.Equals, state.HoldStatus)
 }

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -9,7 +9,7 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Install empty sketch SDK"
-  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF  
+  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
   wq
   EOF
 
@@ -50,3 +50,24 @@ execute: |
   workshop_exec info | grep -v notes | yq '.content["sketch"].installed' | MATCH '\(x3\)$'
   workshop_exec connections ws-sketch | MATCH "*.ws-sketch/sketch:sketch-plug.*:mount"
   workshop_exec exec -- test -d /home/workshop/ws-sketch-test
+
+  echo "Remove the sketch"
+  workshop_exec sketch-sdk --remove
+
+  echo "Install empty sketch SDK"
+  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  wq
+  EOF
+
+  echo "Add a breaking change to sketch"
+  ! sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  i
+    plugs:
+      test:
+        interface: mount
+  .
+  wq
+  EOF
+
+  echo "Abort the change"
+  workshop_exec refresh --abort


### PR DESCRIPTION
# Description

The task status should be set to DoStatus if the task is aborted after a wait. That makes the state system to put the task on hold if, for example, `workshop refresh --abort` was called, and prevent running the undo logic for the uncompleted task.

Previously, the task status was automatically set to WaitedStatus (Doing), which caused the undo logic to run for unfinished tasks. Given that the Workshop tasks implement revert logic to clean up partial changes, the undo must not be run for unfinished tasks (it's not always idempotent).

Arguably, the undo logic should not be run for any task that wasn't in Done.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
