### PR TITLE
Fix tests for other users

### DIFF
--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -282,7 +282,7 @@ var mockWorkshopWithTunnels = `{"type":"sync","status-code":200,"status":"OK","r
                 },
                 "to":{
                     "protocol":"unix",
-                    "path":"/run/user/1000/gopls.socket"
+                    "path":"/run/user/%s/gopls.socket"
                 }
             }]
         }
@@ -308,7 +308,7 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkTunnels(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
-			_, err = fmt.Fprintln(w, fmt.Sprintf(mockWorkshopWithTunnels, user.HomeDir))
+			_, err = fmt.Fprintln(w, fmt.Sprintf(mockWorkshopWithTunnels, user.Uid))
 			c.Assert(err, check.IsNil)
 		default:
 			c.Errorf("expected 2 calls, now on %d", n)
@@ -327,7 +327,7 @@ sdks:
     tunnels:
       gopls:
         from:  127.0.0.1:60915/tcp
-        to:    /run/user/1000/gopls.socket
+        to:    /run/user/%s/gopls.socket
   go:
     tracking:   latest/edge
     installed:  1.8.0  2017-02-19  \(1\)
@@ -335,6 +335,6 @@ sdks:
       snap-cache:
         from:  0.0.0.0:12345/tcp
         to:    /run/snap-proxy.socket
-`, m.prjDir))
+`, m.prjDir, user.Uid))
 	c.Check(n, check.Equals, 2)
 }

--- a/internal/interfaces/builtin/tunnel_test.go
+++ b/internal/interfaces/builtin/tunnel_test.go
@@ -971,13 +971,7 @@ slots:
 `, s.projectId, "ws", "system", "tunnel-slot")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 
-	u := user.User{
-		Uid:      "1111",
-		Gid:      "2222",
-		Username: "testuser",
-		HomeDir:  "/home/testhome",
-	}
-	deviceSpec := lxd_device.NewSpecification(&u, "client")
+	deviceSpec := lxd_device.NewSpecification(&testuser, "client")
 
 	err := deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot)
 	c.Check(err, check.ErrorMatches, `unexpected variable "PWD"`)


### PR DESCRIPTION
# Description

I originally wrote these to work for any user, not just 1000, but must have broken it at some point during other changes. Also one of the tests doesn't rely on faking a user so I removed that.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
