### PR TITLE
Add configuration for errcheck linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          args: "--out-format=colored-line-number --enable-only errcheck"
+          args: "--out-format=colored-line-number --config=.golangci.errcheck.yaml"
           only-new-issues: true
           skip-cache: true
 

--- a/.golangci.errcheck.yaml
+++ b/.golangci.errcheck.yaml
@@ -1,0 +1,13 @@
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+
+issues:
+  # these values ensure that all issues will be surfaced
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+run:
+  build-tags: [integration]
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.63.4
+    rev: v1.64.5
     hooks:
       - id: golangci-lint
       - id: golangci-lint
         alias: errcheck
         name: errcheck
         args:
-          - --enable-only=errcheck
+          - --config=.golangci.errcheck.yaml

--- a/internal/osutil/exec.go
+++ b/internal/osutil/exec.go
@@ -121,7 +121,7 @@ func RunAndWait(argv []string, env []string, timeout time.Duration, tomb *tomb.T
 		// cmd.Wait came back from waiting the killed process
 		break
 	}
-	fmt.Fprintf(buffer, "\n<%s>", abortOrTimeoutError)
+	_, _ = fmt.Fprintf(buffer, "\n<%s>", abortOrTimeoutError)
 
 	return buffer.Bytes(), abortOrTimeoutError
 }

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -53,20 +53,22 @@ func (c *baseCommand) setStdout(w io.Writer) {
 	c.stdout = w
 }
 
-func (c *baseCommand) printf(format string, a ...interface{}) {
+func (c *baseCommand) printf(format string, a ...interface{}) (int, error) {
 	if c.stdout != nil {
-		fmt.Fprintf(c.stdout, format, a...)
+		return fmt.Fprintf(c.stdout, format, a...)
 	}
+	return 0, nil
 }
 
 func (c *baseCommand) setStderr(w io.Writer) {
 	c.stderr = w
 }
 
-func (c *baseCommand) errorf(format string, a ...interface{}) {
+func (c *baseCommand) errorf(format string, a ...interface{}) (int, error) {
 	if c.stderr != nil {
-		fmt.Fprintf(c.stderr, format, a...)
+		return fmt.Fprintf(c.stderr, format, a...)
 	}
+	return 0, nil
 }
 
 func (c *baseCommand) setContext(context *hookstate.Context) {

--- a/internal/overlord/hookstate/ctlcmd/export_test.go
+++ b/internal/overlord/hookstate/ctlcmd/export_test.go
@@ -31,11 +31,17 @@ func (c *MockCommand) Execute(args []string) error {
 	c.Args = args
 
 	if c.FakeStdout != "" {
-		c.printf("%s", c.FakeStdout)
+		_, err := c.printf("%s", c.FakeStdout)
+		if err != nil {
+			return err
+		}
 	}
 
 	if c.FakeStderr != "" {
-		c.errorf("%s", c.FakeStderr)
+		_, err := c.errorf("%s", c.FakeStderr)
+		if err != nil {
+			return err
+		}
 	}
 
 	if c.ExecuteError {


### PR DESCRIPTION
# Description

Pulling this out of https://github.com/canonical/workshop/pull/284 because it's a prerequisite for https://github.com/canonical/workshop/pull/307.

A side effect of --enable-only is bypassing the golangci-lint default exclusions [1]. Instead we can use a separate config file until it's possible to enable errcheck globally.

[1] https://golangci-lint.run/usage/false-positives/#default-exclusions

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
