### PR TITLE
Mount SDKs as volumes

### DIFF
--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -58,7 +58,7 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 
 	repo := s.d.overlord.InterfaceManager().Repository()
 
-	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
 	ref, err := repo.Connected(s.project.ProjectId, "manysdks", "test-sdk", "data")
 	c.Assert(err, check.IsNil)
 	conn, err := repo.Connection(ref[0])
@@ -91,7 +91,7 @@ func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
 
 	repo := s.d.overlord.InterfaceManager().Repository()
 
-	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
 	ref, err := repo.Connected(s.project.ProjectId, "manysdks", "test-sdk", "data")
 	c.Assert(err, check.IsNil)
 	conn, err := repo.Connection(ref[0])
@@ -148,7 +148,7 @@ func (s *apiSuite) TestWorkshopRemountPlugDisconnected(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
 
 	_, err := s.d.overlord.InterfaceManager().Repository().DisconnectSdk(s.project.ProjectId, "manysdks", "test-sdk")
 	c.Check(err, check.IsNil)
@@ -173,7 +173,7 @@ func (s *apiSuite) TestWorkshopRemountInvalidSetup(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
 
 	// Setup
 	requests := []*bytes.Buffer{
@@ -202,7 +202,7 @@ func (s *apiSuite) TestWorkshopRemountInvalidInterface(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
 
 	// Setup
 	requests := []*bytes.Buffer{
@@ -226,7 +226,7 @@ func (s *apiSuite) TestWorkshopRemountStaticSlotSourceFails(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "workshopconns", workshopconns, testsdks)
+	s.launchWorkshop(c, "workshopconns", workshopconns, apiSuiteSdks)
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"host-source":%q}`, c.MkDir())),

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -743,10 +743,10 @@ func mockSdkVolume(sdkdir string, metayaml string) error {
 
 func (s *apiSuite) mockSdkVolumes(c *check.C, sdks map[string]testSdk) {
 	for _, info := range sdks {
-		err := s.b.CreateVolume(s.ctx, info.s.VolumeName())
+		err := s.b.CreateVolume(s.ctx, sdk.VolumeName(info.s.Name, info.s.Revision.String()))
 		c.Assert(err, check.IsNil)
 
-		vfs := s.b.WorkshopVolumeContents[info.s.VolumeName()]
+		vfs := s.b.WorkshopVolumeContents[sdk.VolumeName(info.s.Name, info.s.Revision.String())]
 		err = mockSdkVolume(vfs, info.meta)
 		c.Assert(err, check.IsNil)
 	}
@@ -1953,8 +1953,8 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
 		{Workshop: "manysdks", Name: workshop.AptCacheVolumeName("manysdks", s.project.ProjectId)},
-		{Workshop: "manysdks", Name: s2.VolumeName()},
-		{Workshop: "manysdks", Name: s1.VolumeName()},
+		{Workshop: "manysdks", Name: sdk.VolumeName(s2.Name, s2.Revision.String())},
+		{Workshop: "manysdks", Name: sdk.VolumeName(s1.Name, s1.Revision.String())},
 	})
 	s.b.AttachVolumeCalls = s.b.AttachVolumeCalls[:0]
 
@@ -1977,8 +1977,8 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
 		{Workshop: "manysdks", Name: workshop.AptCacheVolumeName("manysdks", s.project.ProjectId)},
-		{Workshop: "manysdks", Name: s1.VolumeName()},
-		{Workshop: "manysdks", Name: s2.VolumeName()},
+		{Workshop: "manysdks", Name: sdk.VolumeName(s1.Name, s1.Revision.String())},
+		{Workshop: "manysdks", Name: sdk.VolumeName(s2.Name, s2.Revision.String())},
 	})
 }
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -14,16 +14,18 @@ import (
 	"sync"
 	"time"
 
-	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 var (
@@ -268,16 +270,22 @@ plugs:
 `
 )
 
-var testsdks = map[string]string{
-	"test-sdk":   testsdk,
-	"test-sdk-2": testsdk2,
+type testSdk struct {
+	s    sdk.Setup
+	meta string
 }
 
-func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string, sdks map[string]string) {
+var apiSuiteSdks = map[string]testSdk{
+	"test-sdk":   testSdk{s: sdk.Setup{Name: "test-sdk", Revision: sdk.R(1)}, meta: testsdk},
+	"test-sdk-2": testSdk{s: sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(1)}, meta: testsdk2},
+}
+
+func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string, sdks map[string]testSdk) {
 	s.createWFile(c, name, yaml)
 
 	defer s.store.SetActionCallback(storeAction)()
-	defer s.mockDoInstallSdk(c, name, sdks)()
+	defer s.store.SetDownloadCallback(storeDownload)()
+	s.mockSdkVolumes(c, sdks)
 
 	reqbuf := bytes.NewBufferString(fmt.Sprintf(`{"names":["%s"],"action":"launch"}`, name))
 	s.vars = map[string]string{"id": s.project.ProjectId}
@@ -303,8 +311,8 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
-	s.launchWorkshop(c, "basic", basic, map[string]string{})
+	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
+	s.launchWorkshop(c, "basic", basic, map[string]testSdk{})
 
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
 	s.vars = map[string]string{"id": s.project.ProjectId}
@@ -370,7 +378,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "manysdks", manysdks, testsdks)
+	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
 
 	w, ok := s.b.Workshops[s.project.ProjectId]["manysdks"]
 	c.Assert(ok, check.Equals, true)
@@ -488,7 +496,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "somebound", somebound, testsdks)
+	s.launchWorkshop(c, "somebound", somebound, apiSuiteSdks)
 
 	w, ok := s.b.Workshops[s.project.ProjectId]["somebound"]
 	c.Assert(ok, check.Equals, true)
@@ -583,7 +591,7 @@ func (s *apiSuite) TestGetWorkshopScripts(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "scripts", scripts, map[string]string{})
+	s.launchWorkshop(c, "scripts", scripts, map[string]testSdk{})
 
 	// Get Workshop scripts
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}/scripts")
@@ -686,10 +694,24 @@ func (s *apiSuite) createWFile(c *check.C, name, yaml string) {
 	c.Assert(err, check.IsNil)
 }
 
+func storeDownload(ctx context.Context, setup sdk.Setup, report *progress.Reporter) error {
+	// Emulate store action behaviour which would reuse the existing SDK if
+	// present.
+	sdkdir := filepath.Join(dirs.SdkDownloads, setup.Filename())
+	_, isDir, err := osutil.ExistsIsDir(sdkdir)
+	if isDir {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return mockSdkVolume(filepath.Join(dirs.SdkDownloads, setup.Filename()), apiSuiteSdks[setup.Name].meta)
+}
+
 func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
 	var result = []sdk.SdkResult{}
 	for _, act := range actions {
-		info, err := sdk.ReadSdkInfo([]byte(testsdks[act.Name]), act.ProjectId, act.Workshop)
+		info, err := sdk.ReadSdkInfo([]byte(apiSuiteSdks[act.Name].meta), act.ProjectId, act.Workshop)
 		if err != nil {
 			return nil, err
 		}
@@ -700,56 +722,34 @@ func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult,
 	return result, nil
 }
 
-func (s *apiSuite) mockDoInstallSdk(c *check.C, ws string, sdks map[string]string) func() {
-	order := 0
-	s.b.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
-		// check if the command is to install an SDK
-		if args.Command[0] != "tar" {
-			return workshop.ExecContext{WaitExecution: func(ctx context.Context) error { return nil }}, nil
-		}
-
-		fs, err := s.b.WorkshopFs(s.ctx, ws)
-		c.Check(err, check.IsNil)
-		defer fs.Close()
-
-		// Get the SDK name from the exec command (we don't have a separate
-		// method to install an SDK now).
-		sdkname, found := strings.CutSuffix(filepath.Base(args.Command[3]), "_1.sdk")
-		c.Check(found, check.Equals, true)
-
-		// Install meta.
-		metadir := filepath.Join(sdk.SdkRevPath(sdkname, "1"), "meta")
-		err = fs.MkdirAll(metadir, 0755)
-		c.Check(err, check.IsNil)
-		err = fs.Symlink(sdk.SdkRevPath(sdkname, "1"), sdk.SdkCurrentPath(sdkname))
-		c.Check(err, check.IsNil)
-		file, err := fs.OpenFile(filepath.Join(metadir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
-		c.Check(err, check.IsNil)
-		defer file.Close()
-		syaml, exists := sdks[sdkname]
-		c.Check(exists, check.Equals, true)
-		_, err = file.Write([]byte(syaml))
-		c.Check(err, check.IsNil)
-
-		// Record installation order.
-		order += 1
-		orderPath := filepath.Join(sdk.SdkRevPath(sdkname, "1"), "order")
-		err = afero.WriteFile(fs, orderPath, []byte(fmt.Sprintln(order)), 0644)
-		c.Check(err, check.IsNil)
-
-		// Install hooks.
-		hooksdir := sdk.SdkHooksDir(sdkname)
-		err = fs.MkdirAll(hooksdir, 0755)
-		c.Check(err, check.IsNil)
-		for _, hook := range []string{"setup-base", "save-state", "restore-state"} {
-			setuphook, err := fs.OpenFile(sdk.SdkHookPath(sdkname, hook), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0744)
-			c.Check(err, check.IsNil)
-			defer setuphook.Close()
-		}
-
-		return workshop.ExecContext{WaitExecution: func(ctx context.Context) error { return nil }}, nil
+func mockSdkVolume(sdkdir string, metayaml string) error {
+	metadir := filepath.Join(sdkdir, "meta")
+	if err := os.MkdirAll(metadir, 0755); err != nil {
+		return err
 	}
-	return func() { s.b.ExecCallback = nil }
+
+	file, err := os.OpenFile(filepath.Join(metadir, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if _, err = file.Write([]byte(metayaml)); err != nil {
+		return err
+	}
+
+	hooksdir := filepath.Join(sdkdir, "sdk", "hooks")
+	return os.MkdirAll(hooksdir, 0755)
+}
+
+func (s *apiSuite) mockSdkVolumes(c *check.C, sdks map[string]testSdk) {
+	for _, info := range sdks {
+		err := s.b.CreateVolume(s.ctx, info.s.VolumeName())
+		c.Assert(err, check.IsNil)
+
+		vfs := s.b.WorkshopVolumeContents[info.s.VolumeName()]
+		err = mockSdkVolume(vfs, info.meta)
+		c.Assert(err, check.IsNil)
+	}
 }
 
 func (s *apiSuite) mockSketchSdk(c *check.C, ws string, meta string) {
@@ -841,7 +841,8 @@ func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopslot", workshopslot)
-	defer s.mockDoInstallSdk(c, "workshopslot", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopslot"],"action":"launch"}`),
@@ -871,7 +872,8 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
 		return fmt.Errorf(`cannot assign profile to "manysdks"`)
@@ -913,7 +915,8 @@ func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "somebound", somebound)
-	defer s.mockDoInstallSdk(c, "somebound", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["somebound"],"action":"launch"}`),
@@ -949,7 +952,8 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "masterunknown", masterunknown)
-	defer s.mockDoInstallSdk(c, "masterunknown", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["masterunknown"],"action":"launch"}`),
@@ -974,7 +978,8 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "slaveunknown", slaveunknown)
-	defer s.mockDoInstallSdk(c, "slaveunknown", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["slaveunknown"],"action":"launch"}`),
@@ -999,7 +1004,8 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "bindincompatible", bindincompatible)
-	defer s.mockDoInstallSdk(c, "bindincompatible", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["bindincompatible"],"action":"launch"}`),
@@ -1025,7 +1031,8 @@ func (s *apiSuite) TestLaunchWorkshopWithPlugOK(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "workshopplug", workshopplug)
-	defer s.mockDoInstallSdk(c, "workshopplug", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopplug"],"action":"launch"}`),
@@ -1057,7 +1064,8 @@ func (s *apiSuite) TestLaunchWorkshopPlugAddedAndBound(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "workshopplugbound", workshopplugbound)
-	defer s.mockDoInstallSdk(c, "workshopplugbound", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopplugbound"],"action":"launch"}`),
@@ -1093,7 +1101,8 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
-	defer s.mockDoInstallSdk(c, "workshopconns", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
@@ -1144,7 +1153,8 @@ func (s *apiSuite) TestWorkshopConnectionsUnknownPlug(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopbrokenconn", workshopbrokenconn)
-	defer s.mockDoInstallSdk(c, "workshopbrokenconn", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopbrokenconn"],"action":"launch"}`),
@@ -1177,7 +1187,8 @@ func (s *apiSuite) TestWorkshopConnectionsPlugIsBoundTo(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "connsplugbound", connsplugbound)
-	defer s.mockDoInstallSdk(c, "connsplugbound", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["connsplugbound"],"action":"launch"}`),
@@ -1232,7 +1243,8 @@ func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
 	s.runActionTest(c, requests, expected)
 
 	s.createWFile(c, "basic", basic_refreshed)
-	defer s.mockDoInstallSdk(c, "basic", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"refresh"}`),
@@ -1272,13 +1284,14 @@ func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
 	})
 }
 
-func (s *apiSuite) TestRefreshWorkshopReturnsPreviousWorkshopIfFailed(c *check.C) {
+func (s *apiSuite) TestRefreshWorkshopRestoresPreviousWorkshopIfFailed(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`)}
@@ -1620,7 +1633,7 @@ func (s *apiSuite) TestLaunchWorkshopRefreshLaunchInProgress(c *check.C) {
 	defer s.d.Overlord().Stop()
 
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
 
 	var errOnce sync.Once
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
@@ -1664,7 +1677,7 @@ func (s *apiSuite) TestLaunchWorkshopContinueSuccess(c *check.C) {
 	defer s.d.Overlord().Stop()
 
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
 
 	var errOnce sync.Once
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
@@ -1744,7 +1757,7 @@ func (s *apiSuite) TestLaunchWorkshopChangeAbort(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
 
 	var errOnce sync.Once
 	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
@@ -1790,7 +1803,7 @@ func (s *apiSuite) TestRefreshWorkshopPartialOK(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
 	s.mockSketchSdk(c, "manysdks", `name: sketch
 base: ubuntu@22.04
 plugs:
@@ -1798,6 +1811,7 @@ plugs:
     interface: mount
     workshop-target: /etc
 `)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -1864,10 +1878,11 @@ func (s *apiSuite) TestRefreshWorkshopPartialConflictChange(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
 	s.mockSketchSdk(c, "manysdks", `name: illegal%
 base: ubuntu@22.04
 `)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -1911,10 +1926,11 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Install test-sdk-2 first.
 	s.createWFile(c, "manysdks", manysdks_reversed)
-	defer s.mockDoInstallSdk(c, "manysdks", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"remove"}`),
 	}
 	expected := []*expectedResp{
 		{
@@ -1923,47 +1939,47 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 			Kind:    "launch",
 			Summary: `Launch "manysdks" workshop`,
 		},
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "remove",
+			Summary: `Remove "manysdks" workshop`,
+		},
 	}
 	s.runActionTest(c, requests, expected)
 
-	fs, err := s.b.WorkshopFs(s.ctx, "manysdks")
-	c.Assert(err, check.IsNil)
+	s1 := apiSuiteSdks["test-sdk"].s
+	s2 := apiSuiteSdks["test-sdk-2"].s
 
-	order, err := afero.ReadFile(fs, filepath.Join(sdk.SdkCurrentPath("test-sdk-2"), "order"))
-	c.Assert(err, check.IsNil)
-	c.Check(string(order), check.Equals, "1\n")
-
-	order, err = afero.ReadFile(fs, filepath.Join(sdk.SdkCurrentPath("test-sdk"), "order"))
-	c.Assert(err, check.IsNil)
-	c.Check(string(order), check.Equals, "2\n")
+	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
+		{Workshop: "manysdks", Name: workshop.AptCacheVolumeName("manysdks", s.project.ProjectId)},
+		{Workshop: "manysdks", Name: s2.VolumeName()},
+		{Workshop: "manysdks", Name: s1.VolumeName()},
+	})
+	s.b.AttachVolumeCalls = s.b.AttachVolumeCalls[:0]
 
 	// Install test-sdk first this time.
 	s.createWFile(c, "manysdks", manysdks)
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
 	}
 	expected = []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
-			Kind:    "refresh",
-			Summary: `Refresh "manysdks" workshop`,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
 		},
 	}
 
 	s.runActionTest(c, requests, expected)
 
-	fs, err = s.b.WorkshopFs(s.ctx, "manysdks")
-	c.Assert(err, check.IsNil)
-
-	order, err = afero.ReadFile(fs, filepath.Join(sdk.SdkCurrentPath("test-sdk"), "order"))
-	c.Assert(err, check.IsNil)
-	c.Check(string(order), check.Equals, "3\n")
-
-	order, err = afero.ReadFile(fs, filepath.Join(sdk.SdkCurrentPath("test-sdk-2"), "order"))
-	c.Assert(err, check.IsNil)
-	c.Check(string(order), check.Equals, "4\n")
+	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
+		{Workshop: "manysdks", Name: workshop.AptCacheVolumeName("manysdks", s.project.ProjectId)},
+		{Workshop: "manysdks", Name: s1.VolumeName()},
+		{Workshop: "manysdks", Name: s2.VolumeName()},
+	})
 }
 
 func (s *apiSuite) TestStartWorkshop(c *check.C) {
@@ -2058,7 +2074,8 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
-	defer s.mockDoInstallSdk(c, "workshopconns", testsdks)()
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -276,8 +276,8 @@ type testSdk struct {
 }
 
 var apiSuiteSdks = map[string]testSdk{
-	"test-sdk":   testSdk{s: sdk.Setup{Name: "test-sdk", Revision: sdk.R(1)}, meta: testsdk},
-	"test-sdk-2": testSdk{s: sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(1)}, meta: testsdk2},
+	"test-sdk":   {s: sdk.Setup{Name: "test-sdk", Revision: sdk.R(1)}, meta: testsdk},
+	"test-sdk-2": {s: sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(1)}, meta: testsdk2},
 }
 
 func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string, sdks map[string]testSdk) {

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -41,8 +41,10 @@ var (
 	BaseDir string
 	// Work directory
 	ExecDir string
-	// The directory to store downloaded SDKs
+	// The directory to store unpacked SDKs
 	SdkDir string
+	// The directory to store downloaded SDKs
+	SdkDownloads string
 	// Path to the daemon's unix socket
 	SocketPath string
 	// State lock file
@@ -89,6 +91,8 @@ func SetRootDir(rootdir string) {
 	}
 	BaseDir = rootdir
 	SdkDir = filepath.Join(BaseDir, "sdk")
+	SdkDownloads = filepath.Join(BaseDir, "cache")
+
 	WorkshopStateLockFile = filepath.Join(BaseDir, "state.lock")
 	WorkshopTlsDir = filepath.Join(BaseDir, "tls")
 	WorkshopdRunDir = filepath.Join(BaseDir, "/run/workshopd")
@@ -100,6 +104,9 @@ func CreateDirs() error {
 		return err
 	}
 	if err := os.MkdirAll(SdkDir, 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(SdkDownloads, 0755); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(WorkshopdRunDir, 0755); err != nil {

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -44,8 +44,8 @@ func (f *storeIntegration) TestStoreDownloadOK(c *check.C) {
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable"}
 	err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(setup.Filename(), testutil.FilePresent)
-	c.Assert(os.Remove(setup.Filename()), check.IsNil)
+	c.Assert(setup.Filepath(), testutil.FilePresent)
+	c.Assert(os.Remove(setup.Filepath()), check.IsNil)
 }
 
 func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
@@ -58,24 +58,24 @@ func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
 	}}
 	err := s.DownloadSdk(context.Background(), setup, r)
 	c.Assert(err, check.IsNil)
-	c.Assert(setup.Filename(), testutil.FilePresent)
+	c.Assert(setup.Filepath(), testutil.FilePresent)
 	c.Check(done > 0, check.Equals, true)
 	c.Check(total > 0, check.Equals, true)
 	c.Check(done == total, check.Equals, true)
-	c.Assert(os.Remove(setup.Filename()), check.IsNil)
+	c.Assert(os.Remove(setup.Filepath()), check.IsNil)
 }
 
 func (f *storeIntegration) TestStoreDownloadCleanupPrevious(c *check.C) {
 	s := store.New()
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
-	prev := filepath.Join(dirs.SdkDir, setup.Name) + "_5.sdk"
+	prev := filepath.Join(dirs.SdkDownloads, setup.Name) + "_5.sdk"
 	_, err := os.Create(prev)
 	c.Assert(err, check.IsNil)
 	err = s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(setup.Filename(), testutil.FilePresent)
+	c.Assert(setup.Filepath(), testutil.FilePresent)
 	c.Assert(prev, testutil.FileAbsent)
-	c.Assert(os.Remove(setup.Filename()), check.IsNil)
+	c.Assert(os.Remove(setup.Filepath()), check.IsNil)
 }
 
 func (f *storeIntegration) TestStoreDownloadNotfound(c *check.C) {
@@ -83,7 +83,7 @@ func (f *storeIntegration) TestStoreDownloadNotfound(c *check.C) {
 	setup := sdk.Setup{Name: "test-sdk-unknown", Channel: "latest/stable"}
 	err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.ErrorMatches, `SDK not found in "latest/stable"`)
-	c.Assert(setup.Filename(), testutil.FileAbsent)
+	c.Assert(setup.Filepath(), testutil.FileAbsent)
 }
 
 func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.C) {
@@ -97,7 +97,7 @@ func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
 
 	// Lock the file to emulate a concurrent download is going on
-	target := setup.Filename()
+	target := setup.Filepath()
 	fl, err := sdk.OpenLock(setup.Name)
 	c.Assert(err, check.IsNil)
 	c.Assert(fl.Lock(), check.IsNil)
@@ -107,7 +107,7 @@ func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.
 	go func() {
 		err := s.DownloadSdk(context.Background(), setup, nil)
 		c.Check(err, check.IsNil)
-		c.Check(m.String(), check.Matches, fmt.Sprintf(`(?s)*.DEBUG: SDK Store on Download: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_1.sdk.*`, dirs.SdkDir))
+		c.Check(m.String(), check.Matches, fmt.Sprintf(`(?s)*.DEBUG: SDK Store on Download: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_1.sdk.*`, dirs.SdkDownloads))
 		wg.Done()
 	}()
 
@@ -135,7 +135,7 @@ func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 55}}
 	err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(setup.Filename(), testutil.FileAbsent)
+	c.Assert(setup.Filepath(), testutil.FileAbsent)
 }
 
 func (s *storeIntegration) TestSdkActionInstallStoreError(c *check.C) {

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -142,7 +142,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 	}
 	defer r.Close()
 
-	target := setup.Filename()
+	target := setup.Filepath()
 	if !osutil.FileExists(target) {
 		file, err := os.Create(target)
 		if err != nil {

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -36,7 +36,7 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 
 	if hook.HookType == SaveState || hook.HookType == RestoreState {
 		volume := workshop.WorkshopStateVolumeName(w, prj.ProjectId)
-		if err := h.backend.AttachVolume(ctx, w, volume, dirs.WorkshopStateDir); err != nil {
+		if err := h.backend.AttachVolume(ctx, w, volume, dirs.WorkshopStateDir, false); err != nil {
 			return fmt.Errorf("cannot run hook %q for SDK %q: %w", hook.Type(), hook.Sdk, err)
 		}
 

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -124,7 +124,9 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
 	err := s.backend.CreateVolume(s.ctx, volume)
 	c.Assert(err, check.IsNil)
-	defer s.backend.DeleteVolume(s.ctx, volume)
+	defer func() {
+		_ = s.backend.DeleteVolume(s.ctx, volume)
+	}()
 
 	s.state.Unlock()
 	s.se.Ensure()
@@ -171,8 +173,9 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
 	err := s.backend.CreateVolume(s.ctx, volume)
 	c.Assert(err, check.IsNil)
-	defer s.backend.DeleteVolume(s.ctx, volume)
-
+	defer func() {
+		_ = s.backend.DeleteVolume(s.ctx, volume)
+	}()
 	// Setup state storage (must be already set by the save-state in a real use
 	// case).
 	vfs := s.backend.WorkshopVolumeContents[volume]
@@ -210,7 +213,9 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
 	err := s.backend.CreateVolume(s.ctx, volume)
 	c.Assert(err, check.IsNil)
-	defer s.backend.DeleteVolume(s.ctx, volume)
+	defer func() {
+		_ = s.backend.DeleteVolume(s.ctx, volume)
+	}()
 
 	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -3,6 +3,8 @@ package hookstate_test
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
@@ -119,20 +121,25 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
+	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
+	err := s.backend.CreateVolume(s.ctx, volume)
+	c.Assert(err, check.IsNil)
+	defer s.backend.DeleteVolume(s.ctx, volume)
+
 	s.state.Unlock()
 	s.se.Ensure()
 	s.se.Wait()
 	s.state.Lock()
+	c.Assert(chg.Err(), check.IsNil)
 	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
 		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
 
-	// ensure that the save-state handler has created the required state
+	// Ensure that the save-state handler has created the required state
 	// directory (reattach the volume to the workshop to check).
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
 	defer ws.Close()
-	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
 	err = s.backend.AttachVolume(s.ctx, "ws", volume, dirs.WorkshopStateDir)
 	c.Check(err, check.IsNil)
 	info, err := ws.Stat("/var/lib/workshop/state/sdk/one")
@@ -161,12 +168,16 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	// setup state storage (must be already set by the save-state in a real use
+	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
+	err := s.backend.CreateVolume(s.ctx, volume)
+	c.Assert(err, check.IsNil)
+	defer s.backend.DeleteVolume(s.ctx, volume)
+
+	// Setup state storage (must be already set by the save-state in a real use
 	// case).
-	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
+	vfs := s.backend.WorkshopVolumeContents[volume]
 	c.Check(err, check.IsNil)
-	defer ws.Close()
-	err = ws.MkdirAll("/var/lib/workshop/state/sdk/one", 0755)
+	err = os.MkdirAll(filepath.Join(vfs, "sdk", "one"), 0755)
 	c.Check(err, check.IsNil)
 
 	s.state.Unlock()
@@ -195,6 +206,12 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 	chg.AddTask(t1)
 
 	s.launchWorkshop(c, "one")
+
+	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
+	err := s.backend.CreateVolume(s.ctx, volume)
+	c.Assert(err, check.IsNil)
+	defer s.backend.DeleteVolume(s.ctx, volume)
+
 	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -142,7 +142,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
 	defer ws.Close()
-	err = s.backend.AttachVolume(s.ctx, "ws", volume, dirs.WorkshopStateDir)
+	err = s.backend.AttachVolume(s.ctx, "ws", volume, dirs.WorkshopStateDir, false)
 	c.Check(err, check.IsNil)
 	info, err := ws.Stat("/var/lib/workshop/state/sdk/one")
 	c.Check(err, check.IsNil)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -365,8 +365,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c *check.C) {
 	// Setup
 	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{sdk.Setup{Name: "conflict-1", Channel: "latest/stable"}, conflictingTarget1},
-		{sdk.Setup{Name: "conflict-2", Channel: "latest/stable"}, conflictingTarget2},
+		{sdk.Setup{Name: "conflict-1", Channel: "latest/stable", Revision: sdk.R(1)}, conflictingTarget1},
+		{sdk.Setup{Name: "conflict-2", Channel: "latest/stable", Revision: sdk.R(1)}, conflictingTarget2},
 	})
 	repo := s.mgr.Repository()
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget1, s.prj.ProjectId, "ws")), check.IsNil)

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"html/template"
+	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
@@ -82,6 +84,31 @@ type testSdkSetup struct {
 	yaml string
 }
 
+var systemYaml = `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  slot:
+    interface: mount
+    attr: slot-value
+`
+
+func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev int64) {
+	vfs := c.MkDir()
+
+	meta := filepath.Join(vfs, "meta")
+	err := os.MkdirAll(meta, 0755)
+	c.Assert(err, check.IsNil)
+	err = os.WriteFile(filepath.Join(meta, "sdk.yaml"), []byte(sdkYaml), 0644)
+	c.Assert(err, check.IsNil)
+
+	s.state.Lock()
+	be := s.o.WorkshopBackend()
+	s.state.Unlock()
+	err = be.ImportVolume(s.ctx, sdk.VolumeName(name, strconv.FormatInt(rev, 10)), vfs)
+	c.Assert(err, check.IsNil)
+}
+
 func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []testSdkSetup) (*workshop.Workshop, error) {
 	ctx := context.WithValue(s.ctx, workshop.ContextProjectId, s.prj.ProjectId)
 
@@ -102,18 +129,11 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	c.Assert(err, check.IsNil)
 	defer wsfs.Close()
 
-	var systemYaml = `name: system
-base: ubuntu@22.04
-type: system
-slots:
-  slot:
-    interface: mount
-    attr: slot-value
-`
 	c.Assert(wsfs.MkdirAll(filepath.Join(dirs.WorkshopSdksDir, sdk.System.String(), "x1", "meta"), 0755), check.IsNil)
 	s.writeSDKMetaFile(c, wsfs, sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}}, systemYaml)
+
 	for _, setup := range sdks {
-		s.writeSDKMetaFile(c, wsfs, setup.Setup, setup.yaml)
+		s.mockSdk(c, setup.Setup.Name, setup.yaml, int64(setup.Revision.N))
 	}
 
 	w, err := s.wsbackend.Workshop(ctx, ws)
@@ -122,10 +142,15 @@ slots:
 	err = w.LinkSdk(ctx, sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}})
 	c.Assert(err, check.IsNil)
 
-	for _, s := range sdks {
-		if err = w.LinkSdk(ctx, s.Setup); err != nil {
-			c.Assert(err, check.IsNil)
-		}
+	s.state.Lock()
+	be := s.o.WorkshopBackend()
+	s.state.Unlock()
+
+	for _, sk := range sdks {
+		err = be.AttachVolume(ctx, ws, sdk.VolumeName(sk.Name, sk.Revision.String()), filepath.Join(dirs.WorkshopSdksDir, sk.Name, sk.Revision.String()))
+		c.Assert(err, check.IsNil)
+		err = w.LinkSdk(ctx, sk.Setup)
+		c.Assert(err, check.IsNil)
 	}
 
 	return w, nil
@@ -210,8 +235,8 @@ slots:
   attr2: value2
 `
 	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{sdk.Setup{Name: "consumer", Channel: "latest/stable"}, consumerYaml},
-		{sdk.Setup{Name: "producer", Channel: "latest/stable"}, producerYaml},
+		{sdk.Setup{Name: "consumer", Channel: "latest/stable", Revision: sdk.R(1)}, consumerYaml},
+		{sdk.Setup{Name: "producer", Channel: "latest/stable", Revision: sdk.R(1)}, producerYaml},
 	})
 
 	s.state.Lock()
@@ -253,8 +278,8 @@ slots:
   attr2: value2
 `
 	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{sdk.Setup{Name: "consumer", Channel: "latest/stable"}, consumerYaml},
-		{sdk.Setup{Name: "producer", Channel: "latest/stable"}, producerYaml},
+		{sdk.Setup{Name: "consumer", Channel: "latest/stable", Revision: sdk.R(1)}, consumerYaml},
+		{sdk.Setup{Name: "producer", Channel: "latest/stable", Revision: sdk.R(1)}, producerYaml},
 	})
 
 	s.state.Lock()

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -147,7 +147,7 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	s.state.Unlock()
 
 	for _, sk := range sdks {
-		err = be.AttachVolume(ctx, ws, sdk.VolumeName(sk.Name, sk.Revision.String()), filepath.Join(dirs.WorkshopSdksDir, sk.Name, sk.Revision.String()))
+		err = be.AttachVolume(ctx, ws, sdk.VolumeName(sk.Name, sk.Revision.String()), filepath.Join(dirs.WorkshopSdksDir, sk.Name, sk.Revision.String()), true)
 		c.Assert(err, check.IsNil)
 		err = w.LinkSdk(ctx, sk.Setup)
 		c.Assert(err, check.IsNil)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -170,7 +170,7 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	// Mount the SDK content at the workshop location.
 	sdkPath := filepath.Join(dirs.WorkshopSdksDir, sdkSetup.Name, sdkSetup.Revision.String())
 
-	return m.backend.AttachVolume(ctx, w, sdkSetup.VolumeName(), sdkPath)
+	return m.backend.AttachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision.String()), sdkPath)
 }
 
 func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -187,7 +187,7 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	return m.backend.DetachVolume(ctx, w, sdkSetup.VolumeName())
+	return m.backend.DetachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision.String()))
 }
 
 func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -1,6 +1,7 @@
 package sdkstate
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces/policy"
+	"github.com/canonical/workshop/internal/logger"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
@@ -79,11 +81,13 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	if err = m.maybeCreateVolume(ctx, rec); err != nil {
-		return err
+	err = m.backend.ImportVolume(ctx, sdk.VolumeName(rec.Name, rec.Revision.String()), rec.Filepath())
+	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
+		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", sdk.VolumeName(rec.Name, rec.Revision.String()))
+		return nil
 	}
 
-	return nil
+	return err
 }
 
 func (m *SdkManager) doInstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -174,7 +174,7 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	// Mount the SDK content at the workshop location.
 	sdkPath := filepath.Join(dirs.WorkshopSdksDir, sdkSetup.Name, sdkSetup.Revision.String())
 
-	return m.backend.AttachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision.String()), sdkPath)
+	return m.backend.AttachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision.String()), sdkPath, true)
 }
 
 func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -1,8 +1,6 @@
 package sdkstate
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,8 +9,6 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces/policy"
-	"github.com/canonical/workshop/internal/logger"
-	"github.com/canonical/workshop/internal/osutil"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
@@ -79,7 +75,15 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		},
 	}
 
-	return store.DownloadSdk(ctx, rec, reporter)
+	if err = store.DownloadSdk(ctx, rec, reporter); err != nil {
+		return err
+	}
+
+	if err = m.maybeCreateVolume(ctx, rec); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (m *SdkManager) doInstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -153,71 +157,20 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	// The install tasks should hold the lock until the SDK is unpacked in the
-	// workshop. There are could be multiple of them reading the file
-	// concurrently and, hence, TryLock, so a writer (e.g. DownloadSdk) would
-	// not corrupt the file before it is installed.
-	fl, err := sdk.OpenLock(sdkSetup.Name)
+	// Directory: /var/lib/workshop/sdk/<name>/<revision>/
+	fs, err := m.backend.WorkshopFs(ctx, w)
 	if err != nil {
 		return err
 	}
-	if err = fl.TryLock(); err != nil && !errors.Is(err, osutil.ErrAlreadyLocked) {
+	defer fs.Close()
+	if err = fs.MkdirAll(dirs.WorkshopSdksDir, 0755); err != nil {
 		return err
 	}
-	defer fl.Close()
 
-	target := filepath.Join("/root", filepath.Base(sdkSetup.Filename()))
-	sdkMount := workshop.Mount{Name: sdkSetup.Name, What: sdkSetup.Filename(), Where: target}
-	if err = m.backend.AddWorkshopMount(ctx, w, sdkMount); err != nil {
-		return err
-	}
-	umount := func() {
-		// Make sure the SDK file will be unmounted once installed into the workshop
-		if err := m.backend.RemoveWorkshopMount(ctx, w, sdkMount.Name); err != nil {
-			logger.Debugf("cannot unmount SDK %q from workshop %q: %v", sdkMount.Name, w, err)
-		}
-	}
-	defer umount()
-
-	// example: /var/lib/workshop/sdk/cuda/712/
+	// Mount the SDK content at the workshop location.
 	sdkPath := filepath.Join(dirs.WorkshopSdksDir, sdkSetup.Name, sdkSetup.Revision.String())
 
-	// create a memory out/err to log the hook output into the task's log
-	var out bytes.Buffer
-
-	// Unpack the SDK to the desired location in the workshop
-	//   Note: the following command requires ~ tar >= 1.29 due to --one-top-level
-	args := workshop.Execution{
-		ExecArgs: workshop.ExecArgs{
-			UserId:  0,
-			GroupId: 0,
-			Command: []string{
-				"tar",
-				"--extract",
-				"--file",
-				target,
-				"--one-top-level=" + sdkPath,
-				"--no-same-owner",
-			},
-			WorkDir: "/",
-		},
-		ExecControls: workshop.ExecControls{
-			Stdin:  nil,
-			Stdout: nil,
-			Stderr: &out,
-		},
-	}
-
-	exectx, err := m.backend.Exec(ctx, w, &args)
-	if err != nil {
-		return err
-	}
-
-	if err = exectx.WaitExecution(ctx); err != nil {
-		return fmt.Errorf("%w: %v", err, out.String())
-	}
-
-	return err
+	return m.backend.AttachVolume(ctx, w, sdkSetup.VolumeName(), sdkPath)
 }
 
 func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -234,17 +187,7 @@ func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	fs, err := m.backend.WorkshopFs(ctx, w)
-	if err != nil {
-		return err
-	}
-	defer fs.Close()
-
-	if err = fs.RemoveAll(sdk.SdkRevPath(sdkSetup.Name, sdkSetup.Revision.String())); err != nil {
-		return fmt.Errorf("cannot undo SDK %q installation: %w", sdkSetup.Name, err)
-	}
-
-	return nil
+	return m.backend.DetachVolume(ctx, w, sdkSetup.VolumeName())
 }
 
 func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -188,22 +187,20 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
+	err := s.backend.CreateVolume(s.ctx, newSdk.VolumeName())
+	c.Assert(err, check.IsNil)
+	defer s.backend.DeleteVolume(s.ctx, newSdk.VolumeName())
+
 	s.state.Unlock()
 	s.se.Ensure()
 	s.se.Wait()
 	s.state.Lock()
 
-	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
-	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals, []string{
-		"tar",
-		"--extract",
-		"--file",
-		"/root/test-2_2.sdk",
-		"--one-top-level=/var/lib/workshop/sdk/test-2/2",
-		"--no-same-owner",
-	})
 	c.Check(chg.Err(), check.IsNil)
-	c.Check(t1.Status(), check.Equals, state.DoneStatus)
+	c.Check(chg.Status(), check.Equals, state.DoneStatus)
+
+	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 1)
+	c.Assert(s.backend.WorkshopVolumeMountPoints["test-2-2"], check.Equals, "/var/lib/workshop/sdk/test-2/2")
 }
 
 func (s *sdkStateSuite) TestDoInstallSdkSuccessWhenLocked(c *check.C) {
@@ -221,6 +218,10 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccessWhenLocked(c *check.C) {
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
+	err := s.backend.CreateVolume(s.ctx, newSdk.VolumeName())
+	c.Assert(err, check.IsNil)
+	defer s.backend.DeleteVolume(s.ctx, newSdk.VolumeName())
+
 	// Lock the sdk pretending there is another concurrent doInstall that has
 	// already captured the lock.
 	l, err := sdk.OpenLock(newSdk.Name)
@@ -233,46 +234,11 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccessWhenLocked(c *check.C) {
 	s.se.Wait()
 	s.state.Lock()
 
-	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
-	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals, []string{
-		"tar",
-		"--extract",
-		"--file",
-		"/root/test-2_2.sdk",
-		"--one-top-level=/var/lib/workshop/sdk/test-2/2",
-		"--no-same-owner",
-	})
+	c.Check(chg.Err(), check.IsNil)
+	c.Check(chg.Status(), check.Equals, state.DoneStatus)
 
-	c.Check(t1.Status(), check.Equals, state.DoneStatus)
-}
-
-func (s *sdkStateSuite) TestDoInstallSdkExecFail(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	newSdk := sdk.Info{Name: "test"}
-	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", newSdk)
-	t1 := s.state.NewTask("install-sdk", "test")
-	t1.Set("sdk-retrieve-task", t.ID())
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-	chg.AddTask(t)
-
-	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
-		args.Stderr.Write([]byte(os.ErrDeadlineExceeded.Error()))
-		return workshop.ExecContext{}, os.ErrDeadlineExceeded
-	}
-
-	s.state.Unlock()
-	s.se.Ensure()
-	s.se.Wait()
-	s.state.Lock()
-
-	c.Check(strings.HasSuffix(t1.Log()[0], os.ErrDeadlineExceeded.Error()), check.Equals, true)
+	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 1)
+	c.Assert(s.backend.WorkshopVolumeMountPoints["test-2-2"], check.Equals, "/var/lib/workshop/sdk/test-2/2")
 }
 
 func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
@@ -280,39 +246,41 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	defer s.state.Unlock()
 
 	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
+
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
+
 	t1 := s.state.NewTask("install-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
+	t1.WaitFor(t)
 
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
 	terr.WaitFor(t1)
+
+	err := s.backend.CreateVolume(s.ctx, newSdk.VolumeName())
+	c.Assert(err, check.IsNil)
+	defer s.backend.DeleteVolume(s.ctx, newSdk.VolumeName())
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("workshop", "ws")
 	chg.Set("project-id", s.project.ProjectId)
 	chg.Set("user", "testuser")
-	chg.AddTask(t1)
 	chg.AddTask(t)
+	chg.AddTask(t1)
 	chg.AddTask(terr)
 
-	// emulate install behaviour that unpacks an SDK to a certain directory
-	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
-		fs, _ := s.backend.WorkshopFs(ctx, name)
-		fs.MkdirAll(filepath.Join(dirs.WorkshopSdksDir, "new"), 0755)
-		return workshop.ExecContext{}, nil
-	}
+	setWorkshopProject("ws", s.project, t, t1, terr)
 
 	s.state.Unlock()
-	s.se.Ensure()
-	s.se.Wait()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
 	s.state.Lock()
 
-	// make sure SDK dir was removed
-	fs, err := s.backend.WorkshopFs(s.ctx, "ws")
-	c.Check(err, check.IsNil)
-	exist, _ := afero.Exists(fs, filepath.Join(dirs.WorkshopSdksDir, "new"))
-	c.Check(exist, check.Equals, false)
+	c.Check(t1.Status(), check.Equals, state.UndoneStatus)
+
+	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 0)
 }
 
 func (s *sdkStateSuite) TestDoInstallSystemSdkSuccess(c *check.C) {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -148,17 +149,17 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	}}
 	err = s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Assert(err, check.IsNil)
-
-	s.mockTestSdk(c, "test", sdkYaml, 1)
 }
 
-func (s *sdkStateSuite) mockTestSdk(c *check.C, name, sdkYaml string, rev int64) {
-	sdkPath := filepath.Join(dirs.WorkshopSdksDir, name, strconv.FormatInt(rev, 10), "meta", "sdk.yaml")
-	fs, err := s.backend.WorkshopFs(s.ctx, "ws")
+func (s *sdkStateSuite) mockSdk(c *check.C, name, sdkYaml string, rev int64) {
+	vfs := c.MkDir()
+
+	meta := filepath.Join(vfs, "meta")
+	err := os.MkdirAll(meta, 0755)
 	c.Assert(err, check.IsNil)
-	err = fs.MkdirAll(filepath.Dir(sdkPath), 0755)
+	err = os.WriteFile(filepath.Join(meta, "sdk.yaml"), []byte(sdkYaml), 0644)
 	c.Assert(err, check.IsNil)
-	err = afero.WriteFile(fs, sdkPath, []byte(sdkYaml), 0644)
+	err = s.backend.ImportVolume(s.ctx, sdk.VolumeName(name, strconv.FormatInt(rev, 10)), vfs)
 	c.Assert(err, check.IsNil)
 }
 
@@ -176,6 +177,8 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
+	s.mockSdk(c, "test-2", sdkYaml, 2)
+
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
@@ -186,10 +189,6 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 	chg.AddTask(t)
-
-	err := s.backend.CreateVolume(s.ctx, newSdk.VolumeName())
-	c.Assert(err, check.IsNil)
-	defer s.backend.DeleteVolume(s.ctx, newSdk.VolumeName())
 
 	s.state.Unlock()
 	s.se.Ensure()
@@ -203,7 +202,7 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	c.Assert(s.backend.WorkshopVolumeMountPoints["test-2-2"], check.Equals, "/var/lib/workshop/sdk/test-2/2")
 }
 
-func (s *sdkStateSuite) TestDoInstallSdkSuccessWhenLocked(c *check.C) {
+func (s *sdkStateSuite) TestDoInstallSdkWhenVolumeExists(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
@@ -218,9 +217,9 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccessWhenLocked(c *check.C) {
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
-	err := s.backend.CreateVolume(s.ctx, newSdk.VolumeName())
+	err := s.backend.CreateVolume(s.ctx, sdk.VolumeName(newSdk.Name, newSdk.Revision.String()))
 	c.Assert(err, check.IsNil)
-	defer s.backend.DeleteVolume(s.ctx, newSdk.VolumeName())
+	defer s.backend.DeleteVolume(s.ctx, sdk.VolumeName(newSdk.Name, newSdk.Revision.String()))
 
 	// Lock the sdk pretending there is another concurrent doInstall that has
 	// already captured the lock.
@@ -246,6 +245,7 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	defer s.state.Unlock()
 
 	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
+	s.mockSdk(c, "test-2", sdkYaml, 2)
 
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
@@ -256,10 +256,6 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
 	terr.WaitFor(t1)
-
-	err := s.backend.CreateVolume(s.ctx, newSdk.VolumeName())
-	c.Assert(err, check.IsNil)
-	defer s.backend.DeleteVolume(s.ctx, newSdk.VolumeName())
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("workshop", "ws")
@@ -351,21 +347,28 @@ func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
 	testSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: sdk.Revision{N: 1}, InstallTime: &s.installTime}
+	s.mockSdk(c, "test", sdkYaml, 1)
 
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", testSdk)
-	t1 := s.state.NewTask("link-sdk", "test")
+	t1 := s.state.NewTask("install-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
+	t2 := s.state.NewTask("link-sdk", "test")
+	t2.Set("sdk-retrieve-task", t.ID())
+	t2.WaitFor(t1)
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t, t1)
+	setWorkshopProject("ws", s.project, t, t1, t2)
 	chg.Set("user", "testuser")
+	chg.AddTask(t2)
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
 	s.state.Unlock()
-	s.se.Ensure()
-	s.se.Wait()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
 	s.state.Lock()
 
 	c.Check(chg.Err(), check.Equals, nil)
@@ -389,18 +392,22 @@ func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
 	defer s.state.Unlock()
 
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-	s.mockTestSdk(c, "test-broken", sdkYamlViolatesPolicy, 2)
+	s.mockSdk(c, "test-broken", sdkYamlViolatesPolicy, 2)
 
 	testSdk := sdk.Setup{Name: "test-broken", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
 
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", testSdk)
-	t1 := s.state.NewTask("link-sdk", "test-broken")
+	t1 := s.state.NewTask("install-sdk", "...")
 	t1.Set("sdk-retrieve-task", t.ID())
+	t2 := s.state.NewTask("link-sdk", "test-broken")
+	t2.Set("sdk-retrieve-task", t.ID())
+	t2.WaitFor(t1)
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t, t1)
+	setWorkshopProject("ws", s.project, t, t1, t2)
 	chg.Set("user", "testuser")
+	chg.AddTask(t2)
 	chg.AddTask(t1)
 	chg.AddTask(t)
 
@@ -434,23 +441,28 @@ func (s *sdkStateSuite) TestUndoLinkSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+	s.mockSdk(c, "test", sdkYaml, 1)
 
 	newSdk := sdk.Info{Workshop: "ws", Name: "test", Revision: sdk.Revision{N: 1}}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
+	t1 := s.state.NewTask("install-sdk", "...")
+	t1.Set("sdk-retrieve-task", t.ID())
 	link := s.state.NewTask("link-sdk", "test")
 	link.Set("sdk-retrieve-task", t.ID())
+	link.WaitFor(t1)
 
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
 	terr.WaitFor(link)
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, link, t)
+	setWorkshopProject("ws", s.project, link, t, t1)
 
 	chg.Set("user", "testuser")
 	chg.AddTask(link)
 	chg.AddTask(t)
 	chg.AddTask(terr)
+	chg.AddTask(t1)
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
@@ -475,13 +487,15 @@ func (s *sdkStateSuite) TestUndoLinkSdkRestorePreviousRev(c *check.C) {
 	defer s.state.Unlock()
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
-	// Install a second revision.
-	s.mockTestSdk(c, "test", sdkYamlRev2, 2)
+	s.mockSdk(c, "test", sdkYaml, 1)
+	s.mockSdk(c, "test", sdkYamlRev2, 2)
 	wp, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
 
 	// Link the first revision to emulate that an SDK has already been linked to
 	// the previous rev, so that undo can update records properly.
+	err = wp.Backend.AttachVolume(s.ctx, wp.Name, sdk.VolumeName("test", "1"), "/var/lib/workshop/sdk/test/1")
+	c.Assert(err, check.IsNil)
 	err = wp.LinkSdk(s.ctx, sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}})
 	c.Assert(err, check.IsNil)
 
@@ -531,23 +545,28 @@ func (s *sdkStateSuite) TestUndoLinkSdkRestorePreviousRev(c *check.C) {
 func (s *sdkStateSuite) TestLinkSdkBadInterfacesFound(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
+	s.mockSdk(c, "test", sdkYaml, 1)
 
 	newSdk := sdk.Info{Workshop: "ws", Name: "test", Revision: sdk.Revision{N: 1}}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
+	t1 := s.state.NewTask("install-sdk", "...")
+	t1.Set("sdk-retrieve-task", t.ID())
 	link := s.state.NewTask("link-sdk", "test")
 	link.Set("sdk-retrieve-task", t.ID())
+	link.WaitFor(t1)
 
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
 	terr.WaitFor(link)
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, link, t)
+	setWorkshopProject("ws", s.project, link, t, t1)
 
 	chg.Set("user", "testuser")
 	chg.AddTask(link)
 	chg.AddTask(t)
 	chg.AddTask(terr)
+	chg.AddTask(t1)
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -487,7 +487,7 @@ func (s *sdkStateSuite) TestUndoLinkSdkRestorePreviousRev(c *check.C) {
 
 	// Link the first revision to emulate that an SDK has already been linked to
 	// the previous rev, so that undo can update records properly.
-	err = wp.Backend.AttachVolume(s.ctx, wp.Name, sdk.VolumeName("test", "1"), "/var/lib/workshop/sdk/test/1")
+	err = wp.Backend.AttachVolume(s.ctx, wp.Name, sdk.VolumeName("test", "1"), "/var/lib/workshop/sdk/test/1", true)
 	c.Assert(err, check.IsNil)
 	err = wp.LinkSdk(s.ctx, sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}})
 	c.Assert(err, check.IsNil)

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -219,14 +219,7 @@ func (s *sdkStateSuite) TestDoInstallSdkWhenVolumeExists(c *check.C) {
 
 	err := s.backend.CreateVolume(s.ctx, sdk.VolumeName(newSdk.Name, newSdk.Revision.String()))
 	c.Assert(err, check.IsNil)
-	defer s.backend.DeleteVolume(s.ctx, sdk.VolumeName(newSdk.Name, newSdk.Revision.String()))
-
-	// Lock the sdk pretending there is another concurrent doInstall that has
-	// already captured the lock.
-	l, err := sdk.OpenLock(newSdk.Name)
-	c.Assert(err, check.IsNil)
-	c.Assert(l.Lock(), check.IsNil)
-	defer l.Close()
+	defer func() { _ = s.backend.DeleteVolume(s.ctx, sdk.VolumeName(newSdk.Name, newSdk.Revision.String())) }()
 
 	s.state.Unlock()
 	s.se.Ensure()
@@ -269,7 +262,7 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		_ = s.se.Ensure()
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -366,7 +359,7 @@ func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		_ = s.se.Ensure()
 		s.se.Wait()
 	}
 	s.state.Lock()

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -1,9 +1,14 @@
 package sdkstate
 
 import (
+	"context"
+	"errors"
+
 	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/logger"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	backend "github.com/canonical/workshop/internal/workshop"
 )
@@ -30,4 +35,22 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 
 func (w *SdkManager) Ensure() error {
 	return nil
+}
+
+func (w *SdkManager) maybeCreateVolume(ctx context.Context, s sdk.Setup) error {
+	fl, err := sdk.OpenLock(s.Name)
+	if err != nil {
+		return err
+	}
+	if err = fl.Lock(); err != nil {
+		return err
+	}
+	defer fl.Close()
+
+	err = w.backend.ImportVolume(ctx, s.VolumeName(), s.Filepath())
+	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
+		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", s.VolumeName())
+		return nil
+	}
+	return err
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -1,14 +1,9 @@
 package sdkstate
 
 import (
-	"context"
-	"errors"
-
 	"github.com/canonical/workshop/internal/interfaces"
-	"github.com/canonical/workshop/internal/logger"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
-	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	backend "github.com/canonical/workshop/internal/workshop"
 )
@@ -35,22 +30,4 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 
 func (w *SdkManager) Ensure() error {
 	return nil
-}
-
-func (w *SdkManager) maybeCreateVolume(ctx context.Context, s sdk.Setup) error {
-	fl, err := sdk.OpenLock(s.Name)
-	if err != nil {
-		return err
-	}
-	if err = fl.Lock(); err != nil {
-		return err
-	}
-	defer fl.Close()
-
-	err = w.backend.ImportVolume(ctx, sdk.VolumeName(s.Name, s.Revision.String()), s.Filepath())
-	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
-		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", sdk.VolumeName(s.Name, s.Revision.String()))
-		return nil
-	}
-	return err
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -47,9 +47,9 @@ func (w *SdkManager) maybeCreateVolume(ctx context.Context, s sdk.Setup) error {
 	}
 	defer fl.Close()
 
-	err = w.backend.ImportVolume(ctx, s.VolumeName(), s.Filepath())
+	err = w.backend.ImportVolume(ctx, sdk.VolumeName(s.Name, s.Revision.String()), s.Filepath())
 	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
-		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", s.VolumeName())
+		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", sdk.VolumeName(s.Name, s.Revision.String()))
 		return nil
 	}
 	return err

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -187,7 +187,7 @@ func (m *WorkshopManager) doMountAptCache(task *state.Task, tomb *tomb.Tomb) err
 	defer cancel()
 
 	volume := workshop.AptCacheVolumeName(w, prj.ProjectId)
-	return m.backend.AttachVolume(ctx, w, volume, dirs.AptCachePath)
+	return m.backend.AttachVolume(ctx, w, volume, dirs.AptCachePath, false)
 }
 
 func (m *WorkshopManager) undoMountAptCache(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -370,7 +370,7 @@ func (s *workshopHandlers) TestAptCache(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -358,9 +358,28 @@ func (s *workshopHandlers) TestAptCache(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// Create volume for apt cache
+	s.createWFile(c, "ws", wsJammy)
+	wf := &workshop.File{Name: "ws", Base: "ubuntu@22.04"}
+
 	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("create-apt-cache", "...")
+	t1 := s.state.NewTask("create-workshop", "...")
+	t1.Set("workshop-file", wf)
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+
+	// Create volume for apt cache
+	chg = s.state.NewChange("sample", "...")
+	t1 = s.state.NewTask("create-apt-cache", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -179,7 +179,7 @@ func (s *workshopHandlers) TestUndoStash(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		_ = s.se.Ensure()
 		s.se.Wait()
 	}
 	s.state.Lock()

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -787,12 +787,10 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*s
 	removeAptCache := st.NewTask("remove-apt-cache", fmt.Sprintf("Remove apt cache for %q", w.Name))
 	removeAptCache.WaitFor(remove)
 
-	// The apt cache cannot be removed until the workshop has stopped,
-	// which currently happens as part of remove-workshop.
-	// Since there is no way to undo remove-workshop,
-	// we run remove-apt-cache in a separate lane.
-	// If an error occurs when removing the cache,
-	// it will not affect the other tasks.
+	// The apt cache cannot be removed until the workshop has stopped, which
+	// currently happens as part of remove-workshop. Since there is no way to
+	// undo remove-workshop, we run remove-apt-cache in a separate lane. If an
+	// error occurs when removing the cache, it will not affect the other tasks.
 	cleanupLane := st.NewLane()
 	removeAptCache.JoinLane(cleanupLane)
 

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -31,8 +31,8 @@ func (s *Setup) Filename() string {
 	return fmt.Sprintf("%s_%s.sdk", s.Name, s.Revision.String())
 }
 
-func (s *Setup) VolumeName() string {
-	return fmt.Sprintf("%s-%s", s.Name, s.Revision.String())
+func VolumeName(name, revision string) string {
+	return fmt.Sprintf("%s-%s", name, revision)
 }
 
 type sdkYaml struct {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -23,8 +23,16 @@ type Setup struct {
 	InstallTime      *time.Time `json:"install-time"`
 }
 
+func (s *Setup) Filepath() string {
+	return filepath.Join(dirs.SdkDownloads, s.Filename())
+}
+
 func (s *Setup) Filename() string {
-	return filepath.Join(dirs.SdkDir, fmt.Sprintf("%s_%s.sdk", s.Name, s.Revision.String()))
+	return fmt.Sprintf("%s_%s.sdk", s.Name, s.Revision.String())
+}
+
+func (s *Setup) VolumeName() string {
+	return fmt.Sprintf("%s-%s", s.Name, s.Revision.String())
 }
 
 type sdkYaml struct {

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -85,7 +85,7 @@ type VolumeManager interface {
 	ImportVolume(ctx context.Context, name string, tarball string) error
 
 	// Attach the volume to the workshop. The volume must be created before.
-	AttachVolume(ctx context.Context, wp, name, what string) error
+	AttachVolume(ctx context.Context, wp, name, what string, ro bool) error
 
 	// Detach the volume from the workshop.
 	DetachVolume(ctx context.Context, wp, name string) error

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	ErrWorkshopNotLaunched = errors.New("workshop not launched")
-	ErrVolumeAlreadyExists = errors.New("storage volume already exists")
+	ErrVolumeAlreadyExists = errors.New("volume already exists")
 	ErrSdkProfileNotFound  = errors.New("sdk profile not found")
 
 	LookupUsername = user.Lookup
@@ -74,6 +74,9 @@ type VolumeManager interface {
 	// mount the device to the workshop, it must be mounted to the required
 	// workshop as a separate operation.
 	CreateVolume(ctx context.Context, name string) error
+
+	// Import a tarball into the volume. The tarball must be a valid tarball filepath.
+	ImportVolume(ctx context.Context, name string, tarball string) error
 
 	AttachVolume(ctx context.Context, wp, name, what string) error
 

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -26,6 +26,7 @@ const (
 
 var (
 	ErrWorkshopNotLaunched = errors.New("workshop not launched")
+	ErrVolumeNotFound      = errors.New("volume not found")
 	ErrVolumeAlreadyExists = errors.New("volume already exists")
 	ErrSdkProfileNotFound  = errors.New("sdk profile not found")
 
@@ -69,6 +70,11 @@ type Stash interface {
 	RemoveWorkshopStash(ctx context.Context, name string) error
 }
 
+type VolumeInfo struct {
+	Name   string
+	Config map[string]string
+}
+
 type VolumeManager interface {
 	// Create a temporary storage volume for the workshop. It does not
 	// mount the device to the workshop, it must be mounted to the required
@@ -78,13 +84,18 @@ type VolumeManager interface {
 	// Import a tarball into the volume. The tarball must be a valid tarball filepath.
 	ImportVolume(ctx context.Context, name string, tarball string) error
 
+	// Attach the volume to the workshop. The volume must be created before.
 	AttachVolume(ctx context.Context, wp, name, what string) error
 
+	// Detach the volume from the workshop.
 	DetachVolume(ctx context.Context, wp, name string) error
 
 	// Delete a temporary storage volume for the workshop. It does not
 	// unmount the volume from the workshop if mounted.
 	DeleteVolume(ctx context.Context, name string) error
+
+	// Get the volume information.
+	Volume(ctx context.Context, name string) (VolumeInfo, error)
 }
 
 type BaseImageManager interface {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -392,7 +392,7 @@ func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, name string) err
 	return nil
 }
 
-func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, what string) error {
+func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, what string, ro bool) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -467,6 +467,22 @@ func (s *FakeWorkshopBackend) DeleteVolume(ctx context.Context, name string) err
 	return nil
 }
 
+func (s *FakeWorkshopBackend) Volume(ctx context.Context, name string) (workshop.VolumeInfo, error) {
+	s.volumeLock.Lock()
+	defer s.volumeLock.Unlock()
+
+	if !s.WorkshopVolumes[name] {
+		return workshop.VolumeInfo{}, workshop.ErrVolumeNotFound
+	}
+
+	meta, err := os.ReadFile(filepath.Join(s.WorkshopVolumeContents[name], "meta", "sdk.yaml"))
+	if err != nil {
+		return workshop.VolumeInfo{}, err
+	}
+
+	return workshop.VolumeInfo{Name: name, Config: map[string]string{workshop.ConfigVolumeMeta: string(meta)}}, nil
+}
+
 func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, error) {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/x-go/randutil"
@@ -44,6 +44,11 @@ type DownloadCall struct {
 	Base string
 }
 
+type AttachVolumeCall struct {
+	Workshop string
+	Name     string
+}
+
 type WorkshopFsCallback func(ctx context.Context, name string) (workshop.WorkshopFs, error)
 
 type FakeWorkshopBackend struct {
@@ -52,8 +57,9 @@ type FakeWorkshopBackend struct {
 	// workshops put to stash (e.g. during refresh)
 	StashedWorkshops map[string]map[string]*FakeWorkshop
 	// storage volumes, the key is a volume name
+	volumeLock                sync.Mutex
 	WorkshopVolumes           map[string]bool
-	WorkshopVolumeContents    map[string]map[string]bool
+	WorkshopVolumeContents    map[string]string
 	WorkshopVolumeMountPoints map[string]string
 	// the key is a username
 	projects map[string][]workshop.Project
@@ -67,6 +73,8 @@ type FakeWorkshopBackend struct {
 	DownloadBaseCallback func(ctx context.Context, base string, report *progress.Reporter) error
 	DownloadBaseCalls    []*DownloadCall
 
+	AttachVolumeCalls []AttachVolumeCall
+
 	BaseDir string
 }
 
@@ -75,7 +83,7 @@ func New(baseDir string) (*FakeWorkshopBackend, error) {
 	be.Workshops = make(map[string]map[string]*FakeWorkshop)
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
 	be.WorkshopVolumes = make(map[string]bool)
-	be.WorkshopVolumeContents = make(map[string]map[string]bool)
+	be.WorkshopVolumeContents = make(map[string]string)
 	be.WorkshopVolumeMountPoints = make(map[string]string)
 	be.projects = make(map[string][]workshop.Project)
 
@@ -366,28 +374,62 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	return nil
 }
 
-func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, what string) error {
-	s.WorkshopVolumeMountPoints[name] = what
+func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, name string) error {
+	s.volumeLock.Lock()
+	defer s.volumeLock.Unlock()
 
-	paths := s.WorkshopVolumeContents[name]
-	if paths == nil {
-		s.WorkshopVolumeContents[name] = map[string]bool{}
-		return nil
+	if s.WorkshopVolumes[name] {
+		return workshop.ErrVolumeAlreadyExists
 	}
+
+	vfs := filepath.Join(s.BaseDir, "volumes", name)
+	if err := os.MkdirAll(vfs, 0755); err != nil {
+		return err
+	}
+
+	s.WorkshopVolumeContents[name] = vfs
+	s.WorkshopVolumes[name] = true
+	return nil
+}
+
+func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, what string) error {
+	s.volumeLock.Lock()
+	defer s.volumeLock.Unlock()
+
+	s.AttachVolumeCalls = append(s.AttachVolumeCalls, AttachVolumeCall{Workshop: wp, Name: name})
+
 	wfs, err := s.WorkshopFs(ctx, wp)
 	if err != nil {
 		return err
 	}
 	defer wfs.Close()
-	for path := range paths {
-		if err = wfs.MkdirAll(path, 0755); err != nil {
-			return err
-		}
+
+	mnt, err := wfs.(*FakeInstanceFs).Fs.(*afero.BasePathFs).RealPath(what)
+	if err != nil {
+		return err
 	}
+
+	volumeFs := s.WorkshopVolumeContents[name]
+	if volumeFs == "" {
+		return fmt.Errorf("volume %q not found", name)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(mnt), 0755); err != nil {
+		return err
+	}
+
+	if err := os.Symlink(volumeFs, mnt); err != nil {
+		return err
+	}
+
+	s.WorkshopVolumeMountPoints[name] = what
 	return nil
 }
 
 func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string) error {
+	s.volumeLock.Lock()
+	defer s.volumeLock.Unlock()
+
 	target := s.WorkshopVolumeMountPoints[name]
 
 	wfs, err := s.WorkshopFs(ctx, wp)
@@ -396,23 +438,32 @@ func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string)
 	}
 	defer wfs.Close()
 
-	afero.Walk(wfs, target, func(path string, info fs.FileInfo, err error) error {
-		s.WorkshopVolumeContents[name][path] = true
-		return nil
-	})
-
-	err = wfs.RemoveAll(target)
+	err = wfs.Remove(target)
 	delete(s.WorkshopVolumeMountPoints, name)
 	return err
 }
 
-func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, name string) error {
+// ImportVolume imports a tarball into the volume. The tarball must be a valid
+// directory (unpacked so that the tests could provide a temp directory instead
+// of a packed tarball).
+func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, name string, tarball string) error {
+	s.volumeLock.Lock()
+	defer s.volumeLock.Unlock()
+
+	if s.WorkshopVolumes[name] {
+		return workshop.ErrVolumeAlreadyExists
+	}
+	s.WorkshopVolumeContents[name] = tarball
 	s.WorkshopVolumes[name] = true
 	return nil
 }
 
 func (s *FakeWorkshopBackend) DeleteVolume(ctx context.Context, name string) error {
+	s.volumeLock.Lock()
+	defer s.volumeLock.Unlock()
+
 	delete(s.WorkshopVolumes, name)
+	delete(s.WorkshopVolumeContents, name)
 	return nil
 }
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	LxdSock     = "/var/snap/lxd/common/lxd/unix.socket"
-	storagePool = "default"
+	LxdSock           = "/var/snap/lxd/common/lxd/unix.socket"
+	storagePool       = "workshop"
+	storagePoolDriver = "zfs"
 )
 
 var (
@@ -70,6 +71,41 @@ func New() (*Backend, error) {
 
 	if srv := os.Getenv("WORKSHOP_IMAGE_SERVER"); srv != "" {
 		imageServer = srv
+	}
+
+	// Create LXD storage pool if it doesn't exist
+	conn, err := lxd.ConnectLXDUnixWithContext(context.Background(), LxdSock, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Disconnect()
+
+	pools, err := conn.GetStoragePools()
+	if err != nil {
+		return nil, err
+	}
+
+	poolExists := false
+	for _, pool := range pools {
+		if pool.Name == storagePool {
+			if pool.Driver != storagePoolDriver {
+				return nil, fmt.Errorf("storage pool %q already exists with different driver %q", storagePool, pool.Driver)
+			}
+
+			poolExists = true
+			break
+		}
+	}
+
+	if !poolExists {
+		req := api.StoragePoolsPost{
+			Name:   storagePool,
+			Driver: storagePoolDriver,
+		}
+		err := conn.CreateStoragePool(req)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &server, nil
@@ -317,7 +353,7 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, device work
 	}
 	if device.Type == workshop.Volume {
 		inst.Devices[device.Name] = map[string]string{"type": "disk",
-			"pool":   "default",
+			"pool":   storagePool,
 			"path":   device.What,
 			"source": device.Where}
 	} else {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -745,11 +745,22 @@ func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string)
 		return err
 	}
 
+	// Generate index.yaml for the volume.
 	if err = os.WriteFile(filepath.Join(dir, "index.yaml"), []byte(volumeIndexContent(name)), 0644); err != nil {
 		return err
 	}
 
 	newtar := filepath.Join(dir, filepath.Base(tarball))
+
+	// Read the metadata to store it as a volume's property. This is not ideal
+	// when the backend knows the name of the file with metadata as the volume
+	// manager should be able to import any tarball as a volume. But given that
+	// it is only applicable to SDKs in the nearest future, it should be acceptable
+	// as the alternative would be to change the interface to accept the metadata.
+	meta, err := os.ReadFile(filepath.Join(dir, "volume", "meta", "sdk.yaml"))
+	if err != nil {
+		return err
+	}
 
 	repack := exec.CommandContext(ctx, "tar",
 		"--remove-files",
@@ -785,7 +796,14 @@ func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string)
 		return err
 	}
 
-	return op.WaitContext(ctx)
+	if err = op.WaitContext(ctx); err != nil {
+		return err
+	}
+
+	return conn.UpdateStoragePoolVolume(storagePool, "custom", name, api.StorageVolumePut{
+		Config: map[string]string{
+			workshop.ConfigVolumeMeta: string(meta),
+		}}, "")
 }
 
 func (s *Backend) AttachVolume(ctx context.Context, wp, name, what string) error {
@@ -804,6 +822,28 @@ func (s *Backend) DeleteVolume(ctx context.Context, name string) error {
 	defer conn.Disconnect()
 
 	return conn.DeleteStoragePoolVolume(storagePool, "custom", name)
+}
+
+func (s *Backend) Volume(ctx context.Context, name string) (workshop.VolumeInfo, error) {
+	var info workshop.VolumeInfo
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return info, err
+	}
+	defer conn.Disconnect()
+
+	vol, _, err := conn.GetStoragePoolVolume(storagePool, "custom", name)
+	if api.StatusErrorCheck(err, http.StatusNotFound) {
+		return info, workshop.ErrVolumeNotFound
+	}
+
+	if err != nil {
+		return info, err
+	}
+
+	info.Name = vol.Name
+	info.Config = vol.Config
+	return info, nil
 }
 
 func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -649,6 +650,106 @@ func (s *Backend) CreateVolume(ctx context.Context, name string) error {
 		return workshop.ErrVolumeAlreadyExists
 	}
 	return err
+}
+
+var volumeIndex = `name: %s
+backend: %s
+type: custom
+config:
+  volume:
+    name: %s
+    description: "SDK Volume"
+    type: custom
+    content_type: filesystem
+`
+
+func volumeIndexContent(name string) string {
+	return fmt.Sprintf(volumeIndex, name, storagePool, name)
+}
+
+func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string) error {
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Disconnect()
+
+	_, _, err = conn.GetStoragePoolVolume(storagePool, "custom", name)
+	if err == nil {
+		return workshop.ErrVolumeAlreadyExists
+	}
+	if !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return err
+	}
+
+	// The tarballs will be transformed into a LXD-compatible backup format to
+	// create them directly as a custom volume. The LXD's tar archive has the
+	// following format:
+	//
+	// backup/
+	//	volume/
+	//  index.yaml
+
+	dir, err := os.MkdirTemp("", name)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	unpack := exec.CommandContext(ctx, "tar",
+		"--extract",
+		"--file="+tarball,
+		"--transform",
+		"s,^,volume/,",
+		"--directory="+dir,
+	)
+
+	if _, err := unpack.Output(); err != nil {
+		logger.Debugf("Failed to unpack volume tarball: %v", err)
+		return err
+	}
+
+	if err = os.WriteFile(filepath.Join(dir, "index.yaml"), []byte(volumeIndexContent(name)), 0644); err != nil {
+		return err
+	}
+
+	newtar := filepath.Join(dir, filepath.Base(tarball))
+
+	repack := exec.CommandContext(ctx, "tar",
+		"--remove-files",
+		"--create",
+		"--file",
+		newtar,
+		"--transform",
+		"s,^,backup/,",
+		"--directory="+dir,
+		"--no-same-owner",
+		"volume/",
+		"index.yaml",
+	)
+
+	if _, err := repack.Output(); err != nil {
+		logger.Debugf("Failed to repack volume tarball: %v", err)
+		return err
+	}
+
+	f, err := os.Open(newtar)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	vol := lxd.StoragePoolVolumeBackupArgs{
+		BackupFile: f,
+		Name:       name,
+	}
+
+	op, err := conn.CreateStoragePoolVolumeFromBackup(storagePool, vol)
+	if err != nil {
+		return err
+	}
+
+	return op.WaitContext(ctx)
 }
 
 func (s *Backend) AttachVolume(ctx context.Context, wp, name, what string) error {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -37,11 +36,19 @@ var (
 	checkNvidiaRuntime = checkNvidia
 )
 
+type volumeGuard struct {
+	c       chan struct{}
+	counter int32
+}
+
 var (
 	// However many backend instances are created, downloads are always a single
 	// instance map with the LXD backend.
 	imageLock        sync.Mutex
 	currentDownloads map[string]*downloadOp
+
+	volumeGuardsLock sync.Mutex
+	volumeGuards     map[string]*volumeGuard
 )
 
 //go:embed start_command.sh
@@ -53,6 +60,10 @@ func init() {
 	if currentDownloads == nil {
 		currentDownloads = make(map[string]*downloadOp)
 	}
+
+	volumeGuardsLock.Lock()
+	defer volumeGuardsLock.Unlock()
+	volumeGuards = make(map[string]*volumeGuard)
 }
 
 type Backend struct {
@@ -665,185 +676,6 @@ func (s *Backend) WorkshopFs(ctx context.Context, name string) (workshop.Worksho
 	}
 
 	return workshop.NewWorkshopFs(sftp), nil
-}
-
-func (s *Backend) CreateVolume(ctx context.Context, name string) error {
-	conn, err := s.LxdClient(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Disconnect()
-
-	// Create the storage volume entry
-	vol := api.StorageVolumesPost{}
-	vol.Name = name
-	vol.Type = "custom"
-	vol.ContentType = "filesystem"
-	vol.Config = map[string]string{}
-
-	err = conn.CreateStoragePoolVolume(storagePool, vol)
-	if api.StatusErrorCheck(err, http.StatusConflict) {
-		return workshop.ErrVolumeAlreadyExists
-	}
-	return err
-}
-
-var volumeIndex = `name: %s
-backend: %s
-type: custom
-config:
-  volume:
-    name: %s
-    description: "SDK Volume"
-    type: custom
-    content_type: filesystem
-`
-
-func volumeIndexContent(name string) string {
-	return fmt.Sprintf(volumeIndex, name, storagePool, name)
-}
-
-func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string) error {
-	conn, err := s.LxdClient(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Disconnect()
-
-	_, _, err = conn.GetStoragePoolVolume(storagePool, "custom", name)
-	if err == nil {
-		return workshop.ErrVolumeAlreadyExists
-	}
-	if !api.StatusErrorCheck(err, http.StatusNotFound) {
-		return err
-	}
-
-	// The tarballs will be transformed into a LXD-compatible backup format to
-	// create them directly as a custom volume. The LXD's tar archive has the
-	// following format:
-	//
-	// backup/
-	//	volume/
-	//  index.yaml
-
-	dir, err := os.MkdirTemp("", name)
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(dir)
-
-	unpack := exec.CommandContext(ctx, "tar",
-		"--extract",
-		"--file="+tarball,
-		"--transform",
-		"s,^,volume/,",
-		"--directory="+dir,
-	)
-
-	if _, err := unpack.Output(); err != nil {
-		logger.Debugf("Failed to unpack volume tarball: %v", err)
-		return err
-	}
-
-	// Generate index.yaml for the volume.
-	if err = os.WriteFile(filepath.Join(dir, "index.yaml"), []byte(volumeIndexContent(name)), 0644); err != nil {
-		return err
-	}
-
-	newtar := filepath.Join(dir, filepath.Base(tarball))
-
-	// Read the metadata to store it as a volume's property. This is not ideal
-	// when the backend knows the name of the file with metadata as the volume
-	// manager should be able to import any tarball as a volume. But given that
-	// it is only applicable to SDKs in the nearest future, it should be acceptable
-	// as the alternative would be to change the interface to accept the metadata.
-	meta, err := os.ReadFile(filepath.Join(dir, "volume", "meta", "sdk.yaml"))
-	if err != nil {
-		return err
-	}
-
-	repack := exec.CommandContext(ctx, "tar",
-		"--remove-files",
-		"--create",
-		"--file",
-		newtar,
-		"--transform",
-		"s,^,backup/,",
-		"--directory="+dir,
-		"--no-same-owner",
-		"volume/",
-		"index.yaml",
-	)
-
-	if _, err := repack.Output(); err != nil {
-		logger.Debugf("Failed to repack volume tarball: %v", err)
-		return err
-	}
-
-	f, err := os.Open(newtar)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	vol := lxd.StoragePoolVolumeBackupArgs{
-		BackupFile: f,
-		Name:       name,
-	}
-
-	op, err := conn.CreateStoragePoolVolumeFromBackup(storagePool, vol)
-	if err != nil {
-		return err
-	}
-
-	if err = op.WaitContext(ctx); err != nil {
-		return err
-	}
-
-	return conn.UpdateStoragePoolVolume(storagePool, "custom", name, api.StorageVolumePut{
-		Config: map[string]string{
-			workshop.ConfigVolumeMeta: string(meta),
-		}}, "")
-}
-
-func (s *Backend) AttachVolume(ctx context.Context, wp, name, what string) error {
-	return s.AddWorkshopMount(ctx, wp, workshop.Mount{Name: name, What: what, Where: name, Type: workshop.Volume})
-}
-
-func (s *Backend) DetachVolume(ctx context.Context, wp, name string) error {
-	return s.RemoveWorkshopMount(ctx, wp, name)
-}
-
-func (s *Backend) DeleteVolume(ctx context.Context, name string) error {
-	conn, err := s.LxdClient(ctx)
-	if err != nil {
-		return err
-	}
-	defer conn.Disconnect()
-
-	return conn.DeleteStoragePoolVolume(storagePool, "custom", name)
-}
-
-func (s *Backend) Volume(ctx context.Context, name string) (workshop.VolumeInfo, error) {
-	var info workshop.VolumeInfo
-	conn, err := s.LxdClient(ctx)
-	if err != nil {
-		return info, err
-	}
-	defer conn.Disconnect()
-
-	vol, _, err := conn.GetStoragePoolVolume(storagePool, "custom", name)
-	if api.StatusErrorCheck(err, http.StatusNotFound) {
-		return info, workshop.ErrVolumeNotFound
-	}
-
-	if err != nil {
-		return info, err
-	}
-
-	info.Name = vol.Name
-	info.Config = vol.Config
-	return info, nil
 }
 
 func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -364,12 +364,13 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, device work
 	}
 	if device.Type == workshop.Volume {
 		inst.Devices[device.Name] = map[string]string{"type": "disk",
-			"pool":   storagePool,
-			"path":   device.What,
-			"source": device.Where}
+			"pool":     storagePool,
+			"path":     device.What,
+			"source":   device.Where,
+			"readonly": fmt.Sprint(device.ReadOnly)}
 	} else {
 		inst.Devices[device.Name] = map[string]string{"type": "disk", "source": device.What,
-			"path": device.Where}
+			"path": device.Where, "readonly": fmt.Sprint(device.ReadOnly)}
 	}
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
 	if err != nil {

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -19,7 +19,7 @@ import (
 var lxdProjectConfig = map[string]string{
 	"features.images":          "false",
 	"features.profiles":        "true",
-	"features.storage.volumes": "true",
+	"features.storage.volumes": "false",
 }
 
 func LxdProjectName(user string) string {

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -8,7 +8,6 @@ import (
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/workshop"
@@ -47,17 +46,6 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		}
 	})
 
-	volume := workshop.AptCacheVolumeName(name, projectId)
-	if err = s.DetachVolume(ctx, name, volume); err != nil {
-		return err
-	}
-
-	rev.Add(func() {
-		if err := s.AttachVolume(ctx, name, volume, dirs.AptCachePath); err != nil {
-			logger.Debugf("Cannot attach apt cache for %q after failed stash: %s", name, err.Error())
-		}
-	})
-
 	if err = s.moveInstanceAndProfiles(conn, instance, stashedInsance, LxdProjectName(user), LxdSystemProjectName(user)); err != nil {
 		return err
 	}
@@ -87,11 +75,6 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 
 	if err := s.moveInstanceAndProfiles(conn, stashedInsance, instance, LxdSystemProjectName(user), LxdProjectName(user)); err != nil {
 		return err
-	}
-
-	volume := workshop.AptCacheVolumeName(name, projectId)
-	if err = s.AttachVolume(ctx, name, volume, dirs.AptCachePath); err != nil {
-		logger.Debugf("Cannot reattach apt cache for %q after stash: %s", name, err.Error())
 	}
 
 	if err := s.updateInstanceState(conn, ctx, name, "start", false); err != nil {

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -1,0 +1,264 @@
+package lxdbackend
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	lxd "github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/shared/api"
+
+	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+var volumeIndex = `name: %s
+backend: %s
+type: custom
+config:
+  volume:
+    name: %s
+    description: "SDK Volume"
+    type: custom
+    content_type: filesystem
+`
+
+func volumeIndexContent(name string) string {
+	return fmt.Sprintf(volumeIndex, name, storagePool, name)
+}
+
+// LockVolume ensures exclusive access to the specified volume. If there is an
+// ongoing operation on the volume, the calling goroutine will block until the
+// lock is available. This function creates a new channel for the volume (if one
+// doesn't already exist) and uses it to synchronize access by allowing only one
+// goroutine at a time to perform operations on the volume.
+//
+// The channel operates as a mutex: each goroutine trying to access the volume
+// must receive a value from the channel, and only the first goroutine to do so
+// will acquire the lock. Once a goroutine finishes its operation, it will
+// release the lock by sending to the channel (thus allowing the next goroutine
+// to proceed).
+func lockVolume(ctx context.Context, volume string) error {
+	volumeGuardsLock.Lock()
+	guard, ok := volumeGuards[volume]
+	if !ok {
+		guard = &volumeGuard{}
+		guard.counter = 0
+		guard.c = make(chan struct{}, 1)
+		volumeGuards[volume] = guard
+
+		guard.c <- struct{}{}
+	}
+	guard.counter += 1
+	volumeGuardsLock.Unlock()
+
+	select {
+	case <-guard.c:
+		return nil
+	case <-ctx.Done():
+		volumeGuardsLock.Lock()
+		guard.counter -= 1
+		if guard.counter == 0 {
+			close(guard.c)
+			delete(volumeGuards, volume)
+		}
+		volumeGuardsLock.Unlock()
+		return ctx.Err()
+	}
+}
+
+// UnlockVolume releases the lock on the specified volume, allowing other
+// goroutines to access it. If there are no remaining goroutines waiting for the
+// volume, the channel used for synchronisation will be closed and removed. This
+// ensures that resources are cleaned up and no unnecessary channels remain in
+// memory once the volume is no longer locked.
+func unlockVolume(volume string) {
+	volumeGuardsLock.Lock()
+	defer volumeGuardsLock.Unlock()
+
+	guard, ok := volumeGuards[volume]
+	if !ok {
+		panic(fmt.Errorf("%q volume is not locked", volume))
+	}
+	guard.c <- struct{}{}
+
+	guard.counter -= 1
+	if guard.counter == 0 {
+		close(guard.c)
+		delete(volumeGuards, volume)
+	}
+}
+
+func (s *Backend) CreateVolume(ctx context.Context, name string) error {
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Disconnect()
+
+	// Create the storage volume entry
+	vol := api.StorageVolumesPost{}
+	vol.Name = name
+	vol.Type = "custom"
+	vol.ContentType = "filesystem"
+	vol.Config = map[string]string{}
+
+	err = conn.CreateStoragePoolVolume(storagePool, vol)
+	if api.StatusErrorCheck(err, http.StatusConflict) {
+		return workshop.ErrVolumeAlreadyExists
+	}
+	return err
+}
+
+func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string) error {
+	// There could be multiple launches that require the same volume. We don't
+	// want to unpack and import the volume multiple times.
+	if err := lockVolume(ctx, name); err != nil {
+		return err
+	}
+	defer unlockVolume(name)
+
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Disconnect()
+
+	_, _, err = conn.GetStoragePoolVolume(storagePool, "custom", name)
+	if err == nil {
+		return workshop.ErrVolumeAlreadyExists
+	}
+	if !api.StatusErrorCheck(err, http.StatusNotFound) {
+		return err
+	}
+
+	// The tarballs will be transformed into a LXD-compatible backup format to
+	// create them directly as a custom volume. The LXD's tar archive has the
+	// following format:
+	//
+	// backup/
+	//	volume/
+	//  index.yaml
+
+	dir, err := os.MkdirTemp("", name)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	unpack := exec.CommandContext(ctx, "tar",
+		"--extract",
+		"--file="+tarball,
+		"--transform",
+		"s,^,volume/,",
+		"--directory="+dir,
+	)
+
+	if _, err := unpack.Output(); err != nil {
+		logger.Debugf("Failed to unpack volume tarball: %v", err)
+		return err
+	}
+
+	// Generate index.yaml for the volume.
+	if err = os.WriteFile(filepath.Join(dir, "index.yaml"), []byte(volumeIndexContent(name)), 0644); err != nil {
+		return err
+	}
+
+	newtar := filepath.Join(dir, filepath.Base(tarball))
+
+	// Read the metadata to store it as a volume's property. This is not ideal
+	// when the backend knows the name of the file with metadata as the volume
+	// manager should be able to import any tarball as a volume. But given that
+	// it is only applicable to SDKs in the nearest future, it should be acceptable
+	// as the alternative would be to change the interface to accept the metadata.
+	meta, err := os.ReadFile(filepath.Join(dir, "volume", "meta", "sdk.yaml"))
+	if err != nil {
+		return err
+	}
+
+	repack := exec.CommandContext(ctx, "tar",
+		"--remove-files",
+		"--create",
+		"--file",
+		newtar,
+		"--transform",
+		"s,^,backup/,",
+		"--directory="+dir,
+		"--no-same-owner",
+		"volume/",
+		"index.yaml",
+	)
+
+	if _, err := repack.Output(); err != nil {
+		logger.Debugf("Failed to repack volume tarball: %v", err)
+		return err
+	}
+
+	f, err := os.Open(newtar)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	vol := lxd.StoragePoolVolumeBackupArgs{
+		BackupFile: f,
+		Name:       name,
+	}
+
+	op, err := conn.CreateStoragePoolVolumeFromBackup(storagePool, vol)
+	if err != nil {
+		return err
+	}
+
+	if err = op.WaitContext(ctx); err != nil {
+		return err
+	}
+
+	return conn.UpdateStoragePoolVolume(storagePool, "custom", name, api.StorageVolumePut{
+		Config: map[string]string{
+			workshop.ConfigVolumeMeta: string(meta),
+		}}, "")
+}
+
+func (s *Backend) AttachVolume(ctx context.Context, wp, name, what string) error {
+	return s.AddWorkshopMount(ctx, wp, workshop.Mount{Name: name, What: what, Where: name, Type: workshop.Volume})
+}
+
+func (s *Backend) DetachVolume(ctx context.Context, wp, name string) error {
+	return s.RemoveWorkshopMount(ctx, wp, name)
+}
+
+func (s *Backend) DeleteVolume(ctx context.Context, name string) error {
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Disconnect()
+
+	return conn.DeleteStoragePoolVolume(storagePool, "custom", name)
+}
+
+func (s *Backend) Volume(ctx context.Context, name string) (workshop.VolumeInfo, error) {
+	var info workshop.VolumeInfo
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return info, err
+	}
+	defer conn.Disconnect()
+
+	vol, _, err := conn.GetStoragePoolVolume(storagePool, "custom", name)
+	if api.StatusErrorCheck(err, http.StatusNotFound) {
+		return info, workshop.ErrVolumeNotFound
+	}
+
+	if err != nil {
+		return info, err
+	}
+
+	info.Name = vol.Name
+	info.Config = vol.Config
+	return info, nil
+}

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -223,8 +223,8 @@ func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string)
 		}}, "")
 }
 
-func (s *Backend) AttachVolume(ctx context.Context, wp, name, what string) error {
-	return s.AddWorkshopMount(ctx, wp, workshop.Mount{Name: name, What: what, Where: name, Type: workshop.Volume})
+func (s *Backend) AttachVolume(ctx context.Context, wp, name, what string, ro bool) error {
+	return s.AddWorkshopMount(ctx, wp, workshop.Mount{Name: name, What: what, Where: name, Type: workshop.Volume, ReadOnly: ro})
 }
 
 func (s *Backend) DetachVolume(ctx context.Context, wp, name string) error {

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -5,7 +5,9 @@ package helper
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	lxd "github.com/canonical/lxd/client"
@@ -147,4 +149,35 @@ func RemoveTestVolume(c *check.C, ctx context.Context, bd workshop.Backend) {
 	volume := workshop.AptCacheVolumeName("test", projectId)
 	err := bd.DeleteVolume(ctx, volume)
 	c.Assert(err, check.IsNil)
+}
+
+func MockSdkTarball(c *check.C, name, path, meta string) string {
+	sdkfs := filepath.Join(path, name)
+
+	metadir := filepath.Join(sdkfs, "meta")
+	err := os.MkdirAll(metadir, 0755)
+	c.Assert(err, check.IsNil)
+
+	err = os.WriteFile(filepath.Join(metadir, "sdk.yaml"), []byte(meta), 0644)
+	c.Assert(err, check.IsNil)
+
+	hooksdir := filepath.Join(sdkfs, "sdk", "hooks")
+	err = os.MkdirAll(hooksdir, 0755)
+	c.Assert(err, check.IsNil)
+
+	tarball := filepath.Join(path, fmt.Sprintf("%s_1.sdk", name))
+	pack := exec.CommandContext(context.Background(), "tar",
+		"--strip-components=1",
+		"--remove-files",
+		"--create",
+		"--file",
+		tarball,
+		"--directory="+sdkfs,
+		"--no-same-owner",
+		".",
+	)
+	output, err := pack.CombinedOutput()
+	c.Check(err, check.IsNil, check.Commentf("%s", string(output)))
+
+	return tarball
 }

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -128,7 +128,7 @@ printf '%s\n' "$@"
 	volume := workshop.AptCacheVolumeName(wf.Name, prj.ProjectId)
 	err = bd.CreateVolume(ctx, volume)
 	c.Assert(err, check.IsNil)
-	err = bd.AttachVolume(ctx, wf.Name, volume, dirs.AptCachePath)
+	err = bd.AttachVolume(ctx, wf.Name, volume, dirs.AptCachePath, false)
 	c.Assert(err, check.IsNil)
 
 	err = bd.StartWorkshop(ctx, "test")

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -131,6 +131,12 @@ func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
+func (f *wsOps) TestLxdBackendStorageVolumeImport(c *check.C) {
+	// Execute
+	err := f.bd.ImportVolume(f.ctx, "test", f.project.Path)
+	c.Assert(err, check.IsNil)
+}
+
 func (f *wsOps) TestLxdBackendDeleteWorkshop(c *check.C) {
 	// Execute
 	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -5,9 +5,11 @@ package lxdbackend_integration_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/user"
 	"sync"
+	"sync/atomic"
 
 	"gopkg.in/check.v1"
 
@@ -131,9 +133,103 @@ func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (f *wsOps) TestLxdBackendStorageVolumeImport(c *check.C) {
+var testsdk = `name: test-sdk
+title: title
+base: ubuntu@20.04
+version: '0.1.2'
+summary: summary
+description: SDK
+sdkcraft-started-at: '2020-04-22T19:12:07.903032Z'
+`
+
+func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	// Execute
-	err := f.bd.ImportVolume(f.ctx, "test", f.project.Path)
+	sdkfs := c.MkDir()
+	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
+
+	cmd := testutil.FakeCommand(c, "tar", `/usr/bin/tar "$@"`)
+
+	var wg sync.WaitGroup
+
+	var successCnt, existCnt int32
+	wg.Add(5)
+	for i := 0; i < 5; i++ {
+		go func() {
+			err := f.bd.ImportVolume(f.ctx, "test-1", tarball)
+			if err == nil {
+				atomic.AddInt32(&successCnt, 1)
+			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
+				atomic.AddInt32(&existCnt, 1)
+			} else {
+				c.Logf("unexpected error: %v", err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	c.Check(atomic.LoadInt32(&successCnt), check.Equals, int32(1))
+	c.Check(atomic.LoadInt32(&existCnt), check.Equals, int32(4))
+
+	c.Check(cmd.Calls(), check.HasLen, 2)
+
+	vinfo, err := f.bd.Volume(f.ctx, "test-1")
+	c.Check(err, check.IsNil)
+	c.Check(vinfo.Name, check.Equals, "test-1")
+	c.Check(vinfo.Config, check.DeepEquals, map[string]string{"user.sdk.meta": testsdk})
+
+	err = f.bd.DeleteVolume(f.ctx, "test-1")
+	c.Assert(err, check.IsNil)
+}
+
+func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
+	// Execute
+	sdkfs := c.MkDir()
+	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
+
+	cmd := testutil.FakeCommand(c, "tar", `/usr/bin/tar "$@"`)
+
+	var wg sync.WaitGroup
+
+	var successCnt, existCnt, canceled int32
+	wg.Add(5)
+	for i := 0; i < 5; i++ {
+		newctx, cancel := context.WithCancel(f.ctx)
+
+		if i%2 == 0 {
+			cancel()
+		} else {
+			defer cancel()
+		}
+
+		go func() {
+			err := f.bd.ImportVolume(newctx, "test-1", tarball)
+			if err == nil {
+				atomic.AddInt32(&successCnt, 1)
+			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
+				atomic.AddInt32(&existCnt, 1)
+			} else if errors.Is(err, context.Canceled) {
+				atomic.AddInt32(&canceled, 1)
+			} else {
+				c.Logf("unexpected error: %v", err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	c.Check(atomic.LoadInt32(&successCnt), check.Equals, int32(1))
+	c.Check(atomic.LoadInt32(&existCnt), check.Equals, int32(1))
+	c.Check(atomic.LoadInt32(&canceled), check.Equals, int32(3))
+
+	c.Check(cmd.Calls(), check.HasLen, 2)
+
+	vinfo, err := f.bd.Volume(f.ctx, "test-1")
+	c.Check(err, check.IsNil)
+	c.Check(vinfo.Name, check.Equals, "test-1")
+	c.Check(vinfo.Config, check.DeepEquals, map[string]string{"user.sdk.meta": testsdk})
+
+	err = f.bd.DeleteVolume(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
 }
 

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/afero"
 	"golang.org/x/exp/slices"
 
 	"github.com/canonical/workshop/internal/osutil"
@@ -23,6 +24,7 @@ var (
 	ConfigProjectId         = "user.workshop.project-id"
 	ConfigWorkshopFile      = "user.workshop.file"
 	ConfigWorkshopSdks      = "user.workshop.sdks"
+	ConfigVolumeMeta        = "user.sdk.meta"
 	ConfigProjectPathDevice = "workshop.project"
 )
 
@@ -186,31 +188,62 @@ func AptCacheVolumeName(ws, pid string) string {
 	return fmt.Sprintf("%s-%s-cache-apt", ws, pid)
 }
 
+func (w *Workshop) metaFromVolume(ctx context.Context, setup sdk.Setup) (string, error) {
+	vinfo, err := w.Backend.Volume(ctx, sdk.VolumeName(setup.Name, setup.Revision.String()))
+	if err != nil {
+		return "", err
+	}
+
+	meta, ok := vinfo.Config[ConfigVolumeMeta]
+	if !ok {
+		return "", fmt.Errorf("cannot find %q SDK metadata", setup.Name)
+	}
+	return meta, nil
+}
+
+func (w *Workshop) metaFromFs(ctx context.Context, setup sdk.Setup) (string, error) {
+	fs, err := w.Backend.WorkshopFs(ctx, w.Name)
+	if err != nil {
+		return "", err
+	}
+	defer fs.Close()
+
+	metapath := sdk.SdkMetaPath(setup.Name)
+	meta, err := afero.ReadFile(fs, metapath)
+	return string(meta), err
+}
+
 // Reads information about the installed SDK from its meta file.
 func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, error) {
+	// TODO: isLocal should rely on the SDK source and not the name of the SDK.
+	// Currently, a sketch or system SDK are both considered local and these are
+	// the only SDKs of that source. This requires rework, once an arbitrary SDK
+	// can be installed from a local source, e.g. to support workshop try.
+	isLocal := func(n string) bool {
+		return n == sdk.Sketch || n == sdk.System.String()
+	}
+
 	setup, ok := w.Sdks[sdkName]
 	if sdkName != sdk.System.String() && !ok {
 		return nil, fmt.Errorf("SDK %q is not installed in %q workshop", sdkName, w.Name)
 	}
+	if sdkName == sdk.System.String() {
+		setup = sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: 1}}
+	}
 
-	wsfs, err := w.Backend.WorkshopFs(ctx, w.Name)
+	var err error
+	var meta string
+	if isLocal(sdkName) {
+		meta, err = w.metaFromFs(ctx, setup)
+	} else {
+		meta, err = w.metaFromVolume(ctx, setup)
+	}
+
 	if err != nil {
 		return nil, err
 	}
-	defer wsfs.Close()
 
-	yamlf, err := wsfs.Open(sdk.SdkMetaPath(sdkName))
-	if err != nil {
-		return nil, fmt.Errorf("cannot read %q SDK metadata (%v)", sdkName, err)
-	}
-	defer yamlf.Close()
-
-	data, err := io.ReadAll(yamlf)
-	if err != nil {
-		return nil, err
-	}
-
-	info, err := sdk.ReadSdkInfo(data, w.Project.ProjectId, w.Name)
+	info, err := sdk.ReadSdkInfo([]byte(meta), w.Project.ProjectId, w.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -226,9 +259,9 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	// binds, slots).
 	idx := slices.IndexFunc(w.File.Sdks, func(sr SdkRecord) bool { return sr.Name == info.Name })
 
-	// system SDK is an optional entry in a workshop file, so it's not an error
+	// system and sketch SDK is an optional entry in a workshop file, so it's not an error
 	// scenario.
-	if idx == -1 && (sdkName == sdk.System.String() || sdkName == sdk.Sketch) {
+	if idx == -1 && isLocal(sdkName) {
 		return info, nil
 	}
 

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -30,7 +30,7 @@ for p in $(echo "$projects" | xargs -L1 echo); do
     lxc image delete $images --project "$p"
   fi
 
-  lxc storage volume list default --project "$p"
+  lxc storage volume list --project "$p"
   volumes=$(lxc storage volume list default type=custom -c n -f compact --project "$p" | awk 'NR>1 {printf "%s ", $1}')
   echo "Removing storage volumes: $volumes"
   for volume in $(echo "$volumes" | xargs -L1 echo); do

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -29,13 +29,16 @@ for p in $(echo "$projects" | xargs -L1 echo); do
     # shellcheck disable=SC2086
     lxc image delete $images --project "$p"
   fi
-
-  lxc storage volume list --project "$p"
-  volumes=$(lxc storage volume list default type=custom -c n -f compact --project "$p" | awk 'NR>1 {printf "%s ", $1}')
-  echo "Removing storage volumes: $volumes"
-  for volume in $(echo "$volumes" | xargs -L1 echo); do
-    lxc storage volume delete default "$volume" --project "$p"
-  done
-
-  lxc project delete "$p" 
 done 
+
+# Storage pool volumes are shared among projects and removed last.
+storage_pool="workshop"
+volumes=$(lxc storage volume list "$storage_pool" -c pnt type=custom -f compact --all-projects | awk 'NR>1 {printf "%s ", $1}')
+echo "$volumes" | xargs -n1 -r | while read -r volume; do
+  lxc storage volume delete "$storage_pool" "$volume"
+done
+lxc storage delete "$storage_pool"
+
+for p in $(echo "$projects" | xargs -L1 echo); do
+  lxc project delete "$p" 
+done

--- a/tests/lib/sdk/test-sdk-setup-fail/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-setup-fail/sdk/hooks/setup-base
@@ -1,2 +1,8 @@
 #!/usr/bin/bash
-echo "Set up base failed!"; exit 1
+
+if [ -f /home/workshop/setup-base-pass ]; then
+    exit 0
+else
+    echo "Set up base failed!"
+    exit 1
+fi

--- a/tests/main/launch-continue/task.yaml
+++ b/tests/main/launch-continue/task.yaml
@@ -10,8 +10,8 @@ execute: |
   echo "Check the workshop is in Pending state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-cont[[:space:]]+Pending[[:space:]]+wait-on-error$"
 
-  echo "\"Fix\" the SDK error by replacing the setup-base hook"
-  workshop_exec exec --uid 0 --gid 0 -- sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
+  echo "\"Fix\" the SDK error by creating an expected file"
+  workshop_exec exec -- touch /home/workshop/setup-base-pass
 
   echo "Check the 'workshop launch --continue' command reverts to the previous state"
   workshop_exec launch --continue | MATCH "\"ws-launch-cont\" launched"

--- a/tests/main/launch-multiple/.workshop/ws-one.yaml
+++ b/tests/main/launch-multiple/.workshop/ws-one.yaml
@@ -1,0 +1,5 @@
+name: ws-one
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic
+    channel: latest/stable

--- a/tests/main/launch-multiple/.workshop/ws-three.yaml
+++ b/tests/main/launch-multiple/.workshop/ws-three.yaml
@@ -1,0 +1,5 @@
+name: ws-three
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic
+    channel: latest/stable

--- a/tests/main/launch-multiple/.workshop/ws-two.yaml
+++ b/tests/main/launch-multiple/.workshop/ws-two.yaml
@@ -1,0 +1,5 @@
+name: ws-two
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic
+    channel: latest/stable

--- a/tests/main/launch-multiple/task.yaml
+++ b/tests/main/launch-multiple/task.yaml
@@ -1,0 +1,11 @@
+summary: Ensure that launch for multiple workshops works correctly
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check workshop can be launched with a basic SDK"
+  workshop_exec launch ws-one ws-two ws-three
+  workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-one[[:space:]]*Ready[[:space:]]*-"
+  workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-two[[:space:]]*Ready[[:space:]]*-"
+  workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-three[[:space:]]*Ready[[:space:]]*-"
+
+  workshop_exec remove ws-one ws-two ws-three

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -16,8 +16,8 @@ execute: |
   echo "Check the workshop is in Pending state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-cont[[:space:]]+Pending[[:space:]]+wait-on-error$"
 
-  echo "\"Fix\" the SDK error by replacing the setup-base hook"
-  workshop_exec exec --uid 0 --gid 0 -- sed -i "s/exit 1/exit 0/g" /var/lib/workshop/sdk/test-sdk-setup-fail/current/sdk/hooks/setup-base
+  echo "\"Fix\" the SDK error by creating an expected file"
+  workshop_exec exec -- touch /home/workshop/setup-base-pass
 
   echo "Check the 'workshop refresh --continue' command reverts to the previous state"
   workshop_exec refresh --continue | MATCH "\"ws-refresh-cont\" refreshed"

--- a/tests/main/remove-snap/task.yaml
+++ b/tests/main/remove-snap/task.yaml
@@ -15,10 +15,18 @@ execute: |
   echo "Modify apt cache for later"
   workshop_exec exec --project $(pwd)/project-1 ws-snap-remove-1 sudo touch /var/cache/apt/archives/sentinel
 
+  echo "Run workshop as another user to have multiple LXD projects"
+  sudo useradd -m -s /bin/bash abc
+  sudo -u abc 2>&1 -- workshop list --project $(pwd)/project-1 
+
   echo "Check that workshops will be removed on snap removal"       
   snap remove workshop
-  snap install --dangerous --classic /workshop/tests/*.snap
+  sudo deluser --remove-home abc
 
+  echo "Check that workshop storage pool has been removed"
+  $(lxc storage list -f compact | awk 'NR>1 {print $1}' | grep -q workshop) && (echo "workshop storage pool must be removed" && exit 1) 
+
+  snap install --dangerous --classic /workshop/tests/*.snap
   [[ $(workshop_exec list --global | wc -c) -eq 0 ]] || (echo "no workshops must remain after snap removal" && exit 1)
 
   echo "Check that cache storage has been removed"


### PR DESCRIPTION
# Description

Managing SDKs as read-only volumes is required to support restoring from a previous workshop snapshot for `workshop refresh`. An SDK is attached to a workshop(s) as a read-only volume before running other tasks. 

One caveat to consider is that the system will have as many versions of an SDK volume as many revisions are used by the running workshops at the time. Without a zfs deduplication or compression that suggests unwanted duplication assumingan average SDK does not have significant content differences amongst its revisions. The possible duplication issue will not be solved under this scope. Based on the assumed use cases, it can be tolerated or solved with zfs
de-duplication in the following Workshop releases.

On another implementation note, Workshop has to transform SDKs into an acceptable LXD backup tar format to import them as volumes. This is a temporary solution and requires an extension for the LXD API to be able to import an arbitrary tarball into a custom volume without attaching it to a workshop or using the backup functionality. 

## Managing zfs storage

Workshop will create and use a zfs loop-backend using LXD API. This is a 30 GB non auto-expandable zfs pool with compression and trimming enabled by default. Thus, extending zfs pool needs addressing in the documentation: https://documentation.ubuntu.com/lxd/en/stable-4.0/storage/#growing-a-loop-backed-zfs-pool. (cc @akcano where would you suggest it to go?).

## Breaking changes

- Workshop starts using "zfs" LXD storage backend. That requires relaunch of the existing workshops.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
