### PR TITLE
doc(ROS 2): rename ROS2 into ROS 2

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -26,9 +26,9 @@ Study examples
 
 .. @artefact SDK
 
-This section presents a case study for `ROS 2 <https://www.ros.org/>`_,
+This section presents a case study for `ROS 2 <https://www.ros.org/>`_,
 a popular robotics-oriented framework.
-The articles discuss the design of a ROS 2-oriented SDK and its practical usage:
+The articles discuss the design of a ROS 2-oriented SDK and its practical usage:
 
 .. toctree::
    :maxdepth: 2

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -26,9 +26,9 @@ Study examples
 
 .. @artefact SDK
 
-This section presents a case study for `ROS2 <https://www.ros.org/>`_,
+This section presents a case study for `ROS 2 <https://www.ros.org/>`_,
 a popular robotics-oriented framework.
-The articles discuss the design of a ROS2-oriented SDK and its practical usage:
+The articles discuss the design of a ROS 2-oriented SDK and its practical usage:
 
 .. toctree::
    :maxdepth: 2

--- a/docs/how-to/ros2/index.rst
+++ b/docs/how-to/ros2/index.rst
@@ -1,12 +1,12 @@
 .. _how_ros2:
 
-ROS2: case study
+ROS 2: case study
 ================
 
 .. @artefact SDK
 
 These topics present an end-to-end scenario
-of using |ws_markup| and |sdk_markup| with `ROS2 <https://www.ros.org/>`_,
+of using |ws_markup| and |sdk_markup| with `ROS 2 <https://www.ros.org/>`_,
 a popular robotics-oriented framework:
 
 .. toctree::

--- a/docs/how-to/ros2/index.rst
+++ b/docs/how-to/ros2/index.rst
@@ -1,12 +1,12 @@
 .. _how_ros2:
 
-ROS 2: case study
+ROS 2: case study
 =================
 
 .. @artefact SDK
 
 These topics present an end-to-end scenario
-of using |ws_markup| and |sdk_markup| with `ROS 2 <https://www.ros.org/>`_,
+of using |ws_markup| and |sdk_markup| with `ROS 2 <https://www.ros.org/>`_,
 a popular robotics-oriented framework:
 
 .. toctree::

--- a/docs/how-to/ros2/index.rst
+++ b/docs/how-to/ros2/index.rst
@@ -1,7 +1,7 @@
 .. _how_ros2:
 
 ROS 2: case study
-================
+=================
 
 .. @artefact SDK
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -848,7 +848,7 @@ and have had your first taste of what it can do for you.
 
 - If you wish to try building and publishing a full-fledged SDK,
   continue to the |sdk_markup| :ref:`how-to guide <how_use_sdkcraft>`;
-  the :ref:`ROS2 case study <how_ros2>`
+  the :ref:`ROS 2 case study <how_ros2>`
   describes the entire process of building an SDK and using it in |ws_markup|
   in extra detail.
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -848,7 +848,7 @@ and have had your first taste of what it can do for you.
 
 - If you wish to try building and publishing a full-fledged SDK,
   continue to the |sdk_markup| :ref:`how-to guide <how_use_sdkcraft>`;
-  the :ref:`ROS 2 case study <how_ros2>`
+  the :ref:`ROS 2 case study <how_ros2>`
   describes the entire process of building an SDK and using it in |ws_markup|
   in extra detail.
 


### PR DESCRIPTION
# Description
ROS2 is usually noted ROS 2.

# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
