### PR TITLE
Add tunnel interface

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -25,6 +25,25 @@ type Mount struct {
 	WorkshopTarget string  `json:"workshop-target"`
 }
 
+type Endpoint struct {
+	Protocol string `json:"protocol"`
+	Path     string `json:"path,omitempty"`
+	Host     string `json:"host,omitempty"`
+	Port     uint16 `json:"port,omitempty"`
+}
+
+type Tunnel struct {
+	Plug PlugRef  `json:"plug"`
+	Slot SlotRef  `json:"slot"`
+	From Endpoint `json:"from"`
+	To   Endpoint `json:"to"`
+}
+
+type TunnelInfo struct {
+	Plugs []*Tunnel `json:"plugs"`
+	Slots []*Tunnel `json:"slots"`
+}
+
 type Sdk struct {
 	Name        string       `json:"name"`
 	Version     string       `json:"version,omitempty"`
@@ -34,6 +53,7 @@ type Sdk struct {
 	InstallTime time.Time    `json:"install-time"`
 	Health      *HealthCheck `json:"health-check,omitempty"`
 	Mounts      []*Mount     `json:"mounts,omitempty"`
+	Tunnels     *TunnelInfo  `json:"tunnels,omitempty"`
 }
 
 type Workshops struct {

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -32,6 +32,7 @@ import (
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/ptyutil"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 type CmdExec struct {
@@ -263,8 +264,8 @@ func (c *CmdShell) Run(cmd *cobra.Command, av []string) error {
 
 	flags := &ExecFlags{
 		WorkingDir: "/project",
-		UserId:     1000,
-		GroupId:    1000,
+		UserId:     workshop.Uid,
+		GroupId:    workshop.Gid,
 	}
 
 	return exec(c.root, flags, args)
@@ -349,8 +350,8 @@ func (c *CmdRun) Run(cmd *cobra.Command, av []string) error {
 func commonVars(f *pflag.FlagSet, flags *ExecFlags) {
 	f.StringVarP(&flags.WorkingDir, "cwd", "w", "/project", "Set the working directory in the workshop.")
 	f.StringArrayVar(&flags.Env, "env", []string{}, "Set an environment variable, e.g. 'FOO=bar'; if only the name is provided, the value is inherited from the CLI environment.")
-	f.IntVar(&flags.UserId, "uid", 1000, "Run as a specific workshop user.")
-	f.IntVar(&flags.GroupId, "gid", 1000, "Run as a member of a specific workshop group.")
+	f.IntVar(&flags.UserId, "uid", workshop.Uid, "Run as a specific workshop user.")
+	f.IntVar(&flags.GroupId, "gid", workshop.Gid, "Run as a member of a specific workshop group.")
 	f.DurationVar(&flags.Timeout, "timeout", 0, "Set a timeout; valid units are ns, us or µs, ms, s, m, h.")
 	f.BoolVarP(&flags.Interactive, "interactive", "i", false, "Force interactive mode.")
 	f.BoolVarP(&flags.NonInteractive, "non-interactive", "I", false, "Force non-interactive mode.")

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -3,10 +3,12 @@ package main
 import (
 	"cmp"
 	"fmt"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -126,6 +128,28 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 
 	if len(workshop.Sdks) > 0 {
 		fmt.Fprintf(w, "sdks:\n")
+
+		var tunnels []*client.Tunnel
+		for _, sk := range workshop.Sdks {
+			if sk.Tunnels == nil {
+				continue
+			}
+			tunnels = append(tunnels, sk.Tunnels.Slots...)
+		}
+		if len(tunnels) > 0 {
+			fmt.Fprintf(w, "  system:\n")
+			fmt.Fprintf(w, "    tunnels:\n")
+
+			slices.SortFunc(tunnels, func(a, b *client.Tunnel) int {
+				return cmp.Compare(a.Plug.Name, b.Plug.Name)
+			})
+			for _, tunnel := range tunnels {
+				fmt.Fprintf(w, "      %s:\n", tunnel.Plug.Name)
+				fmt.Fprintf(w, "        from:\t%s\n", formatEndpoint(tunnel.From))
+				fmt.Fprintf(w, "        to:\t%s\n", formatEndpoint(tunnel.To))
+			}
+		}
+
 		for _, sk := range workshop.Sdks {
 			fmt.Fprintf(w, "  %s:\n", sk.Name)
 			if sk.Name == sdk.Sketch {
@@ -169,6 +193,18 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 					}
 				}
 			}
+
+			if sk.Tunnels != nil && len(sk.Tunnels.Plugs) > 0 {
+				fmt.Fprintf(w, "    tunnels:\n")
+				slices.SortFunc(sk.Tunnels.Plugs, func(a, b *client.Tunnel) int {
+					return cmp.Compare(a.Plug.Name, b.Plug.Name)
+				})
+				for _, tunnel := range sk.Tunnels.Plugs {
+					fmt.Fprintf(w, "      %s:\n", tunnel.Plug.Name)
+					fmt.Fprintf(w, "        from:\t%s\n", formatEndpoint(tunnel.From))
+					fmt.Fprintf(w, "        to:\t%s\n", formatEndpoint(tunnel.To))
+				}
+			}
 		}
 	}
 
@@ -185,4 +221,14 @@ func sketchSdkChannel(projectId, workshop string) string {
 
 	path := sdk.WorkshopSketchSdk(home, projectId, workshop)
 	return contractHomeDirectory(path)
+}
+
+func formatEndpoint(endpoint client.Endpoint) string {
+	if endpoint.Protocol == "unix" {
+		return endpoint.Path
+	}
+
+	port := strconv.FormatUint(uint64(endpoint.Port), 10)
+	hostPort := net.JoinHostPort(endpoint.Host, port)
+	return fmt.Sprintf("%s/%s", hostPort, endpoint.Protocol)
 }

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -158,12 +158,12 @@ var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","re
         "revision":"1",
         "build-time":"2017-02-19T17:23:05.592623Z",
         "install-time":"2017-03-22T09:01:00.0Z",
-	      "mounts":[{
+        "mounts":[{
             "host-source":"/home/user/src",
             "workshop-target":"/home/workshop/target", 
             "plug":{
                 "project-id":"42ws42ws",
-                "workshop":"workshop",
+                "workshop":"ws",
                 "sdk":"go",
                 "plug":"plug-name"
             }
@@ -172,7 +172,7 @@ var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","re
             "workshop-target":"/home/workshop/target", 
             "plug":{
                 "project-id":"42ws42ws",
-                "workshop":"workshop",
+                "workshop":"ws",
                 "sdk":"go",
                 "plug":"plug-default"
             }
@@ -222,6 +222,119 @@ sdks:
       plug-name:
         host-source:      /home/user/src
         workshop-target:  /home/workshop/target
+`, m.prjDir))
+	c.Check(n, check.Equals, 2)
+}
+
+var mockWorkshopWithTunnels = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "name":"ws",
+    "base":"ubuntu@22.04",
+    "project-id":"42424242",
+    "status":"Ready",
+    "sdks":[{
+        "name":"go",
+        "version":"1.8.0",
+        "channel":"latest/edge",
+        "revision":"1",
+        "build-time":"2017-02-19T17:23:05.592623Z",
+        "install-time":"2017-03-22T09:01:00.0Z",
+        "tunnels":{
+            "plugs":[{
+                "plug":{
+                    "project-id":"42ws42ws",
+                    "workshop":"ws",
+                    "sdk":"go",
+                    "plug":"snap-cache"
+                },
+                "slot":{
+                    "project-id":"42ws42ws",
+                    "workshop":"ws",
+                    "sdk":"system",
+                    "slot":"snap-cache"
+                },
+                "from":{
+                    "protocol":"tcp",
+                    "host":"0.0.0.0",
+                    "port":12345
+                },
+                "to":{
+                    "protocol":"unix",
+                    "path":"/run/snap-proxy.socket"
+                }
+            }],
+            "slots":[{
+                "plug":{
+                    "project-id":"42ws42ws",
+                    "workshop":"ws",
+                    "sdk":"system",
+                    "plug":"gopls"
+                },
+                "slot":{
+                    "project-id":"42ws42ws",
+                    "workshop":"ws",
+                    "sdk":"go",
+                    "slot":"gopls"
+                },
+                "from":{
+                    "protocol":"tcp",
+                    "host":"127.0.0.1",
+                    "port":60915
+                },
+                "to":{
+                    "protocol":"unix",
+                    "path":"/run/user/1000/gopls.socket"
+                }
+            }]
+        }
+    }]
+}}`
+
+func (m *workshopInfo) TestWorkshopInfoWithSdkTunnels(c *check.C) {
+	cmd := &CmdInfo{root: &CmdRoot{}}
+	workshop := "ws"
+	n := 0
+	user, err := user.Current()
+	c.Assert(err, check.IsNil)
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			_, err = fmt.Fprintln(w, r)
+			c.Assert(err, check.IsNil)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
+			w.WriteHeader(200)
+			_, err = fmt.Fprintln(w, fmt.Sprintf(mockWorkshopWithTunnels, user.HomeDir))
+			c.Assert(err, check.IsNil)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err = cmd.Run(cmd.Command(), []string{workshop})
+	c.Assert(err, check.IsNil)
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`name:     ws
+base:     ubuntu@22.04
+project:  %s
+status:   ready
+notes:    -
+sdks:
+  system:
+    tunnels:
+      gopls:
+        from:  127.0.0.1:60915/tcp
+        to:    /run/user/1000/gopls.socket
+  go:
+    tracking:   latest/edge
+    installed:  1.8.0  2017-02-19  \(1\)
+    tunnels:
+      snap-cache:
+        from:  0.0.0.0:12345/tcp
+        to:    /run/snap-proxy.socket
 `, m.prjDir))
 	c.Check(n, check.Equals, 2)
 }

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -114,6 +114,13 @@ plugs:
   # vs-code-settings:
   #   interface: mount
   #   workshop-target: /home/workshop/.config/Code/User
+
+slots:
+  # EXAMPLE: expose SDK services to the host
+  # See https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/interfaces/tunnel-interface/
+  # dashboard:
+  #   interface: tunnel
+  #   endpoint: 8080
 `
 
 var (

--- a/docs/.coverage.yaml
+++ b/docs/.coverage.yaml
@@ -254,6 +254,12 @@
     - SK028
     - SK039
 
+"tunnel interface":
+  category: interface
+  type: concept
+  specs:
+  - SK033
+
 "workshop (CLI)":
   category: "workshop (CLI)"
   type: tool

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -32,12 +32,15 @@ gopkg
 GPG
 GPUs
 GUIs
+hostname
+hostnames
 html
 http
 https
 IDEs
 init
 IoT
+IPv
 iteratively
 Jupyter
 JupyterLab
@@ -83,8 +86,10 @@ subcommand
 subcommands
 subdirectory
 sudo
+TCP
 transactional
 ubuntu
+UDP
 uid
 uncomment
 unicode

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -68,6 +68,7 @@ roadmap
 ros
 ROS
 rosdep
+runtime
 sdk
 SDK
 sdkcraft

--- a/docs/explanation/interfaces/tunnel-interface.rst
+++ b/docs/explanation/interfaces/tunnel-interface.rst
@@ -121,6 +121,40 @@ To check if a plug or slot is connected:
      tunnel     ws/system:app         ws/service-sdk:app  manual
 
 
+This means that :samp:`client-sdk` can access
+the :samp:`shared` service running on the host,
+and the host can access the :samp:`app` service
+provided by :samp:`service-sdk`.
+
+.. @artefact workshop info
+
+.. code-block:: console
+
+   $ workshop info dev
+
+     name:     dev
+     base:     ubuntu@22.04
+     project:  /home/user/workshop/dev
+     status:   ready
+     notes:    -
+     sdks:
+       system:
+         tunnels:
+           app:
+             from:  0.0.0.0:8081/tcp
+             to:    127.0.0.1:8080/tcp
+       client-sdk:
+         tracking:   latest/stable
+         installed:  2024-03-02  (1)
+         tunnels:
+           shared:
+             from:  [::1]:1080/tcp
+             to:    127.0.0.1:18080/tcp
+       service-sdk:
+         tracking:   latest/edge
+         installed:  2025-06-07  (2)
+
+
 See also
 --------
 
@@ -138,5 +172,6 @@ Reference:
 - :ref:`ref_workshop_connect`
 - :ref:`ref_workshop_connections`
 - :ref:`ref_workshop_disconnect`
+- :ref:`ref_workshop_info`
 - :ref:`ref_workshop_launch`
 - :ref:`ref_workshop_refresh`

--- a/docs/explanation/interfaces/tunnel-interface.rst
+++ b/docs/explanation/interfaces/tunnel-interface.rst
@@ -1,0 +1,127 @@
+.. _exp_tunnel_interface:
+
+Tunnel interface
+================
+
+.. @artefact tunnel interface
+
+The tunnel interface
+enables workshops to share network services with the host system,
+and vice versa.
+It supports connections over TCP, UDP and Unix domain sockets.
+
+SDKs advertise their services using tunnel interface slots.
+For example, if an SDK installs and advertises a web app,
+users can access the app from their usual browser
+after creating a tunnel from the host system to the workshop.
+
+SDKs request access to services using tunnel interface plugs.
+Some services have dedicated interfaces
+(e.g. the :ref:`SSH interface <exp_ssh_interface>`),
+which should be used instead.
+
+
+.. _exp_tunnel_plug:
+
+Tunnel interface plug
+---------------------
+
+Most SDKs declare tunnel interface plugs in their SDK definitions,
+but the :ref:`system SDK <exp_system_sdk>` has none by default,
+so system SDK plugs must be declared in the workshop definition.
+
+A basic structure would include the name of the plug,
+the interface (:samp:`tunnel`)
+and, optionally, an address (:samp:`endpoint`).
+
+Plugs designate addresses that clients can connect to.
+Regular SDKs are used for clients inside the workshop.
+The system SDK is used for clients from the host system.
+
+
+.. _exp_tunnel_slot:
+
+Tunnel interface slot
+---------------------
+
+Most SDKs declare tunnel interface slots in their SDK definitions,
+but the :ref:`system SDK <exp_system_sdk>` has none by default,
+so system SDK slots must be declared in the workshop definition.
+
+A basic structure would include the name of the slot,
+the interface (:samp:`tunnel`)
+and, optionally, an address (:samp:`endpoint`).
+
+Slots designate an address that a service can listen on.
+Regular SDKs should make this service available inside the workshop.
+The system SDK relies on the user to run this service on the host.
+
+
+.. _exp_tunnel_connection:
+
+Connection
+----------
+
+The interface isn't connected automatically at launch and refresh
+for security reasons.
+The :command:`workshop connect` and :command:`workshop disconnect` commands
+can be invoked manually after the workshop has started:
+
+.. @artefact workshop connect
+.. @artefact workshop disconnect
+
+.. code-block:: console
+
+   $ workshop connect ws/client-sdk:shared
+   $ workshop disconnect ws/client-sdk:shared
+   $ workshop connect ws/system:app ws/service-sdk:app
+   $ workshop disconnect ws/service-sdk:app
+
+
+Establishing a tunnel connection means
+that |ws_markup| will listen on the plug address,
+forwarding incoming network connections to the slot address.
+
+When a system SDK plug is connected to a regular SDK slot,
+clients on the host can access services inside the workshop.
+When a regular SDK plug is connected to a system SDK slot,
+clients in the workshop can access services on the host.
+
+|ws_markup| doesn't support connections within the system SDK
+or between regular SDKs.
+In these cases clients can connect to services directly,
+without the need for a tunnel.
+
+To check if a plug or slot is connected:
+
+.. @artefact workshop connections
+
+.. code-block:: console
+
+   $ workshop connections --all
+
+     Interface  Plug                  Slot                Notes
+     ...
+     tunnel     ws/client-sdk:shared  ws/system:shared    manual
+     tunnel     ws/system:app         ws/service-sdk:app  manual
+
+
+See also
+--------
+
+Explanation:
+
+- :ref:`exp_interfaces`
+- :ref:`exp_plugs_slots`
+- :ref:`exp_sdk_definition`
+- :ref:`exp_workshop_definition`
+
+
+Reference:
+
+- :ref:`ref_tunnel_interface`
+- :ref:`ref_workshop_connect`
+- :ref:`ref_workshop_connections`
+- :ref:`ref_workshop_disconnect`
+- :ref:`ref_workshop_launch`
+- :ref:`ref_workshop_refresh`

--- a/docs/explanation/interfaces/tunnel-interface.rst
+++ b/docs/explanation/interfaces/tunnel-interface.rst
@@ -98,9 +98,58 @@ that |ws_markup| will listen on the plug address,
 forwarding incoming network connections to the slot address.
 
 When a system SDK plug is connected to a regular SDK slot,
-clients on the host can access services inside the workshop.
+clients on the host can access services inside the workshop:
+
+.. mermaid::
+   :alt: Exposing SDK services to the host system
+   :caption: Exposing SDK services to the host system
+   :align: center
+   :config: {"theme":"neutral"}
+
+   flowchart LR
+     subgraph Host
+       Client --> Plug
+
+       subgraph system[System SDK]
+         Plug
+       end
+     end
+
+     Plug -- Tunnel --> Slot
+
+     subgraph Workshop
+       subgraph regular[Regular SDK]
+         Slot --> Service
+       end
+     end
+
+
 When a regular SDK plug is connected to a system SDK slot,
-clients in the workshop can access services on the host.
+clients in the workshop can access services on the host:
+
+.. mermaid::
+   :alt: Sharing system services with a workshop
+   :caption: Sharing system services with a workshop
+   :align: center
+   :config: {"theme":"neutral"}
+
+   flowchart RL
+     subgraph Workshop
+       subgraph regular[Regular SDK]
+         Client --> Plug
+       end
+     end
+
+     Plug -- Tunnel --> Slot
+
+     subgraph Host
+       subgraph system[System SDK]
+         Slot
+       end
+
+       Slot --> Service
+     end
+
 
 |ws_markup| doesn't support connections within the system SDK
 or between regular SDKs.

--- a/docs/explanation/interfaces/tunnel-interface.rst
+++ b/docs/explanation/interfaces/tunnel-interface.rst
@@ -62,10 +62,25 @@ The system SDK relies on the user to run this service on the host.
 Connection
 ----------
 
-The interface isn't connected automatically at launch and refresh
+The interface is connected automatically at launch or refresh,
+provided that:
+
+- The plug is declared in the system SDK
+
+- The slot is declared in a regular SDK
+
+- The plug listens on :samp:`localhost` or a Unix domain socket
+
+- The plug can be matched to the slot by its name
+  or via a :samp:`connections` entry in the :ref:`definition <exp_workshop_definition>`,
+  both subject to |ws_markup|'s
+  :ref:`validation rules <exp_interfaces_validation>`.
+
+
+Otherwise, it isn't connected automatically,
 for security reasons.
 The :command:`workshop connect` and :command:`workshop disconnect` commands
-can be invoked manually after the workshop has started:
+can be invoked after the workshop has started:
 
 .. @artefact workshop connect
 .. @artefact workshop disconnect

--- a/docs/explanation/sdks/sdks.rst
+++ b/docs/explanation/sdks/sdks.rst
@@ -124,6 +124,7 @@ Currently, |ws_markup| and |sdk_markup| support the following:
 - :ref:`GPU interface <exp_gpu_interface>` (auto-connected)
 - :ref:`Mount interface <exp_mount_interface>` (auto-connected)
 - :ref:`SSH interface <exp_ssh_interface>` (manually connected)
+- :ref:`Tunnel interface <exp_tunnel_interface>` (manually connected)
 
 
 .. _exp_plugs_slots:

--- a/docs/explanation/sdks/sdks.rst
+++ b/docs/explanation/sdks/sdks.rst
@@ -124,7 +124,7 @@ Currently, |ws_markup| and |sdk_markup| support the following:
 - :ref:`GPU interface <exp_gpu_interface>` (auto-connected)
 - :ref:`Mount interface <exp_mount_interface>` (auto-connected)
 - :ref:`SSH interface <exp_ssh_interface>` (manually connected)
-- :ref:`Tunnel interface <exp_tunnel_interface>` (manually connected)
+- :ref:`Tunnel interface <exp_tunnel_interface>` (sometimes auto-connected)
 
 
 .. _exp_plugs_slots:

--- a/docs/reference/definitions/workshop-definition.rst
+++ b/docs/reference/definitions/workshop-definition.rst
@@ -336,6 +336,14 @@ Endpoints are formatted as follows:
    * - Path
      - An absolute path to a Unix domain socket.
 
+       :envvar:`$HOME` expands into the user's home directory and
+       :envvar:`$XDG_RUNTIME_DIR` expands into the user runtime directory
+       (e.g. :file:`/run/user/1000`).
+
+       For security reasons,
+       tunnel interface plugs in the system SDK
+       cannot listen on sockets outside these two directories.
+
    * - String
      - An abstract socket name.
 

--- a/docs/reference/definitions/workshop-definition.rst
+++ b/docs/reference/definitions/workshop-definition.rst
@@ -265,6 +265,92 @@ They have no attributes.
 The only SSH interface slot is :samp:`system:ssh-agent`.
 
 
+Tunnel interface
+~~~~~~~~~~~~~~~~
+
+.. @artefact tunnel interface
+
+Tunnel interface plugs and slots are described by the following attributes:
+
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 2 1 6
+
+   * - Key
+     - Value
+     - Description
+
+   * - :samp:`endpoint`
+     - string
+     - A network address or Unix domain socket
+       to be used as one end of the tunnel.
+
+
+Endpoints are formatted as follows:
+
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 2 7
+
+   * - Type
+     - Format
+
+   * - Endpoint
+     - :samp:`<ADDRESS>/<PROTOCOL>` for network endpoints.
+       May be shortened to :samp:`<ADDRESS>` or :samp:`<PROTOCOL>`
+
+       :samp:`<PATH>` or :samp:`@<STRING>` for Unix domain sockets.
+
+   * - Address
+     - :samp:`<HOST>:<PORT>`.
+       May be shortened to :samp:`<HOST>` or :samp:`<PORT>`.
+
+   * - Protocol
+     - Either :samp:`tcp` or :samp:`udp`.
+       The default is :samp:`tcp`.
+
+   * - Host
+     - An IPv4 or IPv6 address.
+
+       If a port is supplied,
+       IPv6 addresses must be enclosed in square brackets.
+
+       Supported aliases: :samp:`localhost`, :samp:`ip6-localhost` and :samp:`ip6-loopback`.
+
+       The default is :samp:`localhost`.
+
+   * - Port
+     - A TCP or UDP port number (1–65535).
+
+       May be omitted,
+       but only on one side of a connection.
+       For such connections,
+       both sides use the same port.
+
+       For security reasons,
+       tunnel interface plugs in the system SDK
+       cannot use privileged ports (1–1023).
+
+   * - Path
+     - An absolute path to a Unix domain socket.
+
+   * - String
+     - An abstract socket name.
+
+
+The default :samp:`endpoint` is the default network address (:samp:`localhost/tcp`).
+
+Endpoints which start with :samp:`[` or :samp:`@`
+need to be quoted in YAML:
+
+.. code-block:: yaml
+
+   endpoint: '[::1]:8080/tcp'
+   endpoint: '@abstract.sock'
+
+
 JSON Schema
 -----------
 

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -259,6 +259,7 @@ TCP and UDP endpoints look like :samp:`<IPv4>:<PORT>/<PROTOCOL>` or :samp:`'[<IP
 but supports the aliases :samp:`localhost`, :samp:`ip6-localhost` and :samp:`ip6-loopback`.
 
 Unix domain socket endpoints are either paths to a socket file or abstract sockets of the form :samp:`'@<STRING>'`.
+The :envvar:`$HOME` and :envvar:`$XDG_RUNTIME_DIR` variables can be used in paths.
 
 Attributes can be abbreviated by omitting :samp:`tcp` and :samp:`localhost`:
 

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -57,6 +57,7 @@ Currently, |ws_markup| and |sdk_markup| support the following interface plugs:
 - :ref:`GPU <ref_gpu_interface>`
 - :ref:`Mount <ref_mount_interface>`
 - :ref:`SSH <ref_ssh_interface>`
+- :ref:`Tunnel <ref_tunnel_interface>`
 
 
 Slots can only be defined for the :samp:`mount` interface.
@@ -211,6 +212,101 @@ via a Unix domain socket.
 .. note::
 
    See the :ref:`explanation <exp_ssh_interface>` for more details.
+
+
+.. _ref_tunnel_interface:
+
+Tunnel interface
+~~~~~~~~~~~~~~~~
+
+.. @artefact tunnel interface
+
+A tunnel plug in the definition must specify the plug name, the interface and optionally an endpoint:
+
+.. code-block:: yaml
+   :caption: sdkcraft.yaml
+
+   # ...
+   plugs:
+     <NAME>:
+       interface: tunnel
+       endpoint: <ENDPOINT>
+
+
+Similarly, a tunnel *slot* in the definition must specify the slot name, the interface and optionally an endpoint:
+
+.. code-block:: yaml
+   :caption: sdkcraft.yaml
+
+   # ...
+   slots:
+     <NAME>:
+       interface: tunnel
+       endpoint: <ENDPOINT>
+
+
+When a tunnel interface plug is connected to a slot,
+clients can connect to the address of the plug.
+The connection will be forwarded to the address of the slot.
+Regular SDKs define the workshop side of the connection,
+leaving the host system to the :ref:`system SDK <exp_system_sdk>`.
+
+The supported protocols are TCP, UDP and Unix domain sockets.
+Unix domain sockets are compatible with TCP, but UDP plugs can only connect to UDP slots.
+
+TCP and UDP endpoints look like :samp:`<IPv4>:<PORT>/<PROTOCOL>` or :samp:`'[<IPv6>]:<PORT>/<PROTOCOL>'`.
+|ws_markup| doesn't resolve hostnames,
+but supports the aliases :samp:`localhost`, :samp:`ip6-localhost` and :samp:`ip6-loopback`.
+
+Unix domain socket endpoints are either paths to a socket file or abstract sockets of the form :samp:`'@<STRING>'`.
+
+Attributes can be abbreviated by omitting :samp:`tcp` and :samp:`localhost`:
+
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 4 10
+
+   * - Address
+     - Alternatives
+
+   * - :samp:`127.0.0.1:1234/tcp`
+
+     - :samp:`localhost:1234/tcp`, :samp:`1234/tcp`, :samp:`127.0.0.1:1234`, :samp:`1234`
+
+   * - :samp:`0.0.0.0:1234/tcp`
+
+     - :samp:`0.0.0.0:1234`
+
+   * - :samp:`'[::1]:1234/tcp'`
+
+     - :samp:`ip6-localhost:1234/tcp`, :samp:`ip6-loopback:1234`, :samp:`'[::1]:1234'`
+
+   * - :samp:`127.0.0.1:1234/udp`
+
+     - :samp:`localhost:1234/udp`, :samp:`1234/udp`
+
+   * - :samp:`'[::]:1234/udp'`
+
+     -
+
+   * - :samp:`/run/service.sock`
+
+     -
+
+   * - :samp:`'@abstract'`
+
+     -
+
+
+Port numbers may also be omitted,
+but only on one side of a connection.
+For such connections,
+both sides use the same port.
+
+.. note::
+
+   See the :ref:`explanation <exp_tunnel_interface>` for more details.
 
 
 .. _ref_sdk_hooks:

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -27,8 +27,6 @@ type execPayload struct {
 	Height      int               `json:"height"`
 }
 
-var defaultUID, defaultGID = 1000, 1000
-
 func normaliseUserGroupIds(usrId, grpId *int) (int, int, error) {
 	if usrId != nil && grpId == nil {
 		return 0, 0, errors.New("must specify group, not just user")
@@ -38,11 +36,11 @@ func normaliseUserGroupIds(usrId, grpId *int) (int, int, error) {
 		return 0, 0, errors.New("must specify user, not just group")
 	}
 
-	userId := defaultUID
+	userId := workshop.Uid
 	if usrId != nil {
 		userId = *usrId
 	}
-	groupId := defaultGID
+	groupId := workshop.Gid
 	if grpId != nil {
 		groupId = *grpId
 	}
@@ -105,12 +103,12 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 
 	// We do not set PATH here as it's something LXD takes care of. Set HOME and
 	// USER if the user is a known default user.
-	if userId == defaultUID {
+	if userId == workshop.Uid {
 		if environment["HOME"] == "" {
-			environment["HOME"] = "/home/workshop"
+			environment["HOME"] = workshop.User.HomeDir
 		}
 		if environment["USER"] == "" {
-			environment["USER"] = "workshop"
+			environment["USER"] = workshop.User.Username
 		}
 	}
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -300,7 +300,7 @@ func endpoints(conn connectionJSON) (*Endpoint, *Endpoint, error) {
 
 func parseEndpoint(endpoint string) (*Endpoint, error) {
 	// Leave unix sockets untouched.
-	if filepath.IsAbs(endpoint) || strings.HasPrefix(endpoint, "@") {
+	if filepath.IsAbs(endpoint) || strings.HasPrefix(endpoint, "@") || strings.HasPrefix(endpoint, "$") {
 		return &Endpoint{Protocol: "unix", Path: endpoint}, nil
 	}
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,6 +17,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/canonical/workshop/internal/metautil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -47,6 +51,7 @@ type SdkInfo struct {
 	InstallTime *time.Time       `json:"install-time,omitempty"`
 	Health      *HealthCheckInfo `json:"health-check,omitempty"`
 	Mounts      []*Mount         `json:"mounts,omitempty"`
+	Tunnels     *TunnelInfo      `json:"tunnels,omitempty"`
 }
 
 type Mount struct {
@@ -54,6 +59,25 @@ type Mount struct {
 	WorkshopSource string      `json:"workshop-source,omitempty"`
 	HostSource     string      `json:"host-source,omitempty"`
 	WorkshopTarget string      `json:"workshop-target,omitempty"`
+}
+
+type TunnelInfo struct {
+	Plugs []*Tunnel `json:"plugs,omitempty"`
+	Slots []*Tunnel `json:"slots,omitempty"`
+}
+
+type Tunnel struct {
+	Plug sdk.PlugRef `json:"plug"`
+	Slot sdk.SlotRef `json:"slot"`
+	From Endpoint    `json:"from"`
+	To   Endpoint    `json:"to"`
+}
+
+type Endpoint struct {
+	Protocol string `json:"protocol"`
+	Path     string `json:"path,omitempty"`
+	Host     string `json:"host,omitempty"`
+	Port     uint16 `json:"port,omitempty"`
 }
 
 type Workshops struct {
@@ -168,6 +192,141 @@ func mountInfos(sk sdk.Ref, mnts []workshop.Mount) []*Mount {
 	}
 
 	return infos
+}
+
+// TODO: reimplement using SDK profiles once system SDK is available.
+func tunnels(conns *connectionsJSON) (map[string]*TunnelInfo, error) {
+	var tunnels = map[string]*TunnelInfo{}
+
+	masters := map[sdk.PlugRef][]sdk.PlugRef{}
+	for _, plug := range conns.Plugs {
+		if plug.Bind == nil {
+			continue
+		}
+
+		ref := *plug.Bind
+		sref := sdk.PlugRef{ProjectId: plug.ProjectId, Workshop: plug.Workshop, Sdk: plug.Sdk, Name: plug.Name}
+		masters[ref] = append(masters[ref], sref)
+	}
+
+	for _, conn := range conns.Established {
+		listen, connect, err := endpoints(conn)
+		if err != nil {
+			return nil, err
+		}
+
+		tunnel := Tunnel{
+			Plug: conn.Plug,
+			Slot: conn.Slot,
+			From: *listen,
+			To:   *connect,
+		}
+
+		sk := conn.Plug.Sdk
+		if sk == sdk.System.String() {
+			sk = conn.Slot.Sdk
+		}
+		info, ok := tunnels[sk]
+		if !ok {
+			info = &TunnelInfo{}
+			tunnels[sk] = info
+		}
+		if sk == conn.Plug.Sdk {
+			info.Plugs = append(info.Plugs, &tunnel)
+		} else {
+			info.Slots = append(info.Slots, &tunnel)
+		}
+
+		if slaves, ok := masters[conn.Plug]; ok {
+			for _, slave := range slaves {
+				t := tunnel
+				t.Plug = slave
+
+				if conn.Plug.Sdk != sdk.System.String() {
+					sk = slave.Sdk
+				}
+				info, ok := tunnels[sk]
+				if !ok {
+					info = &TunnelInfo{}
+					tunnels[sk] = info
+				}
+				if sk == slave.Sdk {
+					info.Plugs = append(info.Plugs, &t)
+				} else {
+					info.Slots = append(info.Slots, &t)
+				}
+			}
+		}
+	}
+
+	return tunnels, nil
+}
+
+func endpoints(conn connectionJSON) (*Endpoint, *Endpoint, error) {
+	v, ok := metautil.LookupAttr(conn.PlugAttrs, nil, "endpoint")
+	if !ok {
+		return nil, nil, &sdk.AttributeNotFoundError{Attribute: "endpoint", Plug: &conn.Plug}
+	}
+	var address string
+	if err := metautil.SetValueFromAttribute(v, &address); err != nil {
+		return nil, nil, fmt.Errorf("invalid attribute %q for plug %q: %w", "endpoint", conn.Plug.ShortRef(), err)
+	}
+	listen, err := parseEndpoint(address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v, ok = metautil.LookupAttr(conn.SlotAttrs, nil, "endpoint")
+	if !ok {
+		return nil, nil, &sdk.AttributeNotFoundError{Attribute: "endpoint", Slot: &conn.Slot}
+	}
+	if err := metautil.SetValueFromAttribute(v, &address); err != nil {
+		return nil, nil, fmt.Errorf("invalid attribute %q for slot %q: %w", "endpoint", conn.Slot.ShortRef(), err)
+	}
+	connect, err := parseEndpoint(address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if (listen.Protocol == "tcp" || listen.Protocol == "udp") && listen.Port == 0 {
+		listen.Port = connect.Port
+	}
+	if (connect.Protocol == "tcp" || connect.Protocol == "udp") && connect.Port == 0 {
+		connect.Port = listen.Port
+	}
+
+	return listen, connect, nil
+}
+
+func parseEndpoint(endpoint string) (*Endpoint, error) {
+	// Leave unix sockets untouched.
+	if filepath.IsAbs(endpoint) || strings.HasPrefix(endpoint, "@") {
+		return &Endpoint{Protocol: "unix", Path: endpoint}, nil
+	}
+
+	protocol := "tcp"
+	idx := strings.LastIndexByte(endpoint, '/')
+	if idx >= 0 {
+		protocol = endpoint[idx+1:]
+		endpoint = endpoint[:idx]
+	}
+
+	host, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		host = endpoint
+		port = ""
+	}
+
+	result := &Endpoint{Protocol: protocol, Host: host}
+	if port != "" {
+		number, err := strconv.ParseUint(port, 10, 16)
+		if err != nil {
+			return nil, err
+		}
+		result.Port = uint16(number)
+	}
+
+	return result, nil
 }
 
 func newWorkshopChange(st *state.State, kind string, user, projectId, action string, names []string) *state.Change {
@@ -410,6 +569,16 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("workshop name required")
 	}
 
+	conns, err := collectConnections(c.d.overlord.InterfaceManager(), collectFilter{
+		projectId: projectId,
+		workshop:  name,
+		ifaceName: "tunnel",
+		connected: true,
+	})
+	if err != nil {
+		return statusInternalError("collecting connection information failed: %w", err)
+	}
+
 	state := c.d.overlord.State()
 	state.Lock()
 	defer state.Unlock()
@@ -427,6 +596,14 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("%w", err)
 	}
 	info := workshopToInfo(w, sdks, health)
+
+	ts, err := tunnels(conns)
+	if err != nil {
+		return statusBadRequest("%w", err)
+	}
+	for _, sk := range info.Sdks {
+		sk.Tunnels = ts[sk.Name]
+	}
 
 	files, err := wrkmgr.WorkshopFiles(ctx, projectId)
 	if err != nil {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -121,6 +121,32 @@ sdks:
     channel: latest/stable
 `
 
+	workshoptunnels = `name: tunnels
+base: ubuntu@22.04
+sdks:
+  - name: system
+    plugs:
+      api:
+        interface: tunnel
+        endpoint: 0.0.0.0:8888/tcp
+    slots:
+      dns:
+        interface: tunnel
+        endpoint: 127.0.0.53/udp
+  - name: test-sdk
+    channel: latest/stable
+    plugs:
+      dns:
+        interface: tunnel
+        endpoint: 127.0.0.1:5353/udp
+  - name: test-sdk-2
+    channel: latest/stable
+    slots:
+      api:
+        interface: tunnel
+        endpoint: '@testapi'
+`
+
 	somebound = `name: somebound
 base: ubuntu@22.04
 sdks:
@@ -415,19 +441,19 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 }
 
 func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
-	// Setup (create a running workshop with a few mounts)
+	// Setup (create a running workshop with a few mounts and tunnels)
 	s.daemon(c)
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
+	s.launchWorkshop(c, "tunnels", workshoptunnels, apiSuiteSdks)
 
-	w, ok := s.b.Workshops[s.project.ProjectId]["manysdks"]
+	w, ok := s.b.Workshops[s.project.ProjectId]["tunnels"]
 	c.Assert(ok, check.Equals, true)
 
 	p := workshop.NewSdkProfile("test-sdk")
 	p.Mounts["data"] = workshop.Mount{Name: "data",
-		What:  sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk", "data"),
+		What:  sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "tunnels", "test-sdk", "data"),
 		Where: "/opt/data",
 		Type:  workshop.HostWorkshop,
 	}
@@ -435,7 +461,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 
 	p = workshop.NewSdkProfile("test-sdk-2")
 	p.Mounts["photos"] = workshop.Mount{Name: "photos",
-		What:  sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk-2", "photos"),
+		What:  sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "tunnels", "test-sdk-2", "photos"),
 		Where: "/opt/data2",
 		Type:  workshop.HostWorkshop,
 	}
@@ -446,10 +472,29 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 	}
 	w.Profiles["test-sdk-2"] = p
 
+	// TODO: extend above setup with tunnels once system SDK profile is available.
+	// Also need coverage for tunnel plug binding logic.
+	connsState := map[string]interface{}{
+		"b8639dea/tunnels/system:api b8639dea/tunnels/test-sdk-2:api": map[string]interface{}{
+			"interface":   "tunnel",
+			"plug-static": map[string]interface{}{"endpoint": "0.0.0.0:8888/tcp"},
+			"slot-static": map[string]interface{}{"endpoint": "@testapi"},
+		},
+		"b8639dea/tunnels/test-sdk:dns b8639dea/tunnels/system:dns": map[string]interface{}{
+			"interface":   "tunnel",
+			"plug-static": map[string]interface{}{"endpoint": "127.0.0.1:5353/udp"},
+			"slot-static": map[string]interface{}{"endpoint": "127.0.0.53/udp"},
+		},
+	}
+	st := s.d.Overlord().State()
+	st.Lock()
+	st.Set("conns", connsState)
+	st.Unlock()
+
 	// Get Workshop info
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}")
-	s.vars = map[string]string{"id": s.project.ProjectId, "name": "manysdks"}
-	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops/manysdks", nil)
+	s.vars = map[string]string{"id": s.project.ProjectId, "name": "tunnels"}
+	req, err := s.createProjectsRequest("GET", "/v1/projects/"+s.project.ProjectId+"/workshops/tunnels", nil)
 	c.Assert(err, check.IsNil)
 
 	rsp := v1GetProjectWorkshop(projectsCmd, req, nil).(*resp)
@@ -471,7 +516,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 	}
 	c.Check(result, check.DeepEquals, Workshop{
 		WorkshopInfo: WorkshopInfo{
-			Name:      "manysdks",
+			Name:      "tunnels",
 			Base:      "ubuntu@22.04",
 			ProjectId: s.project.ProjectId,
 			Status:    "Ready",
@@ -486,13 +531,41 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 					InstallTime: &install1,
 					Mounts: []*Mount{
 						{
-							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk", "data"),
+							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "tunnels", "test-sdk", "data"),
 							WorkshopTarget: "/opt/data",
 							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
-								Workshop:  "manysdks",
+								Workshop:  "tunnels",
 								Sdk:       "test-sdk",
 								Name:      "data",
+							},
+						},
+					},
+					Tunnels: &TunnelInfo{
+						Plugs: []*Tunnel{
+							{
+								Plug: sdk.PlugRef{
+									ProjectId: s.project.ProjectId,
+									Workshop:  "tunnels",
+									Sdk:       "test-sdk",
+									Name:      "dns",
+								},
+								Slot: sdk.SlotRef{
+									ProjectId: s.project.ProjectId,
+									Workshop:  "tunnels",
+									Sdk:       "system",
+									Name:      "dns",
+								},
+								From: Endpoint{
+									Protocol: "udp",
+									Host:     "127.0.0.1",
+									Port:     5353,
+								},
+								To: Endpoint{
+									Protocol: "udp",
+									Host:     "127.0.0.53",
+									Port:     5353,
+								},
 							},
 						},
 					},
@@ -506,11 +579,11 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 					InstallTime: &install2,
 					Mounts: []*Mount{
 						{
-							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk-2", "photos"),
+							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "tunnels", "test-sdk-2", "photos"),
 							WorkshopTarget: "/opt/data2",
 							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
-								Workshop:  "manysdks",
+								Workshop:  "tunnels",
 								Sdk:       "test-sdk-2",
 								Name:      "photos",
 							},
@@ -520,16 +593,43 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 							WorkshopTarget: "/opt/data2",
 							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
-								Workshop:  "manysdks",
+								Workshop:  "tunnels",
 								Sdk:       "test-sdk-2",
 								Name:      "photos2",
+							},
+						},
+					},
+					Tunnels: &TunnelInfo{
+						Slots: []*Tunnel{
+							{
+								Plug: sdk.PlugRef{
+									ProjectId: s.project.ProjectId,
+									Workshop:  "tunnels",
+									Sdk:       "system",
+									Name:      "api",
+								},
+								Slot: sdk.SlotRef{
+									ProjectId: s.project.ProjectId,
+									Workshop:  "tunnels",
+									Sdk:       "test-sdk-2",
+									Name:      "api",
+								},
+								From: Endpoint{
+									Protocol: "tcp",
+									Host:     "0.0.0.0",
+									Port:     8888,
+								},
+								To: Endpoint{
+									Protocol: "unix",
+									Path:     "@testapi",
+								},
 							},
 						},
 					},
 				},
 			},
 		},
-		Path: workshop.Filepath(s.project.Path, "manysdks")})
+		Path: workshop.Filepath(s.project.Path, "tunnels")})
 }
 
 func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -103,7 +103,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 				Protocol: "unix",
 			},
 			Listen: workshop.ProxyTarget{
-				Address:  filepath.Join("/run/user/1000/", wayland),
+				Address:  filepath.Join("/run/user", workshop.User.Uid, wayland),
 				Protocol: "unix",
 			},
 			Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -106,6 +106,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 				Address:  filepath.Join("/run/user/1000/", wayland),
 				Protocol: "unix",
 			},
+			Direction: workshop.WorkshopToHost,
 		}
 	}
 
@@ -118,9 +119,10 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 			Protocol: "unix",
 		}
 		desktop.X11 = &workshop.ProxyEntry{
-			Name:    plug.Sdk().Name + "-" + "x11",
-			Connect: proxyTarget,
-			Listen:  proxyTarget,
+			Name:      plug.Sdk().Name + "-" + "x11",
+			Connect:   proxyTarget,
+			Listen:    proxyTarget,
+			Direction: workshop.WorkshopToHost,
 		}
 	}
 

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -85,7 +85,8 @@ exit 0`)
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
 				Address:  "/run/user/1000/wayland-1",
-				Protocol: "unix"}}}
+				Protocol: "unix"},
+			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 
@@ -121,7 +122,8 @@ exit 0`)
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
 				Address:  "/tmp/.X11-unix/X0",
-				Protocol: "unix"}}}
+				Protocol: "unix"},
+			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 
@@ -158,7 +160,8 @@ exit 0`)
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
 				Address:  "/tmp/.X11-unix/X0",
-				Protocol: "unix"}},
+				Protocol: "unix"},
+			Direction: workshop.WorkshopToHost},
 		Wayland: &workshop.ProxyEntry{
 			Name: "consumer-wayland",
 			Connect: workshop.ProxyTarget{
@@ -166,7 +169,8 @@ exit 0`)
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
 				Address:  "/run/user/1000/wayland-0",
-				Protocol: "unix"}}}
+				Protocol: "unix"},
+			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 

--- a/internal/interfaces/builtin/gpu.go
+++ b/internal/interfaces/builtin/gpu.go
@@ -65,17 +65,9 @@ func (iface *gpuInterface) StaticInfo() interfaces.StaticInfo {
 	}
 }
 
-func (iface *gpuInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
-	return nil
-}
-
 func (iface *gpuInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
-}
-
-func (iface *gpuInterface) MountConnectedSlot(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	return nil
 }
 
 func (iface *gpuInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -209,10 +209,6 @@ func (iface *mountInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo)
 	return true
 }
 
-func (iface *mountInterface) MountConnectedSlot(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	return nil
-}
-
 // Interactions with the mount backend.
 func (iface *mountInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	if slot.Sdk().Type == sdk.System {

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -152,7 +152,7 @@ func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 		return fmt.Errorf(`mount slot "workshop-source" is not a string (found %T)`, source)
 	}
 
-	if strings.HasPrefix(path, "$SDK") {
+	if strings.HasPrefix(path, "$SDK/") {
 		path = strings.Replace(path, "$SDK", sdk.SdkCurrentPath(slot.Sdk.Name), 1)
 	}
 
@@ -184,7 +184,7 @@ func (iface *mountInterface) workshopSource(slot *interfaces.ConnectedSlot) (str
 		return "", err
 	}
 
-	if strings.HasPrefix(source, "$SDK") {
+	if strings.HasPrefix(source, "$SDK/") {
 		return strings.Replace(source, "$SDK", sdk.SdkCurrentPath(slot.Sdk().Name), 1), nil
 	}
 	return source, nil

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -101,6 +101,7 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 				Address:  toSocket,
 				Protocol: "unix",
 			},
+			Direction: workshop.WorkshopToHost,
 		},
 	})
 }

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -83,6 +83,7 @@ exit 0`)
 			Address:  "/var/lib/workshop/run/consumer-ssh-agent.ssh",
 			Protocol: "unix",
 		},
+		Direction: workshop.WorkshopToHost,
 	}}
 	c.Assert(deviceSpec.Profile.Agent, check.DeepEquals, expectedProxy)
 }

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -40,14 +41,28 @@ const tunnelBaseDeclarationSlots = `
   tunnel:
     allow-installation: true
     allow-connection: true
-    deny-auto-connection: true
+    allow-auto-connection: true
 `
 
 const tunnelBaseDeclarationPlugs = `
   tunnel:
     allow-installation: true
     allow-connection: true
-    deny-auto-connection: true
+    allow-auto-connection:
+      -
+        plug-sdk-type:
+          - system
+        slot-sdk-type:
+          - regular
+        slot-names:
+          - $PLUG
+      -
+        plug-sdk-type:
+          - system
+        slot-sdk-type:
+          - regular
+        plug-attributes:
+          auto-explicit: true
 `
 
 var knownTunnelAttributes = []string{"endpoint"}
@@ -202,8 +217,26 @@ func parseAddress(address string) (string, string) {
 }
 
 func (iface *tunnelInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
-	// allow what declarations allowed
-	return true
+	var endpoint string
+	if err := plug.Attr("endpoint", &endpoint); err != nil {
+		logger.Noticef("Cannot auto-connect: %v", err)
+		return false
+	}
+
+	target := parseEndpoint(endpoint)
+	if !isIP(target.Protocol) {
+		// Allow what declarations allowed.
+		return true
+	}
+
+	host, _ := parseAddress(target.Address)
+	if ip := net.ParseIP(host); ip != nil {
+		// Avoid automatically exposing workshop services to other hosts.
+		return ip.IsLoopback()
+	}
+
+	logger.Noticef("Cannot auto-connect plug %q: invalid IP address %q", plug.Ref().ShortRef(), host)
+	return false
 }
 
 func (iface *tunnelInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -1,0 +1,316 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+const tunnelSummary = `allows SDKs and the host to share network services`
+
+const tunnelBaseDeclarationSlots = `
+  tunnel:
+    allow-installation: true
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+const tunnelBaseDeclarationPlugs = `
+  tunnel:
+    allow-installation: true
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+var knownTunnelAttributes = []string{"endpoint"}
+
+type tunnelInterface struct{}
+
+func (iface *tunnelInterface) Name() string {
+	return "tunnel"
+}
+
+func (iface *tunnelInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              tunnelSummary,
+		BaseDeclarationPlugs: tunnelBaseDeclarationPlugs,
+		BaseDeclarationSlots: tunnelBaseDeclarationSlots,
+		AffectsPlugOnRefresh: true,
+	}
+}
+
+func (iface *tunnelInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
+	for name := range plug.Attrs {
+		if !slices.Contains(knownTunnelAttributes, name) {
+			return fmt.Errorf(`unknown attribute for tunnel interface plug: %q`, name)
+		}
+	}
+
+	address, err := normalizeEndpoint(plug)
+	if err != nil {
+		return err
+	}
+	if plug.Attrs == nil {
+		plug.Attrs = make(map[string]interface{})
+	}
+	plug.Attrs["endpoint"] = address
+
+	return nil
+}
+
+func (iface *tunnelInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
+	for name := range slot.Attrs {
+		if !slices.Contains(knownTunnelAttributes, name) {
+			return fmt.Errorf(`unknown attribute for tunnel interface slot: %q`, name)
+		}
+	}
+
+	address, err := normalizeEndpoint(slot)
+	if err != nil {
+		return err
+	}
+	if slot.Attrs == nil {
+		slot.Attrs = make(map[string]interface{})
+	}
+	slot.Attrs["endpoint"] = address
+
+	return nil
+
+}
+
+func normalizeEndpoint(attrs interfaces.Attrer) (string, error) {
+	var port int64
+	var endpoint string
+	var attrError *sdk.AttributeNotFoundError
+	if err := attrs.Attr("endpoint", &port); err == nil {
+		endpoint = strconv.FormatInt(port, 10)
+	} else if err = attrs.Attr("endpoint", &endpoint); err != nil && !errors.As(err, &attrError) {
+		return "", err
+	}
+
+	target := parseEndpoint(endpoint)
+	if isIP(target.Protocol) {
+		address, err := normalizeAddress(target.Address)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s/%s", address, target.Protocol), nil
+	}
+	return endpoint, nil
+}
+
+func normalizeAddress(address string) (string, error) {
+	host, port := parseAddress(address)
+	if strings.HasPrefix(address, "[") && !strings.ContainsRune(host, ':') {
+		return "", fmt.Errorf("invalid bracketed address %q", address)
+	}
+
+	switch host {
+	case "localhost":
+		host = "127.0.0.1"
+	case "ip6-localhost", "ip6-loopback":
+		host = "::1"
+	}
+
+	if net.ParseIP(host) == nil {
+		return "", fmt.Errorf("invalid IP address %q", host)
+	}
+
+	if port == "" {
+		return host, nil
+	}
+
+	_, err := strconv.ParseUint(port, 10, 16)
+	var numErr *strconv.NumError
+	if errors.As(err, &numErr) {
+		return "", fmt.Errorf("invalid port %q: %w", numErr.Num, numErr.Err)
+	} else if err != nil {
+		return "", err
+	}
+
+	return net.JoinHostPort(host, port), nil
+}
+
+func parseEndpoint(endpoint string) workshop.ProxyTarget {
+	// Leave unix sockets untouched.
+	if filepath.IsAbs(endpoint) || strings.HasPrefix(endpoint, "@") {
+		return workshop.ProxyTarget{Address: endpoint, Protocol: "unix"}
+	}
+
+	if strings.HasSuffix(endpoint, "/udp") {
+		address := strings.TrimSuffix(endpoint, "/udp")
+		return workshop.ProxyTarget{Address: address, Protocol: "udp"}
+	}
+
+	if endpoint == "udp" || endpoint == "tcp" {
+		return workshop.ProxyTarget{Address: "", Protocol: endpoint}
+	}
+
+	address := strings.TrimSuffix(endpoint, "/tcp")
+	return workshop.ProxyTarget{Address: address, Protocol: "tcp"}
+}
+
+func isIP(protocol string) bool {
+	return protocol == "tcp" || protocol == "udp"
+}
+
+func parseAddress(address string) (string, string) {
+	if !strings.ContainsFunc(address, func(c rune) bool { return c < '0' || '9' < c }) {
+		return "localhost", address
+	}
+
+	host, port, err := net.SplitHostPort(address)
+	if err == nil && host != "" && port != "" {
+		return host, port
+	}
+
+	// Remove square brackets from standalone address.
+	host, port, err = net.SplitHostPort(address + ":")
+	if err == nil && host != "" && port == "" {
+		return host, port
+	}
+
+	return address, ""
+}
+
+func (iface *tunnelInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+func (iface *tunnelInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	entry := workshop.ProxyEntry{Name: plug.Name()}
+
+	if plug.Sdk().Type == sdk.System {
+		if slot.Sdk().Type == sdk.System {
+			return errors.New("cannot connect system SDK to itself")
+		}
+		entry.Direction = workshop.HostToWorkshop
+	} else {
+		if slot.Sdk().Type == sdk.Regular {
+			return errors.New("cannot connect regular SDKs from the same workshop")
+		}
+		entry.Direction = workshop.WorkshopToHost
+	}
+
+	var endpoint string
+	if err := plug.Attr("endpoint", &endpoint); err != nil {
+		return err
+	}
+	entry.Listen = parseEndpoint(endpoint)
+	if err := slot.Attr("endpoint", &endpoint); err != nil {
+		return err
+	}
+	entry.Connect = parseEndpoint(endpoint)
+
+	if err := checkProtocols(entry.Listen.Protocol, entry.Connect.Protocol); err != nil {
+		return err
+	}
+	if err := inferPorts(&entry.Listen, &entry.Connect); err != nil {
+		return err
+	}
+	if err := checkListenPort(entry.Listen, entry.Direction); err != nil {
+		return err
+	}
+
+	return spec.AddTunnelEntry(workshop.Tunnel{ProxyEntry: entry})
+}
+
+func checkProtocols(listen, connect string) error {
+	switch {
+	case listen == "udp" && connect != "udp":
+	case listen != "udp" && connect == "udp":
+	default:
+		return nil
+	}
+	return fmt.Errorf("%s and %s are incompatible", listen, connect)
+}
+
+func inferPorts(listen, connect *workshop.ProxyTarget) error {
+	var connectHost, connectPort string
+	needConnectPort := false
+	if isIP(connect.Protocol) {
+		connectHost, connectPort = parseAddress(connect.Address)
+		needConnectPort = connectPort == ""
+	}
+
+	if !isIP(listen.Protocol) {
+		if needConnectPort {
+			return errors.New("both ports unspecified")
+		}
+		return nil
+	}
+
+	listenHost, listenPort := parseAddress(listen.Address)
+
+	// Infer missing port from peer.
+	if listenPort == "" {
+		if connectPort == "" {
+			return errors.New("both ports unspecified")
+		}
+		listen.Address = net.JoinHostPort(listenHost, connectPort)
+	} else if needConnectPort {
+		connect.Address = net.JoinHostPort(connectHost, listenPort)
+	}
+
+	return nil
+}
+
+func checkListenPort(listen workshop.ProxyTarget, direction workshop.ProxyDirection) error {
+	if !isIP(listen.Protocol) {
+		return nil
+	}
+
+	_, listenPort := parseAddress(listen.Address)
+
+	port, err := strconv.ParseUint(listenPort, 10, 16)
+	if err != nil {
+		return err
+	}
+
+	if port == 0 {
+		// TODO: Add support for binding port 0
+		// if LXD adds a way to query the assigned port.
+		return fmt.Errorf("port %v not currently supported", port)
+	}
+
+	if direction == workshop.HostToWorkshop && port < 1024 {
+		// Avoid bypassing CAP_NET_BIND_SERVICE (for simplicity,
+		// we assume the end user doesn't have this capability).
+		return fmt.Errorf("port %v is privileged", port)
+	}
+
+	return nil
+}
+
+func init() {
+	registerIface(&tunnelInterface{})
+}

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os/user"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -176,7 +177,7 @@ func normalizeAddress(address string) (string, error) {
 
 func parseEndpoint(endpoint string) workshop.ProxyTarget {
 	// Leave unix sockets untouched.
-	if filepath.IsAbs(endpoint) || strings.HasPrefix(endpoint, "@") {
+	if filepath.IsAbs(endpoint) || strings.HasPrefix(endpoint, "@") || strings.HasPrefix(endpoint, "$") {
 		return workshop.ProxyTarget{Address: endpoint, Protocol: "unix"}
 	}
 
@@ -273,6 +274,24 @@ func (iface *tunnelInterface) MountConnectedPlug(spec *lxd_device.Specification,
 	if err := checkListenPort(entry.Listen, entry.Direction); err != nil {
 		return err
 	}
+	if entry.Direction == workshop.HostToWorkshop {
+		if err := expandPath(&entry.Listen, spec.User); err != nil {
+			return err
+		}
+		if err := authorizePath(entry.Listen, spec.User); err != nil {
+			return err
+		}
+		if err := expandPath(&entry.Connect, &workshop.User); err != nil {
+			return err
+		}
+	} else if entry.Direction == workshop.WorkshopToHost {
+		if err := expandPath(&entry.Listen, &workshop.User); err != nil {
+			return err
+		}
+		if err := expandPath(&entry.Connect, spec.User); err != nil {
+			return err
+		}
+	}
 
 	return spec.AddTunnelEntry(workshop.Tunnel{ProxyEntry: entry})
 }
@@ -342,6 +361,47 @@ func checkListenPort(listen workshop.ProxyTarget, direction workshop.ProxyDirect
 	}
 
 	return nil
+}
+
+func expandPath(target *workshop.ProxyTarget, user *user.User) error {
+	if target.Protocol != "unix" || !strings.HasPrefix(target.Address, "$") {
+		return nil
+	}
+
+	if strings.HasPrefix(target.Address, "$HOME/") {
+		target.Address = strings.Replace(target.Address, "$HOME", user.HomeDir, 1)
+		return nil
+	}
+	if strings.HasPrefix(target.Address, "$XDG_RUNTIME_DIR/") {
+		runtimeDir := filepath.Join("/run/user", user.Uid)
+		target.Address = strings.Replace(target.Address, "$XDG_RUNTIME_DIR", runtimeDir, 1)
+		return nil
+	}
+
+	variable, _, _ := strings.Cut(target.Address[1:], "/")
+	return fmt.Errorf("unexpected variable %q", variable)
+}
+
+// authorizePath attempts to ensure that the user is allowed to create the given socket.
+// The parent directory has to exist for LXD to create the socket,
+// so we can evaluate symlinks to ensure it belongs to $HOME or $XDG_RUNTIME_DIR.
+// FIXME: this doesn't take bind mounts into account.
+func authorizePath(listen workshop.ProxyTarget, user *user.User) error {
+	if listen.Protocol != "unix" || strings.HasPrefix(listen.Address, "@") {
+		return nil
+	}
+
+	realDir, err := filepath.EvalSymlinks(filepath.Dir(listen.Address))
+	if err != nil {
+		return fmt.Errorf("cannot create socket %q: %w", listen.Address, err)
+	}
+
+	runtimeDir := filepath.Join("/run/user", user.Uid)
+	if strings.HasPrefix(realDir, user.HomeDir) || strings.HasPrefix(realDir, runtimeDir) {
+		return nil
+	}
+
+	return fmt.Errorf("user %q cannot create socket %q for security reasons", user.Username, listen.Address)
 }
 
 func init() {

--- a/internal/interfaces/builtin/tunnel_test.go
+++ b/internal/interfaces/builtin/tunnel_test.go
@@ -20,9 +20,11 @@
 package builtin_test
 
 import (
+	"github.com/canonical/workshop/internal/asserts"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/interfaces/policy"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -831,4 +833,246 @@ slots:
 		Direction: workshop.WorkshopToHost,
 	}
 	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}
+
+func (s *tunnelSuite) TestAutoConnectHostToWorkshop(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "system", "web")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "service", "web")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	cc := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := cc.CheckAutoConnect()
+	c.Check(err, check.IsNil)
+}
+
+func (s *tunnelSuite) TestAutoConnectWorkshopToHost(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "client", "web")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "system", "web")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	cc := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := cc.CheckAutoConnect()
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by plug rule of interface "tunnel"`)
+}
+
+func (s *tunnelSuite) TestAutoConnectHostToHost(c *check.C) {
+	info := sdk.MockInfo(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+slots:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8000/tcp
+`, s.projectId, "ws")
+
+	plug := info.Plugs["web"]
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := info.Slots["web"]
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	cc := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := cc.CheckAutoConnect()
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by plug rule of interface "tunnel"`)
+}
+
+func (s *tunnelSuite) TestAutoConnectWorkshopToWorkshop(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "client", "web")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "service", "web")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	cc := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := cc.CheckAutoConnect()
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by plug rule of interface "tunnel"`)
+}
+
+func (s *tunnelSuite) TestAutoConnectDifferentName(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	cc := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := cc.CheckAutoConnect()
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by plug rule of interface "tunnel"`)
+}
+
+func (s *tunnelSuite) TestAutoConnectExplicit(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	// Simulate a workshop definition file with:
+	// connections:
+	//   - plug: system:tunnel-plug
+	//     slot: service:tunnel-slot
+	connectedPlug.SetAttr("auto-explicit", "true")
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	cc := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := cc.CheckAutoConnect()
+	c.Check(err, check.IsNil)
+}
+
+func (s *tunnelSuite) TestAutoConnectExplicitAndSameName(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "system", "web")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	// Simulate a workshop definition file with:
+	// connections:
+	//   - plug: system:web
+	//     slot: service:web
+	connectedPlug.SetAttr("auto-explicit", "true")
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  web:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+`, s.projectId, "ws", "service", "web")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	cc := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := cc.CheckAutoConnect()
+	c.Check(err, check.IsNil)
+}
+
+func (s *tunnelSuite) TestAutoConnectLocalhost(c *check.C) {
+	info := sdk.MockInfo(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  loopback4:
+    interface: tunnel
+    endpoint: 127.0.0.1:8080/tcp
+  loopback6:
+    interface: tunnel
+    endpoint: '[::1]:8080/tcp'
+  wildcard4:
+    interface: tunnel
+    endpoint: 0.0.0.0:8080/tcp
+  wildcard6:
+    interface: tunnel
+    endpoint: '[::]:8080/tcp'
+`, s.projectId, "ws")
+
+	iface, err := interfaces.ByName("tunnel")
+	c.Assert(err, check.IsNil)
+
+	c.Check(iface.AutoConnect(info.Plugs["loopback4"], nil), check.Equals, true)
+	c.Check(iface.AutoConnect(info.Plugs["loopback6"], nil), check.Equals, true)
+	c.Check(iface.AutoConnect(info.Plugs["wildcard4"], nil), check.Equals, false)
+	c.Check(iface.AutoConnect(info.Plugs["wildcard6"], nil), check.Equals, false)
 }

--- a/internal/interfaces/builtin/tunnel_test.go
+++ b/internal/interfaces/builtin/tunnel_test.go
@@ -1,0 +1,834 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshop"
+	"gopkg.in/check.v1"
+)
+
+type tunnelSuite struct {
+	iface     interfaces.Interface
+	projectId string
+}
+
+var _ = check.Suite(&tunnelSuite{
+	iface: builtin.MustInterface("tunnel"),
+})
+
+func (s *tunnelSuite) SetUpTest(c *check.C) {
+	s.projectId = "42424242"
+}
+
+func (s *tunnelSuite) TestName(c *check.C) {
+	c.Assert(s.iface.Name(), check.Equals, "tunnel")
+}
+
+func (s *tunnelSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *tunnelSuite) TestSanitizePlugTCP(c *check.C) {
+	plug := builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 1.1.1.1:8080/tcp
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "1.1.1.1:8080/tcp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugUDPOnly(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: udp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "127.0.0.1/udp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugNoTCP(c *check.C) {
+	plug := builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 0.0.0.0:5555
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "0.0.0.0:5555/tcp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugNoHost(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 4321/udp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "127.0.0.1:4321/udp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugHostOnly(c *check.C) {
+	plug := builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 1.0.0.1
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "1.0.0.1/tcp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugNoPort(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 10.11.12.13/udp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "10.11.12.13/udp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugPortOnly(c *check.C) {
+	plug := builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 9999
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "127.0.0.1:9999/tcp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugLocalhost(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: localhost:0/udp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "127.0.0.1:0/udp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugNoEndpoint(c *check.C) {
+	plug := builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel:
+`, s.projectId, "ws", "tunnel-sdk", "tunnel")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "127.0.0.1/tcp")
+}
+
+func (s *tunnelSuite) TestSanitizePlugUnixPath(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: /tmp/unix.sock
+`, s.projectId, "ws", "system", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "/tmp/unix.sock")
+}
+
+func (s *tunnelSuite) TestSanitizePlugUnknownAttribute(c *check.C) {
+	plug := builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    workshop-target: /mnt
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-plug")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `unknown attribute for tunnel interface plug: "workshop-target"`)
+}
+
+func (s *tunnelSuite) TestSanitizePlugWrongType(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: false
+`, s.projectId, "ws", "system", "tunnel-plug")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `invalid attribute "endpoint" for plug "ws/system:tunnel-plug": expected string but found bool`)
+}
+
+func (s *tunnelSuite) TestSanitizePlugStrayColon(c *check.C) {
+	plug := builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: :9876/tcp
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-plug")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `invalid IP address ":9876"`)
+}
+
+func (s *tunnelSuite) TestSanitizePlugStraySlash(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 10.2.3.4:80/
+`, s.projectId, "ws", "system", "tunnel-plug")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `invalid port "80/": invalid syntax`)
+}
+
+func (s *tunnelSuite) TestSanitizePlugInvalidIPv4(c *check.C) {
+	plug := builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 10.2.3.4.5.6:7777/tcp
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-plug")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `invalid IP address "10.2.3.4.5.6"`)
+}
+
+func (s *tunnelSuite) TestSanitizeSlotUDP(c *check.C) {
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '[2606:4700:4700::1111]:53/udp'
+`, s.projectId, "ws", "system", "tunnel-slot")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Check(slot.Attrs["endpoint"], check.Equals, "[2606:4700:4700::1111]:53/udp")
+}
+
+func (s *tunnelSuite) TestSanitizeSlotNoTCP(c *check.C) {
+	slot := builtin.MockSlot(c, `name: tunnel-sdk
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '[::]:4567'
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-slot")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Check(slot.Attrs["endpoint"], check.Equals, "[::]:4567/tcp")
+}
+
+func (s *tunnelSuite) TestSanitizeSlotUDPOnly(c *check.C) {
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: udp
+`, s.projectId, "ws", "system", "tunnel-slot")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Check(slot.Attrs["endpoint"], check.Equals, "127.0.0.1/udp")
+}
+
+func (s *tunnelSuite) TestSanitizeSlotHostOnly(c *check.C) {
+	slot := builtin.MockSlot(c, `name: tunnel-sdk
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 2606:4700:4700::1001
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-slot")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Check(slot.Attrs["endpoint"], check.Equals, "2606:4700:4700::1001/tcp")
+}
+
+func (s *tunnelSuite) TestSanitizeSlotNoPort(c *check.C) {
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '[::ffff:192.168.1.23]/udp'
+`, s.projectId, "ws", "system", "tunnel-slot")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Check(slot.Attrs["endpoint"], check.Equals, "::ffff:192.168.1.23/udp")
+}
+
+func (s *tunnelSuite) TestSanitizeSlotPortOnly(c *check.C) {
+	slot := builtin.MockSlot(c, `name: tunnel-sdk
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '11111'
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-slot")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Check(slot.Attrs["endpoint"], check.Equals, "127.0.0.1:11111/tcp")
+}
+
+func (s *tunnelSuite) TestSanitizeSlotLocalhost(c *check.C) {
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: ip6-localhost:1234/udp
+`, s.projectId, "ws", "system", "tunnel-slot")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Check(slot.Attrs["endpoint"], check.Equals, "[::1]:1234/udp")
+}
+
+func (s *tunnelSuite) TestSanitizeSlotUnixAbstract(c *check.C) {
+	slot := builtin.MockSlot(c, `name: tunnel-sdk
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '@abstract.sock'
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-slot")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Check(slot.Attrs["endpoint"], check.Equals, "@abstract.sock")
+}
+
+func (s *tunnelSuite) TestSanitizeSlotUnknownAttribute(c *check.C) {
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    host-source: /home/user/snap
+`, s.projectId, "ws", "system", "tunnel-slot")
+	err := interfaces.BeforePrepareSlot(s.iface, slot)
+	c.Check(err, check.ErrorMatches, `unknown attribute for tunnel interface slot: "host-source"`)
+}
+
+func (s *tunnelSuite) TestSanitizeSlotStrayColon(c *check.C) {
+	slot := builtin.MockSlot(c, `name: tunnel-sdk
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '[fd12:3456:789a:1::1]:/udp'
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-slot")
+	err := interfaces.BeforePrepareSlot(s.iface, slot)
+	c.Check(err, check.ErrorMatches, `invalid IP address "\[fd12:3456:789a:1::1\]:"`)
+}
+
+func (s *tunnelSuite) TestSanitizeSlotBracketedIPv4(c *check.C) {
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '[2.2.2.2]:8080'
+`, s.projectId, "ws", "system", "tunnel-slot")
+	err := interfaces.BeforePrepareSlot(s.iface, slot)
+	c.Check(err, check.ErrorMatches, `invalid bracketed address "\[2\.2\.2\.2\]:8080"`)
+}
+
+func (s *tunnelSuite) TestSanitizeSlotBracketedHost(c *check.C) {
+	slot := builtin.MockSlot(c, `name: tunnel-sdk
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '[localhost]'
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-slot")
+	err := interfaces.BeforePrepareSlot(s.iface, slot)
+	c.Check(err, check.ErrorMatches, `invalid bracketed address "\[localhost\]"`)
+}
+
+func (s *tunnelSuite) TestSanitizeSlotInvalidIPv6(c *check.C) {
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: '[:::]:8080/udp'
+`, s.projectId, "ws", "system", "tunnel-slot")
+	err := interfaces.BeforePrepareSlot(s.iface, slot)
+	c.Check(err, check.ErrorMatches, `invalid IP address ":::"`)
+}
+
+func (s *tunnelSuite) TestSanitizeSlotInvalidPort(c *check.C) {
+	slot := builtin.MockSlot(c, `name: tunnel-sdk
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 66666
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-slot")
+	err := interfaces.BeforePrepareSlot(s.iface, slot)
+	c.Check(err, check.ErrorMatches, `invalid port "66666": value out of range`)
+}
+
+func (s *tunnelSuite) TestConnectHostToWorkshop(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 0.0.0.0:12345/udp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/udp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "system")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the tunnel specification.
+	expectedEntry := workshop.ProxyEntry{
+		Name: "tunnel-plug",
+		Connect: workshop.ProxyTarget{
+			Address:  "127.0.0.1:54321",
+			Protocol: "udp"},
+		Listen: workshop.ProxyTarget{
+			Address:  "0.0.0.0:12345",
+			Protocol: "udp"},
+		Direction: workshop.HostToWorkshop,
+	}
+	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}
+
+func (s *tunnelSuite) TestConnectWorkshopToHost(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: /run/tunnel.sock
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/tcp
+`, s.projectId, "ws", "system", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "client")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the tunnel specification.
+	expectedEntry := workshop.ProxyEntry{
+		Name: "tunnel-plug",
+		Connect: workshop.ProxyTarget{
+			Address:  "127.0.0.1:54321",
+			Protocol: "tcp"},
+		Listen: workshop.ProxyTarget{
+			Address:  "/run/tunnel.sock",
+			Protocol: "unix"},
+		Direction: workshop.WorkshopToHost,
+	}
+	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}
+
+func (s *tunnelSuite) TestConnectHostToHost(c *check.C) {
+	info := sdk.MockInfo(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:12345/tcp
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/tcp
+`, s.projectId, "ws")
+
+	plug := info.Plugs["tunnel-plug"]
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := info.Slots["tunnel-slot"]
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "system")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "cannot connect system SDK to itself")
+}
+
+func (s *tunnelSuite) TestConnectWorkshopToWorkshop(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:12345/tcp
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/tcp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "system")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "cannot connect regular SDKs from the same workshop")
+}
+
+func (s *tunnelSuite) TestConnectUDPToTCP(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:12345/udp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/tcp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "system")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "udp and tcp are incompatible")
+}
+
+func (s *tunnelSuite) TestConnectUnixToUDP(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: /tmp/sock
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/udp
+`, s.projectId, "ws", "system", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "client")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "unix and udp are incompatible")
+}
+
+func (s *tunnelSuite) TestInferListenPort(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1/tcp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/tcp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "system")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the tunnel specification.
+	expectedEntry := workshop.ProxyEntry{
+		Name: "tunnel-plug",
+		Connect: workshop.ProxyTarget{
+			Address:  "127.0.0.1:54321",
+			Protocol: "tcp"},
+		Listen: workshop.ProxyTarget{
+			Address:  "127.0.0.1:54321",
+			Protocol: "tcp"},
+		Direction: workshop.HostToWorkshop,
+	}
+	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}
+
+func (s *tunnelSuite) TestInferConnectPort(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:12345/tcp
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1/tcp
+`, s.projectId, "ws", "system", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "client")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the tunnel specification.
+	expectedEntry := workshop.ProxyEntry{
+		Name: "tunnel-plug",
+		Connect: workshop.ProxyTarget{
+			Address:  "127.0.0.1:12345",
+			Protocol: "tcp"},
+		Listen: workshop.ProxyTarget{
+			Address:  "127.0.0.1:12345",
+			Protocol: "tcp"},
+		Direction: workshop.WorkshopToHost,
+	}
+	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}
+
+func (s *tunnelSuite) TestInferBothPorts(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1/udp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1/udp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "system")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "both ports unspecified")
+}
+
+func (s *tunnelSuite) TestInferPortFromSocket(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: /tmp/sock
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1/tcp
+`, s.projectId, "ws", "system", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "client")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "both ports unspecified")
+}
+
+func (s *tunnelSuite) TestListenAnyHostPort(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:0/tcp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/tcp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "system")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "port 0 not currently supported")
+}
+
+func (s *tunnelSuite) TestListenAnyWorkshopPort(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:0/tcp
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:54321/tcp
+`, s.projectId, "ws", "system", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "client")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "port 0 not currently supported")
+}
+
+func (s *tunnelSuite) TestListenPrivilegedPort(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:22/tcp
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:80/tcp
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "system")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, "port 22 is privileged")
+}
+
+func (s *tunnelSuite) TestConnectPrivilegedPort(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: 127.0.0.1:22/tcp
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: 127.0.0.1:80/tcp
+`, s.projectId, "ws", "system", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "client")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the tunnel specification.
+	expectedEntry := workshop.ProxyEntry{
+		Name: "tunnel-plug",
+		Connect: workshop.ProxyTarget{
+			Address:  "127.0.0.1:80",
+			Protocol: "tcp"},
+		Listen: workshop.ProxyTarget{
+			Address:  "127.0.0.1:22",
+			Protocol: "tcp"},
+		Direction: workshop.WorkshopToHost,
+	}
+	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}

--- a/internal/interfaces/builtin/tunnel_test.go
+++ b/internal/interfaces/builtin/tunnel_test.go
@@ -20,6 +20,11 @@
 package builtin_test
 
 import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
 	"github.com/canonical/workshop/internal/asserts"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
@@ -173,6 +178,27 @@ plugs:
 `, s.projectId, "ws", "system", "tunnel-plug")
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
 	c.Check(plug.Attrs["endpoint"], check.Equals, "/tmp/unix.sock")
+
+	plug = builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: $HOME/.local/state/tunnel-sdk/unix.sock
+`, s.projectId, "ws", "system", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "$HOME/.local/state/tunnel-sdk/unix.sock")
+
+	plug = builtin.MockPlug(c, `name: tunnel-sdk
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: $XDG_RUNTIME_DIR/tunnel-sdk.sock
+`, s.projectId, "ws", "tunnel-sdk", "tunnel-plug")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["endpoint"], check.Equals, "$XDG_RUNTIME_DIR/tunnel-sdk.sock")
 }
 
 func (s *tunnelSuite) TestSanitizePlugUnknownAttribute(c *check.C) {
@@ -833,6 +859,169 @@ slots:
 		Direction: workshop.WorkshopToHost,
 	}
 	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}
+
+func (s *tunnelSuite) TestExpandHomeDirectory(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: $HOME/.local/state/app/unix.sock
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: $HOME/app/unix.sock
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	u := user.User{
+		Uid:      "1111",
+		Gid:      "2222",
+		Username: "testuser",
+		HomeDir:  c.MkDir(),
+	}
+	socket := filepath.Join(u.HomeDir, ".local", "state", "app", "unix.sock")
+	c.Assert(os.MkdirAll(filepath.Dir(socket), os.ModePerm), check.IsNil)
+	deviceSpec := lxd_device.NewSpecification(&u, "system")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the tunnel specification.
+	expectedEntry := workshop.ProxyEntry{
+		Name: "tunnel-plug",
+		Connect: workshop.ProxyTarget{
+			Address:  "/home/workshop/app/unix.sock",
+			Protocol: "unix"},
+		Listen: workshop.ProxyTarget{
+			Address:  socket,
+			Protocol: "unix"},
+		Direction: workshop.HostToWorkshop,
+	}
+	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}
+
+func (s *tunnelSuite) TestExpandRuntimeDirectory(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: $XDG_RUNTIME_DIR/app.sock
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: $XDG_RUNTIME_DIR/app/unix.sock
+`, s.projectId, "ws", "system", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	u := user.User{
+		Uid:      "1111",
+		Gid:      "2222",
+		Username: "testuser",
+		HomeDir:  "/home/testhome",
+	}
+	deviceSpec := lxd_device.NewSpecification(&u, "client")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the tunnel specification.
+	expectedEntry := workshop.ProxyEntry{
+		Name: "tunnel-plug",
+		Connect: workshop.ProxyTarget{
+			Address:  "/run/user/1111/app/unix.sock",
+			Protocol: "unix"},
+		Listen: workshop.ProxyTarget{
+			Address:  "/run/user/1000/app.sock",
+			Protocol: "unix"},
+		Direction: workshop.WorkshopToHost,
+	}
+	c.Check(deviceSpec.Profile.Tunnels, check.DeepEquals, []workshop.Tunnel{{ProxyEntry: expectedEntry}})
+}
+
+func (s *tunnelSuite) TestExpandOtherDirectory(c *check.C) {
+	plug := builtin.MockPlug(c, `name: client
+base: ubuntu@22.04
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: $PWD/app.sock
+`, s.projectId, "ws", "client", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: $PWD/app/unix.sock
+`, s.projectId, "ws", "system", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	u := user.User{
+		Uid:      "1111",
+		Gid:      "2222",
+		Username: "testuser",
+		HomeDir:  "/home/testhome",
+	}
+	deviceSpec := lxd_device.NewSpecification(&u, "client")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, `unexpected variable "PWD"`)
+}
+
+func (s *tunnelSuite) TestUnauthorizedUnixPath(c *check.C) {
+	plug := builtin.MockPlug(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+  tunnel-plug:
+    interface: tunnel
+    endpoint: /etc/shadow
+`, s.projectId, "ws", "system", "tunnel-plug")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: service
+base: ubuntu@22.04
+slots:
+  tunnel-slot:
+    interface: tunnel
+    endpoint: /run/app.sock
+`, s.projectId, "ws", "service", "tunnel-slot")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	u := user.User{
+		Uid:      "1111",
+		Gid:      "2222",
+		Username: "testuser",
+		HomeDir:  c.MkDir(),
+	}
+	deviceSpec := lxd_device.NewSpecification(&u, "system")
+
+	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, `user "testuser" cannot create socket "/etc/shadow" for security reasons`)
+
+	fakeEtc := c.MkDir()
+	shadowLink := filepath.Join(u.HomeDir, "etc", "shadow")
+	c.Assert(os.Symlink(fakeEtc, filepath.Dir(shadowLink)), check.IsNil)
+	plug.Attrs["endpoint"] = shadowLink
+	connectedPlug = interfaces.NewConnectedPlug(plug, nil, nil)
+
+	err = deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
+	c.Check(err, check.ErrorMatches, fmt.Sprintf(`user "testuser" cannot create socket %q for security reasons`, shadowLink))
 }
 
 func (s *tunnelSuite) TestAutoConnectHostToWorkshop(c *check.C) {

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -143,8 +143,8 @@ func (plug *ConnectedPlug) Attr(key string, val interface{}) error {
 func (plug *ConnectedPlug) getAttribute(dynamicAttrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := metautil.LookupAttr(plug.staticAttrs, dynamicAttrs, key)
 	if !ok {
-		err := fmt.Errorf("attribute %q not found for plug %q", key, plug.Ref().ShortRef())
-		return sdk.AttributeNotFoundError{Err: err}
+		ref := plug.Ref()
+		return &sdk.AttributeNotFoundError{Attribute: key, Plug: &ref}
 	}
 
 	if err := metautil.SetValueFromAttribute(v, val); err != nil {
@@ -214,8 +214,8 @@ func (slot *ConnectedSlot) Attr(key string, val interface{}) error {
 func (slot *ConnectedSlot) getAttribute(dynamicAttrs map[string]interface{}, key string, val interface{}) error {
 	v, ok := metautil.LookupAttr(slot.staticAttrs, dynamicAttrs, key)
 	if !ok {
-		err := fmt.Errorf("attribute %q not found for slot %q", key, slot.Ref().ShortRef())
-		return sdk.AttributeNotFoundError{Err: err}
+		ref := slot.Ref()
+		return &sdk.AttributeNotFoundError{Attribute: key, Slot: &ref}
 	}
 
 	if err := metautil.SetValueFromAttribute(v, val); err != nil {

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -21,7 +21,6 @@ package interfaces
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/canonical/workshop/internal/interfaces/utils"
 	"github.com/canonical/workshop/internal/metautil"
@@ -72,32 +71,6 @@ type Attrer interface {
 	Attr(path string, value interface{}) error
 	// Lookup returns attribute value for given path, or false. Dotted paths are supported.
 	Lookup(path string) (value interface{}, ok bool)
-}
-
-func lookupAttr(staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string) (interface{}, bool) {
-	var v interface{}
-	comps := strings.FieldsFunc(path, func(r rune) bool { return r == '.' })
-	if len(comps) == 0 {
-		return nil, false
-	}
-	if _, ok := dynamicAttrs[comps[0]]; ok {
-		v = dynamicAttrs
-	} else {
-		v = staticAttrs
-	}
-
-	for _, comp := range comps {
-		m, ok := v.(map[string]interface{})
-		if !ok {
-			return nil, false
-		}
-		v, ok = m[comp]
-		if !ok {
-			return nil, false
-		}
-	}
-
-	return v, true
 }
 
 // NewConnectedSlot creates an object representing a connected slot.
@@ -168,7 +141,7 @@ func (plug *ConnectedPlug) Attr(key string, val interface{}) error {
 }
 
 func (plug *ConnectedPlug) getAttribute(dynamicAttrs map[string]interface{}, key string, val interface{}) error {
-	v, ok := lookupAttr(plug.staticAttrs, dynamicAttrs, key)
+	v, ok := metautil.LookupAttr(plug.staticAttrs, dynamicAttrs, key)
 	if !ok {
 		err := fmt.Errorf("attribute %q not found for plug %q", key, plug.Ref().ShortRef())
 		return sdk.AttributeNotFoundError{Err: err}
@@ -181,7 +154,7 @@ func (plug *ConnectedPlug) getAttribute(dynamicAttrs map[string]interface{}, key
 }
 
 func (plug *ConnectedPlug) Lookup(path string) (interface{}, bool) {
-	return lookupAttr(plug.staticAttrs, plug.dynamicAttrs, path)
+	return metautil.LookupAttr(plug.staticAttrs, plug.dynamicAttrs, path)
 }
 
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
@@ -239,7 +212,7 @@ func (slot *ConnectedSlot) Attr(key string, val interface{}) error {
 }
 
 func (slot *ConnectedSlot) getAttribute(dynamicAttrs map[string]interface{}, key string, val interface{}) error {
-	v, ok := lookupAttr(slot.staticAttrs, dynamicAttrs, key)
+	v, ok := metautil.LookupAttr(slot.staticAttrs, dynamicAttrs, key)
 	if !ok {
 		err := fmt.Errorf("attribute %q not found for slot %q", key, slot.Ref().ShortRef())
 		return sdk.AttributeNotFoundError{Err: err}
@@ -252,7 +225,7 @@ func (slot *ConnectedSlot) getAttribute(dynamicAttrs map[string]interface{}, key
 }
 
 func (slot *ConnectedSlot) Lookup(path string) (interface{}, bool) {
-	return lookupAttr(slot.staticAttrs, slot.dynamicAttrs, path)
+	return metautil.LookupAttr(slot.staticAttrs, slot.dynamicAttrs, path)
 }
 
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -32,11 +32,15 @@ func BeforePreparePlug(iface Interface, plugInfo *sdk.PlugInfo) error {
 		return fmt.Errorf("cannot sanitize plug %q (interface %q) using interface %q",
 			plugInfo.Ref().ShortRef(), plugInfo.Interface, iface.Name())
 	}
-	var err error
 	if iface, ok := iface.(PlugSanitizer); ok {
-		err = iface.BeforePreparePlug(plugInfo)
+		return iface.BeforePreparePlug(plugInfo)
 	}
-	return err
+
+	// Plugs which accept attributes should define BeforePreparePlug.
+	for name := range plugInfo.Attrs {
+		return fmt.Errorf(`unknown attribute for %s interface plug: %q`, iface.Name(), name)
+	}
+	return nil
 }
 
 func BeforeConnectPlug(iface Interface, plug *ConnectedPlug) error {
@@ -64,11 +68,14 @@ func BeforePrepareSlot(iface Interface, slotInfo *sdk.SlotInfo) error {
 		return fmt.Errorf("cannot sanitize slot %q (interface %q) using interface %q",
 			slotInfo.Ref(), slotInfo.Interface, iface.Name())
 	}
-	var err error
 	if iface, ok := iface.(SlotSanitizer); ok {
-		err = iface.BeforePrepareSlot(slotInfo)
+		return iface.BeforePrepareSlot(slotInfo)
 	}
-	return err
+	// Slots which accept attributes should define BeforePrepareSlot.
+	for name := range slotInfo.Attrs {
+		return fmt.Errorf(`unknown attribute for %s interface slot: %q`, iface.Name(), name)
+	}
+	return nil
 }
 
 // Interfaces holds information about a list of plugs, slots and their connections.

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -225,8 +225,7 @@ func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop str
 	}
 	defer env.Close()
 
-	varline := fmt.Sprintln("export SSH_AUTH_SOCK=" + strings.TrimPrefix(dev.Listen.Address, "unix:"))
-	_, err = env.Write([]byte(varline))
+	_, err = fmt.Fprintf(env, "export SSH_AUTH_SOCK=%s\n", dev.Listen.Address)
 	if err != nil {
 		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
 	}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -267,7 +267,8 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	}
 
 	if dev.Wayland != nil {
-		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen.Address, "/run/user/1000/")
+		prefix := filepath.Join("/run/user", workshop.User.Uid) + "/"
+		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen.Address, prefix)
 	}
 
 	if dev.X11 != nil {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -329,7 +329,7 @@ func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error)
 func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(ctx, b.Name(), sdkInfo)
 	if err != nil {
-		return fmt.Errorf("cannot obtain device snippets for workshop %q: %w", sdkInfo.Workshop, err)
+		return err
 	}
 	spec := s.(*Specification)
 

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -132,7 +132,12 @@ func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 	// card*/render* dri devices by LXD properly. Both will be assigned to
 	// the group provided in "gid"; there is no way to assign video to card*
 	// and render to render* devices.
-	s.devices[gpu.Name] = map[string]string{"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"}
+	s.devices[gpu.Name] = map[string]string{
+		"type":    "gpu",
+		"gputype": "physical",
+		"uid":     workshop.User.Uid,
+		"gid":     workshop.User.Gid,
+	}
 
 	return nil
 }
@@ -165,8 +170,8 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 			"source":   path,
 			"path":     path,
 			"required": "false",
-			"uid":      "1000",
-			"gid":      "1000",
+			"uid":      workshop.User.Uid,
+			"gid":      workshop.User.Gid,
 		}
 		s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, name)] = "camera"
 	}
@@ -185,8 +190,8 @@ func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey stri
 	case workshop.WorkshopToHost:
 		device["bind"] = "instance"
 		if entry.Listen.Protocol == "unix" {
-			device["uid"] = "1000"
-			device["gid"] = "1000"
+			device["uid"] = workshop.User.Uid
+			device["gid"] = workshop.User.Gid
 		}
 	case workshop.HostToWorkshop:
 		device["bind"] = "host"

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -84,11 +84,17 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 	return nil
 }
 
-// Ssh Agent and Desktop are both of the lxc 'proxy' type
+// Tunnel, SSH Agent and Desktop are all of the lxc 'proxy' type
 // These are network protocol proxy devices that open a port on the host or in a workhop.
-// 'from', 'to' are the source and destination addresses (paths in the case of unix sockets),
+// 'listen', 'connect' are the source and destination addresses (paths in the case of unix sockets),
 // see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
 // bind denotes where the port is open (can be: instance, host)
+
+func (s *Specification) AddTunnelEntry(tunnel workshop.Tunnel) error {
+	s.Profile.Tunnels = append(s.Profile.Tunnels, tunnel)
+	s.addProxyEntry(&tunnel.ProxyEntry, "tunnel")
+	return nil
+}
 
 func (s *Specification) SetSshAgent(agent workshop.SshAgent) error {
 	s.Profile.Agent = &agent

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -170,12 +170,24 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 
 func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey string) {
 	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, entry.Name)] = configKey
-	s.devices[entry.Name] = map[string]string{
+	device := map[string]string{
 		"type":    "proxy",
 		"connect": entry.Connect.Protocol + ":" + entry.Connect.Address,
 		"listen":  entry.Listen.Protocol + ":" + entry.Listen.Address,
-		"uid":     "1000",
-		"gid":     "1000",
-		"bind":    "instance",
 	}
+	switch entry.Direction {
+	case workshop.WorkshopToHost:
+		device["bind"] = "instance"
+		if entry.Listen.Protocol == "unix" {
+			device["uid"] = "1000"
+			device["gid"] = "1000"
+		}
+	case workshop.HostToWorkshop:
+		device["bind"] = "host"
+		if entry.Listen.Protocol == "unix" {
+			device["uid"] = s.User.Uid
+			device["gid"] = s.User.Gid
+		}
+	}
+	s.devices[entry.Name] = device
 }

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -369,6 +369,7 @@ exit 0
 	c.Check(prof.Agent.Connect.Protocol, check.Equals, "unix")
 	c.Check(prof.Agent.Listen.Address, check.Equals, "/run/consumer-ssh-agent.ssh")
 	c.Check(prof.Agent.Listen.Protocol, check.Equals, "unix")
+	c.Check(prof.Agent.Direction, check.Equals, workshop.WorkshopToHost)
 
 	buf := f.readWorkshopFile(c, "/etc/profile.d/consumer-ssh-agent.sh")
 	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/consumer-ssh-agent.ssh\n")

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -102,6 +102,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 	snowflakes := map[string]bool{
 		"mount":     true,
 		"ssh-agent": true,
+		"tunnel":    true,
 	}
 
 	// these simply auto-connect, anything else doesn't
@@ -160,7 +161,16 @@ slots:
 func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *check.C) {
 	all := builtin.Interfaces()
 
+	// these have more complex or in flux policies and have their
+	// own separate tests
+	snowflakes := map[string]bool{
+		"tunnel": true,
+	}
+
 	for _, iface := range all {
+		if snowflakes[iface.Name()] {
+			continue
+		}
 		c.Check(iface.AutoConnect(nil, nil), Equals, true)
 	}
 }

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -59,10 +59,10 @@ func checkPlugInstallationAltConstraints(plug *sdk.PlugInfo, altConstraints []*a
 }
 
 func checkPlugConnectionConstraints1(connc *ConnectCandidate, constraints *asserts.PlugConnectionConstraints) error {
-	if err := checkNameConstraints(constraints.PlugNames, connc.Plug.Interface(), "plug name", connc.Plug.Name()); err != nil {
+	if err := checkPlugNameConstraints(constraints.PlugNames, connc.Plug.Interface(), connc.Slot.Name(), "plug name", connc.Plug.Name()); err != nil {
 		return err
 	}
-	if err := checkNameConstraints(constraints.SlotNames, connc.Slot.Interface(), "slot name", connc.Slot.Name()); err != nil {
+	if err := checkSlotNameConstraints(constraints.SlotNames, connc.Slot.Interface(), connc.Plug.Name(), "slot name", connc.Slot.Name()); err != nil {
 		return err
 	}
 
@@ -124,6 +124,28 @@ func checkNameConstraints(c *asserts.NameConstraints, iface, which, name string)
 	return c.Check(which, name, special)
 }
 
+func checkPlugNameConstraints(c *asserts.NameConstraints, iface, slot, which, name string) error {
+	if c == nil {
+		return nil
+	}
+	special := map[string]string{
+		"$INTERFACE": iface,
+		"$SLOT":      slot,
+	}
+	return c.Check(which, name, special)
+}
+
+func checkSlotNameConstraints(c *asserts.NameConstraints, iface, plug, which, name string) error {
+	if c == nil {
+		return nil
+	}
+	special := map[string]string{
+		"$INTERFACE": iface,
+		"$PLUG":      plug,
+	}
+	return c.Check(which, name, special)
+}
+
 func checkSlotInstallationConstraints(slot *sdk.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
 	if err := checkNameConstraints(constraints.SlotNames, slot.Interface, "slot name", slot.Name); err != nil {
 		return err
@@ -170,10 +192,10 @@ func checkSlotConnectionAltConstraints(connc *ConnectCandidate, altConstraints [
 }
 
 func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asserts.SlotConnectionConstraints) error {
-	if err := checkNameConstraints(constraints.PlugNames, connc.Plug.Interface(), "plug name", connc.Plug.Name()); err != nil {
+	if err := checkPlugNameConstraints(constraints.PlugNames, connc.Plug.Interface(), connc.Slot.Name(), "plug name", connc.Plug.Name()); err != nil {
 		return err
 	}
-	if err := checkNameConstraints(constraints.SlotNames, connc.Slot.Interface(), "slot name", connc.Slot.Name()); err != nil {
+	if err := checkSlotNameConstraints(constraints.SlotNames, connc.Slot.Interface(), connc.Plug.Name(), "slot name", connc.Slot.Name()); err != nil {
 		return err
 	}
 

--- a/internal/metautil/path_lookup.go
+++ b/internal/metautil/path_lookup.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package metautil
+
+import "strings"
+
+func LookupAttr(static, dynamic map[string]interface{}, path string) (interface{}, bool) {
+	parts := strings.FieldsFunc(path, func(r rune) bool { return r == '.' })
+	if len(parts) == 0 {
+		return nil, false
+	}
+
+	var v interface{}
+	if _, ok := dynamic[parts[0]]; ok {
+		v = dynamic
+	} else {
+		v = static
+	}
+
+	for _, part := range parts {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		v, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return v, true
+}

--- a/internal/metautil/type_conversions.go
+++ b/internal/metautil/type_conversions.go
@@ -82,9 +82,17 @@ func SetValueFromAttribute(attrVal interface{}, val interface{}) error {
 
 	converted, err := convertValue(reflect.ValueOf(attrVal), rt.Elem())
 	if err != nil {
-		return fmt.Errorf("expected %s but found %s", rt.Elem().Name(), reflect.TypeOf(attrVal).Name())
+		return fmt.Errorf("expected %s but found %s", nameOrString(rt.Elem()), nameOrString(reflect.TypeOf(attrVal)))
 	}
 
 	reflect.ValueOf(val).Elem().Set(converted)
 	return nil
+}
+
+func nameOrString(t reflect.Type) string {
+	name := t.Name()
+	if name != "" {
+		return name
+	}
+	return t.String()
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -299,22 +299,25 @@ type SlotInfo struct {
 	Label     string
 }
 
-type AttributeNotFoundError struct{ Err error }
-
-func (e AttributeNotFoundError) Error() string {
-	return e.Err.Error()
+type AttributeNotFoundError struct {
+	Attribute string
+	Plug      *PlugRef
+	Slot      *SlotRef
 }
 
-func (e AttributeNotFoundError) Is(target error) bool {
-	_, ok := target.(AttributeNotFoundError)
-	return ok
+func (e *AttributeNotFoundError) Error() string {
+	if e.Slot == nil {
+		return fmt.Sprintf("attribute %q not found for plug %q", e.Attribute, e.Plug.ShortRef())
+	}
+	return fmt.Sprintf("attribute %q not found for slot %q", e.Attribute, e.Slot.ShortRef())
+
 }
 
 func (slot *SlotInfo) Attr(key string, val interface{}) error {
 	v, ok := slot.Lookup(key)
 	if !ok {
-		err := fmt.Errorf("attribute %q not found for slot %q", key, slot.Ref().ShortRef())
-		return AttributeNotFoundError{Err: err}
+		ref := slot.Ref()
+		return &AttributeNotFoundError{Attribute: key, Slot: &ref}
 	}
 
 	if err := metautil.SetValueFromAttribute(v, val); err != nil {
@@ -377,8 +380,8 @@ type PlugInfo struct {
 func (plug *PlugInfo) Attr(key string, val interface{}) error {
 	v, ok := plug.Lookup(key)
 	if !ok {
-		err := fmt.Errorf("attribute %q not found for plug %q", key, plug.Ref().ShortRef())
-		return AttributeNotFoundError{Err: err}
+		ref := plug.Ref()
+		return &AttributeNotFoundError{Attribute: key, Plug: &ref}
 	}
 
 	if err := metautil.SetValueFromAttribute(v, val); err != nil {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -310,27 +310,6 @@ func (e AttributeNotFoundError) Is(target error) bool {
 	return ok
 }
 
-func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
-	var v interface{}
-	comps := strings.FieldsFunc(path, func(r rune) bool { return r == '.' })
-	if len(comps) == 0 {
-		return nil, false
-	}
-	v = attrs
-	for _, comp := range comps {
-		m, ok := v.(map[string]interface{})
-		if !ok {
-			return nil, false
-		}
-		v, ok = m[comp]
-		if !ok {
-			return nil, false
-		}
-	}
-
-	return v, true
-}
-
 func (slot *SlotInfo) Attr(key string, val interface{}) error {
 	v, ok := slot.Lookup(key)
 	if !ok {
@@ -345,7 +324,7 @@ func (slot *SlotInfo) Attr(key string, val interface{}) error {
 }
 
 func (slot *SlotInfo) Lookup(key string) (interface{}, bool) {
-	return lookupAttr(slot.Attrs, key)
+	return metautil.LookupAttr(slot.Attrs, nil, key)
 }
 
 func (slot *SlotInfo) Ref() SlotRef {
@@ -409,7 +388,7 @@ func (plug *PlugInfo) Attr(key string, val interface{}) error {
 }
 
 func (plug *PlugInfo) Lookup(key string) (interface{}, bool) {
-	return lookupAttr(plug.Attrs, key)
+	return metautil.LookupAttr(plug.Attrs, nil, key)
 }
 
 func (plug *PlugInfo) Ref() PlugRef {

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -22,6 +22,9 @@ type WorkshopConfigFilter func(config map[string]string) bool
 const (
 	ContextProjectId = ContextKeyProjectId("project-id")
 	ContextUser      = ContextKeyUser("user")
+
+	Uid = 1000
+	Gid = 1000
 )
 
 var (
@@ -31,6 +34,13 @@ var (
 	ErrSdkProfileNotFound  = errors.New("sdk profile not found")
 
 	LookupUsername = user.Lookup
+
+	User = user.User{
+		Uid:      "1000",
+		Gid:      "1000",
+		Username: "workshop",
+		HomeDir:  "/home/workshop",
+	}
 )
 
 func NewWorkshopConfigFilter(key string, value string) WorkshopConfigFilter {

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -13,10 +13,18 @@ type ProxyTarget struct {
 	Protocol string
 }
 
+type ProxyDirection int
+
+const (
+	HostToWorkshop ProxyDirection = iota
+	WorkshopToHost
+)
+
 type ProxyEntry struct {
-	Name    string
-	Connect ProxyTarget
-	Listen  ProxyTarget
+	Name      string
+	Connect   ProxyTarget
+	Listen    ProxyTarget
+	Direction ProxyDirection
 }
 
 func (p *ProxyEntry) Equal(other *ProxyEntry) bool {

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -47,6 +47,10 @@ type Mount struct {
 	ReadOnly bool      `json:"readonly"`
 }
 
+type Tunnel struct {
+	ProxyEntry
+}
+
 type SshAgent struct {
 	ProxyEntry
 }
@@ -81,6 +85,7 @@ type SdkProfile struct {
 
 	Camera  *Camera
 	Mounts  map[string]Mount
+	Tunnels []Tunnel
 	Agent   *SshAgent
 	Gpu     *Gpu
 	Desktop *Desktop

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -881,7 +881,7 @@ runcmd:
 	}
 
 	cfg := map[string]string{
-		"raw.idmap":                fmt.Sprint("uid ", userid, " 1000\ngid ", groupid, " 1000"),
+		"raw.idmap":                fmt.Sprintf("uid %s %s\ngid %s %s", userid, workshop.User.Uid, groupid, workshop.User.Gid),
 		"security.nesting":         "true",
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -49,6 +49,12 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 		case "proxy":
 			devtype := config[DeviceTypeConfigKey(profile, name)]
 			switch devtype {
+			case "tunnel":
+				proxyEntry, err := proxyEntryFromLxdDevice(name, dev)
+				if err != nil {
+					return pr, err
+				}
+				pr.Tunnels = append(pr.Tunnels, workshop.Tunnel{ProxyEntry: *proxyEntry})
 			case "ssh-agent":
 				proxyEntry, err := proxyEntryFromLxdDevice(name, dev)
 				if err != nil {

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -125,6 +125,16 @@ func proxyEntryFromLxdDevice(name string, dev map[string]string) (*workshop.Prox
 		return nil, fmt.Errorf("internal error: cannot deserialise proxy device in lxd profile: listen entry %q invalid", listen)
 	}
 
+	var direction workshop.ProxyDirection
+	switch dev["bind"] {
+	case "instance":
+		direction = workshop.WorkshopToHost
+	case "host":
+		direction = workshop.HostToWorkshop
+	default:
+		return nil, fmt.Errorf("internal error: cannot deserialise proxy device in lxd profile: bind entry %q invalid", dev["bind"])
+	}
+
 	return &workshop.ProxyEntry{
 		Name: name,
 		Connect: workshop.ProxyTarget{
@@ -135,5 +145,6 @@ func proxyEntryFromLxdDevice(name string, dev map[string]string) (*workshop.Prox
 			Address:  listen[1],
 			Protocol: listen[0],
 		},
+		Direction: direction,
 	}, nil
 }

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -43,7 +43,9 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 					},
 					Listen: workshop.ProxyTarget{
 						Address:  ".workshop.socket",
-						Protocol: "unix"}}},
+						Protocol: "unix",
+					},
+					Direction: workshop.WorkshopToHost}},
 		}, {
 			Sdk:    "sdk",
 			Mounts: map[string]workshop.Mount{},
@@ -56,7 +58,9 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 					},
 					Listen: workshop.ProxyTarget{
 						Address:  ".workshop.socket",
-						Protocol: "unix"}}},
+						Protocol: "unix",
+					},
+					Direction: workshop.WorkshopToHost}},
 		}, {
 			Sdk: "sdk",
 			Mounts: map[string]workshop.Mount{

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -34,6 +34,19 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		}, {
 			Sdk:    "sdk",
 			Mounts: map[string]workshop.Mount{},
+			Tunnels: []workshop.Tunnel{{
+				ProxyEntry: workshop.ProxyEntry{
+					Name: "http",
+					Connect: workshop.ProxyTarget{
+						Address:  "127.0.0.1:8080",
+						Protocol: "tcp"},
+					Listen: workshop.ProxyTarget{
+						Address:  "0.0.0.0:8000",
+						Protocol: "tcp"},
+					Direction: workshop.HostToWorkshop}}},
+		}, {
+			Sdk:    "sdk",
+			Mounts: map[string]workshop.Mount{},
 			Agent: &workshop.SshAgent{
 				ProxyEntry: workshop.ProxyEntry{
 					Name: "ssh-agent",
@@ -115,6 +128,16 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		}, {
 			"sdk",
 			map[string]map[string]string{
+				"http": {
+					"type":    "proxy",
+					"connect": "tcp:127.0.0.1:8080",
+					"listen":  "tcp:0.0.0.0:8000",
+					"bind":    "host"}},
+			map[string]string{
+				"user.workshop.sdk.http.type": "tunnel"},
+		}, {
+			"sdk",
+			map[string]map[string]string{
 				"ssh-agent": {
 					"type":    "proxy",
 					"connect": "unix:.host.socket",
@@ -157,5 +180,6 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		c.Assert(res.Camera, check.DeepEquals, expected[i].Camera)
 		c.Assert(res.Gpu, check.DeepEquals, expected[i].Gpu)
 		c.Assert(res.Mounts, testutil.DeepUnsortedMatches, expected[i].Mounts)
+		c.Assert(res.Tunnels, testutil.DeepUnsortedMatches, expected[i].Tunnels)
 	}
 }

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -58,16 +58,14 @@ execute: |
   # sketch SDK
 
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  $
-  a
+  1/^plugs:$/a
     ssh-agent:
   .
   wq
   EOF
 
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  10
-  i
+  1/^hooks:$/a
     setup-base: |
       apt-get update
       apt-get install -y delve clang

--- a/tests/lib/sdk/test-sdk-tunnel/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-tunnel/latest/stable/meta/sdk.yaml
@@ -1,0 +1,27 @@
+name: test-sdk-tunnel
+title: test-sdk-tunnel
+base: ubuntu@22.04
+
+summary: test-sdk-tunnel SDK
+description: |
+  test-sdk-tunnel SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+plugs:
+  alias:
+    interface: tunnel
+  conflict:
+    interface: tunnel
+    endpoint: 5432
+  postgres:
+    interface: tunnel
+    endpoint: 5432
+slots:
+  http:
+    interface: tunnel
+    endpoint: '[::1]:8000'
+  unix-abstract:
+    interface: tunnel
+    endpoint: '@abstract'
+  unused:
+    interface: tunnel

--- a/tests/lib/sdk/test-sdk-tunnel/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-tunnel/latest/stable/meta/sdk.yaml
@@ -17,6 +17,9 @@ plugs:
     interface: tunnel
     endpoint: 5432
 slots:
+  auto-connect-by-name:
+    interface: tunnel
+    endpoint: 9999
   http:
     interface: tunnel
     endpoint: '[::1]:8000'

--- a/tests/main/interface-tunnel/.workshop.yaml
+++ b/tests/main/interface-tunnel/.workshop.yaml
@@ -15,7 +15,7 @@ sdks:
       tunnel:
       unix-path:
         interface: tunnel
-        endpoint: /home/ubuntu/test-tunnel.sock
+        endpoint: $HOME/test-tunnel.sock
     slots:
       postgres:
         interface: tunnel

--- a/tests/main/interface-tunnel/.workshop.yaml
+++ b/tests/main/interface-tunnel/.workshop.yaml
@@ -1,0 +1,23 @@
+name: ws-tunnel
+base: ubuntu@22.04
+sdks:
+  - name: system
+    plugs:
+      conflict:
+        interface: tunnel
+        endpoint: '0.0.0.0:8000'
+      test-sdk-http:
+        interface: tunnel
+        endpoint: 8001
+      tunnel:
+      unix-path:
+        interface: tunnel
+        endpoint: /home/ubuntu/test-tunnel.sock
+    slots:
+      postgres:
+        interface: tunnel
+        endpoint: 54321
+      unused:
+        interface: tunnel
+  - name: test-sdk-tunnel
+    channel: latest/stable

--- a/tests/main/interface-tunnel/.workshop.yaml
+++ b/tests/main/interface-tunnel/.workshop.yaml
@@ -3,6 +3,9 @@ base: ubuntu@22.04
 sdks:
   - name: system
     plugs:
+      auto-connect-by-name:
+        interface: tunnel
+        endpoint: 9999
       conflict:
         interface: tunnel
         endpoint: '0.0.0.0:8000'
@@ -21,3 +24,6 @@ sdks:
         interface: tunnel
   - name: test-sdk-tunnel
     channel: latest/stable
+connections:
+  - plug: system:test-sdk-http
+    slot: test-sdk-tunnel:http

--- a/tests/main/interface-tunnel/task.yaml
+++ b/tests/main/interface-tunnel/task.yaml
@@ -32,17 +32,17 @@ execute: |
   echo "Check workshop can connect to host"
   systemd-run --unit fakepostgres.service -- \
     systemd-socket-activate --accept --inetd --listen '127.0.0.1:54321' -- \
-    sed s/foo/bar/
-  workshop_exec exec ws-tunnel -- bash -c 'echo fooFOOfoo | nc -N localhost 5432' | MATCH '^barFOOfoo$'
-  workshop_exec exec ws-tunnel -- bash -c 'echo barFOOfoo | nc -N localhost 54321' | MATCH '^barFOObar$'
+    bash -c 'head -n1 | sed s/foo/bar/'
+  workshop_exec exec ws-tunnel -- bash -c 'echo fooFOOfoo | nc localhost 5432' | MATCH '^barFOOfoo$'
+  workshop_exec exec ws-tunnel -- bash -c 'echo barFOOfoo | nc localhost 54321' | MATCH '^barFOObar$'
 
   echo "Check host can connect to workshop"
   workshop_exec exec ws-tunnel -- \
     systemd-run --user -- \
     systemd-socket-activate --accept --inetd --listen '[::1]:8000' -- \
-    sed s/FOO/BAR/g
-  echo fooFOOfooFOO | nc -N localhost 8000 | MATCH '^fooBARfooBAR$'
-  echo BARFOOBAR | nc -N localhost 8001 | MATCH '^BARBARBAR$'
+    bash -c 'head -n1 | sed s/FOO/BAR/g'
+  echo fooFOOfooFOO | nc localhost 8000 | MATCH '^fooBARfooBAR$'
+  echo BARFOOBAR | nc localhost 8001 | MATCH '^BARBARBAR$'
 
   echo "Check that plugs cannot bind to same address"
   (! workshop_exec connect ws-tunnel/test-sdk-tunnel:conflict :unused) | MATCH 'listen tcp 127.0.0.1:5432: bind: address already in use|Failed to receive file descriptor via abstract unix socket|Please look in'

--- a/tests/main/interface-tunnel/task.yaml
+++ b/tests/main/interface-tunnel/task.yaml
@@ -11,22 +11,22 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  echo "Check manual connections"
+  echo "Check automatic connection"
   workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/test-sdk-tunnel:postgres.+\-.+\-$"
   workshop_exec connections ws-tunnel | MATCH "^tunnel.+\-.+ws-tunnel/system:postgres.+\-$"
-  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:test-sdk-http.+\-.+\-$"
-  workshop_exec connections ws-tunnel | MATCH "^tunnel.+\-.+ws-tunnel/test-sdk-tunnel:http.+\-$"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:auto-connect-by-name.+ws-tunnel/test-sdk-tunnel:auto-connect-by-name.+\-$"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:test-sdk-http.+ws-tunnel/test-sdk-tunnel:http.+\-$"
+
+  echo "Check manual connection"
   workshop_exec connect ws-tunnel/test-sdk-tunnel:postgres
   workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/test-sdk-tunnel:postgres.+ws-tunnel/system:postgres.+manual$"
-  workshop_exec connect ws-tunnel/system:test-sdk-http ws-tunnel/test-sdk-tunnel:http
-  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:test-sdk-http.+ws-tunnel/test-sdk-tunnel:http.+manual$"
 
   echo "Check multiple plugs can connect to one slot"
   workshop_exec connect ws-tunnel/test-sdk-tunnel:alias :postgres
   workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/test-sdk-tunnel:postgres.+ws-tunnel/system:postgres.+manual$"
   workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/test-sdk-tunnel:alias.+ws-tunnel/system:postgres.+manual$"
   workshop_exec connect ws-tunnel/system:tunnel ws-tunnel/test-sdk-tunnel:http
-  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:test-sdk-http.+ws-tunnel/test-sdk-tunnel:http.+manual$"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:test-sdk-http.+ws-tunnel/test-sdk-tunnel:http.+\-$"
   workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:tunnel.+ws-tunnel/test-sdk-tunnel:http.+manual$"
 
   echo "Check workshop can connect to host"

--- a/tests/main/interface-tunnel/task.yaml
+++ b/tests/main/interface-tunnel/task.yaml
@@ -1,0 +1,66 @@
+summary: Check tunnel interface scenarios
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-tunnel
+restore: |
+  . "$TESTSLIB"/utils.sh
+  rm -f /home/ubuntu/test-tunnel.sock
+  usermod --gid ubuntu --remove --groups ubuntu ubuntu
+  systemctl stop fakepostgres.service || true
+  workshop_exec remove ws-tunnel
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check manual connections"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/test-sdk-tunnel:postgres.+\-.+\-$"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+\-.+ws-tunnel/system:postgres.+\-$"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:test-sdk-http.+\-.+\-$"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+\-.+ws-tunnel/test-sdk-tunnel:http.+\-$"
+  workshop_exec connect ws-tunnel/test-sdk-tunnel:postgres
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/test-sdk-tunnel:postgres.+ws-tunnel/system:postgres.+manual$"
+  workshop_exec connect ws-tunnel/system:test-sdk-http ws-tunnel/test-sdk-tunnel:http
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:test-sdk-http.+ws-tunnel/test-sdk-tunnel:http.+manual$"
+
+  echo "Check multiple plugs can connect to one slot"
+  workshop_exec connect ws-tunnel/test-sdk-tunnel:alias :postgres
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/test-sdk-tunnel:postgres.+ws-tunnel/system:postgres.+manual$"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/test-sdk-tunnel:alias.+ws-tunnel/system:postgres.+manual$"
+  workshop_exec connect ws-tunnel/system:tunnel ws-tunnel/test-sdk-tunnel:http
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:test-sdk-http.+ws-tunnel/test-sdk-tunnel:http.+manual$"
+  workshop_exec connections ws-tunnel | MATCH "^tunnel.+ws-tunnel/system:tunnel.+ws-tunnel/test-sdk-tunnel:http.+manual$"
+
+  echo "Check workshop can connect to host"
+  systemd-run --unit fakepostgres.service -- \
+    systemd-socket-activate --accept --inetd --listen '127.0.0.1:54321' -- \
+    sed s/foo/bar/
+  workshop_exec exec ws-tunnel -- bash -c 'echo fooFOOfoo | nc -N localhost 5432' | MATCH '^barFOOfoo$'
+  workshop_exec exec ws-tunnel -- bash -c 'echo barFOOfoo | nc -N localhost 54321' | MATCH '^barFOObar$'
+
+  echo "Check host can connect to workshop"
+  workshop_exec exec ws-tunnel -- \
+    systemd-run --user -- \
+    systemd-socket-activate --accept --inetd --listen '[::1]:8000' -- \
+    sed s/FOO/BAR/g
+  echo fooFOOfooFOO | nc -N localhost 8000 | MATCH '^fooBARfooBAR$'
+  echo BARFOOBAR | nc -N localhost 8001 | MATCH '^BARBARBAR$'
+
+  echo "Check that plugs cannot bind to same address"
+  (! workshop_exec connect ws-tunnel/test-sdk-tunnel:conflict :unused) | MATCH 'listen tcp 127.0.0.1:5432: bind: address already in use|Failed to receive file descriptor via abstract unix socket|Please look in'
+  # FIXME: device is still in LXD profile; reconnect to enable disconnect (which removes the profile)
+  if workshop_exec connect ws-tunnel/test-sdk-tunnel:conflict :unused; then
+    workshop_exec disconnect ws-tunnel/test-sdk-tunnel:conflict
+  fi
+  (! workshop_exec connect ws-tunnel/system:conflict ws-tunnel/test-sdk-tunnel:unused) | MATCH 'listen tcp 0.0.0.0:8000: bind: address already in use|Failed to receive file descriptor via abstract unix socket|Please look in'
+  # FIXME: device is still in LXD profile; reconnect to enable disconnect (which removes the profile)
+  if workshop_exec connect ws-tunnel/system:conflict ws-tunnel/test-sdk-tunnel:unused; then
+    workshop_exec disconnect ws-tunnel/system:conflict
+  fi
+
+  echo "Check that unix sockets have correct permissions"
+  usermod --append --groups ubuntu --gid games ubuntu
+  workshop_exec connect ws-tunnel/system:unix-path ws-tunnel/test-sdk-tunnel:unix-abstract
+  stat --format='%F %U %G' /home/ubuntu/test-tunnel.sock | MATCH '^socket ubuntu games$'
+  usermod --gid ubuntu --remove --groups ubuntu ubuntu
+  workshop_exec disconnect ws-tunnel/system:unix-path
+  # FIXME: https://github.com/canonical/lxd/issues/14972
+  # test ! -e /home/ubuntu/test-tunnel.sock

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -10,7 +10,7 @@ execute: |
 
   echo "Install empty sketch SDK"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  wq
+  q
   EOF
 
   workshop_exec info | grep -v notes | yq '.sdks["sketch"].tracking' | MATCH '^~/.local/share/workshop/project/.*/sdk/sketch/ws-sketch$'
@@ -26,8 +26,7 @@ execute: |
 
   echo "Add setup-base"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  10
-  i
+  1/^hooks:$/a
     setup-base: |
       mkdir -p /home/workshop/ws-sketch-test
   .
@@ -38,8 +37,7 @@ execute: |
 
   echo "Add a new mount"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  $
-  a
+  1/^plugs:$/a
     sketch-plug:
       interface: mount
       workshop-target: /home/workshop/ws-sketch-test
@@ -56,14 +54,13 @@ execute: |
 
   echo "Install empty sketch SDK"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  wq
+  q
   EOF
 
   echo "Add a breaking change to sketch"
   ! sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  $
-  a
-    test:
+  1/^plugs:$/a
+    unique-mount-plug-name:
       interface: mount
       workshop-typo: /mnt
   .
@@ -72,15 +69,13 @@ execute: |
 
   echo "Fix the breaking change"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  $
-  s/typo/target/
+  %s/workshop-typo/workshop-target/
   wq
   EOF
 
   echo "Add another breaking change to sketch"
   ! sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  $
-  a
+  1/^  unique-mount-plug-name:$/a
       unknown-attribute: true
   .
   wq


### PR DESCRIPTION
# Description

Adds the `tunnel` interface, allowing communication between network services in the workshop and on the host. This adds extra data to the `workshop info` API and output. It's also included in the `sketch-sdk` template.

Interfaces which don't define plug/slot sanitize functions are no longer allowed to have attributes. This is to prevent users from faking meaningful dynamic attributes like `auto-explicit`. The downside is that it may be harder to introduce new attributes in future (e.g. SDKs might be tied to new versions of Workshop).

The spread tests require `netcat`, and `systemd` version 230 or later. Should be fine since the prepare step already depends on `netcat`, and `focal` has `system` 245.

## Known issues:

- If connect fails, the LXD profile is still updated. A second connect will erroneously succeed (but can then be safely disconnected). Seems unlikely to be fully resolved upstream so we'll have to work around this at some point.
- Disconnecting a unix socket plug doesn't remove the socket: https://github.com/canonical/lxd/issues/14972.
- Port conflict error messages are currently inconsistent: https://github.com/canonical/lxd/issues/15023.
- Proxy devices closed too early: https://github.com/canonical/lxd/issues/15024.
- `workshop info` uses the current connections instead of the SDK profiles. This complicates the code, but is required for now because the system SDK is hidden from `workshop info`.
- Can't listen on port 0. There's not much point doing so unless we provide a way for users to query the randomly allocated port. I've already created a lot of work for the LXD team, so this can wait until we have users who want this feature.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
