### PR TITLE
Configure apt to exclude suggested and recommended packages

### DIFF
--- a/docs/how-to/use-sdkcraft.rst
+++ b/docs/how-to/use-sdkcraft.rst
@@ -304,6 +304,11 @@ named :file:`setup-base`:
 It runs when the workshop is launched or refreshed,
 installing the prerequisites and preparing it for use.
 
+.. note::
+
+   For workshops, apt is configured to exclude recommended and suggested 
+   packages by default.
+
 
 Persist: save and restore
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -860,6 +860,15 @@ write_files:
     [Install]
     WantedBy=multi-user.target
   path: /etc/systemd/system/xauth-copy.service
+- content: |
+    # Installed by workshop
+    
+    # Don't automatically install recommended packages
+    APT::Install-Recommends "0";
+
+    # Don't automatically install suggested packages
+    APT::Install-Suggests "0";
+  path: /etc/apt/apt.conf.d/01norecommend
 runcmd:
   - systemctl daemon-reload
   - systemctl enable xauth-copy.service

--- a/tests/main/launch/task.yaml
+++ b/tests/main/launch/task.yaml
@@ -3,7 +3,12 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Test launch for all the supported bases"
-  
+
+  function check_apt() {
+    workshop_exec exec "$1" -- test -f /etc/apt/apt.conf.d/01norecommend
+    workshop_exec exec "$1" -- bash -c 'sudo apt update && diff <(sudo apt-get -o DPkg::Lock::Timeout=60 install --no-install-recommends --no-install-suggests gnome <<< n) <(sudo apt-get -o DPkg::Lock::Timeout=60 install gnome <<< n | grep -v "Waiting for cache")'
+  }
+
   function launch_and_validate() {
     workshop_exec launch "$1"
     workshop_exec list | MATCH "$(pwd)[[:space:]]*$1[[:space:]]*Ready[[:space:]]*-"
@@ -11,6 +16,8 @@ execute: |
     workshop_exec exec "$1" test -S /var/lib/workshop/run/workshop.socket.untrusted
     # ensure the apt cache is mounted
     workshop_exec exec "$1" mountpoint /var/cache/apt/archives
+    # ensure apt is configured to exclude suggested and recommended packages
+    check_apt "$1"
     workshop_exec remove "$1"
   }
   


### PR DESCRIPTION
# Description

Small PR that configures apt (via apt.conf.d) to exclude suggested and recommended packages by default. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
