### PR TITLE
Fix wayland socket issue in spread

### DIFF
--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -51,6 +51,7 @@ execute: |
   EOF
 
   echo "Connect the desktop interface for an x11 session"
+  sudo -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 systemctl --user unset-environment WAYLAND_DISPLAY
   sudo -u ubuntu touch /tmp/.Xauthority
   sudo -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 systemctl --user set-environment DISPLAY=:0 XAUTHORITY=/tmp/.Xauthority
   workshop_exec connect ws-desktop/test-sdk-desktop:desktop :desktop


### PR DESCRIPTION
# Description
Fixes: https://github.com/canonical/workshop/actions/runs/13665540077/job/38207709073

This doesn't fix the root cause (lxd trying to bind the socket before systemd has created the runtime directory) however in practice this does not seem to be an issue. 

We decided to only introduce the additional complexity required to symlink the socket if we encounter this issue in the wild. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
