### PR TITLE
Move PlugRef and SlotRef to sdk package

### DIFF
--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -33,6 +33,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -43,7 +44,7 @@ type collectFilter struct {
 	connected bool
 }
 
-func (c *collectFilter) plugOrConnectedSlotMatches(plug *interfaces.PlugRef, connectedSlots []interfaces.SlotRef) bool {
+func (c *collectFilter) plugOrConnectedSlotMatches(plug *sdk.PlugRef, connectedSlots []sdk.SlotRef) bool {
 	for _, slot := range connectedSlots {
 		if c.slotOrConnectedPlugMatches(&slot, nil) {
 			return true
@@ -55,7 +56,7 @@ func (c *collectFilter) plugOrConnectedSlotMatches(plug *interfaces.PlugRef, con
 	return true
 }
 
-func (c *collectFilter) slotOrConnectedPlugMatches(slot *interfaces.SlotRef, connectedPlugs []interfaces.PlugRef) bool {
+func (c *collectFilter) slotOrConnectedPlugMatches(slot *sdk.SlotRef, connectedPlugs []sdk.PlugRef) bool {
 	for _, plug := range connectedPlugs {
 		if c.plugOrConnectedSlotMatches(&plug, nil) {
 			return true
@@ -74,7 +75,7 @@ func (c *collectFilter) ifaceMatches(ifaceName string) bool {
 	return true
 }
 
-type bySlotRef []interfaces.SlotRef
+type bySlotRef []sdk.SlotRef
 
 func (b bySlotRef) Len() int      { return len(b) }
 func (b bySlotRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
@@ -82,7 +83,7 @@ func (b bySlotRef) Less(i, j int) bool {
 	return b[i].SortsBefore(b[j])
 }
 
-type byPlugRef []interfaces.PlugRef
+type byPlugRef []sdk.PlugRef
 
 func (b byPlugRef) Len() int      { return len(b) }
 func (b byPlugRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
@@ -109,8 +110,8 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 
 	var connsjson connectionsJSON
 	var connStates map[string]ifacestate.ConnectionState
-	plugConns := map[string][]interfaces.SlotRef{}
-	slotConns := map[string][]interfaces.PlugRef{}
+	plugConns := map[string][]sdk.SlotRef{}
+	slotConns := map[string][]sdk.PlugRef{}
 
 	var err error
 	connStates, err = ifaceMgr.ConnectionStates()
@@ -143,8 +144,8 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 		if !filter.ifaceMatches(cstate.Interface) {
 			continue
 		}
-		plugRef := interfaces.PlugRef{ProjectId: cref.PlugRef.ProjectId, Workshop: cref.PlugRef.Workshop, Sdk: cref.PlugRef.Sdk, Name: cref.PlugRef.Name}
-		slotRef := interfaces.SlotRef{ProjectId: cref.SlotRef.ProjectId, Workshop: cref.SlotRef.Workshop, Sdk: cref.SlotRef.Sdk, Name: cref.SlotRef.Name}
+		plugRef := cref.PlugRef
+		slotRef := cref.SlotRef
 		plugID := plugRef.String()
 		slotID := slotRef.String()
 
@@ -169,7 +170,7 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 	}
 
 	for _, plug := range ifaces.Plugs {
-		plugRef := interfaces.PlugRef{ProjectId: plug.Sdk.ProjectId, Workshop: plug.Sdk.Workshop, Sdk: plug.Sdk.Name, Name: plug.Name}
+		plugRef := plug.Ref()
 		connectedSlots, connected := plugConns[plugRef.String()]
 		if !connected && filter.connected {
 			continue
@@ -178,14 +179,9 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 			continue
 		}
 		sort.Sort(bySlotRef(connectedSlots))
-		var bind *interfaces.PlugRef
+		var bind *sdk.PlugRef
 		if pb, ok := plug.Sdk.PlugBinds[plug.Name]; ok {
-			bind = &interfaces.PlugRef{
-				ProjectId: pb.ProjectId,
-				Workshop:  pb.Workshop,
-				Sdk:       pb.Sdk,
-				Name:      pb.Name,
-			}
+			bind = &pb
 		}
 		pj := &plugJSON{
 			ProjectId:   plugRef.ProjectId,
@@ -201,7 +197,7 @@ func collectConnections(ifaceMgr *ifacestate.InterfaceManager, filter collectFil
 		connsjson.Plugs = append(connsjson.Plugs, pj)
 	}
 	for _, slot := range ifaces.Slots {
-		slotRef := interfaces.SlotRef{ProjectId: slot.Sdk.ProjectId, Workshop: slot.Sdk.Workshop, Sdk: slot.Sdk.Name, Name: slot.Name}
+		slotRef := slot.Ref()
 		connectedPlugs, connected := slotConns[slotRef.String()]
 		if !connected && filter.connected {
 			continue

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -118,7 +118,7 @@ func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop
 
 func (s *apiSuite) mockInstalledSDKBoundPlug(c *check.C, yaml string, w string, from, to string) *workshop.Workshop {
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
-	info.PlugBinds[from] = &sdk.PlugBind{
+	info.PlugBinds[from] = sdk.PlugRef{
 		ProjectId: s.project.ProjectId,
 		Workshop:  w,
 		Sdk:       info.Name,
@@ -1106,8 +1106,8 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, check.HasLen, 1)
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{{
-		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}})
 }
 
@@ -1165,12 +1165,12 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 	c.Assert(ifaces.Connections, check.HasLen, 2)
 
 	mainConn := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}
 	boundConn := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug2"},
-		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug2"},
+		SlotRef: sdk.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{mainConn, boundConn})
 
@@ -1336,8 +1336,8 @@ func (s *apiSuite) TestConnectAlreadyConnected(c *check.C) {
 	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 	connRef := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}
 	st := d.Overlord().State()
 	st.Lock()
@@ -1440,8 +1440,8 @@ type disconnectOpts struct {
 func (s *apiSuite) connect(c *check.C, plug string) *interfaces.ConnRef {
 	repo := s.d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: plug},
-		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: plug},
+		SlotRef: sdk.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}
 	_, err := repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, check.IsNil)
@@ -1612,8 +1612,8 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 
 	repo := d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}
 	_, err := repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, check.IsNil)
@@ -1830,8 +1830,8 @@ func (s *apiSuite) TestDisconnectFailureOnConflict(c *check.C) {
 
 	repo := d.Overlord().InterfaceManager().Repository()
 	connRef := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
 	}
 	_, err := repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, check.IsNil)

--- a/internal/daemon/api_json.go
+++ b/internal/daemon/api_json.go
@@ -20,7 +20,7 @@
 package daemon
 
 import (
-	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 // plugJSON aids in marshaling snap.PlugInfo into JSON.
@@ -32,9 +32,9 @@ type plugJSON struct {
 	Interface string                 `json:"interface,omitempty"`
 	Attrs     map[string]interface{} `json:"attrs,omitempty"`
 	Label     string                 `json:"label,omitempty"`
-	Bind      *interfaces.PlugRef    `json:"bind,omitempty"`
+	Bind      *sdk.PlugRef    `json:"bind,omitempty"`
 	// Connections are synthesized, they are not on the original type.
-	Connections []interfaces.SlotRef `json:"connections,omitempty"`
+	Connections []sdk.SlotRef `json:"connections,omitempty"`
 }
 
 // slotJSON aids in marshaling snap.SlotInfo into JSON.
@@ -47,7 +47,7 @@ type slotJSON struct {
 	Attrs     map[string]interface{} `json:"attrs,omitempty"`
 	Label     string                 `json:"label,omitempty"`
 	// Connections are synthesized, they are not on the original type.
-	Connections []interfaces.PlugRef `json:"connections,omitempty"`
+	Connections []sdk.PlugRef `json:"connections,omitempty"`
 }
 
 // interfaceAction is an action performed on the interface system.
@@ -61,8 +61,8 @@ type interfaceAction struct {
 // connectionsJSON aids in marshalling information about a single connection
 // into JSON
 type connectionJSON struct {
-	Slot      interfaces.SlotRef     `json:"slot"`
-	Plug      interfaces.PlugRef     `json:"plug"`
+	Slot      sdk.SlotRef     `json:"slot"`
+	Plug      sdk.PlugRef     `json:"plug"`
 	Interface string                 `json:"interface"`
 	Manual    bool                   `json:"manual,omitempty"`
 	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -8,15 +8,15 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
 type mountRequest struct {
-	Action     string             `json:"action"`
-	Plug       interfaces.PlugRef `json:"plug"`
-	HostSource string             `json:"host-source"`
+	Action     string      `json:"action"`
+	Plug       sdk.PlugRef `json:"plug"`
+	HostSource string      `json:"host-source"`
 }
 
 func newMountChange(st *state.State, user string, reqData *mountRequest) *state.Change {

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -238,7 +238,7 @@ func (s *apiSuite) TestWorkshopRemountStaticSlotSourceFails(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "remount",
 			Summary:   `Remount workshopconns/test-sdk:data`,
-			ChangeErr: `(?s).*SDK "system" does not have attribute "host-source" for interface "mount".*`,
+			ChangeErr: `(?s).*attribute "host-source" not found for slot "workshopconns/system:training".*`,
 		},
 	}
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -95,11 +95,13 @@ func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo 
 	return &ws
 }
 
-func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health healthstate.HealthState, mounts map[string][]*Mount) *WorkshopInfo {
+func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health healthstate.HealthState) *WorkshopInfo {
 	var info WorkshopInfo
 	info.Name = w.Name
 	info.ProjectId = w.Project.ProjectId
 	info.Base = w.Base
+
+	mnts := w.Mounts(sdks)
 
 	for _, sk := range w.Sdks {
 		sdkInfo := sdks[sk.Name]
@@ -116,7 +118,8 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 			}
 		}
 
-		sdkMounts := mounts[sk.Name]
+		ref := sdk.Ref{ProjectId: info.ProjectId, Workshop: info.Name, Sdk: sk.Name}
+		mntInfos := mountInfos(ref, mnts[sk.Name])
 
 		info.Sdks = append(info.Sdks, &SdkInfo{
 			Name:        sk.Name,
@@ -126,7 +129,7 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 			BuildTime:   sdkInfo.BuildTime,
 			InstallTime: sk.InstallTime,
 			Health:      healthInfo,
-			Mounts:      sdkMounts,
+			Mounts:      mntInfos,
 		})
 	}
 
@@ -138,53 +141,33 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 	return &info
 }
 
-func mounts(w *workshop.Workshop, sdks map[string]*sdk.Info) (map[string][]*Mount, error) {
-	var mnts = map[string][]*Mount{}
+func mountInfos(sk sdk.Ref, mnts []workshop.Mount) []*Mount {
+	if mnts == nil {
+		return nil
+	}
 
-	masters := map[sdk.PlugRef][]sdk.PlugRef{}
-	for _, sk := range sdks {
-		for name, m := range sk.PlugBinds {
-			s := sdk.PlugRef{ProjectId: sk.ProjectId, Workshop: sk.Workshop, Sdk: sk.Name, Name: name}
-			masters[m] = append(masters[m], s)
+	infos := make([]*Mount, 0, len(mnts))
+	for _, mnt := range mnts {
+		pref := sdk.PlugRef{ProjectId: sk.ProjectId, Workshop: sk.Workshop, Sdk: sk.Sdk, Name: mnt.Name}
+		switch mnt.Type {
+		case workshop.HostWorkshop:
+			info := &Mount{
+				Plug:           pref,
+				HostSource:     mnt.What,
+				WorkshopTarget: mnt.Where,
+			}
+			infos = append(infos, info)
+		case workshop.WorkshopWorkshop:
+			info := &Mount{
+				Plug:           pref,
+				WorkshopSource: mnt.What,
+				WorkshopTarget: mnt.Where,
+			}
+			infos = append(infos, info)
 		}
 	}
 
-	for _, prof := range w.Profiles {
-		for _, dev := range prof.Mounts {
-			pref := sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: prof.Sdk, Name: dev.Name}
-
-			if dev.Type == workshop.HostWorkshop {
-				mnt := &Mount{
-					Plug:           pref,
-					HostSource:     dev.What,
-					WorkshopTarget: dev.Where,
-				}
-				mnts[prof.Sdk] = append(mnts[prof.Sdk], mnt)
-				if slaves, ok := masters[pref]; ok {
-					for _, slave := range slaves {
-						mnt := &Mount{
-							Plug:           slave,
-							HostSource:     dev.What,
-							WorkshopTarget: dev.Where,
-						}
-						mnts[slave.Sdk] = append(mnts[slave.Sdk], mnt)
-					}
-				}
-			}
-
-			if dev.Type == workshop.WorkshopWorkshop {
-				pref := sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: prof.Sdk, Name: dev.Name}
-				mnt := &Mount{
-					Plug:           pref,
-					WorkshopSource: dev.What,
-					WorkshopTarget: dev.Where,
-				}
-				mnts[prof.Sdk] = append(mnts[prof.Sdk], mnt)
-			}
-		}
-	}
-
-	return mnts, nil
+	return infos
 }
 
 func newWorkshopChange(st *state.State, kind string, user, projectId, action string, names []string) *state.Change {
@@ -242,7 +225,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	for _, w := range workshops {
 		health := wrkmgr.WorkshopHealth(w)
 		if ignoreStatus || health.Status == status {
-			wi := workshopToInfo(w, nil, health, nil)
+			wi := workshopToInfo(w, nil, health)
 			info.Workshops = append(info.Workshops, wi)
 		}
 	}
@@ -442,11 +425,7 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	if err != nil {
 		return statusBadRequest("%w", err)
 	}
-
-	ms, err := mounts(w, sdks)
-	if err != nil {
-		return statusBadRequest("%w", err)
-	}
+	info := workshopToInfo(w, sdks, health)
 
 	files, err := wrkmgr.WorkshopFiles(ctx, projectId)
 	if err != nil {
@@ -454,7 +433,7 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	rsp := Workshop{
-		WorkshopInfo: *workshopToInfo(w, sdks, health, ms),
+		WorkshopInfo: *info,
 		Path:         files[w.Name],
 	}
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -51,10 +50,10 @@ type SdkInfo struct {
 }
 
 type Mount struct {
-	Plug           interfaces.PlugRef `json:"plug"`
-	WorkshopSource string             `json:"workshop-source,omitempty"`
-	HostSource     string             `json:"host-source,omitempty"`
-	WorkshopTarget string             `json:"workshop-target,omitempty"`
+	Plug           sdk.PlugRef `json:"plug"`
+	WorkshopSource string      `json:"workshop-source,omitempty"`
+	HostSource     string      `json:"host-source,omitempty"`
+	WorkshopTarget string      `json:"workshop-target,omitempty"`
 }
 
 type Workshops struct {
@@ -142,25 +141,25 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 func mounts(w *workshop.Workshop, sdks map[string]*sdk.Info) (map[string][]*Mount, error) {
 	var mnts = map[string][]*Mount{}
 
-	masters := map[interfaces.PlugRef][]interfaces.PlugRef{}
+	masters := map[sdk.PlugRef][]sdk.PlugRef{}
 	for _, sk := range sdks {
-		for s, m := range sk.PlugBinds {
-			ref := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: m.Sdk, Name: m.Name}
-			sref := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: sk.Name, Name: s}
-			masters[ref] = append(masters[ref], sref)
+		for name, m := range sk.PlugBinds {
+			s := sdk.PlugRef{ProjectId: sk.ProjectId, Workshop: sk.Workshop, Sdk: sk.Name, Name: name}
+			masters[m] = append(masters[m], s)
 		}
 	}
 
-	for name, prof := range w.Profiles {
+	for _, prof := range w.Profiles {
 		for _, dev := range prof.Mounts {
+			pref := sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: prof.Sdk, Name: dev.Name}
+
 			if dev.Type == workshop.HostWorkshop {
-				pref := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: prof.Sdk, Name: dev.Name}
 				mnt := &Mount{
 					Plug:           pref,
 					HostSource:     dev.What,
 					WorkshopTarget: dev.Where,
 				}
-				mnts[name] = append(mnts[name], mnt)
+				mnts[prof.Sdk] = append(mnts[prof.Sdk], mnt)
 				if slaves, ok := masters[pref]; ok {
 					for _, slave := range slaves {
 						mnt := &Mount{
@@ -172,14 +171,15 @@ func mounts(w *workshop.Workshop, sdks map[string]*sdk.Info) (map[string][]*Moun
 					}
 				}
 			}
+
 			if dev.Type == workshop.WorkshopWorkshop {
-				pref := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: name, Name: dev.Name}
+				pref := sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: prof.Sdk, Name: dev.Name}
 				mnt := &Mount{
 					Plug:           pref,
 					WorkshopSource: dev.What,
 					WorkshopTarget: dev.Where,
 				}
-				mnts[name] = append(mnts[name], mnt)
+				mnts[prof.Sdk] = append(mnts[prof.Sdk], mnt)
 			}
 		}
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -446,7 +446,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 						{
 							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk", "data"),
 							WorkshopTarget: "/opt/data",
-							Plug: interfaces.PlugRef{
+							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
 								Workshop:  "manysdks",
 								Sdk:       "test-sdk",
@@ -466,7 +466,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 						{
 							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "manysdks", "test-sdk-2", "photos"),
 							WorkshopTarget: "/opt/data2",
-							Plug: interfaces.PlugRef{
+							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
 								Workshop:  "manysdks",
 								Sdk:       "test-sdk-2",
@@ -476,7 +476,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 						{
 							WorkshopSource: "/photos",
 							WorkshopTarget: "/opt/data2",
-							Plug: interfaces.PlugRef{
+							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
 								Workshop:  "manysdks",
 								Sdk:       "test-sdk-2",
@@ -551,7 +551,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 						{
 							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
 							WorkshopTarget: "/opt/data2",
-							Plug: interfaces.PlugRef{
+							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
 								Workshop:  "somebound",
 								Sdk:       "test-sdk",
@@ -571,7 +571,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 						{
 							HostSource:     sdk.SdkMountHostSource(s.userhome, s.project.ProjectId, "somebound", "test-sdk-2", "photos"),
 							WorkshopTarget: "/opt/data2",
-							Plug: interfaces.PlugRef{
+							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
 								Workshop:  "somebound",
 								Sdk:       "test-sdk-2",
@@ -1129,8 +1129,8 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk", Name: "data"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: sdk.System.String(), Name: "training"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk", Name: "data"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: sdk.System.String(), Name: "training"},
 		},
 	})
 
@@ -1138,11 +1138,11 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "photos"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: sdk.System.String(), Name: "mount"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "photos"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: sdk.System.String(), Name: "mount"},
 		}, {
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "gpu"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: sdk.System.String(), Name: "gpu"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "gpu"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: sdk.System.String(), Name: "gpu"},
 		},
 	})
 }
@@ -1266,8 +1266,8 @@ func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk", Name: "data"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: sdk.System.String(), Name: "mount"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk", Name: "data"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: sdk.System.String(), Name: "mount"},
 		},
 	})
 
@@ -1275,11 +1275,11 @@ func (s *apiSuite) TestRefreshWorkshopSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk-2", Name: "photos"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: sdk.System.String(), Name: "mount"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk-2", Name: "photos"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: sdk.System.String(), Name: "mount"},
 		}, {
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk-2", Name: "gpu"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: sdk.System.String(), Name: "gpu"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: "test-sdk-2", Name: "gpu"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "basic", Sdk: sdk.System.String(), Name: "gpu"},
 		},
 	})
 }
@@ -1330,8 +1330,8 @@ func (s *apiSuite) TestRefreshWorkshopRestoresPreviousWorkshopIfFailed(c *check.
 
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk", Name: "data"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: sdk.System.String(), Name: "mount"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk", Name: "data"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: sdk.System.String(), Name: "mount"},
 		},
 	})
 
@@ -1339,12 +1339,12 @@ func (s *apiSuite) TestRefreshWorkshopRestoresPreviousWorkshopIfFailed(c *check.
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk-2", Name: "photos"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: sdk.System.String(), Name: "mount"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk-2", Name: "photos"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: sdk.System.String(), Name: "mount"},
 		},
 		{
-			PlugRef: interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk-2", Name: "gpu"},
-			SlotRef: interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: sdk.System.String(), Name: "gpu"},
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: "test-sdk-2", Name: "gpu"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "manysdks", Sdk: sdk.System.String(), Name: "gpu"},
 		},
 	})
 }

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -120,7 +120,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	if xauth != "" {
 		m := workshop.Mount{}
 		m.Name = plug.Sdk().Name + "-" + "xauth"
-		m.Type = 0
+		m.Type = workshop.HostWorkshop
 		m.What = workshopdXauth
 		m.Where = filepath.Join(dirs.WorkshopRunDir, "Xauthority")
 		spec.AddMountEntry(m)

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -178,7 +178,7 @@ func (iface *mountInterface) workshopSource(slot *interfaces.ConnectedSlot) (str
 	}
 
 	if strings.HasPrefix(source, "$SDK") {
-		return strings.Replace(source, "$SDK", sdk.SdkCurrentPath(slot.Ref().Sdk), 1), nil
+		return strings.Replace(source, "$SDK", sdk.SdkCurrentPath(slot.Sdk().Name), 1), nil
 	}
 	return source, nil
 }

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -100,16 +100,6 @@ func lookupAttr(staticAttrs map[string]interface{}, dynamicAttrs map[string]inte
 	return v, true
 }
 
-func getAttribute(sdkName string, ifaceName string, staticAttrs map[string]interface{}, dynamicAttrs map[string]interface{}, path string, val interface{}) error {
-	v, ok := lookupAttr(staticAttrs, dynamicAttrs, path)
-	if !ok {
-		err := fmt.Errorf("SDK %q does not have attribute %q for interface %q", sdkName, path, ifaceName)
-		return sdk.AttributeNotFoundError{Err: err}
-	}
-
-	return metautil.SetValueFromAttribute(sdkName, ifaceName, path, v, val)
-}
-
 // NewConnectedSlot creates an object representing a connected slot.
 func NewConnectedSlot(slot *sdk.SlotInfo, staticAttrs, dynamicAttrs map[string]interface{}) *ConnectedSlot {
 	var static map[string]interface{}
@@ -157,7 +147,7 @@ func (plug *ConnectedPlug) Sdk() *sdk.Info {
 
 // StaticAttr returns a static attribute with the given key, or error if attribute doesn't exist.
 func (plug *ConnectedPlug) StaticAttr(key string, val interface{}) error {
-	return getAttribute(plug.Sdk().Name, plug.Interface(), plug.staticAttrs, nil, key, val)
+	return plug.getAttribute(nil, key, val)
 }
 
 // StaticAttrs returns all static attributes.
@@ -174,7 +164,20 @@ func (plug *ConnectedPlug) DynamicAttrs() map[string]interface{} {
 // attribute if dynamic one doesn't exist. Error is returned if neither dynamic nor static
 // attribute exist.
 func (plug *ConnectedPlug) Attr(key string, val interface{}) error {
-	return getAttribute(plug.Sdk().Name, plug.Interface(), plug.staticAttrs, plug.dynamicAttrs, key, val)
+	return plug.getAttribute(plug.dynamicAttrs, key, val)
+}
+
+func (plug *ConnectedPlug) getAttribute(dynamicAttrs map[string]interface{}, key string, val interface{}) error {
+	v, ok := lookupAttr(plug.staticAttrs, dynamicAttrs, key)
+	if !ok {
+		err := fmt.Errorf("attribute %q not found for plug %q", key, plug.Ref().ShortRef())
+		return sdk.AttributeNotFoundError{Err: err}
+	}
+
+	if err := metautil.SetValueFromAttribute(v, val); err != nil {
+		return fmt.Errorf("invalid attribute %q for plug %q: %w", key, plug.Ref().ShortRef(), err)
+	}
+	return nil
 }
 
 func (plug *ConnectedPlug) Lookup(path string) (interface{}, bool) {
@@ -215,7 +218,7 @@ func (slot *ConnectedSlot) Sdk() *sdk.Info {
 
 // StaticAttr returns a static attribute with the given key, or error if attribute doesn't exist.
 func (slot *ConnectedSlot) StaticAttr(key string, val interface{}) error {
-	return getAttribute(slot.Sdk().Name, slot.Interface(), slot.staticAttrs, nil, key, val)
+	return slot.getAttribute(nil, key, val)
 }
 
 // StaticAttrs returns all static attributes.
@@ -232,7 +235,20 @@ func (slot *ConnectedSlot) DynamicAttrs() map[string]interface{} {
 // attribute if dynamic one doesn't exist. Error is returned if neither dynamic nor static
 // attribute exist.
 func (slot *ConnectedSlot) Attr(key string, val interface{}) error {
-	return getAttribute(slot.Sdk().Name, slot.Interface(), slot.staticAttrs, slot.dynamicAttrs, key, val)
+	return slot.getAttribute(slot.dynamicAttrs, key, val)
+}
+
+func (slot *ConnectedSlot) getAttribute(dynamicAttrs map[string]interface{}, key string, val interface{}) error {
+	v, ok := lookupAttr(slot.staticAttrs, dynamicAttrs, key)
+	if !ok {
+		err := fmt.Errorf("attribute %q not found for slot %q", key, slot.Ref().ShortRef())
+		return sdk.AttributeNotFoundError{Err: err}
+	}
+
+	if err := metautil.SetValueFromAttribute(v, val); err != nil {
+		return fmt.Errorf("invalid attribute %q for slot %q: %w", key, slot.Ref().ShortRef(), err)
+	}
+	return nil
 }
 
 func (slot *ConnectedSlot) Lookup(path string) (interface{}, bool) {

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -194,8 +194,8 @@ func (plug *ConnectedPlug) SetAttr(key string, value interface{}) error {
 }
 
 // Ref returns the PlugRef for this plug.
-func (plug *ConnectedPlug) Ref() *PlugRef {
-	return &PlugRef{ProjectId: plug.Sdk().ProjectId, Workshop: plug.Sdk().Workshop, Sdk: plug.Sdk().Name, Name: plug.Name()}
+func (plug *ConnectedPlug) Ref() sdk.PlugRef {
+	return plug.plugInfo.Ref()
 }
 
 // Interface returns the name of the interface for this slot.
@@ -252,8 +252,8 @@ func (slot *ConnectedSlot) SetAttr(key string, value interface{}) error {
 }
 
 // Ref returns the SlotRef for this slot.
-func (slot *ConnectedSlot) Ref() *SlotRef {
-	return &SlotRef{ProjectId: slot.Sdk().ProjectId, Workshop: slot.Sdk().Workshop, Sdk: slot.Sdk().Name, Name: slot.Name()}
+func (slot *ConnectedSlot) Ref() sdk.SlotRef {
+	return slot.slotInfo.Ref()
 }
 
 // Interface returns the name of the interface for this connection.

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -20,8 +20,6 @@
 package interfaces_test
 
 import (
-	"errors"
-
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -84,7 +82,7 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 
 	var val string
 	var intVal int
-	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `SDK "producer" does not have attribute "unknown" for interface "interface"`)
+	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `attribute "unknown" not found for slot "ws/producer:slot"`)
 
 	attrs := slot.StaticAttrs()
 	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
@@ -95,9 +93,9 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 	slot.StaticAttr("attr", &val)
 	c.Assert(val, check.Equals, "value")
 
-	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `SDK "producer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(slot.StaticAttr("attr", &intVal), check.ErrorMatches, `SDK "producer" has interface "interface" with invalid value type "string" for "attr" attribute: \*int`)
-	c.Check(slot.StaticAttr("attr", val), check.ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
+	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `attribute "unknown" not found for slot "ws/producer:slot"`)
+	c.Check(slot.StaticAttr("attr", &intVal), check.ErrorMatches, `invalid attribute "attr" for slot "ws/producer:slot": expected int but found string`)
+	c.Check(slot.StaticAttr("attr", val), check.ErrorMatches, `invalid attribute "attr" for slot "ws/producer:slot": internal error: value must be a pointer`)
 
 	// static attributes passed via args take precedence over slot.Attrs
 	slot2 := interfaces.NewConnectedSlot(s.slot, map[string]interface{}{"foo": "bar"}, nil)
@@ -123,7 +121,7 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 
 	var val string
 	var intVal int
-	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `SDK "consumer" does not have attribute "unknown" for interface "interface"`)
+	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `attribute "unknown" not found for plug "ws/consumer:plug"`)
 
 	attrs := plug.StaticAttrs()
 	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
@@ -133,9 +131,9 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 	plug.StaticAttr("attr", &val)
 	c.Assert(val, check.Equals, "value")
 
-	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `SDK "consumer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(plug.StaticAttr("attr", &intVal), check.ErrorMatches, `SDK "consumer" has interface "interface" with invalid value type "string" for "attr" attribute: \*int`)
-	c.Check(plug.StaticAttr("attr", val), check.ErrorMatches, `internal error: cannot get "attr" attribute of interface "interface" with non-pointer value`)
+	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `attribute "unknown" not found for plug "ws/consumer:plug"`)
+	c.Check(plug.StaticAttr("attr", &intVal), check.ErrorMatches, `invalid attribute "attr" for plug "ws/consumer:plug": expected int but found string`)
+	c.Check(plug.StaticAttr("attr", val), check.ErrorMatches, `invalid attribute "attr" for plug "ws/consumer:plug": internal error: value must be a pointer`)
 
 	// static attributes passed via args take precedence over plug.Attrs
 	plug2 := interfaces.NewConnectedPlug(s.plug, map[string]interface{}{"foo": "bar"}, nil)
@@ -146,7 +144,7 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
 	attrs := map[string]interface{}{
 		"foo":    "bar",
-		"number": int(100),
+		"number": int(101),
 	}
 	slot := interfaces.NewConnectedSlot(s.slot, nil, attrs)
 	c.Assert(slot, check.NotNil)
@@ -162,7 +160,7 @@ func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
 	c.Assert(strVal, check.Equals, "value")
 
 	c.Assert(slot.Attr("number", &intVal), check.IsNil)
-	c.Assert(intVal, check.Equals, int64(100))
+	c.Assert(intVal, check.Equals, int64(101))
 
 	err := slot.SetAttr("other", map[string]interface{}{"number-two": int(222)})
 	c.Assert(err, check.IsNil)
@@ -170,9 +168,9 @@ func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
 	num := mapVal["number-two"]
 	c.Assert(num, check.Equals, int64(222))
 
-	c.Check(slot.Attr("unknown", &strVal), check.ErrorMatches, `SDK "producer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(slot.Attr("foo", &intVal), check.ErrorMatches, `SDK "producer" has interface "interface" with invalid value type "string" for "foo" attribute: \*int64`)
-	c.Check(slot.Attr("number", intVal), check.ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
+	c.Check(slot.Attr("unknown", &strVal), check.ErrorMatches, `attribute "unknown" not found for slot "ws/producer:slot"`)
+	c.Check(slot.Attr("foo", &intVal), check.ErrorMatches, `invalid attribute "foo" for slot "ws/producer:slot": expected int64 but found string`)
+	c.Check(slot.Attr("number", intVal), check.ErrorMatches, `invalid attribute "number" for slot "ws/producer:slot": internal error: value must be a pointer`)
 }
 
 func (s *connSuite) TestDottedPathSlot(c *check.C) {
@@ -292,9 +290,9 @@ func (s *connSuite) TestDynamicPlugAttrs(c *check.C) {
 	num := mapVal["number-two"]
 	c.Assert(num, check.Equals, int64(222))
 
-	c.Check(plug.Attr("unknown", &strVal), check.ErrorMatches, `SDK "consumer" does not have attribute "unknown" for interface "interface"`)
-	c.Check(plug.Attr("foo", &intVal), check.ErrorMatches, `SDK "consumer" has interface "interface" with invalid value type "string" for "foo" attribute: \*int64`)
-	c.Check(plug.Attr("number", intVal), check.ErrorMatches, `internal error: cannot get "number" attribute of interface "interface" with non-pointer value`)
+	c.Check(plug.Attr("unknown", &strVal), check.ErrorMatches, `attribute "unknown" not found for plug "ws/consumer:plug"`)
+	c.Check(plug.Attr("foo", &intVal), check.ErrorMatches, `invalid attribute "foo" for plug "ws/consumer:plug": expected int64 but found string`)
+	c.Check(plug.Attr("number", intVal), check.ErrorMatches, `invalid attribute "number" for plug "ws/consumer:plug": internal error: value must be a pointer`)
 }
 
 func (s *connSuite) TestOverwriteStaticAttrError(c *check.C) {
@@ -356,28 +354,4 @@ func (s *connSuite) TestNewConnectedSlotExplicitStaticAttrs(c *check.C) {
 	c.Assert(slot, check.NotNil)
 	c.Assert(slot.StaticAttrs(), check.DeepEquals, map[string]interface{}{"baz": "boom"})
 	c.Assert(slot.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"foo": "bar"})
-}
-
-func (s *connSuite) TestGetAttributeUnhappy(c *check.C) {
-	attrs := map[string]interface{}{}
-	var stringVal string
-	err := interfaces.GetAttribute("sdk0", "iface0", attrs, attrs, "non-existent", &stringVal)
-	c.Check(stringVal, check.Equals, "")
-	c.Check(err, check.ErrorMatches, `SDK "sdk0" does not have attribute "non-existent" for interface "iface0"`)
-	c.Check(errors.Is(err, sdk.AttributeNotFoundError{}), check.Equals, true)
-}
-
-func (s *connSuite) TestGetAttributeHappy(c *check.C) {
-	staticAttrs := map[string]interface{}{
-		"attr0": "a string",
-		"attr1": 12,
-	}
-	dynamicAttrs := map[string]interface{}{
-		"attr0": "second string",
-		"attr1": 42,
-	}
-	var intVal int
-	err := interfaces.GetAttribute("sdk0", "iface0", staticAttrs, dynamicAttrs, "attr1", &intVal)
-	c.Check(err, check.IsNil)
-	c.Check(intVal, check.Equals, 42)
 }

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -108,13 +108,13 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 func (s *connSuite) TestSlotRef(c *check.C) {
 	slot := interfaces.NewConnectedSlot(s.slot, nil, nil)
 	c.Assert(slot, check.NotNil)
-	c.Assert(*slot.Ref(), check.DeepEquals, interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "producer", Name: "slot"})
+	c.Assert(slot.Ref(), check.DeepEquals, sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "producer", Name: "slot"})
 }
 
 func (s *connSuite) TestPlugRef(c *check.C) {
 	plug := interfaces.NewConnectedPlug(s.plug, nil, nil)
 	c.Assert(plug, check.NotNil)
-	c.Assert(*plug.Ref(), check.DeepEquals, interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(plug.Ref(), check.DeepEquals, sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "consumer", Name: "plug"})
 }
 
 func (s *connSuite) TestStaticPlugAttrs(c *check.C) {

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -30,7 +30,7 @@ import (
 func BeforePreparePlug(iface Interface, plugInfo *sdk.PlugInfo) error {
 	if iface.Name() != plugInfo.Interface {
 		return fmt.Errorf("cannot sanitize plug %q (interface %q) using interface %q",
-			PlugRef{ProjectId: plugInfo.Sdk.ProjectId, Workshop: plugInfo.Sdk.Workshop, Sdk: plugInfo.Sdk.Name, Name: plugInfo.Name}, plugInfo.Interface, iface.Name())
+			plugInfo.Ref().ShortRef(), plugInfo.Interface, iface.Name())
 	}
 	var err error
 	if iface, ok := iface.(PlugSanitizer); ok {
@@ -42,7 +42,7 @@ func BeforePreparePlug(iface Interface, plugInfo *sdk.PlugInfo) error {
 func BeforeConnectPlug(iface Interface, plug *ConnectedPlug) error {
 	if iface.Name() != plug.plugInfo.Interface {
 		return fmt.Errorf("cannot sanitize connection for plug %q (interface %q) using interface %q",
-			PlugRef{ProjectId: plug.Sdk().Name, Workshop: plug.plugInfo.Sdk.Workshop, Sdk: plug.plugInfo.Sdk.Name, Name: plug.plugInfo.Name}, plug.plugInfo.Interface, iface.Name())
+			plug.plugInfo.Ref().ShortRef(), plug.plugInfo.Interface, iface.Name())
 	}
 	var err error
 	if iface, ok := iface.(ConnPlugSanitizer); ok {
@@ -58,91 +58,17 @@ var ByName = func(name string) (iface Interface, err error) {
 	panic("ByName is unset, import interfaces/builtin to initialize this")
 }
 
-// PlugRef is a reference to a plug.
-type PlugRef struct {
-	ProjectId string `json:"project-id"`
-	Workshop  string `json:"workshop"`
-	Sdk       string `json:"sdk"`
-	Name      string `json:"plug"`
-}
-
-func NewPlugRef(info *sdk.PlugInfo) PlugRef {
-	return PlugRef{ProjectId: info.Sdk.ProjectId, Workshop: info.Sdk.Workshop, Sdk: info.Sdk.Name, Name: info.Name}
-}
-
-func (ref PlugRef) SdkRef() sdk.Ref {
-	return sdk.Ref{ProjectId: ref.ProjectId, Workshop: ref.Workshop, Sdk: ref.Sdk}
-}
-
-// String returns the "project-id/workshop/sdk:plug" representation of a plug reference.
-func (ref PlugRef) String() string {
-	return fmt.Sprintf("%s:%s", ref.SdkRef().String(), ref.Name)
-}
-
-// ShortRef returns the "workshop/sdk:plug" representation of a plug reference (human-friendly).
-func (ref PlugRef) ShortRef() string {
-	return fmt.Sprintf("%s:%s", ref.SdkRef().ShortRef(), ref.Name)
-}
-
-// SortsBefore returns true when plug should be sorted before the other
-func (ref PlugRef) SortsBefore(other PlugRef) bool {
-	if ref.Workshop != other.Workshop {
-		return ref.Workshop < other.Workshop
-	}
-	if ref.Sdk != other.Sdk {
-		return ref.Sdk < other.Sdk
-	}
-	return ref.Name < other.Name
-}
-
 // Sanitize slot with a given interface.
 func BeforePrepareSlot(iface Interface, slotInfo *sdk.SlotInfo) error {
 	if iface.Name() != slotInfo.Interface {
 		return fmt.Errorf("cannot sanitize slot %q (interface %q) using interface %q",
-			SlotRef{ProjectId: slotInfo.Sdk.ProjectId, Workshop: slotInfo.Sdk.Workshop, Sdk: slotInfo.Sdk.Name, Name: slotInfo.Name}, slotInfo.Interface, iface.Name())
+			slotInfo.Ref(), slotInfo.Interface, iface.Name())
 	}
 	var err error
 	if iface, ok := iface.(SlotSanitizer); ok {
 		err = iface.BeforePrepareSlot(slotInfo)
 	}
 	return err
-}
-
-// SlotRef is a reference to a slot.
-type SlotRef struct {
-	ProjectId string `json:"project-id"`
-	Workshop  string `json:"workshop"`
-	Sdk       string `json:"sdk"`
-	Name      string `json:"slot"`
-}
-
-func NewSlotRef(info *sdk.SlotInfo) SlotRef {
-	return SlotRef{ProjectId: info.Sdk.ProjectId, Workshop: info.Sdk.Workshop, Sdk: info.Sdk.Name, Name: info.Name}
-}
-
-func (ref SlotRef) SdkRef() sdk.Ref {
-	return sdk.Ref{ProjectId: ref.ProjectId, Workshop: ref.Workshop, Sdk: ref.Sdk}
-}
-
-// String returns the "project-id/workshop/sdk:slot" representation of a slot reference.
-func (ref SlotRef) String() string {
-	return fmt.Sprintf("%s:%s", ref.SdkRef().String(), ref.Name)
-}
-
-// ShortRef returns the "workshop/sdk:slot" representation of a slot reference (human-friendly).
-func (ref SlotRef) ShortRef() string {
-	return fmt.Sprintf("%s:%s", ref.SdkRef().ShortRef(), ref.Name)
-}
-
-// SortsBefore returns true when slot should be sorted before the other
-func (ref SlotRef) SortsBefore(other SlotRef) bool {
-	if ref.Workshop != other.Workshop {
-		return ref.Workshop < other.Workshop
-	}
-	if ref.Sdk != other.Sdk {
-		return ref.Sdk < other.Sdk
-	}
-	return ref.Name < other.Name
 }
 
 // Interfaces holds information about a list of plugs, slots and their connections.
@@ -163,16 +89,13 @@ type Info struct {
 
 // ConnRef holds information about plug and slot reference that form a particular connection.
 type ConnRef struct {
-	PlugRef PlugRef
-	SlotRef SlotRef
+	PlugRef sdk.PlugRef
+	SlotRef sdk.SlotRef
 }
 
 // NewConnRef creates a connection reference for given plug and slot
 func NewConnRef(plug *sdk.PlugInfo, slot *sdk.SlotInfo) *ConnRef {
-	return &ConnRef{
-		PlugRef: PlugRef{ProjectId: plug.Sdk.ProjectId, Workshop: plug.Sdk.Workshop, Sdk: plug.Sdk.Name, Name: plug.Name},
-		SlotRef: SlotRef{ProjectId: slot.Sdk.ProjectId, Workshop: slot.Sdk.Workshop, Sdk: slot.Sdk.Name, Name: slot.Name},
-	}
+	return &ConnRef{PlugRef: plug.Ref(), SlotRef: slot.Ref()}
 }
 
 // ID returns a string identifying a given connection.

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -55,25 +55,25 @@ func (s *CoreSuite) TearDownTest(c *C) {
 
 // PlugRef.String works as expected
 func (s *CoreSuite) TestPlugRefString(c *C) {
-	ref := interfaces.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "sdk", Name: "plug"}
+	ref := sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "sdk", Name: "plug"}
 	c.Check(ref.String(), Equals, s.projectId+"/ws/sdk:plug")
-	refPtr := &interfaces.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "sdk", Name: "plug"}
+	refPtr := &sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "sdk", Name: "plug"}
 	c.Check(refPtr.String(), Equals, s.projectId+"/ws/sdk:plug")
 }
 
 // SlotRef.String works as expected
 func (s *CoreSuite) TestSlotRefString(c *C) {
-	ref := interfaces.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "sdk", Name: "slot"}
+	ref := sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "sdk", Name: "slot"}
 	c.Check(ref.String(), Equals, s.projectId+"/ws/sdk:slot")
-	refPtr := &interfaces.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "sdk", Name: "slot"}
+	refPtr := &sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "sdk", Name: "slot"}
 	c.Check(refPtr.String(), Equals, s.projectId+"/ws/sdk:slot")
 }
 
 // ConnRef.ID works as expected
 func (s *CoreSuite) TestConnRefID(c *C) {
 	conn := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"},
 	}
 	c.Check(conn.ID(), Equals, fmt.Sprintf("%s/ws/consumer:plug %s/ws/producer:slot", s.projectId, s.projectId))
 }
@@ -83,8 +83,8 @@ func (s *CoreSuite) TestParseConnRef(c *C) {
 	ref, err := interfaces.ParseConnRef("42424242/ws/consumer:plug 42424242/ws/producer:slot")
 	c.Assert(err, IsNil)
 	c.Check(ref, DeepEquals, &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"},
 	})
 	_, err = interfaces.ParseConnRef("garbage")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: "garbage"`)
@@ -204,7 +204,7 @@ plugs:
 	}, plug), ErrorMatches, "broken")
 	c.Assert(interfaces.BeforePreparePlug(&ifacetest.TestInterface{
 		InterfaceName: "other",
-	}, plug), ErrorMatches, fmt.Sprintf(`cannot sanitize plug "%s/ws/sdk:plug" \(interface "iface"\) using interface "other"`, s.projectId))
+	}, plug), ErrorMatches, `cannot sanitize plug "ws/sdk:plug" \(interface "iface"\) using interface "other"`)
 }
 
 func (s *CoreSuite) TestSanitizeSlot(c *C) {

--- a/internal/interfaces/export_test.go
+++ b/internal/interfaces/export_test.go
@@ -42,7 +42,3 @@ type ByInterfaceName byInterfaceName
 func (c ByInterfaceName) Len() int           { return byInterfaceName(c).Len() }
 func (c ByInterfaceName) Swap(i, j int)      { byInterfaceName(c).Swap(i, j) }
 func (c ByInterfaceName) Less(i, j int) bool { return byInterfaceName(c).Less(i, j) }
-
-var (
-	GetAttribute = getAttribute
-)

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -165,16 +165,16 @@ func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
 	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
 
 	connref := &interfaces.ConnRef{
-		PlugRef: interfaces.NewPlugRef(cinfo.Plugs["one"]),
-		SlotRef: interfaces.NewSlotRef(pinfo.Slots["slot"]),
+		PlugRef: cinfo.Plugs["one"].Ref(),
+		SlotRef: pinfo.Slots["slot"].Ref(),
 	}
 
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	connref = &interfaces.ConnRef{
-		PlugRef: interfaces.NewPlugRef(cinfo.Plugs["two"]),
-		SlotRef: interfaces.NewSlotRef(pinfo.Slots["home"]),
+		PlugRef: cinfo.Plugs["two"].Ref(),
+		SlotRef: pinfo.Slots["home"].Ref(),
 	}
 
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
@@ -258,8 +258,8 @@ func (f *backendDeviceSuite) TestSetupHostWorkshopMounts(c *check.C) {
 	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
 
 	connref := &interfaces.ConnRef{
-		PlugRef: interfaces.NewPlugRef(cinfo.Plugs["one"]),
-		SlotRef: interfaces.NewSlotRef(pinfo.Slots["slot"]),
+		PlugRef: cinfo.Plugs["one"].Ref(),
+		SlotRef: pinfo.Slots["slot"].Ref(),
 	}
 
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
@@ -293,8 +293,8 @@ func (f *backendDeviceSuite) TestSetupUpdateProfile(c *check.C) {
 	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
 
 	connref := &interfaces.ConnRef{
-		PlugRef: interfaces.NewPlugRef(cinfo.Plugs["one"]),
-		SlotRef: interfaces.NewSlotRef(pinfo.Slots["slot"]),
+		PlugRef: cinfo.Plugs["one"].Ref(),
+		SlotRef: pinfo.Slots["slot"].Ref(),
 	}
 
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
@@ -341,8 +341,8 @@ func (f *backendDeviceSuite) TestSetupSshAgent(c *check.C) {
 	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
 
 	connref := &interfaces.ConnRef{
-		PlugRef: interfaces.NewPlugRef(cinfo.Plugs["ssh-agent"]),
-		SlotRef: interfaces.NewSlotRef(pinfo.Slots["ssh-agent"]),
+		PlugRef: cinfo.Plugs["ssh-agent"].Ref(),
+		SlotRef: pinfo.Slots["ssh-agent"].Ref(),
 	}
 
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -74,7 +74,7 @@ func checkPlugConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	}
 	plugSdk, slotSdk := connc.Plug.Sdk(), connc.Slot.Sdk()
 	if plugSdk.ProjectId != slotSdk.ProjectId || plugSdk.Workshop != slotSdk.Workshop {
-		return fmt.Errorf("%q cannot be connected to the %q (SDK from a different workshop)", connc.Plug.Ref(), connc.Slot.Ref())
+		return fmt.Errorf("%q cannot be connected to the %q (SDK from a different workshop)", connc.Plug.Ref().String(), connc.Slot.Ref().String())
 	}
 	return nil
 }
@@ -176,7 +176,7 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 
 	plugSdk, slotSdk := connc.Plug.Sdk(), connc.Slot.Sdk()
 	if plugSdk.ProjectId != slotSdk.ProjectId || plugSdk.Workshop != slotSdk.Workshop {
-		return fmt.Errorf("%q cannot be connected to the %q (SDK from a different workshop)", connc.Plug.Ref(), connc.Slot.Ref())
+		return fmt.Errorf("%q cannot be connected to the %q (SDK from a different workshop)", connc.Plug.Ref().String(), connc.Slot.Ref().String())
 	}
 
 	return nil

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -28,7 +28,7 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 )
 
-func checkPlugInstallationConstraints1(ic *InstallCandidate, plug *sdk.PlugInfo, constraints *asserts.PlugInstallationConstraints) error {
+func checkPlugInstallationConstraints1(plug *sdk.PlugInfo, constraints *asserts.PlugInstallationConstraints) error {
 	if err := checkNameConstraints(constraints.PlugNames, plug.Interface, "plug name", plug.Name); err != nil {
 		return err
 	}
@@ -43,11 +43,11 @@ func checkPlugInstallationConstraints1(ic *InstallCandidate, plug *sdk.PlugInfo,
 	return nil
 }
 
-func checkPlugInstallationAltConstraints(ic *InstallCandidate, plug *sdk.PlugInfo, altConstraints []*asserts.PlugInstallationConstraints) error {
+func checkPlugInstallationAltConstraints(plug *sdk.PlugInfo, altConstraints []*asserts.PlugInstallationConstraints) error {
 	var firstErr error
 	// OR of constraints
 	for _, constraints := range altConstraints {
-		err := checkPlugInstallationConstraints1(ic, plug, constraints)
+		err := checkPlugInstallationConstraints1(plug, constraints)
 		if err == nil {
 			return nil
 		}
@@ -115,7 +115,7 @@ func checkNameConstraints(c *asserts.NameConstraints, iface, which, name string)
 	return c.Check(which, name, special)
 }
 
-func checkSlotInstallationConstraints(ic *InstallCandidate, slot *sdk.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
+func checkSlotInstallationConstraints(slot *sdk.SlotInfo, constraints *asserts.SlotInstallationConstraints) error {
 	if err := checkNameConstraints(constraints.SlotNames, slot.Interface, "slot name", slot.Name); err != nil {
 		return err
 	}
@@ -130,11 +130,11 @@ func checkSlotInstallationConstraints(ic *InstallCandidate, slot *sdk.SlotInfo, 
 	return nil
 }
 
-func checkSlotInstallationAltConstraints(ic *InstallCandidate, slot *sdk.SlotInfo, altConstraints []*asserts.SlotInstallationConstraints) error {
+func checkSlotInstallationAltConstraints(slot *sdk.SlotInfo, altConstraints []*asserts.SlotInstallationConstraints) error {
 	var firstErr error
 	// OR of constraints
 	for _, constraints := range altConstraints {
-		err := checkSlotInstallationConstraints(ic, slot, constraints)
+		err := checkSlotInstallationConstraints(slot, constraints)
 		if err == nil {
 			return nil
 		}

--- a/internal/interfaces/policy/policy.go
+++ b/internal/interfaces/policy/policy.go
@@ -37,10 +37,10 @@ type InstallCandidate struct {
 }
 
 func (ic *InstallCandidate) checkSlotRule(slot *sdk.SlotInfo, rule *asserts.SlotRule) error {
-	if checkSlotInstallationAltConstraints(ic, slot, rule.DenyInstallation) == nil {
+	if checkSlotInstallationAltConstraints(slot, rule.DenyInstallation) == nil {
 		return fmt.Errorf("installation denied by %q slot rule of interface %q", slot.Name, slot.Interface)
 	}
-	if checkSlotInstallationAltConstraints(ic, slot, rule.AllowInstallation) != nil {
+	if checkSlotInstallationAltConstraints(slot, rule.AllowInstallation) != nil {
 		return fmt.Errorf("installation not allowed by %q slot rule of interface %q", slot.Name, slot.Interface)
 	}
 	return nil
@@ -48,10 +48,10 @@ func (ic *InstallCandidate) checkSlotRule(slot *sdk.SlotInfo, rule *asserts.Slot
 
 func (ic *InstallCandidate) checkPlugRule(plug *sdk.PlugInfo, rule *asserts.PlugRule) error {
 	context := ""
-	if checkPlugInstallationAltConstraints(ic, plug, rule.DenyInstallation) == nil {
+	if checkPlugInstallationAltConstraints(plug, rule.DenyInstallation) == nil {
 		return fmt.Errorf("installation denied by %q plug rule of interface %q%s", plug.Name, plug.Interface, context)
 	}
-	if checkPlugInstallationAltConstraints(ic, plug, rule.AllowInstallation) != nil {
+	if checkPlugInstallationAltConstraints(plug, rule.AllowInstallation) != nil {
 		return fmt.Errorf("installation not allowed by %q plug rule of interface %q%s", plug.Name, plug.Interface, context)
 	}
 	return nil
@@ -118,7 +118,7 @@ func (connc *ConnectCandidate) PlugAttr(arg string) (interface{}, error) {
 func (connc *ConnectCandidate) SlotAttr(arg string) (interface{}, error) {
 	return nestedGet("slot", connc.Slot, arg)
 }
-func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule, sdkRule bool) (interfaces.SideArity, error) {
+func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule) (interfaces.SideArity, error) {
 	context := ""
 	denyConst := rule.DenyConnection
 	allowConst := rule.AllowConnection
@@ -137,7 +137,7 @@ func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule
 	return sideArity{allowedConstraints.SlotsPerPlug}, nil
 }
 
-func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule, sdkRule bool) (interfaces.SideArity, error) {
+func (connc *ConnectCandidate) checkSlotRule(kind string, rule *asserts.SlotRule) (interfaces.SideArity, error) {
 	denyConst := rule.DenyConnection
 	allowConst := rule.AllowConnection
 	if kind == "auto-connection" {
@@ -168,10 +168,10 @@ func (connc *ConnectCandidate) check(kind string) (interfaces.SideArity, error) 
 	}
 
 	if rule := baseDecl.PlugRule(iface); rule != nil {
-		return connc.checkPlugRule(kind, rule, false)
+		return connc.checkPlugRule(kind, rule)
 	}
 	if rule := baseDecl.SlotRule(iface); rule != nil {
-		return connc.checkSlotRule(kind, rule, false)
+		return connc.checkSlotRule(kind, rule)
 	}
 	return nil, nil
 }

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -606,7 +606,7 @@ func (r *Repository) Disconnect(plugProjectId, plugWorkshop, plugSdkName, plugNa
 	if r.slotPlugs[slot][plug] == nil {
 		return &NotConnectedError{
 			message: fmt.Sprintf("cannot disconnect %q from %q: not connected",
-				NewPlugRef(plug).ShortRef(), NewSlotRef(slot).ShortRef()),
+				plug.Ref().ShortRef(), slot.Ref().ShortRef()),
 		}
 	}
 	r.disconnect(plug, slot)
@@ -914,12 +914,12 @@ func (r *Repository) RemoveSdk(projectId, workshop, sdkName string) error {
 
 	for _, plug := range r.plugs[key] {
 		if len(r.plugSlots[plug]) > 0 {
-			return fmt.Errorf("cannot remove connected plug %q", NewPlugRef(plug).ShortRef())
+			return fmt.Errorf("cannot remove connected plug %q", plug.Ref().ShortRef())
 		}
 	}
 	for _, slot := range r.slots[key] {
 		if len(r.slotPlugs[slot]) > 0 {
-			return fmt.Errorf("cannot remove connected slot %q", NewSlotRef(slot).ShortRef())
+			return fmt.Errorf("cannot remove connected slot %q", slot.Ref().ShortRef())
 		}
 	}
 
@@ -1117,7 +1117,7 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 	// Ensure that plug and slot are compatible
 	if slot.Interface != plug.Interface {
 		return nil, fmt.Errorf("cannot connect %q (%q interface) to %q (%q interface)",
-			NewPlugRef(plug).ShortRef(), plug.Interface, NewSlotRef(slot).ShortRef(), slot.Interface)
+			plug.Ref().ShortRef(), plug.Interface, slot.Ref().ShortRef(), slot.Interface)
 	}
 	return NewConnRef(plug, slot), nil
 }

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1026,9 +1026,10 @@ func (s *RepositorySuite) TestSdkSpecificationBoundPlugs(c *C) {
 	// the plug's connection is bound which means it has the "bind" dynamic
 	// attribute that points to the connection it is bound to
 	bref := interfaces.ConnRef{
-		PlugRef: PlugRef{ProjectId: s.plug.Sdk.ProjectId, Workshop: s.plug.Sdk.Workshop, Sdk: s.plug.Sdk.Name, Name: "some-plug"},
-		SlotRef: SlotRef{ProjectId: s.slot.Sdk.ProjectId, Workshop: s.slot.Sdk.Workshop, Sdk: s.slot.Sdk.Name, Name: s.slot.Name},
+		PlugRef: s.plug.Ref(),
+		SlotRef: s.slot.Ref(),
 	}
+	bref.PlugRef.Name = "some-plug"
 	s.plug.Attrs["bind"] = bref.ID()
 	c.Assert(repo.AddPlug(s.plug), IsNil)
 	c.Assert(repo.AddSlot(s.slot), IsNil)
@@ -1347,8 +1348,8 @@ func (s *DisconnectSdkSuite) TestNotConnected(c *C) {
 
 func (s *DisconnectSdkSuite) TestOutgoingConnection(c *C) {
 	connRef := &ConnRef{
-		PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
-		SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-a"}}
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-a"}}
 	_, err := s.repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	// Disconnect s1 with which has an outgoing connection to s2
@@ -1360,8 +1361,8 @@ func (s *DisconnectSdkSuite) TestOutgoingConnection(c *C) {
 
 func (s *DisconnectSdkSuite) TestIncomingConnection(c *C) {
 	connRef := &ConnRef{
-		PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-b"},
-		SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-b"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}
 	_, err := s.repo.Connect(connRef, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	// Disconnect s1 with which has an incoming connection from s2
@@ -1375,13 +1376,13 @@ func (s *DisconnectSdkSuite) TestCrossConnection(c *C) {
 	// This test is symmetric wrt s1 <-> s2 connections
 	for _, sdkName := range []string{"s1", "s2"} {
 		connRef1 := &ConnRef{
-			PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
-			SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-a"}}
+			PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
+			SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-a"}}
 		_, err := s.repo.Connect(connRef1, nil, nil, nil, nil, nil)
 		c.Assert(err, IsNil)
 		connRef2 := &ConnRef{
-			PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-b"},
-			SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}
+			PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2", Name: "iface-b"},
+			SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}
 		_, err = s.repo.Connect(connRef2, nil, nil, nil, nil, nil)
 		c.Assert(err, IsNil)
 		affected, err := s.repo.DisconnectSdk("42424242", "ws", sdkName)
@@ -1393,8 +1394,8 @@ func (s *DisconnectSdkSuite) TestCrossConnection(c *C) {
 
 func (s *DisconnectSdkSuite) TestParallelInstances(c *C) {
 	_, err := s.repo.Connect(&ConnRef{
-		PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
-		SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2-instance", Name: "iface-a"}}, nil, nil, nil, nil, nil)
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-a"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2-instance", Name: "iface-a"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	affected, err := s.repo.DisconnectSdk("42424242", "ws", "s1")
 	c.Assert(err, IsNil)
@@ -1402,8 +1403,8 @@ func (s *DisconnectSdkSuite) TestParallelInstances(c *C) {
 	c.Check(affected, testutil.DeepContains, s.s2Instance)
 
 	_, err = s.repo.Connect(&ConnRef{
-		PlugRef: PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2-instance", Name: "iface-b"},
-		SlotRef: SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}, nil, nil, nil, nil, nil)
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s2-instance", Name: "iface-b"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "s1", Name: "iface-b"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	affected, err = s.repo.DisconnectSdk("42424242", "ws", "s1")
 	c.Assert(err, IsNil)
@@ -1517,8 +1518,8 @@ func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
 	conn, err := s.emptyRepo.Connect(&ConnRef{
-		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
-		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
 	c.Assert(err, IsNil)
 	c.Assert(conn, NotNil)
 
@@ -1554,8 +1555,8 @@ func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
 
 	conn, err := s.emptyRepo.Connect(&ConnRef{
-		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
-		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot connect plug "ws-s1/s1:consumer": invalid plug`)
 	c.Assert(conn, IsNil)
@@ -1582,8 +1583,8 @@ func (s *RepositorySuite) TestBeforeConnectValidationPolicyCheckFailure(c *C) {
 	}
 
 	conn, err := s.emptyRepo.Connect(&ConnRef{
-		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
-		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws-s1", Sdk: "s1", Name: "consumer"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws-s2", Sdk: "s2", Name: "producer"}}, nil, plugDynAttrs, nil, slotDynAttrs, policyCheck)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `policy check failed`)
 	c.Assert(conn, IsNil)
@@ -1607,15 +1608,15 @@ func (s *RepositorySuite) TestConnection(c *C) {
 	c.Assert(conn.Slot.Name(), Equals, "slot")
 
 	_, err = s.testRepo.Connection(&ConnRef{
-		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"},
-		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"}})
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"}})
 	c.Assert(err, ErrorMatches, `SDK "ws/a" has no plug named "b"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 
 	_, err = s.testRepo.Connection(&ConnRef{
-		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"}})
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"}})
 	c.Assert(err, ErrorMatches, `SDK "ws/a" has no slot named "b"`)
 	e, _ = err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
@@ -1688,16 +1689,16 @@ plugs:
 
 	// Connect a few things for the tests below.
 	_, err := r.Connect(&ConnRef{
-		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i1"},
-		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i1"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	_, err = r.Connect(&ConnRef{
-		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i1"},
-		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i1"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s2", Name: "i1"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 	_, err = r.Connect(&ConnRef{
-		PlugRef: PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i2"},
-		SlotRef: SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s3", Name: "i2"}}, nil, nil, nil, nil, nil)
+		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i2"},
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s3", Name: "i2"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	// Without any names or options we get the summary of all the interfaces.

--- a/internal/interfaces/sorting_test.go
+++ b/internal/interfaces/sorting_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 type SortingSuite struct{}
@@ -34,8 +35,8 @@ var _ = Suite(&SortingSuite{})
 
 func newConnRef(plugWs, plugSdk, plug, slotWs, slotSdk, slot string) *interfaces.ConnRef {
 	return &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{Workshop: plugWs, Sdk: plugSdk, Name: plug},
-		SlotRef: interfaces.SlotRef{Workshop: slotWs, Sdk: slotSdk, Name: slot}}
+		PlugRef: sdk.PlugRef{Workshop: plugWs, Sdk: plugSdk, Name: plug},
+		SlotRef: sdk.SlotRef{Workshop: slotWs, Sdk: slotSdk, Name: slot}}
 }
 
 func (s *SortingSuite) TestByInterfaceName(c *C) {
@@ -73,11 +74,11 @@ func (s *SortingSuite) TestByConnRef(c *C) {
 	})
 }
 
-func newSlotRef(workshop, sdk, name string) *interfaces.SlotRef {
-	return &interfaces.SlotRef{Workshop: workshop, Sdk: sdk, Name: name}
+func newSlotRef(workshop, sk, name string) *sdk.SlotRef {
+	return &sdk.SlotRef{Workshop: workshop, Sdk: sk, Name: name}
 }
 
-type bySlotRef []*interfaces.SlotRef
+type bySlotRef []*sdk.SlotRef
 
 func (b bySlotRef) Len() int      { return len(b) }
 func (b bySlotRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
@@ -86,7 +87,7 @@ func (b bySlotRef) Less(i, j int) bool {
 }
 
 func (s *SortingSuite) TestSortSlotRef(c *C) {
-	list := []*interfaces.SlotRef{
+	list := []*sdk.SlotRef{
 		newSlotRef("abc", "name-2", "slot-3"),
 		newSlotRef("def", "name-2_instance", "slot-1"),
 		newSlotRef("def", "name-2", "slot-2"),
@@ -95,7 +96,7 @@ func (s *SortingSuite) TestSortSlotRef(c *C) {
 	}
 	sort.Sort(bySlotRef(list))
 
-	c.Assert(list, DeepEquals, []*interfaces.SlotRef{
+	c.Assert(list, DeepEquals, []*sdk.SlotRef{
 		newSlotRef("abc", "name-2", "slot-3"),
 		newSlotRef("abc", "name-2", "slot-4"),
 		newSlotRef("def", "name-2", "slot-1"),
@@ -104,7 +105,7 @@ func (s *SortingSuite) TestSortSlotRef(c *C) {
 	})
 }
 
-type byPlugRef []*interfaces.PlugRef
+type byPlugRef []*sdk.PlugRef
 
 func (b byPlugRef) Len() int      { return len(b) }
 func (b byPlugRef) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
@@ -112,12 +113,12 @@ func (b byPlugRef) Less(i, j int) bool {
 	return b[i].SortsBefore(*b[j])
 }
 
-func newPlugRef(workshop, sdk, name string) *interfaces.PlugRef {
-	return &interfaces.PlugRef{Workshop: workshop, Sdk: sdk, Name: name}
+func newPlugRef(workshop, sk, name string) *sdk.PlugRef {
+	return &sdk.PlugRef{Workshop: workshop, Sdk: sk, Name: name}
 }
 
 func (s *SortingSuite) TestSortPlugRef(c *C) {
-	list := []*interfaces.PlugRef{
+	list := []*sdk.PlugRef{
 		newPlugRef("abc", "name-2", "plug-3"),
 		newPlugRef("def", "name-2_instance", "plug-1"),
 		newPlugRef("abc", "name-2", "plug-4"),
@@ -126,7 +127,7 @@ func (s *SortingSuite) TestSortPlugRef(c *C) {
 	}
 	sort.Sort(byPlugRef(list))
 
-	c.Assert(list, DeepEquals, []*interfaces.PlugRef{
+	c.Assert(list, DeepEquals, []*sdk.PlugRef{
 		newPlugRef("abc", "name-2", "plug-3"),
 		newPlugRef("abc", "name-2", "plug-4"),
 		newPlugRef("def", "name-2", "plug-1"),

--- a/internal/metautil/type_conversions.go
+++ b/internal/metautil/type_conversions.go
@@ -20,6 +20,7 @@
 package metautil
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 )
@@ -70,23 +71,20 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 }
 
 // SetValueFromAttribute attempts to convert the attribute value read from the
-// given sdk/interface into the desired type.
-//
-// The sdkName, ifaceName and attrName are only used to produce contextual
-// error messages, but are not otherwise significant. This function only
+// given sdk/interface into the desired type. This function only
 // operates converting the attrVal parameter into a value which can fit into
 // the val parameter, which therefore must be a pointer.
-func SetValueFromAttribute(sdkName string, ifaceName string, attrName string, attrVal interface{}, val interface{}) error {
+func SetValueFromAttribute(attrVal interface{}, val interface{}) error {
 	rt := reflect.TypeOf(val)
 	if rt.Kind() != reflect.Ptr || val == nil {
-		return fmt.Errorf("internal error: cannot get %q attribute of interface %q with non-pointer value", attrName, ifaceName)
+		return errors.New("internal error: value must be a pointer")
 	}
 
 	converted, err := convertValue(reflect.ValueOf(attrVal), rt.Elem())
 	if err != nil {
-		return fmt.Errorf("SDK %q has interface %q with invalid value type %q for %q attribute: %s", sdkName, ifaceName, reflect.TypeOf(attrVal), attrName, reflect.TypeOf(val))
+		return fmt.Errorf("expected %s but found %s", rt.Elem().Name(), reflect.TypeOf(attrVal).Name())
 	}
-	rv := reflect.ValueOf(val)
-	rv.Elem().Set(converted)
+
+	reflect.ValueOf(val).Elem().Set(converted)
 	return nil
 }

--- a/internal/metautil/type_conversions.go
+++ b/internal/metautil/type_conversions.go
@@ -69,25 +69,6 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 	return nullValue, fmt.Errorf(`cannot convert value "%v" into a %v`, value, outputType)
 }
 
-// AttributeNotCompatibleError represents a type mismatch error between an interface
-// attribute and an expected type.
-type AttributeNotCompatibleError struct {
-	SdkName       string
-	InterfaceName string
-	AttributeName string
-	AttributeType reflect.Type
-	ExpectedType  reflect.Type
-}
-
-func (e AttributeNotCompatibleError) Error() string {
-	return fmt.Sprintf("SDK %q has interface %q with invalid value type %q for %q attribute: %s", e.SdkName, e.InterfaceName, e.AttributeType, e.AttributeName, e.ExpectedType)
-}
-
-func (e AttributeNotCompatibleError) Is(target error) bool {
-	_, ok := target.(AttributeNotCompatibleError)
-	return ok
-}
-
 // SetValueFromAttribute attempts to convert the attribute value read from the
 // given sdk/interface into the desired type.
 //
@@ -103,13 +84,7 @@ func SetValueFromAttribute(sdkName string, ifaceName string, attrName string, at
 
 	converted, err := convertValue(reflect.ValueOf(attrVal), rt.Elem())
 	if err != nil {
-		return AttributeNotCompatibleError{
-			SdkName:       sdkName,
-			InterfaceName: ifaceName,
-			AttributeName: attrName,
-			AttributeType: reflect.TypeOf(attrVal),
-			ExpectedType:  reflect.TypeOf(val),
-		}
+		return fmt.Errorf("SDK %q has interface %q with invalid value type %q for %q attribute: %s", sdkName, ifaceName, reflect.TypeOf(attrVal), attrName, reflect.TypeOf(val))
 	}
 	rv := reflect.ValueOf(val)
 	rv.Elem().Set(converted)

--- a/internal/metautil/type_conversions_test.go
+++ b/internal/metautil/type_conversions_test.go
@@ -99,7 +99,7 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 func (s *conversionssSuite) TestSetValueFromAttributeHappy(c *C) {
 	interfaceArray := []interface{}{12, -3}
 	var outputValue []int
-	err := metautil.SetValueFromAttribute("sdk0", "iface0", "attr0", interfaceArray, &outputValue)
+	err := metautil.SetValueFromAttribute(interfaceArray, &outputValue)
 	c.Assert(err, IsNil)
 	c.Check(outputValue, DeepEquals, []int{12, -3})
 }
@@ -107,36 +107,27 @@ func (s *conversionssSuite) TestSetValueFromAttributeHappy(c *C) {
 func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 	var outputBool bool
 	data := []struct {
-		sdkName       string
-		ifaceName     string
-		attrName      string
 		inputValue    interface{}
 		outputValue   interface{}
 		expectedError string
 	}{
 		// error if output value parameter is not a pointer
 		{
-			"sdk1",
-			"iface1",
-			"attr1",
 			"input value",
 			"I'm not a pointer",
-			`internal error: cannot get "attr1" attribute of interface "iface1" with non-pointer value`,
+			"internal error: value must be a pointer",
 		},
 
 		// error if value cannot be converted
 		{
-			"sdk2",
-			"iface2",
-			"attr2",
 			"input value",
 			&outputBool,
-			`SDK "sdk2" has interface "iface2" with invalid value type "string" for "attr2" attribute: \*bool`,
+			`expected bool but found string`,
 		},
 	}
 
 	for _, td := range data {
-		err := metautil.SetValueFromAttribute(td.sdkName, td.ifaceName, td.attrName, td.inputValue, td.outputValue)
+		err := metautil.SetValueFromAttribute(td.inputValue, td.outputValue)
 		c.Check(err, ErrorMatches, td.expectedError, Commentf("input value %v", td.inputValue))
 	}
 }

--- a/internal/metautil/type_conversions_test.go
+++ b/internal/metautil/type_conversions_test.go
@@ -20,13 +20,11 @@
 package metautil_test
 
 import (
-	"errors"
 	"reflect"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/metautil"
-	"github.com/canonical/workshop/internal/testutil"
 )
 
 type conversionssSuite struct{}
@@ -141,9 +139,4 @@ func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 		err := metautil.SetValueFromAttribute(td.sdkName, td.ifaceName, td.attrName, td.inputValue, td.outputValue)
 		c.Check(err, ErrorMatches, td.expectedError, Commentf("input value %v", td.inputValue))
 	}
-}
-
-func (s *conversionssSuite) TestAttributeNotCompatibleIsTypeCheck(c *C) {
-	c.Assert(metautil.AttributeNotCompatibleError{}, testutil.ErrorIs, metautil.AttributeNotCompatibleError{})
-	c.Assert(metautil.AttributeNotCompatibleError{}, Not(testutil.ErrorIs), errors.New(""))
 }

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 type ChangeSetup struct {
@@ -68,8 +68,8 @@ func checkWorkshop(task *state.Task, projectId, workshop string) (bool, error) {
 
 	if task.Kind() == "disconnect" {
 		// disconnect can affect more then one workshop
-		var plugRef interfaces.PlugRef
-		var slotRef interfaces.SlotRef
+		var plugRef sdk.PlugRef
+		var slotRef sdk.SlotRef
 		if err := task.Get("plug", &plugRef); err != nil {
 			return false, err
 		}

--- a/internal/overlord/conflict/conflict_test.go
+++ b/internal/overlord/conflict/conflict_test.go
@@ -5,9 +5,9 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/canonical/workshop/internal/interfaces"
 	conflict "github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -32,8 +32,8 @@ func (s *conflictSuite) newChange(kind string) *state.Change {
 func (s *conflictSuite) newChangeDisconnect(kind string) *state.Change {
 	change := s.state.NewChange(kind, "test")
 	task := s.state.NewTask("disconnect", "test")
-	task.Set("slot", interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "ws"})
-	task.Set("plug", interfaces.SlotRef{ProjectId: s.project.ProjectId, Workshop: "another-ws"})
+	task.Set("slot", sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "ws"})
+	task.Set("plug", sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "another-ws"})
 	change.AddTask(task)
 	change.Set("project-id", s.project.ProjectId)
 	return change

--- a/internal/overlord/ifacestate/export_test.go
+++ b/internal/overlord/ifacestate/export_test.go
@@ -14,8 +14,8 @@ var (
 
 func UpdateConnectionInConnState(conns map[string]*schema.ConnState, conn *interfaces.Connection, autoConnect, undesired bool) {
 	connRef := &interfaces.ConnRef{
-		PlugRef: *conn.Plug.Ref(),
-		SlotRef: *conn.Slot.Ref(),
+		PlugRef: conn.Plug.Ref(),
+		SlotRef: conn.Slot.Ref(),
 	}
 
 	conns[connRef.ID()] = &schema.ConnState{

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -160,8 +160,8 @@ func workshopConns(wp *workshop.Workshop) []interfaces.ConnRef {
 	conns := []interfaces.ConnRef{}
 	for _, wconn := range wp.File.Connections {
 		conns = append(conns, interfaces.ConnRef{
-			PlugRef: interfaces.PlugRef{ProjectId: wp.Project.ProjectId, Workshop: wp.Name, Sdk: wconn.PlugRef.Sdk, Name: wconn.PlugRef.Name},
-			SlotRef: interfaces.SlotRef{ProjectId: wp.Project.ProjectId, Workshop: wp.Name, Sdk: wconn.SlotRef.Sdk, Name: wconn.SlotRef.Name},
+			PlugRef: sdk.PlugRef{ProjectId: wp.Project.ProjectId, Workshop: wp.Name, Sdk: wconn.PlugRef.Sdk, Name: wconn.PlugRef.Name},
+			SlotRef: sdk.SlotRef{ProjectId: wp.Project.ProjectId, Workshop: wp.Name, Sdk: wconn.SlotRef.Sdk, Name: wconn.SlotRef.Name},
 		})
 	}
 	return conns
@@ -179,7 +179,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 	var slotDynamic = make(map[string]map[string]interface{})
 
 	for _, plug := range info.Plugs {
-		ref := interfaces.NewPlugRef(plug)
+		ref := plug.Ref()
 		master, slaves := MaybeBound(wp, ref)
 		if master != ref {
 			// the plug is bound to, its connection will be setup together with
@@ -199,7 +199,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 				slotDynamic[connRef.ID()]["host-source"] = src
 			}
 
-			slotRef := interfaces.NewSlotRef(slot)
+			slotRef := slot.Ref()
 			// save associated binds as a dynamic attribute
 			for _, slave := range slaves {
 				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
@@ -224,7 +224,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 		candidates := m.repo.AutoConnectCandidatePlugs(info.ProjectId, info.Workshop,
 			info.Name, slot.Name, autoConnectChecker(wconns))
 		for _, plug := range candidates {
-			ref := interfaces.NewPlugRef(plug)
+			ref := plug.Ref()
 			master, slaves := MaybeBound(wp, ref)
 			if master != ref {
 				// the plug is bound to, its connection will be setup together with
@@ -241,7 +241,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 				slotDynamic[connRef.ID()]["host-source"] = src
 			}
 
-			slotRef := interfaces.NewSlotRef(slot)
+			slotRef := slot.Ref()
 			for _, slave := range slaves {
 				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
 
@@ -375,9 +375,9 @@ func (m *InterfaceManager) doDisconnectInterfaces(task *state.Task, tomb *tomb.T
 	return nil
 }
 
-func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRef, error) {
-	var plugRef interfaces.PlugRef
-	var slotRef interfaces.SlotRef
+func getPlugAndSlotRefs(task *state.Task) (sdk.PlugRef, sdk.SlotRef, error) {
+	var plugRef sdk.PlugRef
+	var slotRef sdk.SlotRef
 	if err := task.Get("plug", &plugRef); err != nil {
 		return plugRef, slotRef, err
 	}
@@ -387,18 +387,18 @@ func getPlugAndSlotRefs(task *state.Task) (interfaces.PlugRef, interfaces.SlotRe
 	return plugRef, slotRef, nil
 }
 
-func MaybeBound(w *workshop.Workshop, ref interfaces.PlugRef) (interfaces.PlugRef, []interfaces.PlugRef) {
-	var masters = make(map[interfaces.PlugRef][]interfaces.PlugRef)
-	var slaves = make(map[interfaces.PlugRef]interfaces.PlugRef)
+func MaybeBound(w *workshop.Workshop, ref sdk.PlugRef) (sdk.PlugRef, []sdk.PlugRef) {
+	var masters = make(map[sdk.PlugRef][]sdk.PlugRef)
+	var slaves = make(map[sdk.PlugRef]sdk.PlugRef)
 
 	for _, s := range w.File.Sdks {
 		for name, pl := range s.Plugs {
 			if pl.Bind == nil {
 				continue
 			}
-			sdk, plug := pl.Bind.Sdk, pl.Bind.Name
-			mkey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: sdk, Name: plug}
-			skey := interfaces.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: s.Name, Name: name}
+			sk, plug := pl.Bind.Sdk, pl.Bind.Name
+			mkey := sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: sk, Name: plug}
+			skey := sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: s.Name, Name: name}
 			masters[mkey] = append(masters[mkey], skey)
 			slaves[skey] = mkey
 		}
@@ -984,7 +984,7 @@ func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
-	var plug interfaces.PlugRef
+	var plug sdk.PlugRef
 	if err := task.Get("plug", &plug); err != nil {
 		return err
 	}
@@ -1002,7 +1002,7 @@ func (m *InterfaceManager) doRemount(task *state.Task, tomb *tomb.Tomb) error {
 	return m.remount(ctx, task, &plug, source, inst.Running)
 }
 
-func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *interfaces.PlugRef, source string, workshopRunning bool) error {
+func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *sdk.PlugRef, source string, workshopRunning bool) error {
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -482,7 +482,7 @@ func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Chang
 
 	t1 := s.state.NewTask("remount", "remount")
 	t1.Set("host-source", newSource)
-	t1.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
+	t1.Set("plug", sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
 	setWorkshopProject("ws-consumer", s.prj, t1)
 
 	chg := s.state.NewChange("sample", "...")
@@ -805,9 +805,9 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C)
 
 func (s *interfaceHandlersSuite) newDisconnectInterfacesChange(sdkName string) *state.Change {
 	t1 := s.state.NewTask("auto-disconnect", "...")
-	t1.Set("plug", interfaces.PlugRef{
+	t1.Set("plug", sdk.PlugRef{
 		ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
-	t1.Set("slot", interfaces.PlugRef{
+	t1.Set("slot", sdk.PlugRef{
 		ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "producer", Name: "slot"})
 	t1.Set("sdk", sdkName)
 	setWorkshopProject("ws-consumer", s.prj, t1)
@@ -828,8 +828,8 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	})
 
 	connRef := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
 	}
 
 	s.state.Lock()
@@ -982,8 +982,8 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesSuccess(c *check.C)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
 	connRef := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
 	}
 
 	s.state.Lock()
@@ -1033,8 +1033,8 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesManualRestored(c *c
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
 	connRef := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
 	}
 
 	s.state.Lock()
@@ -1076,8 +1076,8 @@ func (s *interfaceHandlersSuite) disconnectChange(c *check.C, workshop string, f
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("disconnect", "...")
-	plugRef := interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "consumer", Name: "plug"}
-	slotRef := interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "producer", Name: "slot"}
+	plugRef := sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "consumer", Name: "plug"}
+	slotRef := sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "producer", Name: "slot"}
 	t1.Set("plug", plugRef)
 	t1.Set("slot", slotRef)
 	t1.Set("forget", forget)
@@ -1345,8 +1345,8 @@ func (s *interfaceHandlersSuite) connectChange(workshop string, auto bool, delay
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("connect", "...")
-	plugRef := interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "consumer", Name: "plug"}
-	slotRef := interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "producer", Name: "slot"}
+	plugRef := sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "consumer", Name: "plug"}
+	slotRef := sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: workshop, Sdk: "producer", Name: "slot"}
 	t1.Set("plug", plugRef)
 	t1.Set("slot", slotRef)
 	t1.Set("auto", auto)
@@ -1383,8 +1383,8 @@ func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
 	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
-	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	c.Assert(conns[0].PlugRef, check.DeepEquals, sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(conns[0].SlotRef, check.DeepEquals, sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
@@ -1414,8 +1414,8 @@ func (s *interfaceHandlersSuite) TestConnectSuccessSetupBackend(c *check.C) {
 	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
-	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	c.Assert(conns[0].PlugRef, check.DeepEquals, sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(conns[0].SlotRef, check.DeepEquals, sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
@@ -1490,8 +1490,8 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
-	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	c.Assert(conns[0].PlugRef, check.DeepEquals, sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(conns[0].SlotRef, check.DeepEquals, sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
 
 	conn, err := repo.Connection(conns[0])
 	c.Assert(err, check.IsNil)
@@ -1525,8 +1525,8 @@ func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 	conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].PlugRef, check.DeepEquals, interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
-	c.Assert(conns[0].SlotRef, check.DeepEquals, interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	c.Assert(conns[0].PlugRef, check.DeepEquals, sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	c.Assert(conns[0].SlotRef, check.DeepEquals, sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
 
 	stateConns, err := ifacestate.GetConns(s.state)
 	c.Assert(err, check.IsNil)
@@ -1777,8 +1777,8 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
 	s.state.Lock()
 	c1 := s.state.NewChange("sample", "")
 	t1 := s.state.NewTask("connect", "")
-	t1.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
-	t1.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	t1.Set("slot", sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	t1.Set("plug", sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
 	setWorkshopProject("ws", s.prj, t1)
 	c1.AddTask(t1)
 	c1.Set("project-id", s.prj.ProjectId)
@@ -1807,8 +1807,8 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
 	c2 := s.state.NewChange("sample", "")
 	t2 := s.state.NewTask("disconnect", "")
 
-	t2.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
-	t2.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	t2.Set("slot", sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	t2.Set("plug", sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
 	setWorkshopProject("ws", s.prj, t2)
 	c2.AddTask(t2)
 	c2.Set("project-id", s.prj.ProjectId)
@@ -1851,8 +1851,8 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailureAuto(c *check.C) {
 	s.state.Lock()
 	c1 := s.state.NewChange("sample", "")
 	t1 := s.state.NewTask("connect", "")
-	t1.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
-	t1.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	t1.Set("slot", sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	t1.Set("plug", sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
 	t1.Set("auto", true)
 	setWorkshopProject("ws", s.prj, t1)
 	c1.AddTask(t1)
@@ -1882,8 +1882,8 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailureAuto(c *check.C) {
 	c2 := s.state.NewChange("sample", "")
 	t2 := s.state.NewTask("disconnect", "")
 
-	t2.Set("slot", interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
-	t2.Set("plug", interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
+	t2.Set("slot", sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "producer", Name: "slot"})
+	t2.Set("plug", sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug-ssh"})
 	setWorkshopProject("ws", s.prj, t2)
 	c2.AddTask(t2)
 	c2.Set("project-id", s.prj.ProjectId)

--- a/internal/overlord/ifacestate/helpers.go
+++ b/internal/overlord/ifacestate/helpers.go
@@ -20,7 +20,7 @@ type checker = func(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSl
 
 func autoConnectChecker(workshopConns []interfaces.ConnRef) checker {
 	return func(p *interfaces.ConnectedPlug, s *interfaces.ConnectedSlot) (bool, error) {
-		conn := interfaces.ConnRef{PlugRef: *p.Ref(), SlotRef: *s.Ref()}
+		conn := interfaces.ConnRef{PlugRef: p.Ref(), SlotRef: s.Ref()}
 		// The pair is explicitly connected in a workshop file.
 		if slices.Contains(workshopConns, conn) {
 			// The interface's policy will be able to determine whether the
@@ -38,7 +38,7 @@ func autoConnectChecker(workshopConns []interfaces.ConnRef) checker {
 		// mount interface plug connected explicitly should reject connections
 		// to other slots.
 		if slices.ContainsFunc(workshopConns, func(conn interfaces.ConnRef) bool {
-			return conn.PlugRef == *p.Ref()
+			return conn.PlugRef == p.Ref()
 		}) {
 			return false, nil
 		}

--- a/internal/overlord/ifacestate/helpers_test.go
+++ b/internal/overlord/ifacestate/helpers_test.go
@@ -89,7 +89,7 @@ func (s *helpersSuite) TestAutoConnectChecker(c *check.C) {
 	_, err = policyCheck(plugMount, slotMount)
 	c.Assert(err, check.NotNil)
 
-	connRef := interfaces.ConnRef{PlugRef: *plugMount.Ref(), SlotRef: *slotMount.Ref()}
+	connRef := interfaces.ConnRef{PlugRef: plugMount.Ref(), SlotRef: slotMount.Ref()}
 	workshopConns = append(workshopConns, connRef)
 	policyCheck = ifacestate.AutoConnectChecker(workshopConns)
 

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -210,8 +210,8 @@ func (m *InterfaceManager) ResolveDisconnect(
 		}
 		connected = func(plugPrj, plugWs, plugSdk, plug, slotPrj, slotWs, slotSdk, slot string) (bool, error) {
 			cref := interfaces.ConnRef{
-				PlugRef: interfaces.PlugRef{ProjectId: plugPrj, Workshop: plugWs, Sdk: plugSdk, Name: plug},
-				SlotRef: interfaces.SlotRef{ProjectId: slotPrj, Workshop: slotWs, Sdk: slotSdk, Name: slot},
+				PlugRef: sdk.PlugRef{ProjectId: plugPrj, Workshop: plugWs, Sdk: plugSdk, Name: plug},
+				SlotRef: sdk.SlotRef{ProjectId: slotPrj, Workshop: slotWs, Sdk: slotSdk, Name: slot},
 			}
 			_, ok := conns[cref.ID()]
 			return ok, nil
@@ -236,8 +236,8 @@ func (m *InterfaceManager) ResolveDisconnect(
 	} else {
 		connected = func(plugPrj, plugWs, plugSdk, plug, slotPrj, slotWs, slotSdk, slot string) (bool, error) {
 			_, err := m.repo.Connection(&interfaces.ConnRef{
-				PlugRef: interfaces.PlugRef{ProjectId: plugPrj, Workshop: plugWs, Sdk: plugSdk, Name: plug},
-				SlotRef: interfaces.SlotRef{ProjectId: slotPrj, Workshop: slotWs, Sdk: slotSdk, Name: slot},
+				PlugRef: sdk.PlugRef{ProjectId: plugPrj, Workshop: plugWs, Sdk: plugSdk, Name: plug},
+				SlotRef: sdk.SlotRef{ProjectId: slotPrj, Workshop: slotWs, Sdk: slotSdk, Name: slot},
 			})
 			if _, notConnected := err.(*interfaces.NotConnectedError); notConnected {
 				return false, nil
@@ -270,8 +270,8 @@ func (m *InterfaceManager) ResolveDisconnect(
 		if err != nil {
 			return nil, err
 		}
-		plugRef := interfaces.PlugRef{ProjectId: plugProject, Workshop: plugWorkshop, Sdk: plugSdk, Name: plugName}
-		slotRef := interfaces.SlotRef{ProjectId: slotProject, Workshop: slotWorkshop, Sdk: slotSdk, Name: slotName}
+		plugRef := sdk.PlugRef{ProjectId: plugProject, Workshop: plugWorkshop, Sdk: plugSdk, Name: plugName}
+		slotRef := sdk.SlotRef{ProjectId: slotProject, Workshop: slotWorkshop, Sdk: slotSdk, Name: slotName}
 		if !isConnected {
 			if forget {
 				return nil, fmt.Errorf("cannot forget connection between %q and %q: not connected",
@@ -447,8 +447,8 @@ func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
 		})
 		if idx != -1 {
 			return fmt.Errorf(`cannot connect %q: target %q is also mounted by %q`,
-				interfaces.NewPlugRef(plug).ShortRef(), candidateTarget,
-				interfaces.NewPlugRef(allPlugs[idx]).ShortRef())
+				plug.Ref().ShortRef(), candidateTarget,
+				allPlugs[idx].Ref().ShortRef())
 		}
 	}
 	return nil

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -196,8 +196,8 @@ plugs:
 	ifaces := repo.Interfaces()
 	c.Assert(ifaces.Connections, check.HasLen, 1)
 	cref := &interfaces.ConnRef{
-		PlugRef: interfaces.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: interfaces.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: sdk.System.String(), Name: "slot"}}
+		PlugRef: sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: sdk.System.String(), Name: "slot"}}
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{cref})
 
 	conn, err := repo.Connection(cref)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/canonical/workshop/internal/dirs"
-	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/cmdstate"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
@@ -806,7 +805,7 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*s
 	return removeSet, nil
 }
 
-func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug interfaces.PlugRef, source string, projectId string) (*state.TaskSet, error) {
+func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug sdk.PlugRef, source string, projectId string) (*state.TaskSet, error) {
 	if !filepath.IsAbs(source) {
 		return nil, fmt.Errorf("cannot remount: the `source` path must be absolute")
 	}

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
-	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
@@ -726,7 +725,7 @@ func (s *requestSuite) TestRemountSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	plug := interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-1", Sdk: "sdk-1", Name: "plug"}
+	plug := sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-1", Sdk: "sdk-1", Name: "plug"}
 	sdks := []workshop.SdkRecord{
 		{Name: "sdk-1", Channel: "latest/stable"},
 	}
@@ -747,7 +746,7 @@ func (s *requestSuite) TestRemountSuccess(c *check.C) {
 	c.Assert(w, check.Equals, "ws-1")
 	c.Assert(p, check.DeepEquals, s.project)
 
-	var plugRef interfaces.PlugRef
+	var plugRef sdk.PlugRef
 	var src string
 	c.Assert(task.Get("plug", &plugRef), check.IsNil)
 	c.Assert(plugRef, check.DeepEquals, plug)
@@ -759,7 +758,7 @@ func (s *requestSuite) TestRemountWorkshopNotReady(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	plug := interfaces.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-1", Sdk: "sdk-1", Name: "plug"}
+	plug := sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "ws-1", Sdk: "sdk-1", Name: "plug"}
 	sdks := []workshop.SdkRecord{
 		{Name: "sdk-1", Channel: "latest/stable"},
 	}

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -70,7 +70,7 @@ type Info struct {
 	BuildTime *time.Time
 
 	Plugs     map[string]*PlugInfo
-	PlugBinds map[string]*PlugBind
+	PlugBinds map[string]PlugRef
 	Slots     map[string]*SlotInfo
 	// Plugs or slots with issues (they are not included in Plugs or Slots)
 	BadInterfaces map[string]string
@@ -84,7 +84,7 @@ func (i *Info) Ref() Ref {
 	}
 }
 
-func (i *Info) SetupPlugBinds(binds map[string]*PlugBind) error {
+func (i *Info) SetupPlugBinds(binds map[string]PlugRef) error {
 	if i.Type == System {
 		return nil
 	}
@@ -186,7 +186,7 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 		Type:          Type(sdkYaml.Type),
 		BuildTime:     sdkYaml.BuildTime,
 		Plugs:         make(map[string]*PlugInfo),
-		PlugBinds:     make(map[string]*PlugBind),
+		PlugBinds:     make(map[string]PlugRef),
 		Slots:         make(map[string]*SlotInfo),
 		BadInterfaces: make(map[string]string),
 	}
@@ -348,9 +348,41 @@ func (slot *SlotInfo) Lookup(key string) (interface{}, bool) {
 	return lookupAttr(slot.Attrs, key)
 }
 
-// String returns the representation of the slot as sdk:slot string.
-func (slot *SlotInfo) String() string {
-	return fmt.Sprintf("%s:%s", slot.Sdk.Name, slot.Name)
+func (slot *SlotInfo) Ref() SlotRef {
+	return SlotRef{ProjectId: slot.Sdk.ProjectId, Workshop: slot.Sdk.Workshop, Sdk: slot.Sdk.Name, Name: slot.Name}
+}
+
+// SlotRef is a reference to a slot.
+type SlotRef struct {
+	ProjectId string `json:"project-id"`
+	Workshop  string `json:"workshop"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"slot"`
+}
+
+func (ref SlotRef) SdkRef() Ref {
+	return Ref{ProjectId: ref.ProjectId, Workshop: ref.Workshop, Sdk: ref.Sdk}
+}
+
+// String returns the "project-id/workshop/sdk:slot" representation of a slot reference.
+func (ref SlotRef) String() string {
+	return fmt.Sprintf("%s:%s", ref.SdkRef().String(), ref.Name)
+}
+
+// ShortRef returns the "workshop/sdk:slot" representation of a slot reference (human-friendly).
+func (ref SlotRef) ShortRef() string {
+	return fmt.Sprintf("%s:%s", ref.SdkRef().ShortRef(), ref.Name)
+}
+
+// SortsBefore returns true when slot should be sorted before the other
+func (ref SlotRef) SortsBefore(other SlotRef) bool {
+	if ref.Workshop != other.Workshop {
+		return ref.Workshop < other.Workshop
+	}
+	if ref.Sdk != other.Sdk {
+		return ref.Sdk < other.Sdk
+	}
+	return ref.Name < other.Name
 }
 
 // PlugInfo provides information about a plug.
@@ -371,11 +403,41 @@ func (plug *PlugInfo) Lookup(key string) (interface{}, bool) {
 	return lookupAttr(plug.Attrs, key)
 }
 
-type PlugBind struct {
-	ProjectId string
-	Workshop  string
-	Sdk       string
-	Name      string
+func (plug *PlugInfo) Ref() PlugRef {
+	return PlugRef{ProjectId: plug.Sdk.ProjectId, Workshop: plug.Sdk.Workshop, Sdk: plug.Sdk.Name, Name: plug.Name}
+}
+
+// PlugRef is a reference to a plug.
+type PlugRef struct {
+	ProjectId string `json:"project-id"`
+	Workshop  string `json:"workshop"`
+	Sdk       string `json:"sdk"`
+	Name      string `json:"plug"`
+}
+
+func (ref PlugRef) SdkRef() Ref {
+	return Ref{ProjectId: ref.ProjectId, Workshop: ref.Workshop, Sdk: ref.Sdk}
+}
+
+// String returns the "project-id/workshop/sdk:plug" representation of a plug reference.
+func (ref PlugRef) String() string {
+	return fmt.Sprintf("%s:%s", ref.SdkRef().String(), ref.Name)
+}
+
+// ShortRef returns the "workshop/sdk:plug" representation of a plug reference (human-friendly).
+func (ref PlugRef) ShortRef() string {
+	return fmt.Sprintf("%s:%s", ref.SdkRef().ShortRef(), ref.Name)
+}
+
+// SortsBefore returns true when plug should be sorted before the other
+func (ref PlugRef) SortsBefore(other PlugRef) bool {
+	if ref.Workshop != other.Workshop {
+		return ref.Workshop < other.Workshop
+	}
+	if ref.Sdk != other.Sdk {
+		return ref.Sdk < other.Sdk
+	}
+	return ref.Name < other.Name
 }
 
 func SdkRootPath(sdkName string) string {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -331,17 +331,17 @@ func lookupAttr(attrs map[string]interface{}, path string) (interface{}, bool) {
 	return v, true
 }
 
-func getAttribute(sdkName string, ifaceName string, attrs map[string]interface{}, key string, val interface{}) error {
-	v, ok := lookupAttr(attrs, key)
+func (slot *SlotInfo) Attr(key string, val interface{}) error {
+	v, ok := slot.Lookup(key)
 	if !ok {
-		return AttributeNotFoundError{fmt.Errorf("SDK %q does not have attribute %q for interface %q", sdkName, key, ifaceName)}
+		err := fmt.Errorf("attribute %q not found for slot %q", key, slot.Ref().ShortRef())
+		return AttributeNotFoundError{Err: err}
 	}
 
-	return metautil.SetValueFromAttribute(sdkName, ifaceName, key, v, val)
-}
-
-func (slot *SlotInfo) Attr(key string, val interface{}) error {
-	return getAttribute(slot.Sdk.Name, slot.Interface, slot.Attrs, key, val)
+	if err := metautil.SetValueFromAttribute(v, val); err != nil {
+		return fmt.Errorf("invalid attribute %q for slot %q: %w", key, slot.Ref().ShortRef(), err)
+	}
+	return nil
 }
 
 func (slot *SlotInfo) Lookup(key string) (interface{}, bool) {
@@ -396,7 +396,16 @@ type PlugInfo struct {
 }
 
 func (plug *PlugInfo) Attr(key string, val interface{}) error {
-	return getAttribute(plug.Sdk.Name, plug.Interface, plug.Attrs, key, val)
+	v, ok := plug.Lookup(key)
+	if !ok {
+		err := fmt.Errorf("attribute %q not found for plug %q", key, plug.Ref().ShortRef())
+		return AttributeNotFoundError{Err: err}
+	}
+
+	if err := metautil.SetValueFromAttribute(v, val); err != nil {
+		return fmt.Errorf("invalid attribute %q for plug %q: %w", key, plug.Ref().ShortRef(), err)
+	}
+	return nil
 }
 
 func (plug *PlugInfo) Lookup(key string) (interface{}, bool) {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -269,13 +269,13 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 		return nil, fmt.Errorf("internal error: %q SDK is installed but not declared in the workshop file", info.Name)
 	}
 
-	binds := map[string]*sdk.PlugBind{}
+	binds := map[string]sdk.PlugRef{}
 	plugs := map[string]interface{}{}
 	for name, m := range w.File.Sdks[idx].Plugs {
 		if m.Bind == nil {
 			plugs[name] = m.Attributes
 		} else {
-			binds[name] = &sdk.PlugBind{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: m.Bind.Sdk, Name: m.Bind.Name}
+			binds[name] = sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: m.Bind.Sdk, Name: m.Bind.Name}
 		}
 	}
 

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -308,6 +308,40 @@ func (w *Workshop) SdkInfos(ctx context.Context) (map[string]*sdk.Info, error) {
 	return infos, nil
 }
 
+// Mounts returns a map of active mounts,
+// given a map of SDK info as returned by SdkInfos.
+func (w *Workshop) Mounts(sdks map[string]*sdk.Info) map[string][]Mount {
+	if sdks == nil {
+		return nil
+	}
+
+	masters := map[sdk.PlugRef][]PlugRef{}
+	for _, sk := range sdks {
+		for name, m := range sk.PlugBinds {
+			s := PlugRef{Sdk: sk.Name, Name: name}
+			masters[m] = append(masters[m], s)
+		}
+	}
+
+	mnts := map[string][]Mount{}
+	for _, prof := range w.Profiles {
+		for _, mnt := range prof.Mounts {
+			mnts[prof.Sdk] = append(mnts[prof.Sdk], mnt)
+			if mnt.Type != HostWorkshop {
+				continue
+			}
+
+			pref := sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: prof.Sdk, Name: mnt.Name}
+			for _, slave := range masters[pref] {
+				mnt.Name = slave.Name
+				mnts[slave.Sdk] = append(mnts[slave.Sdk], mnt)
+			}
+		}
+	}
+
+	return mnts
+}
+
 func install(wfs WorkshopFs, srcfs fs.FS, src, dst string, perm fs.FileMode) error {
 	dstdir := filepath.Dir(dst)
 	if err := wfs.MkdirAll(dstdir, 0755); err != nil {


### PR DESCRIPTION
# Description

This allows certain packages, like `workshop`, to access `PlugRef` and `SlotRef`, which makes a few things simpler. In particular it removes the need for `PlugInfo.ShortRef()`, which I was going to introduce as part of the `port-forward` PR.

I'm making this PR separately since it's the kind of change which is likely to create more merge conflicts the longer we wait, and doesn't depend on any of the `port-forward` design decisions.

Shouldn't affect the docs but @akcano you might want to review the error message changes in 86aee761407c05835f54f69e7c3cdc3d52d5f3fa.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
