### PR TITLE
Add code completion for command arguments

### DIFF
--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -57,24 +57,10 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	clientOpts := client.ChangesOptions{
-		ProjectPath: c.root.project,
-		Selector:    client.ChangesAll,
-	}
-
-	chngs, err := cli.Changes(&clientOpts)
+	chngs, err := c.changes(cli)
 	if err != nil {
 		return err
 	}
-
-	slices.SortFunc(chngs, func(a, b *client.Change) int {
-		if a.SpawnTime.Before(b.SpawnTime) {
-			return -1
-		} else if a.SpawnTime.After(b.SpawnTime) {
-			return 1
-		}
-		return 0
-	})
 
 	if len(chngs) > 0 {
 		w := tabWriter()
@@ -98,4 +84,26 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	return nil
+}
+
+func (c *CmdChanges) changes(cli *client.Client) ([]*client.Change, error) {
+	clientOpts := client.ChangesOptions{
+		ProjectPath: c.root.project,
+		Selector:    client.ChangesAll,
+	}
+
+	chngs, err := cli.Changes(&clientOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(chngs, func(a, b *client.Change) int {
+		if a.SpawnTime.Before(b.SpawnTime) {
+			return -1
+		} else if a.SpawnTime.After(b.SpawnTime) {
+			return 1
+		}
+		return 0
+	})
+	return chngs, nil
 }

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -54,7 +56,8 @@ $ workshop connect nimble/go:mod-cache :mount
 
 A full version of the command that also lists the target SDK ('system'):
 $ workshop connect nimble/go:mod-cache nimble/system:mount`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.complete(),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -131,4 +134,50 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	return nil
+}
+
+func (c *CmdConnect) complete() ValidArgsFunction {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		cli, err := c.root.client()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		project, err := cli.Project(c.root.project)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		// Create map of endpoint string and associated plugs
+		disconnectedPlugs := make(map[string]client.Plug)
+		for _, plug := range connections.Plugs {
+			if len(plug.Connections) == 0 {
+				plugString := endpoint(plug.Workshop, plug.Sdk, plug.Name)
+				disconnectedPlugs[plugString] = plug
+			}
+		}
+
+		var completions []string
+		switch len(args) {
+		case 0:
+			// No arguments, show list of plugs
+			completions = slices.Collect(maps.Keys(disconnectedPlugs))
+		case 1:
+			plug, ok := disconnectedPlugs[args[0]]
+			if !ok {
+				break
+			}
+			for _, slot := range connections.Slots {
+				if plug.Interface == slot.Interface && plug.Workshop == slot.Workshop {
+					completions = append(completions, endpoint(slot.Workshop, slot.Sdk, slot.Name))
+				}
+			}
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/cmd/workshop/connect_test.go
+++ b/cmd/workshop/connect_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"slices"
 
+	"github.com/spf13/cobra"
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
 )
 
 type connectSuite struct {
@@ -188,4 +192,148 @@ func (m *connectSuite) TestDisconnectSlotNotProvided(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"ws/sdk:plug"})
 	c.Assert(err, check.IsNil)
+}
+
+func (m *connectSuite) TestConnectCompletionAllDisconnected(c *check.C) {
+	plugs, slots := testPlugsSlots(m.prjId)
+	conns := client.Connections{
+		Established: nil,
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	expected := []string{
+		"workshop/sdk:ssh-agent",
+		"workshop/sdk:mount",
+		"workshop/another-sdk:desktop",
+		"another-workshop/sdk:desktop",
+		"workshop/sdk:desktop",
+	}
+
+	cmd := CmdConnect{
+		root: &CmdRoot{},
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	for _, completion := range completions {
+		c.Check(slices.Contains(expected, completion), check.Equals, true)
+	}
+
+	// Test slots
+	for i, plug := range conns.Plugs {
+		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+		c.Assert(completions, check.DeepEquals, []string{endpoint(conns.Slots[i].Workshop, conns.Slots[i].Sdk, conns.Slots[i].Name)})
+	}
+}
+
+func (m *connectSuite) TestConnectCompletionSomeDisconnected(c *check.C) {
+	plugs, slots := testPlugsSlots(m.prjId)
+
+	plugs[0].Connections = []client.SlotRef{{}}
+	plugs[1].Connections = []client.SlotRef{{}}
+
+	conns := client.Connections{
+		Established: nil,
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
+
+	cmd := CmdConnect{
+		root: &CmdRoot{},
+	}
+
+	expected := []string{
+		"workshop/sdk:mount",
+		"another-workshop/sdk:desktop",
+	}
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	for _, completion := range completions {
+		c.Check(slices.Contains(expected, completion), check.Equals, true)
+	}
+
+	// Test slots
+	var slotCompletions []string
+	for _, plug := range plugs {
+		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+		slotCompletions = append(slotCompletions, completions...)
+	}
+	c.Check(slotCompletions, check.DeepEquals, []string{"workshop/sdk:mount", "another-workshop/sdk:desktop"})
+}
+
+func (m *connectSuite) TestConnectCompletionAllConnected(c *check.C) {
+	plugs, slots := testPlugsSlots(m.prjId)
+
+	for i := range plugs {
+		plugs[i].Connections = []client.SlotRef{{}}
+	}
+
+	conns := client.Connections{
+		Established: nil,
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
+
+	cmd := CmdConnect{
+		root: &CmdRoot{},
+	}
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(len(completions), check.Equals, 0)
+
+	// Test slots
+	for _, plug := range plugs {
+		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+		c.Check(len(completions), check.Equals, 0)
+	}
+}
+
+func (m *connectSuite) TestConnectCompletionWorkshopMismatch(c *check.C) {
+	plugs := []client.Plug{
+		{
+			ProjectId: m.prjId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+	}
+
+	slots := []client.Slot{
+		{
+			ProjectId: m.prjId,
+			Workshop:  "another-workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+	}
+
+	conns := client.Connections{
+		Established: nil,
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 2)
+
+	cmd := CmdConnect{
+		root: &CmdRoot{},
+	}
+
+	completions, compDirective := cmd.complete()(cmd.Command(), []string{"workshop/sdk:desktop"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(len(completions), check.Equals, 0)
 }

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -42,7 +42,8 @@ $ workshop connections nimble
 
 List connections for all workshops in the current project directory:
 $ workshop connections`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Pending", "Stopped"}),
 	}
 
 	cmd.Flags().BoolVar(&c.all, "all", false, "Include disconnected plugs in the output.")

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -51,7 +53,8 @@ $ workshop disconnect nimble/go:mod-cache nimble/system:mount
 Disconnect all plugs connected to the 'mount' slot of the 'system' SDK
 under the 'nimble' workshop in the current project directory:
 $ workshop disconnect nimble/system:mount`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.complete(),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.forget, "forget",
@@ -113,4 +116,46 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	return nil
+}
+
+func (c *CmdDisconnect) complete() ValidArgsFunction {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		cli, err := c.root.client()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		project, err := cli.Project(c.root.project)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		// Create map of endpoint strings and associated plugs
+		connectedPlugs := make(map[string]client.Plug)
+		for _, plug := range connections.Plugs {
+			if len(plug.Connections) > 0 {
+				ref := endpoint(plug.Workshop, plug.Sdk, plug.Name)
+				connectedPlugs[ref] = plug
+			}
+		}
+
+		var completion []string
+		switch len(args) {
+		case 0:
+			// No arguments, show list of plugs
+			completion = slices.Collect(maps.Keys(connectedPlugs))
+		case 1:
+			if plug, ok := connectedPlugs[args[0]]; ok {
+				for _, slot := range plug.Connections {
+					completion = append(completion, endpoint(slot.Workshop, slot.Sdk, slot.Name))
+				}
+			}
+		}
+		return completion, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/cmd/workshop/disconnect_test.go
+++ b/cmd/workshop/disconnect_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"slices"
 
+	"github.com/spf13/cobra"
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
 )
 
 type disconnectSuite struct {
@@ -143,4 +147,172 @@ func (m *disconnectSuite) TestDisconnectPlugOrSlotProvided(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"ws/sdk:plug"})
 	c.Assert(err, check.IsNil)
+}
+
+func (m *disconnectSuite) TestDisconnectCompletionAllDisconnected(c *check.C) {
+	plugs, slots := testPlugsSlots(m.prjId)
+
+	conns := client.Connections{
+		Established: nil,
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	cmd := CmdDisconnect{
+		root: &CmdRoot{},
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Assert(len(completions), check.Equals, 0)
+
+	// Test slots
+	for _, plug := range plugs {
+		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+		c.Assert(len(completions), check.Equals, 0)
+	}
+}
+
+func (m *disconnectSuite) TestDisconnectCompletionSomeDisconnected(c *check.C) {
+	plugs, slots := testPlugsSlots(m.prjId)
+	established := []client.Connection{
+		plugSlotToConn(plugs[0], slots[0], true),
+		plugSlotToConn(plugs[1], slots[1], true),
+	}
+
+	conns := client.Connections{
+		Established: established,
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	expected := []string{
+		"workshop/sdk:desktop",
+		"workshop/sdk:ssh-agent",
+	}
+
+	cmd := CmdDisconnect{
+		root: &CmdRoot{},
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	for _, completion := range completions {
+		c.Check(slices.Contains(expected, completion), check.Equals, true)
+	}
+
+	// Test slots
+	for _, plug := range plugs {
+		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+		if len(completions) == 1 {
+			c.Check(slices.Contains(expected, completions[0]), check.Equals, true)
+			break
+		}
+		c.Assert(len(completions), check.Equals, 0)
+	}
+}
+
+func (m *disconnectSuite) TestDisconnectCompletionAllConnected(c *check.C) {
+	plugs, slots := testPlugsSlots(m.prjId)
+	established := []client.Connection{
+		plugSlotToConn(plugs[0], slots[0], true),
+		plugSlotToConn(plugs[1], slots[1], true),
+		plugSlotToConn(plugs[2], slots[2], true),
+		plugSlotToConn(plugs[3], slots[3], true),
+	}
+
+	conns := client.Connections{
+		Established: established,
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	expected := []string{
+		"workshop/sdk:ssh-agent",
+		"workshop/sdk:mount",
+		"workshop/another-sdk:desktop",
+		"another-workshop/sdk:desktop",
+		"workshop/sdk:desktop",
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
+
+	cmd := CmdDisconnect{
+		root: &CmdRoot{},
+	}
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	for _, completion := range completions {
+		c.Check(slices.Contains(expected, completion), check.Equals, true)
+	}
+
+	// Test slots
+	for _, plug := range plugs {
+		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+		if len(completions) == 1 {
+			c.Check(slices.Contains(expected, completions[0]), check.Equals, true)
+			break
+		}
+		c.Assert(len(completions), check.Equals, 0)
+	}
+}
+
+func (m *disconnectSuite) TestDisconnectCompletionWorkshopMismatch(c *check.C) {
+	plugs := []client.Plug{
+		{
+			ProjectId: m.prjId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+		{
+			ProjectId: m.prjId,
+			Workshop:  "another-workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+	}
+
+	slots := []client.Slot{
+		{
+			ProjectId: m.prjId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+		{
+			ProjectId: m.prjId,
+			Workshop:  "another-workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+	}
+
+	conns := client.Connections{
+		Established: []client.Connection{plugSlotToConn(plugs[0], slots[0], true)},
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 4)
+
+	cmd := CmdDisconnect{
+		root: &CmdRoot{},
+	}
+
+	completions, compDirective := cmd.complete()(cmd.Command(), []string{"another-workshop/sdk:desktop"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(len(completions), check.Equals, 0)
 }

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -182,7 +182,8 @@ $ workshop exec -I -- sh
 
 Run a command as root (the default is 'workshop'):
 $ workshop exec --uid 0 nimble id`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Pending"}),
 	}
 
 	cmd.Flags().SortFlags = false

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -49,7 +49,8 @@ $ workshop info nimble
 
 The name is optional if the project has only one workshop:
 $ workshop info`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName(nil),
 	}
 
 	return cmd

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
+
+	"github.com/canonical/workshop/client"
 )
 
 type CmdLaunch struct {
@@ -53,7 +56,8 @@ $ workshop launch nimble jazzy
 
 The name is optional if the project has only one workshop:
 $ workshop launch`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.complete(),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",
@@ -149,4 +153,39 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	return nil
+}
+
+func (c *CmdLaunch) complete() ValidArgsFunction {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		cli, err := c.root.client()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		project, err := cli.Project(c.root.project)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		instances, files, err := cli.List(&client.ListOptions{ProjectId: project.Id})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		var workshops []string
+		for _, file := range files {
+			isInstance := false
+			for _, instance := range instances {
+				if file.Name == instance.Name {
+					isInstance = true
+					break
+				}
+			}
+			if !isInstance && !slices.Contains(args, file.Name) {
+				workshops = append(workshops, file.Name)
+			}
+		}
+
+		return workshops, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/spf13/cobra"
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
 )
 
 type workshopLaunch struct {
 	BaseWorkshopSuite
+	client *client.Client
 	prjDir string
 	prjId  string
 }
@@ -19,6 +23,7 @@ func (m *workshopLaunch) SetUpTest(c *check.C) {
 	m.prjDir = c.MkDir()
 	m.prjId = "42424242"
 	m.BaseWorkshopSuite.SetUpTest(c)
+	m.client = &client.Client{}
 }
 
 func (m *workshopLaunch) TestLaunchSuccess(c *check.C) {
@@ -181,4 +186,42 @@ func (m *workshopLaunch) TestLaunchIncompatibleOptions(c *check.C) {
 
 	err = cmd.Run(nil, []string{"ws", "ws-1"})
 	c.Assert(err, check.ErrorMatches, "cannot launch: '--wait-on-error' incompatible with multiple workshops")
+}
+
+func (m *workshopLaunch) TestLaunchCompletions(c *check.C) {
+	wsInfo := []*client.WorkshopInfo{
+		{
+			ProjectId: m.prjId,
+			Name:      "workshop-exists",
+			Status:    "Ready",
+		},
+	}
+
+	wsFile := []*client.WorkshopFile{
+		{
+			ProjectId: m.prjId,
+			Name:      "workshop-exists",
+			Path:      "/tmp/workshop",
+		},
+		{
+			ProjectId: m.prjId,
+			Name:      "workshop-notexists",
+			Path:      "/tmp/workshop1",
+		},
+	}
+
+	w := client.Workshops{
+		Workshops: wsInfo,
+		Files:     wsFile,
+	}
+
+	cmd := CmdLaunch{
+		root: &CmdRoot{},
+	}
+
+	m.listRedirectHelper(c, w, m.prjId, m.prjDir, len(wsFile))
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(completions, check.DeepEquals, []string{"workshop-notexists"})
 }

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -81,7 +81,8 @@ $ workshop refresh --continue
 
 Refresh the sketch SDK in the 'nimble' workshop:
 $ workshop refresh nimble/sketch`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Pending"}),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -47,7 +47,8 @@ Remount the 'mod-cache' mount interface plug of the 'go' SDK
 under the 'nimble' workshop in the current project directory
 to '~/new-cache-mount/' on the host:
 $ workshop remount nimble/go:mod-cache ~/new-cache-mount`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.complete(),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -95,4 +96,40 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	return nil
+}
+
+func (c *CmdRemount) complete() ValidArgsFunction {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		cli, err := c.root.client()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		project, err := cli.Project(c.root.project)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		var completions []string
+		if len(args) == 0 {
+			// A mount must be connected for remount to work, only show currently
+			// connected mounts
+			for _, conn := range connections.Established {
+				if conn.Interface == "mount" {
+					completions = append(completions, endpoint(conn.Plug.Workshop, conn.Plug.Sdk, conn.Plug.Name))
+				}
+			}
+			// We don't want file comp if there was no workshop name provided and
+			// no completion was generated
+			if len(completions) == 0 {
+				return completions, cobra.ShellCompDirectiveNoFileComp
+			}
+		}
+		return completions, cobra.ShellCompDirectiveFilterDirs
+	}
 }

--- a/cmd/workshop/remount_test.go
+++ b/cmd/workshop/remount_test.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/spf13/cobra"
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
 )
 
 type remountSuite struct {
 	BaseWorkshopSuite
+	client *client.Client
 	prjDir string
 	prjId  string
 }
@@ -19,6 +23,7 @@ func (m *remountSuite) SetUpTest(c *check.C) {
 	m.prjDir = c.MkDir()
 	m.prjId = "42424242"
 	m.BaseWorkshopSuite.SetUpTest(c)
+	m.client = &client.Client{}
 }
 
 func (m *remountSuite) TestRemountSuccess(c *check.C) {
@@ -65,4 +70,51 @@ func (m *remountSuite) TestRemountBrokenReference(c *check.C) {
 	cmd := &CmdRemount{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"ws:sdk:plug", "/new/source"})
 	c.Assert(err, check.ErrorMatches, `invalid plug or slot reference "ws:sdk:plug" \(expected <WORKSHOP>/<SDK>:<PLUG>\)`)
+}
+
+func (m *remountSuite) TestRemountCompletions(c *check.C) {
+	plugs, slots := testPlugsSlots(m.prjId)
+
+	conns := client.Connections{
+		Established: []client.Connection{plugSlotToConn(plugs[2], slots[2], false)},
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 4)
+
+	cmd := CmdRemount{
+		root: &CmdRoot{},
+	}
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveFilterDirs)
+	c.Check(completions, check.DeepEquals, []string{"workshop/sdk:mount"})
+
+	// Check slot completion, note this is only ensuring that we don't return the
+	// plug multiple times. Directory completion can only be instrumented with
+	// end-to-end testing
+	completions, compDirective = cmd.complete()(cmd.Command(), []string{"workshop/sdk:mount"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveFilterDirs)
+	c.Assert(len(completions), check.Equals, 0)
+}
+
+func (m *remountSuite) TestRemountCompletionsNoComp(c *check.C) {
+	plugs, slots := testPlugsSlots(m.prjId)
+
+	conns := client.Connections{
+		Established: nil,
+		Plugs:       plugs,
+		Slots:       slots,
+	}
+
+	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 4)
+
+	cmd := CmdRemount{
+		root: &CmdRoot{},
+	}
+
+	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(completions, check.DeepEquals, []string(nil))
 }

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -42,7 +42,8 @@ $ workshop remove nimble jazzy
 
 The name is optional if the project has only one workshop:
 $ workshop remove`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Stopped"}),
 	}
 
 	return cmd

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -87,6 +88,42 @@ func (c *CmdRoot) preRun(cmd *cobra.Command, args []string) error {
 func (c *CmdRoot) postRun(cmd *cobra.Command, args []string) {
 	if c.cli != nil {
 		maybePresentWarnings(c.cli.WarningsSummary())
+	}
+}
+
+type ValidArgsFunction func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+func (c *CmdRoot) completeWorkshopName(status []string) ValidArgsFunction {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		cli, err := c.client()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		project, err := cli.Project(c.project)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		workshopInfo, _, err := cli.List(&client.ListOptions{ProjectId: project.Id})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		desiredStatus := func(s string) bool {
+			if status == nil {
+				return true
+			}
+			return slices.Contains(status, s)
+		}
+
+		var workshops []string
+		for _, workshop := range workshopInfo {
+			if desiredStatus(workshop.Status) && !slices.Contains(args, workshop.Name) {
+				workshops = append(workshops, workshop.Name)
+			}
+		}
+		return workshops, cobra.ShellCompDirectiveNoFileComp
 	}
 }
 

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -3,13 +3,18 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/rand"
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/testutil"
 )
@@ -67,6 +72,95 @@ func (s *BaseWorkshopSuite) Stderr() string {
 	return s.stderr.String()
 }
 
+func (s *BaseWorkshopSuite) TestWorkshopInfoList(c *check.C) {
+	prjId := "42424242"
+	prjDir := c.MkDir()
+
+	status := []string{"Ready", "Pending", "Stopped", "Error"}
+	expected := make(map[string][]string)
+
+	var wsInfo []*client.WorkshopInfo
+	for i := range 20 {
+		index := rand.Intn(len(status) - 1)
+		info := &client.WorkshopInfo{
+			ProjectId: "42424242",
+			Name:      "test" + strconv.Itoa(i),
+			Status:    status[index],
+		}
+		wsInfo = append(wsInfo, info)
+		switch index {
+		case 0:
+			expected["Ready"] = append(expected["Ready"], info.Name)
+		case 1:
+			expected["Pending"] = append(expected["Pending"], info.Name)
+		case 2:
+			expected["Stopped"] = append(expected["Stopped"], info.Name)
+		case 3:
+			expected["Error"] = append(expected["Error"], info.Name)
+		}
+	}
+
+	w := client.Workshops{
+		Workshops: wsInfo,
+	}
+
+	cmd := &CmdRoot{}
+
+	s.listRedirectHelper(c, w, prjId, prjDir, len(status)*2)
+
+	for _, st := range status {
+		result, compDirective := cmd.completeWorkshopName([]string{st})(cmd.Command(prjDir), nil, "")
+		c.Check(result, check.DeepEquals, expected[st])
+		c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	}
+}
+
+func (m *BaseWorkshopSuite) listRedirectHelper(c *check.C, w client.Workshops, prjId, prjDir string, expected int) {
+	workshops, err := json.Marshal(w)
+	c.Assert(err, check.IsNil)
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch {
+		case n%2 != 0 && n <= expected:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, prjId, prjDir)
+			fmt.Fprintln(w, r)
+		case n%2 == 0 && n <= expected:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects/42424242/workshops")
+			rsp := fmt.Sprintf(`{"type": "sync", "result": %s}`, workshops)
+			fmt.Fprintln(w, rsp)
+		}
+	})
+}
+
+func (m *BaseWorkshopSuite) connectionsRedirectHelper(c *check.C, conns client.Connections, prjId, prjDir string, expected int) {
+	connections, err := json.Marshal(conns)
+	c.Assert(err, check.IsNil)
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch {
+		case n%2 != 0 && n <= expected:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, prjId, prjDir)
+			fmt.Fprintln(w, r)
+		case n%2 == 0 && n <= expected:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/connections")
+			r := fmt.Sprintf(`{"type": "sync", "result": %s}`, connections)
+			fmt.Fprintln(w, r)
+		default:
+			c.Errorf("expected %d calls, now on %d", expected, n)
+		}
+	})
+}
+
 // EncodeResponseBody writes JSON-serialized body to the response writer.
 func EncodeResponseBody(c *check.C, w http.ResponseWriter, body interface{}) {
 	encoder := json.NewEncoder(w)
@@ -82,4 +176,88 @@ func DecodedRequestBody(c *check.C, r *http.Request) map[string]interface{} {
 	err := decoder.Decode(&body)
 	c.Assert(err, check.IsNil)
 	return body
+}
+
+func testPlugsSlots(projectId string) ([]client.Plug, []client.Slot) {
+	plugs := []client.Plug{
+		{
+			ProjectId: projectId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+		{
+			ProjectId: projectId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "ssh-agent",
+			Interface: "ssh-agent",
+		},
+		{
+			ProjectId: projectId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "mount",
+			Interface: "mount",
+		},
+		{
+			ProjectId: projectId,
+			Workshop:  "another-workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+	}
+
+	slots := []client.Slot{
+		{
+			ProjectId: projectId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+		{
+			ProjectId: projectId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "ssh-agent",
+			Interface: "ssh-agent",
+		},
+		{
+			ProjectId: projectId,
+			Workshop:  "workshop",
+			Sdk:       "sdk",
+			Name:      "mount",
+			Interface: "mount",
+		},
+		{
+			ProjectId: projectId,
+			Workshop:  "another-workshop",
+			Sdk:       "sdk",
+			Name:      "desktop",
+			Interface: "desktop",
+		},
+	}
+	return plugs, slots
+}
+
+func plugSlotToConn(plug client.Plug, slot client.Slot, manual bool) client.Connection {
+	return client.Connection{
+		Plug: client.PlugRef{
+			ProjectId: plug.ProjectId,
+			Workshop:  plug.Workshop,
+			Sdk:       plug.Sdk,
+			Name:      plug.Name,
+		},
+		Slot: client.SlotRef{
+			ProjectId: slot.ProjectId,
+			Workshop:  slot.Workshop,
+			Sdk:       slot.Sdk,
+			Name:      slot.Name,
+		},
+		Interface: plug.Interface,
+		Manual:    manual,
+	}
 }

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -66,7 +66,8 @@ $ workshop sketch-sdk
 
 Stash the sketch SDK, temporarily reverting the changes in the workshop:
 $ workshop sketch-sdk nimble --stash`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Pending"}),
 	}
 
 	cmd.Flags().BoolVar(&c.stash, "stash", false, "Stash the sketch SDK and remove it from the workshop.")

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -42,7 +42,8 @@ $ workshop start nimble jazzy
 
 The name is optional if the project has only one workshop:
 $ workshop start`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Stopped"}),
 	}
 
 	return cmd

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -42,7 +42,8 @@ $ workshop stop nimble jazzy
 
 The name is optional if the project has only one workshop:
 $ workshop stop`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready"}),
 	}
 
 	return cmd

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -42,7 +42,8 @@ Notes:
 		Example: `
 List the tasks under change ID 42:
 $ workshop tasks 42`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.complete(),
 	}
 
 	return cmd
@@ -111,4 +112,37 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	return nil
+}
+
+func (c *CmdTasks) complete() ValidArgsFunction {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		cli, err := c.root.client()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		changesCmd := CmdChanges{
+			root: c.root,
+		}
+
+		changes, err := changesCmd.changes(cli)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		l := len(changes)
+		num := min(l, 10)
+		completions := make([]string, l)
+
+		for _, chg := range changes[l-num : l] {
+			completions = append(completions, fmt.Sprintf("%s\t%-5s %s\n", chg.ID, chg.Status, chg.Summary))
+		}
+
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -102,3 +102,4 @@ X11
 XAUTHORITY
 yaml
 YYYY
+zsh

--- a/docs/reference/cli/workshop.rst
+++ b/docs/reference/cli/workshop.rst
@@ -84,6 +84,7 @@ and also has a number of global flags:
 
 
 
+.. _ref_workshop_cli_completion:
 
 Shell completion
 ----------------
@@ -94,6 +95,14 @@ follow the instructions offered by **workshop completion**:
 .. code-block:: console
 
    $ workshop completion -h
+
+
+To see instructions for a specific shell:
+
+.. code-block:: console
+
+   $ workshop completion zsh -h
+
 
 For example, in your :file:`~/.bashrc` file:
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -638,7 +638,41 @@ This makes :file:`/home/user/mod/` on the host
 act as the Go modules cache for the workshop.
 
 
+Install shell completions
+-------------------------
+
+|ws_markup| features shell completion for popular shells
+such as :program:`bash`, :program:`zsh` and :program:`fish`.
+Bash completion is configured automatically;
+to install completion for other shells,
+use :ref:`completion <ref_workshop_cli_completion>`.
+
+To see how this can be useful, let's look at the :command:`connect` command above.
+This command contains up to six sections that must be remembered:
+
+- The names of the plug and the slot themselves.
+- Their respective workshop\ :sup:`*` names.
+- Their respective SDK\ :sup:`*` names.
+
+:sup:`*` *Workshop and SDK names may be omitted for system SDK slots*
+
+This would look something like:
+
+.. code-block:: console
+
+   $ workshop connect <workshop>/<sdk>:<plug> <workshop>/<sdk>:<slot>
+
+
+Shell completion can simplify this by automatically finding appropriate
+candidate plugs and slots for you, eliminating the need to run
+:command:`workshop connections` to see what's available.
+
+After installation, you can access command completion by pressing the :kbd:`Tab` key
+while typing or after entering a command.
+
+
 .. _tut_sketch:
+
 
 Sketch an SDK (optional)
 ------------------------

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,7 @@ apps:
     environment:
       WORKSHOP_SOCKET: $SNAP_COMMON/workshop/workshop.socket
     command: bin/workshop
+    completer: workshop-completer.sh
   workshopd:
     environment:
       WORKSHOP: ${SNAP_DATA}
@@ -63,10 +64,14 @@ parts:
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshop" ./cmd/workshop
       go build -o "${CRAFT_PART_INSTALL}/bin/workshopd" ./cmd/workshopd
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshopctl" ./cmd/workshopctl
+
+      # Generate completions script
+      "${CRAFT_PART_INSTALL}/bin/workshop" completion bash > "${CRAFT_PART_INSTALL}/workshop-completer.sh"
     prime:
       - bin/workshop
       - bin/workshopd
       - bin/workshopctl
+      - workshop-completer.sh
   wrappers:
     plugin: dump
     source: snap/local/

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -1,0 +1,55 @@
+summary: Check that shell completion is installed with the snap
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  # The completion functionality is well covered in unit tests. We check four
+  # small examples here that each use different code paths.
+  sudo -iu ubuntu -- bash << EOF
+    source /usr/share/bash-completion/bash_completion
+    cd /workshop/tests/main/completion
+    echo "Test launch completion"
+    COMP_WORDS=(workshop launch w)
+    COMP_LINE='workshop launch w'
+    COMP_POINT=\${#COMP_LINE}
+    COMP_CWORD=2
+
+    _xfunc workshop _complete_from_snap workshop
+
+    echo "\$COMPREPLY" | grep -q -e ws-comp
+    echo "Launch workshop"
+    workshop launch "\$COMPREPLY"
+
+    echo "Test connect completion"
+    COMP_WORDS=(workshop connect w)
+    COMP_LINE='workshop connect w'
+    COMP_POINT=\${#COMP_LINE}
+    COMP_CWORD=2
+
+    _xfunc workshop _complete_from_snap workshop
+
+    echo "\$COMPREPLY" | grep -q -e ws-comp/test-sdk-desktop:desktop
+
+    echo "Test remount dir completion"
+    mkdir -p /home/ubuntu/tmp/tmp
+    COMP_WORDS=(workshop remount ws-comp/test-sdk-mount:one /home/ubuntu/tmp/t)
+    COMP_LINE='workshop stop w'
+    COMP_POINT=\${#COMP_LINE}
+    COMP_CWORD=2
+
+    _xfunc workshop _complete_from_snap workshop
+
+    echo "\$COMPREPLY" | grep -q -e tmp
+
+    echo "Test stop completion"
+    COMP_WORDS=(workshop stop w)
+    COMP_LINE='workshop stop w'
+    COMP_POINT=\${#COMP_LINE}
+    COMP_CWORD=2
+
+    _xfunc workshop _complete_from_snap workshop
+
+    echo "\$COMPREPLY" | grep -q -e ws-comp
+  EOF

--- a/tests/main/completion/workshop.yaml
+++ b/tests/main/completion/workshop.yaml
@@ -1,0 +1,7 @@
+name: ws-comp
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-desktop
+    channel: latest/stable
+  - name: test-sdk-mount
+    channel: latest/stable


### PR DESCRIPTION
# Description
Adds dynamic shell completion to all commands that would benefit from it. 
All completions are checked for validity. That is, where a completion is provided, the user should expect to be able to hit `enter` and have the command succeed. 

Highlights include `connect` and `remount`.

Commands will now not provide file/folder completions unless relevant to the command in question (ie. remount). 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [x] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
