### PR TITLE
Doc: Remove shebang from example hooks

### DIFF
--- a/docs/how-to/craft-sdks.rst
+++ b/docs/how-to/craft-sdks.rst
@@ -288,8 +288,6 @@ named :file:`setup-base`:
 .. code-block:: shell
    :caption: setup-base
 
-   #!/usr/bin/bash
-
    snap install --classic go
    echo "PATH=/home/workshop/go/bin:$PATH" >> /home/workshop/.bashrc
    
@@ -323,14 +321,12 @@ named :file:`save-state` and :file:`restore-state`:
 .. code-block:: shell
    :caption: save-state
 
-   #!/usr/bin/bash
    rsync -a /home/workshop/my_work/ $SDK_STATE_DIR
 
 
 .. code-block:: shell
    :caption: restore-state
 
-   #!/usr/bin/bash
    rsync -a $SDK_STATE_DIR/ /home/workshop/my_work
 
 
@@ -363,8 +359,6 @@ Finally, create a hook named :file:`check-health`:
 
 .. code-block:: shell
    :caption: check-health
-
-   #!/usr/bin/bash
 
    if go version > /dev/null 2>&1; then
      workshopctl set-health okay

--- a/docs/how-to/ros2/design-sdk/setup-base
+++ b/docs/how-to/ros2/design-sdk/setup-base
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 # shellcheck disable=all
 
 set -e

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -278,17 +278,10 @@ which can be defined when the SDK's is built using |sdk_markup|:
      - Configures the base image for the SDK to become operational.
 
 
-Each hooks is defined in a text file of the same name
+Each hook is defined in a text file of the same name
 under :samp:`hooks/` in the :ref:`source directory <ref_sdk_directory>`.
-At run-time, they are executed as shell scripts
-under :samp:`root` inside the workshop,
-so each hook must start with a shebang directive,
-for example:
-
-.. code-block:: shell
-
-   #!/usr/bin/bash
-
+At run-time, they are executed by :command:`bash`
+as :samp:`root` inside the workshop.
 
 A hook can signal an error by returning a non-zero exit code;
 a zero code indicates success.

--- a/tests/lib/sdk/test-sdk-basic/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-basic/latest/stable/sdk/hooks/setup-base
@@ -1,2 +1,1 @@
-#!/usr/bin/bash
 echo "setup-base ran successfully!"

--- a/tests/lib/sdk/test-sdk-environment/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-environment/latest/stable/sdk/hooks/setup-base
@@ -1,2 +1,1 @@
-#!/usr/bin/bash
 echo "export FOO=BAR" > /etc/profile.d/environment.sh

--- a/tests/lib/sdk/test-sdk-go/foxy/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/foxy/stable/sdk/hooks/setup-base
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 sudo snap install go --classic
 echo "PATH=/home/workshop/go/bin:$PATH" >>/home/workshop/.bashrc
 

--- a/tests/lib/sdk/test-sdk-go/jammy/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/jammy/stable/sdk/hooks/setup-base
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 sudo snap install go --classic
 echo "PATH=/home/workshop/go/bin:$PATH" >>/home/workshop/.bashrc
 

--- a/tests/lib/sdk/test-sdk-go/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/latest/stable/sdk/hooks/setup-base
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 sudo snap install go --classic
 echo "PATH=/home/workshop/go/bin:$PATH" >>/home/workshop/.bashrc
 

--- a/tests/lib/sdk/test-sdk-go/noble/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/noble/stable/sdk/hooks/setup-base
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 echo "setup-base ran successfully!"
 sudo snap install go --classic
 echo "PATH=/home/workshop/go/bin:$PATH" >> /home/workshop/.bashrc

--- a/tests/lib/sdk/test-sdk-health-error/latest/stable/sdk/hooks/check-health
+++ b/tests/lib/sdk/test-sdk-health-error/latest/stable/sdk/hooks/check-health
@@ -1,2 +1,1 @@
-#!/usr/bin/bash
 workshopctl set-health error --code unknown-problem "Health check failed"

--- a/tests/lib/sdk/test-sdk-health-error/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-health-error/latest/stable/sdk/hooks/setup-base
@@ -1,2 +1,1 @@
-#!/usr/bin/bash
 echo "Set up base ran successfully!"

--- a/tests/lib/sdk/test-sdk-health-ok/latest/stable/sdk/hooks/check-health
+++ b/tests/lib/sdk/test-sdk-health-ok/latest/stable/sdk/hooks/check-health
@@ -1,3 +1,2 @@
-#!/usr/bin/bash
 workshopctl set-health okay
 echo -n "Health check finished successfully"

--- a/tests/lib/sdk/test-sdk-health-ok/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-health-ok/latest/stable/sdk/hooks/setup-base
@@ -1,2 +1,1 @@
-#!/usr/bin/bash
 echo "Set up base ran successfully!"

--- a/tests/lib/sdk/test-sdk-health-waiting/latest/stable/sdk/hooks/check-health
+++ b/tests/lib/sdk/test-sdk-health-waiting/latest/stable/sdk/hooks/check-health
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 counter_file="/root/counter"
 if [ ! -f "$counter_file" ]; then
     echo "0" > "$counter_file"

--- a/tests/lib/sdk/test-sdk-health-waiting/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-health-waiting/latest/stable/sdk/hooks/setup-base
@@ -1,2 +1,1 @@
-#!/usr/bin/bash
 echo "Set up base ran successfully!"

--- a/tests/lib/sdk/test-sdk-mount-broken/latest/stable/sdk/hooks/restore-state
+++ b/tests/lib/sdk/test-sdk-mount-broken/latest/stable/sdk/hooks/restore-state
@@ -1,5 +1,3 @@
-#!/usr/bin/bash
-
 state=$(cat "$SDK_STATE_DIR/state")
 echo "latest/stable restore-state to ~/state: $state"
 cp -f "$SDK_STATE_DIR"/state ~/ || true

--- a/tests/lib/sdk/test-sdk-mount-broken/latest/stable/sdk/hooks/save-state
+++ b/tests/lib/sdk/test-sdk-mount-broken/latest/stable/sdk/hooks/save-state
@@ -1,5 +1,3 @@
-#!/usr/bin/bash
-
 state=$(cat ~/state)
 echo "latest/stable save-state from ~/state: $state"
 cp ~/state "$SDK_STATE_DIR" 2>/dev/null || true

--- a/tests/lib/sdk/test-sdk-mount-broken/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-mount-broken/latest/stable/sdk/hooks/setup-base
@@ -1,2 +1,1 @@
-#!/usr/bin/bash
 echo "Set up base ran successfully!"

--- a/tests/lib/sdk/test-sdk-mount/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-mount/latest/stable/sdk/hooks/setup-base
@@ -1,4 +1,3 @@
-#!/usr/bin/bash
 mkdir -p /mnt/one
 mkdir -p /opt/two
 mkdir -p /mnt/wp-plug

--- a/tests/lib/sdk/test-sdk-multiple-plugs/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-multiple-plugs/latest/stable/sdk/hooks/setup-base
@@ -1,3 +1,1 @@
-#!/usr/bin/bash
-
 exit 0

--- a/tests/lib/sdk/test-sdk-setup-fail/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-setup-fail/latest/stable/sdk/hooks/setup-base
@@ -1,5 +1,3 @@
-#!/usr/bin/bash
-
 if [ -f /home/workshop/setup-base-pass ]; then
     exit 0
 else

--- a/tests/lib/sdk/test-sdk-ssh-agent/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-ssh-agent/latest/stable/sdk/hooks/setup-base
@@ -1,3 +1,1 @@
-#!/usr/bin/bash
-
 exit 0


### PR DESCRIPTION
# Description

They have no effect, which could be misleading to some users.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
