### PR TITLE
Shell completion for shell, run and scripts

### DIFF
--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -91,7 +91,7 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 
 func (c *CmdChanges) changes(cli *client.Client) ([]*client.Change, error) {
 	clientOpts := client.ChangesOptions{
-		ProjectPath: c.root.project,
+		ProjectPath: c.root.project(),
 		Selector:    client.ChangesAll,
 	}
 

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -73,7 +73,7 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (c *CmdConnect) complete(cmd *cobra.Command, args []string, toComplete stri
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -139,16 +139,19 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 func (c *CmdConnect) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	cli, err := c.root.client()
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	project, err := cli.Project(c.root.project)
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -138,7 +138,7 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -74,7 +74,7 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (c *CmdDisconnect) complete(cmd *cobra.Command, args []string, toComplete s
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -121,16 +121,19 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 func (c *CmdDisconnect) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	cli, err := c.root.client()
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	project, err := cli.Project(c.root.project)
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -247,7 +247,8 @@ $ workshop shell nimble
 
 The name is optional if the project has only one workshop:
 $ workshop shell`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Waiting"}),
 	}
 
 	return cmd

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -367,7 +367,7 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		return err
 	}
 
-	project, err := cli.Project(root.project)
+	project, err := cli.Project(root.project())
 	if err != nil {
 		return err
 	}
@@ -616,7 +616,7 @@ func (c *CmdScripts) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	p, err := cli.Project(c.root.project)
+	p, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -293,7 +293,8 @@ Scripts can accept arguments,
 if a separator or a workshop name is provided:
 $ workshop run -- build --debug
 `,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.complete,
 	}
 
 	cmd.Flags().SortFlags = false
@@ -346,6 +347,41 @@ func (c *CmdRun) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	return exec(c.root, &c.flags, args)
+}
+
+func (c *CmdRun) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	scriptIdx := 1
+	dashIdx := len(os.Args) - 2 - len(args)
+	// TODO: Replace with cmd.ArgsLenAtDash() == 0.
+	// See https://github.com/spf13/cobra/issues/1877.
+	if dashIdx >= 0 && os.Args[dashIdx] == "--" {
+		scriptIdx = 0
+	} else if scriptIdx < len(args) && args[scriptIdx] == "--" {
+		scriptIdx++
+	}
+
+	if scriptIdx > len(args) {
+		// Just complete workshop names, even though script names are valid
+		// if there's a single workshop.
+		return c.root.doCompleteWorkshopNames(args, []string{"Ready", "Waiting"})
+	}
+	if scriptIdx < len(args) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	scriptsCmd := CmdScripts{root: c.root}
+	scripts, err := scriptsCmd.scripts(args)
+	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
+		return nil, cobra.ShellCompDirectiveError
+	}
+	names := make([]string, 0, len(scripts))
+	for name := range scripts {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
 func commonVars(f *pflag.FlagSet, flags *ExecFlags) {
@@ -612,25 +648,7 @@ $ workshop scripts`,
 }
 
 func (c *CmdScripts) Run(cmd *cobra.Command, av []string) error {
-	cli, err := c.root.client()
-	if err != nil {
-		return err
-	}
-
-	p, err := cli.Project(c.root.project())
-	if err != nil {
-		return err
-	}
-
-	if len(av) == 0 {
-		name, err := cli.SingleWorkshopName(p)
-		if err != nil {
-			return err
-		}
-		av = []string{name}
-	}
-
-	scripts, err := cli.ListScripts(p.Id, av[0])
+	scripts, err := c.scripts(av)
 	if err != nil || len(scripts) == 0 {
 		return err
 	}
@@ -638,4 +656,26 @@ func (c *CmdScripts) Run(cmd *cobra.Command, av []string) error {
 	encoder := yaml.NewEncoder(Stdout)
 	encoder.SetIndent(2)
 	return encoder.Encode(scripts)
+}
+
+func (c *CmdScripts) scripts(av []string) (map[string]client.Script, error) {
+	cli, err := c.root.client()
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := cli.Project(c.root.project())
+	if err != nil {
+		return nil, err
+	}
+
+	if len(av) == 0 {
+		name, err := cli.SingleWorkshopName(p)
+		if err != nil {
+			return nil, err
+		}
+		av = []string{name}
+	}
+
+	return cli.ListScripts(p.Id, av[0])
 }

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -631,7 +631,7 @@ type CmdScripts struct {
 
 func (c *CmdScripts) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "scripts",
+		Use:   "scripts [<WORKSHOP>]",
 		Args:  cobra.MaximumNArgs(1),
 		Short: shortScriptsHelp,
 		Long:  longScriptsHelp,
@@ -641,7 +641,8 @@ $ workshop scripts nimble
 
 The name is optional if the project has only one workshop:
 $ workshop scripts`,
-		RunE: c.Run,
+		RunE:              c.Run,
+		ValidArgsFunction: c.root.completeWorkshopName(nil),
 	}
 
 	return cmd

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 
+	"github.com/spf13/cobra"
 	"gopkg.in/check.v1"
 )
 
@@ -24,6 +26,9 @@ var mockWorkshopWithScripts = `{"type":"sync","status-code":200,"status":"OK","r
         "script":"echo bar\n"
     }
 }}`
+var mockWorkshopScriptsError = `{"type":"error","status-code":404,"status":"Not Found","result":{
+    "message":"workshop not found"
+}}`
 
 func (m *workshopExec) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
@@ -38,7 +43,7 @@ func (m *workshopExec) TestWorkshopScripts(c *check.C) {
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 4:
+		case 1, 4, 6:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
@@ -57,8 +62,13 @@ func (m *workshopExec) TestWorkshopScripts(c *check.C) {
 			} else {
 				fmt.Fprintln(w, mockWorkshopWithScripts)
 			}
+		case 7:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/wrong-name/scripts", m.prjId))
+			w.WriteHeader(404)
+			fmt.Fprintln(w, mockWorkshopScriptsError)
 		default:
-			c.Errorf("expected 2 calls, now on %d", n)
+			c.Errorf("expected 7 calls, now on %d", n)
 		}
 	})
 
@@ -76,5 +86,90 @@ func (m *workshopExec) TestWorkshopScripts(c *check.C) {
 foo:
   script: echo foo
 `)
-	c.Check(n, check.Equals, 5)
+
+	err = cmd.Run(cmd.Command(), []string{"wrong-name"})
+	c.Check(err, check.ErrorMatches, "workshop not found")
+
+	c.Check(n, check.Equals, 7)
+}
+
+func (m *workshopExec) TestWorkshopRunCompletion(c *check.C) {
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3, 5, 7, 10:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 8:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
+		case 4, 9, 11:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws/scripts", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithScripts)
+		case 6:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/wrong-name/scripts", m.prjId))
+			w.WriteHeader(404)
+			fmt.Fprintln(w, mockWorkshopScriptsError)
+		default:
+			c.Errorf("expected 11 calls, now on %d", n)
+		}
+	})
+
+	cmd := &CmdRun{root: &CmdRoot{cwd: m.prjDir}}
+	run := cmd.Command()
+
+	// TODO: remove this workaround once this bug is fixed:
+	// https://github.com/spf13/cobra/issues/1877
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	os.Args = []string{"workshop", "__complete", "run", ""}
+	result, compDirective := run.ValidArgsFunction(run, nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"ws"})
+
+	os.Args = []string{"workshop", "__complete", "run", "ws", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"ws"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+
+	os.Args = []string{"workshop", "__complete", "run", "wrong-name", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"wrong-name"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveError)
+	c.Check(result, check.HasLen, 0)
+
+	os.Args = []string{"workshop", "__complete", "run", "ws", "foo", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "foo"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.HasLen, 0)
+
+	os.Args = []string{"workshop", "__complete", "run", "--", ""}
+	result, compDirective = run.ValidArgsFunction(run, nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+
+	os.Args = []string{"workshop", "__complete", "run", "--", "foo", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"foo"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.HasLen, 0)
+
+	os.Args = []string{"workshop", "__complete", "run", "ws", "--", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "--"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+
+	os.Args = []string{"workshop", "__complete", "run", "ws", "--", "foo", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "--", "foo"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.HasLen, 0)
+
+	c.Check(n, check.Equals, 11)
 }

--- a/cmd/workshop/gendocs.go
+++ b/cmd/workshop/gendocs.go
@@ -64,7 +64,7 @@ func (c *CmdDocs) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	err = gencodo.GenDocsTree(
-		c.root.Command(c.root.project),
+		c.root.Command(),
 		docDir,
 		td,
 		filePrepender,

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -82,7 +82,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -158,16 +158,19 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 func (c *CmdLaunch) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	cli, err := c.root.client()
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	project, err := cli.Project(c.root.project)
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	instances, files, err := cli.List(&client.ListOptions{ProjectId: project.Id})
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -102,7 +102,7 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (c *CmdLaunch) complete(cmd *cobra.Command, args []string, toComplete strin
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -79,7 +79,7 @@ func (c *CmdList) runList() error {
 	}
 
 	if !c.global {
-		project, err := cli.Project(c.root.project)
+		project, err := cli.Project(c.root.project())
 		if err != nil {
 			return err
 		}

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	logger.SetLogger(l)
 
-	rootCmd := (&CmdRoot{}).Command(cwd)
+	rootCmd := (&CmdRoot{cwd: cwd}).Command()
 
 	if err = rootCmd.Execute(); err != nil {
 		exitError, ok := err.(*client.ExitError)

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/logger"
@@ -21,6 +22,8 @@ func main() {
 	logger.SetLogger(l)
 
 	rootCmd := (&CmdRoot{cwd: cwd}).Command()
+	// Work around https://github.com/spf13/cobra/issues/2257.
+	rootCmd.SetArgs(slices.Clone(os.Args[1:]))
 
 	if err = rootCmd.Execute(); err != nil {
 		exitError, ok := err.(*client.ExitError)

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -133,7 +133,7 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -82,7 +82,7 @@ $ workshop refresh --continue
 Refresh the sketch SDK in the 'nimble' workshop:
 $ workshop refresh nimble/sketch`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Waiting"}),
+		ValidArgsFunction: c.root.completeWorkshopNames([]string{"Ready", "Waiting"}),
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.WaitOnError, "wait-on-error",

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -76,7 +76,7 @@ func (c *CmdRemount) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (c *CmdRemount) complete(cmd *cobra.Command, args []string, toComplete stri
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -111,16 +111,19 @@ func (c *CmdRemount) complete(cmd *cobra.Command, args []string, toComplete stri
 
 	cli, err := c.root.client()
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	project, err := cli.Project(c.root.project)
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, Interface: "mount"})
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -59,7 +59,7 @@ func (c *CmdRemove) Run(cmd *cobra.Command, av []string) error {
 
 	c.skipAbort = true
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -91,40 +91,52 @@ func (c *CmdRoot) postRun(cmd *cobra.Command, args []string) {
 	}
 }
 
-type ValidArgsFunction func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
-
-func (c *CmdRoot) completeWorkshopName(status []string) ValidArgsFunction {
+func (c *CmdRoot) completeWorkshopName(status []string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cli, err := c.client()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
+		if len(args) > 0 {
+			return []string{}, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		project, err := cli.Project(c.project)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		workshopInfo, _, err := cli.List(&client.ListOptions{ProjectId: project.Id})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		desiredStatus := func(s string) bool {
-			if status == nil {
-				return true
-			}
-			return slices.Contains(status, s)
-		}
-
-		var workshops []string
-		for _, workshop := range workshopInfo {
-			if desiredStatus(workshop.Status) && !slices.Contains(args, workshop.Name) {
-				workshops = append(workshops, workshop.Name)
-			}
-		}
-		return workshops, cobra.ShellCompDirectiveNoFileComp
+		return c.doCompleteWorkshopNames(args, status)
 	}
+}
+
+func (c *CmdRoot) completeWorkshopNames(status []string) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return c.doCompleteWorkshopNames(args, status)
+	}
+}
+
+func (c *CmdRoot) doCompleteWorkshopNames(args []string, status []string) ([]string, cobra.ShellCompDirective) {
+	cli, err := c.client()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	project, err := cli.Project(c.project)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	workshopInfo, _, err := cli.List(&client.ListOptions{ProjectId: project.Id})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	desiredStatus := func(s string) bool {
+		if status == nil {
+			return true
+		}
+		return slices.Contains(status, s)
+	}
+
+	var workshops []string
+	for _, workshop := range workshopInfo {
+		if desiredStatus(workshop.Status) && !slices.Contains(args, workshop.Name) {
+			workshops = append(workshops, workshop.Name)
+		}
+	}
+	return workshops, cobra.ShellCompDirectiveNoFileComp
 }
 
 var (

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -86,7 +86,7 @@ func (c *CmdRoot) preRun(cmd *cobra.Command, args []string) error {
 }
 
 func (c *CmdRoot) postRun(cmd *cobra.Command, args []string) {
-	if c.cli != nil {
+	if c.cli != nil && cmd.Name() != cobra.ShellCompRequestCmd {
 		maybePresentWarnings(c.cli.WarningsSummary())
 	}
 }

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -110,16 +110,19 @@ func (c *CmdRoot) completeWorkshopNames(status []string) cobra.CompletionFunc {
 func (c *CmdRoot) doCompleteWorkshopNames(args []string, status []string) ([]string, cobra.ShellCompDirective) {
 	cli, err := c.client()
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	project, err := cli.Project(c.project)
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	workshopInfo, _, err := cli.List(&client.ListOptions{ProjectId: project.Id})
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -14,11 +14,12 @@ import (
 )
 
 type CmdRoot struct {
-	cli     *client.Client
-	project string
+	cwd string
+	cli *client.Client
+	prj string
 }
 
-func (c *CmdRoot) Command(cwd string) *cobra.Command {
+func (c *CmdRoot) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "workshop",
 		// Avoid printing errors twice
@@ -26,7 +27,6 @@ func (c *CmdRoot) Command(cwd string) *cobra.Command {
 		SilenceUsage:     true,
 		TraverseChildren: true,
 
-		PersistentPreRunE: c.preRun,
 		PersistentPostRun: c.postRun,
 	}
 
@@ -53,7 +53,7 @@ func (c *CmdRoot) Command(cwd string) *cobra.Command {
 	cmd.AddCommand((&CmdSketches{root: c}).Command())
 	cmd.AddCommand((&CmdDocs{root: c}).Command())
 
-	cmd.PersistentFlags().StringVarP(&c.project, "project", "p", cwd, "Specify the project's directory path.")
+	cmd.PersistentFlags().StringVarP(&c.prj, "project", "p", c.cwd, "Specify the project's directory path.")
 	cmd.PersistentFlags().BoolP("help", "h", false, "Print the help message for the command.")
 
 	cmd.DisableAutoGenTag = true
@@ -76,13 +76,19 @@ func (c *CmdRoot) client() (*client.Client, error) {
 	return cli, err
 }
 
-func (c *CmdRoot) preRun(cmd *cobra.Command, args []string) error {
-	project, err := filepath.Abs(c.project)
-	if err != nil {
-		return err
+func (c *CmdRoot) project() string {
+	if c.cwd == "" {
+		return c.prj
 	}
-	c.project = project
-	return nil
+	// Avoid filepath.Abs because it returns an error.
+	return abs(c.cwd, c.prj)
+}
+
+func abs(cwd, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(cwd, path)
 }
 
 func (c *CmdRoot) postRun(cmd *cobra.Command, args []string) {
@@ -114,7 +120,7 @@ func (c *CmdRoot) doCompleteWorkshopNames(args []string, status []string) ([]str
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	project, err := cli.Project(c.project)
+	project, err := cli.Project(c.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -107,7 +107,7 @@ func (s *rootSuite) TestWorkshopNameCompletion(c *check.C) {
 		Workshops: wsInfo,
 	}
 
-	cmd := &CmdRoot{}
+	cmd := &CmdRoot{cwd: s.prjDir}
 
 	s.listRedirectHelper(c, w, s.prjId, s.prjDir, len(statuses)*8)
 
@@ -115,22 +115,22 @@ func (s *rootSuite) TestWorkshopNameCompletion(c *check.C) {
 		single := cmd.completeWorkshopName([]string{st})
 		multiple := cmd.completeWorkshopNames([]string{st})
 
-		result, compDirective := single(cmd.Command(s.prjDir), nil, "")
+		result, compDirective := single(cmd.Command(), nil, "")
 		c.Check(result, check.DeepEquals, expected[st])
 		c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 
 		if len(expected[st]) > 0 {
-			result, compDirective = single(cmd.Command(s.prjDir), expected[st][:1], "")
+			result, compDirective = single(cmd.Command(), expected[st][:1], "")
 			c.Check(result, check.HasLen, 0)
 			c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 		}
 
-		result, compDirective = multiple(cmd.Command(s.prjDir), nil, "")
+		result, compDirective = multiple(cmd.Command(), nil, "")
 		c.Check(result, check.DeepEquals, expected[st])
 		c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 
 		if len(expected[st]) > 0 {
-			result, compDirective = multiple(cmd.Command(s.prjDir), expected[st][:1], "")
+			result, compDirective = multiple(cmd.Command(), expected[st][:1], "")
 			rest := expected[st][1:]
 			if len(rest) == 0 {
 				rest = nil

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -72,16 +72,27 @@ func (s *BaseWorkshopSuite) Stderr() string {
 	return s.stderr.String()
 }
 
-func (s *BaseWorkshopSuite) TestWorkshopInfoList(c *check.C) {
-	prjId := "42424242"
-	prjDir := c.MkDir()
+type rootSuite struct {
+	BaseWorkshopSuite
+	prjDir string
+	prjId  string
+}
 
+var _ = check.Suite(&rootSuite{})
+
+func (s *rootSuite) SetUpTest(c *check.C) {
+	s.prjDir = c.MkDir()
+	s.prjId = "42424242"
+	s.BaseWorkshopSuite.SetUpTest(c)
+}
+
+func (s *rootSuite) TestWorkshopNameCompletion(c *check.C) {
 	statuses := []string{"Ready", "Pending", "Waiting", "Stopped", "Error"}
 	expected := make(map[string][]string)
 
 	var wsInfo []*client.WorkshopInfo
 	for i := range 20 {
-		index := rand.Intn(len(statuses) - 1)
+		index := rand.Intn(len(statuses))
 		status := statuses[index]
 		info := &client.WorkshopInfo{
 			ProjectId: "42424242",
@@ -98,12 +109,35 @@ func (s *BaseWorkshopSuite) TestWorkshopInfoList(c *check.C) {
 
 	cmd := &CmdRoot{}
 
-	s.listRedirectHelper(c, w, prjId, prjDir, len(statuses)*2)
+	s.listRedirectHelper(c, w, s.prjId, s.prjDir, len(statuses)*8)
 
 	for _, st := range statuses {
-		result, compDirective := cmd.completeWorkshopName([]string{st})(cmd.Command(prjDir), nil, "")
+		single := cmd.completeWorkshopName([]string{st})
+		multiple := cmd.completeWorkshopNames([]string{st})
+
+		result, compDirective := single(cmd.Command(s.prjDir), nil, "")
 		c.Check(result, check.DeepEquals, expected[st])
 		c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+
+		if len(expected[st]) > 0 {
+			result, compDirective = single(cmd.Command(s.prjDir), expected[st][:1], "")
+			c.Check(result, check.HasLen, 0)
+			c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+		}
+
+		result, compDirective = multiple(cmd.Command(s.prjDir), nil, "")
+		c.Check(result, check.DeepEquals, expected[st])
+		c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+
+		if len(expected[st]) > 0 {
+			result, compDirective = multiple(cmd.Command(s.prjDir), expected[st][:1], "")
+			rest := expected[st][1:]
+			if len(rest) == 0 {
+				rest = nil
+			}
+			c.Check(result, check.DeepEquals, rest)
+			c.Check(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+		}
 	}
 }
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -195,7 +195,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	if err != nil {
 		return err
 	}
-	p, err := cli.Project(c.root.project)
+	p, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}
@@ -405,7 +405,7 @@ func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintf(w, "Project\tWorkshop\tRev\tNotes\n")
 	}
 
-	p, err := cli.Project(c.root.project)
+	p, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -43,7 +43,7 @@ $ workshop start nimble jazzy
 The name is optional if the project has only one workshop:
 $ workshop start`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Stopped"}),
+		ValidArgsFunction: c.root.completeWorkshopNames([]string{"Stopped"}),
 	}
 
 	return cmd

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -59,7 +59,7 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 
 	c.skipAbort = true
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -59,7 +59,7 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 
 	c.skipAbort = true
 
-	project, err := cli.Project(c.root.project)
+	project, err := cli.Project(c.root.project())
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -43,7 +43,7 @@ $ workshop stop nimble jazzy
 The name is optional if the project has only one workshop:
 $ workshop stop`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready"}),
+		ValidArgsFunction: c.root.completeWorkshopNames([]string{"Ready"}),
 	}
 
 	return cmd

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -120,17 +120,17 @@ func (c *CmdTasks) complete(cmd *cobra.Command, args []string, toComplete string
 	}
 
 	cli, err := c.root.client()
-
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
 	changesCmd := CmdChanges{
 		root: c.root,
 	}
-
 	changes, err := changesCmd.changes(cli)
 	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
 	}
 


### PR DESCRIPTION
# Description

Adds shell completion for shell, run and scripts. The run implementation requires an ugly workaround for https://github.com/spf13/cobra/issues/1877. I also found a slightly better workaround here: https://github.com/spf13/cobra/pull/2259.

Fixes a few other issues:
- Some commands were completing multiple workshop names despite only accepting one.
- Completion was previously able to print the "new warnings" message.
- Completion didn't work if the command had a relative `--project` path.

Errors during completion can be debugged more easily by setting `BASH_COMP_DEBUG_FILE=/tmp/err.log`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
