### PR TITLE
Remove workshop instance if doCreateWorkshop was cancelled

### DIFF
--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
+	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -87,9 +88,21 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 		return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
 	}
 
+	rev := revert.New()
+	defer rev.Fail()
+
 	if err = m.backend.LaunchWorkshop(ctx, &wf); err != nil {
 		return err
 	}
+
+	cleanupCtx := context.WithoutCancel(ctx)
+	rev.Add(func() {
+		cleanupCtx, cancel := context.WithTimeout(cleanupCtx, 30*time.Second)
+		defer cancel()
+		if err1 := m.backend.RemoveWorkshop(cleanupCtx, w); err1 != nil {
+			logger.Noticef("On doCreateWorkshop: cannot remove %q workshop on cleanup: %v", w, err1)
+		}
+	})
 
 	// Create workshop base and run directories
 	fs, err := m.backend.WorkshopFs(ctx, wf.Name)
@@ -98,7 +111,12 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	}
 	defer fs.Close()
 
-	return fs.MkdirAll(dirs.WorkshopRunDir, 0755)
+	if err = fs.MkdirAll(dirs.WorkshopRunDir, 0755); err != nil {
+		return err
+	}
+
+	rev.Success()
+	return nil
 }
 
 func (m *WorkshopManager) doCreateAptCache(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -288,6 +288,36 @@ func (s *workshopHandlers) TestCreateWorkshopWithSystemSdk(c *check.C) {
 	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
 }
 
+func (s *workshopHandlers) TestCreateWorkshopCleaunup(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.createWFile(c, "ws", wsJammy)
+	wf := &workshop.File{Name: "ws", Base: "ubuntu@22.04"}
+
+	reset := s.backend.SetWorkshopFsCallback(func(ctx context.Context, name string) (workshop.WorkshopFs, error) {
+		return nil, errors.New("fs is unavailable")
+	})
+	defer reset()
+
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("create-workshop", "...")
+	t1.Set("workshop-file", wf)
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	_, err := s.backend.Workshop(s.ctx, "ws")
+	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
+}
+
 func (s *workshopHandlers) TestDownloadBase(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -44,6 +44,8 @@ type DownloadCall struct {
 	Base string
 }
 
+type WorkshopFsCallback func(ctx context.Context, name string) (workshop.WorkshopFs, error)
+
 type FakeWorkshopBackend struct {
 	// the key is a project-id - workshop name
 	Workshops map[string]map[string]*FakeWorkshop
@@ -59,7 +61,7 @@ type FakeWorkshopBackend struct {
 	ExecCallback ExecFunc
 	ExecCalls    []*ExecCall
 
-	WorkshopFsCallback func(ctx context.Context, name string) (workshop.WorkshopFs, error)
+	WorkshopFsCallback WorkshopFsCallback
 	WorkshopFsCalls    []*FsCall
 
 	DownloadBaseCallback func(ctx context.Context, base string, report *progress.Reporter) error
@@ -284,6 +286,14 @@ func (f *FakeWorkshopBackend) GetWorkshopsByConfig(ctx context.Context, filter w
 		}
 	}
 	return res, nil
+}
+
+func (s *FakeWorkshopBackend) SetWorkshopFsCallback(c WorkshopFsCallback) func() {
+	old := s.WorkshopFsCallback
+	s.WorkshopFsCallback = c
+	return func() {
+		s.WorkshopFsCallback = old
+	}
 }
 
 func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (workshop.WorkshopFs, error) {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -133,7 +133,8 @@ func (s *Backend) LaunchWorkshop(ctx context.Context, file *workshop.File) error
 		return err
 	}
 
-	return op.WaitContext(ctx)
+	// CreateInstance cannot be cancelled in LXD.
+	return op.Wait()
 }
 
 func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Context, name, action string, force bool) error {
@@ -596,18 +597,17 @@ func (s *Backend) RemoveWorkshop(ctx context.Context, name string) (err error) {
 	}
 
 	// ignore possible errors (e.g. container is already stopped)
-	ctxRemove := context.WithoutCancel(ctx)
-	_ = s.updateInstanceState(conn, ctxRemove, name, "stop", true)
+	if err = s.updateInstanceState(conn, ctx, name, "stop", true); err != nil {
+		logger.Noticef("On RemoveWorkshop: failed to stop %q workshop: %v", name, err)
+	}
 
 	op, err := conn.DeleteInstance(InstanceName(name, projectId))
 	if err != nil {
 		return err
 	}
 
-	if err = op.WaitContext(ctx); err != nil {
-		return err
-	}
-	return nil
+	// DeleteInstance cannot be cancelled in LXD.
+	return op.Wait()
 }
 
 func (s *Backend) WorkshopFs(ctx context.Context, name string) (workshop.WorkshopFs, error) {


### PR DESCRIPTION
# Description
LXD does not allow its API clients to cancel a CreateInstance or DeleteInstance operation. Thus, the approach here is to wait for the operation to finish on the LXD side and remove the instance created if the task was aborted.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
