### PR TITLE
Avoid treating .workshop as a project if it contains workshop.yaml

### DIFF
--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -306,6 +306,11 @@ func isProject(dir string) bool {
 		}
 		files = nil
 	}
+
+	// Special case for <PROJECT>/.workshop/workshop.yaml.
+	if len(files) == 0 && filepath.Base(dir) == Directory && isProject(filepath.Dir(dir)) {
+		return false
+	}
 	for _, name := range Filenames {
 		files = append(files, filepath.Join(dir, name))
 	}

--- a/internal/workshop/project_test.go
+++ b/internal/workshop/project_test.go
@@ -139,6 +139,21 @@ func (p *projectSuite) TestTrackNewProject(c *check.C) {
 	_, _, err = tracker.Track(d)
 	c.Assert(err, check.ErrorMatches, `not a project \(no workshop files found\)`)
 	c.Assert(tracker.Projects, check.HasLen, 3)
+
+	// Workshop named "workshop"
+	d = c.MkDir()
+	subdir := filepath.Join(d, ".workshop")
+	c.Assert(os.Mkdir(subdir, os.ModePerm), check.IsNil)
+	_, err = os.Create(filepath.Join(subdir, "workshop.yaml"))
+	c.Assert(err, check.IsNil)
+
+	project, result, err = tracker.Track(subdir)
+	c.Assert(err, check.IsNil)
+	c.Check(result, check.Equals, workshop.ProjectAdded)
+	c.Check(project.Path, check.Equals, d)
+	c.Check(project.ProjectId, check.Not(check.Equals), "")
+	c.Check(tracker.Projects, check.HasLen, 4)
+	c.Assert(workshop.LockPath(d), testutil.FilePresent)
 }
 
 func (p *projectSuite) TestTrackProjectSubDirectory(c *check.C) {


### PR DESCRIPTION
# Description

Thanks to a discussion with @lachypjones, I realised there's a bug in the project detection logic: if `.workshop/workshop.yaml` exists, and a workshop command is run from the `.workshop` directory, it treats `.workshop` as a new project. It should use the parent directory instead.

Fixed by adding a check for this specific case. We probably get some interesting behaviour for `.workshop/.workshop/.workshop/.workshop/workshop.yaml` but I don't think that's something which will come up in practice.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
