### PR TITLE
Populate workshop environment on-demand during exec call

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -48,6 +48,7 @@ type WorkshopInfo struct {
 	Status    string   `json:"status"`
 	Sdks      []*Sdk   `json:"sdks,omitempty"`
 	Notes     []string `json:"notes,omitempty"`
+	Env       []string `json:"env,omitempty"`
 }
 
 type WorkshopFile struct {

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -48,13 +48,14 @@ type CmdRun struct {
 }
 
 type ExecFlags struct {
-	WorkingDir     string
-	Env            []string
-	UserId         int
-	GroupId        int
-	Timeout        time.Duration
-	Interactive    bool
-	NonInteractive bool
+	WorkingDir       string
+	Env              []string
+	UserId           int
+	GroupId          int
+	Timeout          time.Duration
+	Interactive      bool
+	NonInteractive   bool
+	CleanEnvironment bool
 }
 
 type ExecArgs struct {
@@ -62,6 +63,7 @@ type ExecArgs struct {
 	implicit bool
 	command  []string
 	script   bool
+	shell    bool
 }
 
 var shortExecHelp = "Run a command and wait for it to complete"
@@ -251,7 +253,7 @@ $ workshop shell`,
 }
 
 func (c *CmdShell) Run(cmd *cobra.Command, av []string) error {
-	args := &ExecArgs{command: []string{"sudo", "-i", "-u", "workshop", "bash", "-c", "cd /project; exec bash"}}
+	args := &ExecArgs{shell: true}
 
 	if len(av) > 0 {
 		args.workshop = av[0]
@@ -346,6 +348,7 @@ func commonVars(f *pflag.FlagSet, flags *ExecFlags) {
 	f.DurationVar(&flags.Timeout, "timeout", 0, "Set a timeout; valid units are ns, us or µs, ms, s, m, h.")
 	f.BoolVarP(&flags.Interactive, "interactive", "i", false, "Force interactive mode.")
 	f.BoolVarP(&flags.NonInteractive, "non-interactive", "I", false, "Force non-interactive mode.")
+	f.BoolVar(&flags.CleanEnvironment, "clean-environment", false, "Use a clean environment, variables passed in via flags will remain present")
 }
 
 func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
@@ -363,28 +366,32 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		return err
 	}
 
-	workshop := args.workshop
-	if args.implicit {
-		workshop, err = cli.SingleWorkshopName(project)
+	var workshop *client.Workshop
+	if !args.implicit {
+		workshop, err = cli.Workshop(project.Id, args.workshop)
+		if err != nil {
+			return err
+		}
+	} else {
+		workshop, err = cli.SingleWorkshop(project)
 		if err != nil {
 			return err
 		}
 	}
 
-	if args.script {
-		logger.Debugf("Running script %q", args.command)
-	} else {
-		logger.Debugf("Running %q", args.command)
-	}
-
-	// Set up environment variables.
 	env := make(map[string]string)
 	term, ok := os.LookupEnv("TERM")
 	if ok {
 		env["TERM"] = term
 	}
 
-	for _, kv := range flags.Env {
+	if flags.CleanEnvironment {
+		workshop.Env = flags.Env
+	} else {
+		workshop.Env = append(workshop.Env, flags.Env...)
+	}
+
+	for i, kv := range workshop.Env {
 		parts := strings.SplitN(kv, "=", 2)
 		key := parts[0]
 
@@ -396,9 +403,30 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 			if !ok {
 				continue
 			}
+			if args.shell {
+				workshop.Env[i] = workshop.Env[i] + "=" + value
+			}
 		}
 
 		env[key] = value
+	}
+
+	switch {
+	case args.script:
+		logger.Debugf("Running script %q", args.command)
+	case args.shell:
+		args.command = []string{"sudo"}
+		for _, s := range workshop.Env {
+			// If there is no '=' in the string, the env var was not set in the host
+			// environment. This is not an error.
+			if strings.Contains(s, "=") {
+				args.command = append(args.command, s)
+			}
+		}
+		args.command = append(args.command, "-i", "-u", "workshop", "bash", "-c", "cd /project; exec bash")
+		logger.Debugf("Running shell %q", args.command)
+	default:
+		logger.Debugf("Running %q", args.command)
 	}
 
 	stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
@@ -456,7 +484,7 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 	}
 
 	// Start the command.
-	process, err := cli.Exec(opts, workshop, project.Id)
+	process, err := cli.Exec(opts, workshop.Name, project.Id)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -69,6 +69,7 @@ type WorkshopInfo struct {
 	Status    string     `json:"status"`
 	Sdks      []*SdkInfo `json:"sdks,omitempty"`
 	Notes     []string   `json:"notes,omitempty"`
+	Env       []string   `json:"env,omitempty"`
 }
 
 type WorkshopFileInfo struct {
@@ -135,6 +136,7 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 		info.Notes = append(info.Notes, health.Code)
 	}
 	info.Status = health.Status.String()
+	info.Env = workshopEnv(w)
 
 	return &info
 }
@@ -490,4 +492,11 @@ func v1GetProjectWorkshopScripts(c *Command, r *http.Request, _ *userState) Resp
 	}
 
 	return SyncResponse(compat, http.StatusOK)
+}
+
+func workshopEnv(w *workshop.Workshop) (env []string) {
+	for _, p := range w.Profiles {
+		env = append(env, p.Environment...)
+	}
+	return
 }

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -27,9 +27,11 @@ import (
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/x11"
 )
 
 const desktopSummary = `allows SDKs to use the host's wayland compositor`
@@ -87,6 +89,15 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	}
 
 	desktop := workshop.Desktop{}
+	var wsEnv []string
+
+	// These variables will be inherited from the host
+	wsEnv = append(wsEnv, "XDG_BACKEND")
+	wsEnv = append(wsEnv, "XDG_SESSION_TYPE")
+	wsEnv = append(wsEnv, "QT_QPA_PLATFORM")
+	wsEnv = append(wsEnv, "ELECTRON_OZONE_PLATFORM_HINT")
+	wsEnv = append(wsEnv, "WAYLAND_DISPLAY")
+	wsEnv = append(wsEnv, "DISPLAY")
 
 	wayland := env["WAYLAND_DISPLAY"]
 	display := env["DISPLAY"]
@@ -96,6 +107,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	}
 
 	if wayland != "" {
+		// Setup profile entries
 		desktop.Wayland = &workshop.ProxyEntry{}
 		desktop.Wayland.Name = plug.Sdk().Name + "-" + "wayland"
 		desktop.Wayland.Connect = filepath.Join(xdg, wayland)
@@ -106,14 +118,15 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	// on the host. This then gives users the option to modify their xhost
 	// settings to allow connections from the container and container user.
 	if display != "" {
+		// Setup profile entries
 		desktop.X11 = &workshop.ProxyEntry{}
 		desktop.X11.Name = plug.Sdk().Name + "-" + "x11"
 		desktop.X11.Connect = filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":"))
 		desktop.X11.Listen = desktop.X11.Connect
 	}
 
-	// We mount the Xauthority inside a parent folder to ensure that the mounted
-	// cookie is updated when the host cookie changes (ie. reboot).
+	// We mount the Xauthority cookie inside a parent folder to ensure that it's
+	// updated when the host cookie changes (ie. reboot).
 	// https://discuss.linuxcontainers.org/t/mount-single-file/17975
 	workshopdXauth := filepath.Join(dirs.WorkshopdRunDir, spec.User.Uid, "Xauthority")
 	xauth := env["XAUTHORITY"]
@@ -126,7 +139,24 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 		spec.AddMountEntry(m)
 	}
 
-	return spec.SetDesktop(desktop)
+	// The .Xauthority cookie contains a 128bit key used to authenticate
+	// consumers of the X11 socket. It is generated on each boot with a random
+	// suffix, because of this we need to ensure there exists a
+	// consistently-named copy of the cookie for the LXC profile. There are two
+	// cases where we need to copy the cookie, one is on workshopd startup as we
+	// iterate through the list of projects, the other is on connect because
+	// this could be the first workshop launched, in which case the user would
+	// not have had a project. We handle it here for the connect, presence of
+	// the copied cookie after reboot is the responsibility of the interface
+	// manager.
+	if xauth != "" {
+		wsEnv = append(wsEnv, "XAUTHORITY=/tmp/.Xauthority")
+		if err := x11.MigrateXauthority(spec.User, xauth); err != nil {
+			logger.Noticef("cannot migrate Xauthority file for user %s, X11 applications may not work: %v", spec.User.Username, err)
+		}
+	}
+
+	return spec.SetDesktop(desktop, wsEnv)
 }
 
 func init() {

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -90,7 +90,7 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 	fromSocket := sock
 	toSocket := filepath.Join(dirs.WorkshopRunDir, name+".ssh")
 
-	return spec.SetSshAgent(workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: name, Connect: fromSocket, Listen: toSocket}})
+	return spec.SetSshAgent(workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: name, Connect: fromSocket, Listen: toSocket}}, []string{"SSH_AUTH_SOCK=" + toSocket})
 }
 
 func init() {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path/filepath"
 	"slices"
-	"strings"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -19,10 +17,8 @@ import (
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
-	"github.com/canonical/workshop/internal/x11"
 )
 
 const (
@@ -205,99 +201,7 @@ func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string,
 	})
 }
 
-func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop string) error {
-	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
-	if err != nil {
-		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
-	}
-	defer env.Close()
-
-	varline := fmt.Sprintln("export SSH_AUTH_SOCK=" + strings.TrimPrefix(dev.Listen, "unix:"))
-	_, err = env.Write([]byte(varline))
-	if err != nil {
-		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
-	}
-	return nil
-}
-
-func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) error {
-	return fs.Remove(filepath.Join("/etc/profile.d", dev.Name+".sh"))
-}
-
-func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.User, ws string) error {
-	env, err := systemd.UserEnvironment(user)
-	if err != nil {
-		return err
-	}
-
-	backend := env["XDG_BACKEND"]
-
-	var envVars map[string]string
-	envFile, err := fs.Create(filepath.Join("/etc/profile.d", "desktop"+".sh"))
-	if err != nil {
-		return fmt.Errorf("cannot configure required environment for %q: %w", ws, err)
-	}
-	defer envFile.Close()
-
-	// Use Wayland as the default backend in the case where it's unset
-	if (backend == "wayland" || backend == "") && dev.Wayland != nil {
-		envVars = map[string]string{
-			"QT_QPA_PLATFORM":  "wayland-egl",
-			"XDG_SESSION_TYPE": "wayland",
-			"XDG_BACKEND":      "wayland",
-		}
-	} else {
-		envVars = map[string]string{
-			"QT_QPA_PLATFORM":  "xcb",
-			"XDG_SESSION_TYPE": "x11",
-			"XDG_BACKEND":      "x11",
-		}
-	}
-
-	if dev.Wayland != nil {
-		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen, "/run/user/1000/")
-	}
-
-	if dev.X11 != nil {
-		envVars["DISPLAY"] = ":" + strings.TrimPrefix(filepath.Base(dev.X11.Listen), "X")
-	}
-
-	// The .Xauthority cookie contains a 128bit key used to authenticate consumers
-	// of the X11 socket. It is generated on each boot with a random suffix,
-	// because of this we need to ensure there exists a consistently-named copy
-	// of the cookie for the LXC profile. There are two cases where we need to
-	// copy the cookie, one is on workshopd startup as we iterate through the
-	// list of projects, the other is on connect because this could be the first
-	// workshop launched, in which case the user would not have had a project. We
-	// handle it here for the connect, presence of the copied cookie after reboot
-	// is the responsibility of the interface manager.
-	xauth := env["XAUTHORITY"]
-	if xauth != "" {
-		envVars["XAUTHORITY"] = "/tmp/.Xauthority"
-		if err := x11.MigrateXauthority(user, xauth); err != nil {
-			logger.Noticef("cannot migrate Xauthority file for user %s, X11 applications may not work: %v", user.Username, err)
-		}
-	}
-
-	envVars["ELECTRON_OZONE_PLATFORM_HINT"] = "auto"
-
-	for key, val := range envVars {
-		_, err = envFile.WriteString("export " + key + "=" + val + "\n")
-		if err != nil {
-			return fmt.Errorf("cannot set %s for %q: %w", key, ws, err)
-		}
-	}
-
-	return nil
-}
-
 func removeDesktop(fs workshop.WorkshopFs) error {
-	if err := fs.Remove("/etc/profile.d/desktop.sh"); err != nil {
-		if !errors.Is(err, afero.ErrFileNotFound) {
-			return err
-		}
-	}
-
 	if err := fs.Remove("/tmp/.Xauthority"); err != nil {
 		if !errors.Is(err, afero.ErrFileNotFound) {
 			return err
@@ -363,20 +267,6 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		}
 	}
 
-	if spec.Profile.Agent != nil {
-		err = installSshAgent(fs, *spec.Profile.Agent, sdkInfo.Workshop)
-		if err != nil {
-			return err
-		}
-	}
-
-	if spec.Profile.Desktop != nil {
-		err = installDesktop(fs, *spec.Profile.Desktop, spec.User, sdkInfo.Workshop)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Either create or update an existing LXD profile for the SDK so that later
 	// it can be assigned to the required workshop.
 	prevp, err := lxdbackend.Profile(conn, sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Sdk)
@@ -386,13 +276,6 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		for key, dev := range prevp.Mounts {
 			if _, exist := spec.Profile.Mounts[key]; !exist {
 				if err = removeMount(conn, fs, sdkInfo.ProjectId, sdkInfo.Workshop, dev); err != nil {
-					return err
-				}
-			}
-		}
-		if prevp.Agent != nil {
-			if spec.Profile.Agent == nil || *prevp.Agent != *spec.Profile.Agent {
-				if err = removeSshAgent(fs, *prevp.Agent); err != nil {
 					return err
 				}
 			}
@@ -464,12 +347,6 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 
 	for _, dev := range prof.Mounts {
 		if err = removeMount(conn, fs, projectId, w, dev); err != nil {
-			return err
-		}
-	}
-
-	if prof.Agent != nil {
-		if err = removeSshAgent(fs, *prof.Agent); err != nil {
 			return err
 		}
 	}

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -89,14 +89,16 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 // see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
 // bind denotes where the port is open (can be: instance, host)
 
-func (s *Specification) SetSshAgent(agent workshop.SshAgent) error {
+func (s *Specification) SetSshAgent(agent workshop.SshAgent, env []string) error {
 	s.Profile.Agent = &agent
+	s.AmendEnvironment(env)
 	s.addProxyEntry(&agent.ProxyEntry, "ssh-agent")
 	return nil
 }
 
-func (s *Specification) SetDesktop(desktop workshop.Desktop) error {
+func (s *Specification) SetDesktop(desktop workshop.Desktop, env []string) error {
 	s.Profile.Desktop = &desktop
+	s.AmendEnvironment(env)
 
 	if desktop.Wayland != nil {
 		s.addProxyEntry(desktop.Wayland, "desktop-wayland")
@@ -165,6 +167,12 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 	}
 
 	return nil
+}
+
+func (s *Specification) AmendEnvironment(env []string) {
+	s.Profile.Environment = append(s.Profile.Environment, env...)
+
+	s.config[lxdbackend.EnvironmentConfigKey(s.Profile.Sdk)] = lxdbackend.EnvironmentConfigValue(s.Profile.Environment)
 }
 
 func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey string) {

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -20,7 +20,6 @@ import (
 	backend "github.com/canonical/workshop/internal/interfaces/backends"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
-	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -333,17 +332,9 @@ exit 0
 	c.Check(prof.Agent.Connect, check.Equals, "unix:/run/.workshop.socket")
 	c.Check(prof.Agent.Listen, check.Equals, "unix:/run/consumer-ssh-agent.ssh")
 
-	buf := f.readWorkshopFile(c, "/etc/profile.d/consumer-ssh-agent.sh")
-	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/consumer-ssh-agent.ssh\n")
-
 	f.repo.DisconnectAll([]*interfaces.ConnRef{connref})
 
 	// Update profile (ssh-agent must be removed as it was disconnected).
 	err = b.Setup(f.ctx, cref, f.repo)
 	c.Assert(err, check.IsNil)
-
-	fs, err := f.be.WorkshopFs(f.ctx, "test")
-	c.Assert(err, check.IsNil)
-	_, err = fs.Stat("/etc/profile.d/consumer-ssh-agent.sh")
-	c.Assert(osutil.IsDirNotExist(err), check.Equals, true)
 }

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -39,7 +39,8 @@ type Gpu struct {
 }
 
 type SdkProfile struct {
-	Sdk string
+	Sdk         string
+	Environment []string
 
 	Camera  *Camera
 	Mounts  map[string]Mount

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -25,6 +25,25 @@ func DeviceTypeConfigKey(sdk, dev string) string {
 	return fmt.Sprintf("user.workshop.%s.%s.type", sdk, dev)
 }
 
+func EnvironmentConfigKey(sdk string) string {
+	return fmt.Sprintf("user.workshop.%s.environment", sdk)
+}
+
+func EnvironmentConfigValue(env []string) string {
+	sb := strings.Builder{}
+	for _, s := range env {
+		sb.WriteString(s + ",")
+	}
+	return sb.String()
+}
+
+func EnvironmentConfigToSlice(env string) []string {
+	var e []string
+	splits := strings.Split(env, ",")
+	e = append(e, splits...)
+	return e
+}
+
 func Profile(conn lxd.InstanceServer, pid, wp, profile string) (workshop.SdkProfile, error) {
 	name := ProfileName(pid, wp, profile)
 	lxdp, _, err := conn.GetProfile(name)
@@ -40,6 +59,7 @@ func Profile(conn lxd.InstanceServer, pid, wp, profile string) (workshop.SdkProf
 
 func lxdToSdkProfile(profile string, devs map[string]map[string]string, config map[string]string) (workshop.SdkProfile, error) {
 	var pr = workshop.NewSdkProfile(profile)
+	pr.Environment = EnvironmentConfigToSlice(config[EnvironmentConfigKey(profile)])
 	for name, dev := range devs {
 		switch dev["type"] {
 		case "disk":

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -24,30 +24,28 @@ execute: |
   workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
 
   echo "Check that the expected environment is configured inside the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  sudo WAYLAND_DISPLAY=wayland-1 XDG_SESSION_TYPE=wayland -u ubuntu workshop exec ws-desktop /bin/bash -s <<"EOF"
       set -e
       [ -n "$WAYLAND_DISPLAY" ]
-      [ -n "$QT_QPA_PLATFORM" ]
+      [ -z "$QT_QPA_PLATFORM" ]
       [ -n "$XDG_SESSION_TYPE" ]
-      [ -n "$ELECTRON_OZONE_PLATFORM_HINT" ]
+      [ -z "$ELECTRON_OZONE_PLATFORM_HINT" ]
   EOF
 
   echo "Check that the required mounts are configured inside the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop /bin/bash -s <<"EOF"
       set -e
-      [ -S "/run/user/1000/${WAYLAND_DISPLAY}" ]
+      [ -S "/run/user/1000/wayland-1" ]
   EOF
 
   echo "Disconnect the desktop interface"
   workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
 
   echo "Check that the environment is removed from the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  sudo WAYLAND_DISPLAY=wayland-1 XDG_SESSION_TYPE=wayland -u ubuntu workshop exec ws-desktop /bin/bash -s <<"EOF"
       set -e
       [ -z "$WAYLAND_DISPLAY" ]
-      [ -z "$QT_QPA_PLATFORM" ]
-      [ "$XDG_SESSION_TYPE" == "unspecified" ]
-      [ -z "$ELECTRON_OZONE_PLATFORM_HINT" ]
+      [ -z "$XDG_SESSION_TYPE" ]
   EOF
 
   echo "Connect the desktop interface for an x11 session"
@@ -56,43 +54,44 @@ execute: |
   workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
 
   echo "Check that the expected environment is configured inside the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  sudo DISPLAY=:0 XDG_SESSION_TYPE=x11 -u ubuntu workshop exec ws-desktop /bin/bash -s <<"EOF"
       set -e
       [ -n "$DISPLAY" ]
+      [ -n "$XDG_SESSION_TYPE" ]
       [ -n "$XAUTHORITY" ]
   EOF
 
   echo "Check that the required mounts are configured inside the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop /bin/bash -s <<"EOF"
       set -e
-      [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
-      [ -f "${XAUTHORITY}" ]
+      [ -S "/tmp/.X11-unix/X0" ]
+      [ -f "/tmp/.Xauthority" ]
   EOF
 
   echo "Check that the required mounts are present after restart"
   workshop_exec stop ws-desktop
   workshop_exec start ws-desktop
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop /bin/bash -s <<"EOF"
       set -e
-      [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
-      [ -f "${XAUTHORITY}" ]
+      [ -S "/tmp/.X11-unix/X0" ]
+      [ -f "/tmp/.Xauthority" ]
   EOF
 
   echo "Disconnect the desktop interface"
   workshop_exec disconnect ws-desktop/test-sdk-desktop:desktop
 
   echo "Check that the expected environment is removed from the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  sudo DISPLAY=:0 XDG_SESSION_TYPE=x11 -u ubuntu workshop exec ws-desktop /bin/bash -s <<"EOF"
       set -e
       [ -z "$DISPLAY" ]
+      [ -z "$XDG_SESSION_TYPE" ]
       [ -z "$XAUTHORITY" ]
   EOF
 
   echo "Check that the required mounts are removed from the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop /bin/bash -s <<"EOF"
       set -e
-      [ ! -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
-      [ ! -f "${XAUTHORITY}" ]
+      [ ! -f "/tmp/.Xauthority" ]
   EOF
 
   echo "Reconnect the desktop interface with a different socket name"
@@ -100,17 +99,17 @@ execute: |
   workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop
 
   echo "Check that the expected environment is configured inside the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  sudo DISPLAY=:1 XDG_SESSION_TYPE=x11 -u ubuntu workshop exec ws-desktop /bin/bash -s <<"EOF"
       set -e
       [ "$DISPLAY" == ":1" ]
       [ -n "$XAUTHORITY" ]
   EOF
 
   echo "Check that the required mounts are configured inside the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop /bin/bash -s <<"EOF"
       set -e
-      [ -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
-      [ -f "${XAUTHORITY}" ]
+      [ -S "/tmp/.X11-unix/X1" ]
+      [ -f "/tmp/.Xauthority" ]
   EOF
 
   echo "Check refreshing to an empty workshop definition"
@@ -123,15 +122,14 @@ execute: |
   [ -z "$(workshop_exec connections --all)" ]
 
   echo "Check that the expected environment is removed from the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  sudo DISPLAY=:1 XDG_SESSION_TYPE=x11 -u ubuntu workshop exec ws-desktop /bin/bash -s <<"EOF"
       set -e
       [ -z "$DISPLAY" ]
       [ -z "$XAUTHORITY" ]
   EOF
 
   echo "Check that the required mounts are removed from the workshop"
-  workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
+  workshop_exec exec ws-desktop /bin/bash -s <<"EOF"
       set -e
-      [ ! -S "/tmp/.X11-unix/X${DISPLAY:1}" ]
-      [ ! -f "${XAUTHORITY}" ]
+      [ ! -f "/tmp/.Xauthority" ]
   EOF


### PR DESCRIPTION
# Description

# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
