### PR TITLE
Avoid printing additional error message for certain exit statuses

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -531,7 +531,13 @@ func (s *Backend) execCommand(conn lxd.InstanceServer, ctx context.Context, name
 			defer conn.Disconnect()
 
 			if err := op.WaitContext(ctx); err != nil {
-				return err
+				switch err.Error() {
+				case "Command not executable", "Command not found":
+					// Usually a nonzero exit status is not an error,
+					// but LXD translates 126 and 127 into the above messages.
+				default:
+					return err
+				}
 			}
 
 			// waiting for any remaining data IO to be flushed LXD closes this channel


### PR DESCRIPTION
# Description

Usually a nonzero exit status isn't an error, but [LXD translates 126 and 127 into specific error messages](https://github.com/canonical/lxd/pull/11024). This works around that issue, although maybe we should ask the LXD team to make their API more consistent.

Before:
```console
$ workshop exec -- foo
foo: line 1: exec: foo: not found
error: cannot perform the following tasks:
- Exec command "sudo" (Command not found)
$ workshop exec -- /etc/profile
/etc/profile: line 1: /etc/profile: Permission denied
/etc/profile: line 1: exec: /etc/profile: cannot execute: Permission denied
error: cannot perform the following tasks:
- Exec command "sudo" (Command not executable)
```

After:
```console
$ workshop exec -- foo
foo: line 1: exec: foo: not found
$ workshop exec -- /etc/profile
/etc/profile: line 1: /etc/profile: Permission denied
/etc/profile: line 1: exec: /etc/profile: cannot execute: Permission denied
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
