### PR TITLE
Add no-wait option for refresh cmd

### DIFF
--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -94,6 +94,9 @@ $ workshop refresh nimble/sketch`,
 	cmd.PersistentFlags().BoolVar(&c.Abort, "abort",
 		false,
 		"Abort the previously paused operation, reverting any changes.")
+	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
+		false,
+		"Return the change ID, don't wait for the operation to finish.")
 
 	return cmd
 }

--- a/docs/reference/cli/workshop-refresh.rst
+++ b/docs/reference/cli/workshop-refresh.rst
@@ -118,6 +118,11 @@ Refresh the sketch SDK in the 'nimble' workshop:
    Continue the previously paused operation.
 
 
+--no-wait
+
+   Return the change ID, don't wait for the operation to finish.
+
+
 --wait-on-error
 
    Pause the operation on error; to resume, use '--continue' or '--abort'.

--- a/tests/main/refresh/single/health.exp
+++ b/tests/main/refresh/single/health.exp
@@ -1,0 +1,27 @@
+#!/usr/bin/expect -f
+
+set success 0 
+
+while {1} {
+    spawn workshop info
+    set result [wait]
+    expect {
+        -re "message:\[ \]*Cannot finish health check" {
+            puts "Seen the expected SDK health messages"
+            set success 1
+            continue
+        }
+        -re "ready" {
+            if { $success == 1 } {
+                exit 0
+            }
+            puts "Could not find the expected SDK health message"
+            exit 1
+        }
+        timeout { 
+            puts "Timed out while waiting for the SDK health message"
+            exit 1
+        }
+    }
+    after 500
+}

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -1,10 +1,13 @@
 summary: Check that basic refresh scenarios work correctly for the transactional mode
 prepare: |
   . "$TESTSLIB"/utils.sh
+  apt-add-repository -y universe
+  apt install expect -y --no-install-recommends
   workshop_exec launch --project single
   workshop_exec launch ws-refresh ws-refresh-sdk ws-refresh-snapshots --project multi
 restore: |
   . "$TESTSLIB"/utils.sh
+  apt remove -y expect
   workshop_exec remove --project single
   workshop_exec remove ws-refresh ws-refresh-sdk ws-refresh-snapshots --project multi
 execute: |
@@ -20,6 +23,15 @@ execute: |
   echo "Check apt cache is preserved across refreshes"
   workshop_exec exec -- mountpoint /var/cache/apt/archives
   workshop_exec exec -- sudo test -f /var/cache/apt/archives/sentinel
+
+  echo "Check workshop refresh --no-wait"
+  echo -e "sdks:\n  - name: test-sdk-health-waiting\n    channel: latest/stable" >> workshop.yaml
+  workshop_exec refresh --no-wait
+  
+  # The refresh process here takes about 10s. 
+  # The hook check-health should fail four times before final success.
+  # Check tests/lib/sdk/test-sdk-health-waiting/latest/stable/sdk/hooks/check-health for details
+  sudo -u ubuntu 2>&1 -- expect -f ./health.exp
 
   echo "Check refresh supports multi-workshop projects"
   cd ../multi


### PR DESCRIPTION
# Description

`workshop refresh` supports `--no-wait` option - immediately returns the change’s ID.

https://warthogs.atlassian.net/jira/software/c/projects/WSP/boards/1645?selectedIssue=WSP-587

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
