### PR TITLE
Remove today from tests for workshop changes

### DIFF
--- a/tests/main/changes/task.yaml
+++ b/tests/main/changes/task.yaml
@@ -5,6 +5,6 @@ execute: |
   workshop_exec launch
 
   echo "The launch change must present in the list"
-  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-changes\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Launch \"ws-changes\" workshop$"
   
   workshop_exec remove

--- a/tests/main/check-health/task.yaml
+++ b/tests/main/check-health/task.yaml
@@ -5,19 +5,19 @@ execute: |
   workshop_exec launch ws-ok
 
   echo "Check health reported okay"
-  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-ok\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Launch \"ws-ok\" workshop$"
   workshop_exec refresh ws-ok  
-  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws-ok\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Refresh \"ws-ok\" workshop$"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-ok[[:space:]]+Ready[[:space:]]+-$" 
   workshop_exec remove ws-ok
 
   echo "Check health reported waiting"  
   workshop_exec launch ws-waiting    
-  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-waiting\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Launch \"ws-waiting\" workshop$"
   workshop_exec refresh ws-waiting
   workshop_exec remove ws-waiting
   
   echo "Check health reported error"
   workshop_exec launch ws-error || true
-  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Error[[:space:]]+today[: [:alnum:]]+[[:space:]]+Launch \"ws-error\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Error[[:space:]]+[:, [:alnum:]]+[[:space:]]+Launch \"ws-error\" workshop$"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-error[[:space:]]+Off[[:space:]]+-$" 

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -26,7 +26,7 @@ execute: |
   workshop_exec refresh ws-refresh
 
   echo "Check refresh change is Done"
-  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws-refresh\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Refresh \"ws-refresh\" workshop$"
 
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh[[:space:]]+Ready[[:space:]]+-$"
@@ -34,7 +34,7 @@ execute: |
   workshop_exec refresh ws-refresh-sdk
 
   echo "Check refresh change is Done"
-  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+today[: [:alnum:]]+[[:space:]]+Refresh \"ws-refresh-sdk\" workshop$"
+  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Refresh \"ws-refresh-sdk\" workshop$"
 
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-sdk[[:space:]]+Ready[[:space:]]+-$"


### PR DESCRIPTION
# Description

If these tests run at the start of a new day, the output can contain "yesterday" instead of "today." Rather than allowing yesterday we should just accept anything which looks like a human-readable date.

I checked that `timeutil.Human` is only used by `changes` and `tasks`, and only in the tests for `changes`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
