### PR TITLE
Fix sshAgent and Desktop profile equality checks

### DIFF
--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -96,20 +96,32 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	}
 
 	if wayland != "" {
-		desktop.Wayland = &workshop.ProxyEntry{}
-		desktop.Wayland.Name = plug.Sdk().Name + "-" + "wayland"
-		desktop.Wayland.Connect = filepath.Join(xdg, wayland)
-		desktop.Wayland.Listen = filepath.Join("/run/user/1000/", wayland)
+		desktop.Wayland = &workshop.ProxyEntry{
+			Name: plug.Sdk().Name + "-" + "wayland",
+			Connect: workshop.ProxyTarget{
+				Address:  filepath.Join(xdg, wayland),
+				Protocol: "unix",
+			},
+			Listen: workshop.ProxyTarget{
+				Address:  filepath.Join("/run/user/1000/", wayland),
+				Protocol: "unix",
+			},
+		}
 	}
 
 	// We pass through the X11 socket regardless of whether XAUTHORITY is present
 	// on the host. This then gives users the option to modify their xhost
 	// settings to allow connections from the container and container user.
 	if display != "" {
-		desktop.X11 = &workshop.ProxyEntry{}
-		desktop.X11.Name = plug.Sdk().Name + "-" + "x11"
-		desktop.X11.Connect = filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":"))
-		desktop.X11.Listen = desktop.X11.Connect
+		proxyTarget := workshop.ProxyTarget{
+			Address:  filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":")),
+			Protocol: "unix",
+		}
+		desktop.X11 = &workshop.ProxyEntry{
+			Name:    plug.Sdk().Name + "-" + "x11",
+			Connect: proxyTarget,
+			Listen:  proxyTarget,
+		}
 	}
 
 	// We mount the Xauthority inside a parent folder to ensure that the mounted

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -4,13 +4,14 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"gopkg.in/check.v1"
+
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
-	"gopkg.in/check.v1"
 )
 
 type desktopSuite struct {
@@ -76,11 +77,15 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedProxy := &workshop.Desktop{}
-	expectedProxy.Wayland = &workshop.ProxyEntry{}
-	expectedProxy.Wayland.Name = "consumer-wayland"
-	expectedProxy.Wayland.Connect = "/tmp/wayland-1"
-	expectedProxy.Wayland.Listen = "/run/user/1000/wayland-1"
+	expectedProxy := &workshop.Desktop{
+		Wayland: &workshop.ProxyEntry{
+			Name: "consumer-wayland",
+			Connect: workshop.ProxyTarget{
+				Address:  "/tmp/wayland-1",
+				Protocol: "unix"},
+			Listen: workshop.ProxyTarget{
+				Address:  "/run/user/1000/wayland-1",
+				Protocol: "unix"}}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 
@@ -108,11 +113,15 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedProxy := &workshop.Desktop{}
-	expectedProxy.X11 = &workshop.ProxyEntry{}
-	expectedProxy.X11.Name = "consumer-x11"
-	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
-	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
+	expectedProxy := &workshop.Desktop{
+		X11: &workshop.ProxyEntry{
+			Name: "consumer-x11",
+			Connect: workshop.ProxyTarget{
+				Address:  "/tmp/.X11-unix/X0",
+				Protocol: "unix"},
+			Listen: workshop.ProxyTarget{
+				Address:  "/tmp/.X11-unix/X0",
+				Protocol: "unix"}}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 
@@ -141,15 +150,23 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedProxy := &workshop.Desktop{}
-	expectedProxy.Wayland = &workshop.ProxyEntry{}
-	expectedProxy.X11 = &workshop.ProxyEntry{}
-	expectedProxy.Wayland.Name = "consumer-wayland"
-	expectedProxy.Wayland.Connect = "/tmp/wayland-0"
-	expectedProxy.Wayland.Listen = "/run/user/1000/wayland-0"
-	expectedProxy.X11.Name = "consumer-x11"
-	expectedProxy.X11.Connect = "/tmp/.X11-unix/X0"
-	expectedProxy.X11.Listen = "/tmp/.X11-unix/X0"
+	expectedProxy := &workshop.Desktop{
+		X11: &workshop.ProxyEntry{
+			Name: "consumer-x11",
+			Connect: workshop.ProxyTarget{
+				Address:  "/tmp/.X11-unix/X0",
+				Protocol: "unix"},
+			Listen: workshop.ProxyTarget{
+				Address:  "/tmp/.X11-unix/X0",
+				Protocol: "unix"}},
+		Wayland: &workshop.ProxyEntry{
+			Name: "consumer-wayland",
+			Connect: workshop.ProxyTarget{
+				Address:  "/tmp/wayland-0",
+				Protocol: "unix"},
+			Listen: workshop.ProxyTarget{
+				Address:  "/run/user/1000/wayland-0",
+				Protocol: "unix"}}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -90,7 +90,19 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 	fromSocket := sock
 	toSocket := filepath.Join(dirs.WorkshopRunDir, name+".ssh")
 
-	return spec.SetSshAgent(workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: name, Connect: fromSocket, Listen: toSocket}})
+	return spec.SetSshAgent(workshop.SshAgent{
+		ProxyEntry: workshop.ProxyEntry{
+			Name: name,
+			Connect: workshop.ProxyTarget{
+				Address:  fromSocket,
+				Protocol: "unix",
+			},
+			Listen: workshop.ProxyTarget{
+				Address:  toSocket,
+				Protocol: "unix",
+			},
+		},
+	})
 }
 
 func init() {

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -73,7 +73,17 @@ exit 0`)
 	defer fake.Restore()
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedProxy := &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: "consumer-" + plug.Name, Connect: "/tmp/dir/ssh", Listen: "/var/lib/workshop/run/consumer-ssh-agent.ssh"}}
+	expectedProxy := &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{
+		Name: "consumer-" + plug.Name,
+		Connect: workshop.ProxyTarget{
+			Address:  "/tmp/dir/ssh",
+			Protocol: "unix",
+		},
+		Listen: workshop.ProxyTarget{
+			Address:  "/var/lib/workshop/run/consumer-ssh-agent.ssh",
+			Protocol: "unix",
+		},
+	}}
 	c.Assert(deviceSpec.Profile.Agent, check.DeepEquals, expectedProxy)
 }
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -311,6 +311,7 @@ func removeDesktop(fs workshop.WorkshopFs) error {
 		}
 	}
 
+	// The Xauth cookie may not always exist. Ignore any errors relating to this
 	if err := fs.Remove("/tmp/.Xauthority"); err != nil {
 		if !errors.Is(err, afero.ErrFileNotFound) {
 			return err
@@ -409,20 +410,19 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 				}
 			}
 		}
-		if prevp.Agent != nil {
-			if spec.Profile.Agent == nil || *prevp.Agent != *spec.Profile.Agent {
-				if err = removeSshAgent(fs, *prevp.Agent); err != nil {
-					return err
-				}
+
+		if prevp.Agent != nil && !prevp.Agent.Equal(spec.Profile.Agent) {
+			if err = removeSshAgent(fs, *prevp.Agent); err != nil {
+				return err
 			}
 		}
-		if prevp.Desktop != nil {
-			if spec.Profile.Desktop == nil || *prevp.Desktop != *spec.Profile.Desktop {
-				if err = removeDesktop(fs); err != nil {
-					return err
-				}
+
+		if prevp.Desktop != nil && !prevp.Desktop.Equal(spec.Profile.Desktop) {
+			if err = removeDesktop(fs); err != nil {
+				return err
 			}
 		}
+
 		return conn.UpdateProfile(name, newp, "")
 	}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -225,7 +225,7 @@ func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop str
 	}
 	defer env.Close()
 
-	varline := fmt.Sprintln("export SSH_AUTH_SOCK=" + strings.TrimPrefix(dev.Listen, "unix:"))
+	varline := fmt.Sprintln("export SSH_AUTH_SOCK=" + strings.TrimPrefix(dev.Listen.Address, "unix:"))
 	_, err = env.Write([]byte(varline))
 	if err != nil {
 		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
@@ -268,11 +268,11 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	}
 
 	if dev.Wayland != nil {
-		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen, "/run/user/1000/")
+		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen.Address, "/run/user/1000/")
 	}
 
 	if dev.X11 != nil {
-		envVars["DISPLAY"] = ":" + strings.TrimPrefix(filepath.Base(dev.X11.Listen), "X")
+		envVars["DISPLAY"] = ":" + strings.TrimPrefix(filepath.Base(dev.X11.Listen.Address), "X")
 	}
 
 	// The .Xauthority cookie contains a 128bit key used to authenticate consumers

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -306,9 +306,7 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 
 func removeDesktop(fs workshop.WorkshopFs) error {
 	if err := fs.Remove("/etc/profile.d/desktop.sh"); err != nil {
-		if !errors.Is(err, afero.ErrFileNotFound) {
-			return err
-		}
+		return err
 	}
 
 	// The Xauth cookie may not always exist. Ignore any errors relating to this

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -172,8 +172,8 @@ func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey stri
 	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, entry.Name)] = configKey
 	s.devices[entry.Name] = map[string]string{
 		"type":    "proxy",
-		"connect": "unix:" + entry.Connect,
-		"listen":  "unix:" + entry.Listen,
+		"connect": entry.Connect.Protocol + ":" + entry.Connect.Address,
+		"listen":  entry.Listen.Protocol + ":" + entry.Listen.Address,
 		"uid":     "1000",
 		"gid":     "1000",
 		"bind":    "instance",

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -365,8 +365,10 @@ exit 0
 	c.Assert(err, check.IsNil)
 	c.Assert(prof.Agent, check.NotNil)
 	c.Check(prof.Agent.Name, check.Equals, "consumer-ssh-agent")
-	c.Check(prof.Agent.Connect, check.Equals, "/run/.workshop.socket")
-	c.Check(prof.Agent.Listen, check.Equals, "/run/consumer-ssh-agent.ssh")
+	c.Check(prof.Agent.Connect.Address, check.Equals, "/run/.workshop.socket")
+	c.Check(prof.Agent.Connect.Protocol, check.Equals, "unix")
+	c.Check(prof.Agent.Listen.Address, check.Equals, "/run/consumer-ssh-agent.ssh")
+	c.Check(prof.Agent.Listen.Protocol, check.Equals, "unix")
 
 	buf := f.readWorkshopFile(c, "/etc/profile.d/consumer-ssh-agent.sh")
 	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/consumer-ssh-agent.ssh\n")

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -129,6 +129,8 @@ plugs:
         workshop-target: /mnt
     ssh-agent:
         interface: ssh-agent
+    desktop:
+        interface: desktop
 `)
 
 var producer = []byte(`name: producer
@@ -143,6 +145,8 @@ slots:
         workshop-source: /home
     ssh-agent:
         interface: ssh-agent
+    desktop:
+        interface: desktop
 `)
 
 var producer2 = []byte(`name: producer2
@@ -325,11 +329,7 @@ func (f *backendDeviceSuite) TestSetupUpdateProfile(c *check.C) {
 
 func (f *backendDeviceSuite) TestSetupSshAgent(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-	old := dirs.WorkshopRunDir
-	dirs.WorkshopRunDir = "/run"
-	defer func() {
-		dirs.WorkshopRunDir = old
-	}()
+	defer mockWorkshopRunDir()()
 
 	cinfo, err := sdk.ReadSdkInfo(consumer, f.pid, "test")
 	c.Assert(err, check.IsNil)
@@ -365,8 +365,8 @@ exit 0
 	c.Assert(err, check.IsNil)
 	c.Assert(prof.Agent, check.NotNil)
 	c.Check(prof.Agent.Name, check.Equals, "consumer-ssh-agent")
-	c.Check(prof.Agent.Connect, check.Equals, "unix:/run/.workshop.socket")
-	c.Check(prof.Agent.Listen, check.Equals, "unix:/run/consumer-ssh-agent.ssh")
+	c.Check(prof.Agent.Connect, check.Equals, "/run/.workshop.socket")
+	c.Check(prof.Agent.Listen, check.Equals, "/run/consumer-ssh-agent.ssh")
 
 	buf := f.readWorkshopFile(c, "/etc/profile.d/consumer-ssh-agent.sh")
 	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/consumer-ssh-agent.ssh\n")
@@ -381,4 +381,97 @@ exit 0
 	c.Assert(err, check.IsNil)
 	_, err = fs.Stat("/etc/profile.d/consumer-ssh-agent.sh")
 	c.Assert(osutil.IsDirNotExist(err), check.Equals, true)
+}
+
+func (f *backendDeviceSuite) TestSetupMultipleInterfaces(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+	defer mockWorkshopRunDir()()
+
+	cinfo, err := sdk.ReadSdkInfo(consumer, f.pid, "test")
+	c.Assert(err, check.IsNil)
+
+	pinfo, err := sdk.ReadSdkInfo(producer, f.pid, "test")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(f.repo.AddSdk(cinfo), check.IsNil)
+	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
+
+	sshConnRef := &interfaces.ConnRef{
+		PlugRef: cinfo.Plugs["ssh-agent"].Ref(),
+		SlotRef: pinfo.Slots["ssh-agent"].Ref(),
+	}
+
+	desktopConnRef := &interfaces.ConnRef{
+		PlugRef: cinfo.Plugs["desktop"].Ref(),
+		SlotRef: pinfo.Slots["desktop"].Ref(),
+	}
+
+	b := lxd_device.Backend{}
+	cref := sdk.Ref{ProjectId: "42424242", Workshop: "test", Sdk: "consumer"}
+
+	systemdCmd := testutil.FakeCommand(c, "sudo", `
+echo XDG_RUNTIME_DIR=/run/user/1000
+echo SSH_AUTH_SOCK=/run/.workshop.socket
+echo DISPLAY=:0
+echo WAYLAND_DISPLAY=1
+exit 0
+`)
+	defer systemdCmd.Restore()
+
+	setupSshAgent := func() {
+		_, err = f.repo.Connect(sshConnRef, nil, nil, nil, nil, nil)
+		c.Assert(err, check.IsNil)
+		err = b.Setup(f.ctx, cref, f.repo)
+		c.Assert(err, check.IsNil)
+	}
+
+	setupDesktop := func() {
+		_, err = f.repo.Connect(desktopConnRef, nil, nil, nil, nil, nil)
+		c.Assert(err, check.IsNil)
+		err = b.Setup(f.ctx, cref, f.repo)
+		c.Assert(err, check.IsNil)
+	}
+
+	validateAndDisconnect := func() {
+		// Validate Profile
+		prof, err := lxdbackend.Profile(f.client, f.pid, "test", "consumer")
+		c.Assert(err, check.IsNil)
+
+		c.Assert(prof.Agent, check.NotNil)
+		c.Assert(prof.Desktop, check.NotNil)
+
+		// Validate Filesystem
+		fs, err := f.be.WorkshopFs(f.ctx, "test")
+		c.Assert(err, check.IsNil)
+		_, err = fs.Stat("/etc/profile.d/consumer-ssh-agent.sh")
+		c.Assert(err, check.IsNil)
+		_, err = fs.Stat("/etc/profile.d/desktop.sh")
+		c.Assert(err, check.IsNil)
+
+		// Disconnect and setup
+		f.repo.DisconnectAll([]*interfaces.ConnRef{sshConnRef, desktopConnRef})
+		err = b.Setup(f.ctx, cref, f.repo)
+		c.Assert(err, check.IsNil)
+		_, err = fs.Stat("/etc/profile.d/consumer-ssh-agent.sh")
+		c.Assert(err, check.NotNil)
+		_, err = fs.Stat("/etc/profile.d/desktop.sh")
+		c.Assert(err, check.NotNil)
+	}
+
+	setupSshAgent()
+	setupDesktop()
+	validateAndDisconnect()
+
+	// Repeat with interfaces in reverse order
+	setupDesktop()
+	setupSshAgent()
+	validateAndDisconnect()
+}
+
+func mockWorkshopRunDir() (restore func()) {
+	old := dirs.WorkshopRunDir
+	dirs.WorkshopRunDir = "/run"
+	return func() {
+		dirs.WorkshopRunDir = old
+	}
 }

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -8,10 +8,15 @@ const (
 	Volume
 )
 
+type ProxyTarget struct {
+	Address  string
+	Protocol string
+}
+
 type ProxyEntry struct {
 	Name    string
-	Connect string
-	Listen  string
+	Connect ProxyTarget
+	Listen  ProxyTarget
 }
 
 type Camera struct {
@@ -71,4 +76,3 @@ func NewSdkProfile(sdkName string) SdkProfile {
 		Mounts: make(map[string]Mount),
 	}
 }
-

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -30,9 +30,25 @@ type SshAgent struct {
 	ProxyEntry
 }
 
+func (s *SshAgent) Equal(other *SshAgent) bool {
+	if s == nil || other == nil {
+		return s == other
+	}
+
+	return *s == *other
+}
+
 type Desktop struct {
 	Wayland *ProxyEntry
 	X11     *ProxyEntry
+}
+
+func (d *Desktop) Equal(other *Desktop) bool {
+	if d == nil || other == nil {
+		return d == other
+	}
+
+	return *d.Wayland == *other.Wayland && *d.X11 == *other.X11
 }
 
 type Gpu struct {
@@ -55,3 +71,4 @@ func NewSdkProfile(sdkName string) SdkProfile {
 		Mounts: make(map[string]Mount),
 	}
 }
+

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -50,17 +50,29 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			devtype := config[DeviceTypeConfigKey(profile, name)]
 			switch devtype {
 			case "ssh-agent":
-				pr.Agent = &workshop.SshAgent{ProxyEntry: *proxyEntryFromLxdDevice(name, dev)}
+				proxyEntry, err := proxyEntryFromLxdDevice(name, dev)
+				if err != nil {
+					return pr, err
+				}
+				pr.Agent = &workshop.SshAgent{ProxyEntry: *proxyEntry}
 			case "desktop-wayland":
 				if pr.Desktop == nil {
 					pr.Desktop = &workshop.Desktop{}
 				}
-				pr.Desktop.Wayland = proxyEntryFromLxdDevice(name, dev)
+				proxyEntry, err := proxyEntryFromLxdDevice(name, dev)
+				if err != nil {
+					return pr, err
+				}
+				pr.Desktop.Wayland = proxyEntry
 			case "desktop-x11":
 				if pr.Desktop == nil {
 					pr.Desktop = &workshop.Desktop{}
 				}
-				pr.Desktop.X11 = proxyEntryFromLxdDevice(name, dev)
+				proxyEntry, err := proxyEntryFromLxdDevice(name, dev)
+				if err != nil {
+					return pr, err
+				}
+				pr.Desktop.X11 = proxyEntry
 			default:
 				logger.Noticef("On reading %q SDK profile: unknown device type: %q", profile, devtype)
 			}
@@ -102,12 +114,26 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 	return pr, nil
 }
 
-// Constructs a ProxyEntry from an LXD device entry. Removes the 'unix:' prefix
-// if present.
-func proxyEntryFromLxdDevice(name string, dev map[string]string) *workshop.ProxyEntry {
-	return &workshop.ProxyEntry{
-		Name:    name,
-		Connect: strings.TrimPrefix(dev["connect"], "unix:"),
-		Listen:  strings.TrimPrefix(dev["listen"], "unix:"),
+// Constructs a ProxyEntry from an LXD device entry
+func proxyEntryFromLxdDevice(name string, dev map[string]string) (*workshop.ProxyEntry, error) {
+	connect := strings.SplitN(dev["connect"], ":", 2)
+	listen := strings.SplitN(dev["listen"], ":", 2)
+	if len(connect) != 2 {
+		return nil, fmt.Errorf("internal error: cannot deserialise proxy device in lxd profile: connect entry %q invalid", connect)
 	}
+	if len(listen) != 2 {
+		return nil, fmt.Errorf("internal error: cannot deserialise proxy device in lxd profile: listen entry %q invalid", listen)
+	}
+
+	return &workshop.ProxyEntry{
+		Name: name,
+		Connect: workshop.ProxyTarget{
+			Address:  connect[1],
+			Protocol: connect[0],
+		},
+		Listen: workshop.ProxyTarget{
+			Address:  listen[1],
+			Protocol: listen[0],
+		},
+	}, nil
 }

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -50,17 +50,17 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			devtype := config[DeviceTypeConfigKey(profile, name)]
 			switch devtype {
 			case "ssh-agent":
-				pr.Agent = &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: name, Connect: dev["connect"], Listen: dev["listen"]}}
+				pr.Agent = &workshop.SshAgent{ProxyEntry: *proxyEntryFromLxdDevice(name, dev)}
 			case "desktop-wayland":
 				if pr.Desktop == nil {
 					pr.Desktop = &workshop.Desktop{}
 				}
-				pr.Desktop.Wayland = &workshop.ProxyEntry{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
+				pr.Desktop.Wayland = proxyEntryFromLxdDevice(name, dev)
 			case "desktop-x11":
 				if pr.Desktop == nil {
 					pr.Desktop = &workshop.Desktop{}
 				}
-				pr.Desktop.X11 = &workshop.ProxyEntry{Name: name, Connect: dev["connect"], Listen: dev["listen"]}
+				pr.Desktop.X11 = proxyEntryFromLxdDevice(name, dev)
 			default:
 				logger.Noticef("On reading %q SDK profile: unknown device type: %q", profile, devtype)
 			}
@@ -100,4 +100,14 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 		}
 	}
 	return pr, nil
+}
+
+// Constructs a ProxyEntry from an LXD device entry. Removes the 'unix:' prefix
+// if present.
+func proxyEntryFromLxdDevice(name string, dev map[string]string) *workshop.ProxyEntry {
+	return &workshop.ProxyEntry{
+		Name:    name,
+		Connect: strings.TrimPrefix(dev["connect"], "unix:"),
+		Listen:  strings.TrimPrefix(dev["listen"], "unix:"),
+	}
 }

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -18,8 +18,8 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		{Sdk: "sdk", Camera: &workshop.Camera{Name: "camera"}, Mounts: map[string]workshop.Mount{}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Gpu: &workshop.Gpu{Name: "gpu"}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"userdisk": {Name: "userdisk", What: "/home", Where: "/opt", Type: workshop.HostWorkshop}}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: "ssh-agent", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Desktop: &workshop.Desktop{Wayland: &workshop.ProxyEntry{Name: "desktop", Connect: "unix:.host.socket", Listen: "unix:.workshop.socket"}}},
+		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: "ssh-agent", Connect: ".host.socket", Listen: ".workshop.socket"}}},
+		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Desktop: &workshop.Desktop{Wayland: &workshop.ProxyEntry{Name: "desktop", Connect: ".host.socket", Listen: ".workshop.socket"}}},
 		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"plug": {Name: "plug", What: "/var", Where: "/etc", Type: workshop.WorkshopWorkshop}}},
 	}
 

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -15,12 +15,56 @@ var _ = check.Suite(&ProfileSuite{})
 
 func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 	expected := []workshop.SdkProfile{
-		{Sdk: "sdk", Camera: &workshop.Camera{Name: "camera"}, Mounts: map[string]workshop.Mount{}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Gpu: &workshop.Gpu{Name: "gpu"}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"userdisk": {Name: "userdisk", What: "/home", Where: "/opt", Type: workshop.HostWorkshop}}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Agent: &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{Name: "ssh-agent", Connect: ".host.socket", Listen: ".workshop.socket"}}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{}, Desktop: &workshop.Desktop{Wayland: &workshop.ProxyEntry{Name: "desktop", Connect: ".host.socket", Listen: ".workshop.socket"}}},
-		{Sdk: "sdk", Mounts: map[string]workshop.Mount{"plug": {Name: "plug", What: "/var", Where: "/etc", Type: workshop.WorkshopWorkshop}}},
+		{
+			Sdk:    "sdk",
+			Camera: &workshop.Camera{Name: "camera"},
+			Mounts: map[string]workshop.Mount{},
+		}, {
+			Sdk:    "sdk",
+			Mounts: map[string]workshop.Mount{},
+			Gpu:    &workshop.Gpu{Name: "gpu"},
+		}, {
+			Sdk: "sdk",
+			Mounts: map[string]workshop.Mount{
+				"userdisk": {
+					Name:  "userdisk",
+					What:  "/home",
+					Where: "/opt",
+					Type:  workshop.HostWorkshop}},
+		}, {
+			Sdk:    "sdk",
+			Mounts: map[string]workshop.Mount{},
+			Agent: &workshop.SshAgent{
+				ProxyEntry: workshop.ProxyEntry{
+					Name: "ssh-agent",
+					Connect: workshop.ProxyTarget{
+						Address:  ".host.socket",
+						Protocol: "unix",
+					},
+					Listen: workshop.ProxyTarget{
+						Address:  ".workshop.socket",
+						Protocol: "unix"}}},
+		}, {
+			Sdk:    "sdk",
+			Mounts: map[string]workshop.Mount{},
+			Desktop: &workshop.Desktop{
+				Wayland: &workshop.ProxyEntry{
+					Name: "desktop",
+					Connect: workshop.ProxyTarget{
+						Address:  ".host.socket",
+						Protocol: "unix",
+					},
+					Listen: workshop.ProxyTarget{
+						Address:  ".workshop.socket",
+						Protocol: "unix"}}},
+		}, {
+			Sdk: "sdk",
+			Mounts: map[string]workshop.Mount{
+				"plug": {
+					Name:  "plug",
+					What:  "/var",
+					Where: "/etc",
+					Type:  workshop.WorkshopWorkshop}}},
 	}
 
 	for i, t := range []struct {
@@ -28,12 +72,79 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		devs map[string]map[string]string
 		cfg  map[string]string
 	}{
-		{"sdk", map[string]map[string]string{"camera": {"type": "none"}, "camera/video0": {"type": "unix-char", "source": "/dev/video0", "path": "/dev/video0", "required": "false", "uid": "1000", "gid": "1000"}}, map[string]string{"user.workshop.sdk.camera": `{"name": "camera"}`, "user.workshop.sdk.camera.type": "camera", "user.workshop.sdk.camera/video0.type": "camera"}},
-		{"sdk", map[string]map[string]string{"gpu": {"type": "gpu", "gputype": "physical", "uid": "1000", "gid": "1000"}}, map[string]string{}},
-		{"sdk", map[string]map[string]string{"userdisk": {"type": "disk", "source": "/home", "path": "/opt"}}, map[string]string{}},
-		{"sdk", map[string]map[string]string{"ssh-agent": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{"user.workshop.sdk.ssh-agent.type": "ssh-agent"}},
-		{"sdk", map[string]map[string]string{"desktop": {"type": "proxy", "connect": "unix:.host.socket", "listen": "unix:.workshop.socket", "uid": "1000", "gid": "1000", "bind": "instance"}}, map[string]string{"user.workshop.sdk.desktop.type": "desktop-wayland"}},
-		{"sdk", map[string]map[string]string{"plug": {"type": "none"}}, map[string]string{"user.workshop.sdk.plug": `{"name": "plug", "what": "/var", "where": "/etc", "type": 1}`, "user.workshop.sdk.plug.type": "mount"}},
+		{
+			"sdk",
+			map[string]map[string]string{
+				"camera": {
+					"type": "none",
+				},
+				"camera/video0": {
+					"type":     "unix-char",
+					"source":   "/dev/video0",
+					"path":     "/dev/video0",
+					"required": "false",
+					"uid":      "1000",
+					"gid":      "1000"}},
+			map[string]string{
+				"user.workshop.sdk.camera": `{
+          "name": "camera"
+        }`,
+				"user.workshop.sdk.camera.type":        "camera",
+				"user.workshop.sdk.camera/video0.type": "camera"},
+		}, {
+			"sdk",
+			map[string]map[string]string{
+				"gpu": {
+					"type":    "gpu",
+					"gputype": "physical",
+					"uid":     "1000",
+					"gid":     "1000"}},
+			map[string]string{},
+		}, {
+			"sdk",
+			map[string]map[string]string{
+				"userdisk": {
+					"type":   "disk",
+					"source": "/home",
+					"path":   "/opt"}},
+			map[string]string{},
+		}, {
+			"sdk",
+			map[string]map[string]string{
+				"ssh-agent": {
+					"type":    "proxy",
+					"connect": "unix:.host.socket",
+					"listen":  "unix:.workshop.socket",
+					"uid":     "1000",
+					"gid":     "1000",
+					"bind":    "instance"}},
+			map[string]string{
+				"user.workshop.sdk.ssh-agent.type": "ssh-agent"},
+		}, {
+			"sdk",
+			map[string]map[string]string{
+				"desktop": {
+					"type":    "proxy",
+					"connect": "unix:.host.socket",
+					"listen":  "unix:.workshop.socket",
+					"uid":     "1000",
+					"gid":     "1000",
+					"bind":    "instance"}},
+			map[string]string{
+				"user.workshop.sdk.desktop.type": "desktop-wayland"},
+		}, {
+			"sdk",
+			map[string]map[string]string{
+				"plug": {
+					"type": "none"}},
+			map[string]string{
+				"user.workshop.sdk.plug": `{
+          "name": "plug",
+          "what": "/var",
+          "where": "/etc", 
+          "type": 1}`,
+				"user.workshop.sdk.plug.type": "mount"},
+		},
 	} {
 		res, err := lxdbackend.LxdToSdkProfile(t.name, t.devs, t.cfg)
 		c.Assert(err, check.IsNil)


### PR DESCRIPTION
# Description
As reproduced and solved by Dmitry, connecting sshAgent and Desktop in a workshop would result in the former having it's remove logic executed. This fixes the equality check causing this behavior. 

This also modifies the desktop removal logic to return an error in cases where the `profile.d` entry no longer exists. This now matches the behavior of ssh-agent.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
