### PR TITLE
Remove coverage badge from README

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,9 +1,3 @@
-|Coverage badge|
-
-.. |Coverage badge| image:: https://github.com/canonical/workshop/wiki/coverage/coverage.svg
-   :target: https://github.com/canonical/workshop/wiki/coverage/coverage.html
-
-
 Workshop
 ========
 


### PR DESCRIPTION
# Description
Removes the broken coverage badge from the README. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
