### PR TITLE
Doc: Add interfaces to workshop definition reference

### DIFF
--- a/docs/explanation/workshops/workshops.rst
+++ b/docs/explanation/workshops/workshops.rst
@@ -127,32 +127,33 @@ This example adds a slot, a plug and two connections to its SDKs:
 
 .. code-block:: yaml
    :caption: .workshop/digits-cuda.yaml
-   :emphasize-lines: 5-8, 11-14, 17-21
+   :emphasize-lines: 6-9, 12-15, 18-22
 
    base: ubuntu@22.04
    name: digits-cuda
    sdks:
-     - name: system
-       slots:
-         images:
-           interface: mount
-           workshop-source: /project/training-data/low-res
      - name: tensorflow
        channel: latest/stable
        plugs:
          cuda:
            interface: mount
            workshop-target: /usr/local/cuda/lib64
+     - name: imagenet
+       channel: latest/stable
+       slots:
+         images:
+           interface: mount
+           workshop-source: $SDK/images
      - name: cuda
        channel: latest/stable
    connections:
      - plug: tensorflow:cuda
        slot: cuda:libs
      - plug: tensorflow:images
-       slot: system:images
+       slot: imagenet:images
 
 
-Here, :samp:`system:images`
+Here, :samp:`imagenet:images`
 is a :ref:`mount interface <exp_mount_interface>` slot,
 whose :samp:`workshop-source` attribute points to a directory in the workshop.
 At run-time, the :samp:`tensorflow:images` plug is connected to the slot

--- a/docs/reference/definitions/workshop-definition.rst
+++ b/docs/reference/definitions/workshop-definition.rst
@@ -106,7 +106,8 @@ Each SDK is described with the following keys:
    * - :samp:`name` (required)
      - string
      - Name of an existing SDK
-       that is available from the SDK store.
+       that is available from the SDK store,
+       or :samp:`system`.
 
    * - :samp:`channel` (required)
      - string
@@ -120,6 +121,8 @@ Each SDK is described with the following keys:
        `snap-like format <https://snapcraft.io/docs/channels>`__
        of :samp:`<TRACK>/<RISK>`
        without the :samp:`<BRANCH>` part.
+
+       Not required for the :ref:`system SDK <ref_system_sdk>`.
 
    * - :samp:`plugs`
      - object
@@ -140,13 +143,31 @@ Each SDK is described with the following keys:
        and the relevant attributes (described below).
 
 
+.. _ref_system_sdk:
+
+System SDK
+~~~~~~~~~~
+
+.. @artefact system SDK
+
+The system SDK is built in to every workshop,
+and isn't available in the SDK store,
+so it doesn't require a :samp:`channel`.
+
+The system SDK declares slots for many interfaces.
+These represent resources provided by the host system.
+The workshop definition can define additional plugs and slots
+for all SDKs,
+including the system SDK.
+
+
 Camera interface
 ~~~~~~~~~~~~~~~~
 
 .. @artefact camera interface
 
 Camera interface plugs must be named :samp:`camera`
-and can't belong to the :ref:`system SDK <exp_system_sdk>`.
+and can't belong to the :ref:`system SDK <ref_system_sdk>`.
 They have no attributes.
 
 The only camera interface slot is :samp:`system:camera`.
@@ -158,7 +179,7 @@ Desktop interface
 .. @artefact desktop interface
 
 Desktop interface plugs must be named :samp:`desktop`
-and can't belong to the :ref:`system SDK <exp_system_sdk>`.
+and can't belong to the :ref:`system SDK <ref_system_sdk>`.
 They have no attributes.
 
 The only desktop interface slot is :samp:`system:desktop`.
@@ -170,7 +191,7 @@ GPU interface
 .. @artefact GPU interface
 
 GPU interface plugs must be named :samp:`gpu`
-and can't belong to the :ref:`system SDK <exp_system_sdk>`.
+and can't belong to the :ref:`system SDK <ref_system_sdk>`.
 They have no attributes.
 
 The only GPU interface slot is :samp:`system:gpu`.
@@ -181,7 +202,7 @@ Mount interface
 
 .. @artefact mount interface
 
-Mount interface plugs can't belong to the :ref:`system SDK <exp_system_sdk>`.
+Mount interface plugs can't belong to the :ref:`system SDK <ref_system_sdk>`.
 They are described by the following attributes:
 
 .. @artefact mount interface attributes
@@ -205,7 +226,7 @@ They are described by the following attributes:
      - Whether the target directory should be read-only.
 
 
-The only mount interface slot in the :ref:`system SDK <exp_system_sdk>` is :samp:`system:mount`.
+The only mount interface slot in the :ref:`system SDK <ref_system_sdk>` is :samp:`system:mount`.
 It has a single dynamic attribute named :samp:`host-source`,
 which can be only configured at :ref:`remount <ref_workshop_remount>`.
 
@@ -238,7 +259,7 @@ SSH interface
 .. @artefact SSH interface
 
 SSH interface plugs must be named :samp:`ssh-agent`
-and can't belong to the :ref:`system SDK <exp_system_sdk>`.
+and can't belong to the :ref:`system SDK <ref_system_sdk>`.
 They have no attributes.
 
 The only SSH interface slot is :samp:`system:ssh-agent`.

--- a/docs/reference/definitions/workshop-definition.rst
+++ b/docs/reference/definitions/workshop-definition.rst
@@ -212,14 +212,12 @@ is bound to the :samp:`mod-cache` plug of the :samp:`go` SDK:
            bind: go:mod-cache
 
 
-.. @artefact system SDK
-
-This YAML file, besides using the :samp:`tensorflow` and :samp:`cuda` SDKs,
-defines an additional slot under the system SDK, a plug under :samp:`tensorflow`
+This YAML file, besides using the :samp:`tensorflow`, :samp:`imagenet` and :samp:`cuda` SDKs,
+defines an additional slot under the :samp:`imagenet` SDK, a plug under :samp:`tensorflow`
 and two connections:
 
 - One that connects the :samp:`tensorflow:images` plug
-  to the newly defined :samp:`system:images` slot.
+  to the newly defined :samp:`imagenet:images` slot.
 
 - Another that connects the :samp:`tensorflow:cuda` plug
   to the pre-existing :samp:`cuda:libs`.
@@ -230,24 +228,25 @@ and two connections:
    base: ubuntu@22.04
    name: digits-cuda
    sdks:
-     - name: system
-       slots:
-         images:
-           interface: mount
-           workshop-source: /project/training-data/low-res
      - name: tensorflow
        channel: latest/stable
        plugs:
          cuda:
            interface: mount
            workshop-target: /usr/local/cuda/lib64
+     - name: imagenet
+       channel: latest/stable
+       slots:
+         images:
+           interface: mount
+           workshop-source: $SDK/images
      - name: cuda
        channel: latest/stable
    connections:
      - plug: tensorflow:cuda
        slot: cuda:libs
      - plug: tensorflow:images
-       slot: system:images
+       slot: imagenet:images
 
 
 See also

--- a/docs/reference/definitions/workshop-definition.rst
+++ b/docs/reference/definitions/workshop-definition.rst
@@ -91,7 +91,6 @@ and includes a number of mandatory and optional keys:
 
 Each SDK is described with the following keys:
 
-.. @artefact mount interface attributes
 .. @artefact plug binding
 .. @artefact $SDK
 
@@ -132,24 +131,117 @@ Each SDK is described with the following keys:
          using the :samp:`<SDK>:<PLUG>` format.
 
        - A plug definition must specify the :samp:`interface`
-         and the relevant attributes.
-         The only interface with additional attributes is :samp:`mount`;
-         it requires the :samp:`workshop-target` property
-         to specify a path inside the workshop
-         to be used as the plug's target directory.
+         and the relevant attributes (described below).
 
    * - :samp:`slots`
      - object
      - Defines additional slots under the SDK;
        each entry must specify the :samp:`interface`
-       and the relevant attributes.
+       and the relevant attributes (described below).
 
-       The only interface with additional attributes is :samp:`mount`;
-       it requires the :samp:`workshop-source` property
-       to specify a path inside the workshop
-       for the slot's source directory;
+
+Camera interface
+~~~~~~~~~~~~~~~~
+
+.. @artefact camera interface
+
+Camera interface plugs must be named :samp:`camera`
+and can't belong to the :ref:`system SDK <exp_system_sdk>`.
+They have no attributes.
+
+The only camera interface slot is :samp:`system:camera`.
+
+
+Desktop interface
+~~~~~~~~~~~~~~~~~
+
+.. @artefact desktop interface
+
+Desktop interface plugs must be named :samp:`desktop`
+and can't belong to the :ref:`system SDK <exp_system_sdk>`.
+They have no attributes.
+
+The only desktop interface slot is :samp:`system:desktop`.
+
+
+GPU interface
+~~~~~~~~~~~~~
+
+.. @artefact GPU interface
+
+GPU interface plugs must be named :samp:`gpu`
+and can't belong to the :ref:`system SDK <exp_system_sdk>`.
+They have no attributes.
+
+The only GPU interface slot is :samp:`system:gpu`.
+
+
+Mount interface
+~~~~~~~~~~~~~~~
+
+.. @artefact mount interface
+
+Mount interface plugs can't belong to the :ref:`system SDK <exp_system_sdk>`.
+They are described by the following attributes:
+
+.. @artefact mount interface attributes
+
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 2 1 6
+
+   * - Key
+     - Value
+     - Description
+
+   * - :samp:`workshop-target` (required)
+     - string
+     - A path inside the workshop
+       to be used as the plug's target directory.
+
+   * - :samp:`read-only`
+     - Boolean
+     - Whether the target directory should be read-only.
+
+
+The only mount interface slot in the :ref:`system SDK <exp_system_sdk>` is :samp:`system:mount`.
+It has a single dynamic attribute named :samp:`host-source`,
+which can be only configured at :ref:`remount <ref_workshop_remount>`.
+
+Regular SDKs can declare additional mount interface slots.
+They are described by the following attributes:
+
+.. @artefact mount interface attributes
+.. @artefact $SDK
+
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 2 1 6
+
+   * - Key
+     - Value
+     - Description
+
+   * - :samp:`workshop-source` (required)
+     - string
+     - A path inside the workshop
+       to be used as the slot's source directory;
        :file:`/project` or :envvar:`$SDK`-based paths can be used;
        :envvar:`$SDK` expands into the SDK's installation path in the workshop.
+
+
+SSH interface
+~~~~~~~~~~~~~
+
+.. @artefact SSH interface
+
+SSH interface plugs must be named :samp:`ssh-agent`
+and can't belong to the :ref:`system SDK <exp_system_sdk>`.
+They have no attributes.
+
+The only SSH interface slot is :samp:`system:ssh-agent`.
 
 
 JSON Schema

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -38,9 +38,7 @@ var (
 
 	nameConstraints      = []string{"plug-names", "slot-names"}
 	attributeConstraints = []string{"plug-attributes", "slot-attributes"}
-
-	slotIDConstraints = []string{"plug-sdk-type"}
-	plugIDConstraints = []string{"slot-sdk-type"}
+	idConstraints        = []string{"plug-sdk-type", "slot-sdk-type"}
 
 	sideArityConstraints        = []string{"slots-per-plug", "plugs-per-slot"}
 	sideArityConstraintsSetters = map[string]func(sideArityConstraintsHolder, SideArityConstraint){
@@ -121,6 +119,7 @@ func (ac SideArityConstraint) Any() bool {
 // interface slot for a sdk relevant to its connection or
 // auto-connection.
 type SlotConnectionConstraints struct {
+	SlotSdkTypes []string
 	PlugSdkTypes []string
 
 	SlotNames *NameConstraints
@@ -157,6 +156,8 @@ func (c *SlotConnectionConstraints) setIDConstraints(field string, cstrs []strin
 	switch field {
 	case "plug-sdk-type":
 		c.PlugSdkTypes = cstrs
+	case "slot-sdk-type":
+		c.SlotSdkTypes = cstrs
 	default:
 		panic("unknown SlotConnectionConstraints field " + field)
 	}
@@ -376,7 +377,7 @@ func compileSlotInstallationConstraints(context *subruleContext, cDef constraint
 
 func compileSlotConnectionConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
 	slotConnCstrs := &SlotConnectionConstraints{}
-	err := baseCompileConstraints(context, cDef, slotConnCstrs, nameConstraints, attributeConstraints, slotIDConstraints)
+	err := baseCompileConstraints(context, cDef, slotConnCstrs, nameConstraints, attributeConstraints, idConstraints)
 	if err != nil {
 		return nil, err
 	}
@@ -597,6 +598,7 @@ func compilePlugInstallationConstraints(context *subruleContext, cDef constraint
 // interface plug for a snap relevant to its connection or
 // auto-connection.
 type PlugConnectionConstraints struct {
+	PlugSdkTypes []string
 	SlotSdkTypes []string
 
 	PlugNames *NameConstraints
@@ -642,6 +644,8 @@ func (c *PlugConnectionConstraints) setAttributeConstraints(field string, cstrs 
 
 func (c *PlugConnectionConstraints) setIDConstraints(field string, cstrs []string) {
 	switch field {
+	case "plug-sdk-type":
+		c.PlugSdkTypes = cstrs
 	case "slot-sdk-type":
 		c.SlotSdkTypes = cstrs
 	default:
@@ -667,7 +671,7 @@ func (c *PlugConnectionConstraints) plugsPerSlot() SideArityConstraint {
 
 func compilePlugConnectionConstraints(context *subruleContext, cDef constraintsDef) (constraintsHolder, error) {
 	plugConnCstrs := &PlugConnectionConstraints{}
-	err := baseCompileConstraints(context, cDef, plugConnCstrs, nameConstraints, attributeConstraints, plugIDConstraints)
+	err := baseCompileConstraints(context, cDef, plugConnCstrs, nameConstraints, attributeConstraints, idConstraints)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -645,6 +645,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsPlugNames
 func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsIDConstraints(c *check.C) {
 	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
 		"allow-connection": map[string]interface{}{
+			"plug-sdk-type": []interface{}{sdk.Regular.String()},
 			"slot-sdk-type": []interface{}{sdk.System.String(), sdk.Regular.String()},
 		},
 	})
@@ -652,7 +653,8 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsIDConstrain
 
 	c.Assert(rule.AllowConnection, check.HasLen, 1)
 	cstrs := rule.AllowConnection[0]
-	c.Check(cstrs.SlotSdkTypes, check.DeepEquals, []string{sdk.System.String(), "regular"})
+	c.Check(cstrs.PlugSdkTypes, check.DeepEquals, []string{sdk.Regular.String()})
+	c.Check(cstrs.SlotSdkTypes, check.DeepEquals, []string{sdk.System.String(), sdk.Regular.String()})
 }
 
 func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsPlugNamesSlotNames(c *check.C) {
@@ -1062,7 +1064,22 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstra
 
 	c.Assert(rule.AllowInstallation, check.HasLen, 1)
 	cstrs := rule.AllowInstallation[0]
-	c.Check(cstrs.SlotSdkTypes, check.DeepEquals, []string{sdk.System.String(), "regular"})
+	c.Check(cstrs.SlotSdkTypes, check.DeepEquals, []string{sdk.System.String(), sdk.Regular.String()})
+}
+
+func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsIDConstraints(c *check.C) {
+	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
+		"allow-connection": map[string]interface{}{
+			"plug-sdk-type": []interface{}{sdk.Regular.String()},
+			"slot-sdk-type": []interface{}{sdk.System.String()},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(rule.AllowConnection, check.HasLen, 1)
+	cstrs := rule.AllowConnection[0]
+	c.Check(cstrs.PlugSdkTypes, check.DeepEquals, []string{sdk.Regular.String()})
+	c.Check(cstrs.SlotSdkTypes, check.DeepEquals, []string{sdk.System.String()})
 }
 
 func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.SlotConnectionConstraints, always bool) {
@@ -1212,11 +1229,11 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
 		{`iface:
   allow-connection:
     plug-sdk-ids:
-      - foo`, `allow-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slots-per-plug, plugs-per-slot`},
+      - foo`, `allow-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slot-sdk-type, slots-per-plug, plugs-per-slot`},
 		{`iface:
   deny-connection:
     plug-sdk-ids:
-        - foo`, `deny-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slots-per-plug, plugs-per-slot`},
+        - foo`, `deny-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slot-sdk-type, slots-per-plug, plugs-per-slot`},
 		{`iface:
   allow-connect: true`, `slot rule for interface "iface" must specify at least one of allow-installation, deny-installation, allow-connection, deny-connection, allow-auto-connection, deny-auto-connection`},
 		{`iface:
@@ -1228,7 +1245,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
 		{`iface:
   deny-auto-connection:
     plug-sdk-ids:
-      - foo`, `deny-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slots-per-plug, plugs-per-slot`},
+      - foo`, `deny-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slot-sdk-type, slots-per-plug, plugs-per-slot`},
 		{`iface:
   allow-auto-connection:
     plugs-per-slot: any`, `plugs-per-slot in allow-auto-connection in slot rule for interface "iface" must be an integer >=1 or \*`},
@@ -1251,7 +1268,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *check.C) {
 		{`iface:
   allow-auto-connection:
     plug-sdk-ids:
-      - foo`, `allow-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slots-per-plug, plugs-per-slot`},
+      - foo`, `allow-auto-connection in slot rule for interface "iface" must specify at least one of plug-names, slot-names, plug-attributes, slot-attributes, plug-sdk-type, slot-sdk-type, slots-per-plug, plugs-per-slot`},
 	}
 
 	for i, t := range tests {

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -238,7 +238,7 @@ func (s *apiSuite) TestWorkshopRemountStaticSlotSourceFails(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "remount",
 			Summary:   `Remount workshopconns/test-sdk:data`,
-			ChangeErr: `(?s).*attribute "host-source" not found for slot "workshopconns/system:training".*`,
+			ChangeErr: `(?s).*attribute "host-source" not found for slot "workshopconns/test-sdk-2:training".*`,
 		},
 	}
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -134,10 +134,6 @@ sdks:
 	workshopplug = `name: workshopplug
 base: ubuntu@22.04
 sdks:
-  - name: system
-    slots:
-      training-slot:
-        interface: mount
   - name: test-sdk
     channel: latest/stable
     plugs:
@@ -146,18 +142,11 @@ sdks:
         workshop-target: /opt
   - name: test-sdk-2
     channel: latest/stable
-connections:
-  - plug: test-sdk:training-plug
-    slot: system:training-slot
 `
 
 	workshopplugbound = `name: workshopplugbound
 base: ubuntu@22.04
 sdks:
-  - name: system
-    slots:
-      training-slot:
-        interface: mount
   - name: test-sdk
     channel: latest/stable
     plugs:
@@ -168,20 +157,17 @@ sdks:
         bind: test-sdk:training-plug
   - name: test-sdk-2
     channel: latest/stable
-connections:
-  - plug: test-sdk:training-plug
-    slot: system:training-slot
 `
 
 	workshopslot = `name: workshopslot
 base: ubuntu@22.04
 sdks:
-  - name: system
+  - name: test-sdk
+    channel: latest/stable
     slots:
       training:
         interface: mount
-  - name: test-sdk
-    channel: latest/stable
+        workshop-source: /project/training
   - name: test-sdk-2
     channel: latest/stable
 `
@@ -189,18 +175,17 @@ sdks:
 	workshopconns = `name: workshopconns
 base: ubuntu@22.04
 sdks:
-  - name: system
-    slots:
-      training:
-        interface: mount
-        workshop-source: /project
   - name: test-sdk
     channel: latest/stable
   - name: test-sdk-2
     channel: latest/stable
+    slots:
+      training:
+        interface: mount
+        workshop-source: /project
 connections:
   - plug: test-sdk:data
-    slot: system:training
+    slot: test-sdk-2:training
 `
 
 	workshopbrokenconn = `name: workshopbrokenconn
@@ -218,23 +203,23 @@ connections:
 	connsplugbound = `name: connsplugbound
 base: ubuntu@22.04
 sdks:
-  - name: system
+  - name: test-sdk
+    channel: latest/stable
     slots:
-      training:
-        interface: mount
       photos:
         interface: mount
         workshop-source: /project/photos
-  - name: test-sdk
-    channel: latest/stable
   - name: test-sdk-2
     channel: latest/stable
     plugs:
       photos:
         bind: test-sdk:data
+    slots:
+      training:
+        interface: mount
 connections:
   - plug: test-sdk:data
-    slot: system:training
+    slot: test-sdk-2:training
 `
 
 	testsdk = `
@@ -863,7 +848,7 @@ func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slot(s.project.ProjectId, "workshopslot", sdk.System.String(), "training"), check.Not(check.IsNil))
+	c.Assert(repo.Slot(s.project.ProjectId, "workshopslot", "test-sdk", "training"), check.Not(check.IsNil))
 }
 
 func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
@@ -1054,7 +1039,7 @@ func (s *apiSuite) TestLaunchWorkshopWithPlugOK(c *check.C) {
 	conns, err := repo.Connected(s.project.ProjectId, "workshopplug", "test-sdk", "training-plug")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplug/test-sdk:training-plug %s/workshopplug/system:training-slot`, s.project.ProjectId, s.project.ProjectId))
+	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplug/test-sdk:training-plug %s/workshopplug/system:mount`, s.project.ProjectId, s.project.ProjectId))
 }
 
 func (s *apiSuite) TestLaunchWorkshopPlugAddedAndBound(c *check.C) {
@@ -1087,12 +1072,12 @@ func (s *apiSuite) TestLaunchWorkshopPlugAddedAndBound(c *check.C) {
 	conns, err := repo.Connected(s.project.ProjectId, "workshopplugbound", "test-sdk", "training-plug")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplugbound/test-sdk:training-plug %s/workshopplugbound/system:training-slot`, s.project.ProjectId, s.project.ProjectId))
+	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplugbound/test-sdk:training-plug %s/workshopplugbound/system:mount`, s.project.ProjectId, s.project.ProjectId))
 
 	conns, err = repo.Connected(s.project.ProjectId, "workshopplugbound", "test-sdk", "data")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
-	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplugbound/test-sdk:data %s/workshopplugbound/system:training-slot`, s.project.ProjectId, s.project.ProjectId))
+	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplugbound/test-sdk:data %s/workshopplugbound/system:mount`, s.project.ProjectId, s.project.ProjectId))
 }
 
 func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
@@ -1123,14 +1108,14 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slot(s.project.ProjectId, "workshopconns", sdk.System.String(), "training"), check.Not(check.IsNil))
+	c.Assert(repo.Slot(s.project.ProjectId, "workshopconns", "test-sdk-2", "training"), check.Not(check.IsNil))
 
 	conns, err := repo.Connections(s.project.ProjectId, "workshopconns", "test-sdk")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, testutil.DeepUnsortedMatches, []*interfaces.ConnRef{
 		{
 			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk", Name: "data"},
-			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: sdk.System.String(), Name: "training"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "training"},
 		},
 	})
 
@@ -1143,6 +1128,10 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 		}, {
 			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "gpu"},
 			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: sdk.System.String(), Name: "gpu"},
+		},
+		{
+			PlugRef: sdk.PlugRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk", Name: "data"},
+			SlotRef: sdk.SlotRef{ProjectId: s.project.ProjectId, Workshop: "workshopconns", Sdk: "test-sdk-2", Name: "training"},
 		},
 	})
 }

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -38,12 +37,14 @@ const mountSummary = `allows sharing host code and data with SDKs`
 const mountBaseDeclarationSlots = `
   mount:
     allow-installation:
-      slot-sdk-type:
-        - system
-        - regular
-    deny-installation:
-      slot-attributes:
-        host-source: .*
+      -
+        slot-sdk-type:
+          - system
+        slot-names:
+          - $INTERFACE
+      -
+        slot-sdk-type:
+          - regular
     allow-connection: true
     allow-auto-connection: true
 `
@@ -56,15 +57,15 @@ const mountBaseDeclarationPlugs = `
     allow-connection: true
     allow-auto-connection:
       -
-        slot-names:
-          - $INTERFACE
+        slot-sdk-type:
+          - system
       -
         plug-attributes:
           auto-explicit: true
 `
 
 var knownPlugAttributes = []string{"workshop-target", "read-only"}
-var knownSlotAttributes = []string{"workshop-source", "host-source"}
+var knownSlotAttributes = []string{"workshop-source"}
 
 // mountInterface allows sharing content between sdks
 type mountInterface struct{}
@@ -130,6 +131,13 @@ func (iface *mountInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 }
 
 func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
+	if slot.Sdk.Type == sdk.System {
+		for name := range slot.Attrs {
+			return fmt.Errorf(`unknown attribute for system mount interface slot: %q`, name)
+		}
+		return nil
+	}
+
 	for name := range slot.Attrs {
 		if !slices.Contains(knownSlotAttributes, name) {
 			return fmt.Errorf(`unknown attribute for mount interface slot: %q`, name)
@@ -137,8 +145,7 @@ func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 	}
 	source, exist := slot.Attrs["workshop-source"]
 	if !exist {
-		// perfectly fine scenario for the default mount slot
-		return nil
+		return fmt.Errorf("mount slot must contain source path")
 	}
 	path, ok := source.(string)
 	if !ok {
@@ -208,20 +215,19 @@ func (iface *mountInterface) MountConnectedSlot(spec *lxd_device.Specification, 
 
 // Interactions with the mount backend.
 func (iface *mountInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	source, err := iface.workshopSource(slot)
-	if err != nil && !errors.Is(err, sdk.AttributeNotFoundError{}) {
-		return err
-	}
-	if err == nil {
-		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.WorkshopWorkshop, ReadOnly: iface.readOnly(plug)})
-	}
-
-	source, err = iface.hostSource(spec.User.HomeDir, plug, slot)
-	if err == nil {
+	if slot.Sdk().Type == sdk.System {
+		source, err := iface.hostSource(spec.User.HomeDir, plug, slot)
+		if err != nil {
+			return err
+		}
 		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.HostWorkshop, ReadOnly: iface.readOnly(plug)})
 	}
 
-	return err
+	source, err := iface.workshopSource(slot)
+	if err != nil {
+		return err
+	}
+	return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.WorkshopWorkshop, ReadOnly: iface.readOnly(plug)})
 }
 
 func init() {

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -53,6 +53,10 @@ func (s *mountSuite) TestName(c *check.C) {
 	c.Assert(s.iface.Name(), check.Equals, "mount")
 }
 
+func (s *mountSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
 func (s *mountSuite) TestSanitizeSlotSimple(c *check.C) {
 	const mockSdkYaml = `name: mount-slot-sdk
 base: ubuntu@22.04
@@ -101,6 +105,39 @@ plugs:
 	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	plug := info.Plugs["mount-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "mount interface path is not clean:.*")
+}
+
+func (s *mountSuite) TestSanitizePlugReadOnlyBool(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  workshop-target: /project/training
+  read-only: true
+`, s.projectId, "ws", "consumer", "mount")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+}
+
+func (s *mountSuite) TestSanitizePlugReadOnlyString(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  workshop-target: /project/training
+  read-only: "true"
+`, s.projectId, "ws", "consumer", "mount")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+}
+
+func (s *mountSuite) TestSanitizePlugReadOnlyInvalid(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  workshop-target: /project/training
+  read-only: "invalid"
+`, s.projectId, "ws", "consumer", "mount")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "unknown value \"invalid\" in key \"read-only\" for mount interface plug.*")
 }
 
 func (s *mountSuite) TestSanitizeSlotOK(c *check.C) {
@@ -154,11 +191,7 @@ slots:
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.ErrorMatches, `mount slot \"workshop-source\" must be absolute`)
 }
 
-func (s *mountSuite) TestInterfaces(c *check.C) {
-	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
-}
-
-func (s *mountSuite) TestMountInterface(c *check.C) {
+func (s *mountSuite) TestConnectHostWorkshop(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
 base: ubuntu@22.04
 plugs:
@@ -182,37 +215,4 @@ slots:
 	sourceDir := filepath.Join(testuser.HomeDir, ".local/share/workshop/project/42424242/mount/ws_consumer_mount.sdk")
 	expectedMnt := workshop.Mount{Name: plug.Name, What: sourceDir, Where: "/project/training", Type: workshop.HostWorkshop}
 	c.Assert(deviceSpec.Profile.Mounts, check.DeepEquals, map[string]workshop.Mount{plug.Name: expectedMnt})
-}
-
-func (s *mountSuite) TestMountInterfaceReadOnlyBool(c *check.C) {
-	plug := builtin.MockPlug(c, `name: consumer
-base: ubuntu@22.04
-plugs:
- mount:
-  workshop-target: /project/training
-  read-only: true
-`, s.projectId, "ws", "consumer", "mount")
-	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
-}
-
-func (s *mountSuite) TestMountInterfaceReadOnlyString(c *check.C) {
-	plug := builtin.MockPlug(c, `name: consumer
-base: ubuntu@22.04
-plugs:
- mount:
-  workshop-target: /project/training
-  read-only: "true"
-`, s.projectId, "ws", "consumer", "mount")
-	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
-}
-
-func (s *mountSuite) TestMountInterfaceReadOnlyInvalid(c *check.C) {
-	plug := builtin.MockPlug(c, `name: consumer
-base: ubuntu@22.04
-plugs:
- mount:
-  workshop-target: /project/training
-  read-only: "invalid"
-`, s.projectId, "ws", "consumer", "mount")
-	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.ErrorMatches, "unknown value \"invalid\" in key \"read-only\" for mount interface plug.*")
 }

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -23,9 +23,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/canonical/workshop/internal/asserts"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/interfaces/policy"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -57,9 +59,88 @@ func (s *mountSuite) TestInterfaces(c *check.C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }
 
-func (s *mountSuite) TestSanitizeSlotSimple(c *check.C) {
+func (s *mountSuite) TestInstallSystemSdkSlot(c *check.C) {
+	info := sdk.MockInfo(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+ mount:
+`, s.projectId, "ws")
+
+	ic := policy.InstallCandidate{
+		Sdk:             info,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	c.Check(ic.Check(), check.IsNil)
+}
+
+func (s *mountSuite) TestInstallOtherSystemSdkSlot(c *check.C) {
+	info := sdk.MockInfo(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+ m:
+  interface: mount
+`, s.projectId, "ws")
+
+	ic := policy.InstallCandidate{
+		Sdk:             info,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	c.Check(ic.Check(), check.ErrorMatches, `installation not allowed by "m" slot rule of interface "mount"`)
+}
+
+func (s *mountSuite) TestInstallRegularSdkSlot(c *check.C) {
+	info := sdk.MockInfo(c, `name: producer
+base: ubuntu@22.04
+slots:
+ m:
+  interface: mount
+  workshop-source: /opt
+`, s.projectId, "ws")
+
+	ic := policy.InstallCandidate{
+		Sdk:             info,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	c.Check(ic.Check(), check.IsNil)
+}
+
+func (s *mountSuite) TestInstallSystemSdkPlug(c *check.C) {
+	info := sdk.MockInfo(c, `name: system
+base: ubuntu@22.04
+type: system
+plugs:
+ mount:
+`, s.projectId, "ws")
+
+	ic := policy.InstallCandidate{
+		Sdk:             info,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	c.Check(ic.Check(), check.ErrorMatches, `installation not allowed by "mount" plug rule of interface "mount"`)
+}
+
+func (s *mountSuite) TestInstallRegularSdkPlug(c *check.C) {
+	info := sdk.MockInfo(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  interface: mount
+  workshop-target: /mnt
+`, s.projectId, "ws")
+
+	ic := policy.InstallCandidate{
+		Sdk:             info,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	c.Check(ic.Check(), check.IsNil)
+}
+
+func (s *mountSuite) TestSanitizeSlotSystem(c *check.C) {
 	const mockSdkYaml = `name: mount-slot-sdk
 base: ubuntu@22.04
+type: system
 slots:
  mount-slot:
   interface: mount
@@ -67,6 +148,34 @@ slots:
 	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	slot := info.Slots["mount-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+}
+
+func (s *mountSuite) TestSanitizeSlotSystemWorkshopSource(c *check.C) {
+	const mockSdkYaml = `name: mount-slot-sdk
+base: ubuntu@22.04
+type: system
+slots:
+ mount-slot:
+  interface: mount
+  workshop-source: /opt
+`
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
+	slot := info.Slots["mount-slot"]
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.ErrorMatches, `unknown attribute for system mount interface slot: "workshop-source"`)
+}
+
+func (s *mountSuite) TestSanitizeSlotSystemHostSource(c *check.C) {
+	const mockSdkYaml = `name: mount-slot-sdk
+base: ubuntu@22.04
+type: system
+slots:
+ mount-slot:
+  interface: mount
+  host-source: /usr
+`
+	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
+	slot := info.Slots["mount-slot"]
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.ErrorMatches, `unknown attribute for system mount interface slot: "host-source"`)
 }
 
 func (s *mountSuite) TestSanitizePlugSimple(c *check.C) {
@@ -112,6 +221,7 @@ func (s *mountSuite) TestSanitizePlugReadOnlyBool(c *check.C) {
 base: ubuntu@22.04
 plugs:
  mount:
+  interface: mount
   workshop-target: /project/training
   read-only: true
 `, s.projectId, "ws", "consumer", "mount")
@@ -123,6 +233,7 @@ func (s *mountSuite) TestSanitizePlugReadOnlyString(c *check.C) {
 base: ubuntu@22.04
 plugs:
  mount:
+  interface: mount
   workshop-target: /project/training
   read-only: "true"
 `, s.projectId, "ws", "consumer", "mount")
@@ -134,6 +245,7 @@ func (s *mountSuite) TestSanitizePlugReadOnlyInvalid(c *check.C) {
 base: ubuntu@22.04
 plugs:
  mount:
+  interface: mount
   workshop-target: /project/training
   read-only: "invalid"
 `, s.projectId, "ws", "consumer", "mount")
@@ -162,7 +274,7 @@ slots:
 `
 	info := sdk.MockInfo(c, mockSdkYaml, s.projectId, "ws")
 	slot := info.Slots["mount-slot"]
-	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.IsNil)
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), check.ErrorMatches, "mount slot must contain source path")
 }
 
 func (s *mountSuite) TestSanitizeSlotAbsSourceFails(c *check.C) {
@@ -196,15 +308,17 @@ func (s *mountSuite) TestConnectHostWorkshop(c *check.C) {
 base: ubuntu@22.04
 plugs:
  mount:
+  interface: mount
   workshop-target: /project/training
 `, s.projectId, "ws", "consumer", "mount")
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 
-	slot := builtin.MockSlot(c, `name: producer
+	slot := builtin.MockSlot(c, `name: system
 base: ubuntu@22.04
+type: system
 slots:
  mount:
-`, s.projectId, "ws", "producer", "mount")
+`, s.projectId, "ws", "system", "mount")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 
 	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
@@ -215,4 +329,154 @@ slots:
 	sourceDir := filepath.Join(testuser.HomeDir, ".local/share/workshop/project/42424242/mount/ws_consumer_mount.sdk")
 	expectedMnt := workshop.Mount{Name: plug.Name, What: sourceDir, Where: "/project/training", Type: workshop.HostWorkshop}
 	c.Assert(deviceSpec.Profile.Mounts, check.DeepEquals, map[string]workshop.Mount{plug.Name: expectedMnt})
+}
+
+func (s *mountSuite) TestConnectWorkshopWorkshop(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  interface: mount
+  workshop-target: /project/training
+`, s.projectId, "ws", "consumer", "mount")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+ mount:
+  interface: mount
+  workshop-source: $SDK/training
+`, s.projectId, "ws", "producer", "mount")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec := lxd_device.NewSpecification(&testuser, "consumer")
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the mount specification.
+	expectedMnt := workshop.Mount{Name: plug.Name, What: "/var/lib/workshop/sdk/producer/current/training", Where: "/project/training", Type: workshop.WorkshopWorkshop}
+	c.Assert(deviceSpec.Profile.Mounts, check.DeepEquals, map[string]workshop.Mount{plug.Name: expectedMnt})
+}
+
+func (s *mountSuite) TestAutoConnectHostWorkshop(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  interface: mount
+  workshop-target: /project/training
+`, s.projectId, "ws", "consumer", "mount")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+ mount:
+`, s.projectId, "ws", "system", "mount")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	ic := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := ic.CheckAutoConnect()
+	c.Check(err, check.IsNil)
+}
+
+func (s *mountSuite) TestAutoConnectHostWorkshopExplicit(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  interface: mount
+  workshop-target: /project/training
+`, s.projectId, "ws", "consumer", "mount")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	// Simulate a workshop definition file with:
+	// connections:
+	//   - plug: consumer:mount
+	//     slot: system:mount
+	connectedPlug.SetAttr("auto-explicit", "true")
+
+	slot := builtin.MockSlot(c, `name: system
+base: ubuntu@22.04
+type: system
+slots:
+ mount:
+`, s.projectId, "ws", "system", "mount")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	ic := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := ic.CheckAutoConnect()
+	c.Check(err, check.IsNil)
+}
+
+func (s *mountSuite) TestAutoConnectWorkshopWorkshop(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  interface: mount
+  workshop-target: /project/training
+`, s.projectId, "ws", "consumer", "mount")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+ mount:
+  interface: mount
+  workshop-source: $SDK/training
+`, s.projectId, "ws", "system", "mount")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	ic := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := ic.CheckAutoConnect()
+	c.Check(err, check.ErrorMatches, `auto-connection not allowed by plug rule of interface "mount"`)
+}
+
+func (s *mountSuite) TestAutoConnectWorkshopWorkshopExplicit(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ mount:
+  interface: mount
+  workshop-target: /project/training
+`, s.projectId, "ws", "consumer", "mount")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	// Simulate a workshop definition file with:
+	// connections:
+	//   - plug: consumer:mount
+	//     slot: producer:mount
+	connectedPlug.SetAttr("auto-explicit", "true")
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+ mount:
+  interface: mount
+  workshop-source: $SDK/training
+`, s.projectId, "ws", "system", "mount")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	ic := policy.ConnectCandidate{
+		Plug:            connectedPlug,
+		Slot:            connectedSlot,
+		BaseDeclaration: asserts.BuiltinBaseDeclaration(),
+	}
+	_, err := ic.CheckAutoConnect()
+	c.Check(err, check.IsNil)
 }

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -133,9 +133,20 @@ plugs:
         interface: desktop
 `)
 
-var producer = []byte(`name: producer
+var system = []byte(`name: system
 base: ubuntu@24.04
 type: system
+slots:
+    mount:
+        interface: mount
+    ssh-agent:
+        interface: ssh-agent
+    desktop:
+        interface: desktop
+`)
+
+var producer = []byte(`name: producer
+base: ubuntu@24.04
 slots:
     slot:
         interface: mount
@@ -143,17 +154,6 @@ slots:
     home:
         interface: mount
         workshop-source: /home
-    ssh-agent:
-        interface: ssh-agent
-    desktop:
-        interface: desktop
-`)
-
-var producer2 = []byte(`name: producer2
-base: ubuntu@24.04
-slots:
-    slot:
-        interface: mount
 `)
 
 func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
@@ -255,15 +255,15 @@ func (f *backendDeviceSuite) TestSetupHostWorkshopMounts(c *check.C) {
 	cinfo, err := sdk.ReadSdkInfo(consumer, f.pid, "test")
 	c.Assert(err, check.IsNil)
 
-	pinfo, err := sdk.ReadSdkInfo(producer2, f.pid, "test")
+	sinfo, err := sdk.ReadSdkInfo(system, f.pid, "test")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(f.repo.AddSdk(cinfo), check.IsNil)
-	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
+	c.Assert(f.repo.AddSdk(sinfo), check.IsNil)
 
 	connref := &interfaces.ConnRef{
 		PlugRef: cinfo.Plugs["one"].Ref(),
-		SlotRef: pinfo.Slots["slot"].Ref(),
+		SlotRef: sinfo.Slots["mount"].Ref(),
 	}
 
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
@@ -290,15 +290,15 @@ func (f *backendDeviceSuite) TestSetupUpdateProfile(c *check.C) {
 	cinfo, err := sdk.ReadSdkInfo(consumer, f.pid, "test")
 	c.Assert(err, check.IsNil)
 
-	pinfo, err := sdk.ReadSdkInfo(producer, f.pid, "test")
+	sinfo, err := sdk.ReadSdkInfo(system, f.pid, "test")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(f.repo.AddSdk(cinfo), check.IsNil)
-	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
+	c.Assert(f.repo.AddSdk(sinfo), check.IsNil)
 
 	connref := &interfaces.ConnRef{
 		PlugRef: cinfo.Plugs["one"].Ref(),
-		SlotRef: pinfo.Slots["slot"].Ref(),
+		SlotRef: sinfo.Slots["mount"].Ref(),
 	}
 
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
@@ -334,15 +334,15 @@ func (f *backendDeviceSuite) TestSetupSshAgent(c *check.C) {
 	cinfo, err := sdk.ReadSdkInfo(consumer, f.pid, "test")
 	c.Assert(err, check.IsNil)
 
-	pinfo, err := sdk.ReadSdkInfo(producer, f.pid, "test")
+	sinfo, err := sdk.ReadSdkInfo(system, f.pid, "test")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(f.repo.AddSdk(cinfo), check.IsNil)
-	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
+	c.Assert(f.repo.AddSdk(sinfo), check.IsNil)
 
 	connref := &interfaces.ConnRef{
 		PlugRef: cinfo.Plugs["ssh-agent"].Ref(),
-		SlotRef: pinfo.Slots["ssh-agent"].Ref(),
+		SlotRef: sinfo.Slots["ssh-agent"].Ref(),
 	}
 
 	_, err = f.repo.Connect(connref, nil, nil, nil, nil, nil)
@@ -392,20 +392,20 @@ func (f *backendDeviceSuite) TestSetupMultipleInterfaces(c *check.C) {
 	cinfo, err := sdk.ReadSdkInfo(consumer, f.pid, "test")
 	c.Assert(err, check.IsNil)
 
-	pinfo, err := sdk.ReadSdkInfo(producer, f.pid, "test")
+	sinfo, err := sdk.ReadSdkInfo(system, f.pid, "test")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(f.repo.AddSdk(cinfo), check.IsNil)
-	c.Assert(f.repo.AddSdk(pinfo), check.IsNil)
+	c.Assert(f.repo.AddSdk(sinfo), check.IsNil)
 
 	sshConnRef := &interfaces.ConnRef{
 		PlugRef: cinfo.Plugs["ssh-agent"].Ref(),
-		SlotRef: pinfo.Slots["ssh-agent"].Ref(),
+		SlotRef: sinfo.Slots["ssh-agent"].Ref(),
 	}
 
 	desktopConnRef := &interfaces.ConnRef{
 		PlugRef: cinfo.Plugs["desktop"].Ref(),
-		SlotRef: pinfo.Slots["desktop"].Ref(),
+		SlotRef: sinfo.Slots["desktop"].Ref(),
 	}
 
 	b := lxd_device.Backend{}

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -144,11 +144,12 @@ func (s *baseDeclSuite) TestManualConnection(c *C) {
 }
 
 func (s *baseDeclSuite) TestMountAutoConnection(c *check.C) {
-	slotYaml := fmt.Sprintf(`name: slot-sdk
+	slotYaml := `name: slot-sdk
 base: ubuntu@22.04
+type: system
 slots:
-    %s:
-`, "mount")
+    mount:
+`
 
 	cand := s.connectCand(c, "mount", slotYaml, "", "mock424242", "mock424242", "ws", "ws")
 	arity, err := cand.CheckAutoConnect()

--- a/internal/interfaces/policy/helpers.go
+++ b/internal/interfaces/policy/helpers.go
@@ -72,10 +72,19 @@ func checkPlugConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	if err := constraints.SlotAttributes.Check(connc.Slot, connc); err != nil {
 		return err
 	}
+
 	plugSdk, slotSdk := connc.Plug.Sdk(), connc.Slot.Sdk()
+	if err := checkSdkType(plugSdk, constraints.PlugSdkTypes); err != nil {
+		return err
+	}
+	if err := checkSdkType(slotSdk, constraints.SlotSdkTypes); err != nil {
+		return err
+	}
+
 	if plugSdk.ProjectId != slotSdk.ProjectId || plugSdk.Workshop != slotSdk.Workshop {
 		return fmt.Errorf("%q cannot be connected to the %q (SDK from a different workshop)", connc.Plug.Ref().String(), connc.Slot.Ref().String())
 	}
+
 	return nil
 }
 
@@ -167,6 +176,7 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	if err := checkNameConstraints(constraints.SlotNames, connc.Slot.Interface(), "slot name", connc.Slot.Name()); err != nil {
 		return err
 	}
+
 	if err := constraints.PlugAttributes.Check(connc.Plug, connc); err != nil {
 		return err
 	}
@@ -175,6 +185,13 @@ func checkSlotConnectionConstraints1(connc *ConnectCandidate, constraints *asser
 	}
 
 	plugSdk, slotSdk := connc.Plug.Sdk(), connc.Slot.Sdk()
+	if err := checkSdkType(plugSdk, constraints.PlugSdkTypes); err != nil {
+		return err
+	}
+	if err := checkSdkType(slotSdk, constraints.SlotSdkTypes); err != nil {
+		return err
+	}
+
 	if plugSdk.ProjectId != slotSdk.ProjectId || plugSdk.Workshop != slotSdk.Workshop {
 		return fmt.Errorf("%q cannot be connected to the %q (SDK from a different workshop)", connc.Plug.Ref().String(), connc.Slot.Ref().String())
 	}

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1420,8 +1420,8 @@ func mountAutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
 	return plug.Attrs["mount"] == slot.Attrs["mount"]
 }
 
-// internal helper that creates a new repository with two snaps, one
-// is a mount plug and one a mount slot
+// internal helper that creates a new repository with two SDKs, one
+// has a mount plug and one a mount slot
 func makeMountConnectionTestSdks(c *C, projectId, plugMountToken, slotMountToken string) (*Repository, *sdk.Info, *sdk.Info) {
 	repo := NewRepository()
 	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "mount", AutoConnectCallback: mountAutoConnect})

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -83,7 +83,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: mount
-    workshop-target: /home/workshop
+    workshop-target: /opt
 `
 
 var conflictingTarget2 = `name: conflict-2
@@ -91,7 +91,7 @@ base: ubuntu@22.04
 plugs:
   plug:
     interface: mount
-    workshop-target: /home/workshop
+    workshop-target: /opt
 `
 
 var csetup = sdk.Setup{Name: "consumer", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
@@ -392,7 +392,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c
 	defer s.state.Unlock()
 
 	// Validate
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target "/home/workshop" is also mounted by.*`)
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target "/opt" is also mounted by.*`)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.C) {
@@ -501,14 +501,14 @@ base: ubuntu@22.04
 plugs:
     plug:
         interface: mount
-        workshop-target: /home/workshop
+        workshop-target: /opt
 `
 	var systemYaml = `
 name: system
 base: ubuntu@22.04
 type: system
 slots:
-    slot:
+    mount:
         interface: mount
 `
 	wm, err := s.launchWorkshop(c, "ws-consumer", []testSdkSetup{{csetup, sdkYaml}})
@@ -519,10 +519,10 @@ slots:
 
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
-		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:slot": map[string]interface{}{
+		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount": map[string]interface{}{
 			"interface":    "mount",
 			"auto":         true,
-			"plug-static":  map[string]interface{}{"target": "/opt"},
+			"plug-static":  map[string]interface{}{"workshop-target": "/opt"},
 			"slot-dynamic": map[string]interface{}{"host-source": source},
 		},
 	})
@@ -571,7 +571,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 		Auto:             true,
 		Interface:        "mount",
 		Undesired:        false,
-		StaticPlugAttrs:  map[string]interface{}{"target": "/opt"},
+		StaticPlugAttrs:  map[string]interface{}{"workshop-target": "/opt"},
 		DynamicPlugAttrs: map[string]interface{}{},
 		StaticSlotAttrs:  map[string]interface{}{},
 		DynamicSlotAttrs: map[string]interface{}{"host-source": newSource}})
@@ -617,7 +617,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 		Auto:             true,
 		Interface:        "mount",
 		Undesired:        false,
-		StaticPlugAttrs:  map[string]interface{}{"target": "/opt"},
+		StaticPlugAttrs:  map[string]interface{}{"workshop-target": "/opt"},
 		DynamicPlugAttrs: map[string]interface{}{},
 		StaticSlotAttrs:  map[string]interface{}{},
 		DynamicSlotAttrs: map[string]interface{}{"host-source": newSource}})
@@ -897,7 +897,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	var attrs map[string]interface{}
 	c.Assert(chg.Get("remounts", &attrs), check.IsNil)
 	c.Assert(attrs, check.HasLen, 1)
-	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:slot"],
+	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount"],
 		check.DeepEquals, source)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)

--- a/internal/overlord/ifacestate/helpers_test.go
+++ b/internal/overlord/ifacestate/helpers_test.go
@@ -63,18 +63,19 @@ plugs:
 var producerYaml = `name: producer
 base: ubuntu@22.04
 slots:
-  mount:
-    interface: mount
   slot-mount:
     interface: mount
+    workshop-source: $SDK/produce
 `
 
 func (s *helpersSuite) TestAutoConnectChecker(c *check.C) {
 	consumer := sdk.MockInfo(c, consumerYaml, "42424242", "ws")
 	plugMount := interfaces.NewConnectedPlug(consumer.Plugs["plug-mount"], nil, nil)
 
+	system := sdk.MockInfo(c, systemYaml, "42424242", "ws")
+	autoMount := interfaces.NewConnectedSlot(system.Slots["mount"], nil, nil)
+
 	producer := sdk.MockInfo(c, producerYaml, "42424242", "ws")
-	autoMount := interfaces.NewConnectedSlot(producer.Slots["mount"], nil, nil)
 	slotMount := interfaces.NewConnectedSlot(producer.Slots["slot-mount"], nil, nil)
 
 	workshopConns := []interfaces.ConnRef{}

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -88,9 +88,8 @@ var systemYaml = `name: system
 base: ubuntu@22.04
 type: system
 slots:
-  slot:
+  mount:
     interface: mount
-    attr: slot-value
 `
 
 func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev int64) {
@@ -171,7 +170,7 @@ plugs:
 	})
 
 	s.state.Lock()
-	key := fmt.Sprintf("%s/ws/consumer:plug %s/ws/system:slot", s.prj.ProjectId, s.prj.ProjectId)
+	key := fmt.Sprintf("%s/ws/consumer:plug %s/ws/system:mount", s.prj.ProjectId, s.prj.ProjectId)
 	s.state.Set("conns", map[string]interface{}{
 		key: map[string]interface{}{
 			"interface": "mount",
@@ -197,7 +196,7 @@ plugs:
 	c.Assert(ifaces.Connections, check.HasLen, 1)
 	cref := &interfaces.ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
-		SlotRef: sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: sdk.System.String(), Name: "slot"}}
+		SlotRef: sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: sdk.System.String(), Name: "mount"}}
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{cref})
 
 	conn, err := repo.Connection(cref)
@@ -207,7 +206,7 @@ plugs:
 		"mount": "foo",
 		"attr":  "stored-value",
 	})
-	c.Assert(conn.Slot.Name(), check.Equals, "slot")
+	c.Assert(conn.Slot.Name(), check.Equals, "mount")
 	c.Assert(conn.Slot.StaticAttrs(), check.DeepEquals, map[string]interface{}{
 		"mount": "foo",
 		"attr":  "stored-value",

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -94,8 +94,7 @@ plugs:
     attr2: value2
 slots:
   slot:
-    interface: mount
-    host-source: /root
+    interface: ssh-agent
 `
 
 func (s *sdkStateSuite) SetUpTest(c *check.C) {
@@ -411,7 +410,7 @@ func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
 	}
 	s.state.Lock()
 
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*installation denied by "slot" slot rule of interface "mount".*`)
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*installation not allowed by "slot" slot rule of interface "ssh-agent".*`)
 
 	// not in the fs (removed)
 	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")

--- a/tests/main/launch-abort/task.yaml
+++ b/tests/main/launch-abort/task.yaml
@@ -17,8 +17,8 @@ execute: |
   echo "Ensure SDKs are unlinked successfully during abort"
   echo "Update the workshop file to use test-sdk-mount-broken"
   sed -i 's/test-sdk-setup-fail/test-sdk-mount-broken/g' workshop.yaml
-  workshop_exec launch --wait-on-error || true
+  ! workshop_exec launch --wait-on-error
   sed -i 's/test-sdk-mount-broken/test-sdk-setup-fail/g' workshop.yaml
 
   workshop_exec launch --abort
-  workshop_exec changes | tail -1 | cut -d ' ' -f1 | xargs workshop tasks | tail -2 | MATCH ".*ERROR installation denied by \"one\" slot rule of interface \"mount\""
+  workshop_exec changes | tail -1 | cut -d ' ' -f1 | xargs workshop tasks | tail -2 | MATCH '.*"test-sdk-mount-broken" SDK has bad plugs or slots: one \(unknown attribute for mount interface slot: "host-source"\)'

--- a/tests/main/workshop-connections/.workshop/ws-user-conns.yaml
+++ b/tests/main/workshop-connections/.workshop/ws-user-conns.yaml
@@ -1,11 +1,10 @@
 name: ws-user-conns
 base: ubuntu@22.04
 sdks:
-  - name: system
+  - name: test-sdk-basic
+    channel: latest/stable
     slots:
       user-slot:
-        interface: mount
-      user-slot-2:
         interface: mount
         workshop-source: /project/user-data-2
   - name: test-sdk-mount
@@ -15,9 +14,7 @@ sdks:
         interface: mount
         workshop-target: /mnt/wp-plug
 connections:
-  - plug: test-sdk-mount:one
-    slot: system:user-slot
   - plug: test-sdk-mount:two
-    slot: system:user-slot-2
+    slot: test-sdk-basic:user-slot
   - plug: test-sdk-mount:wp-plug
-    slot: system:user-slot-2
+    slot: test-sdk-basic:user-slot

--- a/tests/main/workshop-connections/.workshop/ws-user-conns.yaml.new
+++ b/tests/main/workshop-connections/.workshop/ws-user-conns.yaml.new
@@ -1,13 +1,14 @@
 name: ws-user-conns
 base: ubuntu@22.04
 sdks:
-  - name: system
+  - name: test-sdk-basic
+    channel: latest/stable
     slots:
-      user-slot-2:
+      user-slot:
         interface: mount
         workshop-source: /project/user-data-2
   - name: test-sdk-mount
     channel: latest/stable
 connections:
   - plug: test-sdk-mount:two
-    slot: system:user-slot-2
+    slot: test-sdk-basic:user-slot

--- a/tests/main/workshop-connections/task.yaml
+++ b/tests/main/workshop-connections/task.yaml
@@ -11,9 +11,9 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Check connections"
-  workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:one.+:user-slot.+\-$"
-  workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:two.+:user-slot-2.+\-$"
-  workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:wp-plug.+:user-slot-2.+\-$"
+  workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:one.+:mount.+\-$"
+  workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:two.+ws-user-conns/test-sdk-basic:user-slot.+\-$"
+  workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:wp-plug.+ws-user-conns/test-sdk-basic:user-slot.+\-$"
 
   echo "Check mounts"
   workshop_exec info | grep -v notes > mounts.log
@@ -25,7 +25,8 @@ execute: |
   mv -f .workshop/ws-user-conns.yaml.new .workshop/ws-user-conns.yaml
   workshop_exec refresh
   workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:one.+:mount.+\-$"
-  workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:two.+:user-slot-2.+\-$"
+  workshop_exec connections ws-user-conns | MATCH "^mount.+ws-user-conns/test-sdk-mount:two.+ws-user-conns/test-sdk-basic:user-slot.+\-$"
+  workshop_exec connections ws-user-conns | NOMATCH "wp-plug"
 
   echo "Check mounts"
   workshop_exec info | grep -v notes > mounts.log


### PR DESCRIPTION
# Description

Most interfaces, especially `port-forward` (coming soon), behave differently in the system SDK. I think this behaviour should be documented alongside the workshop definition rather than the SDK definition. This should also make it easier to remember to update the workshop definition docs when adding a new interface.

There will probably be a fair bit of repetition between these two references, but I think the table-based format is a nice alternative to the example-based format in the SDK definition docs, and it doesn't hurt to have both. If it gets out of hand we could document the system-specific attributes in the workshop definition, and refer to the SDK definition for other attributes.

The docs are much easier to read when interfaces behave consistently, so I changed how the mount interface works.

The system SDK will now only have one mount slot, named "mount". This is the same as most other interfaces, and reinforces the idea that the system SDK is for system resources only (no workshop-source on a system SDK slot).

There's no need to prevent installation of slots with a host-source attribute at the policy level, as this is handled by the slot sanitizer, in line with other interfaces. This attribute is never attached to the slot itself, only to a ConnectedSlot.

I think the previous auto-connect policy would allow auto-connecting any slot named "mount," which doesn't make sense to me because this slot might not have the special host-source logic that the system SDK does. So auto-connect is now based on the slot SDK type (and explicit connections, as before).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
