### PR TITLE
Fix shell completion for workshop remount

### DIFF
--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -57,7 +57,7 @@ $ workshop connect nimble/go:mod-cache :mount
 A full version of the command that also lists the target SDK ('system'):
 $ workshop connect nimble/go:mod-cache nimble/system:mount`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.complete(),
+		ValidArgsFunction: c.complete,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -136,48 +136,46 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 	return nil
 }
 
-func (c *CmdConnect) complete() ValidArgsFunction {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cli, err := c.root.client()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		project, err := cli.Project(c.root.project)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		// Create map of endpoint string and associated plugs
-		disconnectedPlugs := make(map[string]client.Plug)
-		for _, plug := range connections.Plugs {
-			if len(plug.Connections) == 0 {
-				plugString := endpoint(plug.Workshop, plug.Sdk, plug.Name)
-				disconnectedPlugs[plugString] = plug
-			}
-		}
-
-		var completions []string
-		switch len(args) {
-		case 0:
-			// No arguments, show list of plugs
-			completions = slices.Collect(maps.Keys(disconnectedPlugs))
-		case 1:
-			plug, ok := disconnectedPlugs[args[0]]
-			if !ok {
-				break
-			}
-			for _, slot := range connections.Slots {
-				if plug.Interface == slot.Interface && plug.Workshop == slot.Workshop {
-					completions = append(completions, endpoint(slot.Workshop, slot.Sdk, slot.Name))
-				}
-			}
-		}
-		return completions, cobra.ShellCompDirectiveNoFileComp
+func (c *CmdConnect) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cli, err := c.root.client()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
 	}
+
+	project, err := cli.Project(c.root.project)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	// Create map of endpoint string and associated plugs
+	disconnectedPlugs := make(map[string]client.Plug)
+	for _, plug := range connections.Plugs {
+		if len(plug.Connections) == 0 {
+			plugString := endpoint(plug.Workshop, plug.Sdk, plug.Name)
+			disconnectedPlugs[plugString] = plug
+		}
+	}
+
+	var completions []string
+	switch len(args) {
+	case 0:
+		// No arguments, show list of plugs
+		completions = slices.Collect(maps.Keys(disconnectedPlugs))
+	case 1:
+		plug, ok := disconnectedPlugs[args[0]]
+		if !ok {
+			break
+		}
+		for _, slot := range connections.Slots {
+			if plug.Interface == slot.Interface && plug.Workshop == slot.Workshop {
+				completions = append(completions, endpoint(slot.Workshop, slot.Sdk, slot.Name))
+			}
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/workshop/connect_test.go
+++ b/cmd/workshop/connect_test.go
@@ -216,7 +216,7 @@ func (m *connectSuite) TestConnectCompletionAllDisconnected(c *check.C) {
 
 	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	for _, completion := range completions {
 		c.Check(slices.Contains(expected, completion), check.Equals, true)
@@ -224,7 +224,7 @@ func (m *connectSuite) TestConnectCompletionAllDisconnected(c *check.C) {
 
 	// Test slots
 	for i, plug := range conns.Plugs {
-		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		completions, compDirective := cmd.complete(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
 		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 		c.Assert(completions, check.DeepEquals, []string{endpoint(conns.Slots[i].Workshop, conns.Slots[i].Sdk, conns.Slots[i].Name)})
 	}
@@ -253,7 +253,7 @@ func (m *connectSuite) TestConnectCompletionSomeDisconnected(c *check.C) {
 		"another-workshop/sdk:desktop",
 	}
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	for _, completion := range completions {
 		c.Check(slices.Contains(expected, completion), check.Equals, true)
@@ -262,7 +262,7 @@ func (m *connectSuite) TestConnectCompletionSomeDisconnected(c *check.C) {
 	// Test slots
 	var slotCompletions []string
 	for _, plug := range plugs {
-		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		completions, compDirective := cmd.complete(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
 		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 		slotCompletions = append(slotCompletions, completions...)
 	}
@@ -288,13 +288,13 @@ func (m *connectSuite) TestConnectCompletionAllConnected(c *check.C) {
 		root: &CmdRoot{},
 	}
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(len(completions), check.Equals, 0)
 
 	// Test slots
 	for _, plug := range plugs {
-		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		completions, compDirective := cmd.complete(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
 		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 		c.Check(len(completions), check.Equals, 0)
 	}
@@ -333,7 +333,7 @@ func (m *connectSuite) TestConnectCompletionWorkshopMismatch(c *check.C) {
 		root: &CmdRoot{},
 	}
 
-	completions, compDirective := cmd.complete()(cmd.Command(), []string{"workshop/sdk:desktop"}, "")
+	completions, compDirective := cmd.complete(cmd.Command(), []string{"workshop/sdk:desktop"}, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(len(completions), check.Equals, 0)
 }

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -54,7 +54,7 @@ Disconnect all plugs connected to the 'mount' slot of the 'system' SDK
 under the 'nimble' workshop in the current project directory:
 $ workshop disconnect nimble/system:mount`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.complete(),
+		ValidArgsFunction: c.complete,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.forget, "forget",
@@ -118,44 +118,42 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 	return nil
 }
 
-func (c *CmdDisconnect) complete() ValidArgsFunction {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cli, err := c.root.client()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		project, err := cli.Project(c.root.project)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		// Create map of endpoint strings and associated plugs
-		connectedPlugs := make(map[string]client.Plug)
-		for _, plug := range connections.Plugs {
-			if len(plug.Connections) > 0 {
-				ref := endpoint(plug.Workshop, plug.Sdk, plug.Name)
-				connectedPlugs[ref] = plug
-			}
-		}
-
-		var completion []string
-		switch len(args) {
-		case 0:
-			// No arguments, show list of plugs
-			completion = slices.Collect(maps.Keys(connectedPlugs))
-		case 1:
-			if plug, ok := connectedPlugs[args[0]]; ok {
-				for _, slot := range plug.Connections {
-					completion = append(completion, endpoint(slot.Workshop, slot.Sdk, slot.Name))
-				}
-			}
-		}
-		return completion, cobra.ShellCompDirectiveNoFileComp
+func (c *CmdDisconnect) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cli, err := c.root.client()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
 	}
+
+	project, err := cli.Project(c.root.project)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	// Create map of endpoint strings and associated plugs
+	connectedPlugs := make(map[string]client.Plug)
+	for _, plug := range connections.Plugs {
+		if len(plug.Connections) > 0 {
+			ref := endpoint(plug.Workshop, plug.Sdk, plug.Name)
+			connectedPlugs[ref] = plug
+		}
+	}
+
+	var completion []string
+	switch len(args) {
+	case 0:
+		// No arguments, show list of plugs
+		completion = slices.Collect(maps.Keys(connectedPlugs))
+	case 1:
+		if plug, ok := connectedPlugs[args[0]]; ok {
+			for _, slot := range plug.Connections {
+				completion = append(completion, endpoint(slot.Workshop, slot.Sdk, slot.Name))
+			}
+		}
+	}
+	return completion, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/workshop/disconnect_test.go
+++ b/cmd/workshop/disconnect_test.go
@@ -164,13 +164,13 @@ func (m *disconnectSuite) TestDisconnectCompletionAllDisconnected(c *check.C) {
 
 	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Assert(len(completions), check.Equals, 0)
 
 	// Test slots
 	for _, plug := range plugs {
-		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		completions, compDirective := cmd.complete(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
 		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 		c.Assert(len(completions), check.Equals, 0)
 	}
@@ -200,7 +200,7 @@ func (m *disconnectSuite) TestDisconnectCompletionSomeDisconnected(c *check.C) {
 
 	m.connectionsRedirectHelper(c, conns, m.prjId, m.prjDir, 10)
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	for _, completion := range completions {
 		c.Check(slices.Contains(expected, completion), check.Equals, true)
@@ -208,7 +208,7 @@ func (m *disconnectSuite) TestDisconnectCompletionSomeDisconnected(c *check.C) {
 
 	// Test slots
 	for _, plug := range plugs {
-		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		completions, compDirective := cmd.complete(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
 		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 		if len(completions) == 1 {
 			c.Check(slices.Contains(expected, completions[0]), check.Equals, true)
@@ -247,7 +247,7 @@ func (m *disconnectSuite) TestDisconnectCompletionAllConnected(c *check.C) {
 		root: &CmdRoot{},
 	}
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	for _, completion := range completions {
 		c.Check(slices.Contains(expected, completion), check.Equals, true)
@@ -255,7 +255,7 @@ func (m *disconnectSuite) TestDisconnectCompletionAllConnected(c *check.C) {
 
 	// Test slots
 	for _, plug := range plugs {
-		completions, compDirective := cmd.complete()(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
+		completions, compDirective := cmd.complete(cmd.Command(), []string{endpoint(plug.Workshop, plug.Sdk, plug.Name)}, "")
 		c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 		if len(completions) == 1 {
 			c.Check(slices.Contains(expected, completions[0]), check.Equals, true)
@@ -312,7 +312,7 @@ func (m *disconnectSuite) TestDisconnectCompletionWorkshopMismatch(c *check.C) {
 		root: &CmdRoot{},
 	}
 
-	completions, compDirective := cmd.complete()(cmd.Command(), []string{"another-workshop/sdk:desktop"}, "")
+	completions, compDirective := cmd.complete(cmd.Command(), []string{"another-workshop/sdk:desktop"}, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(len(completions), check.Equals, 0)
 }

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -57,7 +57,7 @@ $ workshop launch nimble jazzy
 The name is optional if the project has only one workshop:
 $ workshop launch`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.complete(),
+		ValidArgsFunction: c.complete,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",
@@ -155,37 +155,35 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	return nil
 }
 
-func (c *CmdLaunch) complete() ValidArgsFunction {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cli, err := c.root.client()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		project, err := cli.Project(c.root.project)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		instances, files, err := cli.List(&client.ListOptions{ProjectId: project.Id})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		var workshops []string
-		for _, file := range files {
-			isInstance := false
-			for _, instance := range instances {
-				if file.Name == instance.Name {
-					isInstance = true
-					break
-				}
-			}
-			if !isInstance && !slices.Contains(args, file.Name) {
-				workshops = append(workshops, file.Name)
-			}
-		}
-
-		return workshops, cobra.ShellCompDirectiveNoFileComp
+func (c *CmdLaunch) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cli, err := c.root.client()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
 	}
+
+	project, err := cli.Project(c.root.project)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	instances, files, err := cli.List(&client.ListOptions{ProjectId: project.Id})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var workshops []string
+	for _, file := range files {
+		isInstance := false
+		for _, instance := range instances {
+			if file.Name == instance.Name {
+				isInstance = true
+				break
+			}
+		}
+		if !isInstance && !slices.Contains(args, file.Name) {
+			workshops = append(workshops, file.Name)
+		}
+	}
+
+	return workshops, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -221,7 +221,7 @@ func (m *workshopLaunch) TestLaunchCompletions(c *check.C) {
 
 	m.listRedirectHelper(c, w, m.prjId, m.prjDir, len(wsFile))
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(completions, check.DeepEquals, []string{"workshop-notexists"})
 }

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -99,6 +99,16 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 }
 
 func (c *CmdRemount) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var completions []string
+	switch len(args) {
+	case 0:
+		// continue below
+	case 1:
+		return completions, cobra.ShellCompDirectiveFilterDirs
+	default:
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	cli, err := c.root.client()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
@@ -109,25 +119,17 @@ func (c *CmdRemount) complete(cmd *cobra.Command, args []string, toComplete stri
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
+	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, Interface: "mount"})
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	var completions []string
-	if len(args) == 0 {
-		// A mount must be connected for remount to work, only show currently
-		// connected mounts
-		for _, conn := range connections.Established {
-			if conn.Interface == "mount" {
-				completions = append(completions, endpoint(conn.Plug.Workshop, conn.Plug.Sdk, conn.Plug.Name))
-			}
-		}
-		// We don't want file comp if there was no workshop name provided and
-		// no completion was generated
-		if len(completions) == 0 {
-			return completions, cobra.ShellCompDirectiveNoFileComp
-		}
+	// A mount must be connected for remount to work, only show currently
+	// connected mounts
+	for _, conn := range connections.Established {
+		completions = append(completions, endpoint(conn.Plug.Workshop, conn.Plug.Sdk, conn.Plug.Name))
 	}
-	return completions, cobra.ShellCompDirectiveFilterDirs
+	// We don't want file comp if there was no workshop name provided and
+	// no completion was generated
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -48,7 +48,7 @@ under the 'nimble' workshop in the current project directory
 to '~/new-cache-mount/' on the host:
 $ workshop remount nimble/go:mod-cache ~/new-cache-mount`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.complete(),
+		ValidArgsFunction: c.complete,
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
@@ -98,38 +98,36 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 	return nil
 }
 
-func (c *CmdRemount) complete() ValidArgsFunction {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cli, err := c.root.client()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		project, err := cli.Project(c.root.project)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		var completions []string
-		if len(args) == 0 {
-			// A mount must be connected for remount to work, only show currently
-			// connected mounts
-			for _, conn := range connections.Established {
-				if conn.Interface == "mount" {
-					completions = append(completions, endpoint(conn.Plug.Workshop, conn.Plug.Sdk, conn.Plug.Name))
-				}
-			}
-			// We don't want file comp if there was no workshop name provided and
-			// no completion was generated
-			if len(completions) == 0 {
-				return completions, cobra.ShellCompDirectiveNoFileComp
-			}
-		}
-		return completions, cobra.ShellCompDirectiveFilterDirs
+func (c *CmdRemount) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cli, err := c.root.client()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
 	}
+
+	project, err := cli.Project(c.root.project)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var completions []string
+	if len(args) == 0 {
+		// A mount must be connected for remount to work, only show currently
+		// connected mounts
+		for _, conn := range connections.Established {
+			if conn.Interface == "mount" {
+				completions = append(completions, endpoint(conn.Plug.Workshop, conn.Plug.Sdk, conn.Plug.Name))
+			}
+		}
+		// We don't want file comp if there was no workshop name provided and
+		// no completion was generated
+		if len(completions) == 0 {
+			return completions, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+	return completions, cobra.ShellCompDirectiveFilterDirs
 }

--- a/cmd/workshop/remount_test.go
+++ b/cmd/workshop/remount_test.go
@@ -87,16 +87,16 @@ func (m *remountSuite) TestRemountCompletions(c *check.C) {
 		root: &CmdRoot{},
 	}
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveFilterDirs)
 	c.Check(completions, check.DeepEquals, []string{"workshop/sdk:mount"})
 
 	// Check slot completion, note this is only ensuring that we don't return the
 	// plug multiple times. Directory completion can only be instrumented with
 	// end-to-end testing
-	completions, compDirective = cmd.complete()(cmd.Command(), []string{"workshop/sdk:mount"}, "")
+	completions, compDirective = cmd.complete(cmd.Command(), []string{"workshop/sdk:mount"}, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveFilterDirs)
-	c.Assert(len(completions), check.Equals, 0)
+	c.Assert(completions, check.HasLen, 0)
 }
 
 func (m *remountSuite) TestRemountCompletionsNoComp(c *check.C) {
@@ -114,7 +114,7 @@ func (m *remountSuite) TestRemountCompletionsNoComp(c *check.C) {
 		root: &CmdRoot{},
 	}
 
-	completions, compDirective := cmd.complete()(cmd.Command(), nil, "")
+	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(completions, check.DeepEquals, []string(nil))
 }

--- a/cmd/workshop/remount_test.go
+++ b/cmd/workshop/remount_test.go
@@ -88,7 +88,7 @@ func (m *remountSuite) TestRemountCompletions(c *check.C) {
 	}
 
 	completions, compDirective := cmd.complete(cmd.Command(), nil, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveFilterDirs)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(completions, check.DeepEquals, []string{"workshop/sdk:mount"})
 
 	// Check slot completion, note this is only ensuring that we don't return the
@@ -96,6 +96,10 @@ func (m *remountSuite) TestRemountCompletions(c *check.C) {
 	// end-to-end testing
 	completions, compDirective = cmd.complete(cmd.Command(), []string{"workshop/sdk:mount"}, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveFilterDirs)
+	c.Assert(completions, check.HasLen, 0)
+
+	completions, compDirective = cmd.complete(cmd.Command(), []string{"workshop/sdk:mount", "/new/source"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Assert(completions, check.HasLen, 0)
 }
 

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -43,7 +43,7 @@ Notes:
 List the tasks under change ID 42:
 $ workshop tasks 42`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.complete(),
+		ValidArgsFunction: c.complete,
 	}
 
 	return cmd
@@ -114,35 +114,33 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 	return nil
 }
 
-func (c *CmdTasks) complete() ValidArgsFunction {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) > 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		cli, err := c.root.client()
-
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		changesCmd := CmdChanges{
-			root: c.root,
-		}
-
-		changes, err := changesCmd.changes(cli)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		l := len(changes)
-		num := min(l, 10)
-		completions := make([]string, l)
-
-		for _, chg := range changes[l-num : l] {
-			completions = append(completions, fmt.Sprintf("%s\t%-5s %s\n", chg.ID, chg.Status, chg.Summary))
-		}
-
-		return completions, cobra.ShellCompDirectiveNoFileComp
+func (c *CmdTasks) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+
+	cli, err := c.root.client()
+
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	changesCmd := CmdChanges{
+		root: c.root,
+	}
+
+	changes, err := changesCmd.changes(cli)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	l := len(changes)
+	num := min(l, 10)
+	completions := make([]string, l)
+
+	for _, chg := range changes[l-num : l] {
+		completions = append(completions, fmt.Sprintf("%s\t%-5s %s\n", chg.ID, chg.Status, chg.Summary))
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }


### PR DESCRIPTION
# Description

I noticed `workshop remount <TAB>` wasn't working properly, here is a fix. Also did a little bit of tidying.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
