### PR TITLE
Add command to list workshop scripts

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -61,6 +61,10 @@ type Workshop struct {
 	Path string `json:"path"`
 }
 
+type Script struct {
+	Script string `json:"script"`
+}
+
 type ListOptions struct {
 	ProjectId string
 }
@@ -155,6 +159,15 @@ func (client *Client) singleWorkshopOrFile(project *Project) (*WorkshopInfo, *Wo
 		file = info.Files[0]
 	}
 	return workshop, file, nil
+}
+
+func (client *Client) ListScripts(projectId, name string) (map[string]Script, error) {
+	var scripts map[string]Script
+	_, err := client.doSync("GET", "/v1/projects/"+projectId+"/workshops/"+name+"/scripts", nil, nil, nil, &scripts)
+	if err != nil {
+		return nil, err
+	}
+	return scripts, nil
 }
 
 func (client *Client) Remount(plug *PlugRef, source string) (changeId string, err error) {

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -174,6 +174,16 @@ func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "GET")
 }
 
+func (cs *clientSuite) TestClientListScripts(c *check.C) {
+	cs.rsp = `{"type": "sync", "result": {"foo": {"script": "echo bar\n"}}}`
+
+	scripts, err := cs.cli.ListScripts("42ws42ws", "ws")
+
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.Method, check.Equals, "GET")
+	c.Check(scripts, check.DeepEquals, map[string]client.Script{"foo": {Script: "echo bar\n"}})
+}
+
 func (cs *clientSuite) TestRemountRequest(c *check.C) {
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/sys/unix"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/logger"
@@ -151,6 +152,11 @@ Notes:
 
 - You can set the working directory, environment variables, user and group ID
   for running the script in the workshop; reasonable defaults are provided.
+`
+
+var shortScriptsHelp = "List workshop scripts"
+var longScriptsHelp = `
+This command enumerates all scripts in the workshop, printing a YAML map.
 `
 
 func (c *CmdExec) Command() *cobra.Command {
@@ -540,4 +546,55 @@ func execControlHandler(process *client.ExecProcess, terminal bool, stop <-chan 
 			}
 		}
 	}
+}
+
+type CmdScripts struct {
+	root *CmdRoot
+}
+
+func (c *CmdScripts) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "scripts",
+		Args:  cobra.MaximumNArgs(1),
+		Short: shortScriptsHelp,
+		Long:  longScriptsHelp,
+		Example: `
+List scripts for the 'nimble' workshop in the current project directory:
+$ workshop scripts nimble
+
+The name is optional if the project has only one workshop:
+$ workshop scripts`,
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func (c *CmdScripts) Run(cmd *cobra.Command, av []string) error {
+	cli, err := c.root.client()
+	if err != nil {
+		return err
+	}
+
+	p, err := cli.Project(c.root.project)
+	if err != nil {
+		return err
+	}
+
+	if len(av) == 0 {
+		name, err := cli.SingleWorkshopName(p)
+		if err != nil {
+			return err
+		}
+		av = []string{name}
+	}
+
+	scripts, err := cli.ListScripts(p.Id, av[0])
+	if err != nil || len(scripts) == 0 {
+		return err
+	}
+
+	encoder := yaml.NewEncoder(Stdout)
+	encoder.SetIndent(2)
+	return encoder.Encode(scripts)
 }

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+)
+
+type workshopExec struct {
+	BaseWorkshopSuite
+	prjDir string
+	prjId  string
+}
+
+var _ = check.Suite(&workshopExec{})
+
+var mockWorkshopNoScripts = `{"type":"sync","status-code":200,"status":"OK","result":{}}`
+var mockWorkshopWithScripts = `{"type":"sync","status-code":200,"status":"OK","result":{"foo":{"script":"echo foo"},"bar":{"script":"echo bar\n"}}}`
+
+func (m *workshopExec) SetUpTest(c *check.C) {
+	m.BaseWorkshopSuite.SetUpTest(c)
+
+	m.prjDir = c.MkDir()
+	m.prjId = "42424242"
+}
+
+func (m *workshopExec) TestWorkshopScripts(c *check.C) {
+	cmd := &CmdScripts{root: &CmdRoot{}}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 4:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockSingleWorkshop)
+		case 3, 5:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws/scripts", m.prjId))
+			w.WriteHeader(200)
+			if n == 3 {
+				fmt.Fprintln(w, mockWorkshopNoScripts)
+			} else {
+				fmt.Fprintln(w, mockWorkshopWithScripts)
+			}
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), nil)
+	c.Assert(err, check.IsNil)
+	c.Check(m.stdout.String(), check.Equals, "")
+	m.stdout.Reset()
+	c.Check(n, check.Equals, 3)
+
+	err = cmd.Run(cmd.Command(), []string{"ws"})
+	c.Assert(err, check.IsNil)
+	c.Check(m.stdout.String(), check.Matches, `bar:
+  script: |
+    echo bar
+foo:
+  script: echo foo
+`)
+	c.Check(n, check.Equals, 5)
+}

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -40,6 +40,7 @@ func (c *CmdRoot) Command(cwd string) *cobra.Command {
 	cmd.AddCommand((&CmdExec{root: c}).Command())
 	cmd.AddCommand((&CmdShell{root: c}).Command())
 	cmd.AddCommand((&CmdRun{root: c}).Command())
+	cmd.AddCommand((&CmdScripts{root: c}).Command())
 	cmd.AddCommand((&CmdRemove{root: c}).Command())
 	cmd.AddCommand((&CmdRemount{root: c}).Command())
 	cmd.AddCommand((&CmdConnections{root: c}).Command())

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -49,6 +49,11 @@ var api = []*Command{{
 	UserOK:  true,
 	POST:    v1PostWorkshopMount,
 }, {
+	Path:    "/v1/projects/{id}/workshops/{name}/scripts",
+	GuestOK: false,
+	UserOK:  true,
+	GET:     v1GetProjectWorkshopScripts,
+}, {
 	Path:    "/v1/connections",
 	GuestOK: false,
 	UserOK:  true,

--- a/internal/daemon/api_changes.go
+++ b/internal/daemon/api_changes.go
@@ -128,7 +128,7 @@ func v1GetChanges(c *Command, r *http.Request, _ *userState) Response {
 	query := r.URL.Query()
 
 	if query.Has("workshops") && !query.Has("project-id") {
-		return statusBadRequest("project-id must be provided if workshops are specified")
+		return statusBadRequest("project-id required if workshops are specified")
 	}
 
 	qselect := query.Get("select")

--- a/internal/daemon/api_changes_test.go
+++ b/internal/daemon/api_changes_test.go
@@ -72,7 +72,7 @@ func (s *apiSuite) TestStateChangesProjectAndWorkshopMustBeProvidedTogether(c *c
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result.(*errorResult).Message, check.Equals,
-		"project-id must be provided if workshops are specified")
+		"project-id required if workshops are specified")
 }
 
 func (s *apiSuite) TestStateChangesDefaultToAll(c *check.C) {

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -33,11 +33,11 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 	w := muxVars(r)["name"]
 
 	if projectId == "" {
-		return statusBadRequest("project-id must be provided")
+		return statusBadRequest("project-id required")
 	}
 
 	if w == "" {
-		return statusBadRequest("workshop name must be provided")
+		return statusBadRequest("workshop name required")
 	}
 
 	user, ok := r.Context().Value(workshop.ContextUser).(string)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -343,7 +343,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	if len(reqData.Names) == 0 {
-		return statusBadRequest("cannot %s: at least one workshop name must be provided", reqData.Action)
+		return statusBadRequest("cannot %s: no workshop names provided", reqData.Action)
 	}
 
 	reqData.Names = strutil.Deduplicate(reqData.Names)
@@ -419,11 +419,11 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	name := muxVars(r)["name"]
 
 	if projectId == "" {
-		return statusBadRequest("project-id must be provided")
+		return statusBadRequest("project-id required")
 	}
 
 	if name == "" {
-		return statusBadRequest("workshop name must be provided")
+		return statusBadRequest("workshop name required")
 	}
 
 	state := c.d.overlord.State()
@@ -466,11 +466,11 @@ func v1GetProjectWorkshopScripts(c *Command, r *http.Request, _ *userState) Resp
 	name := muxVars(r)["name"]
 
 	if projectId == "" {
-		return statusBadRequest("project-id must be provided")
+		return statusBadRequest("project-id required")
 	}
 
 	if name == "" {
-		return statusBadRequest("workshop name must be provided")
+		return statusBadRequest("workshop name required")
 	}
 
 	state := c.d.overlord.State()

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -82,6 +82,10 @@ type Workshop struct {
 	Path string `json:"path"`
 }
 
+type Script struct {
+	Script string `json:"script"`
+}
+
 var ensureStateSoon = stateEnsureBefore
 
 func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo {
@@ -455,4 +459,35 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	return SyncResponse(rsp, http.StatusOK)
+}
+
+func v1GetProjectWorkshopScripts(c *Command, r *http.Request, _ *userState) Response {
+	projectId := muxVars(r)["id"]
+	name := muxVars(r)["name"]
+
+	if projectId == "" {
+		return statusBadRequest("project-id must be provided")
+	}
+
+	if name == "" {
+		return statusBadRequest("workshop name must be provided")
+	}
+
+	state := c.d.overlord.State()
+	state.Lock()
+	defer state.Unlock()
+
+	wrkmgr := c.d.overlord.WorkshopManager()
+	file, err := wrkmgr.WorkshopFile(r.Context(), name, projectId)
+	if err != nil {
+		return statusNotFound("%w", err)
+	}
+
+	// Convert strings to objects to allow extra fields in future.
+	compat := make(map[string]Script, len(file.Scripts))
+	for name, script := range file.Scripts {
+		compat[name] = Script{Script: script.String()}
+	}
+
+	return SyncResponse(compat, http.StatusOK)
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -787,7 +787,7 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot launch: at least one workshop name must be provided",
+			Message: "cannot launch: no workshop names provided",
 		},
 		{
 			Type:    ResponseTypeError,

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -44,6 +44,15 @@ sdks:
     channel: latest/stable
 `
 
+	scripts = `name: scripts
+base: ubuntu@22.04
+scripts:
+  oneline: echo one line
+  multiline: |
+    echo two
+    echo lines
+`
+
 	manysdks = `name: manysdks
 base: ubuntu@22.04
 sdks:
@@ -566,6 +575,35 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 			},
 		},
 		Path: workshop.Filepath(s.project.Path, "somebound")})
+}
+
+func (s *apiSuite) TestGetWorkshopScripts(c *check.C) {
+	// Setup (create a running workshop with a mount)
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.launchWorkshop(c, "scripts", scripts, map[string]string{})
+
+	// Get Workshop scripts
+	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}/scripts")
+	s.vars = map[string]string{"id": s.project.ProjectId, "name": "scripts"}
+	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops/scripts/scripts", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := v1GetProjectWorkshopScripts(projectsCmd, req, nil).(*resp)
+
+	// Verify
+	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Assert(rsp.Status, check.Equals, http.StatusOK)
+
+	_, err = rsp.MarshalJSON()
+	c.Assert(err, check.IsNil)
+
+	c.Check(rsp.Result, check.DeepEquals, map[string]Script{
+		"oneline":   {Script: "echo one line"},
+		"multiline": {Script: "echo two\necho lines\n"},
+	})
 }
 
 type expectedResp struct {

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -99,6 +99,28 @@ func (w *WorkshopManager) Workshop(ctx context.Context, name, pId string) (*work
 	return workshop, nil
 }
 
+// Returns latest file for a workshop. The state must be locked,
+// as listing projects can update project metadata.
+func (w *WorkshopManager) WorkshopFile(ctx context.Context, name, pId string) (*workshop.File, error) {
+	user, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
+	}
+
+	projects, err := w.backend.Projects(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	idx := slices.IndexFunc(projects[user], func(p workshop.Project) bool { return p.ProjectId == pId })
+	if idx == -1 {
+		return nil, fmt.Errorf("project %q not found", pId)
+	}
+	p := projects[user][idx]
+
+	return p.Workshop(name)
+}
+
 // Returns all workshop files for a project. The state must be locked,
 // as listing projects can update project metadata.
 func (w *WorkshopManager) WorkshopFiles(ctx context.Context, pId string) (map[string]string, error) {

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -100,15 +100,18 @@ type File struct {
 	Scripts     map[string]Script `yaml:"scripts,omitempty"`
 }
 
-func (p Script) MarshalYAML() (interface{}, error) {
+func (p Script) String() string {
 	// Trim newlines, then append a newline for multi-line scripts.
 	script := strings.Trim(string(p), "\n")
 	if strings.ContainsRune(script, '\n') {
 		script += "\n"
 	}
+	return script
+}
 
+func (p Script) MarshalYAML() (interface{}, error) {
 	node := &yaml.Node{}
-	err := node.Encode(script)
+	err := node.Encode(p.String())
 	return node, err
 }
 


### PR DESCRIPTION
# Description

For example:
```console
$ cat workshop.yaml
name: ws
base: ubuntu@24.04
scripts:
  foo: echo foo
  bar: |
    echo bar
$ workshop scripts ws
bar:
  script: |
    echo bar
foo:
  script: echo foo
```
The response format includes `script:` so it can be extended without breaking anything. In future we will probably support both formats in workshop definitions, e.g.:
```yaml
...
scripts:
  foo: echo foo
  bar:
    script: echo bar
    uid: 0
    gid: 0
```

Like `workshop run`, the docs are a bit lacking, but it would make sense to include scripts in a future how-to guide for CI.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
