### PR TITLE
Prevent sketching when the workshop is not ready

### DIFF
--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -40,7 +40,7 @@ func (m *workshopExec) TestWorkshopScripts(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockSingleWorkshop)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
 		case 3, 5:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws/scripts", m.prjId))

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -16,7 +16,14 @@ type workshopExec struct {
 var _ = check.Suite(&workshopExec{})
 
 var mockWorkshopNoScripts = `{"type":"sync","status-code":200,"status":"OK","result":{}}`
-var mockWorkshopWithScripts = `{"type":"sync","status-code":200,"status":"OK","result":{"foo":{"script":"echo foo"},"bar":{"script":"echo bar\n"}}}`
+var mockWorkshopWithScripts = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "foo":{
+        "script":"echo foo"
+    },
+    "bar":{
+        "script":"echo bar\n"
+    }
+}}`
 
 func (m *workshopExec) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -22,8 +22,6 @@ func (m *workshopInfo) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
-var mockSingleWorkshop = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","notes":["missing-project"]}]},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
-
 var mockWorkshopWithSdks = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","sdks":[{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"],"path":"/home/project/.workshop/ws.yaml"},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
 
 func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
@@ -42,7 +40,7 @@ func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockSingleWorkshop)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Error"))
 		case 3:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -22,7 +22,29 @@ func (m *workshopInfo) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
-var mockWorkshopWithSdks = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","sdks":[{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"],"path":"/home/project/.workshop/ws.yaml"},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
+var mockWorkshopWithSdks = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "name":"ws",
+    "base":"ubuntu@22.04",
+    "project-id":"42424242",
+    "status":"Error",
+    "sdks":[{
+      "name":"go",
+      "version":"1.8.0",
+      "channel":"latest/edge",
+      "revision":"1",
+      "build-time":"2017-02-19T17:23:05.592623Z",
+      "install-time":"2017-03-22T09:01:00.0Z"
+    },{  
+      "name":"sketch",
+      "channel":"",
+      "revision":"x1",
+      "install-time":"2017-03-22T09:01:00.0Z"
+    }],
+    "notes":["missing-project"],
+    "path":"/home/project/.workshop/ws.yaml"
+},
+"warning-timestamp":"2017-03-22T10:01:00.0Z",
+"warning-count":1}`
 
 func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}
@@ -69,7 +91,22 @@ sdks:
 	c.Check(n, check.Equals, 3)
 }
 
-var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Pending","notes":["workshop-note"],"sdks":[{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z","health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}}]}}`
+var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "name":"ws",
+    "base":"ubuntu@22.04",
+    "project-id":"42424242",
+    "status":"Pending",
+    "notes":["workshop-note"],
+    "sdks":[{
+        "name":"go",
+        "version":"1.8.0",
+        "channel":"latest/edge",
+        "revision":"1",
+        "build-time":"2017-02-19T17:23:05.592623Z",
+        "install-time":"2017-03-22T09:01:00.0Z",
+        "health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}
+    }]
+}}`
 
 func (m *workshopInfo) TestWorkshopInfoWithSdkHealthReport(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}
@@ -109,12 +146,39 @@ sdks:
 	c.Check(n, check.Equals, 2)
 }
 
-var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready",
-"sdks":[
-	{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z",
-	"mounts":[{"host-source":"/home/user/src","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}},
-	{"host-source":"%s/.local/share/workshop/project/17942561/mount/ws_go_mod-cache.sdk","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-default"}}]
-}]}}`
+var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "name":"ws",
+    "base":"ubuntu@22.04",
+    "project-id":"42424242",
+    "status":"Ready",
+    "sdks":[{
+        "name":"go",
+        "version":"1.8.0",
+        "channel":"latest/edge",
+        "revision":"1",
+        "build-time":"2017-02-19T17:23:05.592623Z",
+        "install-time":"2017-03-22T09:01:00.0Z",
+	      "mounts":[{
+            "host-source":"/home/user/src",
+            "workshop-target":"/home/workshop/target", 
+            "plug":{
+                "project-id":"42ws42ws",
+                "workshop":"workshop",
+                "sdk":"go",
+                "plug":"plug-name"
+            }
+        },{
+            "host-source":"%s/.local/share/workshop/project/17942561/mount/ws_go_mod-cache.sdk",
+            "workshop-target":"/home/workshop/target", 
+            "plug":{
+                "project-id":"42ws42ws",
+                "workshop":"workshop",
+                "sdk":"go",
+                "plug":"plug-default"
+            }
+        }]
+    }]
+}}`
 
 func (m *workshopInfo) TestWorkshopInfoWithSdkMounts(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -109,7 +109,7 @@ func (c *CmdList) runList() error {
 			// --global flag does not list files for consistency. We may not be
 			// aware of all the project directories on the system and, thus,
 			// will not know all the available "Off" workshops (contrary to the
-			// workshops that are in any other state, i.e. running instances,
+			// workshops that are in any known state, i.e. running instances,
 			// which we always know about from the workshop backend).
 			print(w, workshops, nil, p)
 		}

--- a/cmd/workshop/list_test.go
+++ b/cmd/workshop/list_test.go
@@ -32,14 +32,71 @@ func (m *workshopList) TestHomeDirectoryPathContraction(c *C) {
 	*/
 }
 
-var mockWorkshopList = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Error","notes":["missing-project"]}, {"name":"as-1","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"}],"files":[
-{"name":"ws","project-id":"2","path":"/home/projects/.workshop/ws.yaml"},{"name":"as-1","project-id":"2","path":"/home/projects/.workshop/as-1.yaml"},{"name":"zs-1","project-id":"2","path":"/home/projects/.workshop/zs-1.yaml"},{"name":"ds-1","project-id":"2","path":"/home/projects/.workshop/ds-1.yaml"}]},"warning-timestamp":"1970-01-01T00:00:00.00000000Z","warning-count":1}`
+var mockWorkshopList = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "workshops":[{
+        "name":"ws",
+        "base":"ubuntu@22.04",
+        "project-id":"42424242",
+        "status":"Error",
+        "notes":["missing-project"]
+    },{
+        "name":"as-1",
+        "base":"ubuntu@22.04",
+        "project-id":"42424242",
+        "status":"Ready"
+    }],
+    "files":[{
+        "name":"ws",
+        "project-id":"2",
+        "path":"/home/projects/.workshop/ws.yaml"
+    },{
+        "name":"as-1",
+        "project-id":"2",
+        "path":"/home/projects/.workshop/as-1.yaml"
+    },{
+        "name":"zs-1",
+        "project-id":"2",
+        "path":"/home/projects/.workshop/zs-1.yaml"
+    },{
+        "name":"ds-1",
+        "project-id":"2",
+        "path":"/home/projects/.workshop/ds-1.yaml"
+    }]
+},
+"warning-timestamp":"1970-01-01T00:00:00.00000000Z",
+"warning-count":1}`
 
-var mockWorkshopList2 = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"2","status":"Ready"}],"files":[
-{"name":"ws","project-id":"2","path":"/home/projects/ws"},{"name":"ws2","project-id":"2","path":"/home/projects/ws"}]},"warning-timestamp":"1970-01-01T00:00:00.00000000Z","warning-count":1}`
+var mockWorkshopList2 = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "workshops":[{
+        "name":"ws",
+        "base":"ubuntu@22.04",
+        "project-id":"2",
+        "status":"Ready"
+    }],
+    "files":[{
+        "name":"ws",
+        "project-id":"2",
+        "path":"/home/projects/ws"
+    },{
+        "name":"ws2",
+        "project-id":"2",
+        "path":"/home/projects/ws"
+    }]
+},
+"warning-timestamp":"1970-01-01T00:00:00.00000000Z",
+"warning-count":1}`
 
-var mockWorkshopList3 = `{"type":"sync","status-code":200,"status":"OK","result":{"files":[
-{"name":"ws","project-id":"2","path":"/home/projects/.workshop/ws.yaml"},{"name":"as-1","project-id":"2","path":"/home/projects/.workshop/as-1.yaml"}]}}`
+var mockWorkshopList3 = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "files":[{
+        "name":"ws",
+        "project-id":"2",
+        "path":"/home/projects/.workshop/ws.yaml"
+    },{
+        "name":"as-1",
+        "project-id":"2",
+        "path":"/home/projects/.workshop/as-1.yaml"
+    }]
+}}`
 
 func (m *workshopInfo) TestWorkshopListFilesOnly(c *check.C) {
 	cmd := &CmdList{root: &CmdRoot{}}

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -15,7 +15,14 @@ type workshopRefresh struct {
 
 var _ = check.Suite(&workshopRefresh{})
 
-var mockSingleWorkshopJSON = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"}]}}`
+var mockSingleWorkshopJSON = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "workshops":[{
+        "name":"ws",
+        "base":"ubuntu@22.04",
+        "project-id":"42424242",
+        "status":"Ready"
+    }]
+}}`
 
 var mockReadyChangeJSON = `{"type": "sync", "result":{
     "id":   "four",

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -263,5 +263,15 @@ func plugSlotToConn(plug client.Plug, slot client.Slot, manual bool) client.Conn
 }
 
 func mockSingleWorkshopSpecifyStatus(status string) string {
-	return fmt.Sprintf(`{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":%q,"notes":["missing-project"]}]},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`, status)
+	return fmt.Sprintf(`{"type":"sync","status-code":200,"status":"OK","result":{
+      "workshops":[{
+          "name":"ws",
+          "base":"ubuntu@22.04",
+          "project-id":"42424242",
+          "status":%q,
+          "notes":["missing-project"
+          ]}
+      ]}
+  }`, status,
+	)
 }

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -261,3 +261,7 @@ func plugSlotToConn(plug client.Plug, slot client.Slot, manual bool) client.Conn
 		Manual:    manual,
 	}
 }
+
+func mockSingleWorkshopSpecifyStatus(status string) string {
+	return fmt.Sprintf(`{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":%q,"notes":["missing-project"]}]},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`, status)
+}

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -206,6 +206,11 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		}
 	}
 
+	// Ensure that the workshop is Ready
+	if wp.Status != "Ready" {
+		return fmt.Errorf(`error: cannot sketch %q: workshop currently %q, must be "Ready"`, wp.Name, wp.Status)
+	}
+
 	user, err := osutil.UserMaybeSudoUser()
 	if err != nil {
 		return err

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -23,8 +23,64 @@ type workshopSketch struct {
 
 var _ = check.Suite(&workshopSketch{})
 
-var mockWorkshopWithSdksReady = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready","sdks":[{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"],"path":"/home/project/.workshop/ws.yaml"},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
-var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready","sdks":[{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}]},{"name":"nosketch","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"},{"name":"both","base":"ubuntu@22.04","project-id":"42424242","status":"Ready","sdks":[{"name":"sketch","channel":"","revision":"x3","install-time":"2017-03-22T09:01:00.0Z"}]},{"name":"none","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"}]},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
+var mockWorkshopWithSdksReady = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "name":"ws",
+    "base":"ubuntu@22.04",
+    "project-id":"42424242",
+    "status":"Ready",
+    "sdks":[{
+      "name":"go",
+      "version":"1.8.0",
+      "channel":"latest/edge",
+      "revision":"1",
+      "build-time":"2017-02-19T17:23:05.592623Z",
+      "install-time":"2017-03-22T09:01:00.0Z"
+    },{  
+      "name":"sketch",
+      "channel":"",
+      "revision":"x1",
+      "install-time":"2017-03-22T09:01:00.0Z"
+    }],
+    "path":"/home/project/.workshop/ws.yaml"
+}}`
+
+var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "workshops":[{
+        "name":"ws",
+        "base":"ubuntu@22.04",
+        "project-id":"42424242",
+        "status":"Ready",
+        "sdks":[{
+            "name":"sketch",
+            "channel":"",
+            "revision":"x1",
+            "install-time":"2017-03-22T09:01:00.0Z"
+        }]
+        },{
+        "name":"nosketch",
+        "base":"ubuntu@22.04",
+        "project-id":"42424242",
+        "status":"Ready"
+        },{
+        "name":"both",
+        "base":"ubuntu@22.04",
+        "project-id":"42424242",
+        "status":"Ready",
+        "sdks":[{
+            "name":"sketch",
+            "channel":"",
+            "revision":"x3",
+            "install-time":"2017-03-22T09:01:00.0Z"
+        }]
+        },{
+        "name":"none",
+        "base":"ubuntu@22.04",
+        "project-id":"42424242",
+        "status":"Ready"
+    }]
+},
+"warning-timestamp":"2017-03-22T10:01:00.0Z",
+"warning-count":1}`
 
 var simpleSketchMeta = `name: sketch
 base: ubuntu@22.04

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -23,6 +23,7 @@ type workshopSketch struct {
 
 var _ = check.Suite(&workshopSketch{})
 
+var mockWorkshopWithSdksReady = `{"type":"sync","status-code":200,"status":"OK","result":{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready","sdks":[{"name":"go","version":"1.8.0","channel":"latest/edge","revision":"1","build-time":"2017-02-19T17:23:05.592623Z","install-time":"2017-03-22T09:01:00.0Z"},{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}],"notes":["missing-project"],"path":"/home/project/.workshop/ws.yaml"},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
 var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK","result":{"workshops":[{"name":"ws","base":"ubuntu@22.04","project-id":"42424242","status":"Ready","sdks":[{"name":"sketch","channel":"","revision":"x1","install-time":"2017-03-22T09:01:00.0Z"}]},{"name":"nosketch","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"},{"name":"both","base":"ubuntu@22.04","project-id":"42424242","status":"Ready","sdks":[{"name":"sketch","channel":"","revision":"x3","install-time":"2017-03-22T09:01:00.0Z"}]},{"name":"none","base":"ubuntu@22.04","project-id":"42424242","status":"Ready"}]},"warning-timestamp":"2017-03-22T10:01:00.0Z","warning-count":1}`
 
 var simpleSketchMeta = `name: sketch
@@ -76,7 +77,7 @@ func (m *workshopSketch) mockSketchHappyRefreshPath(c *check.C, refreshname stri
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockWorkshopWithSdks)
+			fmt.Fprintln(w, mockWorkshopWithSdksReady)
 		case 4:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
@@ -252,7 +253,7 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockWorkshopWithSdks)
+			fmt.Fprintln(w, mockWorkshopWithSdksReady)
 		case 4, 9, 11, 14:
 			mode := "wait-on-error"
 			name := fmt.Sprintf("%s/sketch", workshop)
@@ -377,7 +378,7 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockSingleWorkshop)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
 		case 4:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
@@ -474,7 +475,7 @@ func (m *workshopSketch) TestRemoveRemovesSketch(c *check.C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			fmt.Fprintln(w, mockSingleWorkshop)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
 		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
@@ -548,4 +549,35 @@ func (m *workshopSketch) TestSketchesEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Assert(m.stdout.String(), check.Matches, "")
+}
+
+func (m *workshopSketch) TestSketchSdkWorkshopStatusNotReady(c *check.C) {
+	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
+
+	status := []string{"Pending", "Error", "Off", "Stopped"}
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3, 5, 7:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 4, 6, 8:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus(status[n/2-1]))
+		default:
+			c.Errorf("expected 8 calls, now on %d", n)
+		}
+	})
+
+	for i := 1; i <= len(status); i++ {
+		err := cmd.Run(nil, nil)
+		c.Assert(err, check.NotNil)
+		c.Assert(n, check.Equals, i*2)
+	}
 }

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -554,7 +554,7 @@ func (m *workshopSketch) TestSketchesEmpty(c *check.C) {
 func (m *workshopSketch) TestSketchSdkWorkshopStatusNotReady(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
 
-	status := []string{"Pending", "Error", "Off", "Stopped"}
+	status := []string{"Pending", "Error", "Stopped"}
 
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -21,10 +21,9 @@ const (
 	PendingStatus
 	ErrorStatus
 	StoppedStatus
-	OffStatus
 )
 
-var knownStatuses = []string{"Unknown", "Ready", "Pending", "Error", "Stopped", "Off"}
+var knownStatuses = []string{"Unknown", "Ready", "Pending", "Error", "Stopped"}
 
 func StatusLookup(str string) (Status, error) {
 	switch str {
@@ -38,8 +37,6 @@ func StatusLookup(str string) (Status, error) {
 		return ErrorStatus, nil
 	case "stopped":
 		return StoppedStatus, nil
-	case "off":
-		return OffStatus, nil
 	}
 
 	return -1, fmt.Errorf("invalid status %q, must be one of %s",

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -280,7 +280,7 @@ func (s *managerSuite) TestCheckStatusReady(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.OffStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
 	c.Assert(err, check.ErrorMatches, "workshop already running")
 }
 
@@ -302,7 +302,7 @@ func (s *managerSuite) TestCheckStatusPending(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.OffStatus, healthstate.ReadyStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
 	c.Assert(err, testutil.ErrorIs, workshopstate.ErrWaitingOnError)
 }
 
@@ -317,7 +317,7 @@ func (s *managerSuite) TestCheckStatusError(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.OffStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
 	c.Assert(err, check.ErrorMatches, "workshop is unhealthy")
 }
 
@@ -332,6 +332,6 @@ func (s *managerSuite) TestCheckStatusStopped(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.OffStatus, healthstate.PendingStatus, healthstate.ErrorStatus, healthstate.UnknownStatus})
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.ErrorStatus, healthstate.UnknownStatus})
 	c.Assert(err, check.ErrorMatches, "workshop not running")
 }


### PR DESCRIPTION
# Description
Fixes two small issues:
- If a workshop is stopped during a sketch, the subsequent partial refresh will fail (workshop is not running)
- If a workshop is pending during a sketch, the current wait will be aborted (due to sketch auto-aborting)

# Self review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
