### PR TITLE
Pre-download LXD base images for spread runs

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -27,11 +27,25 @@ jobs:
       - name: Install LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.21/stable
+          channel: 6/stable
       - name: Cleanup job workspace
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
+      - name: Pre-download LXD images
+        run: |
+          image_dir="$HOME/images"
+          mkdir -p "$image_dir"
+
+          for version in 22.04 24.04; do
+            if [ ! -f "$image_dir/ubuntu-$version.tar.gz" ]; then
+              lxc image copy "ubuntu:$version/amd64" local: --alias "$version/amd64"
+              lxc image export "$version/amd64" "$image_dir/ubuntu-$version.tar.gz"
+            fi
+          done
+
+          lxc project switch default
+          lxc profile device add default mnt-image disk source=$image_dir path=/mnt
       - name: Checkout Workshop
         uses: actions/checkout@v4
         with:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -246,6 +246,17 @@ of ``Spread``:
 
    spread tests/<TestPathName>
 
+When running locally, you can accelerate the test runs by reusing instances 
+and local LXD base images. For more examples, see the ``spread`` GitHub workflow.
+
+.. code-block:: console
+
+   image_dir=$HOME/images
+   lxc image export <fingerprint> "$image_dir/ubuntu-22.04.tar.gz"   
+   lxc profile device add default mnt-image disk source=$image_dir path=/mnt
+   
+   spread -reuse -resend tests/<TestPathName>
+
 
 To check code coverage:
 

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -10,6 +10,21 @@ function setup_lxd() {
     if [ "$(lxc storage list -f compact | grep -c default)" -eq 0 ]; then
         lxd init --auto --storage-backend=zfs
     fi
+
+    # Import LXD base images instead of downloading in every spread instance.
+    # This assumes images are mounted into the spread instance at /mnt.
+    image_dir="/mnt"
+    versions=("20.04" "22.04" "24.04")
+
+    for version in "${versions[@]}"; do
+        image_file="$image_dir/ubuntu-$version.tar.gz"
+        image_root="$image_dir/ubuntu-$version.tar.gz.root"
+        image_alias="workshop-ubuntu@$version-amd64"
+
+        if [ -f "$image_file" ] && ! lxc image info "$image_alias" &>/dev/null; then
+            lxc image import "$image_file" "$image_root" --alias "$image_alias"
+        fi
+    done
 }
 
 function prepare_environment() {
@@ -23,9 +38,22 @@ function prepare_environment() {
 
     snap install --classic --channel=1.23/stable go
     snap install yq
-    # The unattended upgrades hold locks on reusable instances
-    # and can break a spread run.
-    apt-get remove -y unattended-upgrades
+
+    # The unattended upgrades hold locks on reusable instances and can break a
+    # spread run. This is to prevent the prepare script from failing (e.g. when
+    # reusing an existing spread instance). Since workshops don't currently
+    # interact with apt/dpkg on the host, it shouldn't have implications for the
+    # tests.
+    systemctl stop unattended-upgrades.service || true
+    systemctl disable unattended-upgrades.service || true
+    systemctl disable apt-daily.timer || true
+    systemctl disable apt-daily-upgrade.timer || true
+
+    while pgrep -f "apt|dpkg" >/dev/null; do
+        echo "Waiting for any apt-related process to release the lock..."
+        sleep 5
+    done
+
     apt-get update
     apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)" moreutils jq
 


### PR DESCRIPTION
# Description

This helps with (mainly) local spread runs that reuse existing VMs. The images must populated into a directory on the host and mounted to all the spread VMs via modifying their profiles:

```
lxc profile device add default mnt-image disk source=$image_dir path=/mnt
```

The `prepare` script for the test suites that uses LXD, would import the images before the run instead of letting every spread instance to download it from slow LXD servers multiple times.


# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
