### PR TITLE
Make change ID optional for workshop tasks

### DIFF
--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -18,8 +19,8 @@ type CmdTasks struct {
 
 func (c *CmdTasks) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "tasks <CHANGE ID>",
-		Args:  cobra.ExactArgs(1),
+		Use:   "tasks [<CHANGE ID>]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "List tasks for a specific change",
 		Long: `
 Any substantial operation on a workshop is a change that consists of tasks;
@@ -41,7 +42,10 @@ Notes:
 `,
 		Example: `
 List the tasks under change ID 42:
-$ workshop tasks 42`,
+$ workshop tasks 42
+
+List the tasks under the most recent change to the project:
+$ workshop tasks`,
 		RunE:              c.Run,
 		ValidArgsFunction: c.complete,
 	}
@@ -57,9 +61,25 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	change, err := cli.Change(av[0])
-	if err != nil {
-		return err
+	var change *client.Change
+	if len(av) > 0 {
+		change, err = cli.Change(av[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		changesCmd := CmdChanges{
+			root: c.root,
+		}
+		changes, err := changesCmd.changes(cli)
+		if err != nil {
+			return err
+		}
+
+		if len(changes) == 0 {
+			return errors.New("cannot find any changes")
+		}
+		change = changes[0]
 	}
 
 	if change != nil {

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -79,7 +79,7 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 		if len(changes) == 0 {
 			return errors.New("cannot find any changes")
 		}
-		change = changes[0]
+		change = changes[len(changes)-1]
 	}
 
 	if change != nil {

--- a/docs/explanation/workshops/workshop-cli.rst
+++ b/docs/explanation/workshops/workshop-cli.rst
@@ -59,7 +59,8 @@ There are several categories of commands that vary by their purpose:
 
    * - Utilise
      - :command:`exec`,
-       :command:`shell`
+       :command:`shell`,
+       :command:`run`
      - Run commands inside a workshop.
 
 

--- a/docs/explanation/workshops/workshop-cli.rst
+++ b/docs/explanation/workshops/workshop-cli.rst
@@ -34,10 +34,10 @@ There are several categories of commands that vary by their purpose:
    * - Create, update, delete
      - :command:`connect`,
        :command:`disconnect`,
+       :command:`launch`,
        :command:`refresh`,
-       :command:`remount`
-       :command:`remove`,
-       :command:`launch`
+       :command:`remount`,
+       :command:`remove`
      - Control a workshop's existence;
        not to be confused with starting or stopping a workshop.
 
@@ -50,10 +50,11 @@ There are several categories of commands that vary by their purpose:
      - :command:`changes`,
        :command:`connections`,
        :command:`info`,
+       :command:`list`,
        :command:`okay`,
+       :command:`scripts`,
        :command:`tasks`,
-       :command:`warnings`,
-       :command:`list`
+       :command:`warnings`
      - Enumerate workshops, list their details and recent activities.
 
    * - Utilise

--- a/docs/how-to/use-workshops/debug-workshop-issues.rst
+++ b/docs/how-to/use-workshops/debug-workshop-issues.rst
@@ -82,6 +82,10 @@ list its *tasks* to see the cause:
 
 The SDK-specific reason can be addressed individually.
 
+If no change ID is provided,
+:command:`workshop tasks` inspects the most recent change
+to the current project.
+
 
 Wait on error
 -------------

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -346,6 +346,12 @@ pass the ID of the change to the :ref:`tasks <ref_workshop_tasks>` command:
      140  Done    today at 11:33 GMT  today at 11:33 GMT  Auto-connect interfaces of "go" SDK
 
 
+.. tip::
+
+   To inspect the most recent change,
+   use :command:`workshop tasks` without a change ID.
+
+
 Here, the following happens:
 
 - The :ref:`project directory <tut_define>`

--- a/tests/main/launch-abort/task.yaml
+++ b/tests/main/launch-abort/task.yaml
@@ -12,7 +12,7 @@ execute: |
   workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-abort[[:space:]]+Off[[:space:]]+-$"
 
   echo "Validate the task output from the launch attempt"
-  workshop_exec changes | tail -1 | cut -d ' ' -f1 | xargs workshop tasks | tail -1 | MATCH ".*Aborting for workshop \"ws-launch-abort\"..."
+  workshop_exec tasks | tail -1 | MATCH ".*Aborting for workshop \"ws-launch-abort\"..."
 
   echo "Ensure SDKs are unlinked successfully during abort"
   echo "Update the workshop file to use test-sdk-mount-broken"
@@ -21,4 +21,4 @@ execute: |
   sed -i 's/test-sdk-mount-broken/test-sdk-setup-fail/g' workshop.yaml
 
   workshop_exec launch --abort
-  workshop_exec changes | tail -1 | cut -d ' ' -f1 | xargs workshop tasks | tail -2 | MATCH '.*"test-sdk-mount-broken" SDK has bad plugs or slots: one \(unknown attribute for mount interface slot: "host-source"\)'
+  workshop_exec tasks | tail -2 | MATCH '.*"test-sdk-mount-broken" SDK has bad plugs or slots: one \(unknown attribute for mount interface slot: "host-source"\)'

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -21,4 +21,4 @@ execute: |
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-abort[[:space:]]+Ready[[:space:]]+-$"
 
   echo "Validate the task output from the refresh attempt"
-  workshop_exec changes | tail -1 | cut -d ' ' -f1 | xargs workshop tasks | tail -1 | MATCH ".*Aborting for workshop \"ws-refresh-abort\"..."
+  workshop_exec tasks | tail -1 | MATCH ".*Aborting for workshop \"ws-refresh-abort\"..."


### PR DESCRIPTION
# Description

`workshop tasks` will use the most recent change to the current project.

I updated the tutorial and the troubleshooting section. Maybe `workshop tasks` should be the default for one of these?

Also noticed that I never put `workshop run` or `workshop scripts` in a category, so I've added them and sorted the other entries.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
