### PR TITLE
Use separate LXD bridge for workshops

### DIFF
--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -74,9 +74,9 @@ func (f *backendDeviceSuite) readWorkshopFile(c *check.C, fname string) string {
 func defaultTestDevices() map[string]map[string]string {
 	cwd, _ := os.Getwd()
 	return map[string]map[string]string{
-		"root":             {"type": "disk", "pool": "default", "path": "/"},
+		"root":             {"type": "disk", "pool": "workshop", "path": "/"},
 		"project":          {"type": "disk", "source": cwd, "path": "/project"},
-		"workshop.network": {"type": "nic", "network": "lxdbr0", "name": "eth0"},
+		"workshop.network": {"type": "nic", "network": "workshopbr0", "name": "eth0"},
 	}
 }
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -29,6 +29,8 @@ const (
 	LxdSock           = "/var/snap/lxd/common/lxd/unix.socket"
 	storagePool       = "workshop"
 	storagePoolDriver = "zfs"
+	networkName       = "workshopbr0"
+	networkType       = "bridge"
 )
 
 var (
@@ -104,6 +106,19 @@ func New() (*Backend, error) {
 		return nil, errors.New("LXD not initialized")
 	}
 
+	networks, err := conn.GetNetworks()
+	if err != nil {
+		return nil, err
+	}
+	// Workshop does not require an existing network.
+	// However, once the workshopbr0 network pool exists,
+	// `lxd init --auto` won't add another one,
+	// and non-Workshop LXD containers won't have network access
+	// without further manual configuration.
+	if len(networks) == 0 {
+		return nil, errors.New("LXD not initialized")
+	}
+
 	poolExists := false
 	for _, pool := range pools {
 		if pool.Name == storagePool {
@@ -123,6 +138,35 @@ func New() (*Backend, error) {
 		}
 		err := conn.CreateStoragePool(req)
 		if err != nil {
+			return nil, err
+		}
+	}
+
+	networkExists := false
+	for _, network := range networks {
+		if network.Name == networkName {
+			if network.Type != networkType {
+				return nil, fmt.Errorf("network %q already exists with different type %q", networkName, network.Type)
+			}
+
+			networkExists = true
+			break
+		}
+	}
+
+	if !networkExists {
+		req := api.NetworksPost{
+			Name: networkName,
+			Type: networkType,
+			NetworkPut: api.NetworkPut{
+				Config: map[string]string{
+					"dns.domain": "workshop",
+				},
+				Description: "Bridge network for workshops",
+			},
+		}
+
+		if err := conn.CreateNetwork(req); err != nil {
 			return nil, err
 		}
 	}
@@ -709,7 +753,7 @@ func createDefaultDevices() map[string]map[string]string {
 	swspath := filepath.Join(dirs.WorkshopRunDir, filepath.Base(shostpath))
 	return map[string]map[string]string{
 		"root":                 {"type": "disk", "pool": storagePool, "path": "/"},
-		"workshop.network":     {"type": "nic", "network": "lxdbr0", "name": "eth0"},
+		"workshop.network":     {"type": "nic", "network": networkName, "name": "eth0"},
 		"workshop.socket":      {"type": "proxy", "connect": "unix:" + shostpath, "listen": "unix:" + swspath, "bind": "instance", "mode": "0666"},
 		"workshop.workshopctl": {"type": "disk", "source": filepath.Join(dirs.ExecDir, "workshopctl"), "path": "/usr/bin/workshopctl"},
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -123,7 +123,7 @@ func New() (*Backend, error) {
 	for _, pool := range pools {
 		if pool.Name == storagePool {
 			if pool.Driver != storagePoolDriver {
-				return nil, fmt.Errorf("storage pool %q already exists with different driver %q", storagePool, pool.Driver)
+				return nil, fmt.Errorf("storage pool %q already exists with a different driver: %q", storagePool, pool.Driver)
 			}
 
 			poolExists = true
@@ -146,7 +146,7 @@ func New() (*Backend, error) {
 	for _, network := range networks {
 		if network.Name == networkName {
 			if network.Type != networkType {
-				return nil, fmt.Errorf("network %q already exists with different type %q", networkName, network.Type)
+				return nil, fmt.Errorf("network %q already exists with a different type: %q", networkName, network.Type)
 			}
 
 			networkExists = true

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -95,6 +95,14 @@ func New() (*Backend, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Workshop does not require an existing storage pool.
+	// However, once the workshop storage pool exists,
+	// `lxd init --auto` won't add another one,
+	// and non-Workshop LXD containers can't be launched
+	// without further manual configuration.
+	if len(pools) == 0 {
+		return nil, errors.New("LXD not initialized")
+	}
 
 	poolExists := false
 	for _, pool := range pools {

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -31,8 +31,8 @@ var MinimalImageServer = "simplestreams:https://cloud-images.ubuntu.com/minimal/
 
 func DefaultTestDevices() map[string]map[string]string {
 	return map[string]map[string]string{
-		"root":             {"type": "disk", "pool": "default", "path": "/"},
-		"workshop.network": {"type": "nic", "network": "lxdbr0", "name": "eth0"},
+		"root":             {"type": "disk", "pool": "workshop", "path": "/"},
+		"workshop.network": {"type": "nic", "network": "workshopbr0", "name": "eth0"},
 	}
 }
 

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -31,6 +31,8 @@ for p in $(echo "$projects" | xargs -L1 echo); do
   fi
 done 
 
+lxc network delete workshopbr0
+
 # Storage pool volumes are shared among projects and removed last.
 storage_pool="workshop"
 volumes=$(lxc storage volume list "$storage_pool" -c pnt type=custom -f compact --all-projects | awk 'NR>1 {printf "%s ", $1}')

--- a/tests/main/remove-snap/task.yaml
+++ b/tests/main/remove-snap/task.yaml
@@ -24,7 +24,8 @@ execute: |
   sudo deluser --remove-home abc
 
   echo "Check that workshop storage pool has been removed"
-  $(lxc storage list -f compact | awk 'NR>1 {print $1}' | grep -q workshop) && (echo "workshop storage pool must be removed" && exit 1) 
+  (lxc storage list -f compact | awk 'NR>1 {print $1}' | (! grep -q workshop)) || (echo "workshop storage pool must be removed" && exit 1)
+  (lxc network list -f compact | awk 'NR>1 {print $1}' | (! grep -q workshopbr0)) || (echo "workshop network must be removed" && exit 1)
 
   snap install --dangerous --classic /workshop/tests/*.snap
   [[ $(workshop_exec list --global | wc -c) -eq 0 ]] || (echo "no workshops must remain after snap removal" && exit 1)


### PR DESCRIPTION
# Description

At the moment this just provides another level of separation between Workshop containers and other LXD containers users might have. In future, we may want to lock down this interface (to prevent issues like https://github.com/moby/moby/issues/14041) or apply a workaround for the [UFW issue](https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#ufw-add-rules-for-the-bridge). We could also make workshops addressable as `<NAME>-<ID>.workshop` via `systemd-resolved`.

The network is named `workshopbr0`, similar to `lxdbr0`. I think the maximum length for an interface name is 15 bytes, so we should be able to go all the way to `workshopbr99999` in the unlikely event we need more than one network in future.

I don't think we need to document this, but there are a few new error messages. One of them is based on an existing message, and I hope `LXD not initialized` will be enough to direct users to https://canonical-workshop.readthedocs-hosted.com/en/latest/how-to/use-workshops/troubleshoot/#install-and-start-lxd.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
