### PR TITLE
Prevent WorkshopWorkshop mounts from creating duplicate fstab entries

### DIFF
--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -59,6 +59,14 @@ func lxdClient(ctx context.Context) (lxd.InstanceServer, error) {
 
 func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (reload bool, err error) {
 	if dev.Type == workshop.WorkshopWorkshop {
+		if _, err = fs.Stat(dev.What); err != nil {
+			return false, fmt.Errorf(`stat workshop-source %q: %v`, dev.What, err)
+		}
+
+		if _, err = fs.Stat(dev.Where); err != nil {
+			return false, fmt.Errorf(`stat workshop-target %q: %v`, dev.Where, err)
+		}
+
 		fstab, err := fs.OpenFile("/etc/fstab", os.O_CREATE|os.O_RDWR, 0744)
 		if err != nil {
 			return false, err
@@ -70,21 +78,15 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 			return false, err
 		}
 
-		if _, err = fs.Stat(dev.What); err != nil {
-			return false, fmt.Errorf(`stat workshop-source %q: %v`, dev.What, err)
-		}
-
-		if _, err = fs.Stat(dev.Where); err != nil {
-			return false, fmt.Errorf(`stat workshop-target %q: %v`, dev.Where, err)
-		}
-
 		check := func(me osutil.MountEntry) bool { return me.Name == dev.What && me.Dir == dev.Where }
-		if !slices.ContainsFunc(mounts.Entries, check) {
-			entry := osutil.MountEntry{Name: dev.What, Dir: dev.Where, Type: "none", Options: []string{"bind", "x-systemd.requires=/project"}}
-			mounts.Entries = append(mounts.Entries, entry)
-			if _, err = mounts.WriteTo(fstab); err != nil {
-				return false, err
-			}
+		if slices.ContainsFunc(mounts.Entries, check) {
+			return false, nil
+		}
+
+		entry := osutil.MountEntry{Name: dev.What, Dir: dev.Where, Type: "none", Options: []string{"bind", "x-systemd.requires=/project"}}
+		mounts.Entries = append(mounts.Entries, entry)
+		if _, err = mounts.WriteTo(fstab); err != nil {
+			return false, err
 		}
 		return true, nil
 	}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -67,13 +67,7 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 			return false, fmt.Errorf(`stat workshop-target %q: %v`, dev.Where, err)
 		}
 
-		fstab, err := fs.OpenFile("/etc/fstab", os.O_CREATE|os.O_RDWR, 0744)
-		if err != nil {
-			return false, err
-		}
-		defer fstab.Close()
-
-		mounts, err := osutil.ReadMountProfile(fstab)
+		mounts, err := readMountProfile(fs)
 		if err != nil {
 			return false, err
 		}
@@ -85,7 +79,7 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 
 		entry := osutil.MountEntry{Name: dev.What, Dir: dev.Where, Type: "none", Options: []string{"bind", "x-systemd.requires=/project"}}
 		mounts.Entries = append(mounts.Entries, entry)
-		if _, err = mounts.WriteTo(fstab); err != nil {
+		if err = writeMountProfile(fs, mounts); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -138,6 +132,22 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 	return false, fmt.Errorf(`unknown device type: %v`, dev.Type)
 }
 
+func readMountProfile(fs workshop.WorkshopFs) (*osutil.MountProfile, error) {
+	fstab, err := fs.Open("/etc/fstab")
+	if errors.Is(err, os.ErrNotExist) {
+		return &osutil.MountProfile{}, nil
+	} else if err != nil {
+		return nil, err
+	}
+	defer fstab.Close()
+
+	return osutil.ReadMountProfile(fstab)
+}
+
+func writeMountProfile(fs workshop.WorkshopFs, mounts *osutil.MountProfile) error {
+	return workshop.AtomicWrite(fs, "/etc/fstab", mounts, 0644)
+}
+
 func runMountCommand(conn lxd.InstanceServer, pid, w string, cmd []string) error {
 	var out bytes.Buffer
 
@@ -171,13 +181,7 @@ func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string,
 		return nil
 	}
 
-	fstab, err := fs.OpenFile("/etc/fstab", os.O_CREATE|os.O_RDWR, 0744)
-	if err != nil {
-		return err
-	}
-	defer fstab.Close()
-
-	mounts, err := osutil.ReadMountProfile(fstab)
+	mounts, err := readMountProfile(fs)
 	if err != nil {
 		return err
 	}
@@ -191,7 +195,7 @@ func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string,
 		return nil
 	}
 
-	if err = workshop.AtomicWrite(fs, "/etc/fstab", mounts, 0644); err != nil {
+	if err = writeMountProfile(fs, mounts); err != nil {
 		return err
 	}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -167,45 +167,38 @@ func reloadMounts(conn lxd.InstanceServer, pid, w string) error {
 }
 
 func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string, mnt workshop.Mount) error {
-	if mnt.Type == workshop.WorkshopWorkshop {
-		fstab, err := fs.OpenFile("/etc/fstab", os.O_CREATE|os.O_RDWR, 0744)
-		if err != nil {
-			return err
-		}
-		defer fstab.Close()
-
-		mounts, err := osutil.ReadMountProfile(fstab)
-		if err != nil {
-			return err
-		}
-
-		cnt := 0
-		deleter := func(me osutil.MountEntry) bool {
-			if me.Name == mnt.What && me.Dir == mnt.Where {
-				cnt++
-				return true
-			}
-			return false
-		}
-		mounts.Entries = slices.DeleteFunc(mounts.Entries, deleter)
-		if cnt == 0 {
-			return nil
-		}
-
-		if err = workshop.AtomicWrite(fs, "/etc/fstab", mounts, 0644); err != nil {
-			return err
-		}
-
-		err = runMountCommand(conn, pid, w, []string{
-			"umount",
-			mnt.Where,
-		})
-
-		if err != nil {
-			return err
-		}
+	if mnt.Type != workshop.WorkshopWorkshop {
+		return nil
 	}
-	return nil
+
+	fstab, err := fs.OpenFile("/etc/fstab", os.O_CREATE|os.O_RDWR, 0744)
+	if err != nil {
+		return err
+	}
+	defer fstab.Close()
+
+	mounts, err := osutil.ReadMountProfile(fstab)
+	if err != nil {
+		return err
+	}
+
+	cnt := len(mounts.Entries)
+	deleter := func(me osutil.MountEntry) bool {
+		return me.Name == mnt.What && me.Dir == mnt.Where
+	}
+	mounts.Entries = slices.DeleteFunc(mounts.Entries, deleter)
+	if cnt == len(mounts.Entries) {
+		return nil
+	}
+
+	if err = workshop.AtomicWrite(fs, "/etc/fstab", mounts, 0644); err != nil {
+		return err
+	}
+
+	return runMountCommand(conn, pid, w, []string{
+		"umount",
+		mnt.Where,
+	})
 }
 
 func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop string) error {

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	lxd "github.com/canonical/lxd/client"
@@ -113,6 +114,9 @@ plugs:
     one:
         interface: mount
         workshop-target: /opt
+    two:
+        interface: mount
+        workshop-target: /mnt
     ssh-agent:
         interface: ssh-agent
 `)
@@ -123,7 +127,10 @@ type: system
 slots:
     slot:
         interface: mount
-        workshop-source: /mnt
+        workshop-source: /usr/local
+    home:
+        interface: mount
+        workshop-source: /home
     ssh-agent:
         interface: ssh-agent
 `)
@@ -155,6 +162,14 @@ func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
 	c.Assert(err, check.IsNil)
 
+	connref = &interfaces.ConnRef{
+		PlugRef: interfaces.NewPlugRef(cinfo.Plugs["two"]),
+		SlotRef: interfaces.NewSlotRef(pinfo.Slots["home"]),
+	}
+
+	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
+	c.Assert(err, check.IsNil)
+
 	b := lxd_device.Backend{}
 	cref := sdk.Ref{ProjectId: "42424242", Workshop: "test", Sdk: "consumer"}
 
@@ -164,15 +179,25 @@ func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
 	// Check the LXD profile correctness
 	prof, err := lxdbackend.Profile(f.client, f.pid, "test", "consumer")
 	c.Assert(err, check.IsNil)
-	c.Assert(prof.Mounts, check.HasLen, 1)
+	c.Assert(prof.Mounts, check.HasLen, 2)
 	c.Check(prof.Mounts["one"].Name, check.Equals, "one")
-	c.Check(prof.Mounts["one"].What, check.Equals, "/mnt")
+	c.Check(prof.Mounts["one"].What, check.Equals, "/usr/local")
 	c.Check(prof.Mounts["one"].Where, check.Equals, "/opt")
 	c.Check(prof.Mounts["one"].Type, check.Equals, workshop.WorkshopWorkshop)
+	c.Check(prof.Mounts["two"].Name, check.Equals, "two")
+	c.Check(prof.Mounts["two"].What, check.Equals, "/home")
+	c.Check(prof.Mounts["two"].Where, check.Equals, "/mnt")
+	c.Check(prof.Mounts["two"].Type, check.Equals, workshop.WorkshopWorkshop)
 
 	// Check /etc/fstab and mount
 	fstab := f.readWorkshopFile(c, "/etc/fstab")
-	c.Check(string(fstab), check.Equals, "/mnt /opt none bind,x-systemd.requires=/project 0 0\n")
+	lines := strings.Split(string(fstab), "\n")
+	c.Check(lines, check.HasLen, 3)
+	c.Check(lines[2], check.Equals, "")
+	c.Check(lines[:2], testutil.DeepUnsortedMatches, []string{
+		"/usr/local /opt none bind,x-systemd.requires=/project 0 0",
+		"/home /mnt none bind,x-systemd.requires=/project 0 0",
+	})
 
 	// Check the LXD profile is removed
 	err = b.Remove(f.ctx, "test", "consumer")

--- a/internal/workshop/workshop_fs.go
+++ b/internal/workshop/workshop_fs.go
@@ -75,6 +75,10 @@ func AtomicWrite(fs afero.Fs, filename string, source io.WriterTo, perm os.FileM
 	rev.Add(func() { _ = fs.Remove(temp) })
 
 	_, err = source.WriteTo(file)
+	// TODO: Call file.Sync() here. This is currently a no-op for sftpfs,
+	// see https://github.com/spf13/afero/pull/429.
+	// Also, LXD uses pkg/sftp as its SFTP server,
+	// and that doesn't support the fsync@openssh.com extension.
 	file.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

Fixes an issue where `installMount` was appending to `/etc/fstab` instead of replacing it. Both writes to `/etc/fstab` are now atomic to avoid issues if the write is interrupted.

I tried to make atomic writes durable by adding a call to `fsync`, but:
1. `sftpfs.File.Sync()` is a no-op, see https://github.com/spf13/afero/pull/429.
2. https://github.com/pkg/sftp doesn't support the `fsync@openssh.com` extension.

If the latter is fixed, it's possible to workaround the former issue by creating our own `File` struct which embeds `sftp.File` (not `sftpfs.File`).

The overall read-update-write process is still not atomic though. According to `systemd.mount(5)`:
> In general, configuring mount points through `/etc/fstab` is the preferred approach to manage mounts for humans. For tooling, writing mount units should be preferred over editing `/etc/fstab`.

The downside of mount units is that it requires several `Exec` calls to enable/disable them using `systemctl`. An alternative is to use the `dbus` package from https://github.com/coreos/go-systemd. See https://gist.github.com/jonathan-conder/8301b3b053f385f270287020c59f75fb for an example.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
