### PR TITLE
Make sketch-sdk abort current refresh in progress if needed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -434,6 +434,7 @@ const (
 	ErrorKindDaemonRestart     = "daemon-restart"
 	ErrorKindNoDefaultServices = "no-default-services"
 	ErrorKindUnsuccessful      = "unsuccessful"
+	ErrorKindWaitingOnError    = "waiting-on-error"
 )
 
 func (rsp *response) err(cli *Client) error {

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -294,8 +294,20 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 	cmdrefresh := &CmdRefresh{root: c.root}
 	cmdrefresh.WaitOnError = true
+	refreshArgs := []string{fmt.Sprintf("%s/sketch", wp.Name)}
 
-	return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", wp.Name)})
+	err = cmdrefresh.Run(cmd, refreshArgs)
+	if e, ok := err.(*client.Error); ok && e.Kind == client.ErrorKindWaitingOnError {
+		cmdabort := &CmdRefresh{root: c.root}
+		cmdabort.Abort = true
+		err = cmdabort.Run(cmd, []string{wp.Name})
+		if err != nil {
+			return err
+		}
+
+		err = cmdrefresh.Run(cmd, refreshArgs)
+	}
+	return err
 }
 
 func writeSketchSdk(sketchdir string, content []byte) error {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -224,6 +224,103 @@ plugs:
 	c.Assert(filepath.Join(metadir, "sdk.yaml"), testutil.FileEquals, sketchContent)
 }
 
+func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
+	cmd := &CmdSketch{root: &CmdRoot{}}
+
+	// Runs sketch-sdk with a failing setup-base hook,
+	// then immediately re-runs it to fix the hook.
+	// The second run should automatically abort the first refresh.
+	// The API calls break down as follows:
+	// 1-2: get workshop info
+	// 3-5: refresh --wait-on-error (fails due to setup-base)
+	// 6-7: get workshop info
+	// 8-9. refresh --wait-on-error (fails due to earlier refresh)
+	// 10-12. refresh --abort
+	// 13-15. refresh --wait-on-error
+	n := 0
+	change := 42
+	workshop := "ws"
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3, 6, 8, 10, 13:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 7:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithSdks)
+		case 4, 9, 11, 14:
+			mode := "wait-on-error"
+			name := fmt.Sprintf("%s/sketch", workshop)
+			if n == 11 {
+				mode = "abort"
+				name = workshop
+			}
+
+			change += 1
+			status := 202
+			response := fmt.Sprintf(`{"type":"async", "change": "%d", "status-code": 202}`, change)
+			if n == 9 {
+				status = 400
+				response = `{"type":"error", "result": {"message":"already waiting on error", "kind":"waiting-on-error"}, "status-code": 400}`
+			}
+
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
+				"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode}})
+			w.WriteHeader(status)
+			fmt.Fprintln(w, response)
+		case 5, 12, 15:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/changes/%d", change))
+			if n == 5 {
+				fmt.Fprintln(w, mockWaitChangeJSON)
+			} else if n == 12 {
+				fmt.Fprintln(w, mockAbortedChangeJSON)
+			} else {
+				fmt.Fprintln(w, mockReadyChangeJSON)
+			}
+		default:
+			c.Errorf("expected 15 calls, now on %d", n)
+		}
+	})
+
+	attempts := 0
+	sketchSetup := `name: sketch
+base: ubuntu@22.04
+
+hooks:
+    setup-base: |
+        %s
+`
+	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
+		attempts += 1
+		switch attempts {
+		case 1:
+			return []byte(fmt.Sprintf(sketchSetup, "false")), nil
+		case 2:
+			return []byte(fmt.Sprintf(sketchSetup, "true")), nil
+		default:
+			return nil, fmt.Errorf("expected 2 attempts, now on %d", attempts)
+		}
+	})
+	defer restore()
+
+	err := cmd.Run(cmd.Command(), []string{"ws"})
+	c.Assert(err, check.ErrorMatches, `cannot refresh; fix the errors reported,\nthen run "workshop refresh --continue ws".\nTo abort and revert, run "workshop refresh --abort ws"`)
+
+	err = cmd.Run(cmd.Command(), []string{"ws"})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(n, check.Equals, 15)
+	c.Assert(attempts, check.Equals, 2)
+}
+
 func (m *workshopSketch) TestSketchSdkStashOK(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
 	restore := sdk.WorkshopSketchSdkStash(m.user.HomeDir, m.prjId, "ws")

--- a/internal/daemon/api_changes.go
+++ b/internal/daemon/api_changes.go
@@ -220,7 +220,7 @@ func v1PostChange(c *Command, r *http.Request, _ *userState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
-		return statusBadRequest("cannot decode data from request body: %v", err)
+		return statusBadRequest("cannot decode data from request body: %w", err)
 	}
 
 	if reqData.Action != "abort" {
@@ -256,7 +256,7 @@ func v1GetChangeWait(c *Command, r *http.Request, _ *userState) Response {
 		// whichever is first.
 		timeout, err := time.ParseDuration(timeoutStr)
 		if err != nil {
-			return statusBadRequest("invalid timeout %q: %v", timeoutStr, err)
+			return statusBadRequest("invalid timeout %q: %w", timeoutStr, err)
 		}
 		timer := time.NewTimer(timeout)
 		select {

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -261,7 +261,7 @@ func v1GetConnections(c *Command, r *http.Request, _ *userState) Response {
 
 	if workshop != "" {
 		if err := checkWorkshopExists(r.Context(), c.d.overlord.WorkshopManager(), projectId, workshop); err != nil {
-			return statusNotFound("cannot access workshop %q: %v", workshop, err)
+			return statusNotFound("cannot access workshop %q: %w", workshop, err)
 		}
 	}
 
@@ -272,7 +272,7 @@ func v1GetConnections(c *Command, r *http.Request, _ *userState) Response {
 		connected: onlyConnected,
 	})
 	if err != nil {
-		return statusInternalError("collecting connection information failed: %v", err)
+		return statusInternalError("collecting connection information failed: %w", err)
 	}
 	sort.Sort(byCrefConnJSON(connsjson.Established))
 	sort.Sort(byCrefConnJSON(connsjson.Undesired))
@@ -297,7 +297,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 	var a interfaceAction
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&a); err != nil {
-		return statusBadRequest("cannot decode request body into an interface action: %v", err)
+		return statusBadRequest("cannot decode request body into an interface action: %w", err)
 	}
 	if a.Action == "" {
 		return statusBadRequest("interface action not specified")
@@ -336,7 +336,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 			continue
 		}
 		if err := checkInstalled(a.Plugs[i].ProjectId, a.Plugs[i].Workshop); err != nil {
-			return statusNotFound("cannot access workshop %q: %v", a.Plugs[i].Workshop, err)
+			return statusNotFound("cannot access workshop %q: %w", a.Plugs[i].Workshop, err)
 		}
 	}
 	for i := range a.Slots {
@@ -344,7 +344,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 			continue
 		}
 		if err := checkInstalled(a.Slots[i].ProjectId, a.Slots[i].Workshop); err != nil {
-			return statusNotFound("cannot access workshop %q: %v", a.Slots[i].Workshop, err)
+			return statusNotFound("cannot access workshop %q: %w", a.Slots[i].Workshop, err)
 		}
 	}
 
@@ -362,7 +362,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 			ts, connErr := ifacestate.Connect(st, plugW, connRef)
 			if connErr != nil {
 				if _, ok := connErr.(*ifacestate.ErrAlreadyConnected); !ok {
-					return statusBadRequest(connErr.Error())
+					return statusBadRequest("%w", connErr)
 				}
 			} else {
 				tasksets = append(tasksets, ts)
@@ -407,7 +407,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		}
 	}
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	change := newConnectionChange(st, user, tasksets, &a)

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -57,7 +57,7 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
-		return statusBadRequest("cannot exec: failed to decode data from request body: %v", err)
+		return statusBadRequest("cannot exec: failed to decode data from request body: %w", err)
 	}
 
 	action := "exec"
@@ -94,13 +94,13 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 		var err error
 		timeout, err = time.ParseDuration(reqData.Timeout)
 		if err != nil {
-			return statusBadRequest("invalid timeout: %v", err)
+			return statusBadRequest("invalid timeout: %w", err)
 		}
 	}
 
 	userId, groupId, err := normaliseUserGroupIds(reqData.UserId, reqData.GroupId)
 	if err != nil {
-		return statusBadRequest("cannot %s %s in %q: %v", action, subject, wrkspc, err)
+		return statusBadRequest("cannot %s %s in %q: %w", action, subject, wrkspc, err)
 	}
 
 	// We do not set PATH here as it's something LXD takes care of. Set HOME and
@@ -146,7 +146,7 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 	wsmgr := c.d.overlord.WorkshopManager()
 	taskset, err := wsmgr.Exec(r.Context(), wrkspc, projectId, execArgs, reqData.Script)
 	if err != nil {
-		return statusBadRequest("cannot %s %s in %q: %v", action, subject, wrkspc, err)
+		return statusBadRequest("cannot %s %s in %q: %w", action, subject, wrkspc, err)
 	}
 
 	change := st.NewChange("exec", fmt.Sprintf("Execute %s %q", subject, execArgs.Command[0]))

--- a/internal/daemon/api_projects.go
+++ b/internal/daemon/api_projects.go
@@ -15,7 +15,7 @@ func v1GetProjects(c *Command, r *http.Request, _ *userState) Response {
 
 	projects, err := c.d.overlord.WorkshopBackend().Projects(r.Context())
 	if err != nil {
-		return statusInternalError("cannot get projects list: %v", err)
+		return statusInternalError("cannot get projects list: %w", err)
 	}
 
 	result := make([]workshop.Project, 0)
@@ -37,16 +37,16 @@ func v1PostProjects(c *Command, r *http.Request, _ *userState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
-		return statusBadRequest("cannot decode data from request body: %v", err)
+		return statusBadRequest("cannot decode data from request body: %w", err)
 	}
 
 	wBackend := c.d.overlord.WorkshopBackend()
 
 	prj, created, err := wBackend.CreateOrLoadProject(r.Context(), reqData.Path)
 	if err != nil && !errors.Is(err, workshop.ErrNotProject) {
-		return statusInternalError("cannot create or load project at %q: %v", reqData.Path, err)
+		return statusInternalError("cannot create or load project at %q: %w", reqData.Path, err)
 	} else if errors.Is(err, workshop.ErrNotProject) {
-		return statusBadRequest("%v", err)
+		return statusBadRequest("%w", err)
 	}
 
 	if created {

--- a/internal/daemon/api_tasks.go
+++ b/internal/daemon/api_tasks.go
@@ -54,7 +54,7 @@ func (wr websocketResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rsp.ServeHTTP(w, r)
 	} else if err != nil {
 		logger.Noticef("Websocket %s: cannot connect to %s websocket: %v", wr.task.ID(), wr.websocketID, err)
-		rsp := statusInternalError("%v", err)
+		rsp := statusInternalError("%w", err)
 		rsp.ServeHTTP(w, r)
 	}
 	// In the success case, Connect takes over the connection and upgrades to

--- a/internal/daemon/api_warnings.go
+++ b/internal/daemon/api_warnings.go
@@ -53,7 +53,7 @@ func v1PostWarnings(c *Command, r *http.Request, _ *userState) Response {
 	}
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&op); err != nil {
-		return statusBadRequest("cannot decode request body into warnings operation: %v", err)
+		return statusBadRequest("cannot decode request body into warnings operation: %w", err)
 	}
 	if op.Action != "okay" {
 		return statusBadRequest("unknown warning action %q", op.Action)

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -54,7 +54,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	var reqData mountRequest
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
-		return statusBadRequest("cannot decode data from request body: %v", err)
+		return statusBadRequest("cannot decode data from request body: %w", err)
 	}
 	if reqData.Action != "remount" {
 		return statusBadRequest("unknown action %q", reqData.Action)
@@ -63,7 +63,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	reqData.Plug.ProjectId = projectId
 
 	if err := checkWorkshopExists(r.Context(), o.WorkshopManager(), projectId, w); err != nil {
-		return statusNotFound("cannot access workshop %q: %v", w, err)
+		return statusNotFound("cannot access workshop %q: %w", w, err)
 	}
 
 	change := newMountChange(st, user, &reqData)
@@ -76,7 +76,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	repo := o.InterfaceManager().Repository()
 	connRef, err := repo.Connected(reqData.Plug.ProjectId, reqData.Plug.Workshop, reqData.Plug.Sdk, reqData.Plug.Name)
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	if len(connRef) == 0 {
@@ -85,7 +85,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 
 	conn, err := repo.Connection(connRef[0])
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	if conn.Plug.Interface() != "mount" {
@@ -94,7 +94,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 
 	taskset, err := o.WorkshopManager().Remount(r.Context(), st, reqData.Plug, reqData.HostSource, projectId)
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	change.AddAll(taskset)

--- a/internal/daemon/api_workshopctl.go
+++ b/internal/daemon/api_workshopctl.go
@@ -38,12 +38,12 @@ func v1PostWorkshopCtl(c *Command, r *http.Request, _ *userState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
-		return statusBadRequest("cannot decode data from request body: %v", err)
+		return statusBadRequest("cannot decode data from request body: %w", err)
 	}
 
 	_, uid, _, err := ucrednetGet(r.RemoteAddr)
 	if err != nil {
-		return statusForbidden("cannot get remote user: %s", err)
+		return statusForbidden("cannot get remote user: %w", err)
 	}
 
 	// Ignore missing context error to allow 'workshopctl -h' without a context;
@@ -61,7 +61,7 @@ func v1PostWorkshopCtl(c *Command, r *http.Request, _ *userState) Response {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
 			stdout = []byte(e.Error())
 		} else {
-			return statusBadRequest("%s", err)
+			return statusBadRequest("%w", err)
 		}
 	}
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -223,14 +223,14 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	} else {
 		status, err = healthstate.StatusLookup(wstate)
 		if err != nil {
-			return statusBadRequest(`%v, "all", "available"`, err)
+			return statusBadRequest(`%w, "all", "available"`, err)
 		}
 	}
 
 	wrkmgr := c.d.overlord.WorkshopManager()
 	workshops, err := wrkmgr.Workshops(r.Context(), projectId)
 	if err != nil {
-		return statusInternalError("%v", err)
+		return statusInternalError("%w", err)
 	}
 
 	info := Workshops{}
@@ -254,7 +254,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 		if wstate == "available" && errors.As(err, &fileErr) {
 			state.Warnf("%v", err)
 		} else if err != nil {
-			return statusInternalError("%v", err)
+			return statusInternalError("%w", err)
 		} else {
 			info.Files = make([]*WorkshopFileInfo, 0, len(files))
 			for name, path := range files {
@@ -335,7 +335,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	var reqData workshopReq
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reqData); err != nil {
-		return statusBadRequest("cannot decode data from request body: %v", err)
+		return statusBadRequest("cannot decode data from request body: %w", err)
 	}
 
 	if len(reqData.Names) == 0 {
@@ -358,7 +358,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 
 	mode, err := actionMode(&reqData)
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	user, ok := r.Context().Value(workshop.ContextUser).(string)
@@ -395,7 +395,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	for _, tset := range taskset {
@@ -429,24 +429,24 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	wrkmgr := c.d.overlord.WorkshopManager()
 	w, err := wrkmgr.Workshop(r.Context(), name, projectId)
 	if err != nil {
-		return statusNotFound("%v", err)
+		return statusNotFound("%w", err)
 	}
 	health := wrkmgr.WorkshopHealth(w)
 
 	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
 	sdks, err := w.SdkInfos(ctx)
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	ms, err := mounts(w, sdks)
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	files, err := wrkmgr.WorkshopFiles(ctx, projectId)
 	if err != nil {
-		return statusBadRequest(err.Error())
+		return statusBadRequest("%w", err)
 	}
 
 	rsp := Workshop{

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -603,6 +603,7 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 		c.Check(rsp.Status, check.Equals, expected[num].Status, check.Commentf("case: %v", num))
 
 		if rsp.Type == ResponseTypeError {
+			c.Check(string(rsp.Result.(*errorResult).Kind), check.Equals, expected[num].Kind)
 			c.Check(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
 		}
 
@@ -1858,6 +1859,7 @@ base: ubuntu@22.04
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
 			Message: `cannot refresh "manysdks": waiting on error`,
+			Kind:    "waiting-on-error",
 			Summary: `Refresh "manysdks" workshop`,
 		},
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -45,6 +45,7 @@ import (
 )
 
 var (
+	ErrAccessDenied  = errors.New("access denied")
 	ErrRestartSocket = fmt.Errorf("daemon stop requested to wait for socket activation")
 
 	systemdSdNotify = systemd.SdNotify
@@ -224,7 +225,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// check if we are in degradedMode
 	if c.d.degradedErr != nil && r.Method != "GET" {
-		statusInternalError(c.d.degradedErr.Error()).ServeHTTP(w, r)
+		statusInternalError("%w", c.d.degradedErr).ServeHTTP(w, r)
 		return
 	}
 
@@ -232,7 +233,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case accessOK:
 		// nothing
 	case accessUnauthorized:
-		statusUnauthorized("access denied").ServeHTTP(w, r)
+		statusUnauthorized("%w", ErrAccessDenied).ServeHTTP(w, r)
 		return
 	case accessForbidden:
 		statusForbidden("forbidden").ServeHTTP(w, r)
@@ -255,13 +256,13 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	_, uid, _, err := ucrednetGet(r.RemoteAddr)
 	if err != nil {
-		statusInternalError("cannot get an associated uid: %v", err).ServeHTTP(w, r)
+		statusInternalError("cannot get an associated uid: %w", err).ServeHTTP(w, r)
 		return
 	}
 
 	username, err := LookupUserId(strconv.FormatUint(uint64(uid), 10))
 	if err != nil {
-		statusInternalError("cannot get an associated user name: %v", err).ServeHTTP(w, r)
+		statusInternalError("cannot get an associated user name: %w", err).ServeHTTP(w, r)
 		return
 	}
 

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -16,6 +16,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -136,7 +137,7 @@ type errorResult struct {
 
 func SyncResponse(result interface{}, status int) Response {
 	if err, ok := result.(error); ok {
-		return statusInternalError("internal error: %v", err)
+		return statusInternalError("internal error: %w", err)
 	}
 
 	if rsp, ok := result.(Response); ok {
@@ -172,19 +173,25 @@ func (f fileResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func makeErrorResponder(status int) errorResponder {
 	return func(format string, v ...interface{}) Response {
 		res := &errorResult{}
-		if len(v) == 0 {
-			res.Message = format
-		} else {
-			res.Message = fmt.Sprintf(format, v...)
-		}
-		if status == 401 {
-			res.Kind = errorKindLoginRequired
-		}
-		return &resp{
+		response := &resp{
 			Type:   ResponseTypeError,
 			Result: res,
 			Status: status,
 		}
+
+		if len(v) == 0 {
+			res.Message = format
+			return response
+		}
+
+		err := fmt.Errorf(format, v...)
+		res.Message = err.Error()
+
+		if errors.Is(err, ErrAccessDenied) {
+			res.Kind = errorKindLoginRequired
+		}
+
+		return response
 	}
 }
 

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/overlord/workshopstate"
 )
 
 type ResponseType string
@@ -125,6 +126,7 @@ const (
 	errorKindNotFound          = errorKind("not-found")
 	errorKindPermissionDenied  = errorKind("permission-denied")
 	errorKindGenericFileError  = errorKind("generic-file-error")
+	errorKindWaitingOnError    = errorKind("waiting-on-error")
 )
 
 type errorValue interface{}
@@ -189,6 +191,8 @@ func makeErrorResponder(status int) errorResponder {
 
 		if errors.Is(err, ErrAccessDenied) {
 			res.Kind = errorKindLoginRequired
+		} else if errors.Is(err, workshopstate.ErrWaitingOnError) {
+			res.Kind = errorKindWaitingOnError
 		}
 
 		return response

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -2,6 +2,7 @@ package workshopstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/workshop"
 )
+
+var ErrWaitingOnError = errors.New("waiting on error")
 
 type WorkshopManager struct {
 	backend workshop.Backend
@@ -68,7 +71,7 @@ func (w *WorkshopManager) CheckStatus(ctx context.Context, name, pId string, all
 			return fmt.Errorf("workshop already running")
 		case healthstate.PendingStatus:
 			if health.Code == "wait-on-error" {
-				return fmt.Errorf("waiting on error")
+				return ErrWaitingOnError
 			}
 			return fmt.Errorf("other changes in progress")
 		case healthstate.ErrorStatus:

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -303,7 +303,7 @@ func (s *managerSuite) TestCheckStatusPending(c *check.C) {
 
 	// All other status' should return an error
 	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.OffStatus, healthstate.ReadyStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "waiting on error")
+	c.Assert(err, testutil.ErrorIs, workshopstate.ErrWaitingOnError)
 }
 
 func (s *managerSuite) TestCheckStatusError(c *check.C) {


### PR DESCRIPTION
# Description

Previously this was a common workflow:
```console
$ workshop sketch-sdk
# add some buggy code to setup-base
2025-01-16T13:14:37+13:00 ERROR command exit code 1
error: cannot refresh; fix the errors reported,
then run "workshop refresh --continue ws".
To abort and revert, run "workshop refresh --abort ws"
$ workshop sketch-sdk
# fix bugs
error: cannot refresh "ws": waiting on error
$ workshop refresh --abort
"ws" refresh aborted
$ workshop sketch-sdk
# have to add some whitespace or something to trigger a refresh now
```

The `waiting on error` message should not appear anymore, `sketch-sdk` will abort automatically. The second issue (having to edit the file in some way to trigger a refresh) is still present, but should be much less common so I don't think it's really a problem anymore. Users can just call `workshop refresh ws/sketch` anyway.

I'm a little bit unhappy with the complexity of the test I added, but this is quite a long sequence of tasks so I don't know that there's a way to simplify it much further.

I think it was a good idea to handle this all client-side, e.g. the user will be able to see that a previous refresh was aborted. In order to enable that I needed a way to expose error types to the client, so I opted to replace `fmt.Sprintf()` with `fmt.Errorf().Error()` in the error responders. `Errorf()` will wrap errors formatted with `%w`, so we can inspect them using `errors.Is`. If this gets too complicated, we can switch to `errors.As` with a custom interface.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
