### PR TITLE
Improve refresh performance with snapshots

### DIFF
--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -114,7 +114,6 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	if err != nil {
 		return err
 	}
-	slices.SortFunc(workshop.Sdks, func(a, b *client.Sdk) int { return cmp.Compare(a.Name, b.Name) })
 
 	w := tabWriter()
 	fmt.Fprintf(w, "name:\t%s\n", workshop.Name)
@@ -142,39 +141,26 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 
 	if len(workshop.Sdks) > 0 {
 		fmt.Fprintf(w, "sdks:\n")
-
-		var tunnels []*client.Tunnel
-		for _, sk := range workshop.Sdks {
-			if sk.Tunnels == nil {
-				continue
-			}
-			tunnels = append(tunnels, sk.Tunnels.Slots...)
-		}
-		if len(tunnels) > 0 {
-			fmt.Fprintf(w, "  system:\n")
-			fmt.Fprintf(w, "    tunnels:\n")
-
-			slices.SortFunc(tunnels, func(a, b *client.Tunnel) int {
-				return cmp.Compare(a.Plug.Name, b.Plug.Name)
-			})
-			for _, tunnel := range tunnels {
-				fmt.Fprintf(w, "      %s:\n", tunnel.Plug.Name)
-				fmt.Fprintf(w, "        from:\t%s\n", formatEndpoint(tunnel.From))
-				fmt.Fprintf(w, "        to:\t%s\n", formatEndpoint(tunnel.To))
-			}
-		}
-
 		for _, sk := range workshop.Sdks {
 			fmt.Fprintf(w, "  %s:\n", sk.Name)
-			if sk.Name == sdk.Sketch {
+
+			switch sk.Name {
+			case sdk.Sketch:
 				sk.Channel = sketchSdkChannel(project.Id, workshop.Name)
 				if sk.BuildTime.IsZero() {
 					sk.BuildTime = sk.InstallTime
 				}
-			} else if sk.Channel == "" {
-				sk.Channel = "~"
+			default:
+				if sk.Channel == "" {
+					sk.Channel = "~"
+				}
 			}
-			fmt.Fprintf(w, "    tracking:\t%s\n", sk.Channel)
+
+			// Tracking info is always the same for the system SDK. Omit it to
+			// highlight the difference between it and a regular type SDK.
+			if sk.Name != sdk.System.String() {
+				fmt.Fprintf(w, "    tracking:\t%s\n", sk.Channel)
+			}
 
 			var buildTime string
 			if !sk.BuildTime.IsZero() {

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -270,68 +270,135 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkMountsXdgSet(c *check.C) {
 	c.Check(n, check.Equals, 2)
 }
 
-var mockWorkshopWithTunnels = `{"type":"sync","status-code":200,"status":"OK","result":{
-    "name":"ws",
-    "base":"ubuntu@22.04",
-    "project-id":"42424242",
-    "status":"Ready",
-    "sdks":[{
-        "name":"go",
-        "version":"1.8.0",
-        "channel":"latest/edge",
-        "revision":"1",
-        "build-time":"2017-02-19T17:23:05.592623Z",
-        "install-time":"2017-03-22T09:01:00.0Z",
-        "tunnels":{
-            "plugs":[{
-                "plug":{
-                    "project-id":"42ws42ws",
-                    "workshop":"ws",
-                    "sdk":"go",
-                    "plug":"snap-cache"
-                },
-                "slot":{
-                    "project-id":"42ws42ws",
-                    "workshop":"ws",
-                    "sdk":"system",
-                    "slot":"snap-cache"
-                },
-                "from":{
-                    "protocol":"tcp",
-                    "host":"0.0.0.0",
-                    "port":12345
-                },
-                "to":{
-                    "protocol":"unix",
-                    "path":"/run/snap-proxy.socket"
-                }
-            }],
-            "slots":[{
-                "plug":{
-                    "project-id":"42ws42ws",
-                    "workshop":"ws",
-                    "sdk":"system",
-                    "plug":"gopls"
-                },
-                "slot":{
-                    "project-id":"42ws42ws",
-                    "workshop":"ws",
-                    "sdk":"go",
-                    "slot":"gopls"
-                },
-                "from":{
-                    "protocol":"tcp",
-                    "host":"127.0.0.1",
-                    "port":60915
-                },
-                "to":{
-                    "protocol":"unix",
-                    "path":"/run/user/%s/gopls.socket"
-                }
-            }]
+var mockWorkshopWithTunnels = `{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+    "name": "ws",
+    "base": "ubuntu@22.04",
+    "project-id": "42424242",
+    "status": "Ready",
+    "sdks": [
+      {
+        "name": "system",
+        "revision": "x1",
+        "tunnels": {
+          "plugs": [
+            {
+              "plug": {
+                "project-id": "42ws42ws",
+                "workshop": "ws",
+                "sdk": "system",
+                "plug": "gopls"
+              },
+              "slot": {
+                "project-id": "42ws42ws",
+                "workshop": "ws",
+                "sdk": "go",
+                "slot": "gopls"
+              },
+              "from": {
+                "protocol": "tcp",
+                "host": "127.0.0.1",
+                "port": 60915
+              },
+              "to": {
+                "protocol": "unix",
+                "path": "/run/user/%s/gopls.socket"
+              }
+            }
+          ],
+          "slots": [
+            {
+              "plug": {
+                "project-id": "42ws42ws",
+                "workshop": "ws",
+                "sdk": "go",
+                "plug": "snap-cache"
+              },
+              "slot": {
+                "project-id": "42ws42ws",
+                "workshop": "ws",
+                "sdk": "system",
+                "slot": "snap-cache"
+              },
+              "from": {
+                "protocol": "tcp",
+                "host": "0.0.0.0",
+                "port": 12345
+              },
+              "to": {
+                "protocol": "unix",
+                "path": "/run/snap-proxy.socket"
+              }
+            }
+          ]
         }
-    }]
-}}`
+      },
+      {
+        "name": "go",
+        "version": "1.8.0",
+        "channel": "latest/edge",
+        "revision": "1",
+        "build-time": "2017-02-19T17:23:05.592623Z",
+        "install-time": "2017-03-22T09:01:00.0Z",
+        "tunnels": {
+          "plugs": [
+            {
+              "plug": {
+                "project-id": "42ws42ws",
+                "workshop": "ws",
+                "sdk": "go",
+                "plug": "snap-cache"
+              },
+              "slot": {
+                "project-id": "42ws42ws",
+                "workshop": "ws",
+                "sdk": "system",
+                "slot": "snap-cache"
+              },
+              "from": {
+                "protocol": "tcp",
+                "host": "0.0.0.0",
+                "port": 12345
+              },
+              "to": {
+                "protocol": "unix",
+                "path": "/run/snap-proxy.socket"
+              }
+            }
+          ],
+          "slots": [
+            {
+              "plug": {
+                "project-id": "42ws42ws",
+                "workshop": "ws",
+                "sdk": "system",
+                "plug": "gopls"
+              },
+              "slot": {
+                "project-id": "42ws42ws",
+                "workshop": "ws",
+                "sdk": "go",
+                "slot": "gopls"
+              },
+              "from": {
+                "protocol": "tcp",
+                "host": "127.0.0.1",
+                "port": 60915
+              },
+              "to": {
+                "protocol": "unix",
+                "path": "/run/user/%s/gopls.socket"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`
 
 func (m *workshopInfo) TestWorkshopInfoWithSdkTunnels(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}
@@ -368,6 +435,7 @@ status:   ready
 notes:    -
 sdks:
   system:
+    installed:  \(x1\)
     tunnels:
       gopls:
         from:  127.0.0.1:60915/tcp

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -100,7 +100,7 @@ func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop
 
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
 	wf := s.workshopFile(w, []*sdk.Info{info})
-	c.Assert(s.b.LaunchWorkshop(s.ctx, wf), check.IsNil)
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf), check.IsNil)
 
 	wp, err := s.b.Workshop(s.ctx, w)
 	c.Check(err, check.IsNil)
@@ -126,7 +126,7 @@ func (s *apiSuite) mockInstalledSDKBoundPlug(c *check.C, yaml string, w string, 
 		Name:      to}
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
 	wf := s.workshopFile(w, []*sdk.Info{info})
-	c.Assert(s.b.LaunchWorkshop(s.ctx, wf), check.IsNil)
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf), check.IsNil)
 	wp, err := s.b.Workshop(s.ctx, w)
 	c.Check(err, check.IsNil)
 	return wp

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -27,7 +27,7 @@ func (s *apiSuite) setupExec(c *check.C) *Command {
 
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Scripts: map[string]workshop.Script{"lint": "\n\n\ngolangci-lint run\n"}}
 
-	err := s.b.LaunchWorkshop(s.ctx, wf)
+	err := s.b.LaunchOrRebuildWorkshop(s.ctx, wf)
 	c.Assert(err, check.IsNil)
 
 	wp, err := s.b.Workshop(s.ctx, "ws")

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -225,9 +225,6 @@ func tunnels(conns *connectionsJSON) (map[string]*TunnelInfo, error) {
 		}
 
 		sk := conn.Plug.Sdk
-		if sdk.IsSystem(sk) {
-			sk = conn.Slot.Sdk
-		}
 		info, ok := tunnels[sk]
 		if !ok {
 			info = &TunnelInfo{}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -119,19 +119,21 @@ func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo 
 	return &ws
 }
 
-func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health healthstate.HealthState) *WorkshopInfo {
+func workshopToInfo(ctx context.Context, w *workshop.Workshop, health healthstate.HealthState) (*WorkshopInfo, error) {
 	var info WorkshopInfo
 	info.Name = w.Name
 	info.ProjectId = w.Project.ProjectId
 	info.Base = w.Base
 
+	sdks, err := w.SdkInfosByInstallOrder(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	mnts := w.Mounts(sdks)
 
-	for _, sk := range w.Sdks {
-		sdkInfo := sdks[sk.Name]
-		if sdkInfo == nil {
-			sdkInfo = &sdk.Info{}
-		}
+	for _, sk := range sdks {
+		sdkInfo := sk
 
 		var healthInfo *HealthCheckInfo
 		if sdkHealth, ok := health.SdkHealth[sk.Name]; ok {
@@ -151,7 +153,7 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 			Channel:     sk.Channel,
 			Revision:    sk.Revision.String(),
 			BuildTime:   sdkInfo.BuildTime,
-			InstallTime: sk.InstallTime,
+			InstallTime: w.Sdks[sk.Name].InstallTime,
 			Health:      healthInfo,
 			Mounts:      mntInfos,
 		})
@@ -162,7 +164,7 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 	}
 	info.Status = health.Status.String()
 
-	return &info
+	return &info, nil
 }
 
 func mountInfos(sk sdk.Ref, mnts []workshop.Mount) []*Mount {
@@ -381,10 +383,14 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 
 	info := Workshops{}
 	info.Workshops = make([]*WorkshopInfo, 0, len(workshops))
+	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
 	for _, w := range workshops {
 		health := healthstate.WorkshopHealth(state, w)
 		if ignoreStatus || health.Status == status {
-			wi := workshopToInfo(w, nil, health)
+			wi, err := workshopToInfo(ctx, w, health)
+			if err != nil {
+				return statusBadRequest("%w", err)
+			}
 			info.Workshops = append(info.Workshops, wi)
 		}
 	}
@@ -590,11 +596,11 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	health := healthstate.WorkshopHealth(state, w)
 
 	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
-	sdks, err := w.SdkInfos(ctx)
+
+	info, err := workshopToInfo(ctx, w, health)
 	if err != nil {
 		return statusBadRequest("%w", err)
 	}
-	info := workshopToInfo(w, sdks, health)
 
 	ts, err := tunnels(conns)
 	if err != nil {

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -465,7 +465,7 @@ func refresh(ctx context.Context, st *state.State, mgr *workshopstate.WorkshopMa
 		if sk != sdk.Sketch {
 			return change, taskset, fmt.Errorf(`partial refresh is supported only for "sketch" SDK`)
 		}
-		taskset, err = mgr.RefreshLocalSdk(ctx, pid, wp, sk)
+		taskset, err = mgr.RefreshMany(ctx, pid, []string{wp})
 	} else {
 		change = newWorkshopChange(st, "refresh", user, pid, reqData.Action, reqData.Names)
 		taskset, err = mgr.RefreshMany(ctx, pid, reqData.Names)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -121,7 +121,7 @@ func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo 
 
 // Returns essential workshop properties and its SDKs health statuses (if
 // available).
-func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) (*WorkshopInfo, error) {
+func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) *WorkshopInfo {
 	var info WorkshopInfo
 	info.Name = w.Name
 	info.ProjectId = w.Project.ProjectId
@@ -152,7 +152,7 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) (*Work
 		info.Notes = append(info.Notes, health.Code)
 	}
 	info.Status = health.Status.String()
-	return &info, nil
+	return &info
 }
 
 // Returns essential workshop properties, SDK health statuses (if available) and
@@ -421,10 +421,7 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	for _, w := range workshops {
 		health := healthstate.WorkshopHealth(state, w)
 		if ignoreStatus || health.Status == status {
-			wi, err := workshopToInfo(w, health)
-			if err != nil {
-				return statusBadRequest("%w", err)
-			}
+			wi := workshopToInfo(w, health)
 			info.Workshops = append(info.Workshops, wi)
 		}
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -162,25 +161,6 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 		info.Notes = append(info.Notes, health.Code)
 	}
 	info.Status = health.Status.String()
-
-	// Sort the SDKs in installation order.
-	orderMap := make(map[string]int)
-	for i, v := range w.File.Sdks {
-		// Ignore the order of the system SDK from the definion (if exists).
-		if sdk.IsSystem(v.Name) {
-			continue
-		}
-		orderMap[v.Name] = i
-	}
-	sort.Slice(info.Sdks, func(i, j int) bool {
-		// system SDK is always first. Note: it may or may not present in the
-		// original file in an arbitrary order, but it will always be in the
-		// list of installed SDKs.
-		if sdk.IsSystem(info.Sdks[i].Name) || sdk.IsSystem(info.Sdks[j].Name) {
-			return true
-		}
-		return orderMap[info.Sdks[i].Name] < orderMap[info.Sdks[j].Name]
-	})
 
 	return &info
 }

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -133,8 +133,6 @@ func workshopToInfo(ctx context.Context, w *workshop.Workshop, health healthstat
 	mnts := w.Mounts(sdks)
 
 	for _, sk := range sdks {
-		sdkInfo := sk
-
 		var healthInfo *HealthCheckInfo
 		if sdkHealth, ok := health.SdkHealth[sk.Name]; ok {
 			healthInfo = &HealthCheckInfo{
@@ -149,10 +147,10 @@ func workshopToInfo(ctx context.Context, w *workshop.Workshop, health healthstat
 
 		info.Sdks = append(info.Sdks, &SdkInfo{
 			Name:        sk.Name,
-			Version:     sdkInfo.Version,
+			Version:     sk.Version,
 			Channel:     sk.Channel,
 			Revision:    sk.Revision.String(),
-			BuildTime:   sdkInfo.BuildTime,
+			BuildTime:   sk.BuildTime,
 			InstallTime: w.Sdks[sk.Name].InstallTime,
 			Health:      healthInfo,
 			Mounts:      mntInfos,

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -162,6 +163,25 @@ func workshopToInfo(w *workshop.Workshop, sdks map[string]*sdk.Info, health heal
 	}
 	info.Status = health.Status.String()
 
+	// Sort the SDKs in installation order.
+	orderMap := make(map[string]int)
+	for i, v := range w.File.Sdks {
+		// Ignore the order of the system SDK from the definion (if exists).
+		if sdk.IsSystem(v.Name) {
+			continue
+		}
+		orderMap[v.Name] = i
+	}
+	sort.Slice(info.Sdks, func(i, j int) bool {
+		// system SDK is always first. Note: it may or may not present in the
+		// original file in an arbitrary order, but it will always be in the
+		// list of installed SDKs.
+		if sdk.IsSystem(info.Sdks[i].Name) || sdk.IsSystem(info.Sdks[j].Name) {
+			return true
+		}
+		return orderMap[info.Sdks[i].Name] < orderMap[info.Sdks[j].Name]
+	})
+
 	return &info
 }
 
@@ -223,7 +243,7 @@ func tunnels(conns *connectionsJSON) (map[string]*TunnelInfo, error) {
 		}
 
 		sk := conn.Plug.Sdk
-		if sk == sdk.System.String() {
+		if sdk.IsSystem(sk) {
 			sk = conn.Slot.Sdk
 		}
 		info, ok := tunnels[sk]
@@ -389,11 +409,10 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 		}
 	}
 
-	// If the client queried everything available,
-	// we add workshop files to the response.
-	// Some of these may only exist as files, not instances.
-	// The "available" query is a best-effort version of "all":
-	// if something is wrong with the files we still return the instances.
+	// If the client queried everything available, we add workshop files to the
+	// response. Some of these may only exist as files, not instances. The
+	// "available" query is a best-effort version of "all": if something is
+	// wrong with the files we still return the instances.
 	if ignoreStatus {
 		files, err := wrkmgr.WorkshopFiles(r.Context(), projectId)
 		var fileErr *workshopstate.WorkshopFileError

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -119,7 +119,47 @@ func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo 
 	return &ws
 }
 
-func workshopToInfo(ctx context.Context, w *workshop.Workshop, health healthstate.HealthState) (*WorkshopInfo, error) {
+// Returns essential workshop properties and its SDKs health statuses (if
+// available).
+func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) (*WorkshopInfo, error) {
+	var info WorkshopInfo
+	info.Name = w.Name
+	info.ProjectId = w.Project.ProjectId
+	info.Base = w.Base
+
+	sdkSetups := w.SdksByInstallOrder()
+
+	for _, sk := range sdkSetups {
+		var healthInfo *HealthCheckInfo
+		if sdkHealth, ok := health.SdkHealth[sk.Name]; ok {
+			healthInfo = &HealthCheckInfo{
+				Timestamp: sdkHealth.Timestamp,
+				Message:   sdkHealth.Message,
+				Code:      sdkHealth.Code,
+			}
+		}
+
+		info.Sdks = append(info.Sdks, &SdkInfo{
+			Name:        sk.Name,
+			Channel:     sk.Channel,
+			Revision:    sk.Revision.String(),
+			InstallTime: sk.InstallTime,
+			Health:      healthInfo,
+		})
+	}
+
+	if len(health.Code) > 0 {
+		info.Notes = append(info.Notes, health.Code)
+	}
+	info.Status = health.Status.String()
+	return &info, nil
+}
+
+// Returns essential workshop properties, SDK health statuses (if available) and
+// information about the installed SDKs. This function reads from the workshop's
+// filesystem to obtain certain fields, it has to be used with possible latency
+// changes in mind.
+func workshopToInfoFull(ctx context.Context, w *workshop.Workshop, health healthstate.HealthState) (*WorkshopInfo, error) {
 	var info WorkshopInfo
 	info.Name = w.Name
 	info.ProjectId = w.Project.ProjectId
@@ -378,11 +418,10 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 
 	info := Workshops{}
 	info.Workshops = make([]*WorkshopInfo, 0, len(workshops))
-	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
 	for _, w := range workshops {
 		health := healthstate.WorkshopHealth(state, w)
 		if ignoreStatus || health.Status == status {
-			wi, err := workshopToInfo(ctx, w, health)
+			wi, err := workshopToInfo(w, health)
 			if err != nil {
 				return statusBadRequest("%w", err)
 			}
@@ -592,7 +631,7 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 
 	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
 
-	info, err := workshopToInfo(ctx, w, health)
+	info, err := workshopToInfoFull(ctx, w, health)
 	if err != nil {
 		return statusBadRequest("%w", err)
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -418,8 +418,9 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
-	// for DeepEqual to work correctly
-	install1 := s.installTime
+
+	install1 := time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
+	build1 := time.Date(2020, 4, 22, 19, 12, 7, 903032000, time.UTC)
 	info := rsp.Result.(Workshops)
 
 	c.Check(info.Workshops, testutil.DeepUnsortedMatches, []*WorkshopInfo{{
@@ -436,11 +437,12 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 			{
 				Name:        "test-sdk",
 				Channel:     "latest/stable",
+				Version:     "0.1.2",
 				Revision:    "1",
 				InstallTime: &install1,
+				BuildTime:   &build1,
 			},
 		},
-		Notes: nil,
 	}, {
 		Name:      "basic",
 		Base:      "ubuntu@22.04",

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -143,6 +143,17 @@ sdks:
 base: ubuntu@22.04
 `
 
+	manysdks_extended = `name: manysdks
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-3
+    channel: latest/stable
+  - name: test-sdk-2
+    channel: latest/stable
+  - name: test-sdk
+    channel: latest/stable
+`
+
 	workshoptunnels = `name: tunnels
 base: ubuntu@22.04
 sdks:
@@ -358,6 +369,16 @@ slots:
     workshop-source: /mnt
     interface: mount
 `
+
+	testsdk3 = `
+name: test-sdk-3
+title: title
+base: ubuntu@20.04
+version: '20200401.3f3a63f'
+summary: summary
+description: SDK
+sdkcraft-started-at: '2020-05-03T22:05:35.811829Z'
+`
 )
 
 type testSdk struct {
@@ -368,6 +389,7 @@ type testSdk struct {
 var apiSuiteSdks = map[string]testSdk{
 	"test-sdk":   {s: sdk.Setup{Name: "test-sdk", Revision: sdk.R(1)}, meta: testsdk},
 	"test-sdk-2": {s: sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(1)}, meta: testsdk2},
+	"test-sdk-3": {s: sdk.Setup{Name: "test-sdk-3", Revision: sdk.R(1)}, meta: testsdk3},
 }
 
 func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string, sdks map[string]testSdk) {
@@ -1594,6 +1616,87 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic_refreshed})
+}
+
+func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.createWFile(c, "manysdks", manysdks_extended)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: "test-sdk-3", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+		},
+		plugs: []string{
+			"test-sdk:data",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
+		},
+		slots: []string{
+			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+
+	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+		"test-sdk-3",
+		"test-sdk-2",
+		"test-sdk",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_extended})
 }
 
 func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -122,6 +122,15 @@ sdks:
     channel: latest/stable
 `
 
+	manysdks_newbase = `name: manysdks
+base: ubuntu@24.04
+sdks:
+  - name: test-sdk
+    channel: latest/stable
+  - name: test-sdk-2
+    channel: latest/stable
+`
+
 	workshoptunnels = `name: tunnels
 base: ubuntu@22.04
 sdks:
@@ -2137,6 +2146,87 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks})
+}
+
+func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer func() { _ = s.d.Overlord().Stop() }()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	s.mockSdkVolumes(c, apiSuiteSdks)
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.createWFile(c, "manysdks", manysdks_newbase)
+
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@24.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+		},
+		plugs: []string{
+			"test-sdk:data",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
+		},
+		slots: []string{
+			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+
+	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
 }
 
 func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -442,7 +442,6 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	install1 := time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
-	build1 := time.Date(2020, 4, 22, 19, 12, 7, 903032000, time.UTC)
 	info := rsp.Result.(Workshops)
 
 	c.Check(info.Workshops, testutil.DeepUnsortedMatches, []*WorkshopInfo{{
@@ -459,10 +458,8 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 			{
 				Name:        "test-sdk",
 				Channel:     "latest/stable",
-				Version:     "0.1.2",
 				Revision:    "1",
 				InstallTime: &install1,
-				BuildTime:   &build1,
 			},
 		},
 	}, {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -409,6 +409,11 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 		Status:    "Ready",
 		Sdks: []*SdkInfo{
 			{
+				Name:        "system",
+				Revision:    "x1",
+				InstallTime: &install1,
+			},
+			{
 				Name:        "test-sdk",
 				Channel:     "latest/stable",
 				Revision:    "1",
@@ -427,6 +432,11 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 		Base:      "ubuntu@22.04",
 		ProjectId: s.project.ProjectId,
 		Status:    "Ready",
+		Sdks: []*SdkInfo{{
+			Name:        "system",
+			Revision:    "x1",
+			InstallTime: &install1,
+		}},
 	}})
 
 	c.Check(info.Files, testutil.DeepUnsortedMatches, []*WorkshopFileInfo{{
@@ -527,6 +537,11 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 			Status:    "Ready",
 			Notes:     nil,
 			Sdks: []*SdkInfo{
+				{
+					Name:        "system",
+					Revision:    "x1",
+					InstallTime: &install1,
+				},
 				{
 					Name:        "test-sdk",
 					Version:     "0.1.2",
@@ -689,6 +704,11 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 			Notes:     nil,
 			Sdks: []*SdkInfo{
 				{
+					Name:        "system",
+					Revision:    "x1",
+					InstallTime: &install1,
+				},
+				{
 					Name:        "test-sdk",
 					Version:     "0.1.2",
 					Channel:     "latest/stable",
@@ -790,6 +810,7 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 		st := s.d.state
 		st.Lock()
 		change := st.Change(rsp.Change)
+
 		st.Unlock()
 
 		// Verify
@@ -819,13 +840,17 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 					}
 				}
 			}
+			ticker.Stop()
+
+			st.Lock()
 			c.Check(change.Kind(), check.Equals, expected[num].Kind)
 			c.Check(change.Summary(), check.Equals, expected[num].Summary)
-			st.Lock()
-			if expected[num].ChangeErr != "" {
-				c.Check(change.Err(), check.ErrorMatches, expected[num].ChangeErr, check.Commentf("case: %v", num))
+
+			err := change.Err()
+			if err != nil {
+				c.Check(err, check.ErrorMatches, expected[num].ChangeErr, check.Commentf("case: %v", num))
 			} else {
-				c.Assert(change.Err(), check.IsNil)
+				c.Assert(expected[num].ChangeErr, check.Equals, "")
 			}
 			st.Unlock()
 		}
@@ -1396,7 +1421,7 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 
 		c.Assert(w.Sdks, check.HasLen, len(wantws.sdks))
 		for _, sk := range wantws.sdks {
-			c.Assert(sk, check.DeepEquals, w.Sdks[sk.Name])
+			c.Assert(w.Sdks[sk.Name], check.DeepEquals, sk)
 		}
 
 		repo := s.d.overlord.InterfaceManager().Repository()
@@ -1494,6 +1519,7 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -1509,6 +1535,11 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 
@@ -1558,6 +1589,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
 		connections: []string{
@@ -1566,7 +1598,13 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		plugs: []string{
 			"test-sdk:data",
 		},
-		slots: []string{},
+		slots: []string{
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
 	}}
 
 	s.ensureWorskhops(c, want)
@@ -1615,6 +1653,7 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/edge", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -1630,6 +1669,11 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 	s.ensureWorskhops(c, want)
@@ -1691,6 +1735,7 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(2), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -1706,6 +1751,11 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 	s.ensureWorskhops(c, want)
@@ -1752,6 +1802,7 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -1767,6 +1818,11 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 
@@ -1814,6 +1870,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -1831,6 +1888,11 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 
@@ -1878,6 +1940,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -1893,6 +1956,11 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 
@@ -1940,6 +2008,7 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -1955,6 +2024,11 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 
@@ -2004,6 +2078,7 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2019,6 +2094,11 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 
@@ -2541,9 +2621,10 @@ plugs:
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: "sketch", Channel: "", Revision: sdk.R(-2), RevisionSequence: []sdk.Revision{sdk.R(-1)}, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: "sketch", Channel: "", Revision: sdk.R(-2), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/manysdks/sketch:sketch-plug b8639dea/manysdks/system:mount",
@@ -2559,10 +2640,16 @@ plugs:
 		},
 		slots: []string{
 			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
 		},
 	}}
 
 	s.ensureWorskhops(c, want)
+
 }
 
 func (s *apiSuite) TestRefreshPartialConflictChange(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -154,6 +154,18 @@ sdks:
     channel: latest/stable
 `
 
+	manysdks_system_extended = `name: manysdks
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk
+    channel: latest/stable
+  - name: system
+    slots:
+      tunnel:
+        interface: tunnel
+        endpoint: 8080
+`
+
 	workshoptunnels = `name: tunnels
 base: ubuntu@22.04
 sdks:
@@ -1472,7 +1484,7 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 			c.Assert(ref, check.HasLen, 2)
 
 			p := repo.Plug(s.project.ProjectId, wantws.name, ref[0], ref[1])
-			c.Assert(p, check.NotNil)
+			c.Assert(p, check.NotNil, check.Commentf("plug %q is not found in the repository", plug))
 		}
 
 		for _, slot := range wantws.slots {
@@ -1480,7 +1492,7 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 			c.Assert(ref, check.HasLen, 2)
 
 			s := repo.Slot(s.project.ProjectId, wantws.name, ref[0], ref[1])
-			c.Assert(s, check.NotNil)
+			c.Assert(s, check.NotNil, check.Commentf("slot %q is not found in the repository", slot))
 		}
 
 		var allconns []*interfaces.ConnRef
@@ -2093,6 +2105,79 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_plugadded})
+}
+
+func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	s.mockSdkVolumes(c, apiSuiteSdks)
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.createWFile(c, "manysdks", manysdks_system_extended)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
+		},
+		plugs: []string{
+			"test-sdk:data",
+		},
+		slots: []string{
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+			"system:tunnel",
+		},
+	}}
+
+	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+		"system",
+		"test-sdk",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
 }
 
 func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -2091,13 +2091,11 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		"system",
 		"test-sdk",
 		"test-sdk-2",
-		"system",
 		"test-sdk",
 		"test-sdk-2",
 	})
 
-	// Workshop will be fully rebuilt.
-	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
+	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_plugadded})
 }
 
 func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
@@ -2171,13 +2169,11 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		"system",
 		"test-sdk",
 		"test-sdk-2",
-		"system",
 		"test-sdk",
 		"test-sdk-2",
 	})
 
-	// Workshop will be fully rebuilt.
-	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
+	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks})
 }
 
 func (s *apiSuite) TestRefreshNoChanges(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -556,6 +556,33 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 					Name:        "system",
 					Revision:    "x1",
 					InstallTime: &install1,
+					Tunnels: &TunnelInfo{
+						Plugs: []*Tunnel{
+							{
+								Plug: sdk.PlugRef{
+									ProjectId: s.project.ProjectId,
+									Workshop:  "tunnels",
+									Sdk:       "system",
+									Name:      "api",
+								},
+								Slot: sdk.SlotRef{
+									ProjectId: s.project.ProjectId,
+									Workshop:  "tunnels",
+									Sdk:       "test-sdk-2",
+									Name:      "api",
+								},
+								From: Endpoint{
+									Protocol: "tcp",
+									Host:     "0.0.0.0",
+									Port:     8888,
+								},
+								To: Endpoint{
+									Protocol: "unix",
+									Path:     "@testapi",
+								},
+							},
+						},
+					},
 				},
 				{
 					Name:        "test-sdk",
@@ -631,33 +658,6 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 								Workshop:  "tunnels",
 								Sdk:       "test-sdk-2",
 								Name:      "photos2",
-							},
-						},
-					},
-					Tunnels: &TunnelInfo{
-						Slots: []*Tunnel{
-							{
-								Plug: sdk.PlugRef{
-									ProjectId: s.project.ProjectId,
-									Workshop:  "tunnels",
-									Sdk:       "system",
-									Name:      "api",
-								},
-								Slot: sdk.SlotRef{
-									ProjectId: s.project.ProjectId,
-									Workshop:  "tunnels",
-									Sdk:       "test-sdk-2",
-									Name:      "api",
-								},
-								From: Endpoint{
-									Protocol: "tcp",
-									Host:     "0.0.0.0",
-									Port:     8888,
-								},
-								To: Endpoint{
-									Protocol: "unix",
-									Path:     "@testapi",
-								},
 							},
 						},
 					},
@@ -2960,6 +2960,7 @@ plugs:
 		},
 	}
 
+	s.createWFile(c, "manysdks", manysdks_minusone)
 	s.runActionTest(c, requests, expected)
 
 	want := []expectedWorkshop{{
@@ -2968,23 +2969,17 @@ plugs:
 		sdks: []sdk.Setup{
 			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "sketch", Channel: "", Revision: sdk.R(-2), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/manysdks/sketch:sketch-plug b8639dea/manysdks/system:mount",
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
-			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
-			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
 		},
 		plugs: []string{
 			"sketch:sketch-plug",
 			"test-sdk:data",
-			"test-sdk-2:photos",
-			"test-sdk-2:gpu",
 		},
 		slots: []string{
-			"test-sdk-2:data-slot",
 			"system:camera",
 			"system:desktop",
 			"system:gpu",

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
@@ -1477,6 +1478,30 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 	}
 }
 
+func (s *apiSuite) checkSnapshotCalls(c *check.C, name string, sdks []string) {
+	c.Assert(s.b.SnapshotCalls, check.HasLen, len(sdks))
+
+	for i, sk := range sdks {
+		c.Assert(s.b.SnapshotCalls[i].Snapid, check.Equals, workshop.SnapshotId(name, sk))
+		c.Assert(s.b.SnapshotCalls[i].Workshop, check.Equals, name)
+	}
+}
+
+func (s *apiSuite) checkRestoreCalls(c *check.C, name string, sdks []string, files []string) {
+	c.Assert(s.b.RestoreCalls, check.HasLen, len(sdks))
+	c.Assert(s.b.RestoreCalls, check.HasLen, len(files))
+
+	for i, sk := range sdks {
+		c.Assert(s.b.RestoreCalls[i].Snapid, check.Equals, workshop.SnapshotId(name, sk))
+		c.Assert(s.b.RestoreCalls[i].Workshop, check.Equals, name)
+
+		var f workshop.File
+		err := yaml.Unmarshal([]byte(files[i]), &f)
+		c.Assert(err, check.IsNil)
+		c.Assert(s.b.RestoreCalls[i].File, check.DeepEquals, &f)
+	}
+}
+
 func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
@@ -1496,6 +1521,9 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		},
 	}
 	s.runActionTest(c, requests, expected)
+
+	s.checkSnapshotCalls(c, "basic", []string{
+		"system"})
 
 	s.createWFile(c, "basic", basic_refreshed)
 	s.mockSdkVolumes(c, apiSuiteSdks)
@@ -1544,6 +1572,14 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 	}}
 
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "basic", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic_refreshed})
 }
 
 func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
@@ -1608,6 +1644,14 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 	}}
 
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk"}, []string{manysdks_minusone})
 }
 
 func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
@@ -1677,6 +1721,16 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 		},
 	}}
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_newchan})
 }
 
 func updateSdkStoreRev(name string, rev int, meta string) func() {
@@ -1759,6 +1813,16 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 		},
 	}}
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks})
 }
 
 func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
@@ -1827,6 +1891,14 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 	}}
 
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks_connsadded})
 }
 
 func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
@@ -1897,6 +1969,18 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 	}}
 
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	// Workshop will be fully rebuilt.
+	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
 }
 
 func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
@@ -1965,6 +2049,18 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 	}}
 
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	// Workshop will be fully rebuilt.
+	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
 }
 
 func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
@@ -2033,6 +2129,14 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 	}}
 
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks})
 }
 
 func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
@@ -2103,6 +2207,14 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 	}}
 
 	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks_broken})
 }
 
 func (s *apiSuite) TestRefreshNoRefreshInProgress(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -131,6 +131,18 @@ sdks:
     channel: latest/stable
 `
 
+	manysdks_system = `name: manysdks
+base: ubuntu@24.04
+sdks:
+  - name: test-sdk
+    channel: latest/stable
+  - name: system
+`
+
+	manysdks_allremoved = `name: manysdks
+base: ubuntu@22.04
+`
+
 	workshoptunnels = `name: tunnels
 base: ubuntu@22.04
 sdks:
@@ -2227,6 +2239,144 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
+}
+
+func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer func() { _ = s.d.Overlord().Stop() }()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks_system)
+	s.mockSdkVolumes(c, apiSuiteSdks)
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.createWFile(c, "manysdks", manysdks_minusone)
+
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
+		},
+		plugs: []string{
+			"test-sdk:data",
+		},
+		slots: []string{
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+
+	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"system",
+		"test-sdk",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
+}
+
+func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer func() { _ = s.d.Overlord().Stop() }()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	s.mockSdkVolumes(c, apiSuiteSdks)
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.createWFile(c, "manysdks", manysdks_allremoved)
+
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+		},
+		slots: []string{
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+
+	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_allremoved})
 }
 
 func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -865,7 +865,7 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 			if err != nil {
 				c.Check(err, check.ErrorMatches, expected[num].ChangeErr, check.Commentf("case: %v", num))
 			} else {
-				c.Assert(expected[num].ChangeErr, check.Equals, "")
+				c.Check(expected[num].ChangeErr, check.Equals, "")
 			}
 			st.Unlock()
 		}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -401,7 +401,7 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	s.launchWorkshop(c, "manysdks", manysdks, apiSuiteSdks)
+	s.launchWorkshop(c, "manysdks", manysdks_system, apiSuiteSdks)
 	s.launchWorkshop(c, "basic", basic, map[string]testSdk{})
 
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops")
@@ -419,14 +419,12 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
 	// for DeepEqual to work correctly
-	install1, install2 := s.installTime, s.installTime
+	install1 := s.installTime
 	info := rsp.Result.(Workshops)
-	for _, w := range info.Workshops {
-		slices.SortFunc(w.Sdks, func(a, b *SdkInfo) int { return cmp.Compare(a.Name, b.Name) })
-	}
+
 	c.Check(info.Workshops, testutil.DeepUnsortedMatches, []*WorkshopInfo{{
 		Name:      "manysdks",
-		Base:      "ubuntu@22.04",
+		Base:      "ubuntu@24.04",
 		ProjectId: s.project.ProjectId,
 		Status:    "Ready",
 		Sdks: []*SdkInfo{
@@ -440,12 +438,6 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 				Channel:     "latest/stable",
 				Revision:    "1",
 				InstallTime: &install1,
-			},
-			{
-				Name:        "test-sdk-2",
-				Channel:     "latest/stable",
-				Revision:    "1",
-				InstallTime: &install2,
 			},
 		},
 		Notes: nil,
@@ -546,7 +538,6 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 	// for DeepEqual to work correctly
 	install1, install2 := s.installTime, s.installTime
 	result := rsp.Result.(Workshop)
-	slices.SortFunc(result.Sdks, func(a, b *SdkInfo) int { return cmp.Compare(a.Name, b.Name) })
 	for _, c := range result.Sdks {
 		slices.SortFunc(c.Mounts, func(a, b *Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
 	}

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -354,7 +354,7 @@ func (s *healthSuite) TestCheckStatusStopped(c *check.C) {
 func (s *healthSuite) TestExecCheckHealthNotProvided(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.CheckHealth)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -375,7 +375,7 @@ func (s *healthSuite) TestExecCheckHealthNotProvided(c *check.C) {
 func (s *healthSuite) TestExecCheckHealthSetHealthNotCalled(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.CheckHealth)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -399,7 +399,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthNotCalled(c *check.C) {
 func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.CheckHealth)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -457,7 +457,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.CheckHealth)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -523,7 +523,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.CheckHealth)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -589,7 +589,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 func (s *healthSuite) TestExecCheckHealthTimeout(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.CheckHealth)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.CheckHealth)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -116,7 +116,7 @@ var (
 
 func (s *healthSuite) launchWorkshopWithSDKs(c *check.C, sdks []workshop.SdkRecord) *workshop.Workshop {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: sdks}
-	err := s.backend.LaunchWorkshop(s.ctx, wf)
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -49,35 +49,43 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 
 	switch hook.HookType {
 	case SaveState:
-		{
-			fs, err := h.backend.WorkshopFs(ctx, w)
-			if err != nil {
-				return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
-			}
-			err = fs.MkdirAll(hook.Environment["SDK_STATE_DIR"], 0755)
-			fs.Close()
-			if err != nil {
-				return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
-			}
+		fs, err := h.backend.WorkshopFs(ctx, w)
+		if err != nil {
+			return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
 		}
+		err = fs.MkdirAll(hook.Environment["SDK_STATE_DIR"], 0755)
+		fs.Close()
+		if err != nil {
+			return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
+		}
+
 		return h.executeHook(ctx, task, w, prj.ProjectId, &hook)
 	case RestoreState:
-		{
-			fs, err := h.backend.WorkshopFs(ctx, w)
-			if err != nil {
-				return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
-			}
-			info, err := fs.Stat(hook.Environment["SDK_STATE_DIR"])
-			fs.Close()
-			if err != nil {
-				return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
-			}
 
-			if !info.IsDir() {
-				return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: state storage path is not a directory", hook.Sdk)
-			}
+		fs, err := h.backend.WorkshopFs(ctx, w)
+		if err != nil {
+			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
 		}
+		info, err := fs.Stat(hook.Environment["SDK_STATE_DIR"])
+		fs.Close()
+		if err != nil {
+			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
+		}
+
+		if !info.IsDir() {
+			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: state storage path is not a directory", hook.Sdk)
+		}
+
 		return h.executeHook(ctx, task, w, prj.ProjectId, &hook)
+	case SetupBase:
+		if err = h.executeHook(ctx, task, w, prj.ProjectId, &hook); err != nil {
+			return err
+		}
+		if err = h.backend.Snapshot(ctx, w, workshop.SnapshotId(w, hook.Sdk)); err != nil {
+			return err
+		}
+		return nil
+
 	default:
 		return h.executeHook(ctx, task, w, prj.ProjectId, &hook)
 	}

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -81,11 +81,7 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		if err = h.executeHook(ctx, task, w, prj.ProjectId, &hook); err != nil {
 			return err
 		}
-		if err = h.backend.Snapshot(ctx, w, workshop.SnapshotId(w, hook.Sdk)); err != nil {
-			return err
-		}
-		return nil
-
+		return h.backend.Snapshot(ctx, w, workshop.SnapshotId(w, hook.Sdk))
 	default:
 		return h.executeHook(ctx, task, w, prj.ProjectId, &hook)
 	}

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -97,7 +97,7 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 	chg.AddTask(t1)
 
 	// Launch a workshop provinding no hooks
-	err := s.backend.LaunchWorkshop(s.ctx, &workshop.File{Name: "ws", Base: "ubuntu@20.04"})
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, &workshop.File{Name: "ws", Base: "ubuntu@20.04"})
 	c.Check(err, check.IsNil)
 
 	s.state.Unlock()
@@ -501,7 +501,7 @@ func (s *hookSuite) TestHookWithMultipleHandlersIsError(c *check.C) {
 
 func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{{Name: "one", Channel: "latest/stable"}}}
-	err := s.backend.LaunchWorkshop(s.ctx, wf)
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -89,7 +89,7 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	t1 := hookstate.Hook(s.state, "ws", "new", hookstate.SetupBase)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "new", 0, hookstate.SetupBase)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -112,7 +112,7 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 func (s *hookSuite) TestExecSaveState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.SaveState)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.SaveState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -161,7 +161,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.RestoreState)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.RestoreState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -201,7 +201,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.SaveState)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.SaveState)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -245,7 +245,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.HookWithTimeout(s.state, "ws", "one", hookstate.FakeHook, 100*time.Millisecond)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 100*time.Millisecond, hookstate.FakeHook)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -285,7 +285,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 func (s *hookSuite) TestExecEnsureContextHandlerHappyPath(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.FakeHook)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -309,7 +309,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerHappyPath(c *check.C) {
 func (s *hookSuite) TestExecEnsureContextHandlerUnhappyPath(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.FakeHook)
 
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
@@ -345,7 +345,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerUnhappyPath(c *check.C) {
 func (s *hookSuite) TestExecEnsureContextHandlerErrorFails(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.FakeHook)
 	// The context handler will return an error that must be the final error of
 	// the task.
 	s.mockHandler.ErrorError = true
@@ -384,7 +384,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerErrorFails(c *check.C) {
 func (s *hookSuite) TestExecEnsureContextHandlerIgnoresError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.FakeHook)
 	s.mockHandler.IgnoreOriginalErr = true
 
 	chg := s.state.NewChange("sample", "...")
@@ -420,7 +420,7 @@ func (s *hookSuite) TestExecEnsureContextHandlerIgnoresError(c *check.C) {
 func (s *hookSuite) TestHookTaskHandlerBeforeError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.FakeHook)
 	s.mockHandler.BeforeError = true
 
 	chg := s.state.NewChange("sample", "...")
@@ -448,7 +448,7 @@ func (s *hookSuite) TestHookTaskHandlerBeforeError(c *check.C) {
 func (s *hookSuite) TestHookTaskHandlerDoneError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.FakeHook)
 	s.mockHandler.DoneError = true
 
 	chg := s.state.NewChange("sample", "...")
@@ -474,7 +474,7 @@ func (s *hookSuite) TestHookTaskHandlerDoneError(c *check.C) {
 func (s *hookSuite) TestHookWithMultipleHandlersIsError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	t1 := hookstate.Hook(s.state, "ws", "one", hookstate.FakeHook)
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.FakeHook)
 	s.hookmgr.Register(regexp.MustCompile("^fake-*"), func(context *hookstate.Context) hookstate.Handler {
 		return s.mockHandler
 	})

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -29,6 +29,7 @@ type Handler interface {
 type HandlerGenerator func(*Context) Handler
 
 type HookSetup struct {
+	ProjectId   string            `json:"project-id"`
 	Workshop    string            `json:"workshop"`
 	Sdk         string            `json:"sdk"`
 	HookType    WorkshopHookType  `json:"type"`

--- a/internal/overlord/hookstate/request.go
+++ b/internal/overlord/hookstate/request.go
@@ -9,23 +9,12 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 )
 
-func hookSetup(workshop, sdk string, hook WorkshopHookType) HookSetup {
-	setup := HookSetup{HookType: hook, Workshop: workshop, Sdk: sdk, Environment: map[string]string{}}
+func Hook(st *state.State, pid, workshop, sdk string, timeout time.Duration, hook WorkshopHookType) *state.Task {
+	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
+	setup := HookSetup{HookType: hook, ProjectId: pid, Workshop: workshop, Sdk: sdk, Environment: map[string]string{}}
 	if hook == SaveState || hook == RestoreState {
 		setup.Environment["SDK_STATE_DIR"] = filepath.Join(dirs.WorkshopStateDir, "sdk", sdk)
 	}
-	return setup
-}
-
-func Hook(st *state.State, workshop, sdk string, hook WorkshopHookType) *state.Task {
-	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
-	setup_hook.Set("hook-setup", hookSetup(workshop, sdk, hook))
-	return setup_hook
-}
-
-func HookWithTimeout(st *state.State, workshop, sdk string, hook WorkshopHookType, timeout time.Duration) *state.Task {
-	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
-	setup := hookSetup(workshop, sdk, hook)
 	setup.Timeout = timeout
 	setup_hook.Set("hook-setup", &setup)
 	return setup_hook

--- a/internal/overlord/hookstate/request_test.go
+++ b/internal/overlord/hookstate/request_test.go
@@ -8,19 +8,22 @@ import (
 
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
-type S struct {
-	state *state.State
+type hooksRequestSuite struct {
+	state   *state.State
+	project *workshop.Project
 }
 
-var _ = check.Suite(&S{})
+var _ = check.Suite(&hooksRequestSuite{})
 
-func (s *S) SetUpTest(c *check.C) {
+func (s *hooksRequestSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
+	s.project = &workshop.Project{ProjectId: "42424242", Path: c.MkDir()}
 }
 
-func (s *S) TestCreateHook(c *check.C) {
+func (s *hooksRequestSuite) TestCreateHook(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -35,7 +38,7 @@ func (s *S) TestCreateHook(c *check.C) {
 		hookstate.SaveState,
 		hookstate.RestoreState,
 	} {
-		task := hookstate.Hook(s.state, "test", "go", i)
+		task := hookstate.Hook(s.state, s.project.ProjectId, "test", "go", 0, i)
 
 		var hookSetup hookstate.HookSetup
 		err := task.Get("hook-setup", &hookSetup)
@@ -48,10 +51,10 @@ func (s *S) TestCreateHook(c *check.C) {
 	}
 }
 
-func (s *S) TestCreateHookWithTimeout(c *check.C) {
+func (s *hooksRequestSuite) TestCreateHookWithTimeout(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	task := hookstate.HookWithTimeout(s.state, "test", "go", hookstate.CheckHealth, 5*time.Second)
+	task := hookstate.Hook(s.state, s.project.ProjectId, "test", "go", 5*time.Second, hookstate.CheckHealth)
 	var hookSetup hookstate.HookSetup
 	err := task.Get("hook-setup", &hookSetup)
 	c.Assert(err, check.IsNil)

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -924,49 +924,12 @@ func (m *InterfaceManager) doRemoveProfiles(task *state.Task, tomb *tomb.Tomb) e
 		return err
 	}
 
-	if err = m.repo.RemoveSdk(p.ProjectId, w, s); err != nil {
-		return err
-	}
-
 	for _, backend := range m.repo.Backends() {
 		// If there are not plugs or slots declared by the SDK the profile does
 		// not neccessarily exist for the SDK.
 		if err := backend.Remove(ctx, w, s); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
 			return err
 		}
-	}
-	return nil
-}
-
-func (m *InterfaceManager) undoRemoveProfiles(task *state.Task, tomb *tomb.Tomb) error {
-	st := task.State()
-	user, project, w, err := handlersetup.UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
-	defer cancel()
-
-	st.Lock()
-	sdkName, err := handlersetup.Sdk(task)
-	st.Unlock()
-	if err != nil {
-		return err
-	}
-
-	inst, err := m.backend.Workshop(ctx, w)
-	if err != nil {
-		return err
-	}
-
-	sdkInfo, err := inst.SdkInfo(ctx, sdkName)
-	if err != nil {
-		return err
-	}
-
-	if err := m.repo.AddSdk(sdkInfo); err != nil {
-		return err
 	}
 	return nil
 }

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -865,7 +865,6 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a connected mount plug
-	repo := s.mgr.Repository()
 	source := c.MkDir()
 	s.launchRemountWorkshop(c, source)
 
@@ -881,9 +880,6 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
-	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
-
 	var stateConns map[string]interface{}
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 0)

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -156,7 +156,7 @@ func (m *InterfaceManager) StartUp() error {
 					logger.Noticef("Cannot create internal mounts for %q workshop: %v", workshop.Name, err)
 				}
 
-				infos, err := workshop.SdkInfos(pctx)
+				infos, err := workshop.SdkInfosByInstallOrder(pctx)
 				if err != nil {
 					logger.Noticef("Cannot obtain the installed SDKs for %q workshop: %v", workshop.Name, err)
 					continue

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -44,7 +44,7 @@ func New(s *state.State, r *state.TaskRunner) *InterfaceManager {
 	r.AddHandler("discard-conns", m.doDiscard, m.undoDiscard)
 
 	r.AddHandler("setup-profiles", OnDo(m.doSetupProfiles), m.undoSetupProfiles)
-	r.AddHandler("remove-profiles", OnDo(m.doRemoveProfiles), m.undoRemoveProfiles)
+	r.AddHandler("remove-profiles", OnDo(m.doRemoveProfiles), nil)
 
 	// TODO: there is no use for the undo logic as remount is a single task
 	// change that will either finish successfully or fail (in which case it
@@ -156,14 +156,6 @@ func (m *InterfaceManager) StartUp() error {
 					logger.Noticef("Cannot create internal mounts for %q workshop: %v", workshop.Name, err)
 				}
 
-				system, err := workshop.SdkInfo(pctx, sdk.System.String())
-				if err != nil {
-					continue
-				}
-				if err = m.repo.AddSdk(system); err != nil {
-					continue
-				}
-
 				infos, err := workshop.SdkInfos(pctx)
 				if err != nil {
 					logger.Noticef("Cannot obtain the installed SDKs for %q workshop: %v", workshop.Name, err)
@@ -172,7 +164,7 @@ func (m *InterfaceManager) StartUp() error {
 
 				for _, info := range infos {
 					if err = m.repo.AddSdk(info); err != nil {
-						logger.Noticef("Cannot register %q SDK interfaces:%v", info.Name, err)
+						logger.Noticef("Cannot register %q SDK interfaces: %v", info.Name, err)
 						continue
 					}
 				}

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -121,7 +121,7 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	err = yaml.Unmarshal(workshopFile.Bytes(), &wf)
 	c.Assert(err, check.IsNil)
 
-	err = s.wsbackend.LaunchWorkshop(ctx, &wf)
+	err = s.wsbackend.LaunchOrRebuildWorkshop(ctx, &wf)
 	c.Assert(err, check.IsNil)
 
 	wsfs, err := s.wsbackend.WorkshopFs(ctx, ws)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -127,7 +127,7 @@ func (m *SdkManager) doInstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error 
 	}
 }
 
-func (m *SdkManager) undoInstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error {
+func (m *SdkManager) doUninstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -180,7 +180,7 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return m.backend.AttachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision.String()), sdkPath, true)
 }
 
-func (m *SdkManager) undoInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
+func (m *SdkManager) doUinstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -225,9 +225,9 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 
 	st := task.State()
 	rev.Add(func() {
-		if err := wp.UnlinkSdk(ctx, setup.Name); err != nil {
+		if reverr := wp.UnlinkSdk(ctx, setup.Name); reverr != nil {
 			st.Lock()
-			task.Logf("Link SDK cleanup: could not unlink %q SDK: %v", setup.Name, err)
+			task.Logf("Link SDK cleanup: could not unlink %q SDK: %v", setup.Name, reverr)
 			st.Unlock()
 		}
 	})
@@ -254,13 +254,13 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SdkManager) undoLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
+func (m *SdkManager) doUnlinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
 
-	sdkSetup, err := SdkSetup(task)
+	setup, err := SdkSetup(task)
 	if err != nil {
 		return err
 	}
@@ -268,14 +268,18 @@ func (m *SdkManager) undoLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	if err := m.repo.RemoveSdk(project.ProjectId, w, sdkSetup.Name); err != nil {
-		return err
-	}
-
 	wp, err := m.backend.Workshop(ctx, w)
 	if err != nil {
 		return err
 	}
 
-	return wp.UnlinkSdk(ctx, sdkSetup.Name)
+	if err = wp.UnlinkSdk(ctx, setup.Name); err != nil {
+		return err
+	}
+
+	if err = m.repo.RemoveSdk(project.ProjectId, w, setup.Name); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -180,7 +180,7 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return m.backend.AttachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision.String()), sdkPath, true)
 }
 
-func (m *SdkManager) doUnistallSdk(task *state.Task, tomb *tomb.Tomb) error {
+func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -180,7 +180,7 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return m.backend.AttachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision.String()), sdkPath, true)
 }
 
-func (m *SdkManager) doUinstallSdk(task *state.Task, tomb *tomb.Tomb) error {
+func (m *SdkManager) doUnistallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -277,9 +277,5 @@ func (m *SdkManager) doUnlinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	if err = m.repo.RemoveSdk(project.ProjectId, w, setup.Name); err != nil {
-		return err
-	}
-
-	return nil
+	return m.repo.RemoveSdk(project.ProjectId, w, setup.Name)
 }

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -146,7 +146,7 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 		{Name: "test", Channel: "latest/stable"},
 		{Name: "test-broken", Channel: "latest/stable"},
 	}}
-	err = s.backend.LaunchWorkshop(s.ctx, wf)
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, wf)
 	c.Assert(err, check.IsNil)
 }
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -522,7 +522,6 @@ func (s *sdkStateSuite) TestUndoLinkSdkRestorePreviousRev(c *check.C) {
 	setup, ok := wp.Sdks["test"]
 	c.Assert(ok, check.Equals, true)
 	c.Assert(setup.Revision.N, check.Equals, 1)
-	c.Assert(setup.RevisionSequence, check.HasLen, 0)
 
 	fs, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Assert(err, check.IsNil)

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -21,9 +21,12 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	s.Unlock()
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
-	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.undoInstallSdk)
-	runner.AddHandler("install-local-sdk", OnDo(manager.doInstallLocalSdk), manager.undoInstallLocalSdk)
-	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.undoLinkSdk)
+	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.doUinstallSdk)
+	runner.AddHandler("install-local-sdk", OnDo(manager.doInstallLocalSdk), manager.doUninstallLocalSdk)
+	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.doUnlinkSdk)
+	runner.AddHandler("unlink-sdk", OnDo(manager.doUnlinkSdk), manager.doLinkSdk)
+	runner.AddHandler("remove-sdk", OnDo(manager.doUinstallSdk), nil)
+	runner.AddHandler("remove-local-sdk", OnDo(manager.doUninstallLocalSdk), manager.doInstallLocalSdk)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -21,11 +21,11 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	s.Unlock()
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
-	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.doUnistallSdk)
+	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.doUninstallSdk)
 	runner.AddHandler("install-local-sdk", OnDo(manager.doInstallLocalSdk), manager.doUninstallLocalSdk)
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.doUnlinkSdk)
 	runner.AddHandler("unlink-sdk", OnDo(manager.doUnlinkSdk), manager.doLinkSdk)
-	runner.AddHandler("remove-sdk", OnDo(manager.doUnistallSdk), nil)
+	runner.AddHandler("remove-sdk", OnDo(manager.doUninstallSdk), nil)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -26,7 +26,6 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.doUnlinkSdk)
 	runner.AddHandler("unlink-sdk", OnDo(manager.doUnlinkSdk), manager.doLinkSdk)
 	runner.AddHandler("remove-sdk", OnDo(manager.doUnistallSdk), nil)
-	runner.AddHandler("remove-local-sdk", OnDo(manager.doUninstallLocalSdk), manager.doInstallLocalSdk)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -21,11 +21,11 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	s.Unlock()
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
-	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.doUinstallSdk)
+	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.doUnistallSdk)
 	runner.AddHandler("install-local-sdk", OnDo(manager.doInstallLocalSdk), manager.doUninstallLocalSdk)
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.doUnlinkSdk)
 	runner.AddHandler("unlink-sdk", OnDo(manager.doUnlinkSdk), manager.doLinkSdk)
-	runner.AddHandler("remove-sdk", OnDo(manager.doUinstallSdk), nil)
+	runner.AddHandler("remove-sdk", OnDo(manager.doUnistallSdk), nil)
 	runner.AddHandler("remove-local-sdk", OnDo(manager.doUninstallLocalSdk), manager.doInstallLocalSdk)
 
 	return manager

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -25,10 +25,6 @@ func InstallLocalSdk(st *state.State, setup sdk.Setup) *state.TaskSet {
 	return state.NewTaskSet(install, link)
 }
 
-func InstallSystemSdk(st *state.State) *state.TaskSet {
-	return InstallLocalSdk(st, sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}})
-}
-
 func Install(st *state.State, sdk string, retrieveId string) *state.TaskSet {
 	install := st.NewTask("install-sdk", fmt.Sprintf("Install %q SDK", sdk))
 	install.Set("sdk-retrieve-task", retrieveId)

--- a/internal/overlord/workshopstate/export_test.go
+++ b/internal/overlord/workshopstate/export_test.go
@@ -1,8 +1,7 @@
 package workshopstate
 
 var (
-	Refresh            = refresh
-	StartManyImpl      = startMany
-	StopManyImpl       = stopMany
-	CheckHealthTimeout = checkHealthTimeout
+	Refresh       = refresh
+	StartManyImpl = startMany
+	StopManyImpl  = stopMany
 )

--- a/internal/overlord/workshopstate/export_test.go
+++ b/internal/overlord/workshopstate/export_test.go
@@ -2,7 +2,6 @@ package workshopstate
 
 var (
 	Refresh            = refresh
-	CheckHealthHooks   = checkSdksHealth
 	StartManyImpl      = startMany
 	StopManyImpl       = stopMany
 	CheckHealthTimeout = checkHealthTimeout

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -88,7 +88,7 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	rev := revert.New()
 	defer rev.Fail()
 
-	if err = m.backend.LaunchWorkshop(ctx, &wf); err != nil {
+	if err = m.backend.LaunchOrRebuildWorkshop(ctx, &wf); err != nil {
 		return err
 	}
 
@@ -96,8 +96,8 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	rev.Add(func() {
 		cleanupCtx, cancel := context.WithTimeout(cleanupCtx, 30*time.Second)
 		defer cancel()
-		if err1 := m.backend.RemoveWorkshop(cleanupCtx, w); err1 != nil {
-			logger.Noticef("On doCreateWorkshop: cannot remove %q workshop on cleanup: %v", w, err1)
+		if reverr := m.backend.RemoveWorkshop(cleanupCtx, w); reverr != nil {
+			logger.Noticef("On doCreateWorkshop: cannot remove %q workshop on cleanup: %v", w, reverr)
 		}
 	})
 

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -111,21 +111,20 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 		if err = m.backend.LaunchOrRebuildWorkshop(ctx, &wf); err != nil {
 			return err
 		}
+		// Create workshop base and run directories
+		fs, err := m.backend.WorkshopFs(ctx, wf.Name)
+		if err != nil {
+			return err
+		}
+		defer fs.Close()
+
+		if err = fs.MkdirAll(dirs.WorkshopRunDir, 0755); err != nil {
+			return err
+		}
 	} else {
 		if err = m.backend.Restore(ctx, w, workshop.SnapshotId(w, sdkSnapshot), &wf); err != nil {
 			return err
 		}
-	}
-
-	// Create workshop base and run directories
-	fs, err := m.backend.WorkshopFs(ctx, wf.Name)
-	if err != nil {
-		return err
-	}
-	defer fs.Close()
-
-	if err = fs.MkdirAll(dirs.WorkshopRunDir, 0755); err != nil {
-		return err
 	}
 
 	rev.Success()

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -23,7 +23,7 @@ var StopLogInterval = 30 * time.Second
 
 var StopWorkshop = (workshop.Backend).StopWorkshop
 
-func (m *WorkshopManager) undoCreateWorkshop(task *state.Task, tomb *tomb.Tomb) error {
+func (m *WorkshopManager) undoConstructWorkshop(task *state.Task, tomb *tomb.Tomb) error {
 	user, prj, workshop, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -101,9 +101,9 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 		defer cancel()
 
 		// This may fail if the first workshop launch has failed for some
-		// reason; It is safe to ignore the error in that case.
+		// reason; it is safe to ignore the error in that case.
 		if reverr := m.backend.RemoveWorkshop(cleanupCtx, w); reverr != nil {
-			logger.Noticef("On doCreateWorkshop: cannot remove %q workshop on cleanup: %v", w, reverr)
+			logger.Noticef("On doConstructWorkshop: cannot remove %q workshop on cleanup: %v", w, reverr)
 		}
 	})
 

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -65,7 +65,7 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 	return m.backend.Download(ctx, base, reporter)
 }
 
-func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) error {
+func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -80,26 +80,42 @@ func (m *WorkshopManager) doCreateWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	st.Lock()
 	err = task.Get("workshop-file", &wf)
 	st.Unlock()
-
 	if err != nil {
+		return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
+	}
+
+	var sdkSnapshot string
+	st.Lock()
+	err = task.Get("sdk-snapshot", &sdkSnapshot)
+	st.Unlock()
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
 	}
 
 	rev := revert.New()
 	defer rev.Fail()
 
-	if err = m.backend.LaunchOrRebuildWorkshop(ctx, &wf); err != nil {
-		return err
-	}
-
 	cleanupCtx := context.WithoutCancel(ctx)
 	rev.Add(func() {
 		cleanupCtx, cancel := context.WithTimeout(cleanupCtx, 30*time.Second)
 		defer cancel()
+
+		// This may fail if the first workshop launch has failed for some
+		// reason; It is safe to ignore the error in that case.
 		if reverr := m.backend.RemoveWorkshop(cleanupCtx, w); reverr != nil {
 			logger.Noticef("On doCreateWorkshop: cannot remove %q workshop on cleanup: %v", w, reverr)
 		}
 	})
+
+	if len(sdkSnapshot) == 0 {
+		if err = m.backend.LaunchOrRebuildWorkshop(ctx, &wf); err != nil {
+			return err
+		}
+	} else {
+		if err = m.backend.Restore(ctx, w, workshop.SnapshotId(w, sdkSnapshot), &wf); err != nil {
+			return err
+		}
+	}
 
 	// Create workshop base and run directories
 	fs, err := m.backend.WorkshopFs(ctx, wf.Name)
@@ -308,7 +324,8 @@ func (m *WorkshopManager) undoStashWorkshop(task *state.Task, tomb *tomb.Tomb) e
 	if err = m.backend.UnstashWorkshop(ctx, w); err != nil {
 		return err
 	}
-	return nil
+
+	return m.backend.RemoveWorkshopStash(ctx, w)
 }
 
 func (m *WorkshopManager) doCreateStateStorage(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -107,7 +107,7 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 		}
 	})
 
-	if len(sdkSnapshot) == 0 {
+	if sdkSnapshot == "" {
 		if err = m.backend.LaunchOrRebuildWorkshop(ctx, &wf); err != nil {
 			return err
 		}

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -118,7 +118,7 @@ func (s *workshopHandlers) TestStopPeriodicProgressUpdate(c *check.C) {
 	defer s.state.Unlock()
 	s.createWFile(c, "ws", wsFocal)
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
-	err := s.backend.LaunchWorkshop(s.ctx, wf)
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 
 	t1, err := s.wrkmgr.StopMany(s.ctx, []string{"ws"}, s.project.ProjectId)
@@ -160,7 +160,7 @@ func (s *workshopHandlers) TestUndoStash(c *check.C) {
 		{Name: "test2", Channel: "latest/stable"},
 	}}
 
-	err := s.backend.LaunchWorkshop(s.ctx, wf)
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
 
 	chg := s.state.NewChange("sample", "...")
@@ -204,7 +204,7 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
 
 	for _, wf := range wFiles {
-		err := s.backend.LaunchWorkshop(s.ctx, wf)
+		err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf)
 		c.Check(err, check.IsNil)
 
 		// create content directories
@@ -249,7 +249,6 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	projectContent := workshop.ProjectUserData(userDataDir, s.project.ProjectId)
 	exist, _, _ := osutil.ExistsIsDir(projectContent)
 	c.Assert(exist, check.Equals, false)
-
 }
 
 func (s *workshopHandlers) TestCreateWorkshopNoWorkshopConfigurationFound(c *check.C) {

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -26,7 +26,7 @@ func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	st.Unlock()
 
 	runner.AddHandler("download-base", OnDo(manager.doDownloadBase), nil)
-	runner.AddHandler("create-workshop", OnDo(manager.doCreateWorkshop), manager.undoCreateWorkshop)
+	runner.AddHandler("create-workshop", OnDo(manager.doConstructWorkshop), manager.undoCreateWorkshop)
 	runner.AddHandler("start-workshop", OnDo(manager.doStart), manager.doStop)
 	runner.AddHandler("stop-workshop", OnDo(manager.doStop), manager.doStart)
 	runner.AddHandler("remove-workshop", OnDo(manager.doRemoveWorkshop), nil)

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -26,7 +26,7 @@ func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	st.Unlock()
 
 	runner.AddHandler("download-base", OnDo(manager.doDownloadBase), nil)
-	runner.AddHandler("create-workshop", OnDo(manager.doConstructWorkshop), manager.undoCreateWorkshop)
+	runner.AddHandler("create-workshop", OnDo(manager.doConstructWorkshop), manager.undoConstructWorkshop)
 	runner.AddHandler("start-workshop", OnDo(manager.doStart), manager.doStop)
 	runner.AddHandler("stop-workshop", OnDo(manager.doStop), manager.doStart)
 	runner.AddHandler("remove-workshop", OnDo(manager.doRemoveWorkshop), nil)

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -92,7 +92,7 @@ func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@22.04"}
-	err = s.backend.LaunchWorkshop(s.ctx, &wf)
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf)
 	c.Assert(err, check.IsNil)
 
 	workshop, err := s.backend.Workshop(s.ctx, ws)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -34,10 +34,6 @@ const (
 	EdgeRefreshFirstCleanupTask = state.TaskSetEdge("refresh-cleanup")
 )
 
-var (
-	checkHealthTimeout = 5 * time.Second
-)
-
 func (w *WorkshopManager) loadProject(ctx context.Context, id string) (workshop.Project, error) {
 	username, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
@@ -284,7 +280,7 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	connect := autoconnectSdks(st, sdks)
 	addTaskSet(connect)
 
-	checkHealth := runHooks(st, project.ProjectId, file.Name, sdks, checkHealthTimeout, hookstate.CheckHealth)
+	checkHealth := runHooks(st, project.ProjectId, file.Name, sdks, 5*time.Second, hookstate.CheckHealth)
 	addTaskSet(checkHealth)
 
 	for _, task := range all.Tasks() {
@@ -300,22 +296,45 @@ type refreshWorkshopReq struct {
 	w *workshop.Workshop
 	// Up to date workshop definitions from the project directory.
 	file *workshop.File
+	// Up to date SDK infos (from the store or a local source).
+	infos []sdk.SdkResult
+}
+
+func (w *WorkshopManager) prepareRefresh(ctx context.Context, wps []*workshop.Workshop) ([]refreshWorkshopReq, error) {
+	sto := sdk.StoreService(w.state)
+
+	// Not an error, the state is locked; unlock it to let other requests to be
+	// processed while we are getting the store info sorted.
+	w.state.Unlock()
+	defer w.state.Lock()
+
+	refreshReqs := make([]refreshWorkshopReq, 0, len(wps))
+	for _, w := range wps {
+		file, err := w.Project.Workshop(w.Name)
+		if err != nil {
+			return nil, fmt.Errorf("cannot refresh %q: %w", w.Name, err)
+		}
+
+		infos, err := sdkInfos(sto, ctx, w.Project.ProjectId, file)
+		if err != nil {
+			return nil, err
+		}
+		refreshReqs = append(refreshReqs, refreshWorkshopReq{w: w, file: file, infos: infos})
+	}
+	return refreshReqs, nil
 }
 
 func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, names []string) ([]*state.TaskSet, error) {
-	sto := sdk.StoreService(w.state)
-
-	project, err := w.loadProject(ctx, projectId)
-	if err != nil {
-		return nil, err
-	}
-
 	all, err := w.Workshops(ctx, projectId)
 	if err != nil {
 		return nil, err
 	}
 
-	refreshReqs := make([]refreshWorkshopReq, 0, len(all))
+	refreshReqs, err := w.prepareRefresh(ctx, all)
+	if err != nil {
+		return nil, err
+	}
+
 	allowed := []healthstate.Status{healthstate.ReadyStatus}
 	for _, name := range names {
 		idx := slices.IndexFunc(all, func(w *workshop.Workshop) bool { return w.Name == name })
@@ -327,18 +346,11 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}
 
-		file, err := project.Workshop(name)
-		if err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
-		}
-		refreshReqs = append(refreshReqs, refreshWorkshopReq{w: all[idx], file: file})
 	}
 
 	taskset := make([]*state.TaskSet, 0, len(refreshReqs))
 	for _, req := range refreshReqs {
-		w.state.Unlock()
-		plan, err := resolveRefresh(ctx, sto, req.w, req.file)
-		w.state.Lock()
+		plan, err := resolveRefresh(ctx, req.w, req.file, req.infos)
 		if err != nil {
 			return nil, err
 		}
@@ -458,7 +470,7 @@ func (p refreshPlan) Remove() []sdk.Setup {
 	return p.remove
 }
 
-func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, file *workshop.File) (*refreshPlan, error) {
+func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop.File, newinfos []sdk.SdkResult) (*refreshPlan, error) {
 	fullRefresh := false
 
 	plan := &refreshPlan{
@@ -468,13 +480,8 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 		installOrder: make([]string, 0),
 	}
 
-	infos, err := sdkInfos(sto, ctx, w.Project.ProjectId, file)
-	if err != nil {
-		return nil, err
-	}
-
-	candidates := make([]sdk.Setup, 0, len(infos))
-	for _, s := range infos {
+	candidates := make([]sdk.Setup, 0, len(newinfos))
+	for _, s := range newinfos {
 		candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 	}
 
@@ -516,7 +523,7 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 		}
 	}
 
-	if w.Base != file.Base {
+	if w.Base != newfile.Base {
 		fullRefresh = true
 	}
 
@@ -525,7 +532,7 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 			return reflect.DeepEqual(s1.Plugs, s2.Plugs) &&
 				reflect.DeepEqual(s1.Slots, s2.Slots)
 		}
-		if !slices.EqualFunc(w.File.Sdks, file.Sdks, plugsSlotsChanged) {
+		if !slices.EqualFunc(w.File.Sdks, newfile.Sdks, plugsSlotsChanged) {
 			fullRefresh = true
 		}
 	}
@@ -675,38 +682,6 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	}
 
 	return refresh, nil
-}
-
-func (w *WorkshopManager) RefreshLocalSdk(ctx context.Context, pid string, wpn string, sdkn string) ([]*state.TaskSet, error) {
-	var taskset []*state.TaskSet
-	wp, err := w.Workshop(ctx, wpn, pid)
-	if err != nil {
-		return nil, err
-	}
-	allowed := []healthstate.Status{healthstate.ReadyStatus}
-	if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
-		return nil, fmt.Errorf("cannot refresh %q: %w", wpn, err)
-	}
-
-	file, err := wp.Project.Workshop(wpn)
-	if err != nil {
-		return nil, err
-	}
-
-	sto := sdk.StoreService(w.state)
-	w.state.Unlock()
-	plan, err := resolveRefresh(ctx, sto, wp, file)
-	w.state.Lock()
-	if err != nil {
-		return nil, err
-	}
-
-	ts, err := refresh(ctx, w.state, plan, wp, file)
-	if err != nil {
-		return nil, err
-	}
-	taskset = append(taskset, ts)
-	return taskset, nil
 }
 
 func autoconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -541,10 +541,10 @@ func refresh(ctx context.Context, st *state.State, sto sdk.Store, w *workshop.Wo
 		addTaskSet(disconnect)
 	}
 
-	if plan.RecreateWorkshop() {
-		stash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
-		addTaskSet(state.NewTaskSet(stash))
+	stash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
+	addTaskSet(state.NewTaskSet(stash))
 
+	if plan.RecreateWorkshop() {
 		launch := constructWorkshop(st, file, w.Project)
 		addTaskSet(launch)
 
@@ -590,29 +590,27 @@ func refresh(ctx context.Context, st *state.State, sto sdk.Store, w *workshop.Wo
 		refresh.AddTask(removeStateStorage)
 	}
 
-	if plan.RecreateWorkshop() {
-		// remove the workshop from stash after the state storage was detached
-		removeStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", file.Name))
-		// if the change was aborted during the cleanup stage execution,
-		// there is a chance that some of the workshop copies that had
-		// been created during the refresh were already deleted. If we
-		// start to Undo those workshops' refresh progress we will
-		// endup deleting the workshops that finished their refresh.
-		// Given that they have no copy already, the undo logic
-		// (stash-workshop) will delete the existing workshop
-		// and fail to restore from the copy. We don't want that. Hence,
-		// all the cleanup tasks are extracted into a separate lane. If
-		// any problem happens, the workshops that had finished their
-		// refresh will not be affected.
-		removeStash.JoinLane(cleanupLane)
-		removeStash.WaitFor(lastRefreshTsk)
+	// remove the workshop from stash after the state storage was detached
+	removeStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", file.Name))
+	// if the change was aborted during the cleanup stage execution,
+	// there is a chance that some of the workshop copies that had
+	// been created during the refresh were already deleted. If we
+	// start to Undo those workshops' refresh progress we will
+	// endup deleting the workshops that finished their refresh.
+	// Given that they have no copy already, the undo logic
+	// (stash-workshop) will delete the existing workshop
+	// and fail to restore from the copy. We don't want that. Hence,
+	// all the cleanup tasks are extracted into a separate lane. If
+	// any problem happens, the workshops that had finished their
+	// refresh will not be affected.
+	removeStash.JoinLane(cleanupLane)
+	removeStash.WaitFor(lastRefreshTsk)
 
-		if refresh.MaybeEdge(EdgeRefreshCleanup) == nil {
-			refresh.MarkEdge(removeStash, EdgeRefreshCleanup)
-		}
-
-		refresh.AddTask(removeStash)
+	if refresh.MaybeEdge(EdgeRefreshCleanup) == nil {
+		refresh.MarkEdge(removeStash, EdgeRefreshCleanup)
 	}
+
+	refresh.AddTask(removeStash)
 
 	for _, task := range refresh.Tasks() {
 		task.Set("workshop", file.Name)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -34,6 +34,8 @@ const (
 	EdgeRefreshFirstCleanupTask = state.TaskSetEdge("refresh-cleanup")
 )
 
+var checkHealthTimeout = 5 * time.Second
+
 func (w *WorkshopManager) loadProject(ctx context.Context, id string) (workshop.Project, error) {
 	username, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
@@ -220,7 +222,7 @@ func rebuildWorkshop(st *state.State, file *workshop.File, sdkSnapshot string) *
 		prev = t
 	}
 
-	if sdkSnapshot != "" {
+	if sdkSnapshot == "" {
 		base := st.NewTask("download-base", fmt.Sprintf("Download %q base image", file.Base))
 		base.Set("workshop-base", file.Base)
 		addTask(base)
@@ -282,7 +284,7 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	connect := autoconnectSdks(st, sdks)
 	addTaskSet(connect)
 
-	checkHealth := runHooks(st, project.ProjectId, file.Name, sdks, 5*time.Second, hookstate.CheckHealth)
+	checkHealth := runHooks(st, project.ProjectId, file.Name, sdks, checkHealthTimeout, hookstate.CheckHealth)
 	addTaskSet(checkHealth)
 
 	for _, task := range all.Tasks() {
@@ -430,7 +432,8 @@ func definitionChanged(old, new *workshop.File, sdkName string) bool {
 	newidx := slices.IndexFunc(new.Sdks, byName)
 
 	if oldidx == -1 || newidx == -1 {
-		return false
+		// Check if the SDK definition was added or removed.
+		return oldidx != newidx
 	}
 
 	oldrec := old.Sdks[oldidx]
@@ -493,8 +496,6 @@ func (p refreshPlan) Remove() []sdk.Setup {
 }
 
 func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop.File, newinfos []sdk.SdkResult) (*refreshPlan, error) {
-	fullRefresh := false
-
 	plan := &refreshPlan{
 		install:        make([]sdk.Setup, 0),
 		intact:         make([]sdk.Setup, 0),
@@ -502,10 +503,6 @@ func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop
 		remove:         make([]sdk.Setup, 0),
 		installOrder:   make([]string, 0),
 		installedOrder: make([]string, 0),
-	}
-
-	if w.Base != newfile.Base {
-		fullRefresh = true
 	}
 
 	candidates := make([]sdk.Setup, 0, len(newinfos))
@@ -517,30 +514,33 @@ func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop
 	installed := w.SdksByInstallOrder()
 
 	// Determine if a workshop can be partially updated.
-	lastIntact := 0
-	for ni, s := range candidates {
-		// Do we have this SDK in the same order as in the running workshop?
-		if ni < len(installed) && installed[ni].Name == s.Name {
-			// Has this SDK had any updates?
-			if maybeRefresh(w.Sdks[s.Name], s) {
-				break
-			}
-			// Has this SDK had any changes in the workshop definition?
-			if definitionChanged(w.File, newfile, s.Name) {
-				break
-			}
+	lastIntactIdx := -1
 
-			plan.intact = append(plan.intact, s)
-			// No updates to the SDK - reuse its snapshot and keep looking.
-			// Otherwise, break the loop as the rest require to be reinstalled.
-			plan.sdkSnapshot = s.Name
-			lastIntact = ni
-		} else {
-			break
+	if w.Base == newfile.Base {
+		for ci, s := range candidates {
+			// Do we have this SDK in the same order as in the running workshop?
+			if ci < len(installed) && installed[ci].Name == s.Name {
+				// Has this SDK had any updates?
+				if maybeRefresh(w.Sdks[s.Name], s) {
+					break
+				}
+				// Has this SDK had any changes in the workshop definition?
+				if definitionChanged(w.File, newfile, s.Name) {
+					break
+				}
+
+				plan.intact = append(plan.intact, s)
+				// No updates to the SDK - reuse its snapshot and keep looking.
+				// Otherwise, break the loop as the rest require to be reinstalled.
+				plan.sdkSnapshot = s.Name
+				lastIntactIdx = ci
+			} else {
+				break
+			}
 		}
 	}
 
-	for _, s := range candidates[lastIntact+1:] {
+	for _, s := range candidates[lastIntactIdx+1:] {
 		if installed, exist := w.Sdks[s.Name]; exist {
 			plan.refresh = append(plan.refresh, s)
 			plan.remove = append(plan.remove, installed)
@@ -584,13 +584,6 @@ func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop
 			plan.install = append(plan.install,
 				sdk.Setup{Name: sdk.Sketch, Revision: sdk.Revision{N: -1}})
 		}
-	}
-
-	if fullRefresh {
-		plan.refresh = append(plan.refresh, plan.intact...)
-		plan.remove = append(plan.remove, plan.intact...)
-		plan.intact = plan.intact[:0]
-		plan.sdkSnapshot = ""
 	}
 	return plan, nil
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -688,15 +688,20 @@ func (w *WorkshopManager) RefreshLocalSdk(ctx context.Context, pid string, wpn s
 		return nil, fmt.Errorf("cannot refresh %q: %w", wpn, err)
 	}
 
+	file, err := wp.Project.Workshop(wpn)
+	if err != nil {
+		return nil, err
+	}
+
 	sto := sdk.StoreService(w.state)
 	w.state.Unlock()
-	plan, err := resolveRefresh(ctx, sto, wp, wp.File)
+	plan, err := resolveRefresh(ctx, sto, wp, file)
 	w.state.Lock()
 	if err != nil {
 		return nil, err
 	}
 
-	ts, err := refresh(ctx, w.state, plan, wp, wp.File)
+	ts, err := refresh(ctx, w.state, plan, wp, file)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -53,6 +53,29 @@ func (w *WorkshopManager) loadProject(ctx context.Context, id string) (workshop.
 	return projects[username][idx], nil
 }
 
+var isSystem = func(s sdk.Setup) bool { return s.Name == sdk.System.String() }
+
+func ensureSystemSdk(setups []sdk.Setup) []sdk.Setup {
+	// system SDK has to be installed first.
+	idx := slices.IndexFunc(setups, isSystem)
+	if idx != -1 {
+		setups[0], setups[idx] = setups[idx], setups[0]
+	} else {
+		setups = slices.Insert(setups, 0, sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)})
+	}
+	return setups
+}
+
+func ensureSystemFirst[T any](items []T, match func(T) bool, systemSdk T) []T {
+	idx := slices.IndexFunc(items, match)
+	if idx != -1 {
+		items[0], items[idx] = items[idx], items[0]
+	} else {
+		items = slices.Insert(items, 0, systemSdk)
+	}
+	return items
+}
+
 func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
 	sto := sdk.StoreService(w.state)
 
@@ -82,12 +105,13 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, err
 		}
 
-		setups := make([]sdk.Setup, 0, len(sdks))
+		candidates := make([]sdk.Setup, 0, len(sdks))
 		for _, s := range sdks {
-			setups = append(setups, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
+			candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 		}
+		candidates = ensureSystemSdk(candidates)
 
-		tasks := launch(w.state, file, setups, project)
+		tasks := launch(w.state, file, candidates, project)
 		taskset = append(taskset, tasks)
 	}
 	return taskset, nil
@@ -107,123 +131,152 @@ func sdkStoreInfo(sto sdk.Store, ctx context.Context, projectid string, file *wo
 	return sto.SdkAction(ctx, acts)
 }
 
-func retrieveSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
+func retrieveSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string]string) {
 	retrieve := state.NewTaskSet()
+	retrieveMap := map[string]string{}
 	for _, s := range sdks {
 		if s.Channel != "" {
 			r := sdkstate.Retrieve(st, s)
 			retrieve.AddTask(r)
+			retrieveMap[s.Name] = r.ID()
 		}
 	}
-	return retrieve
+	return retrieve, retrieveMap
 }
 
-func installSdks(st *state.State, pid, w string, sdks []sdk.Setup, retrieveSet *state.TaskSet) *state.TaskSet {
+func installSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
 	var prevInstall *state.TaskSet
-	install := state.NewTaskSet()
-
-	var prevSetup *state.Task
-	setupHook := state.NewTaskSet()
-
-	for idx, setup := range sdks {
-		// The install task sets must not run concurrently as exec ops are not
-		// allowed by LXD to be run concurrently and in general case we cannot
-		// guarantee safety of concurrent installations.
-		var installTs *state.TaskSet
-		if setup.Channel != "" {
-			installTs = sdkstate.Install(st, setup.Name, retrieveSet.Tasks()[idx].ID())
-		} else {
-			installTs = sdkstate.InstallLocalSdk(st, setup)
+	all := state.NewTaskSet()
+	addTaskSet := func(ts *state.TaskSet) {
+		if len(ts.Tasks()) == 0 {
+			return
 		}
 
 		if prevInstall != nil {
-			installTs.WaitAll(prevInstall)
+			ts.WaitAll(prevInstall)
 		}
-		prevInstall = installTs
-		install.AddAll(installTs)
+		prevInstall = ts
 
-		// Make sure that the hook tasks are not concurrent
-		setupHookTask := hookstate.Hook(st, pid, w, setup.Name, 0, hookstate.SetupBase)
-		if prevSetup != nil {
-			setupHookTask.WaitFor(prevSetup)
-		}
-		prevSetup = setupHookTask
-		setupHook.AddTask(setupHookTask)
+		all.AddAll(ts)
 	}
-	setupHook.WaitAll(install)
 
-	all := state.NewTaskSet(install.Tasks()...)
-	all.AddAll(setupHook)
+	for _, setup := range sdks {
+		// The install task sets must not run concurrently as exec ops are not
+		// allowed by LXD to be run concurrently and in general case we cannot
+		// guarantee safety of concurrent installations.
+		var install *state.TaskSet
+		if setup.Channel == "" {
+			install = sdkstate.InstallLocalSdk(st, setup)
+		} else {
+			install = sdkstate.Install(st, setup.Name, retrieveTasks[setup.Name])
+		}
 
+		addTaskSet(install)
+	}
 	return all
 }
 
-func checkSdksHealth(st *state.State, pid, w string, sdks []sdk.Setup) *state.TaskSet {
-	var prev *state.Task
-	checkHealth := state.NewTaskSet()
-	for _, sk := range sdks {
-		check := hookstate.Hook(st, pid, w, sk.Name, checkHealthTimeout, hookstate.CheckHealth)
-		if prev != nil {
-			check.WaitFor(prev)
-		}
-		prev = check
-		checkHealth.AddTask(check)
-	}
-	return checkHealth
-}
+func launchWorkshop(st *state.State, file *workshop.File, project workshop.Project) *state.TaskSet {
+	construct := state.NewTaskSet()
 
-func constructWorkshop(st *state.State, file *workshop.File, project workshop.Project) *state.TaskSet {
+	var prev *state.Task
+	addTask := func(t *state.Task) {
+		construct.AddTask(t)
+		if prev != nil {
+			t.WaitFor(prev)
+		}
+		prev = t
+	}
+
 	base := st.NewTask("download-base", fmt.Sprintf("Download %q base image", file.Base))
 	base.Set("workshop-base", file.Base)
+	addTask(base)
 
 	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", file.Name))
+	addTask(create)
 	create.Set("workshop-file", file)
-	create.WaitFor(base)
 
+	// We're rebuilding the workshop from base, which means, the mounts will
+	// be removed too.
 	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
-	mountProject.WaitFor(create)
+	addTask(mountProject)
 
 	mountAptCache := st.NewTask("mount-apt-cache", fmt.Sprintf("Mount apt cache directory %q", dirs.AptCachePath))
-	mountAptCache.WaitFor(mountProject)
+	addTask(mountAptCache)
 
 	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", file.Name))
-	start.WaitFor(mountAptCache)
-	return state.NewTaskSet(base, create, mountProject, mountAptCache, start)
+	addTask(start)
+
+	return construct
+}
+
+func rebuildWorkshop(st *state.State, file *workshop.File, sdkSnapshot string) *state.TaskSet {
+	construct := state.NewTaskSet()
+
+	var prev *state.Task
+	addTask := func(t *state.Task) {
+		construct.AddTask(t)
+		if prev != nil {
+			t.WaitFor(prev)
+		}
+		prev = t
+	}
+
+	base := st.NewTask("download-base", fmt.Sprintf("Download %q base image", file.Base))
+	base.Set("workshop-base", file.Base)
+	addTask(base)
+
+	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", file.Name))
+	addTask(create)
+	create.Set("workshop-file", file)
+
+	if sdkSnapshot != "" {
+		create.Set("sdk-snapshot", sdkSnapshot)
+	}
+
+	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", file.Name))
+	addTask(start)
+
+	return construct
 }
 
 func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project workshop.Project) *state.TaskSet {
-	retrieve := retrieveSdks(st, sdks)
+	var prevInstall *state.TaskSet
+	all := state.NewTaskSet()
+
+	addTaskSet := func(ts *state.TaskSet) {
+		if len(ts.Tasks()) == 0 {
+			return
+		}
+
+		if prevInstall != nil {
+			ts.WaitAll(prevInstall)
+		}
+		prevInstall = ts
+
+		all.AddAll(ts)
+	}
+
+	retrieve, rmap := retrieveSdks(st, sdks)
+	addTaskSet(retrieve)
 
 	createAptCache := st.NewTask("create-apt-cache", fmt.Sprintf("Create apt cache for %q", file.Name))
+	addTaskSet(state.NewTaskSet(createAptCache))
 
-	create := constructWorkshop(st, file, project)
-	create.WaitAll(retrieve)
-	create.WaitFor(createAptCache)
+	create := launchWorkshop(st, file, project)
+	addTaskSet(create)
 
-	system := sdkstate.InstallSystemSdk(st)
-	system.WaitAll(create)
+	install := installSdks(st, sdks, rmap)
+	addTaskSet(install)
 
-	install := installSdks(st, project.ProjectId, file.Name, sdks, retrieve)
-	install.WaitAll(system)
+	setup := runHooks(st, project.ProjectId, file.Name, sdks, 0, hookstate.SetupBase)
+	addTaskSet(setup)
 
-	full := slices.Clone(sdks)
-	full = slices.Insert(full, 0, sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}})
+	connect := autoconnectSdks(st, sdks)
+	addTaskSet(connect)
 
-	connect := autoconnectSdks(st, full)
-	connect.WaitAll(install)
-	connect.WaitAll(system)
-
-	checkHealth := checkSdksHealth(st, project.ProjectId, file.Name, sdks)
-	checkHealth.WaitAll(connect)
-
-	all := state.NewTaskSet(retrieve.Tasks()...)
-	all.AddAll(retrieve)
-	all.AddTask(createAptCache)
-	all.AddAll(create)
-	all.AddAll(system)
-	all.AddAll(install)
-	all.AddAll(connect)
-	all.AddAll(checkHealth)
+	checkHealth := runHooks(st, project.ProjectId, file.Name, sdks, checkHealthTimeout, hookstate.CheckHealth)
+	addTaskSet(checkHealth)
 
 	for _, task := range all.Tasks() {
 		task.Set("workshop", file.Name)
@@ -274,7 +327,14 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 
 	taskset := make([]*state.TaskSet, 0, len(refreshReqs))
 	for _, req := range refreshReqs {
-		tasks, err := refresh(ctx, w.state, sto, req.w, req.file)
+		w.state.Unlock()
+		plan, err := resolveRefresh(ctx, sto, req.w, req.file)
+		w.state.Lock()
+		if err != nil {
+			return nil, err
+		}
+
+		tasks, err := refresh(ctx, w.state, plan, req.w, req.file)
 		if err != nil {
 			return nil, fmt.Errorf("cannot refresh %q: %w", req.w.Name, err)
 		}
@@ -337,67 +397,57 @@ func maybeSketch(ctx context.Context, pid, wp string) (bool, error) {
 	return true, nil
 }
 
-func maybeRefresh(installed sdk.Setup, candidate *sdk.Info) bool {
-	return installed.Revision != candidate.Revision
+func maybeRefresh(installed sdk.Setup, candidate sdk.Setup) bool {
+	return installed.Channel != candidate.Channel || installed.Revision != candidate.Revision
 }
 
 type refreshPlan struct {
 	install []sdk.Setup
+	intact  []sdk.Setup
 	refresh []sdk.Setup
 	remove  []sdk.Setup
 
-	installOrder  []string
-	refreshAnyway bool
+	sdkSnapshot  string
+	installOrder []string
+	fullRefresh  bool
+}
+
+func (p refreshPlan) ordered(setups ...[]sdk.Setup) []sdk.Setup {
+	ordered := []sdk.Setup{}
+
+	for _, sk := range p.installOrder {
+		for _, setup := range setups {
+			contains := func(sp sdk.Setup) bool { return sk == sp.Name }
+
+			idx := slices.IndexFunc(setup, contains)
+			if idx != -1 {
+				ordered = append(ordered, setup[idx])
+			}
+		}
+	}
+	return ordered
 }
 
 func (p refreshPlan) InstallOrRefresh() []sdk.Setup {
-	ordered := []sdk.Setup{}
+	return p.ordered(p.install, p.refresh)
+}
 
-	for _, s := range p.installOrder {
-		contains := func(sp sdk.Setup) bool { return s == sp.Name }
-
-		idx := slices.IndexFunc(p.install, contains)
-		if idx != -1 {
-			ordered = append(ordered, p.install[idx])
-			continue
-		}
-
-		idx = slices.IndexFunc(p.refresh, contains)
-		if idx != -1 {
-			ordered = append(ordered, p.refresh[idx])
-			continue
-		}
-	}
+func (p refreshPlan) IntactOrRemove() []sdk.Setup {
+	ordered := p.ordered(p.intact)
+	ordered = append(ordered, p.remove...)
 	return ordered
+}
+
+func (p refreshPlan) InstallIntactOrRefresh() []sdk.Setup {
+	return p.ordered(p.install, p.refresh, p.intact)
 }
 
 func (p refreshPlan) Refresh() []sdk.Setup {
-	return p.refresh
+	return p.ordered(p.refresh)
 }
 
-func (p refreshPlan) RefreshOrRemove() []sdk.Setup {
-	ordered := []sdk.Setup{}
-
-	for _, s := range p.installOrder {
-		contains := func(sp sdk.Setup) bool { return s == sp.Name }
-
-		idx := slices.IndexFunc(p.remove, contains)
-		if idx != -1 {
-			ordered = append(ordered, p.remove[idx])
-			continue
-		}
-
-		idx = slices.IndexFunc(p.refresh, contains)
-		if idx != -1 {
-			ordered = append(ordered, p.refresh[idx])
-			continue
-		}
-	}
-	return ordered
-}
-
-func (p refreshPlan) RecreateWorkshop() bool {
-	return p.refreshAnyway || len(p.install) != 0 || len(p.refresh) != 0 || len(p.remove) != 0
+func (p refreshPlan) Remove() []sdk.Setup {
+	return p.remove
 }
 
 func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, file *workshop.File) (*refreshPlan, error) {
@@ -413,92 +463,111 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 		return nil, err
 	}
 
-	// SDKs that only exists in the new workshop definition are to be installed.
-	for _, info := range infos {
-		if _, exist := w.Sdks[info.Name]; !exist {
-			plan.install = append(plan.install, sdk.Setup{Name: info.Name, Channel: info.Channel, Revision: info.Revision})
+	candidates := make([]sdk.Setup, 0, len(infos))
+	for _, s := range infos {
+		candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
+	}
+	candidates = ensureSystemFirst(candidates,
+		isSystem, sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)})
+
+	// Restore the order of SDKs installed in the running workshop.
+	prevOrder := []string{}
+	for _, s := range w.File.Sdks {
+		prevOrder = append(prevOrder, s.Name)
+	}
+	prevOrder = ensureSystemFirst(prevOrder,
+		func(s string) bool { return s == sdk.System.String() },
+		sdk.System.String())
+
+	// Determine if a workshop can be partially updated.
+	lastIntact := 0
+	for ni, s := range candidates {
+		// Do we have this SDK in the same order as in the running workshop?
+		if ni < len(prevOrder) && prevOrder[ni] == s.Name {
+			// Has this SDK had any updates?
+			if !maybeRefresh(w.Sdks[s.Name], s) {
+				plan.intact = append(plan.intact, s)
+				// No updates to the SDK - reuse its snapshot and keep looking.
+				// Otherwise, break the loop as the rest require to be reinstalled.
+				plan.sdkSnapshot = s.Name
+				lastIntact = ni
+				continue
+			}
+			break
+		}
+	}
+
+	for _, s := range candidates[lastIntact+1:] {
+		if installed, exist := w.Sdks[s.Name]; exist {
+			plan.refresh = append(plan.refresh, s)
+			plan.remove = append(plan.remove, installed)
+		} else {
+			plan.install = append(plan.install, s)
 		}
 	}
 
 	// SDKs that only exist in the previous workshop are to be removed.
 	for _, rec := range w.Sdks {
-		if !slices.ContainsFunc(infos, func(r sdk.SdkResult) bool {
-			return r.Info.Name == rec.Name
+		if !slices.ContainsFunc(candidates, func(r sdk.Setup) bool {
+			return r.Name == rec.Name
 		}) {
 			plan.remove = append(plan.remove, rec)
 		}
 	}
 
-	// SDKs that exist in both, the previous and new workshop definiotions, are to be refreshed.
-	for _, info := range infos {
-		// If the SDK is not in the list of the existing SDKs -- it is being
-		// installed, not refreshed.
-		if installed, exist := w.Sdks[info.Name]; exist {
-			plan.refreshAnyway = maybeRefresh(installed, info.Info)
-			if plan.refreshAnyway {
-				break
-			}
+	if w.Base != file.Base {
+		plan.fullRefresh = true
+	}
+
+	if len(plan.refresh) == 0 && len(plan.remove) == 0 && len(plan.install) == 0 {
+		plugsSlotsChanged := func(s1, s2 workshop.SdkRecord) bool {
+			return reflect.DeepEqual(s1.Plugs, s2.Plugs) &&
+				reflect.DeepEqual(s1.Slots, s2.Slots)
 		}
+		if !slices.EqualFunc(w.File.Sdks, file.Sdks, plugsSlotsChanged) {
+			plan.fullRefresh = true
+		}
+	}
+
+	// Establish SDK installation order.
+	for _, s := range candidates {
+		plan.installOrder = append(plan.installOrder, s.Name)
 	}
 
 	sketchFound, err := maybeSketch(ctx, w.Project.ProjectId, w.Name)
 	if err != nil {
 		return nil, err
 	}
-
-	if w.Base != file.Base {
-		plan.refreshAnyway = true
-	}
-
-	if !slices.Equal(w.File.Connections, file.Connections) {
-		plan.refreshAnyway = true
-	}
-
-	cmpRecord := func(s1, s2 workshop.SdkRecord) bool {
-		return reflect.DeepEqual(s1, s2)
-	}
-	if !slices.EqualFunc(w.File.Sdks, file.Sdks, cmpRecord) {
-		plan.refreshAnyway = true
-	}
-
-	// Establish SDK installation order.
-	for _, s := range file.Sdks {
-		plan.installOrder = append(plan.installOrder, s.Name)
-	}
 	if sketchFound {
 		plan.installOrder = append(plan.installOrder, sdk.Sketch)
-	}
 
-	// TODO: refresh only the required SDK when a workshop will be able to
-	// restore from a snapshots. Now, if there is at least one SDK to be
-	// refreshed, then refresh the entire set of SDKs.
-	if plan.refreshAnyway || len(plan.install) > 0 || len(plan.remove) > 0 || sketchFound {
-		for _, info := range infos {
-			if _, exist := w.Sdks[info.Name]; exist {
-				plan.refresh = append(plan.refresh, sdk.Setup{Name: info.Name, Channel: info.Channel, Revision: info.Revision})
-			}
-		}
-
-		if sketchFound {
-			if installed, exist := w.Sdks[sdk.Sketch]; exist {
-				plan.refresh = append(plan.refresh, installed)
-			} else {
-				plan.install = append(plan.install, sdk.Setup{Name: sdk.Sketch, Revision: sdk.Revision{N: -1}})
-			}
+		if installed, exist := w.Sdks[sdk.Sketch]; exist {
+			plan.refresh = append(plan.refresh, sdk.Setup{
+				Name:     sdk.Sketch,
+				Revision: sdk.Revision{N: installed.Revision.N - 1},
+			})
+		} else {
+			plan.install = append(plan.install,
+				sdk.Setup{Name: sdk.Sketch, Revision: sdk.Revision{N: -1}})
 		}
 	}
 
+	// No appropriate snapshots found means the workshop needs to be rebuilt
+	// from scratch.
+	if plan.sdkSnapshot == "" {
+		plan.fullRefresh = true
+	}
+
+	if plan.fullRefresh {
+		plan.refresh = append(plan.refresh, plan.intact...)
+		plan.remove = append(plan.remove, plan.intact...)
+		plan.intact = plan.intact[:0]
+		plan.sdkSnapshot = ""
+	}
 	return plan, nil
 }
 
-func refresh(ctx context.Context, st *state.State, sto sdk.Store, w *workshop.Workshop, file *workshop.File) (*state.TaskSet, error) {
-	st.Unlock()
-	plan, err := resolveRefresh(ctx, sto, w, file)
-	st.Lock()
-	if err != nil {
-		return nil, err
-	}
-
+func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *workshop.Workshop, file *workshop.File) (*state.TaskSet, error) {
 	refresh := state.NewTaskSet()
 	prev := (*state.TaskSet)(nil)
 	addTaskSet := func(ts *state.TaskSet) {
@@ -513,64 +582,59 @@ func refresh(ctx context.Context, st *state.State, sto sdk.Store, w *workshop.Wo
 		prev = ts
 	}
 
-	retrieve := retrieveSdks(st, plan.InstallOrRefresh())
+	retrieve, rmap := retrieveSdks(st, plan.InstallOrRefresh())
 	addTaskSet(retrieve)
 
 	if len(plan.Refresh()) > 0 {
-		saveStateTs := state.NewTaskSet()
 		stateStorage := st.NewTask("create-state-storage", "Create SDK state storage")
-		stateStorage.WaitAll(retrieve)
-		saveStateTs.AddTask(stateStorage)
-
-		// Call save-state hooks for the SDKs that are installed and will not be
-		// removed after this refresh.
-		saveState := createStateHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), hookstate.SaveState)
-		saveState.WaitFor(stateStorage)
-		saveStateTs.AddAll(saveState)
-
-		addTaskSet(saveStateTs)
+		addTaskSet(state.NewTaskSet(stateStorage))
 	}
 
-	if plan.RecreateWorkshop() {
-		disconn := []sdk.Setup{{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}}}
-		disconn = append(disconn, slices.Collect(maps.Values(w.Sdks))...)
-		disconnect := disconnectSdks(st, disconn)
-		addTaskSet(disconnect)
-	} else {
-		disconnect := disconnectSdks(st, plan.RefreshOrRemove())
-		addTaskSet(disconnect)
-	}
+	// Call save-state hooks for the SDKs that are installed and will not be
+	// removed after this refresh.
+	saveState := runHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), 0, hookstate.SaveState)
+	addTaskSet(saveState)
+
+	disconnect := disconnectSdks(st, plan.IntactOrRemove())
+	addTaskSet(disconnect)
+
+	// Unlink and remove SDKs from interfaces repository. If refresh fails, the
+	// SDKs will be linked back and returned to the repository. This is the
+	// reason unlink has to happen before stashing. As the workshop, that will
+	// be reconstructed after stashing, will link and add their SDKs to the
+	// repository in `installSdks` step.
+	unlink := unlinkSdks(st, plan.Remove())
+	addTaskSet(unlink)
 
 	stash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
 	addTaskSet(state.NewTaskSet(stash))
 
-	if plan.RecreateWorkshop() {
-		launch := constructWorkshop(st, file, w.Project)
-		addTaskSet(launch)
+	rebuild := rebuildWorkshop(st, file, plan.sdkSnapshot)
+	addTaskSet(rebuild)
 
-		system := sdkstate.InstallSystemSdk(st)
-		addTaskSet(system)
-	}
+	// Detach (uninstall) volumes of the SDKs from the restored snapshot. If the
+	// refresh fails, a copy of the workshop will be restored that had SDKs
+	// installed previously.
+	// We do not uninstall the SDKs that were installed locally and are to be
+	// removed here as those will not present in the recovered snapshot (as
+	// those are simply copied over into the workshop). These tasks will uninstall
+	// SDKs that were installed from the store as SDK volumes.
+	uninstall := uninstallSdks(st, plan.Remove())
+	addTaskSet(uninstall)
 
-	install := installSdks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), retrieve)
+	install := installSdks(st, plan.InstallOrRefresh(), rmap)
 	addTaskSet(install)
 
-	if plan.RecreateWorkshop() {
-		conn := []sdk.Setup{{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}}}
-		conn = append(conn, plan.InstallOrRefresh()...)
-		connect := autoconnectSdks(st, conn)
-		addTaskSet(connect)
-	} else {
-		connect := autoconnectSdks(st, plan.InstallOrRefresh())
-		addTaskSet(connect)
-	}
+	setup := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), 0, hookstate.SetupBase)
+	addTaskSet(setup)
 
-	if len(plan.Refresh()) > 0 {
-		restoreState := createStateHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), hookstate.RestoreState)
-		addTaskSet(restoreState)
-	}
+	connect := autoconnectSdks(st, plan.InstallIntactOrRefresh())
+	addTaskSet(connect)
 
-	checkHealth := checkSdksHealth(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh())
+	restoreState := runHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), 0, hookstate.RestoreState)
+	addTaskSet(restoreState)
+
+	checkHealth := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), 0, hookstate.CheckHealth)
 	addTaskSet(checkHealth)
 
 	length := len(refresh.Tasks())
@@ -631,75 +695,20 @@ func (w *WorkshopManager) RefreshLocalSdk(ctx context.Context, pid string, wpn s
 		return nil, fmt.Errorf("cannot refresh %q: %w", wpn, err)
 	}
 
-	ts, err := w.refreshLocalSdk(wp, sdkn)
+	sto := sdk.StoreService(w.state)
+	w.state.Unlock()
+	plan, err := resolveRefresh(ctx, sto, wp, wp.File)
+	w.state.Lock()
+	if err != nil {
+		return nil, err
+	}
+
+	ts, err := refresh(ctx, w.state, plan, wp, wp.File)
 	if err != nil {
 		return nil, err
 	}
 	taskset = append(taskset, ts)
 	return taskset, nil
-}
-
-func (w *WorkshopManager) refreshLocalSdk(wp *workshop.Workshop, sdkn string) (*state.TaskSet, error) {
-	cur, installed := wp.Sdks[sdkn]
-	var setup sdk.Setup
-	if installed {
-		setup = sdk.Setup{Name: sdkn, Revision: sdk.Revision{N: cur.Revision.N - 1}}
-	} else {
-		setup = sdk.Setup{Name: sdkn, Revision: sdk.Revision{N: -1}}
-	}
-
-	st := w.state
-	ts := state.NewTaskSet()
-
-	if installed {
-		createStateStorage := st.NewTask("create-state-storage", "Create SDK state storage")
-		ts.AddTask(createStateStorage)
-
-		saveStateHook := hookstate.Hook(st, wp.Project.ProjectId, wp.Name, setup.Name, 0, hookstate.SaveState)
-		saveStateHook.WaitFor(createStateStorage)
-
-		disconnect := st.NewTask("auto-disconnect", fmt.Sprintf(`Disconnect interfaces of %q SDK`, setup.Name))
-		disconnect.Set("sdk", setup.Name)
-		disconnect.WaitFor(saveStateHook)
-		ts.AddTask(saveStateHook)
-		ts.AddTask(disconnect)
-	}
-
-	install := sdkstate.InstallLocalSdk(st, setup)
-	install.WaitAll(ts)
-	ts.AddAll(install)
-
-	setupHook := hookstate.Hook(st, wp.Project.ProjectId, wp.Name, setup.Name, 0, hookstate.SetupBase)
-	setupHook.WaitAll(install)
-	ts.AddTask(setupHook)
-
-	autoconnect := st.NewTask("auto-connect", fmt.Sprintf("Auto-connect interfaces of %q SDK", setup.Name))
-	autoconnect.Set("sdk", setup.Name)
-	autoconnect.WaitFor(setupHook)
-	ts.AddTask(autoconnect)
-
-	if installed {
-		restoreState := hookstate.Hook(st, wp.Project.ProjectId, wp.Name, setup.Name, 0, hookstate.RestoreState)
-		restoreState.WaitFor(autoconnect)
-		ts.AddTask(restoreState)
-	}
-
-	checkHealth := hookstate.Hook(st, wp.Project.ProjectId, wp.Name, setup.Name, 0, hookstate.CheckHealth)
-	checkHealth.WaitAll(ts)
-	ts.AddTask(checkHealth)
-
-	if installed {
-		removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
-		removeStateStorage.WaitFor(checkHealth)
-		ts.AddTask(removeStateStorage)
-	}
-
-	for _, task := range ts.Tasks() {
-		task.Set("workshop", wp.Name)
-		task.Set("project", wp.Project)
-	}
-
-	return ts, nil
 }
 
 func autoconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
@@ -714,8 +723,50 @@ func autoconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 		}
 		prevAuto = autoconnect
 	}
-
 	return autoconnectSet
+}
+
+func uninstallSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
+	var prevRemove *state.Task
+	all := state.NewTaskSet()
+	addTask := func(ts *state.Task) {
+		if prevRemove != nil {
+			ts.WaitFor(prevRemove)
+		}
+		prevRemove = ts
+
+		all.AddTask(ts)
+	}
+
+	for _, setup := range sdks {
+		// The install task sets must not run concurrently as exec ops are not
+		// allowed by LXD to be run concurrently and in general case we cannot
+		// guarantee safety of concurrent installations.
+		if setup.Channel != "" {
+			install := st.NewTask("remove-sdk", fmt.Sprintf("Remove %q SDK", setup.Name))
+			install.Set("sdk-retrieve-task", install.ID())
+			install.Set("sdk-setup", setup)
+			addTask(install)
+		}
+	}
+	return all
+}
+
+func unlinkSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
+	prev := (*state.Task)(nil)
+	unlinkSet := state.NewTaskSet()
+	for _, s := range sdks {
+		unlink := st.NewTask("unlink-sdk", fmt.Sprintf("Unlink %q SDK", s.Name))
+		unlink.Set("sdk-retrieve-task", unlink.ID())
+		unlink.Set("sdk-setup", s)
+		unlinkSet.AddTask(unlink)
+
+		if prev != nil {
+			unlink.WaitFor(prev)
+		}
+		prev = unlink
+	}
+	return unlinkSet
 }
 
 func disconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
@@ -734,22 +785,18 @@ func disconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	return disconnSet
 }
 
-func createStateHooks(st *state.State, pid, w string, installed []sdk.Setup, hooktype hookstate.WorkshopHookType) *state.TaskSet {
-	stateHooks := state.NewTaskSet()
+func runHooks(st *state.State, pid, w string, installed []sdk.Setup, timeout time.Duration, hooktype hookstate.WorkshopHookType) *state.TaskSet {
+	hooks := state.NewTaskSet()
 	prev := (*state.Task)(nil)
 	for _, sk := range installed {
-		if sk.Name == sdk.System.String() {
-			continue
-		}
-
-		stateHook := hookstate.Hook(st, pid, w, sk.Name, 0, hooktype)
-		stateHooks.AddTask(stateHook)
+		hook := hookstate.Hook(st, pid, w, sk.Name, timeout, hooktype)
+		hooks.AddTask(hook)
 		if prev != nil {
-			stateHook.WaitFor(prev)
+			hook.WaitFor(prev)
 		}
-		prev = stateHook
+		prev = hook
 	}
-	return stateHooks
+	return hooks
 }
 
 func (w *WorkshopManager) StartMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
@@ -928,20 +975,32 @@ func removeMany(st *state.State, workshops []*workshop.Workshop, project worksho
 
 func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*state.TaskSet, error) {
 	removeSet := state.NewTaskSet()
+	var prevRemove *state.TaskSet
+	addTaskSet := func(ts *state.TaskSet) {
+		if len(ts.Tasks()) == 0 {
+			return
+		}
+		if prevRemove != nil {
+			ts.WaitAll(prevRemove)
+		}
+		prevRemove = ts
+		removeSet.AddAll(ts)
+	}
 
-	disconn := []sdk.Setup{{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}}}
-	disconn = append(disconn, slices.Collect(maps.Values(w.Sdks))...)
-	disconnectSet := disconnectSdks(st, disconn)
+	disconnectSet := disconnectSdks(st, slices.Collect(maps.Values(w.Sdks)))
+	addTaskSet(disconnectSet)
 
 	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", w.Name))
-	discard.WaitAll(disconnectSet)
+	addTaskSet(state.NewTaskSet(discard))
+
+	unlink := unlinkSdks(st, slices.Collect(maps.Values(w.Sdks)))
+	addTaskSet(unlink)
 
 	remove := st.NewTask("remove-workshop", fmt.Sprintf("Remove %q workshop", w.Name))
-	remove.WaitAll(disconnectSet)
-	remove.WaitFor(discard)
+	addTaskSet(state.NewTaskSet(remove))
 
 	removeAptCache := st.NewTask("remove-apt-cache", fmt.Sprintf("Remove apt cache for %q", w.Name))
-	removeAptCache.WaitFor(remove)
+	addTaskSet(state.NewTaskSet(removeAptCache))
 
 	// The apt cache cannot be removed until the workshop has stopped, which
 	// currently happens as part of remove-workshop. Since there is no way to
@@ -949,11 +1008,6 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*s
 	// error occurs when removing the cache, it will not affect the other tasks.
 	cleanupLane := st.NewLane()
 	removeAptCache.JoinLane(cleanupLane)
-
-	removeSet.AddAll(disconnectSet)
-	removeSet.AddTask(discard)
-	removeSet.AddTask(remove)
-	removeSet.AddTask(removeAptCache)
 
 	for _, task := range removeSet.Tasks() {
 		task.Set("workshop", w.Name)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -20,6 +20,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -33,21 +34,9 @@ const (
 	EdgeRefreshFirstCleanupTask = state.TaskSetEdge("refresh-cleanup")
 )
 
-var checkHealthTimeout = 5 * time.Second
-
 var (
-	systemSetup = sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)}
+	checkHealthTimeout = 5 * time.Second
 )
-
-func ensureSystemFirst[T string | sdk.Setup](items []T, match func(T) bool, systemSdk T) []T {
-	idx := slices.IndexFunc(items, match)
-	if idx != -1 {
-		items[0], items[idx] = items[idx], items[0]
-	} else {
-		items = slices.Insert(items, 0, systemSdk)
-	}
-	return items
-}
 
 func (w *WorkshopManager) loadProject(ctx context.Context, id string) (workshop.Project, error) {
 	username, ok := ctx.Value(workshop.ContextUser).(string)
@@ -91,7 +80,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
 
-		sdks, err = sdkStoreInfo(sto, ctx, projectId, file)
+		sdks, err = sdkInfos(sto, ctx, projectId, file)
 		if err != nil {
 			return nil, err
 		}
@@ -100,7 +89,6 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		for _, s := range sdks {
 			candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 		}
-		candidates = ensureSystemFirst(candidates, func(s sdk.Setup) bool { return sdk.IsSystem(s.Name) }, systemSetup)
 
 		tasks := launch(w.state, file, candidates, project)
 		taskset = append(taskset, tasks)
@@ -108,18 +96,41 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	return taskset, nil
 }
 
-func sdkStoreInfo(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.SdkResult, error) {
+func systemSdkInfo(pid, wname string) (sdk.SdkResult, error) {
+	ybuf, err := system.SystemSdkFs.ReadFile(system.SdkMeta)
+	if err != nil {
+		return sdk.SdkResult{}, err
+	}
+	info, err := sdk.ReadSdkInfo(ybuf, pid, wname)
+	if err != nil {
+		return sdk.SdkResult{}, err
+	}
+	info.Revision = sdk.R(-1)
+	return sdk.SdkResult{Info: info}, nil
+}
+
+func sdkInfos(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.SdkResult, error) {
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
-		// "system" SDK is bootstrapped and installed by Workshop locally in a
-		// separate task.
 		if sdk.IsSystem(sd.Name) {
 			continue
 		}
 		act := sdk.SdkAction{ProjectId: projectid, Workshop: file.Name, Name: sd.Name, Base: file.Base, Channel: sd.Channel, Action: sdk.Install}
 		acts = append(acts, act)
 	}
-	return sto.SdkAction(ctx, acts)
+
+	infos, err := sto.SdkAction(ctx, acts)
+	if err != nil {
+		return nil, err
+	}
+
+	sinfo, err := systemSdkInfo(projectid, file.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	infos = slices.Insert(infos, 0, sinfo)
+	return infos, nil
 }
 
 func retrieveSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string]string) {
@@ -457,7 +468,7 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 		installOrder: make([]string, 0),
 	}
 
-	infos, err := sdkStoreInfo(sto, ctx, w.Project.ProjectId, file)
+	infos, err := sdkInfos(sto, ctx, w.Project.ProjectId, file)
 	if err != nil {
 		return nil, err
 	}
@@ -466,30 +477,24 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 	for _, s := range infos {
 		candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 	}
-	candidates = ensureSystemFirst(candidates, func(s sdk.Setup) bool { return sdk.IsSystem(s.Name) }, systemSetup)
 
 	// Restore the order of SDKs installed in the running workshop.
-	prevOrder := []string{}
-	for _, s := range w.File.Sdks {
-		prevOrder = append(prevOrder, s.Name)
-	}
-	prevOrder = ensureSystemFirst(prevOrder, sdk.IsSystem, sdk.System.String())
+	installed := w.SdksByInstallOrder()
 
 	// Determine if a workshop can be partially updated.
 	lastIntact := 0
 	for ni, s := range candidates {
 		// Do we have this SDK in the same order as in the running workshop?
-		if ni < len(prevOrder) && prevOrder[ni] == s.Name {
+		if ni < len(installed) && installed[ni].Name == s.Name {
 			// Has this SDK had any updates?
-			if !maybeRefresh(w.Sdks[s.Name], s) {
-				plan.intact = append(plan.intact, s)
-				// No updates to the SDK - reuse its snapshot and keep looking.
-				// Otherwise, break the loop as the rest require to be reinstalled.
-				plan.sdkSnapshot = s.Name
-				lastIntact = ni
-				continue
+			if maybeRefresh(w.Sdks[s.Name], s) {
+				break
 			}
-			break
+			plan.intact = append(plan.intact, s)
+			// No updates to the SDK - reuse its snapshot and keep looking.
+			// Otherwise, break the loop as the rest require to be reinstalled.
+			plan.sdkSnapshot = s.Name
+			lastIntact = ni
 		}
 	}
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -401,7 +401,6 @@ type refreshPlan struct {
 
 	sdkSnapshot  string
 	installOrder []string
-	fullRefresh  bool
 }
 
 func (p refreshPlan) ordered(setups ...[]sdk.Setup) []sdk.Setup {
@@ -443,6 +442,8 @@ func (p refreshPlan) Remove() []sdk.Setup {
 }
 
 func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, file *workshop.File) (*refreshPlan, error) {
+	fullRefresh := false
+
 	plan := &refreshPlan{
 		install:      make([]sdk.Setup, 0),
 		refresh:      make([]sdk.Setup, 0),
@@ -507,7 +508,7 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 	}
 
 	if w.Base != file.Base {
-		plan.fullRefresh = true
+		fullRefresh = true
 	}
 
 	if len(plan.refresh) == 0 && len(plan.remove) == 0 && len(plan.install) == 0 {
@@ -516,7 +517,7 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 				reflect.DeepEqual(s1.Slots, s2.Slots)
 		}
 		if !slices.EqualFunc(w.File.Sdks, file.Sdks, plugsSlotsChanged) {
-			plan.fullRefresh = true
+			fullRefresh = true
 		}
 	}
 
@@ -543,9 +544,7 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 		}
 	}
 
-	// No appropriate snapshots found means the workshop needs to be rebuilt
-	// from scratch.
-	if plan.fullRefresh || plan.sdkSnapshot == "" {
+	if fullRefresh {
 		plan.refresh = append(plan.refresh, plan.intact...)
 		plan.remove = append(plan.remove, plan.intact...)
 		plan.intact = plan.intact[:0]

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -220,9 +220,11 @@ func rebuildWorkshop(st *state.State, file *workshop.File, sdkSnapshot string) *
 		prev = t
 	}
 
-	base := st.NewTask("download-base", fmt.Sprintf("Download %q base image", file.Base))
-	base.Set("workshop-base", file.Base)
-	addTask(base)
+	if sdkSnapshot != "" {
+		base := st.NewTask("download-base", fmt.Sprintf("Download %q base image", file.Base))
+		base.Set("workshop-base", file.Base)
+		addTask(base)
+	}
 
 	var summary string
 	if sdkSnapshot == "" {
@@ -433,7 +435,7 @@ type refreshPlan struct {
 }
 
 func (p refreshPlan) ordered(setups ...[]sdk.Setup) []sdk.Setup {
-	ordered := []sdk.Setup{}
+	ordered := make([]sdk.Setup, 0, len(p.installOrder))
 
 	for _, sk := range p.installOrder {
 		for _, setup := range setups {
@@ -442,6 +444,7 @@ func (p refreshPlan) ordered(setups ...[]sdk.Setup) []sdk.Setup {
 			idx := slices.IndexFunc(setup, contains)
 			if idx != -1 {
 				ordered = append(ordered, setup[idx])
+				break
 			}
 		}
 	}
@@ -502,6 +505,8 @@ func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop
 			// Otherwise, break the loop as the rest require to be reinstalled.
 			plan.sdkSnapshot = s.Name
 			lastIntact = ni
+		} else {
+			break
 		}
 	}
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -26,14 +26,29 @@ import (
 const (
 	// mark the last task in a taskset after which refresh becomes irreversible (i.e. the following tasks
 	// will not be possible to undo, e.g. removing an old workshop copy)
-	EdgeLastTaskBeforeRefreshIrreversible = state.TaskSetEdge("last-before-irreversible")
+	EdgeRefreshLastTaskBeforeCleanup = state.TaskSetEdge("last-before-irreversible")
 
 	// mark the tasks that denote irreversible clean up logic for refresh (e.g.
 	// removing state storage and the old workshop copy)
-	EdgeRefreshCleanup = state.TaskSetEdge("refresh-cleanup")
+	EdgeRefreshFirstCleanupTask = state.TaskSetEdge("refresh-cleanup")
 )
 
 var checkHealthTimeout = 5 * time.Second
+
+var (
+	systemSetup = sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)}
+	isSystem    = func(s sdk.Setup) bool { return s.Name == sdk.System.String() }
+)
+
+func ensureSystemFirst[T string | sdk.Setup](items []T, match func(T) bool, systemSdk T) []T {
+	idx := slices.IndexFunc(items, match)
+	if idx != -1 {
+		items[0], items[idx] = items[idx], items[0]
+	} else {
+		items = slices.Insert(items, 0, systemSdk)
+	}
+	return items
+}
 
 func (w *WorkshopManager) loadProject(ctx context.Context, id string) (workshop.Project, error) {
 	username, ok := ctx.Value(workshop.ContextUser).(string)
@@ -51,29 +66,6 @@ func (w *WorkshopManager) loadProject(ctx context.Context, id string) (workshop.
 		return workshop.Project{}, fmt.Errorf("no project found with \"id\" %v", id)
 	}
 	return projects[username][idx], nil
-}
-
-var isSystem = func(s sdk.Setup) bool { return s.Name == sdk.System.String() }
-
-func ensureSystemSdk(setups []sdk.Setup) []sdk.Setup {
-	// system SDK has to be installed first.
-	idx := slices.IndexFunc(setups, isSystem)
-	if idx != -1 {
-		setups[0], setups[idx] = setups[idx], setups[0]
-	} else {
-		setups = slices.Insert(setups, 0, sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)})
-	}
-	return setups
-}
-
-func ensureSystemFirst[T any](items []T, match func(T) bool, systemSdk T) []T {
-	idx := slices.IndexFunc(items, match)
-	if idx != -1 {
-		items[0], items[idx] = items[idx], items[0]
-	} else {
-		items = slices.Insert(items, 0, systemSdk)
-	}
-	return items
 }
 
 func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
@@ -109,7 +101,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		for _, s := range sdks {
 			candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 		}
-		candidates = ensureSystemSdk(candidates)
+		candidates = ensureSystemFirst(candidates, isSystem, systemSetup)
 
 		tasks := launch(w.state, file, candidates, project)
 		taskset = append(taskset, tasks)
@@ -345,7 +337,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 	}
 
 	for _, ts := range taskset {
-		cleanup := ts.MaybeEdge(EdgeRefreshCleanup)
+		cleanup := ts.MaybeEdge(EdgeRefreshFirstCleanupTask)
 		if cleanup == nil {
 			continue
 		}
@@ -360,7 +352,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 		// other changes before execution.
 		for _, otherts := range taskset {
 			if ts != otherts {
-				last, err := otherts.Edge(EdgeLastTaskBeforeRefreshIrreversible)
+				last, err := otherts.Edge(EdgeRefreshLastTaskBeforeCleanup)
 				if err != nil {
 					return nil, err
 				}
@@ -467,8 +459,7 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 	for _, s := range infos {
 		candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 	}
-	candidates = ensureSystemFirst(candidates,
-		isSystem, sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)})
+	candidates = ensureSystemFirst(candidates, isSystem, systemSetup)
 
 	// Restore the order of SDKs installed in the running workshop.
 	prevOrder := []string{}
@@ -554,11 +545,7 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 
 	// No appropriate snapshots found means the workshop needs to be rebuilt
 	// from scratch.
-	if plan.sdkSnapshot == "" {
-		plan.fullRefresh = true
-	}
-
-	if plan.fullRefresh {
+	if plan.fullRefresh || plan.sdkSnapshot == "" {
 		plan.refresh = append(plan.refresh, plan.intact...)
 		plan.remove = append(plan.remove, plan.intact...)
 		plan.intact = plan.intact[:0]
@@ -638,18 +625,16 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	addTaskSet(checkHealth)
 
 	length := len(refresh.Tasks())
-	if length == 0 {
-		return refresh, nil
-	}
+	last := refresh.Tasks()[length-1]
+	refresh.MarkEdge(last, EdgeRefreshLastTaskBeforeCleanup)
 
 	cleanupLane := st.NewLane()
-	lastRefreshTsk := refresh.Tasks()[length-1]
-	refresh.MarkEdge(lastRefreshTsk, EdgeLastTaskBeforeRefreshIrreversible)
+
 	if len(plan.Refresh()) > 0 {
 		removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
-		removeStateStorage.WaitFor(lastRefreshTsk)
+		removeStateStorage.WaitFor(last)
 		removeStateStorage.JoinLane(cleanupLane)
-		refresh.MarkEdge(removeStateStorage, EdgeRefreshCleanup)
+		refresh.MarkEdge(removeStateStorage, EdgeRefreshFirstCleanupTask)
 
 		refresh.AddTask(removeStateStorage)
 	}
@@ -668,10 +653,10 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	// any problem happens, the workshops that had finished their
 	// refresh will not be affected.
 	removeStash.JoinLane(cleanupLane)
-	removeStash.WaitFor(lastRefreshTsk)
+	removeStash.WaitFor(last)
 
-	if refresh.MaybeEdge(EdgeRefreshCleanup) == nil {
-		refresh.MarkEdge(removeStash, EdgeRefreshCleanup)
+	if refresh.MaybeEdge(EdgeRefreshFirstCleanupTask) == nil {
+		refresh.MarkEdge(removeStash, EdgeRefreshFirstCleanupTask)
 	}
 
 	refresh.AddTask(removeStash)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -420,8 +420,23 @@ func maybeSketch(ctx context.Context, pid, wp string) (bool, error) {
 	return true, nil
 }
 
-func maybeRefresh(installed sdk.Setup, candidate sdk.Setup) bool {
+func maybeRefresh(installed, candidate sdk.Setup) bool {
 	return installed.Channel != candidate.Channel || installed.Revision != candidate.Revision
+}
+
+func definitionChanged(old, new *workshop.File, sdkName string) bool {
+	byName := func(s workshop.SdkRecord) bool { return s.Name == sdkName }
+	oldidx := slices.IndexFunc(old.Sdks, byName)
+	newidx := slices.IndexFunc(new.Sdks, byName)
+
+	if oldidx == -1 || newidx == -1 {
+		return false
+	}
+
+	oldrec := old.Sdks[oldidx]
+	newrec := new.Sdks[newidx]
+
+	return !reflect.DeepEqual(oldrec.Plugs, newrec.Plugs) || !reflect.DeepEqual(oldrec.Slots, newrec.Slots)
 }
 
 type refreshPlan struct {
@@ -430,14 +445,15 @@ type refreshPlan struct {
 	refresh []sdk.Setup
 	remove  []sdk.Setup
 
-	sdkSnapshot  string
-	installOrder []string
+	sdkSnapshot    string
+	installOrder   []string
+	installedOrder []string
 }
 
-func (p refreshPlan) ordered(setups ...[]sdk.Setup) []sdk.Setup {
-	ordered := make([]sdk.Setup, 0, len(p.installOrder))
+func (p refreshPlan) ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {
+	ordered := make([]sdk.Setup, 0, len(order))
 
-	for _, sk := range p.installOrder {
+	for _, sk := range order {
 		for _, setup := range setups {
 			contains := func(sp sdk.Setup) bool { return sk == sp.Name }
 
@@ -452,35 +468,44 @@ func (p refreshPlan) ordered(setups ...[]sdk.Setup) []sdk.Setup {
 }
 
 func (p refreshPlan) InstallOrRefresh() []sdk.Setup {
-	return p.ordered(p.install, p.refresh)
+	return p.ordered(p.installOrder, p.install, p.refresh)
 }
 
 func (p refreshPlan) IntactOrRemove() []sdk.Setup {
-	ordered := p.ordered(p.intact)
-	ordered = append(ordered, p.remove...)
+	revOrder := slices.Clone(p.installedOrder)
+	slices.Reverse(revOrder)
+	ordered := p.ordered(revOrder, p.intact, p.remove)
 	return ordered
 }
 
 func (p refreshPlan) InstallIntactOrRefresh() []sdk.Setup {
-	return p.ordered(p.install, p.refresh, p.intact)
+	return p.ordered(p.installOrder, p.install, p.refresh, p.intact)
 }
 
 func (p refreshPlan) Refresh() []sdk.Setup {
-	return p.ordered(p.refresh)
+	return p.ordered(p.installOrder, p.refresh)
 }
 
 func (p refreshPlan) Remove() []sdk.Setup {
-	return p.remove
+	revOrder := slices.Clone(p.installedOrder)
+	slices.Reverse(revOrder)
+	return p.ordered(revOrder, p.remove)
 }
 
 func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop.File, newinfos []sdk.SdkResult) (*refreshPlan, error) {
 	fullRefresh := false
 
 	plan := &refreshPlan{
-		install:      make([]sdk.Setup, 0),
-		refresh:      make([]sdk.Setup, 0),
-		remove:       make([]sdk.Setup, 0),
-		installOrder: make([]string, 0),
+		install:        make([]sdk.Setup, 0),
+		intact:         make([]sdk.Setup, 0),
+		refresh:        make([]sdk.Setup, 0),
+		remove:         make([]sdk.Setup, 0),
+		installOrder:   make([]string, 0),
+		installedOrder: make([]string, 0),
+	}
+
+	if w.Base != newfile.Base {
+		fullRefresh = true
 	}
 
 	candidates := make([]sdk.Setup, 0, len(newinfos))
@@ -500,6 +525,11 @@ func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop
 			if maybeRefresh(w.Sdks[s.Name], s) {
 				break
 			}
+			// Has this SDK had any changes in the workshop definition?
+			if definitionChanged(w.File, newfile, s.Name) {
+				break
+			}
+
 			plan.intact = append(plan.intact, s)
 			// No updates to the SDK - reuse its snapshot and keep looking.
 			// Otherwise, break the loop as the rest require to be reinstalled.
@@ -528,18 +558,9 @@ func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop
 		}
 	}
 
-	if w.Base != newfile.Base {
-		fullRefresh = true
-	}
-
-	if len(plan.refresh) == 0 && len(plan.remove) == 0 && len(plan.install) == 0 {
-		plugsSlotsChanged := func(s1, s2 workshop.SdkRecord) bool {
-			return reflect.DeepEqual(s1.Plugs, s2.Plugs) &&
-				reflect.DeepEqual(s1.Slots, s2.Slots)
-		}
-		if !slices.EqualFunc(w.File.Sdks, newfile.Sdks, plugsSlotsChanged) {
-			fullRefresh = true
-		}
+	// Establish SDK order for the installed SDKs.
+	for _, s := range installed {
+		plan.installedOrder = append(plan.installedOrder, s.Name)
 	}
 
 	// Establish SDK installation order.
@@ -607,9 +628,7 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 
 	// Unlink and remove SDKs from interfaces repository. If refresh fails, the
 	// SDKs will be linked back and returned to the repository. This is the
-	// reason unlink has to happen before stashing. As the workshop, that will
-	// be reconstructed after stashing, will link and add their SDKs to the
-	// repository in `installSdks` step.
+	// reason unlink has to happen before stashing.
 	unlink := unlinkSdks(st, plan.Remove())
 	addTaskSet(unlink)
 
@@ -629,6 +648,7 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	uninstall := uninstallSdks(st, plan.Remove())
 	addTaskSet(uninstall)
 
+	// Install and link updated SDKs to the rebuilt workshop.
 	install := installSdks(st, plan.InstallOrRefresh(), rmap)
 	addTaskSet(install)
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -118,7 +118,7 @@ func retrieveSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	return retrieve
 }
 
-func installSdks(st *state.State, w string, sdks []sdk.Setup, retrieveSet *state.TaskSet) *state.TaskSet {
+func installSdks(st *state.State, pid, w string, sdks []sdk.Setup, retrieveSet *state.TaskSet) *state.TaskSet {
 	var prevInstall *state.TaskSet
 	install := state.NewTaskSet()
 
@@ -143,7 +143,7 @@ func installSdks(st *state.State, w string, sdks []sdk.Setup, retrieveSet *state
 		install.AddAll(installTs)
 
 		// Make sure that the hook tasks are not concurrent
-		setupHookTask := hookstate.Hook(st, w, setup.Name, hookstate.SetupBase)
+		setupHookTask := hookstate.Hook(st, pid, w, setup.Name, 0, hookstate.SetupBase)
 		if prevSetup != nil {
 			setupHookTask.WaitFor(prevSetup)
 		}
@@ -158,11 +158,11 @@ func installSdks(st *state.State, w string, sdks []sdk.Setup, retrieveSet *state
 	return all
 }
 
-func checkSdksHealth(st *state.State, w string, sdks []sdk.Setup) *state.TaskSet {
+func checkSdksHealth(st *state.State, pid, w string, sdks []sdk.Setup) *state.TaskSet {
 	var prev *state.Task
 	checkHealth := state.NewTaskSet()
 	for _, sk := range sdks {
-		check := hookstate.HookWithTimeout(st, w, sk.Name, hookstate.CheckHealth, checkHealthTimeout)
+		check := hookstate.Hook(st, pid, w, sk.Name, checkHealthTimeout, hookstate.CheckHealth)
 		if prev != nil {
 			check.WaitFor(prev)
 		}
@@ -203,7 +203,7 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	system := sdkstate.InstallSystemSdk(st)
 	system.WaitAll(create)
 
-	install := installSdks(st, file.Name, sdks, retrieve)
+	install := installSdks(st, project.ProjectId, file.Name, sdks, retrieve)
 	install.WaitAll(system)
 
 	full := slices.Clone(sdks)
@@ -213,7 +213,7 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	connect.WaitAll(install)
 	connect.WaitAll(system)
 
-	checkHealth := checkSdksHealth(st, file.Name, sdks)
+	checkHealth := checkSdksHealth(st, project.ProjectId, file.Name, sdks)
 	checkHealth.WaitAll(connect)
 
 	all := state.NewTaskSet(retrieve.Tasks()...)
@@ -524,7 +524,7 @@ func refresh(ctx context.Context, st *state.State, sto sdk.Store, w *workshop.Wo
 
 		// Call save-state hooks for the SDKs that are installed and will not be
 		// removed after this refresh.
-		saveState := createStateHooks(st, file.Name, plan.Refresh(), hookstate.SaveState)
+		saveState := createStateHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), hookstate.SaveState)
 		saveState.WaitFor(stateStorage)
 		saveStateTs.AddAll(saveState)
 
@@ -552,7 +552,7 @@ func refresh(ctx context.Context, st *state.State, sto sdk.Store, w *workshop.Wo
 		addTaskSet(system)
 	}
 
-	install := installSdks(st, file.Name, plan.InstallOrRefresh(), retrieve)
+	install := installSdks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), retrieve)
 	addTaskSet(install)
 
 	if plan.RecreateWorkshop() {
@@ -566,11 +566,11 @@ func refresh(ctx context.Context, st *state.State, sto sdk.Store, w *workshop.Wo
 	}
 
 	if len(plan.Refresh()) > 0 {
-		restoreState := createStateHooks(st, file.Name, plan.Refresh(), hookstate.RestoreState)
+		restoreState := createStateHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), hookstate.RestoreState)
 		addTaskSet(restoreState)
 	}
 
-	checkHealth := checkSdksHealth(st, file.Name, plan.InstallOrRefresh())
+	checkHealth := checkSdksHealth(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh())
 	addTaskSet(checkHealth)
 
 	length := len(refresh.Tasks())
@@ -657,7 +657,7 @@ func (w *WorkshopManager) refreshLocalSdk(wp *workshop.Workshop, sdkn string) (*
 		createStateStorage := st.NewTask("create-state-storage", "Create SDK state storage")
 		ts.AddTask(createStateStorage)
 
-		saveStateHook := hookstate.Hook(st, wp.Name, setup.Name, hookstate.SaveState)
+		saveStateHook := hookstate.Hook(st, wp.Project.ProjectId, wp.Name, setup.Name, 0, hookstate.SaveState)
 		saveStateHook.WaitFor(createStateStorage)
 
 		disconnect := st.NewTask("auto-disconnect", fmt.Sprintf(`Disconnect interfaces of %q SDK`, setup.Name))
@@ -671,7 +671,7 @@ func (w *WorkshopManager) refreshLocalSdk(wp *workshop.Workshop, sdkn string) (*
 	install.WaitAll(ts)
 	ts.AddAll(install)
 
-	setupHook := hookstate.Hook(st, wp.Name, setup.Name, hookstate.SetupBase)
+	setupHook := hookstate.Hook(st, wp.Project.ProjectId, wp.Name, setup.Name, 0, hookstate.SetupBase)
 	setupHook.WaitAll(install)
 	ts.AddTask(setupHook)
 
@@ -681,12 +681,12 @@ func (w *WorkshopManager) refreshLocalSdk(wp *workshop.Workshop, sdkn string) (*
 	ts.AddTask(autoconnect)
 
 	if installed {
-		restoreState := hookstate.Hook(st, wp.Name, setup.Name, hookstate.RestoreState)
+		restoreState := hookstate.Hook(st, wp.Project.ProjectId, wp.Name, setup.Name, 0, hookstate.RestoreState)
 		restoreState.WaitFor(autoconnect)
 		ts.AddTask(restoreState)
 	}
 
-	checkHealth := hookstate.Hook(st, wp.Name, setup.Name, hookstate.CheckHealth)
+	checkHealth := hookstate.Hook(st, wp.Project.ProjectId, wp.Name, setup.Name, 0, hookstate.CheckHealth)
 	checkHealth.WaitAll(ts)
 	ts.AddTask(checkHealth)
 
@@ -736,7 +736,7 @@ func disconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	return disconnSet
 }
 
-func createStateHooks(st *state.State, w string, installed []sdk.Setup, hooktype hookstate.WorkshopHookType) *state.TaskSet {
+func createStateHooks(st *state.State, pid, w string, installed []sdk.Setup, hooktype hookstate.WorkshopHookType) *state.TaskSet {
 	stateHooks := state.NewTaskSet()
 	prev := (*state.Task)(nil)
 	for _, sk := range installed {
@@ -744,7 +744,7 @@ func createStateHooks(st *state.State, w string, installed []sdk.Setup, hooktype
 			continue
 		}
 
-		stateHook := hookstate.Hook(st, w, sk.Name, hooktype)
+		stateHook := hookstate.Hook(st, pid, w, sk.Name, 0, hooktype)
 		stateHooks.AddTask(stateHook)
 		if prev != nil {
 			stateHook.WaitFor(prev)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -37,7 +37,6 @@ var checkHealthTimeout = 5 * time.Second
 
 var (
 	systemSetup = sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)}
-	isSystem    = func(s sdk.Setup) bool { return s.Name == sdk.System.String() }
 )
 
 func ensureSystemFirst[T string | sdk.Setup](items []T, match func(T) bool, systemSdk T) []T {
@@ -101,7 +100,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		for _, s := range sdks {
 			candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 		}
-		candidates = ensureSystemFirst(candidates, isSystem, systemSetup)
+		candidates = ensureSystemFirst(candidates, func(s sdk.Setup) bool { return sdk.IsSystem(s.Name) }, systemSetup)
 
 		tasks := launch(w.state, file, candidates, project)
 		taskset = append(taskset, tasks)
@@ -114,7 +113,7 @@ func sdkStoreInfo(sto sdk.Store, ctx context.Context, projectid string, file *wo
 	for _, sd := range file.Sdks {
 		// "system" SDK is bootstrapped and installed by Workshop locally in a
 		// separate task.
-		if sd.Name == sdk.System.String() {
+		if sdk.IsSystem(sd.Name) {
 			continue
 		}
 		act := sdk.SdkAction{ProjectId: projectid, Workshop: file.Name, Name: sd.Name, Base: file.Base, Channel: sd.Channel, Action: sdk.Install}
@@ -218,7 +217,14 @@ func rebuildWorkshop(st *state.State, file *workshop.File, sdkSnapshot string) *
 	base.Set("workshop-base", file.Base)
 	addTask(base)
 
-	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", file.Name))
+	var summary string
+	if sdkSnapshot == "" {
+		summary = fmt.Sprintf("Rebuild %q workshop", file.Name)
+	} else {
+		summary = fmt.Sprintf("Restore %q workshop from %q snapshot", file.Name, sdkSnapshot)
+	}
+
+	create := st.NewTask("create-workshop", summary)
 	addTask(create)
 	create.Set("workshop-file", file)
 
@@ -460,16 +466,14 @@ func resolveRefresh(ctx context.Context, sto sdk.Store, w *workshop.Workshop, fi
 	for _, s := range infos {
 		candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 	}
-	candidates = ensureSystemFirst(candidates, isSystem, systemSetup)
+	candidates = ensureSystemFirst(candidates, func(s sdk.Setup) bool { return sdk.IsSystem(s.Name) }, systemSetup)
 
 	// Restore the order of SDKs installed in the running workshop.
 	prevOrder := []string{}
 	for _, s := range w.File.Sdks {
 		prevOrder = append(prevOrder, s.Name)
 	}
-	prevOrder = ensureSystemFirst(prevOrder,
-		func(s string) bool { return s == sdk.System.String() },
-		sdk.System.String())
+	prevOrder = ensureSystemFirst(prevOrder, sdk.IsSystem, sdk.System.String())
 
 	// Determine if a workshop can be partially updated.
 	lastIntact := 0

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -83,7 +83,7 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@20.04", Sdks: sdks}
-	err = s.backend.LaunchWorkshop(s.ctx, &wf)
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf)
 	c.Assert(err, check.IsNil)
 
 	w, err := s.backend.Workshop(s.ctx, ws)

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -16,11 +16,10 @@ import (
 )
 
 type Setup struct {
-	Name             string     `json:"name"`
-	Channel          string     `json:"channel"`
-	Revision         Revision   `json:"revision"`
-	RevisionSequence []Revision `json:"revision-sequence,omitempty"`
-	InstallTime      *time.Time `json:"install-time"`
+	Name        string     `json:"name"`
+	Channel     string     `json:"channel"`
+	Revision    Revision   `json:"revision"`
+	InstallTime *time.Time `json:"install-time"`
 }
 
 func (s *Setup) Filepath() string {

--- a/internal/sdk/system.go
+++ b/internal/sdk/system.go
@@ -27,3 +27,7 @@ func SystemSdkMeta(base string) string {
 func IsSystem(name string) bool {
 	return name == System.String()
 }
+
+func IsSketch(name string) bool {
+	return name == Sketch
+}

--- a/internal/sdk/system.go
+++ b/internal/sdk/system.go
@@ -23,3 +23,7 @@ slots:
 func SystemSdkMeta(base string) string {
 	return fmt.Sprintf(systemSdkYaml, base)
 }
+
+func IsSystem(name string) bool {
+	return name == System.String()
+}

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -6,3 +6,5 @@ import (
 
 //go:embed meta/*
 var SystemSdkFs embed.FS
+
+const SdkMeta = "meta/sdk.yaml"

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -165,8 +165,11 @@ type Backend interface {
 	// Returns a list of workshops for the project in context.
 	ProjectWorkshops(ctx context.Context) ([]*Workshop, error)
 
-	// Launch a barebone workshop instance using the base provided.
-	LaunchWorkshop(ctx context.Context, file *File) error
+	// Launch a barebone workshop instance. If the workshop exists, wipe out its
+	// rootfs and rebuild it from the workshop file's base image. The
+	// configuration and devices of the rebuilt workshop will be reset to the
+	// default one.
+	LaunchOrRebuildWorkshop(ctx context.Context, file *File) error
 
 	// Delete workshop. Stop the workshop forcefully if not in Stopped before deleting
 	RemoveWorkshop(ctx context.Context, name string) error

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -145,6 +145,8 @@ type Backend interface {
 	Stash
 	VolumeManager
 	BaseImageManager
+	Snapshot
+
 	// The backend will attempt to load a project for the given path
 	// using its mapping between the path and a project id. If the project
 	// is not found, e.g. .lock file was removed by the user, but there is still
@@ -203,6 +205,11 @@ type Backend interface {
 	// and redirect its IO using args.ExecControls. ExecContext.Environment will
 	// contain full (actual)
 	Exec(ctx context.Context, name string, args *Execution) (ExecContext, error)
+}
+
+type Snapshot interface {
+	Snapshot(ctx context.Context, workshop, snapid string) error
+	Restore(ctx context.Context, workshop, snapid string, file *File) error
 }
 
 type cachedBackendKey struct{}

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -145,22 +145,42 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 	if f.Workshops[projectId] == nil {
 		f.Workshops[projectId] = make(map[string]*FakeWorkshop)
 	}
-	if _, ok := f.Workshops[projectId][file.Name]; ok {
-		// rebuild the workshop
-		delete(f.Workshops[projectId], file.Name)
-	}
 
 	ws := &FakeWorkshop{}
-	ws.WorkshopFilesystem, err = NewWorkshopFs(f.BaseDir)
-	if err != nil {
-		return err
-	}
-	ws.Workshop = &workshop.Workshop{Backend: f,
-		Name:    file.Name,
-		Running: false,
-		Project: *prj,
-		Base:    file.Base,
-		File:    file,
+
+	if wpe, ok := f.Workshops[projectId][file.Name]; ok {
+		// rebuild the workshop
+
+		ws = wpe
+		ws.File = file
+		fs := ws.WorkshopFilesystem
+
+		// TODO: Remove locally installed SDKs. These should be removed in a
+		// more elegant way, i.e. unmounted from the workshop in a similar
+		// fashion to regular SDKs installed from the store. Thus, it will make
+		// SDKs "independent" of the workshop, which means that changes will
+		// have to take care of unmounting them from the workshop at the right
+		// time.
+		// NOTE: RemoveAll ignores E_NOENT.
+		if err = fs.RemoveAll(sdk.SdkRootPath("system")); err != nil {
+			return err
+		}
+		if err = fs.RemoveAll(sdk.SdkRootPath("sketch")); err != nil {
+			return err
+		}
+	} else {
+		ws.Workshop = &workshop.Workshop{Backend: f,
+			Name:    file.Name,
+			Running: false,
+			Project: *prj,
+			Base:    file.Base,
+			File:    file,
+		}
+		ws.WorkshopFilesystem, err = NewWorkshopFs(f.BaseDir)
+		if err != nil {
+			return err
+		}
+		f.Workshops[projectId][file.Name] = ws
 	}
 
 	ws.Config = make(map[string]string)
@@ -170,7 +190,6 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 	ws.Sdks = make(map[string]sdk.Setup)
 	ws.Profiles = make(map[string]workshop.SdkProfile, 0)
 
-	f.Workshops[projectId][file.Name] = ws
 	return nil
 }
 
@@ -359,9 +378,10 @@ func (s *FakeWorkshopBackend) UnstashWorkshop(ctx context.Context, name string) 
 	if wp == nil {
 		return fmt.Errorf("stashed workshop %q not found", name)
 	}
-	delete(s.StashedWorkshops[projectId], workshop.StashNamePrefix+name)
 	wp.Name = name
 	s.Workshops[projectId][name] = wp
+	wp.Running = true
+
 	return nil
 }
 
@@ -379,6 +399,8 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	if s.StashedWorkshops[projectId] == nil {
 		s.StashedWorkshops[projectId] = make(map[string]*FakeWorkshop)
 	}
+	wp.Running = false
+
 	wcpy := *wp.Workshop
 	stashed := *wp
 	stashed.Workshop = &wcpy
@@ -509,10 +531,31 @@ func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, 
 	}
 	return userName, projectId, nil
 }
+
 func (b *FakeWorkshopBackend) Download(ctx context.Context, base string, report *progress.Reporter) error {
 	b.DownloadBaseCalls = append(b.DownloadBaseCalls, &DownloadCall{Base: base})
 	if b.DownloadBaseCallback != nil {
 		return b.DownloadBaseCallback(ctx, base, report)
+	}
+	return nil
+}
+
+func (s *FakeWorkshopBackend) Snapshot(ctx context.Context, name, snapid string) error {
+	return nil
+}
+
+func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, file *workshop.File) error {
+	user, projectId, err := s.userProject(ctx)
+	if err != nil {
+		return err
+	}
+
+	prj := s.project(user, projectId)
+
+	if wp, ok := s.Workshops[prj.ProjectId][name]; !ok {
+		return workshop.ErrWorkshopNotLaunched
+	} else {
+		wp.File = file
 	}
 	return nil
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -169,6 +169,7 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 
 		ws = wpe
 		ws.File = file
+		ws.Base = file.Base
 		fs := ws.WorkshopFilesystem
 
 		// TODO: Remove locally installed SDKs. These should be removed in a

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -89,7 +89,7 @@ type FakeWorkshopBackend struct {
 	SnapshotCalls    []SnapshotCall
 	SnapshotCallback func(ctx context.Context, workshop string, snapid string) error
 	RestoreCalls     []RestoreCall
-	RestoreCallback  func(ctx context.Context, workshop string, snapid string) error
+	RestoreCallback  func(ctx context.Context, workshop string, snapid string, File *workshop.File) error
 
 	BaseDir string
 }
@@ -377,8 +377,7 @@ func (s *FakeWorkshopBackend) RemoveWorkshopStash(ctx context.Context, name stri
 		return err
 	}
 
-	wp := s.StashedWorkshops[projectId][workshop.StashNamePrefix+name]
-	if wp == nil {
+	if s.StashedWorkshops[projectId][workshop.StashNamePrefix+name] == nil {
 		return fmt.Errorf("stashed workshop %q not found", name)
 	}
 	delete(s.StashedWorkshops[projectId], workshop.StashNamePrefix+name)
@@ -580,8 +579,8 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, 
 	}
 
 	s.RestoreCalls = append(s.RestoreCalls, RestoreCall{Workshop: name, Snapid: snapid, File: file})
-	if s.SnapshotCallback != nil {
-		return s.SnapshotCallback(ctx, name, snapid)
+	if s.RestoreCallback != nil {
+		return s.RestoreCallback(ctx, name, snapid, file)
 	}
 	return nil
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -134,7 +134,7 @@ func (f *FakeWorkshopBackend) project(user, id string) *workshop.Project {
 	return nil
 }
 
-func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *workshop.File) error {
+func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File) error {
 	user, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -146,7 +146,8 @@ func (f *FakeWorkshopBackend) LaunchWorkshop(ctx context.Context, file *workshop
 		f.Workshops[projectId] = make(map[string]*FakeWorkshop)
 	}
 	if _, ok := f.Workshops[projectId][file.Name]; ok {
-		return errors.New("workshop exists")
+		// rebuild the workshop
+		delete(f.Workshops[projectId], file.Name)
 	}
 
 	ws := &FakeWorkshop{}
@@ -335,6 +336,16 @@ func DoExecDefault(ctx context.Context, name string, args *workshop.Execution) (
 }
 
 func (s *FakeWorkshopBackend) RemoveWorkshopStash(ctx context.Context, name string) error {
+	_, projectId, err := s.userProject(ctx)
+	if err != nil {
+		return err
+	}
+
+	wp := s.StashedWorkshops[projectId][workshop.StashNamePrefix+name]
+	if wp == nil {
+		return fmt.Errorf("stashed workshop %q not found", name)
+	}
+	delete(s.StashedWorkshops[projectId], workshop.StashNamePrefix+name)
 	return nil
 }
 
@@ -368,9 +379,12 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	if s.StashedWorkshops[projectId] == nil {
 		s.StashedWorkshops[projectId] = make(map[string]*FakeWorkshop)
 	}
-	s.StashedWorkshops[projectId][workshop.StashNamePrefix+name] = wp
-	wp.Name = workshop.StashNamePrefix + name
-	delete(s.Workshops[projectId], name)
+	wcpy := *wp.Workshop
+	stashed := *wp
+	stashed.Workshop = &wcpy
+	stashed.Name = workshop.StashNamePrefix + name
+
+	s.StashedWorkshops[projectId][workshop.StashNamePrefix+name] = &stashed
 	return nil
 }
 

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -49,6 +49,17 @@ type AttachVolumeCall struct {
 	Name     string
 }
 
+type SnapshotCall struct {
+	Workshop string
+	Snapid   string
+}
+
+type RestoreCall struct {
+	Workshop string
+	Snapid   string
+	File     *workshop.File
+}
+
 type WorkshopFsCallback func(ctx context.Context, name string) (workshop.WorkshopFs, error)
 
 type FakeWorkshopBackend struct {
@@ -74,6 +85,11 @@ type FakeWorkshopBackend struct {
 	DownloadBaseCalls    []*DownloadCall
 
 	AttachVolumeCalls []AttachVolumeCall
+
+	SnapshotCalls    []SnapshotCall
+	SnapshotCallback func(ctx context.Context, workshop string, snapid string) error
+	RestoreCalls     []RestoreCall
+	RestoreCallback  func(ctx context.Context, workshop string, snapid string) error
 
 	BaseDir string
 }
@@ -541,6 +557,10 @@ func (b *FakeWorkshopBackend) Download(ctx context.Context, base string, report 
 }
 
 func (s *FakeWorkshopBackend) Snapshot(ctx context.Context, name, snapid string) error {
+	s.SnapshotCalls = append(s.SnapshotCalls, SnapshotCall{Workshop: name, Snapid: snapid})
+	if s.SnapshotCallback != nil {
+		return s.SnapshotCallback(ctx, name, snapid)
+	}
 	return nil
 }
 
@@ -556,6 +576,11 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, 
 		return workshop.ErrWorkshopNotLaunched
 	} else {
 		wp.File = file
+	}
+
+	s.RestoreCalls = append(s.RestoreCalls, RestoreCall{Workshop: name, Snapid: snapid, File: file})
+	if s.SnapshotCallback != nil {
+		return s.SnapshotCallback(ctx, name, snapid)
 	}
 	return nil
 }

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -249,22 +249,35 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 	if err != nil {
 		return err
 	}
-	req := api.InstancesPost{
-		InstancePut: api.InstancePut{
-			Devices: defaultDevices(),
-			Config:  config,
-		},
-		Name: InstanceName(file.Name, projectId),
-		Type: api.InstanceType("container"),
-		Source: api.InstanceSource{
-			Type:        "image",
-			Fingerprint: image.Fingerprint,
-			Project:     LxdProjectName(userName),
-		},
-	}
+	devices := defaultDevices()
 
 	inst, _, err := conn.GetInstanceFull(InstanceName(file.Name, projectId))
-	if err == nil {
+	switch {
+	case err != nil && !api.StatusErrorCheck(err, http.StatusNotFound):
+		return err
+	case err != nil && api.StatusErrorCheck(err, http.StatusNotFound):
+		// Create a new workshop.
+		req := api.InstancesPost{
+			InstancePut: api.InstancePut{
+				Devices: devices,
+				Config:  config,
+			},
+			Name: InstanceName(file.Name, projectId),
+			Type: api.InstanceType("container"),
+			Source: api.InstanceSource{
+				Type:        "image",
+				Fingerprint: image.Fingerprint,
+				Project:     LxdProjectName(userName),
+			},
+		}
+		op, err := conn.CreateInstance(req)
+		if err != nil {
+			return err
+		}
+
+		return op.Wait()
+	default:
+		// Rebuild the existing workshop
 		for _, snapshot := range inst.Snapshots {
 			op, err := conn.DeleteInstanceSnapshot(inst.Name, snapshot.Name)
 			if err != nil {
@@ -290,7 +303,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		}
 
 		maps.Copy(rebuilt.Config, config)
-		maps.Copy(rebuilt.Devices, defaultDevices())
+		maps.Copy(rebuilt.Devices, devices)
 
 		op, err := conn.UpdateInstance(rebuilt.Name, rebuilt.Writable(), etag)
 		if err != nil {
@@ -300,13 +313,6 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			return err
 		}
 		return nil
-	} else {
-		op, err := conn.CreateInstance(req)
-		if err != nil {
-			return err
-		}
-
-		return op.Wait()
 	}
 }
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -11,13 +11,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/dirs"
@@ -275,17 +275,24 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			}
 		}
 
-		rop, err := conn.RebuildInstanceFromImage(conn, *image, InstanceName(file.Name, projectId), api.InstanceRebuildPost{})
+		rop, err := conn.RebuildInstanceFromImage(conn, *image, inst.Name, api.InstanceRebuildPost{})
 		if err != nil {
 			return err
 		}
 		if err = rop.Wait(); err != nil {
 			return err
 		}
-		maps.Copy(inst.Config, req.Config)
-		maps.Copy(inst.Devices, req.Devices)
 
-		op, err := conn.UpdateInstance(InstanceName(file.Name, projectId), inst.Writable(), "")
+		// Get an updated instance configuration
+		rebuilt, etag, err := conn.GetInstance(inst.Name)
+		if err != nil {
+			return err
+		}
+
+		maps.Copy(rebuilt.Config, config)
+		maps.Copy(rebuilt.Devices, defaultDevices())
+
+		op, err := conn.UpdateInstance(rebuilt.Name, rebuilt.Writable(), etag)
 		if err != nil {
 			return err
 		}
@@ -831,11 +838,14 @@ func (s *Backend) Restore(ctx context.Context, name, snapid string, file *worksh
 		return err
 	}
 
-	instPut.Restore = ""
+	// The restored snapshot will have an updated file and empty profiles.
+	// Similar to how a launched workshop is associated with its definition.
+	inst, etag, err = conn.GetInstance(InstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+	instPut = inst.Writable()
 	instPut.Profiles = []string{"default"}
-
-	// The restored snapsho will have an updated file. Similar to how a launched
-	// workshop is associated with its definition.
 	f, err := yaml.Marshal(file)
 	if err != nil {
 		return err
@@ -845,7 +855,7 @@ func (s *Backend) Restore(ctx context.Context, name, snapid string, file *worksh
 	// time the snapshot was made. We need the restored configuration to have
 	// the current instance's configuration as it reflects the installed SDKs
 	// list, for example.
-	op, err = conn.UpdateInstance(inst.Name, instPut, "")
+	op, err = conn.UpdateInstance(inst.Name, instPut, etag)
 	if err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1002,7 +1002,7 @@ runcmd:
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,
 		"user.workshop.file":       string(f),
-		"user.workshop.sdks":       "",
+		"user.workshop.sdks":       "{}",
 		// LXC appears to have a race condition wherein a proxy device mounted in
 		// a dynamically created directory has the potential to be 'masked' by this
 		// directory. We create an explicit mount for /tmp here (one such dymanic

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -140,6 +140,11 @@ func New() (*Backend, error) {
 		req := api.StoragePoolsPost{
 			Name:   storagePool,
 			Driver: storagePoolDriver,
+			StoragePoolPut: api.StoragePoolPut{
+				Config: map[string]string{
+					"volume.zfs.remove_snapshots": "true",
+				},
+			},
 		}
 		err := conn.CreateStoragePool(req)
 		if err != nil {
@@ -258,8 +263,18 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		},
 	}
 
-	inst, _, err := conn.GetInstance(InstanceName(file.Name, projectId))
+	inst, _, err := conn.GetInstanceFull(InstanceName(file.Name, projectId))
 	if err == nil {
+		for _, snapshot := range inst.Snapshots {
+			op, err := conn.DeleteInstanceSnapshot(inst.Name, snapshot.Name)
+			if err != nil {
+				return err
+			}
+			if err = op.Wait(); err != nil {
+				return err
+			}
+		}
+
 		rop, err := conn.RebuildInstanceFromImage(conn, *image, InstanceName(file.Name, projectId), api.InstanceRebuildPost{})
 		if err != nil {
 			return err
@@ -268,7 +283,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			return err
 		}
 		maps.Copy(inst.Config, req.Config)
-		inst.Devices = req.Devices
+		maps.Copy(inst.Devices, req.Devices)
 
 		op, err := conn.UpdateInstance(InstanceName(file.Name, projectId), inst.Writable(), "")
 		if err != nil {
@@ -768,6 +783,78 @@ func (s *Backend) RemoveWorkshop(ctx context.Context, name string) (err error) {
 	return op.Wait()
 }
 
+func (s *Backend) Snapshot(ctx context.Context, name, snapid string) error {
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Disconnect()
+
+	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
+	if !ok {
+		return fmt.Errorf("context key project-id not found")
+	}
+
+	op, err := conn.CreateInstanceSnapshot(InstanceName(name, projectId), api.InstanceSnapshotsPost{
+		Name: snapid,
+	})
+	if err != nil {
+		return err
+	}
+	return op.Wait()
+}
+
+func (s *Backend) Restore(ctx context.Context, name, snapid string, file *workshop.File) error {
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Disconnect()
+
+	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
+	if !ok {
+		return fmt.Errorf("context key project-id not found")
+	}
+
+	inst, etag, err := conn.GetInstance(InstanceName(name, projectId))
+	if err != nil {
+		return err
+	}
+
+	instPut := inst.Writable()
+	instPut.Restore = snapid
+	op, err := conn.UpdateInstance(inst.Name, instPut, etag)
+	if err != nil {
+		return err
+	}
+	if err = op.Wait(); err != nil {
+		return err
+	}
+
+	instPut.Restore = ""
+	instPut.Profiles = []string{"default"}
+
+	// The restored snapsho will have an updated file. Similar to how a launched
+	// workshop is associated with its definition.
+	f, err := yaml.Marshal(file)
+	if err != nil {
+		return err
+	}
+	instPut.Config["user.workshop.file"] = string(f)
+	// Restore from a snapshot also restores the workshop configuration at the
+	// time the snapshot was made. We need the restored configuration to have
+	// the current instance's configuration as it reflects the installed SDKs
+	// list, for example.
+	op, err = conn.UpdateInstance(inst.Name, instPut, "")
+	if err != nil {
+		return err
+	}
+	if err = op.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *Backend) WorkshopFs(ctx context.Context, name string) (workshop.WorkshopFs, error) {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
@@ -915,6 +1002,7 @@ runcmd:
 		"user.workshop.project-id": projectId,
 		"user.user-data":           cloudInitConfig,
 		"user.workshop.file":       string(f),
+		"user.workshop.sdks":       "",
 		// LXC appears to have a race condition wherein a proxy device mounted in
 		// a dynamically created directory has the potential to be 'masked' by this
 		// directory. We create an explicit mount for /tmp here (one such dymanic

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -840,22 +840,26 @@ func (s *Backend) Restore(ctx context.Context, name, snapid string, file *worksh
 
 	// The restored snapshot will have an updated file and empty profiles.
 	// Similar to how a launched workshop is associated with its definition.
-	inst, etag, err = conn.GetInstance(InstanceName(name, projectId))
+	restored, etag, err := conn.GetInstance(InstanceName(name, projectId))
 	if err != nil {
 		return err
 	}
-	instPut = inst.Writable()
-	instPut.Profiles = []string{"default"}
+
 	f, err := yaml.Marshal(file)
 	if err != nil {
 		return err
 	}
-	instPut.Config["user.workshop.file"] = string(f)
+
 	// Restore from a snapshot also restores the workshop configuration at the
 	// time the snapshot was made. We need the restored configuration to have
 	// the current instance's configuration as it reflects the installed SDKs
 	// list, for example.
-	op, err = conn.UpdateInstance(inst.Name, instPut, etag)
+	// Reset it to the actual configuration of the instance.
+	restored.Config["user.workshop.sdks"] = instPut.Config["user.workshop.sdks"]
+	restored.Config["user.workshop.file"] = string(f)
+	restored.Profiles = []string{"default"}
+
+	op, err = conn.UpdateInstance(inst.Name, restored.Writable(), etag)
 	if err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -203,7 +204,7 @@ func New() (*Backend, error) {
 	return &server, nil
 }
 
-func (s *Backend) LaunchWorkshop(ctx context.Context, file *workshop.File) error {
+func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File) error {
 	var err error
 	var image *api.Image
 
@@ -213,14 +214,14 @@ func (s *Backend) LaunchWorkshop(ctx context.Context, file *workshop.File) error
 	}
 	defer conn.Disconnect()
 
-	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
-	if !ok {
-		return fmt.Errorf("context key project-id not found")
-	}
-
 	userName, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
 		return fmt.Errorf("context key user not found")
+	}
+
+	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
+	if !ok {
+		return fmt.Errorf("context key project-id not found")
 	}
 
 	// Check if we have the base image stored locally
@@ -257,13 +258,34 @@ func (s *Backend) LaunchWorkshop(ctx context.Context, file *workshop.File) error
 		},
 	}
 
-	op, err := conn.CreateInstance(req)
-	if err != nil {
-		return err
-	}
+	inst, _, err := conn.GetInstance(InstanceName(file.Name, projectId))
+	if err == nil {
+		rop, err := conn.RebuildInstanceFromImage(conn, *image, InstanceName(file.Name, projectId), api.InstanceRebuildPost{})
+		if err != nil {
+			return err
+		}
+		if err = rop.Wait(); err != nil {
+			return err
+		}
+		maps.Copy(inst.Config, req.Config)
+		inst.Devices = req.Devices
 
-	// CreateInstance cannot be cancelled in LXD.
-	return op.Wait()
+		op, err := conn.UpdateInstance(InstanceName(file.Name, projectId), inst.Writable(), "")
+		if err != nil {
+			return err
+		}
+		if err = op.Wait(); err != nil {
+			return err
+		}
+		return nil
+	} else {
+		op, err := conn.CreateInstance(req)
+		if err != nil {
+			return err
+		}
+
+		return op.Wait()
+	}
 }
 
 func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Context, name, action string, force bool) error {

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -86,7 +87,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 // Moves the instance between LXD projects.
 func (s *Backend) copyInstance(conn lxd.InstanceServer, srcName, dstName, sourceProject, targetProject string) error {
 	conn = conn.UseProject(sourceProject)
-	instance, _, err := conn.GetInstance(srcName)
+	instance, etag, err := conn.GetInstance(srcName)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return workshop.ErrWorkshopNotLaunched
@@ -96,10 +97,35 @@ func (s *Backend) copyInstance(conn lxd.InstanceServer, srcName, dstName, source
 
 	dest := conn
 	dest = dest.UseProject(targetProject)
-	instance.Profiles = []string{}
+
+	// Profiles need reseting before making a copy to workaround:
+	// https://github.com/canonical/lxd/issues/15078#issue-2883386254
+	oldProfiles := slices.Clone(instance.Profiles)
+	instance.Profiles = []string{"default"}
+
+	op, err := conn.UpdateInstance(instance.Name, instance.Writable(), etag)
+	if err != nil {
+		return err
+	}
+	if err = op.Wait(); err != nil {
+		return err
+	}
+
+	rev := revert.New()
+	defer rev.Fail()
+
+	rev.Add(func() {
+		instance.Profiles = oldProfiles
+		op, rerr := conn.UpdateInstance(instance.Name, instance.Writable(), "")
+		if rerr != nil {
+			logger.Noticef("On copyInstance: cannot revert profiles assigned to %q workshop: %v", srcName, rerr)
+		}
+		if rerr = op.Wait(); rerr != nil {
+			logger.Noticef("On copyInstance: cannot revert profiles assigned to %q workshop: %v", srcName, rerr)
+		}
+	})
 
 	rop, err := dest.CopyInstance(conn, *instance, &lxd.InstanceCopyArgs{Name: dstName})
-
 	if err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"slices"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -87,7 +86,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 // Moves the instance between LXD projects.
 func (s *Backend) copyInstance(conn lxd.InstanceServer, srcName, dstName, sourceProject, targetProject string) error {
 	conn = conn.UseProject(sourceProject)
-	instance, etag, err := conn.GetInstance(srcName)
+	instance, _, err := conn.GetInstance(srcName)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return workshop.ErrWorkshopNotLaunched
@@ -95,36 +94,7 @@ func (s *Backend) copyInstance(conn lxd.InstanceServer, srcName, dstName, source
 		return err
 	}
 
-	dest := conn
-	dest = dest.UseProject(targetProject)
-
-	// Profiles need reseting before making a copy to workaround:
-	// https://github.com/canonical/lxd/issues/15078#issue-2883386254
-	oldProfiles := slices.Clone(instance.Profiles)
-	instance.Profiles = []string{"default"}
-
-	op, err := conn.UpdateInstance(instance.Name, instance.Writable(), etag)
-	if err != nil {
-		return err
-	}
-	if err = op.Wait(); err != nil {
-		return err
-	}
-
-	rev := revert.New()
-	defer rev.Fail()
-
-	rev.Add(func() {
-		instance.Profiles = oldProfiles
-		op, rerr := conn.UpdateInstance(instance.Name, instance.Writable(), "")
-		if rerr != nil {
-			logger.Noticef("On copyInstance: cannot revert profiles assigned to %q workshop: %v", srcName, rerr)
-		}
-		if rerr = op.Wait(); rerr != nil {
-			logger.Noticef("On copyInstance: cannot revert profiles assigned to %q workshop: %v", srcName, rerr)
-		}
-	})
-
+	dest := conn.UseProject(targetProject)
 	rop, err := dest.CopyInstance(conn, *instance, &lxd.InstanceCopyArgs{Name: dstName})
 	if err != nil {
 		return err
@@ -132,7 +102,6 @@ func (s *Backend) copyInstance(conn lxd.InstanceServer, srcName, dstName, source
 	if err = rop.Wait(); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -46,7 +46,7 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		}
 	})
 
-	if err = s.moveInstance(conn, instance, stashedInsance, LxdProjectName(user), LxdSystemProjectName(user)); err != nil {
+	if err = s.copyInstance(conn, instance, stashedInsance, LxdProjectName(user), LxdSystemProjectName(user)); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 	}
 	defer conn.Disconnect()
 
-	if err := s.moveInstance(conn, stashedInsance, instance, LxdSystemProjectName(user), LxdProjectName(user)); err != nil {
+	if err := s.copyInstance(conn, stashedInsance, instance, LxdSystemProjectName(user), LxdProjectName(user)); err != nil {
 		return err
 	}
 
@@ -84,7 +84,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 }
 
 // Moves the instance between LXD projects.
-func (s *Backend) moveInstance(conn lxd.InstanceServer, srcName, dstName, sourceProject, targetProject string) error {
+func (s *Backend) copyInstance(conn lxd.InstanceServer, srcName, dstName, sourceProject, targetProject string) error {
 	conn = conn.UseProject(sourceProject)
 	instance, _, err := conn.GetInstance(srcName)
 	if err != nil {
@@ -107,12 +107,7 @@ func (s *Backend) moveInstance(conn lxd.InstanceServer, srcName, dstName, source
 		return err
 	}
 
-	op, err := conn.DeleteInstance(srcName)
-	if err != nil {
-		return err
-	}
-
-	return op.Wait()
+	return nil
 }
 
 func (s *Backend) RemoveWorkshopStash(ctx context.Context, name string) error {

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -46,7 +46,7 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		}
 	})
 
-	if err = s.moveInstanceAndProfiles(conn, instance, stashedInsance, LxdProjectName(user), LxdSystemProjectName(user)); err != nil {
+	if err = s.moveInstance(conn, instance, stashedInsance, LxdProjectName(user), LxdSystemProjectName(user)); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 	}
 	defer conn.Disconnect()
 
-	if err := s.moveInstanceAndProfiles(conn, stashedInsance, instance, LxdSystemProjectName(user), LxdProjectName(user)); err != nil {
+	if err := s.moveInstance(conn, stashedInsance, instance, LxdSystemProjectName(user), LxdProjectName(user)); err != nil {
 		return err
 	}
 
@@ -83,34 +83,36 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 	return nil
 }
 
-// Moves the instance between the project and stash area (or the other way around)
-// instanceFrom - the instance's source name
-// instanceTo - the instance's dest name (must be different due to LXD DNS conflicts)
-// source - the LXD project name to move instance from
-// target - the LXD project name to move instance to
-func (s *Backend) moveInstanceAndProfiles(conn lxd.InstanceServer, instanceFrom, instanceTo, source, target string) error {
-	conn = conn.UseProject(source)
-	_, _, err := conn.GetInstance(instanceFrom)
+// Moves the instance between LXD projects.
+func (s *Backend) moveInstance(conn lxd.InstanceServer, srcName, dstName, sourceProject, targetProject string) error {
+	conn = conn.UseProject(sourceProject)
+	instance, _, err := conn.GetInstance(srcName)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return workshop.ErrWorkshopNotLaunched
 		}
 		return err
 	}
-	// Stash the workshop
-	// the new name must not be the same, otherwise the LXD's DNS will fail
-	// the new instance creation; hence, the prefix.
-	if op, err := conn.MigrateInstance(instanceFrom, api.InstancePost{
-		Name:      instanceTo,
-		Project:   target,
-		Migration: true,
-		Profiles:  []string{"default"},
-	}); err != nil {
-		return err
-	} else if err = op.Wait(); err != nil {
+
+	dest := conn
+	dest = dest.UseProject(targetProject)
+	instance.Profiles = []string{}
+
+	rop, err := dest.CopyInstance(conn, *instance, &lxd.InstanceCopyArgs{Name: dstName})
+
+	if err != nil {
 		return err
 	}
-	return nil
+	if err = rop.Wait(); err != nil {
+		return err
+	}
+
+	op, err := conn.DeleteInstance(srcName)
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
 }
 
 func (s *Backend) RemoveWorkshopStash(ctx context.Context, name string) error {
@@ -133,12 +135,12 @@ func (s *Backend) RemoveWorkshopStash(ctx context.Context, name string) error {
 	conn = conn.UseProject(LxdSystemProjectName(user))
 	iname := workshop.StashNamePrefix + InstanceName(name, projectId)
 
-	// 1. Remove the workshop instance
 	op, err := conn.DeleteInstance(iname)
 	if err != nil {
 		return err
-	} else if err = op.WaitContext(ctx); err != nil {
-		return nil
+	}
+	if err = op.Wait(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -122,7 +122,7 @@ printf '%s\n' "$@"
 	prj, _, err := bd.CreateOrLoadProject(ctx, dir)
 	c.Assert(err, check.IsNil)
 
-	err = bd.LaunchWorkshop(ctx, wf)
+	err = bd.LaunchOrRebuildWorkshop(ctx, wf)
 	c.Assert(err, check.IsNil)
 
 	volume := workshop.AptCacheVolumeName(wf.Name, prj.ProjectId)

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -82,16 +82,22 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Validate
-	c.Assert(err, check.IsNil)
 	_, err = f.bd.Workshop(f.ctx, "test")
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.IsNil)
+
+	// Execute
+	err = f.bd.RemoveWorkshop(f.ctx, "test")
+	c.Assert(err, check.IsNil)
 
 	// Execute
 	err = f.bd.UnstashWorkshop(f.ctx, "test")
+	c.Assert(err, check.IsNil)
 
 	// Validate
-	c.Assert(err, check.IsNil)
 	_, err = f.bd.Workshop(f.ctx, "test")
+	c.Assert(err, check.IsNil)
+
+	err = f.bd.RemoveWorkshopStash(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 }
 
@@ -105,7 +111,7 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 	// Validate
 	c.Assert(err, check.IsNil)
 	_, err = f.bd.Workshop(f.ctx, "test")
-	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
+	c.Assert(err, check.IsNil)
 
 	// Execute
 	err = f.bd.RemoveWorkshopStash(f.ctx, "test")
@@ -386,4 +392,45 @@ func (f *wsOps) TestLxdBackendWorkshopStartFailed(c *check.C) {
 	w, err := f.bd.Workshop(f.ctx, "test")
 	c.Check(err, check.IsNil)
 	c.Check(w.Running, check.Equals, false)
+}
+
+func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {
+	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
+
+	err := f.bd.StopWorkshop(f.ctx, "test", true)
+	c.Assert(err, check.IsNil)
+
+	wf := &workshop.File{
+		Name: "test",
+		Base: "ubuntu@24.04"}
+
+	// Execute
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf)
+	c.Assert(err, check.IsNil)
+}
+
+func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
+	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
+
+	err := f.bd.StopWorkshop(f.ctx, "test", true)
+	c.Assert(err, check.IsNil)
+
+	err = f.bd.Snapshot(f.ctx, "test", "snapshot-1")
+	c.Assert(err, check.IsNil)
+
+	wf := &workshop.File{
+		Name: "test",
+		Base: "ubuntu@24.04"}
+
+	// Execute
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf)
+	c.Assert(err, check.IsNil)
+
+	err = f.bd.Snapshot(f.ctx, "test", "snapshot-1")
+	c.Assert(err, check.IsNil)
+
+	err = f.bd.Restore(f.ctx, "test", "snapshot-1", wf)
+	c.Assert(err, check.IsNil)
 }

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -97,7 +97,7 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 
 func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
-	defer helper.RemoveTestVolume(c, f.ctx, f.bd)
+	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
 	// Execute
 	err := f.bd.StashWorkshop(f.ctx, "test")

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/progress"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -414,7 +416,15 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
-	err := f.bd.StopWorkshop(f.ctx, "test", true)
+	w, err := f.bd.Workshop(f.ctx, "test")
+	c.Check(err, check.IsNil)
+	err = w.InstallLocalSdk(f.ctx, sdk.System.String(), "x1", system.SystemSdkFs)
+	c.Check(err, check.IsNil)
+	err = w.LinkSdk(f.ctx, sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)})
+	c.Check(err, check.IsNil)
+	c.Check(w.Sdks, check.HasLen, 1)
+
+	err = f.bd.StopWorkshop(f.ctx, "test", true)
 	c.Assert(err, check.IsNil)
 
 	err = f.bd.Snapshot(f.ctx, "test", "snapshot-1")
@@ -422,15 +432,22 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 
 	wf := &workshop.File{
 		Name: "test",
-		Base: "ubuntu@24.04"}
-
-	// Execute
-	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf)
-	c.Assert(err, check.IsNil)
-
-	err = f.bd.Snapshot(f.ctx, "test", "snapshot-1")
-	c.Assert(err, check.IsNil)
+		Base: "ubuntu@24.04",
+	}
+	// The instance's configuration does not have any SDK in user.workshop.sdks
+	// after this.
+	err = w.UnlinkSdk(f.ctx, sdk.System.String())
+	c.Check(err, check.IsNil)
 
 	err = f.bd.Restore(f.ctx, "test", "snapshot-1", wf)
 	c.Assert(err, check.IsNil)
+
+	w, err = f.bd.Workshop(f.ctx, "test")
+	c.Check(err, check.IsNil)
+	c.Check(w.Running, check.Equals, false)
+	// Check that restore did not restore previous version of
+	// "user.workshop.sdks" or "user.workshop.file" and uses the instance's
+	// configuration, not the snapshot's.
+	c.Check(w.File, check.DeepEquals, wf)
+	c.Check(w.Sdks, check.HasLen, 0)
 }

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -270,15 +270,30 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 
 // Returns a map of SDK info for installed SDKs. The info includes SDK details
 // parsed from its sdk.yaml, such as base, plugs, slots, etc.
-func (w *Workshop) SdkInfos(ctx context.Context) (map[string]*sdk.Info, error) {
-	var infos = make(map[string]*sdk.Info, len(w.Sdks))
+func (w *Workshop) SdkInfosByInstallOrder(ctx context.Context) ([]*sdk.Info, error) {
+	var infos = make([]*sdk.Info, 0, len(w.Sdks))
 	for _, sdk := range w.Sdks {
 		info, err := w.SdkInfo(ctx, sdk.Name)
 		if err != nil {
 			return nil, err
 		}
-		infos[info.Name] = info
+		infos = append(infos, info)
 	}
+
+	orderMap := make(map[string]int)
+	for i, v := range w.File.Sdks {
+		orderMap[v.Name] = i
+	}
+
+	// The workshop definition which defines the install order may or may not
+	// contain the system SDK declared in an arbitrary place. Therefore, we have
+	// to make sure that the system SDK goes first and the sketch SDK goes last.
+	orderMap[sdk.System.String()] = -1
+	orderMap[sdk.Sketch] = len(w.File.Sdks)
+	sort.Slice(infos, func(i, j int) bool {
+		return orderMap[infos[i].Name] < orderMap[infos[j].Name]
+	})
+
 	return infos, nil
 }
 
@@ -289,24 +304,22 @@ func (w *Workshop) SdksByInstallOrder() []sdk.Setup {
 	for i, v := range w.File.Sdks {
 		orderMap[v.Name] = i
 	}
+	// The workshop definition which defines the install order may or may not
+	// contain the system SDK declared in an arbitrary place. Therefore, we have
+	// to make sure that the system SDK goes first and the sketch SDK goes last.
+	orderMap[sdk.System.String()] = -1
+	orderMap[sdk.Sketch] = len(w.File.Sdks)
 	sdks := slices.Collect(maps.Values(w.Sdks))
 	sort.Slice(sdks, func(i, j int) bool {
 		return orderMap[sdks[i].Name] < orderMap[sdks[j].Name]
 	})
 
-	// The workshop definition which defines the install order may or may not
-	// contain the system SDK declared in an arbitrary place. Therefore, we have
-	// to make sure that the system SDK goes first.
-	idx := slices.IndexFunc(sdks, func(s sdk.Setup) bool { return sdk.IsSystem(s.Name) })
-	if idx != -1 {
-		sdks[0], sdks[idx] = sdks[idx], sdks[0]
-	}
 	return sdks
 }
 
 // Mounts returns a map of active mounts,
 // given a map of SDK info as returned by SdkInfos.
-func (w *Workshop) Mounts(sdks map[string]*sdk.Info) map[string][]Mount {
+func (w *Workshop) Mounts(sdks []*sdk.Info) map[string][]Mount {
 	if sdks == nil {
 		return nil
 	}
@@ -407,5 +420,5 @@ func (w *Workshop) InstallLocalSdk(ctx context.Context, name string, rev string,
 }
 
 func SnapshotId(w, sk string) string {
-	return strings.Join([]string{w, sk}, "-")
+	return strings.Join([]string{w, sk}, ".")
 }

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -79,36 +79,29 @@ func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
 	}
 	rev.Add(func() { _ = fs.Remove(current) })
 
-	// We do not track the system SDK in the Sdks field; this is only for the
-	// user-defined SDKs as the system SDK is a special case (e.g. cannot be
-	// removed from the workshop).
-	if s.Name != sdk.System.String() {
-		now := InstallTimeNow()
-		s.InstallTime = &now
+	now := InstallTimeNow()
+	s.InstallTime = &now
 
-		sdksetup, exist := w.Sdks[s.Name]
-		if exist {
-			sdksetup.RevisionSequence = append(sdksetup.RevisionSequence, sdksetup.Revision)
-			sdksetup.Revision = s.Revision
-			w.Sdks[s.Name] = sdksetup
-		} else {
-			w.Sdks[s.Name] = s
-		}
+	_, exist := w.Sdks[s.Name]
+	if exist {
+		return fmt.Errorf("%q SDK is already linked", s.Name)
+	} else {
+		w.Sdks[s.Name] = s
+	}
 
-		sequenceValue, err := json.Marshal(w.Sdks)
-		if err != nil {
-			return err
-		}
+	sequenceValue, err := json.Marshal(w.Sdks)
+	if err != nil {
+		return err
+	}
 
-		err = w.Backend.AddWorkshopConfig(ctx, w.Name,
-			&WorkshopConfigValue{
-				Name:  ConfigWorkshopSdks,
-				Value: string(sequenceValue),
-			})
+	err = w.Backend.AddWorkshopConfig(ctx, w.Name,
+		&WorkshopConfigValue{
+			Name:  ConfigWorkshopSdks,
+			Value: string(sequenceValue),
+		})
 
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
 	rev.Success()
@@ -119,28 +112,19 @@ func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
 // removing the SDK from the workshop "installed" SDKs if there are no more
 // revisions left.
 func (w *Workshop) UnlinkSdk(ctx context.Context, name string) error {
-	if name != sdk.System.String() {
-		setup := w.Sdks[name]
-		if len(setup.RevisionSequence) > 0 {
-			setup.Revision = setup.RevisionSequence[len(setup.RevisionSequence)-1]
-			setup.RevisionSequence = setup.RevisionSequence[:len(setup.RevisionSequence)-1]
-			w.Sdks[name] = setup
-		} else {
-			delete(w.Sdks, name)
-		}
-		newSequence, err := json.Marshal(w.Sdks)
-		if err != nil {
-			return err
-		}
+	delete(w.Sdks, name)
+	newSequence, err := json.Marshal(w.Sdks)
+	if err != nil {
+		return err
+	}
 
-		err = w.Backend.AddWorkshopConfig(ctx, w.Name,
-			&WorkshopConfigValue{
-				Name:  ConfigWorkshopSdks,
-				Value: string(newSequence),
-			})
-		if err != nil {
-			return err
-		}
+	err = w.Backend.AddWorkshopConfig(ctx, w.Name,
+		&WorkshopConfigValue{
+			Name:  ConfigWorkshopSdks,
+			Value: string(newSequence),
+		})
+	if err != nil {
+		return err
 	}
 
 	// Update the 'current' link
@@ -149,16 +133,6 @@ func (w *Workshop) UnlinkSdk(ctx context.Context, name string) error {
 		return err
 	}
 	defer fs.Close()
-
-	if setup, exist := w.Sdks[name]; exist {
-		if err = fs.Remove(sdk.SdkCurrentPath(name)); err != nil {
-			return err
-		}
-		if err = fs.Symlink(sdk.SdkRevPath(name, setup.Revision.String()), sdk.SdkCurrentPath(name)); err != nil {
-			return err
-		}
-		return nil
-	}
 
 	// No revisions left in the sequence, remove the 'current' link.
 	// This will be the case during a launch operation that fails, therefore it's
@@ -343,16 +317,16 @@ func (w *Workshop) Mounts(sdks map[string]*sdk.Info) map[string][]Mount {
 }
 
 func install(wfs WorkshopFs, srcfs fs.FS, src, dst string, perm fs.FileMode) error {
-	dstdir := filepath.Dir(dst)
-	if err := wfs.MkdirAll(dstdir, 0755); err != nil {
-		return err
-	}
-
 	filesrc, err := srcfs.Open(src)
 	if err != nil {
 		return err
 	}
 	defer filesrc.Close()
+
+	dstdir := filepath.Dir(dst)
+	if err := wfs.MkdirAll(dstdir, 0755); err != nil {
+		return err
+	}
 
 	filedst, err := wfs.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, perm)
 	if err != nil {
@@ -379,11 +353,11 @@ func (w *Workshop) InstallLocalSdk(ctx context.Context, name string, rev string,
 	// meta: /var/lib/workshop/sdk/<name>/<rev>/meta
 	metasrc := filepath.Join("meta", "sdk.yaml")
 	metadst := filepath.Join(sdk.SdkRevPath(name, rev), "meta", "sdk.yaml")
-	reverter.Add(func() { _ = wfs.RemoveAll(filepath.Dir(metadst)) })
 
 	if err = install(wfs, src, metasrc, metadst, 0644); err != nil {
 		return err
 	}
+	reverter.Add(func() { _ = wfs.RemoveAll(filepath.Dir(metadst)) })
 
 	// hooks: /var/lib/workshop/sdk/<name>/<rev>/sdk/hooks
 	hooksdir := filepath.Join(sdk.SdkRevPath(name, rev), "sdk", "hooks")
@@ -408,4 +382,8 @@ func (w *Workshop) InstallLocalSdk(ctx context.Context, name string, rev string,
 
 	reverter.Success()
 	return nil
+}
+
+func SnapshotId(w, sk string) string {
+	return strings.Join([]string{w, sk}, "-")
 }

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -7,17 +7,20 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/spf13/afero"
-	"golang.org/x/exp/slices"
 
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdk/system"
 )
 
 var (
@@ -279,6 +282,28 @@ func (w *Workshop) SdkInfos(ctx context.Context) (map[string]*sdk.Info, error) {
 	return infos, nil
 }
 
+// Returns the list of SDKs of the workshop sorted by installation order.
+func (w *Workshop) SdksByInstallOrder() []sdk.Setup {
+	// Sort the SDKs in installation order.
+	orderMap := make(map[string]int)
+	for i, v := range w.File.Sdks {
+		orderMap[v.Name] = i
+	}
+	sdks := slices.Collect(maps.Values(w.Sdks))
+	sort.Slice(sdks, func(i, j int) bool {
+		return orderMap[sdks[i].Name] < orderMap[sdks[j].Name]
+	})
+
+	// The workshop definition which defines the install order may or may not
+	// contain the system SDK declared in an arbitrary place. Therefore, we have
+	// to make sure that the system SDK goes first.
+	idx := slices.IndexFunc(sdks, func(s sdk.Setup) bool { return sdk.IsSystem(s.Name) })
+	if idx != -1 {
+		sdks[0], sdks[idx] = sdks[idx], sdks[0]
+	}
+	return sdks
+}
+
 // Mounts returns a map of active mounts,
 // given a map of SDK info as returned by SdkInfos.
 func (w *Workshop) Mounts(sdks map[string]*sdk.Info) map[string][]Mount {
@@ -348,7 +373,7 @@ func (w *Workshop) InstallLocalSdk(ctx context.Context, name string, rev string,
 	defer reverter.Fail()
 
 	// meta: /var/lib/workshop/sdk/<name>/<rev>/meta
-	metasrc := filepath.Join("meta", "sdk.yaml")
+	metasrc := system.SdkMeta
 	metadst := filepath.Join(sdk.SdkRevPath(name, rev), "meta", "sdk.yaml")
 
 	if err = install(wfs, src, metasrc, metadst, 0644); err != nil {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -317,8 +317,7 @@ func (w *Workshop) SdksByInstallOrder() []sdk.Setup {
 	return sdks
 }
 
-// Mounts returns a map of active mounts,
-// given a map of SDK info as returned by SdkInfos.
+// Mounts returns a map of active SDK mounts for the workshop.
 func (w *Workshop) Mounts(sdks []*sdk.Info) map[string][]Mount {
 	if sdks == nil {
 		return nil

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -194,15 +194,12 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	// the only SDKs of that source. This requires rework, once an arbitrary SDK
 	// can be installed from a local source, e.g. to support workshop try.
 	isLocal := func(n string) bool {
-		return n == sdk.Sketch || n == sdk.System.String()
+		return n == sdk.Sketch || sdk.IsSystem(n)
 	}
 
 	setup, ok := w.Sdks[sdkName]
-	if sdkName != sdk.System.String() && !ok {
+	if !ok {
 		return nil, fmt.Errorf("SDK %q is not installed in %q workshop", sdkName, w.Name)
-	}
-	if sdkName == sdk.System.String() {
-		setup = sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: 1}}
 	}
 
 	var err error

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -286,11 +286,11 @@ func validateConnections(wfile *File) error {
 				conn.PlugRef.String(), conn.SlotRef.String())
 		}
 
-		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.PlugRef.Sdk || conn.PlugRef.Sdk == sdk.System.String() }) {
+		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.PlugRef.Sdk || sdk.IsSystem(conn.PlugRef.Sdk) }) {
 			return fmt.Errorf(`cannot connect plug %q to slot %q: workshop %q has no SDK named %q`,
 				conn.PlugRef.String(), conn.SlotRef.String(), wfile.Name, conn.PlugRef.Sdk)
 		}
-		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.SlotRef.Sdk || conn.SlotRef.Sdk == sdk.System.String() }) {
+		if !slices.ContainsFunc(wfile.Sdks, func(r SdkRecord) bool { return r.Name == conn.SlotRef.Sdk || sdk.IsSystem(conn.SlotRef.Sdk) }) {
 			return fmt.Errorf(`cannot connect plug %q to slot %q: workshop %q has no SDK named %q`,
 				conn.PlugRef.String(), conn.SlotRef.String(), wfile.Name, conn.SlotRef.Sdk)
 		}

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
@@ -25,7 +26,14 @@ type workshopSuite struct {
 var _ = check.Suite(&workshopSuite{})
 
 var workshopyaml = []byte(`name: test-workshop
-base: ubuntu@22.04`)
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-1
+    channel: latest/stable
+  - name: test-sdk-2
+    channel: latest/stable
+  - name: system
+`)
 
 func (f *workshopSuite) SetUpTest(c *check.C) {
 	var err error
@@ -142,4 +150,27 @@ base: ubuntu@22.04`)
 	info, err := wfs.Stat("/var/lib/workshop/sdk/local/x1/sdk/hooks/setup-base")
 	c.Assert(err, check.IsNil)
 	c.Check(info.Mode().Perm(), check.Equals, fs.FileMode(0755))
+}
+
+func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
+	wpath := filepath.Join(f.p.Path, "workshop.yaml")
+	writeFile(c, wpath, string(workshopyaml))
+	file, err := workshop.ReadWorkshop(wpath)
+	c.Assert(err, check.IsNil)
+
+	w := workshop.Workshop{File: file, Name: "test-workshop"}
+	w.Sdks = map[string]sdk.Setup{
+		"test-sdk-1": {Name: "test-sdk-1", Revision: sdk.R(1), Channel: "latest/stable"},
+		"test-sdk-2": {Name: "test-sdk-2", Revision: sdk.R(1), Channel: "latest/edge"},
+		"system":     {Name: "system", Revision: sdk.R(-1)},
+		"sketch":     {Name: "sketch", Revision: sdk.R(-3)},
+	}
+
+	sdks := w.SdksByInstallOrder()
+	c.Assert(sdks, check.DeepEquals, []sdk.Setup{
+		{Name: "system", Revision: sdk.R(-1)},
+		{Name: "test-sdk-1", Revision: sdk.R(1), Channel: "latest/stable"},
+		{Name: "test-sdk-2", Revision: sdk.R(1), Channel: "latest/edge"},
+		{Name: "sketch", Revision: sdk.R(-3)},
+	})
 }

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -66,7 +66,7 @@ func (f *workshopSuite) TestInstallLocalSdkMetaOnlyOK(c *check.C) {
 	file, err := workshop.ReadWorkshop(wpath)
 	c.Assert(err, check.IsNil)
 
-	err = f.bend.LaunchWorkshop(f.ctx, file)
+	err = f.bend.LaunchOrRebuildWorkshop(f.ctx, file)
 	c.Assert(err, check.IsNil)
 
 	w, err := f.bend.Workshop(f.ctx, "test-workshop")
@@ -93,7 +93,7 @@ func (f *workshopSuite) TestInstallLocalSdkNoMetaFails(c *check.C) {
 	file, err := workshop.ReadWorkshop(wpath)
 	c.Assert(err, check.IsNil)
 
-	err = f.bend.LaunchWorkshop(f.ctx, file)
+	err = f.bend.LaunchOrRebuildWorkshop(f.ctx, file)
 	c.Assert(err, check.IsNil)
 
 	w, err := f.bend.Workshop(f.ctx, "test-workshop")
@@ -118,7 +118,7 @@ func (f *workshopSuite) TestInstallLocalSdkWithHooksOK(c *check.C) {
 	file, err := workshop.ReadWorkshop(wpath)
 	c.Assert(err, check.IsNil)
 
-	err = f.bend.LaunchWorkshop(f.ctx, file)
+	err = f.bend.LaunchOrRebuildWorkshop(f.ctx, file)
 	c.Assert(err, check.IsNil)
 
 	w, err := f.bend.Workshop(f.ctx, "test-workshop")

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -47,7 +47,7 @@ function prepare_environment() {
     done
 
     apt-get update
-    apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)" moreutils jq xdelta3
+    apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)" moreutils jq xdelta3 zfsutils-linux
 
     systemctl unmask snapd.service
     systemctl start snapd.service
@@ -135,7 +135,7 @@ function run_sdkcraft() {
 }
 
 # Install sdkcraft from a local snap file
-function install_sdkcraft() {    
+function install_sdkcraft() {
     if stat /sdkcraft/tests/*.snap 2>/dev/null; then
         snap install --classic --dangerous /sdkcraft/tests/*.snap
     else

--- a/tests/main/refresh/multi/.workshop/ws-refresh-snapshots.yaml
+++ b/tests/main/refresh/multi/.workshop/ws-refresh-snapshots.yaml
@@ -1,0 +1,9 @@
+name: ws-refresh-snapshots
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic
+    channel: latest/stable
+  - name: test-sdk-mount
+    channel: latest/stable
+  - name: test-sdk-gpu
+    channel: latest/stable

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -1,12 +1,12 @@
 summary: Check that basic refresh scenarios work correctly for the transactional mode
-prepare: |  
+prepare: |
   . "$TESTSLIB"/utils.sh
   workshop_exec launch --project single
-  workshop_exec launch ws-refresh ws-refresh-sdk --project multi
+  workshop_exec launch ws-refresh ws-refresh-sdk ws-refresh-snapshots --project multi
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove --project single
-  workshop_exec remove ws-refresh ws-refresh-sdk --project multi
+  workshop_exec remove ws-refresh ws-refresh-sdk ws-refresh-snapshots --project multi
 execute: |
   . "$TESTSLIB"/utils.sh
 
@@ -38,3 +38,40 @@ execute: |
 
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-sdk[[:space:]]+Ready[[:space:]]+-$"
+
+
+  validate_snapshots() {
+    local expected_output="$1"
+    local output
+    output=$(zfs list -t snapshot -s creation -o name | grep ws-refresh-snapshots | sed 's|^.*workshop/containers/workshop.ubuntu_||')
+    [ "$expected_output" = "$output" ]
+  }
+
+  echo "Check workshop snapshots exist"
+  pid=$(cat .workshop.lock)
+  expected_snapshots="ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.system
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.basic
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.mount
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.gpu"
+  validate_snapshots "$expected_snapshots"
+
+  echo "Check workshop snapshots updated after an SDK was removed"
+  # Annoyingly, yq snap is in strict mode and won't see these files.
+  cat .workshop/ws-refresh-snapshots.yaml | yq 'del(.sdks[-1])' | sponge .workshop/ws-refresh-snapshots.yaml
+  workshop_exec refresh ws-refresh-snapshots
+  expected_snapshots="ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.system
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.basic
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.mount"
+  validate_snapshots "$expected_snapshots"
+
+  echo "Check workshop was rebuilt from a new image base"
+  cat .workshop/ws-refresh-snapshots.yaml | yq 'del(.sdks)' | sponge .workshop/ws-refresh-snapshots.yaml
+  cat .workshop/ws-refresh-snapshots.yaml | yq '(.base) |= sub("ubuntu@22.04"; "ubuntu@24.04")' | sponge .workshop/ws-refresh-snapshots.yaml
+  workshop_exec refresh ws-refresh-snapshots
+  workshop_exec info ws-refresh-snapshots | MATCH ubuntu@24.04
+  workshop_exec exec ws-refresh-snapshots -- lsb_release -a | MATCH 24.04
+
+  echo "Check workshop refresh when no updates are available"
+  workshop_exec refresh ws-refresh-snapshots
+  expected_snapshots="ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.system"
+  validate_snapshots "$expected_snapshots"

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -39,7 +39,6 @@ execute: |
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-sdk[[:space:]]+Ready[[:space:]]+-$"
 
-
   validate_snapshots() {
     local expected_output="$1"
     local output
@@ -50,9 +49,9 @@ execute: |
   echo "Check workshop snapshots exist"
   pid=$(cat .workshop.lock)
   expected_snapshots="ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.system
-  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.basic
-  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.mount
-  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.gpu"
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.test-sdk-basic
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.test-sdk-mount
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.test-sdk-gpu"
   validate_snapshots "$expected_snapshots"
 
   echo "Check workshop snapshots updated after an SDK was removed"
@@ -60,13 +59,16 @@ execute: |
   cat .workshop/ws-refresh-snapshots.yaml | yq 'del(.sdks[-1])' | sponge .workshop/ws-refresh-snapshots.yaml
   workshop_exec refresh ws-refresh-snapshots
   expected_snapshots="ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.system
-  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.basic
-  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots-test-sdk.mount"
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.test-sdk-basic
+  ws-refresh-snapshots-$pid@snapshot-ws-refresh-snapshots.test-sdk-mount"
   validate_snapshots "$expected_snapshots"
 
   echo "Check workshop was rebuilt from a new image base"
   cat .workshop/ws-refresh-snapshots.yaml | yq 'del(.sdks)' | sponge .workshop/ws-refresh-snapshots.yaml
   cat .workshop/ws-refresh-snapshots.yaml | yq '(.base) |= sub("ubuntu@22.04"; "ubuntu@24.04")' | sponge .workshop/ws-refresh-snapshots.yaml
+
+  # Ensure there is no cached image so that refresh will take care of downloading it.
+  lxc image delete workshop-ubuntu@24.04-amd64 --project workshop.ubuntu
   workshop_exec refresh ws-refresh-snapshots
   workshop_exec info ws-refresh-snapshots | MATCH ubuntu@24.04
   workshop_exec exec ws-refresh-snapshots -- lsb_release -a | MATCH 24.04


### PR DESCRIPTION
# Description

This PR extends the refresh resolver to restore a workshop from a snapshot if it's available to speed up refresh changes. The resolver makes a decision about the exact snapshot that the workshop needs to be restored from based on the updates available for the SDKs that constitute the workshop, changes to the connections or plugs & slots in the workshop definitions. Briefly speaking, if a workshop has been defined as:

```
name: dev
base: ubuntu@22.04
sdks:
  - name: ros2
    channel: latest/stable
  - name: nav2
    channel: latest/stable
```

and `nav2` SDK was the only one that had an update, the resolver would restore the workshop to the snapshot created after installing `ros2` SDK and install a new revision of `nav2` on top of that.

If a workshop's base was changed, the workshop will be rebuilt from scratch by using LXD's `RebuildInstance` API and providing it with a required image.

If the `sketch` SDK exists, it will be refreshed every time as there is no mechanism to detect updates to the local SDKs.

## Implementation notes

The behaviour of stashing has changed from moving the instance with `MigrateInstance` to copying the instance with `CopyInstance` to the stash area (with all the snapshots). This allows rebuilding the workshop in-place and restoring if something went wrong after restoring from an earlier snapshot.

## Out of scope

The `refresh` CLI will be extended with `--rebuild` and `--restore` options to rebuild the entire workshop from scratch or restore it to the last up-to-date snapshot respectively. These options is not part of the PR.

## Breaking changes

* The storage pool is created with `volume.zfs.remove_snapshots: "true"` which allows for removing previous snapshots on restore automatically.
* `system` SDK is tracked as one of the workshop's installed SDKs in `user.workshop.sdks` without any special treatment in operations like `link` or `unlink` SDKs. 

## Known issues

* https://github.com/canonical/lxd/issues/15078

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
