### PR TITLE
Make sketch-sdk abort refresh in progress before status check

### DIFF
--- a/.golangci.errcheck.yaml
+++ b/.golangci.errcheck.yaml
@@ -8,6 +8,11 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 
+  exclude-rules:
+    - path: _test\.go$
+      linters: [errcheck]
+      text: Error return value of `\(\*github.com/canonical/workshop/internal/overlord\.Overlord\)\.Stop` is not checked
+
 run:
   build-tags: [integration]
   timeout: 5m

--- a/client/client.go
+++ b/client/client.go
@@ -434,7 +434,6 @@ const (
 	ErrorKindDaemonRestart     = "daemon-restart"
 	ErrorKindNoDefaultServices = "no-default-services"
 	ErrorKindUnsuccessful      = "unsuccessful"
-	ErrorKindWaitingOnError    = "waiting-on-error"
 )
 
 func (rsp *response) err(cli *Client) error {

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -43,7 +43,7 @@ $ workshop connections nimble
 List connections for all workshops in the current project directory:
 $ workshop connections`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Pending", "Stopped"}),
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Waiting", "Stopped"}),
 	}
 
 	cmd.Flags().BoolVar(&c.all, "all", false, "Include disconnected plugs in the output.")

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -70,7 +70,7 @@ var longExecHelp = `
 The 'exec' subcommand runs an arbitrary command in the specified workshop,
 waiting for it to complete. If a timeout elapses before that, it's terminated.
 
-To accept an 'exec' command, the workshop must be 'Ready' or 'Pending'.
+To accept an 'exec' command, the workshop must be 'Ready' or 'Waiting'.
 A command can run in two modes that determine how it handles standard streams:
 
 - Interactively (for shell sessions)
@@ -106,7 +106,7 @@ var longShellHelp = `
 The 'shell' subcommand runs an interactive terminal session
 in the specified workshop.
 
-To accept a 'shell' command, the workshop must be 'Ready' or 'Pending'.
+To accept a 'shell' command, the workshop must be 'Ready' or 'Waiting'.
 
 
 Notes:
@@ -123,7 +123,7 @@ var longRunHelp = `
 The 'run' subcommand runs a script specified in the workshop definition file,
 waiting for it to complete. If a timeout elapses before that, it's terminated.
 
-To accept a 'run' command, the workshop must be 'Ready' or 'Pending'.
+To accept a 'run' command, the workshop must be 'Ready' or 'Waiting'.
 A command can run in two modes that determine how it handles standard streams:
 
 - Interactively (for shell sessions)
@@ -184,7 +184,7 @@ $ workshop exec -I -- sh
 Run a command as root (the default is 'workshop'):
 $ workshop exec --uid 0 nimble id`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Pending"}),
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Waiting"}),
 	}
 
 	cmd.Flags().SortFlags = false

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -32,7 +32,7 @@ details for a workshop, formatting them as YAML. Specifically, it prints:
 
 - Essential workshop attributes, such as name, base and project directory
 
-- Current status (e.g. 'Ready', 'Pending', 'Off') and notes for the workshop
+- Current status (e.g. 'Ready', 'Pending', 'Stopped') and notes for the workshop
 
 - Individual SDK details, such as name, channel, installation date and revision
 

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -69,13 +69,13 @@ $ workshop refresh nimble jazzy
 The name is optional if the project has only one workshop:
 $ workshop refresh
 
-Refresh workshop, but stop on any errors (won’t accept multiple workshops):
+Refresh workshop, but pause on any errors (won’t accept multiple workshops):
 $ workshop refresh --wait-on-error
 
-After refresh stopped on error, abort the operation:
+After refresh paused on error, abort the operation:
 $ workshop refresh --abort
 
-After refresh stopped on error and the workshop was fixed,
+After refresh paused on error and the workshop was fixed,
 continue the operation:
 $ workshop refresh --continue
 

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -82,7 +82,7 @@ $ workshop refresh --continue
 Refresh the sketch SDK in the 'nimble' workshop:
 $ workshop refresh nimble/sketch`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Pending"}),
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Waiting"}),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -23,13 +23,13 @@ func (c *CmdRemove) Command() *cobra.Command {
 		Long: `
 This command removes the workshops listed as arguments. For each workshop, it:
 
-- Checks that the workshop isn't 'Off' or 'Pending'
+- Checks that the workshop isn't 'Off', 'Pending' or 'Waiting'
 - Stops the workshop if it's not already 'Stopped'
 - Deletes the workshop but preserves its definition
 
 Notes:
 
-- If any listed workshop is 'Off' or 'Pending', none are removed.
+- If any listed workshop is 'Off', 'Pending' or 'Waiting', none are removed.
 
 - To rebuild a removed workshop from scratch, use 'workshop launch'.
 

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -76,28 +76,20 @@ func (s *BaseWorkshopSuite) TestWorkshopInfoList(c *check.C) {
 	prjId := "42424242"
 	prjDir := c.MkDir()
 
-	status := []string{"Ready", "Pending", "Stopped", "Error"}
+	statuses := []string{"Ready", "Pending", "Waiting", "Stopped", "Error"}
 	expected := make(map[string][]string)
 
 	var wsInfo []*client.WorkshopInfo
 	for i := range 20 {
-		index := rand.Intn(len(status) - 1)
+		index := rand.Intn(len(statuses) - 1)
+		status := statuses[index]
 		info := &client.WorkshopInfo{
 			ProjectId: "42424242",
 			Name:      "test" + strconv.Itoa(i),
-			Status:    status[index],
+			Status:    status,
 		}
 		wsInfo = append(wsInfo, info)
-		switch index {
-		case 0:
-			expected["Ready"] = append(expected["Ready"], info.Name)
-		case 1:
-			expected["Pending"] = append(expected["Pending"], info.Name)
-		case 2:
-			expected["Stopped"] = append(expected["Stopped"], info.Name)
-		case 3:
-			expected["Error"] = append(expected["Error"], info.Name)
-		}
+		expected[status] = append(expected[status], info.Name)
 	}
 
 	w := client.Workshops{
@@ -106,9 +98,9 @@ func (s *BaseWorkshopSuite) TestWorkshopInfoList(c *check.C) {
 
 	cmd := &CmdRoot{}
 
-	s.listRedirectHelper(c, w, prjId, prjDir, len(status)*2)
+	s.listRedirectHelper(c, w, prjId, prjDir, len(statuses)*2)
 
-	for _, st := range status {
+	for _, st := range statuses {
 		result, compDirective := cmd.completeWorkshopName([]string{st})(cmd.Command(prjDir), nil, "")
 		c.Check(result, check.DeepEquals, expected[st])
 		c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -67,7 +67,7 @@ $ workshop sketch-sdk
 Stash the sketch SDK, temporarily reverting the changes in the workshop:
 $ workshop sketch-sdk nimble --stash`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Pending"}),
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Waiting"}),
 	}
 
 	cmd.Flags().BoolVar(&c.stash, "stash", false, "Stash the sketch SDK and remove it from the workshop.")

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -206,8 +206,14 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		}
 	}
 
-	// Ensure that the workshop is Ready
-	if wp.Status != "Ready" {
+	// Ensure that the workshop is Ready,
+	// aborting previous sketch if necessary.
+	if wp.Status == "Waiting" {
+		cmdabort := &CmdRefresh{root: c.root, Abort: true}
+		if err = cmdabort.Run(cmd, []string{wp.Name}); err != nil {
+			return err
+		}
+	} else if wp.Status != "Ready" {
 		return fmt.Errorf(`error: cannot sketch %q: workshop currently %q, must be "Ready"`, wp.Name, wp.Status)
 	}
 
@@ -300,20 +306,8 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 	cmdrefresh := &CmdRefresh{root: c.root}
 	cmdrefresh.WaitOnError = true
-	refreshArgs := []string{fmt.Sprintf("%s/sketch", wp.Name)}
 
-	err = cmdrefresh.Run(cmd, refreshArgs)
-	if e, ok := err.(*client.Error); ok && e.Kind == client.ErrorKindWaitingOnError {
-		cmdabort := &CmdRefresh{root: c.root}
-		cmdabort.Abort = true
-		err = cmdabort.Run(cmd, []string{wp.Name})
-		if err != nil {
-			return err
-		}
-
-		err = cmdrefresh.Run(cmd, refreshArgs)
-	}
-	return err
+	return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", wp.Name)})
 }
 
 func writeSketchSdk(sketchdir string, content []byte) error {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -35,10 +35,32 @@ var mockWorkshopWithSdksReady = `{"type":"sync","status-code":200,"status":"OK",
       "revision":"1",
       "build-time":"2017-02-19T17:23:05.592623Z",
       "install-time":"2017-03-22T09:01:00.0Z"
-    },{  
+    },{
       "name":"sketch",
       "channel":"",
       "revision":"x1",
+      "install-time":"2017-03-22T09:01:00.0Z"
+    }],
+    "path":"/home/project/.workshop/ws.yaml"
+}}`
+
+var mockWorkshopWithSdksWaiting = `{"type":"sync","status-code":200,"status":"OK","result":{
+    "name":"ws",
+    "base":"ubuntu@22.04",
+    "project-id":"42424242",
+    "status":"Waiting",
+    "notes":["wait-on-error"],
+    "sdks":[{
+      "name":"go",
+      "version":"1.8.0",
+      "channel":"latest/edge",
+      "revision":"1",
+      "build-time":"2017-02-19T17:23:05.592623Z",
+      "install-time":"2017-03-22T09:01:00.0Z"
+    },{
+      "name":"sketch",
+      "channel":"",
+      "revision":"x2",
       "install-time":"2017-03-22T09:01:00.0Z"
     }],
     "path":"/home/project/.workshop/ws.yaml"
@@ -291,16 +313,15 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 	// 1-2: get workshop info
 	// 3-5: refresh --wait-on-error (fails due to setup-base)
 	// 6-7: get workshop info
-	// 8-9. refresh --wait-on-error (fails due to earlier refresh)
-	// 10-12. refresh --abort
-	// 13-15. refresh --wait-on-error
+	// 8-10. refresh --abort
+	// 11-13. refresh --wait-on-error
 	n := 0
 	change := 42
 	workshop := "ws"
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 3, 6, 8, 10, 13:
+		case 1, 3, 6, 8, 11:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
@@ -309,41 +330,42 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockWorkshopWithSdksReady)
-		case 4, 9, 11, 14:
+			switch n {
+			case 2:
+				fmt.Fprintln(w, mockWorkshopWithSdksReady)
+			case 7:
+				fmt.Fprintln(w, mockWorkshopWithSdksWaiting)
+			}
+		case 4, 9, 12:
 			mode := "wait-on-error"
 			name := fmt.Sprintf("%s/sketch", workshop)
-			if n == 11 {
+			if n == 9 {
 				mode = "abort"
 				name = workshop
 			}
 
 			change += 1
-			status := 202
 			response := fmt.Sprintf(`{"type":"async", "change": "%d", "status-code": 202}`, change)
-			if n == 9 {
-				status = 400
-				response = `{"type":"error", "result": {"message":"already waiting on error", "kind":"waiting-on-error"}, "status-code": 400}`
-			}
 
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
 				"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode}})
-			w.WriteHeader(status)
+			w.WriteHeader(202)
 			fmt.Fprintln(w, response)
-		case 5, 12, 15:
+		case 5, 10, 13:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/changes/%d", change))
-			if n == 5 {
+			switch n {
+			case 5:
 				fmt.Fprintln(w, mockWaitChangeJSON)
-			} else if n == 12 {
+			case 10:
 				fmt.Fprintln(w, mockAbortedChangeJSON)
-			} else {
+			case 13:
 				fmt.Fprintln(w, mockReadyChangeJSON)
 			}
 		default:
-			c.Errorf("expected 15 calls, now on %d", n)
+			c.Errorf("expected 13 calls, now on %d", n)
 		}
 	})
 
@@ -374,7 +396,7 @@ hooks:
 	err = cmd.Run(cmd.Command(), []string{"ws"})
 	c.Assert(err, check.IsNil)
 
-	c.Assert(n, check.Equals, 15)
+	c.Assert(n, check.Equals, 13)
 	c.Assert(attempts, check.Equals, 2)
 }
 
@@ -616,18 +638,18 @@ func (m *workshopSketch) TestSketchSdkWorkshopStatusNotReady(c *check.C) {
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 3, 5, 7:
+		case 1, 3, 5:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
 			fmt.Fprintln(w, r)
-		case 2, 4, 6, 8:
+		case 2, 4, 6:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
 			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus(status[n/2-1]))
 		default:
-			c.Errorf("expected 8 calls, now on %d", n)
+			c.Errorf("expected 6 calls, now on %d", n)
 		}
 	})
 

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -78,7 +78,7 @@ $ workshop warnings`,
 		false,
 		"Show all warnings, including the acknowledged ones.")
 
-	cmd.PersistentFlags().BoolVar(&c.All, "verbose",
+	cmd.PersistentFlags().BoolVar(&c.Verbose, "verbose",
 		false,
 		"Show more information per each warning.")
 

--- a/docs/explanation/workshops/workshops.rst
+++ b/docs/explanation/workshops/workshops.rst
@@ -51,6 +51,11 @@ A workshop's life-cycle can see it switch between several statuses:
      - In the project directory
      - Running, being updated
 
+   * - *Waiting*
+     - Paused for debugging a launch or refresh error
+     - In the project directory
+     - Running
+
    * - *Error*
      - Non-operational
      - Can be missing

--- a/docs/how-to/use-workshops/debug-workshop-issues.rst
+++ b/docs/how-to/use-workshops/debug-workshop-issues.rst
@@ -5,7 +5,7 @@ How to debug issues in workshops
 
 To trace the root cause
 of a workshop misbehaving at :command:`workshop refresh` or any other action,
-you can explore its underlying changes and tasks, stop on error,
+you can explore its underlying changes and tasks, pause on error,
 list system-wide warnings and acknowledge false positives.
 
 

--- a/docs/reference/cli/workshop-exec.rst
+++ b/docs/reference/cli/workshop-exec.rst
@@ -19,7 +19,7 @@ Run a command and wait for it to complete.
 The 'exec' subcommand runs an arbitrary command in the specified workshop,
 waiting for it to complete. If a timeout elapses before that, it's terminated.
 
-To accept an 'exec' command, the workshop must be 'Ready' or 'Pending'.
+To accept an 'exec' command, the workshop must be 'Ready' or 'Waiting'.
 A command can run in two modes that determine how it handles standard streams:
 
 - Interactively (for shell sessions)

--- a/docs/reference/cli/workshop-info.rst
+++ b/docs/reference/cli/workshop-info.rst
@@ -21,7 +21,7 @@ details for a workshop, formatting them as YAML. Specifically, it prints:
 
 - Essential workshop attributes, such as name, base and project directory
 
-- Current status (e.g. 'Ready', 'Pending', 'Off') and notes for the workshop
+- Current status (e.g. 'Ready', 'Pending', 'Stopped') and notes for the workshop
 
 - Individual SDK details, such as name, channel, installation date and revision
 

--- a/docs/reference/cli/workshop-refresh.rst
+++ b/docs/reference/cli/workshop-refresh.rst
@@ -75,21 +75,21 @@ The name is optional if the project has only one workshop:
    $ workshop refresh
 
 
-Refresh workshop, but stop on any errors (won’t accept multiple workshops):
+Refresh workshop, but pause on any errors (won’t accept multiple workshops):
 
 .. code-block:: console
 
    $ workshop refresh --wait-on-error
 
 
-After refresh stopped on error, abort the operation:
+After refresh paused on error, abort the operation:
 
 .. code-block:: console
 
    $ workshop refresh --abort
 
 
-After refresh stopped on error and the workshop was fixed,
+After refresh paused on error and the workshop was fixed,
 continue the operation:
 
 .. code-block:: console

--- a/docs/reference/cli/workshop-remove.rst
+++ b/docs/reference/cli/workshop-remove.rst
@@ -18,13 +18,13 @@ Remove one or many workshops.
 
 This command removes the workshops listed as arguments. For each workshop, it:
 
-- Checks that the workshop isn't 'Off' or 'Pending'
+- Checks that the workshop isn't 'Off', 'Pending' or 'Waiting'.
 - Stops the workshop if it's not already 'Stopped'
 - Deletes the workshop but preserves its definition
 
 Notes:
 
-- If any listed workshop is 'Off' or 'Pending', none are removed.
+- If any listed workshop is 'Off', 'Pending' or 'Waiting', none are removed.
 
 - To rebuild a removed workshop from scratch, use 'workshop launch'.
 

--- a/docs/reference/cli/workshop-run.rst
+++ b/docs/reference/cli/workshop-run.rst
@@ -19,7 +19,7 @@ Run a workshop script and wait for it to complete.
 The 'run' subcommand runs a script specified in the workshop definition file,
 waiting for it to complete. If a timeout elapses before that, it's terminated.
 
-To accept a 'run' command, the workshop must be 'Ready' or 'Pending'.
+To accept a 'run' command, the workshop must be 'Ready' or 'Waiting'.
 A command can run in two modes that determine how it handles standard streams:
 
 - Interactively (for shell sessions)

--- a/docs/reference/cli/workshop-shell.rst
+++ b/docs/reference/cli/workshop-shell.rst
@@ -19,7 +19,7 @@ Start an interactive terminal session for the workshop.
 The 'shell' subcommand runs an interactive terminal session
 in the specified workshop.
 
-To accept a 'shell' command, the workshop must be 'Ready' or 'Pending'.
+To accept a 'shell' command, the workshop must be 'Ready' or 'Waiting'.
 
 
 Notes:

--- a/docs/reference/workshop-status.rst
+++ b/docs/reference/workshop-status.rst
@@ -28,7 +28,7 @@ there is no container yet.
    stateDiagram-v2
        OFF --> READY: launch
        OFF --> ERROR: launch (on error)
-       OFF --> PENDING: launch --wait-on-error (on error)
+       OFF --> WAITING: launch --wait-on-error (on error)
 
 
 Ready
@@ -49,7 +49,7 @@ up and ready to do some work.
        READY --> READY: remount
        READY --> READY: refresh
        READY --> ERROR: refresh (on error)
-       READY --> PENDING: refresh --wait-on-error (on error)
+       READY --> WAITING: refresh --wait-on-error (on error)
 
 
 Stopped
@@ -68,23 +68,32 @@ but is still linked to the project directory.
        STOPPED --> STOPPED: remount
 
 
-Pending
+Waiting
 -------
 
-The workshop is being updated or changing its status;
-only a few commands will be accepted,
-and the container itself is non-operational.
+The workshop is paused
+in the middle of a change
+to allow for interactive debugging;
+only a few commands will be accepted.
 
 .. mermaid::
-   :alt: Pending state
-   :caption: Pending state
+   :alt: Waiting state
+   :caption: Waiting state
    :align: center
 
     stateDiagram-v2
-        PENDING --> OFF: launch --abort
-        PENDING --> READY: launch --continue
-        PENDING --> READY: refresh --abort
-        PENDING --> READY: refresh --continue
+        WAITING --> OFF: launch --abort
+        WAITING --> READY: launch --continue
+        WAITING --> READY: refresh --abort
+        WAITING --> READY: refresh --continue
+
+
+Pending
+-------
+
+An intermediate state
+while the workshop is being updated or changing its status;
+only a few commands will be accepted.
 
 
 Error

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -351,11 +351,17 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		connRef, err = repo.ResolveConnect(a.Plugs[0].ProjectId, a.Plugs[0].Workshop, a.Plugs[0].Sdk, a.Plugs[0].Name,
 			a.Slots[0].ProjectId, a.Slots[0].Workshop, a.Slots[0].Sdk, a.Slots[0].Name)
 		if err == nil {
-			plugW, err := c.d.overlord.WorkshopManager().Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
+			wsmgr := c.d.overlord.WorkshopManager()
+			var plugW, slotW *workshop.Workshop
+			plugW, err = wsmgr.Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
 			if err != nil {
 				break
 			}
-			ts, connErr := ifacestate.Connect(st, plugW, connRef)
+			slotW, err = wsmgr.Workshop(r.Context(), connRef.SlotRef.Workshop, connRef.SlotRef.ProjectId)
+			if err != nil {
+				break
+			}
+			ts, connErr := ifacestate.Connect(st, plugW, slotW, connRef)
 			if connErr != nil {
 				if _, ok := connErr.(*ifacestate.ErrAlreadyConnected); !ok {
 					return statusBadRequest("%w", connErr)
@@ -377,8 +383,14 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		seen := map[interfaces.ConnRef]bool{}
 		for _, connRef := range conns {
 			var ts *state.TaskSet
-			plugW, werr := c.d.overlord.WorkshopManager().Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
-			if werr != nil {
+			wsmgr := c.d.overlord.WorkshopManager()
+			var plugW, slotW *workshop.Workshop
+			plugW, err = wsmgr.Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
+			if err != nil {
+				break
+			}
+			slotW, err = wsmgr.Workshop(r.Context(), connRef.SlotRef.Workshop, connRef.SlotRef.ProjectId)
+			if err != nil {
 				break
 			}
 
@@ -391,7 +403,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 					break
 				}
 			}
-			ts, err = ifacestate.Disconnect(st, plugW, connRef, a.Forget, seen)
+			ts, err = ifacestate.Disconnect(st, plugW, slotW, connRef, a.Forget, seen)
 			if err != nil {
 				break
 			}

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1423,12 +1423,80 @@ func (s *apiSuite) TestConnectFailureOnConflict(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": `workshop "producer-ws" has "conflict" change in progress`,
+			"message": `cannot connect "producer-ws/producer:slot": other changes in progress`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
 		"type":        "error",
 	})
+}
+
+func (s *apiSuite) TestConnectWarnOnExec(c *check.C) {
+	d := s.daemon(c)
+
+	mockIface(c, d, &ifacetest.TestInterface{InterfaceName: "test"})
+
+	cmd := apiCmd("/v1/connections")
+
+	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
+	s.mockInstalledSDK(c, producerYaml, "producer-ws")
+
+	d.Overlord().Loop()
+	defer d.Overlord().Stop()
+
+	action := &client.InterfaceAction{
+		Action: "connect",
+		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"}},
+		Slots:  []client.Slot{{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"}},
+	}
+
+	st := s.d.state
+	st.Lock()
+	chg := st.NewChange("exec", "...")
+	tsk := st.NewTask("exec", "...")
+	chg.AddTask(tsk)
+	tsk.Set("workshop", "producer-ws")
+	chg.Set("project-id", "b8639dea")
+	st.Unlock()
+
+	text, err := json.Marshal(action)
+	c.Assert(err, check.IsNil)
+	buf := bytes.NewBuffer(text)
+	req, err := http.NewRequest("POST", cmd.Path, buf)
+	c.Assert(err, check.IsNil)
+	rec := httptest.NewRecorder()
+	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
+	c.Check(rec.Code, check.Equals, 202)
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	id := body["change"].(string)
+
+	st.Lock()
+	chg = st.Change(id)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+
+	<-chg.Ready()
+
+	st.Lock()
+	err = chg.Err()
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+
+	repo := d.Overlord().InterfaceManager().Repository()
+	ifaces := repo.Interfaces()
+	c.Assert(ifaces.Connections, check.HasLen, 1)
+	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{{
+		PlugRef: sdk.PlugRef{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "b8639dea", Workshop: "producer-ws", Sdk: "producer", Name: "slot"},
+	}})
+
+	st.Lock()
+	warnings := st.AllWarnings()
+	st.Unlock()
+	c.Check(warnings, check.HasLen, 1)
+	c.Check(warnings[0].String(), check.Equals, `active shell sessions in "producer-ws" may need restarting for new connections to take effect`)
 }
 
 type disconnectOpts struct {
@@ -1864,7 +1932,7 @@ func (s *apiSuite) TestDisconnectFailureOnConflict(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]interface{}{
 		"result": map[string]interface{}{
-			"message": `workshop "consumer-ws" has "conflict" change in progress`,
+			"message": `cannot disconnect "consumer-ws/consumer:plug": other changes in progress`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -92,7 +92,7 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest(`cannot remount %q: interface type should be "mount" (now: %q)`, reqData.Plug.ShortRef(), conn.Plug.Interface())
 	}
 
-	taskset, err := o.WorkshopManager().Remount(r.Context(), st, reqData.Plug, reqData.HostSource, projectId)
+	taskset, err := o.WorkshopManager().Remount(r.Context(), st, reqData.Plug, reqData.HostSource)
 	if err != nil {
 		return statusBadRequest("%w", err)
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -223,7 +223,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	info := Workshops{}
 	info.Workshops = make([]*WorkshopInfo, 0, len(workshops))
 	for _, w := range workshops {
-		health := wrkmgr.WorkshopHealth(w)
+		health := healthstate.WorkshopHealth(state, w)
 		if ignoreStatus || health.Status == status {
 			wi := workshopToInfo(w, nil, health)
 			info.Workshops = append(info.Workshops, wi)
@@ -418,7 +418,7 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	if err != nil {
 		return statusNotFound("%w", err)
 	}
-	health := wrkmgr.WorkshopHealth(w)
+	health := healthstate.WorkshopHealth(state, w)
 
 	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
 	sdks, err := w.SdkInfos(ctx)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1522,8 +1522,7 @@ func (s *apiSuite) TestRefreshWorkshopContinueSuccess(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 	// no refresh in progress after continue was successful
-	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "basic", "")
-	c.Assert(err, check.IsNil)
+	c.Assert(conflict.CheckChangeConflict(st, s.project.ProjectId, "basic", nil), check.IsNil)
 }
 
 func (s *apiSuite) TestRefreshWorkshopNoRefreshInProgress(c *check.C) {
@@ -1612,8 +1611,7 @@ func (s *apiSuite) TestRefreshWorkshopChangeAbort(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 	// no refresh in progress after continue was successful
-	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "basic", "")
-	c.Assert(err, check.IsNil)
+	c.Assert(conflict.CheckChangeConflict(st, s.project.ProjectId, "basic", nil), check.IsNil)
 }
 
 func (s *apiSuite) TestLaunchWorkshopRefreshLaunchInProgress(c *check.C) {
@@ -1656,8 +1654,8 @@ func (s *apiSuite) TestLaunchWorkshopRefreshLaunchInProgress(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 	// no wait in progress after continue was successful
-	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "manysdks", "")
-	c.Assert(err, check.ErrorMatches, `*. has "launch" change in progress`)
+	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "manysdks", nil)
+	c.Check(err, check.ErrorMatches, `*. has "launch" change in progress`)
 }
 
 func (s *apiSuite) TestLaunchWorkshopContinueSuccess(c *check.C) {
@@ -1701,8 +1699,7 @@ func (s *apiSuite) TestLaunchWorkshopContinueSuccess(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 	// no wait in progress after continue was successful
-	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "manysdks", "")
-	c.Assert(err, check.IsNil)
+	c.Assert(conflict.CheckChangeConflict(st, s.project.ProjectId, "manysdks", nil), check.IsNil)
 }
 
 func (s *apiSuite) TestLaunchWorkshopNoRefreshInProgress(c *check.C) {
@@ -1782,8 +1779,7 @@ func (s *apiSuite) TestLaunchWorkshopChangeAbort(c *check.C) {
 	st.Lock()
 	defer st.Unlock()
 	// no refresh in progress after continue was successful
-	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "manysdks", "")
-	c.Assert(err, check.IsNil)
+	c.Assert(conflict.CheckChangeConflict(st, s.project.ProjectId, "manysdks", nil), check.IsNil)
 }
 
 func (s *apiSuite) TestRefreshWorkshopPartialOK(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1901,7 +1901,6 @@ base: ubuntu@22.04
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
 			Message: `cannot refresh "manysdks": waiting on error`,
-			Kind:    "waiting-on-error",
 			Summary: `Refresh "manysdks" workshop`,
 		},
 	}

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/internal/logger"
-	"github.com/canonical/workshop/internal/overlord/workshopstate"
 )
 
 type ResponseType string
@@ -126,7 +125,6 @@ const (
 	errorKindNotFound          = errorKind("not-found")
 	errorKindPermissionDenied  = errorKind("permission-denied")
 	errorKindGenericFileError  = errorKind("generic-file-error")
-	errorKindWaitingOnError    = errorKind("waiting-on-error")
 )
 
 type errorValue interface{}
@@ -191,8 +189,6 @@ func makeErrorResponder(status int) errorResponder {
 
 		if errors.Is(err, ErrAccessDenied) {
 			res.Kind = errorKindLoginRequired
-		} else if errors.Is(err, workshopstate.ErrWaitingOnError) {
-			res.Kind = errorKindWaitingOnError
 		}
 
 		return response

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -3,6 +3,7 @@ package conflict
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
@@ -106,30 +107,44 @@ func checkWorkshop(task *state.Task, projectId, workshop string) (bool, error) {
 	return false, nil
 }
 
-// Iterates over the list of running tasks and returns a ChangeConflictError if
-// there is another change running for the provided projectID / workshop pair.
-func CheckChangeConflict(st *state.State, projectId, workshop string, ignoreChange string) error {
+// Iterates over the list of running tasks and returns either nil or
+// a change running for the provided projectID / workshop pair.
+// Ignores certain kinds of changes based on the ignoreKinds argument.
+func findRunningChange(st *state.State, projectId, workshop string, ignoreKinds []string) (*state.Change, error) {
 	for _, task := range st.Tasks() {
 		chg := task.Change()
-		if chg.IsReady() || chg.ID() == ignoreChange {
+		if chg.IsReady() || slices.Contains(ignoreKinds, chg.Kind()) {
 			continue
 		}
 
 		ok, err := checkWorkshop(task, projectId, workshop)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if ok {
-			return &ChangeConflictError{
-				ProjectId:  projectId,
-				Workshop:   workshop,
-				ChangeKind: chg.Kind(),
-				ChangeID:   chg.ID(),
-			}
+			return chg, nil
 		}
-
 	}
-	return nil
+	return nil, nil
+}
+
+// Iterates over the list of running tasks and returns a ChangeConflictError if
+// there is a change running for the provided projectID / workshop pair.
+// Ignores certain kinds of changes based on the ignoreKinds argument.
+func CheckChangeConflict(st *state.State, projectId, workshop string, ignoreKinds []string) error {
+	chg, err := findRunningChange(st, projectId, workshop, ignoreKinds)
+	if err != nil {
+		return err
+	}
+	if chg == nil {
+		return nil
+	}
+	return &ChangeConflictError{
+		ProjectId:  projectId,
+		Workshop:   workshop,
+		ChangeKind: chg.Kind(),
+		ChangeID:   chg.ID(),
+	}
 }
 
 // Attempt to resume the change associated with the Resume/Launch operation
@@ -141,18 +156,9 @@ func ResumeAfterWait(st *state.State,
 		return nil, fmt.Errorf("cannot resume: only abort or continue can be used to resume the operation")
 	}
 
-	var chg *state.Change
-	for _, task := range st.Tasks() {
-		if task.Change().IsReady() {
-			continue
-		}
-
-		if ok, err := checkWorkshop(task, projectId, workshop); err != nil {
-			return nil, err
-		} else if ok {
-			chg = task.Change()
-			break
-		}
+	chg, err := findRunningChange(st, projectId, workshop, []string{"exec"})
+	if err != nil {
+		return nil, err
 	}
 	if chg == nil {
 		return nil, fmt.Errorf("cannot %s: no wait in progress", mode)
@@ -188,4 +194,24 @@ func ResumeAfterWait(st *state.State,
 	}
 
 	return chg, nil
+}
+
+// Iterates over the list of running tasks and returns a change ID if
+// there is a change running for the provided projectID, workshop and kind.
+func FindChangeByKind(st *state.State, projectId, workshop, kind string) (string, error) {
+	for _, task := range st.Tasks() {
+		chg := task.Change()
+		if chg.IsReady() || chg.Kind() != kind {
+			continue
+		}
+
+		ok, err := checkWorkshop(task, projectId, workshop)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return chg.ID(), nil
+		}
+	}
+	return "", errors.New("change not found")
 }

--- a/internal/overlord/conflict/conflict_test.go
+++ b/internal/overlord/conflict/conflict_test.go
@@ -48,8 +48,7 @@ func (s *conflictSuite) TestCheckChangeConflictNotFound(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	err := conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", "")
-	c.Assert(err, check.IsNil)
+	c.Assert(conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", nil), check.IsNil)
 }
 
 func (s *conflictSuite) TestCheckChangeConflictFound(c *check.C) {
@@ -58,7 +57,7 @@ func (s *conflictSuite) TestCheckChangeConflictFound(c *check.C) {
 
 	change := s.newChange("launch")
 
-	err := conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", "")
+	err := conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", nil)
 	c.Assert(err, check.NotNil)
 	conflictErr, ok := err.(*conflict.ChangeConflictError)
 	c.Assert(ok, check.Equals, true)
@@ -74,7 +73,7 @@ func (s *conflictSuite) TestCheckChangeDisconnectConflictFound(c *check.C) {
 
 	change := s.newChangeDisconnect("disconnect")
 
-	err := conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", "")
+	err := conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", nil)
 	c.Assert(err, check.NotNil)
 	conflictErr, ok := err.(*conflict.ChangeConflictError)
 	c.Assert(ok, check.Equals, true)
@@ -83,7 +82,7 @@ func (s *conflictSuite) TestCheckChangeDisconnectConflictFound(c *check.C) {
 	c.Assert(conflictErr.Workshop, check.Equals, "ws")
 	c.Assert(conflictErr.ProjectId, check.Equals, s.project.ProjectId)
 
-	err = conflict.CheckChangeConflict(s.state, s.project.ProjectId, "another-ws", "")
+	err = conflict.CheckChangeConflict(s.state, s.project.ProjectId, "another-ws", nil)
 	c.Assert(err, check.NotNil)
 	conflictErr, ok = err.(*conflict.ChangeConflictError)
 	c.Assert(ok, check.Equals, true)
@@ -100,18 +99,69 @@ func (s *conflictSuite) TestCheckChangeNoConflictWithReadyChange(c *check.C) {
 	change := s.newChange("launch")
 	change.SetStatus(state.DoneStatus)
 
-	err := conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", "")
-	c.Assert(err, check.IsNil)
+	c.Assert(conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", nil), check.IsNil)
 }
 
-func (s *conflictSuite) TestCheckChangeConflictIgnoreChange(c *check.C) {
+func (s *conflictSuite) TestCheckChangeConflictIgnoreKinds(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	change := s.newChange("launch")
+	launch := s.newChange("launch")
+	launch.SetStatus(state.DoneStatus)
+	s.newChange("exec")
+	s.newChange("connect")
 
-	err := conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", change.ID())
+	c.Assert(conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", nil), check.NotNil)
+
+	c.Assert(conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", []string{"connect", "exec"}), check.IsNil)
+}
+
+func (s *conflictSuite) TestFindChangeByKindNotFound(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	id, err := conflict.FindChangeByKind(s.state, s.project.ProjectId, "ws", "exec")
+	c.Check(err, check.ErrorMatches, "change not found")
+	c.Check(id, check.Equals, "")
+}
+
+func (s *conflictSuite) TestFindChangeByKindFound(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	change := s.newChange("exec")
+
+	id, err := conflict.FindChangeByKind(s.state, s.project.ProjectId, "ws", "exec")
 	c.Assert(err, check.IsNil)
+	c.Check(id, check.Equals, change.ID())
+}
+
+func (s *conflictSuite) TestFindChangeByKindIgnoreReadyChanges(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	done := s.newChange("launch")
+	done.SetStatus(state.DoneStatus)
+	doing := s.newChange("launch")
+	done = s.newChange("launch")
+	done.SetStatus(state.DoneStatus)
+
+	id, err := conflict.FindChangeByKind(s.state, s.project.ProjectId, "ws", "launch")
+	c.Assert(err, check.IsNil)
+	c.Check(id, check.Equals, doing.ID())
+}
+
+func (s *conflictSuite) TestFindChangeByKindIgnoreOtherKinds(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.newChange("launch")
+	change := s.newChange("exec")
+	s.newChange("launch")
+
+	id, err := conflict.FindChangeByKind(s.state, s.project.ProjectId, "ws", "exec")
+	c.Assert(err, check.IsNil)
+	c.Check(id, check.Equals, change.ID())
 }
 
 func (s *conflictSuite) TestResumeAfterWaitNothingInProgress(c *check.C) {

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -19,11 +19,12 @@ const (
 	UnknownStatus Status = iota
 	ReadyStatus
 	PendingStatus
+	WaitingStatus
 	ErrorStatus
 	StoppedStatus
 )
 
-var knownStatuses = []string{"Unknown", "Ready", "Pending", "Error", "Stopped"}
+var knownStatuses = []string{"Unknown", "Ready", "Pending", "Waiting", "Error", "Stopped"}
 
 func StatusLookup(str string) (Status, error) {
 	switch str {
@@ -33,6 +34,8 @@ func StatusLookup(str string) (Status, error) {
 		return ReadyStatus, nil
 	case "pending":
 		return PendingStatus, nil
+	case "waiting":
+		return WaitingStatus, nil
 	case "error":
 		return ErrorStatus, nil
 	case "stopped":

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"time"
 
 	"github.com/canonical/x-go/strutil"
 
+	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 type Status int
@@ -100,6 +103,86 @@ type HealthState struct {
 	Message   string                 `json:"message,omitempty"`
 	Code      string                 `json:"code,omitempty"`
 	SdkHealth map[string]HealthCheck `json:"sdk-health,omitempty"`
+}
+
+// Infers the state of a workshop based on the container's state and any of the
+// operations in progress for the workshop. The state must be locked.
+func WorkshopHealth(st *state.State, ws *workshop.Workshop) HealthState {
+	var healthState = HealthState{
+		Timestamp: time.Now(),
+	}
+
+	// Check the project directory exists.
+	if !ws.Project.Exists() {
+		st.Warnf("cannot find project directory %q for workshop %q", ws.Project.Path, ws.Name)
+
+		healthState.Status = ErrorStatus
+		healthState.Code = "missing-project"
+		return healthState
+	}
+
+	if err := conflict.CheckChangeConflict(st, ws.Project.ProjectId, ws.Name, ""); err != nil {
+		conflict, ok := err.(*conflict.ChangeConflictError)
+		if !ok || conflict.ChangeID == "" {
+			healthState.Status = ErrorStatus
+			return healthState
+		}
+
+		change := st.Change(conflict.ChangeID)
+		if change.Status() == state.WaitStatus {
+			healthState.Code = "wait-on-error"
+			healthState.Status = WaitingStatus
+		} else {
+			healthState.Status = PendingStatus
+		}
+
+		healthState.SdkHealth = sdksHealthCheckSummary(change)
+	} else {
+		if ws.Running {
+			healthState.Status = ReadyStatus
+		} else {
+			healthState.Status = StoppedStatus
+		}
+	}
+	return healthState
+}
+
+// Examine the tasks of the change to fetch possible check-health hook results
+// for the workshop's SDKs.
+func sdksHealthCheckSummary(chg *state.Change) map[string]HealthCheck {
+	var sdkChecks = map[string]HealthCheck{}
+	for _, task := range chg.Tasks() {
+		if task.Kind() == "run-hook" {
+			var healthCheck HealthCheck
+			if err := task.Get("health", &healthCheck); err == nil {
+				sdkChecks[healthCheck.Sdk] = healthCheck
+			}
+		}
+	}
+	return sdkChecks
+}
+
+// Checks the provided workshop has one of the allowed health statuses.
+func CheckWorkshopHealth(st *state.State, ws *workshop.Workshop, allowedStatuses []Status) error {
+	health := WorkshopHealth(st, ws)
+
+	if !slices.Contains(allowedStatuses, health.Status) {
+		switch health.Status {
+		case ReadyStatus:
+			return errors.New("workshop already running")
+		case PendingStatus:
+			return errors.New("other changes in progress")
+		case WaitingStatus:
+			return errors.New("waiting on error")
+		case ErrorStatus:
+			return errors.New("workshop unhealthy")
+		case StoppedStatus:
+			return errors.New("workshop not running")
+		default:
+			return errors.New("workshop health unknown")
+		}
+	}
+	return nil
 }
 
 func Init(hookManager *hookstate.HookManager) {

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -121,7 +121,7 @@ func WorkshopHealth(st *state.State, ws *workshop.Workshop) HealthState {
 		return healthState
 	}
 
-	if err := conflict.CheckChangeConflict(st, ws.Project.ProjectId, ws.Name, ""); err != nil {
+	if err := conflict.CheckChangeConflict(st, ws.Project.ProjectId, ws.Name, []string{"exec"}); err != nil {
 		conflict, ok := err.(*conflict.ChangeConflictError)
 		if !ok || conflict.ChangeID == "" {
 			healthState.Status = ErrorStatus

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -19,9 +19,12 @@ package healthstate_test
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
@@ -101,19 +104,36 @@ func ensureTaskHealthIsSet(t *state.Task, expected *healthstate.HealthCheck, c *
 	c.Assert(expected, check.DeepEquals, &health)
 }
 
-func (s *healthSuite) launchWorkshop(c *check.C, newsdk string, createHealthCheck bool) {
-	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{{Name: "one", Channel: "latest/stable"}}}
+var (
+	oneSdk = []workshop.SdkRecord{{Name: "one", Channel: "latest/stable"}}
+
+	oneSdkWithHealthCheck = []workshop.SdkRecord{{
+		Name:    "one",
+		Channel: "latest/stable",
+		Hooks:   map[string]string{hookstate.CheckHealth.String(): ""},
+	}}
+)
+
+func (s *healthSuite) launchWorkshopWithSDKs(c *check.C, sdks []workshop.SdkRecord) *workshop.Workshop {
+	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: sdks}
 	err := s.backend.LaunchWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
-	err = ws.MkdirAll(sdk.SdkHooksDir(newsdk), 0744)
-	c.Check(err, check.IsNil)
 
-	if createHealthCheck {
-		_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.CheckHealth.String()))
+	for _, sk := range sdks {
+		err = ws.MkdirAll(sdk.SdkHooksDir(sk.Name), 0744)
 		c.Check(err, check.IsNil)
+
+		for name, hook := range sk.Hooks {
+			c.Assert(afero.WriteFile(ws, sdk.SdkHookPath(sk.Name, name), []byte(hook), 0644), check.IsNil)
+		}
 	}
+
+	workshop, err := s.backend.Workshop(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	workshop.Running = true
+	return workshop
 }
 
 func (*healthSuite) TestStatusHappy(c *check.C) {
@@ -131,6 +151,206 @@ func (*healthSuite) TestStatusUnhappy(c *check.C) {
 	c.Check(status.String(), check.Equals, "invalid (-1)")
 }
 
+func (s *healthSuite) TestWorkshopHealthReady(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+	health := healthstate.WorkshopHealth(s.state, workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.ReadyStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.HasLen, 0)
+}
+
+func (s *healthSuite) TestWorkshopHealthStopped(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+	c.Assert(s.backend.StopWorkshop(s.ctx, "ws", true), check.IsNil)
+	health := healthstate.WorkshopHealth(s.state, workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.StoppedStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.HasLen, 0)
+}
+
+func (s *healthSuite) TestWorkshopHealthMissingProject(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+	c.Assert(os.RemoveAll(s.project.Path), check.IsNil)
+	health := healthstate.WorkshopHealth(s.state, workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.ErrorStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.Equals, "missing-project")
+
+	warnings := s.state.AllWarnings()
+	c.Check(warnings, check.HasLen, 1)
+	warning := fmt.Sprintf(`cannot find project directory %q for workshop "ws"`, s.project.Path)
+	c.Check(warnings[0].String(), check.Equals, warning)
+}
+
+func (s *healthSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("launch", "test")
+	task := s.state.NewTask("create-workshop", "test task")
+	task.Set("workshop", "ws")
+	chg.Set("project-id", s.project.ProjectId)
+	chg.AddTask(task)
+
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+	health := healthstate.WorkshopHealth(s.state, workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.HasLen, 0)
+}
+
+func (s *healthSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("refresh", "test")
+	chg.SetStatus(state.WaitStatus)
+	task := s.state.NewTask("create-workshop", "test task")
+	task.Set("workshop", "ws")
+	chg.Set("project-id", s.project.ProjectId)
+	chg.AddTask(task)
+
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+	health := healthstate.WorkshopHealth(s.state, workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.WaitingStatus)
+	c.Check(health.SdkHealth, check.HasLen, 0)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.Equals, "wait-on-error")
+}
+
+func (s *healthSuite) TestWorkshopHealthSdkHealth(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("launch", "test")
+	task := s.state.NewTask("run-hook", "test task")
+	healthCheck := healthstate.HealthCheck{
+		Sdk:         "one",
+		CheckResult: healthstate.CheckWaiting,
+		Message:     "still waiting",
+		Code:        "how-much-longer",
+	}
+	task.Set("health", healthCheck)
+	task.Set("workshop", "ws")
+	chg.Set("project-id", s.project.ProjectId)
+	chg.AddTask(task)
+
+	workshop := s.launchWorkshopWithSDKs(c, oneSdk)
+	health := healthstate.WorkshopHealth(s.state, workshop)
+
+	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
+	c.Assert(health.SdkHealth, check.HasLen, 1)
+	c.Assert(health.SdkHealth["one"], check.DeepEquals, healthCheck)
+	c.Check(health.Message, check.HasLen, 0)
+	c.Check(health.Code, check.HasLen, 0)
+}
+
+func (s *healthSuite) TestCheckStatusReady(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+
+	// Ready status should not return an error
+	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ReadyStatus})
+	c.Assert(err, check.IsNil)
+
+	// All other status' should return an error
+	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ErrorStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	c.Assert(err, check.ErrorMatches, "workshop already running")
+}
+
+func (s *healthSuite) TestCheckStatusPending(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("refresh", "test")
+	chg.SetStatus(state.DoingStatus)
+	task := s.state.NewTask("create-workshop", "test task")
+	task.Set("workshop", "ws")
+	chg.Set("project-id", s.project.ProjectId)
+	chg.AddTask(task)
+
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+
+	// Pending status should not return an error
+	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.PendingStatus})
+	c.Assert(err, check.IsNil)
+
+	// All other status' should return an error
+	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	c.Assert(err, check.ErrorMatches, "other changes in progress")
+}
+
+func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("refresh", "test")
+	chg.SetStatus(state.WaitStatus)
+	task := s.state.NewTask("create-workshop", "test task")
+	task.Set("workshop", "ws")
+	chg.Set("project-id", s.project.ProjectId)
+	chg.AddTask(task)
+
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+
+	// Waiting status should not return an error
+	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.WaitingStatus})
+	c.Assert(err, check.IsNil)
+
+	// All other status' should return an error
+	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	c.Assert(err, check.ErrorMatches, "waiting on error")
+}
+
+func (s *healthSuite) TestCheckStatusError(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+	c.Assert(os.RemoveAll(s.project.Path), check.IsNil)
+
+	// Error status should not return an error
+	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ErrorStatus})
+	c.Assert(err, check.IsNil)
+
+	// All other status' should return an error
+	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	c.Assert(err, check.ErrorMatches, "workshop unhealthy")
+}
+
+func (s *healthSuite) TestCheckStatusStopped(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	workshop := s.launchWorkshopWithSDKs(c, nil)
+	c.Assert(s.backend.StopWorkshop(s.ctx, "ws", true), check.IsNil)
+
+	// Stopped status should not return an error
+	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.StoppedStatus})
+	c.Assert(err, check.IsNil)
+
+	// All other status' should return an error
+	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.ErrorStatus, healthstate.UnknownStatus})
+	c.Assert(err, check.ErrorMatches, "workshop not running")
+}
+
 func (s *healthSuite) TestExecCheckHealthNotProvided(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -141,7 +361,7 @@ func (s *healthSuite) TestExecCheckHealthNotProvided(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.launchWorkshop(c, "one", false)
+	s.launchWorkshopWithSDKs(c, oneSdk)
 
 	s.state.Unlock()
 	s.se.Ensure()
@@ -162,7 +382,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthNotCalled(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.launchWorkshop(c, "one", true)
+	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
 	restore := healthstate.FakeRetryTimeout(0 * time.Second)
 	defer restore()
 
@@ -214,7 +434,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
-	s.launchWorkshop(c, "one", true)
+	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
 	s.state.Unlock()
 	s.se.Ensure()
 	s.se.Wait()
@@ -287,7 +507,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
-	s.launchWorkshop(c, "one", true)
+	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
 	s.state.Unlock()
 	for i := 0; i < 2; i = i + 1 {
 		s.se.Ensure()
@@ -344,7 +564,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
-	s.launchWorkshop(c, "one", true)
+	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
 	s.state.Unlock()
 	for i := 0; i < 3; i = i + 1 {
 		s.se.Ensure()
@@ -387,7 +607,7 @@ func (s *healthSuite) TestExecCheckHealthTimeout(c *check.C) {
 		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
-	s.launchWorkshop(c, "one", true)
+	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
 	s.state.Unlock()
 	s.se.Ensure()
 	s.se.Wait()

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/overlord/conflict"
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -19,17 +20,20 @@ func (e ErrAlreadyConnected) Error() string {
 }
 
 // Connect returns a set of tasks for connecting an interface.
-func Connect(st *state.State, plugW *workshop.Workshop, connRef *interfaces.ConnRef) (*state.TaskSet, error) {
-	plugProject, plugWorkshop := connRef.PlugRef.ProjectId, connRef.PlugRef.Workshop
-	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
-	if err != nil {
-		return nil, err
+func Connect(st *state.State, plugW *workshop.Workshop, slotW *workshop.Workshop, connRef *interfaces.ConnRef) (*state.TaskSet, error) {
+	allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.WaitingStatus, healthstate.StoppedStatus}
+	if err := healthstate.CheckWorkshopHealth(st, plugW, allowed); err != nil {
+		return nil, fmt.Errorf("cannot connect %q: %w", connRef.PlugRef.ShortRef(), err)
+	}
+	if err := healthstate.CheckWorkshopHealth(st, slotW, allowed); err != nil {
+		return nil, fmt.Errorf("cannot connect %q: %w", connRef.SlotRef.ShortRef(), err)
 	}
 
-	slotProject, slotWorkshop := connRef.SlotRef.ProjectId, connRef.SlotRef.Workshop
-	err = conflict.CheckChangeConflict(st, slotProject, slotWorkshop, "")
-	if err != nil {
-		return nil, err
+	if _, err := conflict.FindChangeByKind(st, plugW.Project.ProjectId, plugW.Name, "exec"); err == nil {
+		st.Warnf("active shell sessions in %q may need restarting for new connections to take effect", plugW.Name)
+	}
+	if _, err := conflict.FindChangeByKind(st, slotW.Project.ProjectId, slotW.Name, "exec"); err == nil {
+		st.Warnf("active shell sessions in %q may need restarting for new connections to take effect", slotW.Name)
 	}
 
 	// check if the connection already exists
@@ -109,17 +113,13 @@ func disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.Conn
 }
 
 // Disconnect returns a set of tasks for disconnecting an interface.
-func Disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool, seen map[interfaces.ConnRef]bool) (*state.TaskSet, error) {
-	plugProject, plugWorkshop := conn.PlugRef.ProjectId, conn.PlugRef.Workshop
-	err := conflict.CheckChangeConflict(st, plugProject, plugWorkshop, "")
-	if err != nil {
-		return nil, err
+func Disconnect(st *state.State, plugW *workshop.Workshop, slotW *workshop.Workshop, conn *interfaces.ConnRef, forget bool, seen map[interfaces.ConnRef]bool) (*state.TaskSet, error) {
+	allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.WaitingStatus, healthstate.StoppedStatus}
+	if err := healthstate.CheckWorkshopHealth(st, plugW, allowed); err != nil {
+		return nil, fmt.Errorf("cannot disconnect %q: %w", conn.PlugRef.ShortRef(), err)
 	}
-
-	slotProject, slotWorkshop := conn.SlotRef.ProjectId, conn.SlotRef.Workshop
-	err = conflict.CheckChangeConflict(st, slotProject, slotWorkshop, "")
-	if err != nil {
-		return nil, err
+	if err := healthstate.CheckWorkshopHealth(st, slotW, allowed); err != nil {
+		return nil, fmt.Errorf("cannot disconnect %q: %w", conn.SlotRef.ShortRef(), err)
 	}
 
 	return disconnect(st, plugW, conn, forget, seen)

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -2,15 +2,11 @@ package workshopstate
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"time"
 
 	"golang.org/x/exp/slices"
 
-	"github.com/canonical/workshop/internal/overlord/conflict"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
-	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -51,34 +47,6 @@ func (m *WorkshopManager) StartUp() error {
 }
 
 func (w *WorkshopManager) Ensure() error {
-	return nil
-}
-
-// Checks the provided workshop has one of the allowed health statuses.
-func (w *WorkshopManager) CheckStatus(ctx context.Context, name, pId string, allowedStatuses []healthstate.Status) error {
-	wp, err := w.Workshop(ctx, name, pId)
-	if err != nil {
-		return err
-	}
-
-	health := w.WorkshopHealth(wp)
-
-	if !slices.Contains(allowedStatuses, health.Status) {
-		switch health.Status {
-		case healthstate.ReadyStatus:
-			return errors.New("workshop already running")
-		case healthstate.PendingStatus:
-			return errors.New("other changes in progress")
-		case healthstate.WaitingStatus:
-			return errors.New("waiting on error")
-		case healthstate.ErrorStatus:
-			return errors.New("workshop unhealthy")
-		case healthstate.StoppedStatus:
-			return errors.New("workshop not running")
-		default:
-			return errors.New("workshop health unknown")
-		}
-	}
 	return nil
 }
 
@@ -169,62 +137,4 @@ func (w *WorkshopManager) Workshops(ctx context.Context, pId string) ([]*worksho
 	}
 
 	return workshops, nil
-}
-
-// Examine the tasks of the change to fetch possible check-health hook results
-// for the workshop's SDKs.
-func sdksHealthCheckSummary(chg *state.Change) map[string]healthstate.HealthCheck {
-	var SdkChecks = map[string]healthstate.HealthCheck{}
-	for _, task := range chg.Tasks() {
-		if task.Kind() == "run-hook" {
-			var healthCheck healthstate.HealthCheck
-			if err := task.Get("health", &healthCheck); err == nil {
-				SdkChecks[healthCheck.Sdk] = healthCheck
-			}
-		}
-	}
-	return SdkChecks
-}
-
-// Infers the state of a workshop based on the container's state and any of the
-// operations in progress for the workshop. The state must be locked.
-func (w *WorkshopManager) WorkshopHealth(ws *workshop.Workshop) healthstate.HealthState {
-	var healthState = healthstate.HealthState{
-		Timestamp: time.Now(),
-	}
-
-	// Check the project directory exists.
-	if !ws.Project.Exists() {
-		w.state.Warnf("cannot find project directory %q for workshop %q", ws.Project.Path, ws.Name)
-
-		healthState.Status = healthstate.ErrorStatus
-		healthState.Code = "missing-project"
-		return healthState
-	}
-
-	err := conflict.CheckChangeConflict(w.state, ws.Project.ProjectId, ws.Name, "")
-	if err != nil {
-		conflict, ok := err.(*conflict.ChangeConflictError)
-		if !ok || conflict.ChangeID == "" {
-			healthState.Status = healthstate.ErrorStatus
-			return healthState
-		}
-
-		change := w.state.Change(conflict.ChangeID)
-		if change.Status() == state.WaitStatus {
-			healthState.Code = "wait-on-error"
-			healthState.Status = healthstate.WaitingStatus
-		} else {
-			healthState.Status = healthstate.PendingStatus
-		}
-
-		healthState.SdkHealth = sdksHealthCheckSummary(change)
-	} else {
-		if ws.Running {
-			healthState.Status = healthstate.ReadyStatus
-		} else {
-			healthState.Status = healthstate.StoppedStatus
-		}
-	}
-	return healthState
 }

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -15,8 +15,6 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-var ErrWaitingOnError = errors.New("waiting on error")
-
 type WorkshopManager struct {
 	backend workshop.Backend
 	state   *state.State
@@ -72,7 +70,7 @@ func (w *WorkshopManager) CheckStatus(ctx context.Context, name, pId string, all
 		case healthstate.PendingStatus:
 			return errors.New("other changes in progress")
 		case healthstate.WaitingStatus:
-			return ErrWaitingOnError
+			return errors.New("waiting on error")
 		case healthstate.ErrorStatus:
 			return errors.New("workshop unhealthy")
 		case healthstate.StoppedStatus:

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -68,18 +68,17 @@ func (w *WorkshopManager) CheckStatus(ctx context.Context, name, pId string, all
 	if !slices.Contains(allowedStatuses, health.Status) {
 		switch health.Status {
 		case healthstate.ReadyStatus:
-			return fmt.Errorf("workshop already running")
+			return errors.New("workshop already running")
 		case healthstate.PendingStatus:
-			if health.Code == "wait-on-error" {
-				return ErrWaitingOnError
-			}
-			return fmt.Errorf("other changes in progress")
+			return errors.New("other changes in progress")
+		case healthstate.WaitingStatus:
+			return ErrWaitingOnError
 		case healthstate.ErrorStatus:
-			return fmt.Errorf("workshop is unhealthy")
+			return errors.New("workshop unhealthy")
 		case healthstate.StoppedStatus:
-			return fmt.Errorf("workshop not running")
+			return errors.New("workshop not running")
 		default:
-			return fmt.Errorf("workshop health is unknown")
+			return errors.New("workshop health unknown")
 		}
 	}
 	return nil
@@ -216,10 +215,12 @@ func (w *WorkshopManager) WorkshopHealth(ws *workshop.Workshop) healthstate.Heal
 		change := w.state.Change(conflict.ChangeID)
 		if change.Status() == state.WaitStatus {
 			healthState.Code = "wait-on-error"
+			healthState.Status = healthstate.WaitingStatus
+		} else {
+			healthState.Status = healthstate.PendingStatus
 		}
 
 		healthState.SdkHealth = sdksHealthCheckSummary(change)
-		healthState.Status = healthstate.PendingStatus
 	} else {
 		if ws.Running {
 			healthState.Status = healthstate.ReadyStatus

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -192,7 +192,7 @@ func (s *managerSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 	c.Check(health.Code, check.HasLen, 0)
 }
 
-func (s *managerSuite) TestWorkshopHealthOperationInProgressWithNotes(c *check.C) {
+func (s *managerSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -206,7 +206,7 @@ func (s *managerSuite) TestWorkshopHealthOperationInProgressWithNotes(c *check.C
 	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
 	health := s.manager.WorkshopHealth(workshop)
 
-	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
+	c.Assert(health.Status, check.Equals, healthstate.WaitingStatus)
 	c.Check(health.SdkHealth, check.HasLen, 0)
 	c.Check(health.Message, check.HasLen, 0)
 	c.Check(health.Code, check.Equals, "wait-on-error")
@@ -280,7 +280,7 @@ func (s *managerSuite) TestCheckStatusReady(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
 	c.Assert(err, check.ErrorMatches, "workshop already running")
 }
 
@@ -289,7 +289,7 @@ func (s *managerSuite) TestCheckStatusPending(c *check.C) {
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("refresh", "test")
-	chg.SetStatus(state.WaitStatus)
+	chg.SetStatus(state.DoingStatus)
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop", "test")
 	chg.Set("project-id", s.project.ProjectId)
@@ -302,7 +302,29 @@ func (s *managerSuite) TestCheckStatusPending(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	c.Assert(err, check.ErrorMatches, "other changes in progress")
+}
+
+func (s *managerSuite) TestCheckStatusWaiting(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("refresh", "test")
+	chg.SetStatus(state.WaitStatus)
+	task := s.state.NewTask("create-workshop", "test task")
+	task.Set("workshop", "test")
+	chg.Set("project-id", s.project.ProjectId)
+	chg.AddTask(task)
+
+	s.launchWorkshopWithSDKs(c, "test", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
+
+	// Waiting status should not return an error
+	err := s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.WaitingStatus})
+	c.Assert(err, check.IsNil)
+
+	// All other status' should return an error
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
 	c.Assert(err, testutil.ErrorIs, workshopstate.ErrWaitingOnError)
 }
 
@@ -317,8 +339,8 @@ func (s *managerSuite) TestCheckStatusError(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "workshop is unhealthy")
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
+	c.Assert(err, check.ErrorMatches, "workshop unhealthy")
 }
 
 func (s *managerSuite) TestCheckStatusStopped(c *check.C) {
@@ -332,6 +354,6 @@ func (s *managerSuite) TestCheckStatusStopped(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.ErrorStatus, healthstate.UnknownStatus})
+	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.ErrorStatus, healthstate.UnknownStatus})
 	c.Assert(err, check.ErrorMatches, "workshop not running")
 }

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -325,7 +325,7 @@ func (s *managerSuite) TestCheckStatusWaiting(c *check.C) {
 
 	// All other status' should return an error
 	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, testutil.ErrorIs, workshopstate.ErrWaitingOnError)
+	c.Assert(err, check.ErrorMatches, "waiting on error")
 }
 
 func (s *managerSuite) TestCheckStatusError(c *check.C) {

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -11,7 +11,6 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
@@ -84,20 +83,13 @@ func (s *managerSuite) TestAddHandlers(c *check.C) {
 }
 
 func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []workshop.SdkRecord) *workshop.Workshop {
-	return s.launchWorkshopAtPathWithSDKs(c, workshop.Filepath(s.project.Path, ws), ws, sdks)
-}
-
-func (s *managerSuite) launchSingleWorkshopWithSDKs(c *check.C, ws string, sdks []workshop.SdkRecord) *workshop.Workshop {
-	return s.launchWorkshopAtPathWithSDKs(c, filepath.Join(s.project.Path, "workshop.yaml"), ws, sdks)
-}
-
-func (s *managerSuite) launchWorkshopAtPathWithSDKs(c *check.C, path, ws string, sdks []workshop.SdkRecord) *workshop.Workshop {
 	t, err := template.New("workshop").Parse(fmt.Sprintf(workshopTemplate, ws))
 	c.Assert(err, check.IsNil)
 
 	var workshopFile = bytes.NewBuffer([]byte{})
 	c.Assert(t.Execute(workshopFile, sdks), check.IsNil)
 
+	path := workshop.Filepath(s.project.Path, ws)
 	err = os.MkdirAll(filepath.Dir(path), os.ModePerm)
 	c.Assert(err, check.IsNil)
 
@@ -112,131 +104,6 @@ func (s *managerSuite) launchWorkshopAtPathWithSDKs(c *check.C, path, ws string,
 	c.Assert(err, check.IsNil)
 	workshop.Running = true
 	return workshop
-}
-
-func (s *managerSuite) TestWorkshopHealthReady(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
-	health := s.manager.WorkshopHealth(workshop)
-
-	c.Assert(health.Status, check.Equals, healthstate.ReadyStatus)
-	c.Check(health.SdkHealth, check.HasLen, 0)
-	c.Check(health.Message, check.HasLen, 0)
-	c.Check(health.Code, check.HasLen, 0)
-}
-
-func (s *managerSuite) TestSingleWorkshopHealthReady(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	workshop := s.launchSingleWorkshopWithSDKs(c, "test", nil)
-	health := s.manager.WorkshopHealth(workshop)
-
-	c.Assert(health.Status, check.Equals, healthstate.ReadyStatus)
-	c.Check(health.SdkHealth, check.HasLen, 0)
-	c.Check(health.Message, check.HasLen, 0)
-	c.Check(health.Code, check.HasLen, 0)
-}
-
-func (s *managerSuite) TestWorkshopHealthStopped(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
-	c.Assert(s.backend.StopWorkshop(s.ctx, "test", true), check.IsNil)
-	health := s.manager.WorkshopHealth(workshop)
-
-	c.Assert(health.Status, check.Equals, healthstate.StoppedStatus)
-	c.Check(health.SdkHealth, check.HasLen, 0)
-	c.Check(health.Message, check.HasLen, 0)
-	c.Check(health.Code, check.HasLen, 0)
-}
-
-func (s *managerSuite) TestWorkshopHealthMissingProject(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
-	c.Assert(os.RemoveAll(s.project.Path), check.IsNil)
-	health := s.manager.WorkshopHealth(workshop)
-
-	c.Assert(health.Status, check.Equals, healthstate.ErrorStatus)
-	c.Check(health.SdkHealth, check.HasLen, 0)
-	c.Check(health.Message, check.HasLen, 0)
-	c.Check(health.Code, check.Equals, "missing-project")
-
-	warnings := s.state.AllWarnings()
-	c.Check(warnings, check.HasLen, 1)
-	warning := fmt.Sprintf(`cannot find project directory %q for workshop "test"`, s.project.Path)
-	c.Check(warnings[0].String(), check.Equals, warning)
-}
-
-func (s *managerSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	chg := s.state.NewChange("launch", "test")
-	task := s.state.NewTask("create-workshop", "test task")
-	task.Set("workshop", "test")
-	chg.Set("project-id", s.project.ProjectId)
-	chg.AddTask(task)
-
-	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
-	health := s.manager.WorkshopHealth(workshop)
-
-	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
-	c.Check(health.SdkHealth, check.HasLen, 0)
-	c.Check(health.Message, check.HasLen, 0)
-	c.Check(health.Code, check.HasLen, 0)
-}
-
-func (s *managerSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	chg := s.state.NewChange("refresh", "test")
-	chg.SetStatus(state.WaitStatus)
-	task := s.state.NewTask("create-workshop", "test task")
-	task.Set("workshop", "test")
-	chg.Set("project-id", s.project.ProjectId)
-	chg.AddTask(task)
-
-	workshop := s.launchWorkshopWithSDKs(c, "test", nil)
-	health := s.manager.WorkshopHealth(workshop)
-
-	c.Assert(health.Status, check.Equals, healthstate.WaitingStatus)
-	c.Check(health.SdkHealth, check.HasLen, 0)
-	c.Check(health.Message, check.HasLen, 0)
-	c.Check(health.Code, check.Equals, "wait-on-error")
-}
-
-func (s *managerSuite) TestWorkshopHealthSdkHealth(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	chg := s.state.NewChange("launch", "test")
-	task := s.state.NewTask("run-hook", "test task")
-	healthCheck := healthstate.HealthCheck{
-		Sdk:         "test",
-		CheckResult: healthstate.CheckWaiting,
-		Message:     "still waiting",
-		Code:        "how-much-longer",
-	}
-	task.Set("health", healthCheck)
-	task.Set("workshop", "test")
-	chg.Set("project-id", s.project.ProjectId)
-	chg.AddTask(task)
-
-	workshop := s.launchWorkshopWithSDKs(c, "test", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
-	health := s.manager.WorkshopHealth(workshop)
-
-	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
-	c.Assert(health.SdkHealth, check.HasLen, 1)
-	c.Assert(health.SdkHealth["test"], check.DeepEquals, healthCheck)
-	c.Check(health.Message, check.HasLen, 0)
-	c.Check(health.Code, check.HasLen, 0)
 }
 
 func (s *managerSuite) TestRefreshManyOK(c *check.C) {
@@ -268,92 +135,4 @@ func (s *managerSuite) TestRefreshRequireWorkshopExistence(c *check.C) {
 
 	_, err := s.manager.RefreshMany(s.ctx, []string{"test-1", "test-2"}, s.project.ProjectId)
 	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop not launched`)
-}
-
-func (s *managerSuite) TestCheckStatusReady(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	s.launchWorkshopWithSDKs(c, "test", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
-
-	// Ready status should not return an error
-	err := s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus})
-	c.Assert(err, check.IsNil)
-
-	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "workshop already running")
-}
-
-func (s *managerSuite) TestCheckStatusPending(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	chg := s.state.NewChange("refresh", "test")
-	chg.SetStatus(state.DoingStatus)
-	task := s.state.NewTask("create-workshop", "test task")
-	task.Set("workshop", "test")
-	chg.Set("project-id", s.project.ProjectId)
-	chg.AddTask(task)
-
-	s.launchWorkshopWithSDKs(c, "test", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
-
-	// Pending status should not return an error
-	err := s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.PendingStatus})
-	c.Assert(err, check.IsNil)
-
-	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "other changes in progress")
-}
-
-func (s *managerSuite) TestCheckStatusWaiting(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	chg := s.state.NewChange("refresh", "test")
-	chg.SetStatus(state.WaitStatus)
-	task := s.state.NewTask("create-workshop", "test task")
-	task.Set("workshop", "test")
-	chg.Set("project-id", s.project.ProjectId)
-	chg.AddTask(task)
-
-	s.launchWorkshopWithSDKs(c, "test", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
-
-	// Waiting status should not return an error
-	err := s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.WaitingStatus})
-	c.Assert(err, check.IsNil)
-
-	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "waiting on error")
-}
-
-func (s *managerSuite) TestCheckStatusError(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	s.launchWorkshopWithSDKs(c, "test", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
-	c.Assert(os.RemoveAll(s.project.Path), check.IsNil)
-
-	// Error status should not return an error
-	err := s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ErrorStatus})
-	c.Assert(err, check.IsNil)
-
-	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "workshop unhealthy")
-}
-
-func (s *managerSuite) TestCheckStatusStopped(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	s.launchWorkshopWithSDKs(c, "test", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
-	s.backend.StopWorkshop(s.ctx, "test", true)
-
-	// Stopped status should not return an error
-	err := s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.StoppedStatus})
-	c.Assert(err, check.IsNil)
-
-	// All other status' should return an error
-	err = s.manager.CheckStatus(s.ctx, "test", s.project.ProjectId, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.ErrorStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "workshop not running")
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -669,7 +669,7 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 		ctx,
 		name,
 		projectId,
-		[]healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus})
+		[]healthstate.Status{healthstate.ReadyStatus, healthstate.WaitingStatus})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -268,17 +268,6 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, names []string, proje
 		return nil, err
 	}
 
-	for _, name := range names {
-		err = w.CheckStatus(
-			ctx,
-			name,
-			projectId,
-			[]healthstate.Status{healthstate.ReadyStatus})
-		if err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
-		}
-	}
-
 	workshops, err := w.Workshops(ctx, projectId)
 	if err != nil {
 		return nil, err
@@ -290,6 +279,10 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, names []string, proje
 		idx := slices.IndexFunc(workshops, func(w *workshop.Workshop) bool { return w.Name == ws })
 		if idx == -1 {
 			return nil, fmt.Errorf("cannot refresh %q: %w", ws, workshop.ErrWorkshopNotLaunched)
+		}
+		allowed := []healthstate.Status{healthstate.ReadyStatus}
+		if err = healthstate.CheckWorkshopHealth(w.state, workshops[idx], allowed); err != nil {
+			return nil, fmt.Errorf("cannot refresh %q: %w", ws, err)
 		}
 		file, err := project.Workshop(ws)
 		if err != nil {
@@ -326,20 +319,16 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, names []string, proje
 }
 
 func (w *WorkshopManager) RefreshLocalSdk(ctx context.Context, pid string, wpn string, sdkn string) ([]*state.TaskSet, error) {
-	err := w.CheckStatus(
-		ctx,
-		wpn,
-		pid,
-		[]healthstate.Status{healthstate.ReadyStatus})
-	if err != nil {
-		return nil, fmt.Errorf("cannot refresh %q: %w", wpn, err)
-	}
-
 	var taskset []*state.TaskSet
 	wp, err := w.Workshop(ctx, wpn, pid)
 	if err != nil {
 		return nil, err
 	}
+	allowed := []healthstate.Status{healthstate.ReadyStatus}
+	if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+		return nil, fmt.Errorf("cannot refresh %q: %w", wpn, err)
+	}
+
 	ts, err := w.refreshLocalSdk(wp, sdkn)
 	if err != nil {
 		return nil, err
@@ -591,12 +580,12 @@ func createStateHooks(st *state.State, w string, sdks []sdk.Setup, newSdks []wor
 func (w *WorkshopManager) StartMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
 	// check if all the workshops are stopped
 	for _, name := range names {
-		err := w.CheckStatus(
-			ctx,
-			name,
-			projectId,
-			[]healthstate.Status{healthstate.StoppedStatus})
+		wp, err := w.Workshop(ctx, name, projectId)
 		if err != nil {
+			return nil, fmt.Errorf("cannot start %q: %w", name, err)
+		}
+		allowed := []healthstate.Status{healthstate.StoppedStatus}
+		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
 			return nil, fmt.Errorf("cannot start %q: %w", name, err)
 		}
 	}
@@ -628,12 +617,12 @@ func startMany(st *state.State, names []string, project workshop.Project) ([]*st
 
 func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
 	for _, name := range names {
-		err := w.CheckStatus(
-			ctx,
-			name,
-			projectId,
-			[]healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus})
+		wp, err := w.Workshop(ctx, name, projectId)
 		if err != nil {
+			return nil, fmt.Errorf("cannot stop %q: %w", name, err)
+		}
+		allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus}
+		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
 			return nil, fmt.Errorf("cannot stop %q: %w", name, err)
 		}
 	}
@@ -665,21 +654,21 @@ func stopMany(st *state.State, names []string, project workshop.Project) ([]*sta
 }
 
 func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args *workshop.ExecArgs, script bool) (*state.TaskSet, error) {
-	err := w.CheckStatus(
-		ctx,
-		name,
-		projectId,
-		[]healthstate.Status{healthstate.ReadyStatus, healthstate.WaitingStatus})
-	if err != nil {
-		return nil, err
-	}
-
 	project, err := w.loadProject(ctx, projectId)
 	if err != nil {
 		return nil, err
 	}
 
 	ctx = context.WithValue(ctx, workshop.ContextProjectId, project.ProjectId)
+	wp, err := w.backend.Workshop(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.WaitingStatus}
+	if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+		return nil, err
+	}
+
 	wrkspc, err := w.backend.WorkshopFs(ctx, name)
 	if err != nil {
 		return nil, err
@@ -722,17 +711,6 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 }
 
 func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
-	for _, name := range names {
-		err := w.CheckStatus(
-			ctx,
-			name,
-			projectId,
-			[]healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus})
-		if err != nil {
-			return nil, fmt.Errorf("cannot remove %q: %w", name, err)
-		}
-	}
-
 	project, err := w.loadProject(ctx, projectId)
 	if err != nil {
 		return nil, err
@@ -742,10 +720,15 @@ func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projec
 
 	var workshops = make([]*workshop.Workshop, 0, len(names))
 	for _, name := range names {
-		if w, err := w.backend.Workshop(ctx, name); err != nil {
-			return nil, err
-		} else {
-			workshops = append(workshops, w)
+		wp, err := w.backend.Workshop(ctx, name)
+		if err != nil {
+			return nil, fmt.Errorf("cannot remove %q: %w", name, err)
+		}
+		workshops = append(workshops, wp)
+
+		allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus}
+		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+			return nil, fmt.Errorf("cannot remove %q: %w", name, err)
 		}
 	}
 
@@ -801,23 +784,14 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*s
 	return removeSet, nil
 }
 
-func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug sdk.PlugRef, source string, projectId string) (*state.TaskSet, error) {
+func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug sdk.PlugRef, source string) (*state.TaskSet, error) {
 	if !filepath.IsAbs(source) {
 		return nil, fmt.Errorf("cannot remount: the `source` path must be absolute")
 	}
 
 	source = filepath.Clean(source)
 
-	err := w.CheckStatus(
-		ctx,
-		plug.Workshop,
-		projectId,
-		[]healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus})
-	if err != nil {
-		return nil, fmt.Errorf("cannot remount %q: %w", plug.ShortRef(), err)
-	}
-
-	project, err := w.loadProject(ctx, projectId)
+	project, err := w.loadProject(ctx, plug.ProjectId)
 	if err != nil {
 		return nil, err
 	}
@@ -825,6 +799,11 @@ func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug sdk
 	wp, err := w.Workshop(ctx, plug.Workshop, plug.ProjectId)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load workshop %q: %w", plug.Workshop, err)
+	}
+
+	allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus}
+	if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+		return nil, fmt.Errorf("cannot remount %q: %w", plug.ShortRef(), err)
 	}
 
 	master, _ := ifacestate.MaybeBound(wp, plug)

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -732,7 +732,7 @@ func (s *requestSuite) TestRemountSuccess(c *check.C) {
 
 	s.launchWorkshopWithSDKs(c, "ws-1", sdks)
 
-	ts, err := s.mgr.Remount(s.ctx, s.state, plug, source, s.project.ProjectId)
+	ts, err := s.mgr.Remount(s.ctx, s.state, plug, source)
 	c.Assert(err, check.IsNil)
 	c.Assert(ts.Tasks(), check.HasLen, 1)
 
@@ -771,6 +771,6 @@ func (s *requestSuite) TestRemountWorkshopNotReady(c *check.C) {
 	change.AddTask(task)
 	change.Set("project-id", s.project.ProjectId)
 
-	_, err := s.mgr.Remount(s.ctx, s.state, plug, c.MkDir(), s.project.ProjectId)
+	_, err := s.mgr.Remount(s.ctx, s.state, plug, c.MkDir())
 	c.Assert(err, check.ErrorMatches, `cannot remount "ws-1/sdk-1:plug": other changes in progress`)
 }

--- a/tests/main/launch-abort/task.yaml
+++ b/tests/main/launch-abort/task.yaml
@@ -4,8 +4,8 @@ execute: |
 
   workshop_exec launch --wait-on-error || true
 
-  echo "Check the workshop is in Pending state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-abort[[:space:]]+Pending[[:space:]]+wait-on-error$"
+  echo "Check the workshop is in Waiting state"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-abort[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
   echo "Check the 'workshop launch --abort' command reverts to the previous state"
   workshop_exec launch --abort | MATCH "\"ws-launch-abort\" launch aborted"

--- a/tests/main/launch-continue/task.yaml
+++ b/tests/main/launch-continue/task.yaml
@@ -7,8 +7,8 @@ execute: |
 
   workshop_exec launch --wait-on-error || true
 
-  echo "Check the workshop is in Pending state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-cont[[:space:]]+Pending[[:space:]]+wait-on-error$"
+  echo "Check the workshop is in Waiting state"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-cont[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
   echo "\"Fix\" the SDK error by creating an expected file"
   workshop_exec exec -- touch /home/workshop/setup-base-pass

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -13,8 +13,8 @@ execute: |
   workshop_exec refresh --wait-on-error || true
   sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' workshop.yaml
 
-  echo "Check the workshop is in Pending state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-abort[[:space:]]+Pending[[:space:]]+wait-on-error$"
+  echo "Check the workshop is in Waiting state"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-abort[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
   echo "Check the 'workshop refresh --abort' command reverts to the previous state"
   workshop_exec refresh --abort | MATCH "\"ws-refresh-abort\" refresh aborted"

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -13,8 +13,8 @@ execute: |
   workshop_exec refresh --wait-on-error || true
   sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' workshop.yaml
 
-  echo "Check the workshop is in Pending state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-cont[[:space:]]+Pending[[:space:]]+wait-on-error$"
+  echo "Check the workshop is in Waiting state"
+  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-cont[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
   echo "\"Fix\" the SDK error by creating an expected file"
   workshop_exec exec -- touch /home/workshop/setup-base-pass

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -61,10 +61,27 @@ execute: |
 
   echo "Add a breaking change to sketch"
   ! sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  i
-    plugs:
-      test:
-        interface: mount
+  $
+  a
+    test:
+      interface: mount
+      workshop-typo: /mnt
+  .
+  wq
+  EOF
+
+  echo "Fix the breaking change"
+  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  $
+  s/typo/target/
+  wq
+  EOF
+
+  echo "Add another breaking change to sketch"
+  ! sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  $
+  a
+      unknown-attribute: true
   .
   wq
   EOF


### PR DESCRIPTION
# Description

Fixes a regression in the behaviour introduced by https://github.com/canonical/workshop/pull/263. The status check in https://github.com/canonical/workshop/pull/289 happens before `sketch` has a chance to abort the refresh.

It slipped through because I put the wrong status in one of the mocked responses in the unit test. That's fixed now, but I also added an end-to-end test to prevent further regressions.

Previously, the abort is triggered only after attempting a refresh. I've added a new `Waiting` status so that sketch can detect early on if another sketch (or `refresh --wait-on-error`) is paused, without relying on the `Notes` field. The docs now consistently refer to this state as `Waiting` or "paused" (and not "stopped").

I'm assuming if the abort succeeds, the workshop will be `Ready` again (to avoid calling `info` again).

I removed the special error handling for `wait-on-error`, but kept the more general error handling changes from https://github.com/canonical/workshop/pull/263

A separate but related change is that `exec` no longer sets the workshop status to `Pending`. This allows some operations which weren't previously possible during `workshop shell`. I've added a warning when connecting/disconnecting interfaces during a shell session (because the environment won't be updated).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [] I confirm the PR has no implications for documentation.
