### PR TITLE
Ensure minimal workable zfs pool size

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -26,11 +27,13 @@ import (
 )
 
 const (
-	LxdSock           = "/var/snap/lxd/common/lxd/unix.socket"
-	storagePool       = "workshop"
-	storagePoolDriver = "zfs"
-	networkName       = "workshopbr0"
-	networkType       = "bridge"
+	LxdSock               = "/var/snap/lxd/common/lxd/unix.socket"
+	storagePool           = "workshop"
+	storagePoolDriver     = "zfs"
+	storagePoolMinimalGiB = 5
+
+	networkName = "workshopbr0"
+	networkType = "bridge"
 )
 
 var (
@@ -139,6 +142,31 @@ func New() (*Backend, error) {
 		err := conn.CreateStoragePool(req)
 		if err != nil {
 			return nil, err
+		}
+
+		// Ensure the new pool has enough total space available.
+		pool, etag, err := conn.GetStoragePool(storagePool)
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := conn.GetStoragePoolResources(storagePool)
+		if err != nil {
+			return nil, err
+		}
+
+		gibTotal := uint64(res.Space.Total) / (1024 * 1024 * 1024)
+		if gibTotal < storagePoolMinimalGiB {
+			// Ensure the storage pool is no less than 5GiB, otherwise it makes
+			// it running out of space in tests and environments with less than
+			// ~14GiB of available space. LXD defaults to 20% in those cases
+			// which results in a ~2GiB pool size for workshop.
+			pool.Config["size"] = strconv.FormatUint(storagePoolMinimalGiB*1024*1024*1024, 10)
+			if err = conn.UpdateStoragePool(storagePool, pool.Writable(), etag); err != nil {
+				logger.Noticef("On Backend.New: failed to set storage pool to the minimal size: %dGiB, %s", storagePoolMinimalGiB, err)
+				return nil, err
+			}
+			logger.Noticef("On Backend.New: set storage pool to the minimal size: %dGiB", storagePoolMinimalGiB)
 		}
 	}
 

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -35,7 +35,7 @@ lxc network delete workshopbr0
 
 # Storage pool volumes are shared among projects and removed last.
 storage_pool="workshop"
-volumes=$(lxc storage volume list "$storage_pool" -c pnt type=custom -f compact --all-projects | awk 'NR>1 {printf "%s ", $1}')
+volumes=$(lxc storage volume list "$storage_pool" -c nt type=custom -f compact --all-projects | awk 'NR>1 {printf "%s ", $1}')
 echo "$volumes" | xargs -n1 -r | while read -r volume; do
   lxc storage volume delete "$storage_pool" "$volume"
 done


### PR DESCRIPTION
# Description

Ensure the storage pool is no less than 5GiB, otherwise Workshop runs out of space in tests and environments with less than ~14GiB of available space. LXD defaults to 20% in those cases which results in a ~2GiB pool size for Workshop.


# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
