### PR TITLE
Align shell/exec/run sessions and environment

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -251,7 +252,7 @@ $ workshop shell`,
 }
 
 func (c *CmdShell) Run(cmd *cobra.Command, av []string) error {
-	args := &ExecArgs{command: []string{"sudo", "-i", "-u", "workshop", "bash", "-c", "cd /project; exec bash"}}
+	args := &ExecArgs{command: []string{"bash"}}
 
 	if len(av) > 0 {
 		args.workshop = av[0]
@@ -259,7 +260,13 @@ func (c *CmdShell) Run(cmd *cobra.Command, av []string) error {
 		args.implicit = true
 	}
 
-	return exec(c.root, &ExecFlags{WorkingDir: "/project"}, args)
+	flags := &ExecFlags{
+		WorkingDir: "/project",
+		UserId:     1000,
+		GroupId:    1000,
+	}
+
+	return exec(c.root, flags, args)
 }
 
 func (c *CmdRun) Command() *cobra.Command {
@@ -374,15 +381,46 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 	if args.script {
 		logger.Debugf("Running script %q", args.command)
 	} else {
+		// Obtain an exec session as close to a real login shell as possible.
+		// This is required as an lxd exec call is a simple namespace exec, and LXD
+		// ignores the instance configuration by design:
+		// https://documentation.ubuntu.com/lxd/en/latest/instance-exec/#user-groups-and-working-directory
+
+		command := []string{"sudo",
+			"-u",
+			"#" + strconv.Itoa(flags.UserId),
+			"-g",
+			"#" + strconv.Itoa(flags.GroupId),
+			"--preserve-env",
+			"--",
+			"bash",
+			"-l",
+			"-c",
+			`exec -- "$0" "$@"`,
+		}
+		args.command = append(command, args.command...)
 		logger.Debugf("Running %q", args.command)
 	}
 
 	// Set up environment variables.
 	env := make(map[string]string)
+
 	term, ok := os.LookupEnv("TERM")
 	if ok {
 		env["TERM"] = term
 	}
+
+	// The runtime directory will most likely only be valid for the 'workshop'
+	// user. This is created due to enabling lingering for this user during the
+	// workshop start script and will not exist for other users. See:
+	// https://github.com/systemd/systemd/blob/7419291670dd4066594350cce585031f60bc4f0a/src/login/pam_systemd.c#L1288
+	env["XDG_RUNTIME_DIR"] = "/run/user/" + strconv.Itoa(flags.UserId)
+
+	// The session bus address is often determined programatically, however some
+	// programs rely on an explicit environment variable. We set that here. Like
+	// the runtime dir above, we only guarantee that the bus exists for the
+	// workshop user.
+	env["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/run/user/" + strconv.Itoa(flags.UserId) + "/bus"
 
 	for _, kv := range flags.Env {
 		parts := strings.SplitN(kv, "=", 2)
@@ -441,8 +479,8 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 	// combines stderr and stdout in the interactive mode.
 	opts := &client.ExecOptions{
 		Command:     args.command,
-		Script:      args.script,
 		Environment: env,
+		Script:      args.script,
 		WorkingDir:  flags.WorkingDir,
 		UserId:      &flags.UserId,
 		GroupId:     &flags.GroupId,

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -389,7 +390,17 @@ func (m *CommandManager) doInstallScript(task *state.Task, tomb *tomb.Tomb) erro
 	}
 
 	path := filepath.Join(dirs.WorkshopScriptsDir, name)
-	command := []string{"bash", "-ue", "-o", "pipefail", path}
+	command := []string{"sudo",
+		"-u",
+		"#" + strconv.Itoa(args.UserId),
+		"-g", "#" + strconv.Itoa(args.GroupId),
+		"--preserve-env",
+		"--",
+		"bash",
+		"-elo",
+		"pipefail",
+		path,
+	}
 	args.Command = append(command, args.Command[1:]...)
 
 	wfs, err := m.backend.WorkshopFs(ctx, w)

--- a/tests/lib/sdk/test-sdk-environment/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-environment/meta/sdk.yaml
@@ -1,0 +1,10 @@
+name: test-sdk-environment
+title: test-sdk-environment
+base: ubuntu@20.04
+version: '1.0'
+
+summary: test-sdk-environment SDK
+description: |
+  test-sdk-environment SDK
+
+sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'

--- a/tests/lib/sdk/test-sdk-environment/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-environment/sdk/hooks/setup-base
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+echo "export FOO=BAR" > /etc/profile.d/environment.sh

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -24,6 +24,9 @@ execute: |
   sudo -u ubuntu 2>&1 -- env Foo= workshop exec --env Foo -- bash -c '[ -z "${Foo-x}" ]'
   sudo -u ubuntu 2>&1 -- env --unset=Foo workshop exec --env Foo ws-exec bash -c '[ -z "${Foo+x}" ]'
 
+  echo "Check environment variables from interfaces are present"
+  workshop_exec exec -- env | MATCH FOO=BAR
+
   echo "Check default user and group"
   workshop_exec exec -- bash -c 'id -u -n' | MATCH workshop
   workshop_exec exec ws-exec bash -c 'id -g -n' | MATCH workshop
@@ -63,6 +66,7 @@ execute: |
   MATCH '^line$' < multiline.log
   ! workshop_exec run ws-exec fail
   workshop_exec run -- file | MATCH '^script$'
+  workshop_exec run env | MATCH 'FOO=BAR' 
 
   echo "Check scripts can be updated without refreshing"
   sed -i 's/one line/1 LINE/g' workshop.yaml

--- a/tests/main/exec/workshop.yaml
+++ b/tests/main/exec/workshop.yaml
@@ -3,6 +3,8 @@ base: ubuntu@22.04
 sdks:
   - name: test-sdk-basic
     channel: latest/stable
+  - name: test-sdk-environment
+    channel: latest/stable
 scripts:
   oneline: echo one line
   multiline: |
@@ -10,3 +12,4 @@ scripts:
     echo line
   fail: "false"
   file: ./script.sh
+  env: env


### PR DESCRIPTION
# Description
Ensures that workshop `shell`, `exec` and `run` sessions contain user and group information as configured in the instance, and an environment derived from a login shell.

For example:

- Commands that rely on _instance provided_ information for user information (groups, home, etc.) will now work as expected. 
- Environment variables set by interfaces will now be present in all cases

Commands will now at a minimum contain the following:
```
 sudo -u <uid> -g <gid> --preserve-env -- bash -l
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
