### PR TITLE
Doc: Explain scripts, bump version

### DIFF
--- a/docs/explanation/workshops/workshops.rst
+++ b/docs/explanation/workshops/workshops.rst
@@ -87,11 +87,11 @@ A simple definition might look like this:
 .. code-block:: yaml
    :caption: workshop.yaml
 
-   name: golang
+   name: dev
    base: ubuntu@22.04
    sdks:
      - name: go
-       channel: latest/stable
+       channel: jammy/stable
 
 
 .. @artefact SDK
@@ -174,6 +174,64 @@ Also, both connections established here
 are no different from those created via the command line.
 
 
+.. _exp_workshop_definition_scripts:
+
+Scripts
+-------
+
+Another optional part of a workshop definition is the :samp:`scripts` section;
+it contains named shell scripts to be copied and executed inside the workshop.
+
+The following example adds four scripts,
+:samp:`lint`, :samp:`shellcheck`, :samp:`unit` and :samp:`cover`,
+intended as utility helpers for a development environment:
+
+.. code-block:: yaml
+   :caption: .workshop/dev.yaml
+   :emphasize-lines: 6-15
+
+   name: dev
+   base: ubuntu@24.04
+   sdks:
+     - name: go
+       channel: jammy/stable
+   scripts:
+     lint: |
+       golangci-lint run  --out-format=colored-line-number -c .golangci.yaml
+     shellcheck: |
+       git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck
+     unit: |
+       go test ./...
+     cover: |
+       go test ./... -coverprofile=coverage.out
+       go tool cover -html=coverage.out
+
+
+To run these scripts, you use the :command:`workshop run` command:
+
+.. code-block:: console
+
+   $ workshop run lint
+
+
+When you thus invoke a script, it's injected into the workshop
+and executed there in a fashion similar to :command:`workshop exec`.
+Even if you update the :samp:`scripts` section in the definition,
+there's no need to refresh the workshop to use the updated script;
+it's available immediately.
+
+For a quick reference of the scripts in your workshop,
+run :command:`workshop scripts`:
+
+.. code-block:: console
+
+   $ workshop scripts
+
+
+This mechanism avoids the need to maintain helper scripts manually,
+ensuring instead that they are stored with the rest of the workshop's metadata.
+
+
 See also
 --------
 
@@ -183,8 +241,15 @@ Explanation:
 - :ref:`exp_sdk`
 
 
+How-to guides:
+
+- :ref:`how_use_workshops`
+
+
 Reference:
 
 - :ref:`ref_workshop_connections`
 - :ref:`ref_workshop_definition`
+- :ref:`ref_workshop_run`
+- :ref:`ref_workshop_scripts`
 - :ref:`ref_workshop_status`

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -62,7 +62,7 @@ for example:
 
 .. code-block:: console
 
-   sudo snap install --dangerous --classic ./workshop_0.1.10_amd64.snap
+   sudo snap install --dangerous --classic ./workshop_0.1.11_amd64.snap
 
 
 Launching workshops

--- a/docs/reference/definitions/schema.json
+++ b/docs/reference/definitions/schema.json
@@ -39,6 +39,10 @@
             "pattern": "^[a-zA-Z0-9.-]+/(stable|candidate|beta|edge)$",
             "errorMessage": "Channel must follow the pattern <track>/<risk> (e.g., 'latest/stable')."
           },
+          "source": {
+            "type": "string",
+            "description": "Local path or source for the SDK. If set, 'channel' need not be specified."
+          },
           "plugs": {
             "type": "object",
             "description": "Plugs for the SDK.",
@@ -95,13 +99,24 @@
           }
         },
         "required": [
-          "name",
-          "channel"
+          "name"
+        ],
+        "anyOf": [
+          {
+            "required": [
+              "channel"
+            ]
+          },
+          {
+            "required": [
+              "source"
+            ]
+          }
         ],
         "errorMessage": {
           "required": {
             "name": "Each SDK must specify a name.",
-            "channel": "SDK must specify a channel unless installed from a local source."
+            "channel": "Either 'channel' or 'source' must be provided for the SDK."
           }
         }
       }

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -31,10 +31,11 @@ but you can confidently use the pre-release versions.
 
 Latest version:
 
-- `Workshop v0.1.10 <https://github.com/canonical/workshop/releases/tag/v0.1.10>`_
+- `Workshop v0.1.11 <https://github.com/canonical/workshop/releases/tag/v0.1.11>`_
 
 Older versions:
 
+- `Workshop v0.1.10 <https://github.com/canonical/workshop/releases/tag/v0.1.10>`_
 - `Workshop v0.1.9 <https://github.com/canonical/workshop/releases/tag/v0.1.9>`_
 - `Workshop v0.1.8 <https://github.com/canonical/workshop/releases/tag/v0.1.8>`_
 - `Workshop v0.1.7 <https://github.com/canonical/workshop/releases/tag/v0.1.7>`_
@@ -80,7 +81,7 @@ to download and install the latest snap:
 
 .. code-block:: console
 
-   $ sudo snap install --dangerous --classic ./workshop_0.1.10_amd64.snap
+   $ sudo snap install --dangerous --classic ./workshop_0.1.11_amd64.snap
 
 Snaps are available for the :samp:`amd64` and :samp:`arm64` architectures.
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -118,7 +118,7 @@ for example:
 
 .. code-block:: console
 
-   $ sudo snap install --dangerous --classic ./workshop_0.1.10_amd64.snap
+   $ sudo snap install --dangerous --classic ./workshop_0.1.11_amd64.snap
 
 
 The command installs two main components:


### PR DESCRIPTION
The sketch how-to presents a use case for scripts in the how-to section; the only part missing was the explanation.