### PR TITLE
Fix flaky connect exec conflict test

### DIFF
--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
+	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -1457,6 +1458,7 @@ func (s *apiSuite) TestConnectWarnOnExec(c *check.C) {
 	chg.AddTask(tsk)
 	tsk.Set("workshop", "producer-ws")
 	chg.Set("project-id", "b8639dea")
+	s.d.overlord.TaskRunner().AddBlocked(func(t *state.Task, running []*state.Task) bool { return t.ID() == tsk.ID() })
 	st.Unlock()
 
 	text, err := json.Marshal(action)
@@ -1495,7 +1497,7 @@ func (s *apiSuite) TestConnectWarnOnExec(c *check.C) {
 	st.Lock()
 	warnings := st.AllWarnings()
 	st.Unlock()
-	c.Check(warnings, check.HasLen, 1)
+	c.Assert(warnings, check.HasLen, 1)
 	c.Check(warnings[0].String(), check.Equals, `active shell sessions in "producer-ws" may need restarting for new connections to take effect`)
 }
 


### PR DESCRIPTION
# Description

I modelled `TestConnectWarnOnExec` on `TestConnectFailureOnConflict`, which is different because the latter doesn't run the overlord loop. The `exec` change that the former creates is actually started (and quickly fails). This means the `connect` change sometimes doesn't trigger a warning. I've prevented that by blocking the `exec` task. Let me know if there's a simpler way to do this.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
