### PR TITLE
Cleanup StartWorkshop progress if failed

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -172,12 +174,31 @@ func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
 	}
 	defer conn.Disconnect()
 
-	// Workshop started, enable autostart
-	if err = s.addWorkshopConfig(conn, ctx, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "true"}); err != nil {
+	rev := revert.New()
+	defer rev.Fail()
+
+	cleanupCtx := context.WithoutCancel(ctx)
+	rev.Add(func() {
+		cleanupCtxTimeout, cancel := context.WithTimeout(cleanupCtx, 5*time.Second)
+		defer cancel()
+
+		if e := s.AddWorkshopConfig(cleanupCtxTimeout, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "false"}); e != nil {
+			logger.Noticef("On StartWorkshop: cannot reset %q workshop autostart config on cleanup: %v", name, e)
+		}
+
+		// Stop workshop's timeout is handled by LXD API, so no need to have
+		// a context with a timeout.
+		if e := s.StopWorkshop(cleanupCtx, name, true); e != nil {
+			logger.Noticef("On StartWorkshop: cannot stop %q workshop on cleanup: %v", name, e)
+		}
+	})
+
+	if err = s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
 		return err
 	}
 
-	if err = s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
+	// Workshop started, enable autostart.
+	if err = s.addWorkshopConfig(conn, ctx, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "true"}); err != nil {
 		return err
 	}
 
@@ -197,7 +218,12 @@ func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
 		return err
 	}
 
-	return exectx.WaitExecution(ctx)
+	if err = exectx.WaitExecution(ctx); err != nil {
+		return err
+	}
+
+	rev.Success()
+	return nil
 }
 
 func (s *Backend) StopWorkshop(ctx context.Context, name string, force bool) error {
@@ -787,4 +813,12 @@ func FakeDefaultDevices(f func() map[string]map[string]string) func() {
 	oldDefault := defaultDevices
 	defaultDevices = f
 	return func() { defaultDevices = oldDefault }
+}
+
+func FakeStartCommand(script string) func() {
+	old := startCommand
+	startCommand = script
+	return func() {
+		startCommand = old
+	}
 }

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -265,3 +265,23 @@ func (f *wsOps) TestLxdBackendDownloadMultipleBasesConcurrently(c *check.C) {
 		c.Assert(f.deleteimage(c, fp), check.IsNil)
 	}
 }
+
+func (f *wsOps) TestLxdBackendWorkshopStartFailed(c *check.C) {
+	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
+
+	err := f.bd.StopWorkshop(f.ctx, "test", true)
+	c.Check(err, check.IsNil)
+
+	// Leaves the workshop instance in a started state with a failed start
+	// command. The StartWorkshop API must clean up its previous progress, i.e.
+	// set the workshop to the Stopped state.
+	defer lxdbackend.FakeStartCommand("exit 1")()
+
+	err = f.bd.StartWorkshop(f.ctx, "test")
+	c.Check(err, check.NotNil)
+
+	w, err := f.bd.Workshop(f.ctx, "test")
+	c.Check(err, check.IsNil)
+	c.Check(w.Running, check.Equals, false)
+}


### PR DESCRIPTION
# Description

The StartWorkshop backend method does multiple things. If, for example, waiting for the systemd to be ready fails, the
method must clean up its progress made so far. In most cases it means that the instance must be set back to Stopped and the auto-start option reverted.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
