### PR TITLE
Fix transient error where apt is already running

### DIFF
--- a/tests/main/launch/task.yaml
+++ b/tests/main/launch/task.yaml
@@ -6,7 +6,7 @@ execute: |
 
   function check_apt() {
     workshop_exec exec "$1" -- test -f /etc/apt/apt.conf.d/01norecommend
-    workshop_exec exec "$1" -- bash -c 'sudo apt update && diff <(sudo apt-get -o DPkg::Lock::Timeout=60 install --no-install-recommends --no-install-suggests gnome <<< n) <(sudo apt-get -o DPkg::Lock::Timeout=60 install gnome <<< n | grep -v "Waiting for cache")'
+    workshop_exec exec "$1" -- bash -c 'sudo apt update && diff <(sudo apt-get --assume-no --no-install-recommends --no-install-suggests -o Debug::NoLocking=true install gnome) <(sudo apt-get --assume-no -o Debug::NoLocking=true install gnome)'
   }
 
   function launch_and_validate() {


### PR DESCRIPTION
# Description
Fixes https://github.com/canonical/workshop/actions/runs/13383084387/job/37375066764?pr=284

Prevents lock conflicts/timeouts caused by scheduled apt tasks by disabling locking for this transaction (this is not an issue as we're not installing anything). 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
