### PR TITLE
Enable errcheck linter for new code

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,14 @@ jobs:
           args: "--out-format=colored-line-number"
           skip-cache: true
 
+      - name: errcheck
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: "--out-format=colored-line-number --enable-only errcheck"
+          only-new-issues: true
+          skip-cache: true
+
       - name: shellcheck
         run: |
           git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck


### PR DESCRIPTION
# Description

This is the only default linter that's disabled currently. It will take a while to fix/ignore the existing issues, but I think it's worth at least checking for new issues.

Before merging we should probably decide whether it's better to add something to the [`exclude-functions`](https://golangci-lint.run/usage/linters/#errcheck) setting, or put `_ := SomeFunc()` everywhere.

This run tests that it only checks modified lines: https://github.com/canonical/workshop/actions/runs/12799278970/job/35685021098

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
