### PR TITLE
Migrate to golangci-lint 2.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,18 +17,17 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         id: lint
         with:
           version: latest
-          args: "--out-format=colored-line-number"
           skip-cache: true
 
       - name: errcheck
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
-          args: "--out-format=colored-line-number --config=.golangci.errcheck.yaml"
+          args: --config=.golangci.errcheck.yaml
           only-new-issues: true
           skip-cache: true
 

--- a/.golangci.errcheck.yaml
+++ b/.golangci.errcheck.yaml
@@ -1,17 +1,21 @@
+version: '2'
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
+  exclusions:
+    presets:
+      - std-error-handling
+    rules:
+      - path: _test\.go$
+        linters: [errcheck]
+        text: Error return value of `\(\*github.com/canonical/workshop/internal/overlord\.Overlord\)\.Stop` is not checked
 
 issues:
   # these values ensure that all issues will be surfaced
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  exclude-rules:
-    - path: _test\.go$
-      linters: [errcheck]
-      text: Error return value of `\(\*github.com/canonical/workshop/internal/overlord\.Overlord\)\.Stop` is not checked
 
 run:
   build-tags: [integration]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,15 +1,25 @@
+version: '2'
+
+formatters:
+  enable:
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - Prefix(github.com/canonical/workshop)
+
 linters:
   disable:
     - errcheck
   enable:
-    - gci
     - nilerr
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - Prefix(github.com/canonical/workshop)
+  settings:
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/canonical/workshop/internal/overlord/handlersetup
+
 issues:
   # these values ensure that all issues will be surfaced
   max-issues-per-linter: 0

--- a/client/changes.go
+++ b/client/changes.go
@@ -95,7 +95,7 @@ func (client *Client) Change(id string) (*Change, error) {
 		return nil, err
 	}
 
-	chgd.Change.data = chgd.Data
+	chgd.data = chgd.Data
 	return &chgd.Change, nil
 }
 
@@ -174,7 +174,7 @@ func (client *Client) Changes(opts *ChangesOptions) ([]*Change, error) {
 	var chgs []*Change
 	for i := range chgds {
 		chgd := &chgds[i]
-		chgd.Change.data = chgd.Data
+		chgd.data = chgd.Data
 		chgs = append(chgs, &chgd.Change)
 	}
 
@@ -203,6 +203,6 @@ func (client *Client) WaitChange(id string, opts *WaitChangeOptions) (*Change, e
 		return nil, err
 	}
 
-	chgd.Change.data = chgd.Data
+	chgd.data = chgd.Data
 	return &chgd.Change, nil
 }

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -46,7 +46,7 @@ var websocketRegexp = regexp.MustCompile(`^ws://localhost/v1/tasks/T\d+/websocke
 func (s *execSuite) SetUpTest(c *C) {
 	s.clientSuite.SetUpTest(c)
 
-	s.clientSuite.cli.SetDoer(s)
+	s.cli.SetDoer(s)
 
 	s.stdioWs = &testWebsocket{}
 	s.stdoutWs = &testWebsocket{}
@@ -79,7 +79,7 @@ func (cs *execSuite) Do(req *http.Request) (*http.Response, error) {
 		// to LXD now
 		matches := websocketRedirectexp.FindStringSubmatch(req.URL.String())
 		if matches != nil {
-			var header http.Header = make(http.Header)
+			header := make(http.Header)
 			header.Set("Location", fmt.Sprintf("ws://localhost%s", req.URL.Path))
 			return &http.Response{
 				StatusCode: http.StatusTemporaryRedirect,

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 
 	"gopkg.in/check.v1"
-	. "gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/client"
 )
@@ -88,12 +87,12 @@ func (s *connectionsSuite) TestConnectionsNoneConnected(c *check.C) {
 	allCmd := cmd.Command()
 	cmd.all = true
 	err = cmd.Run(allCmd, []string{})
-	c.Check(err, IsNil)
+	c.Check(err, check.IsNil)
 	c.Assert(s.Stdout(), check.Equals, "")
 	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsNotInstalled(c *C) {
+func (s *connectionsSuite) TestConnectionsNotInstalled(c *check.C) {
 	query := url.Values{
 		"project-id": []string{"42424242"},
 		"workshop":   []string{"foo"},
@@ -109,23 +108,23 @@ func (s *connectionsSuite) TestConnectionsNotInstalled(c *C) {
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
 			fmt.Fprintln(w, r)
 		case 2:
-			c.Check(r.Method, Equals, "GET")
-			c.Check(r.URL.Path, Equals, "/v1/connections")
-			c.Check(r.URL.Query(), DeepEquals, query)
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v1/connections")
+			c.Check(r.URL.Query(), check.DeepEquals, query)
 			body, err := io.ReadAll(r.Body)
-			c.Check(err, IsNil)
-			c.Check(body, DeepEquals, []byte{})
+			c.Check(err, check.IsNil)
+			c.Check(body, check.DeepEquals, []byte{})
 			fmt.Fprintln(w, `{"type": "error", "result": {"message": "not found"}, "status-code": 404}`)
 		}
 	})
 	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"foo"})
-	c.Check(err, ErrorMatches, `not found`)
-	c.Assert(s.Stdout(), Equals, "")
-	c.Assert(s.Stderr(), Equals, "")
+	c.Check(err, check.ErrorMatches, `not found`)
+	c.Assert(s.Stdout(), check.Equals, "")
+	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *C) {
+func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *check.C) {
 	query := url.Values{
 		"project-id": []string{"42424242"},
 		"select":     []string{"all"},
@@ -168,12 +167,12 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *C) {
 	command := cmd.Command()
 	cmd.all = true
 	err := cmd.Run(command, []string{})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                                 Slot  Notes\n" +
 		"leds       keyboard-lights/lights:capslock-led  -     -\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
 
 	s.ResetStdStreams()
 
@@ -184,15 +183,15 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *C) {
 	}
 
 	err = cmd.Run(cmd.Command(), []string{"keyboard-lights"})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	expectedStdout = "" +
 		"Interface  Plug                                 Slot  Notes\n" +
 		"leds       keyboard-lights/lights:capslock-led  -     -\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *C) {
+func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *check.C) {
 	result := client.Connections{}
 	query := url.Values{"project-id": []string{"42424242"}, "select": []string{"all"}, "workshop": []string{"foo"}}
 	n := 0
@@ -219,7 +218,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *C) {
 	})
 	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"foo"})
-	c.Check(err, IsNil)
+	c.Check(err, check.IsNil)
 	c.Assert(s.Stdout(), check.Equals, "")
 	c.Assert(s.Stderr(), check.Equals, "")
 
@@ -245,7 +244,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *C) {
 	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
+func (s *connectionsSuite) TestConnectionsSomeConnected(c *check.C) {
 	result := client.Connections{
 		Established: []client.Connection{
 			{
@@ -367,17 +366,17 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *C) {
 	})
 	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                  Notes\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led   -\n" +
 		"leds       keyboard-lights/lights:numlock    keyboard-lights/system:numlock-led    manual\n" +
 		"leds       keyboard-lights/lights:scrollock  keyboard-lights/system:scrollock-led  -\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
+func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *check.C) {
 	result := client.Connections{
 		Established: []client.Connection{
 			{
@@ -506,17 +505,17 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *C) {
 	})
 	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                  Notes\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led   -\n" +
 		"leds       keyboard-lights/lights:numlock    keyboard-lights/system:numlock-led    manual,bind.3\n" +
 		"leds       keyboard-lights/lights:scrollock  keyboard-lights/system:scrollock-led  manual,bind.3\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
+func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *check.C) {
 	result := client.Connections{
 		Established: []client.Connection{
 			{
@@ -644,7 +643,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 	cmdAll := cmd.Command()
 	cmd.all = true
 	err := cmd.Run(cmdAll, []string{})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                          Notes\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
@@ -653,11 +652,11 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *C) {
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
 		"leds       keyboard-lights/lights:numlock    -                                             -\n" +
 		"leds       keyboard-lights/lights:scrollock  keyboard-lights/system:scrollock-led          -\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
+func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *check.C) {
 	result := client.Connections{
 		Established: []client.Connection{
 			{
@@ -775,7 +774,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 	cmdAll := cmd.Command()
 	cmd.all = true
 	err := cmd.Run(cmdAll, []string{})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                              Slot                                          Notes\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
@@ -784,11 +783,11 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *C) {
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led           -\n" +
 		"leds       keyboard-lights/lights:numlock    -                                             bind.6\n" +
 		"leds       keyboard-lights/lights:scrollock  -                                             bind.6\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsOnlyDisconnected(c *C) {
+func (s *connectionsSuite) TestConnectionsOnlyDisconnected(c *check.C) {
 	result := client.Connections{
 		Undesired: []client.Connection{
 			{
@@ -844,16 +843,16 @@ func (s *connectionsSuite) TestConnectionsOnlyDisconnected(c *C) {
 
 	cmd := &CmdConnections{root: &CmdRoot{}}
 	err := cmd.Run(cmd.Command(), []string{"leds-provider"})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
 		"Interface  Plug  Slot                                        Notes\n" +
 		"leds       -     leds-provider/numlock-provider:numlock-led  -\n" +
 		"leds       -     leds-provider/provider:capslock-led         -\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
 }
 
-func (s *connectionsSuite) TestConnectionsFiltering(c *C) {
+func (s *connectionsSuite) TestConnectionsFiltering(c *check.C) {
 	result := client.Connections{}
 	query := url.Values{
 		"project-id": []string{"42424242"},
@@ -890,15 +889,15 @@ func (s *connectionsSuite) TestConnectionsFiltering(c *C) {
 	cmd := &CmdConnections{root: &CmdRoot{}}
 
 	err := cmd.Run(cmd.Command(), []string{"mouse-buttons"})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	cmdAll := cmd.Command()
 	cmd.all = true
 	err = cmd.Run(cmdAll, []string{"mouse-buttons"})
-	c.Assert(err, ErrorMatches, "cannot use --all with workshop name")
+	c.Assert(err, check.ErrorMatches, "cannot use --all with workshop name")
 }
 
-func (s *connectionsSuite) TestConnectionsSorting(c *C) {
+func (s *connectionsSuite) TestConnectionsSorting(c *check.C) {
 	result := client.Connections{
 		Established: []client.Connection{
 			{
@@ -1123,7 +1122,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 	cmdAll := cmd.Command()
 	cmd.all = true
 	err := cmd.Run(cmdAll, []string{})
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
 		"Interface  Plug                         Slot                           Notes\n" +
 		"desktop    abc/foo:desktop-plug         abc/system:desktop             -\n" +
@@ -1136,6 +1135,6 @@ func (s *connectionsSuite) TestConnectionsSorting(c *C) {
 		"x11        abc/foo:x11-plug             abc/system:x11                 -\n" +
 		"x11        def/foo:a-x11-plug           def/system:x11                 -\n" +
 		"x11        def/keyboard-app:x11         def/system:x11                 manual\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
 }

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -602,7 +602,7 @@ func execControlHandler(process *client.ExecProcess, terminal bool, stop <-chan 
 			err = process.SendResize(width, height)
 			if err != nil {
 				logger.Debugf("Cannot set terminal size: %v", err)
-				break
+				break //nolint:staticcheck // SA4011 Keep "ineffective" break for consistency
 			}
 		case unix.SIGHUP:
 			logger.Debugf("Received 'SIGHUP' signal, forwarding and exiting")
@@ -619,7 +619,7 @@ func execControlHandler(process *client.ExecProcess, terminal bool, stop <-chan 
 			err := process.SendSignal(sig.(unix.Signal))
 			if err != nil {
 				logger.Debugf("Cannot forward signal '%s': %v", sig, err)
-				break
+				break //nolint:staticcheck // SA4011 Keep "ineffective" break for consistency
 			}
 		}
 	}

--- a/cmd/workshop/list_test.go
+++ b/cmd/workshop/list_test.go
@@ -7,24 +7,23 @@ import (
 	"path/filepath"
 
 	"gopkg.in/check.v1"
-	. "gopkg.in/check.v1"
 )
 
 type workshopList struct {
 }
 
-var _ = Suite(&workshopList{})
+var _ = check.Suite(&workshopList{})
 
-func (m *workshopList) TestHomeDirectoryPathContraction(c *C) {
+func (m *workshopList) TestHomeDirectoryPathContraction(c *check.C) {
 	home, _ := os.UserHomeDir()
 	r := contractHomeDirectory(filepath.Join(home, "test"))
-	c.Assert(r, Equals, "~/test")
+	c.Assert(r, check.Equals, "~/test")
 	r = contractHomeDirectory(filepath.Join(home, "///test"))
-	c.Assert(r, Equals, "~/test")
+	c.Assert(r, check.Equals, "~/test")
 	r = contractHomeDirectory(home)
-	c.Assert(r, Equals, "~")
+	c.Assert(r, check.Equals, "~")
 	r = contractHomeDirectory("/sys")
-	c.Assert(r, Equals, "/sys")
+	c.Assert(r, check.Equals, "/sys")
 
 	/* This will fail because of how filepath handles path prefixes (not path aware)
 	r = contractHomeDirectory(home + "4")

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -53,9 +53,9 @@ func (s *BaseWorkshopSuite) TearDownTest(c *check.C) {
 
 func (s *BaseWorkshopSuite) RedirectClientToTestServer(handler func(http.ResponseWriter, *http.Request)) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
-	s.BaseTest.AddCleanup(func() { server.Close() })
+	s.AddCleanup(func() { server.Close() })
 	ClientConfig.BaseURL = server.URL
-	s.BaseTest.AddCleanup(func() { ClientConfig.BaseURL = "" })
+	s.AddCleanup(func() { ClientConfig.BaseURL = "" })
 }
 
 func (s *BaseWorkshopSuite) ResetStdStreams() {

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -283,7 +283,7 @@ func lastWarningTimestamp() (time.Time, error) {
 	f, err := os.Open(warnFilename())
 	if err != nil {
 		if os.IsNotExist(err) {
-			return time.Time{}, fmt.Errorf("you must have looked at the warnings before acknowledging them. Try 'workshop warnings'.")
+			return time.Time{}, fmt.Errorf("use 'workshop warnings' to view the warnings before dismissing them")
 		}
 		return time.Time{}, fmt.Errorf("cannot open timestamp file: %v", err)
 

--- a/cmd/workshop/warnings_test.go
+++ b/cmd/workshop/warnings_test.go
@@ -186,7 +186,7 @@ func (s *warningSuite) TestOkay(c *check.C) {
 
 func (s *warningSuite) TestOkayBeforeWarnings(c *check.C) {
 	err := s.cmdO.Run(s.cmdO.Command(), nil)
-	c.Assert(err, check.ErrorMatches, "you must have looked at the warnings before acknowledging them. Try 'workshop warnings'.")
+	c.Assert(err, check.ErrorMatches, "use 'workshop warnings' to view the warnings before dismissing them")
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Equals, "")
 }

--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -61,9 +61,9 @@ func (c *cmdRun) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 
-	cmd.Flags().BoolVar(&c.sharedRunEnterOpts.CreateDirs, "create-dirs", false, sharedRunEnterOptsHelp["create-dirs"])
-	cmd.Flags().String(c.sharedRunEnterOpts.HTTP, "http", sharedRunEnterOptsHelp["http"])
-	cmd.Flags().BoolVar(&c.sharedRunEnterOpts.Verbose, "verbose", false, sharedRunEnterOptsHelp["verbose"])
+	cmd.Flags().BoolVar(&c.CreateDirs, "create-dirs", false, sharedRunEnterOptsHelp["create-dirs"])
+	cmd.Flags().String(c.HTTP, "http", sharedRunEnterOptsHelp["http"])
+	cmd.Flags().BoolVar(&c.Verbose, "verbose", false, sharedRunEnterOptsHelp["verbose"])
 
 	return cmd
 }

--- a/internal/asserts/constraint.go
+++ b/internal/asserts/constraint.go
@@ -293,7 +293,7 @@ func (matcher regexpAttrMatcher) match(apath string, v interface{}, ctx *attrMat
 	default:
 		return fmt.Errorf("%s %q must be a scalar or list", ctx.attrWord, apath)
 	}
-	if !matcher.Regexp.MatchString(s) {
+	if !matcher.MatchString(s) {
 		return fmt.Errorf("%s %q value %q does not match %v", ctx.attrWord, apath, s, matcher.Regexp)
 	}
 	return nil

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -252,7 +252,7 @@ type regexpNameMatcher struct {
 }
 
 func (matcher regexpNameMatcher) match(name string, special map[string]string) error {
-	if !matcher.Regexp.MatchString(name) {
+	if !matcher.MatchString(name) {
 		return fmt.Errorf("%q does not match %v", name, matcher.Regexp)
 	}
 	return nil

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -89,7 +89,7 @@ func attrs(yml string) *attrerObject {
 
 func (s *attrConstraintsSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
 }
 
 func (s *attrConstraintsSuite) TearDownTest(c *check.C) {

--- a/internal/daemon/api_changes.go
+++ b/internal/daemon/api_changes.go
@@ -164,7 +164,7 @@ func v1GetChanges(c *Command, r *http.Request, _ *userState) Response {
 			}
 
 			if query.Has("workshops") {
-				var workshops []string = strings.Split(query.Get("workshops"), ",")
+				workshops := strings.Split(query.Get("workshops"), ",")
 				var workshop string
 				if err := chg.Get("workshop", &workshop); err != nil {
 					return false

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1409,7 +1409,7 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 		}
 
 		for _, plug := range wantws.plugs {
-			ref := strings.SplitN(plug, ":", -1)
+			ref := strings.Split(plug, ":")
 			c.Assert(ref, check.HasLen, 2)
 
 			p := repo.Plug(s.project.ProjectId, wantws.name, ref[0], ref[1])
@@ -1417,7 +1417,7 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 		}
 
 		for _, slot := range wantws.slots {
-			ref := strings.SplitN(slot, ":", -1)
+			ref := strings.Split(slot, ":")
 			c.Assert(ref, check.HasLen, 2)
 
 			s := repo.Slot(s.project.ProjectId, wantws.name, ref[0], ref[1])

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -29,8 +29,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"gopkg.in/check.v1"
-	// XXX Delete import above and make this file like the other ones.
-	. "gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
@@ -102,7 +100,7 @@ func (h *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.lastMethod = r.Method
 }
 
-func (s *daemonSuite) TestExplicitPaths(c *C) {
+func (s *daemonSuite) TestExplicitPaths(c *check.C) {
 	s.socketPath = filepath.Join(c.MkDir(), "custom.socket")
 
 	d := s.newDaemon(c)
@@ -112,12 +110,12 @@ func (s *daemonSuite) TestExplicitPaths(c *C) {
 	defer d.Stop(nil)
 
 	info, err := os.Stat(s.socketPath)
-	c.Assert(err, IsNil)
-	c.Assert(info.Mode(), Equals, os.ModeSocket|0666)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode(), check.Equals, os.ModeSocket|0666)
 
 	info, err = os.Stat(s.socketPath + ".untrusted")
-	c.Assert(err, IsNil)
-	c.Assert(info.Mode(), Equals, os.ModeSocket|0666)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode(), check.Equals, os.ModeSocket|0666)
 }
 
 func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
@@ -1078,18 +1076,18 @@ func (s *daemonSuite) TestHTTPAPI(c *check.C) {
 	port := d.httpListener.Addr().(*net.TCPAddr).Port
 
 	request, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d/v1/changes", port), nil)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	response, err := http.DefaultClient.Do(request)
-	c.Assert(err, IsNil)
-	c.Assert(response.StatusCode, Equals, http.StatusUnauthorized)
+	c.Assert(err, check.IsNil)
+	c.Assert(response.StatusCode, check.Equals, http.StatusUnauthorized)
 
 	err = d.Stop(nil)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	_, err = http.DefaultClient.Do(request)
-	c.Assert(err, ErrorMatches, ".* connection refused")
+	c.Assert(err, check.ErrorMatches, ".* connection refused")
 }
 
-func (s *daemonSuite) TestStopRunning(c *C) {
+func (s *daemonSuite) TestStopRunning(c *check.C) {
 	// d := s.newDaemon(c)
 	// err := d.Init()
 	// c.Assert(err, IsNil)

--- a/internal/interfaces/builtin/camera_test.go
+++ b/internal/interfaces/builtin/camera_test.go
@@ -3,13 +3,14 @@ package builtin_test
 import (
 	"os/user"
 
+	"gopkg.in/check.v1"
+
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
-	"gopkg.in/check.v1"
 )
 
 type cameraSuite struct {

--- a/internal/interfaces/builtin/export_test.go
+++ b/internal/interfaces/builtin/export_test.go
@@ -22,10 +22,10 @@ package builtin
 import (
 	"fmt"
 
+	"gopkg.in/check.v1"
+
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/sdk"
-
-	"gopkg.in/check.v1"
 )
 
 var (

--- a/internal/interfaces/builtin/gpu_test.go
+++ b/internal/interfaces/builtin/gpu_test.go
@@ -3,13 +3,14 @@ package builtin_test
 import (
 	"os/user"
 
+	"gopkg.in/check.v1"
+
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
-	"gopkg.in/check.v1"
 )
 
 type gpuSuite struct {

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -274,7 +274,8 @@ func (iface *tunnelInterface) MountConnectedPlug(spec *lxd_device.Specification,
 	if err := checkListenPort(entry.Listen, entry.Direction); err != nil {
 		return err
 	}
-	if entry.Direction == workshop.HostToWorkshop {
+	switch entry.Direction {
+	case workshop.HostToWorkshop:
 		if err := expandPath(&entry.Listen, spec.User); err != nil {
 			return err
 		}
@@ -284,7 +285,7 @@ func (iface *tunnelInterface) MountConnectedPlug(spec *lxd_device.Specification,
 		if err := expandPath(&entry.Connect, &workshop.User); err != nil {
 			return err
 		}
-	} else if entry.Direction == workshop.WorkshopToHost {
+	case workshop.WorkshopToHost:
 		if err := expandPath(&entry.Listen, &workshop.User); err != nil {
 			return err
 		}

--- a/internal/interfaces/builtin/tunnel_test.go
+++ b/internal/interfaces/builtin/tunnel_test.go
@@ -25,6 +25,8 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"gopkg.in/check.v1"
+
 	"github.com/canonical/workshop/internal/asserts"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
@@ -34,7 +36,6 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
-	"gopkg.in/check.v1"
 )
 
 type tunnelSuite struct {

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -39,7 +39,7 @@ var _ = check.Suite(&connSuite{})
 
 func (s *connSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
 	s.projectId = "42424242"
 	consumer := sdk.MockInfo(c, `
 name: consumer

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -45,7 +45,7 @@ var _ = Suite(&CoreSuite{})
 
 func (s *CoreSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
 	s.projectId = "42424242"
 }
 

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"gopkg.in/check.v1"
-	. "gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/asserts"
 	"github.com/canonical/workshop/internal/interfaces"
@@ -39,7 +38,7 @@ type baseDeclSuite struct {
 	restoreSanitize func()
 }
 
-var _ = Suite(&baseDeclSuite{})
+var _ = check.Suite(&baseDeclSuite{})
 
 func Test(t *testing.T) {
 	check.TestingT(t)
@@ -94,7 +93,7 @@ slots:
 	}
 }
 
-func (s *baseDeclSuite) TestAutoConnection(c *C) {
+func (s *baseDeclSuite) TestAutoConnection(c *check.C) {
 	all := builtin.Interfaces()
 
 	// these have more complex or in flux policies and have their
@@ -115,32 +114,32 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 			continue
 		}
 		expected := autoconnect[iface.Name()]
-		comm := Commentf(iface.Name())
+		comm := check.Commentf(iface.Name())
 
 		// check base declaration
 		cand := s.connectCand(c, iface.Name(), "", "", "", "", "", "")
 		arity, err := cand.CheckAutoConnect()
 		if expected {
-			c.Check(err, IsNil, comm)
-			c.Check(arity.SlotsPerPlugAny(), Equals, false)
+			c.Check(err, check.IsNil, comm)
+			c.Check(arity.SlotsPerPlugAny(), check.Equals, false)
 		} else {
-			c.Check(err, NotNil, comm)
+			c.Check(err, check.NotNil, comm)
 		}
 	}
 }
 
-func (s *baseDeclSuite) TestManualConnection(c *C) {
+func (s *baseDeclSuite) TestManualConnection(c *check.C) {
 	all := builtin.Interfaces()
 
 	for _, iface := range all {
-		comm := Commentf(iface.Name())
+		comm := check.Commentf(iface.Name())
 
 		// check base declaration
 		cand := s.connectCand(c, iface.Name(), "", "", "", "", "", "")
 		arity, err := cand.Check()
-		c.Check(err, IsNil, comm)
+		c.Check(err, check.IsNil, comm)
 		// not currently used outside of tests
-		c.Check(arity.SlotsPerPlugAny(), Equals, true)
+		c.Check(arity.SlotsPerPlugAny(), check.Equals, true)
 	}
 }
 
@@ -171,7 +170,7 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *check.C) {
 		if snowflakes[iface.Name()] {
 			continue
 		}
-		c.Check(iface.AutoConnect(nil, nil), Equals, true)
+		c.Check(iface.AutoConnect(nil, nil), check.Equals, true)
 	}
 }
 
@@ -179,16 +178,16 @@ func (s *baseDeclSuite) TestMountSlotInstallation(c *check.C) {
 	// test mount specially
 	ic := s.installSlotCand(c, "mount", sdk.Regular, ``)
 	err := ic.Check()
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	ic = s.installSlotCand(c, "mount", sdk.System, ``)
 	err = ic.Check()
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *baseDeclSuite) TestComposeBaseDeclaration(c *check.C) {
 	decl, err := policy.ComposeBaseDeclaration(nil)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	c.Assert(string(decl), testutil.Contains, `
 type: base-declaration
 authority-id: canonical
@@ -201,7 +200,7 @@ func (s *baseDeclSuite) TestDoesNotPanic(c *check.C) {
 	// In case there are any issues in the actual interfaces we'd get a panic
 	// on startup. This test prevents this from happing unnoticed.
 	_, err := policy.ComposeBaseDeclaration(builtin.Interfaces())
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *baseDeclSuite) TestSlotPlugFromSameWorkshop(c *check.C) {

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -26,7 +26,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/canonical/workshop/internal/interfaces"
 	. "github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
 	"github.com/canonical/workshop/internal/osutil"
@@ -80,7 +79,7 @@ plugs:
 
 func (s *RepositorySuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 
 	consumer := sdk.MockInfo(c, consumerYaml, s.projectId, "ws")
 	s.plug = consumer.Plugs["plug"]
@@ -1015,7 +1014,7 @@ func (s *RepositorySuite) TestSdkSpecificationBoundPlugs(c *C) {
 	c.Assert(repo.AddInterface(testInterface), IsNil)
 	// the plug's connection is bound which means it has the "bind" dynamic
 	// attribute that points to the connection it is bound to
-	bref := interfaces.ConnRef{
+	bref := ConnRef{
 		PlugRef: s.plug.Ref(),
 		SlotRef: s.slot.Ref(),
 	}
@@ -1231,7 +1230,7 @@ var _ = Suite(&AddRemoveSuite{})
 
 func (s *AddRemoveSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 
 	s.repo = NewRepository()
 	err := s.repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface"})
@@ -1282,7 +1281,7 @@ var _ = Suite(&DisconnectSdkSuite{})
 
 func (s *DisconnectSdkSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 
 	s.repo = NewRepository()
 

--- a/internal/osutil/io_test.go
+++ b/internal/osutil/io_test.go
@@ -243,7 +243,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancel(c *C) {
 
 	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
-	fn := aw.File.Name()
+	fn := aw.Name()
 	c.Check(osutil.FileExists(fn), Equals, true)
 	c.Check(aw.Cancel(), IsNil)
 	c.Check(osutil.FileExists(fn), Equals, false)

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -178,11 +178,12 @@ func ResumeAfterWait(st *state.State,
 
 	for _, tsk := range chg.Tasks() {
 		if tsk.Status() == state.WaitStatus {
-			if mode == ChangeContinue {
+			switch mode {
+			case ChangeContinue:
 				waited := tsk.WaitedStatus()
 				tsk.SetStatus(waited)
 				tsk.Logf("Continuing for workshop %q...", workshop)
-			} else if mode == ChangeAbort {
+			case ChangeAbort:
 				tsk.SetStatus(state.DoStatus)
 				tsk.Logf("Aborting for workshop %q...", workshop)
 			}

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -421,7 +421,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 			WaitExecution: func(ctx context.Context) error {
 				// emulate workshopctl set-health --code=<code> error <message>
 				var err error
-				hookContext, err = s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
+				hookContext, err = s.hookMgr.Context(args.Environment["WORKSHOP_COOKIE"])
 				c.Assert(err, check.IsNil)
 				hookContext.Lock()
 				hookContext.Set("health", result)
@@ -486,7 +486,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
-				hookCtx, err := s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
+				hookCtx, err := s.hookMgr.Context(args.Environment["WORKSHOP_COOKIE"])
 				c.Assert(err, check.IsNil)
 				hookCtx.Lock()
 				var counter int
@@ -550,7 +550,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 		return workshop.ExecContext{
 			WaitExecution: func(ctx context.Context) error {
 				var err error
-				hookContext, err = s.hookMgr.Context(args.ExecArgs.Environment["WORKSHOP_COOKIE"])
+				hookContext, err = s.hookMgr.Context(args.Environment["WORKSHOP_COOKIE"])
 				c.Assert(err, check.IsNil)
 				hookContext.Lock()
 				// emulate workshopctl set-health --code=<code> error <message>

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -653,7 +653,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 	rev.Add(func() {
 		oldConn := &schema.ConnState{}
 		if err1 := task.Get("old-conn", oldConn); err1 != nil {
-			err = fmt.Errorf("On Disconnect: %w\nWhen attempting to revert: internal error: previous connection not found in state", err)
+			err = fmt.Errorf("on disconnect: %w\nWhen attempting to revert: internal error: previous connection not found in state", err)
 		}
 		conns[cref.ID()] = oldConn
 		setConns(st, conns)
@@ -661,7 +661,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		_, err1 := m.repo.Connect(&cref, conn.StaticPlugAttrs, conn.DynamicPlugAttrs, conn.StaticSlotAttrs,
 			conn.DynamicSlotAttrs, nil)
 		if err1 != nil {
-			err = fmt.Errorf("On Disconnect: %w\nWhen attempting to revert: Cannot recover disconnected %q", err, cref.ID())
+			err = fmt.Errorf("on disconnect: %w\nWhen attempting to revert: Cannot recover disconnected %q", err, cref.ID())
 		}
 	})
 

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -64,7 +64,7 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 	s.prj = *prj
 	s.ctx = context.WithValue(s.ctx, workshop.ContextProjectId, s.prj.ProjectId)
 
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {}))
 }
 
 func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
@@ -132,7 +132,7 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	s.writeSDKMetaFile(c, wsfs, sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}}, systemYaml)
 
 	for _, setup := range sdks {
-		s.mockSdk(c, setup.Setup.Name, setup.yaml, int64(setup.Revision.N))
+		s.mockSdk(c, setup.Name, setup.yaml, int64(setup.Revision.N))
 	}
 
 	w, err := s.wsbackend.Workshop(ctx, ws)
@@ -300,7 +300,7 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *check.C) {
-	var isAuto, isUndesired bool = true, false
+	isAuto, isUndesired := true, false
 	s.testConnectionStates(c, isAuto, isUndesired, map[string]ifacestate.ConnectionState{
 		"pid/ws/consumer:plug pid/ws/producer:slot": {
 			Interface: "test",
@@ -321,7 +321,7 @@ func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *check.C) {
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *check.C) {
-	var isAuto, isUndesired bool = true, true
+	isAuto, isUndesired := true, true
 	s.testConnectionStates(c, isAuto, isUndesired, map[string]ifacestate.ConnectionState{
 		"pid/ws/consumer:plug pid/ws/producer:slot": {
 			Interface: "test",

--- a/internal/overlord/overlord_test.go
+++ b/internal/overlord/overlord_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/check.v1"
 	. "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
@@ -78,7 +77,7 @@ func (ovs *overlordSuite) SetUpTest(c *C) {
 	ovs.statePath = filepath.Join(ovs.dir, "state.json")
 
 	b, err := fakebackend.New(c.MkDir())
-	c.Assert(err, check.IsNil)
+	c.Assert(err, IsNil)
 	ovs.restorebackend = overlord.MockWorkshopBackend(b)
 }
 

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -5,11 +5,10 @@ import (
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/workshop"
-	backend "github.com/canonical/workshop/internal/workshop"
 )
 
 type SdkManager struct {
-	backend backend.Backend
+	backend workshop.Backend
 	repo    *interfaces.Repository
 }
 

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -22,7 +22,7 @@ func (s *SdkSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
 	s.projectId = "prj42prj42"
 
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 }
 
 func (s *SdkSuite) TearDownTest(c *check.C) {

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -16,7 +16,7 @@ var _ = check.Suite(&ValidateSuite{})
 
 func (s *ValidateSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
-	s.BaseTest.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
+	s.AddCleanup(sdk.MockSanitizePlugsSlots(func(snapInfo *sdk.Info) {}))
 	s.projectId = "prj-4242"
 }
 

--- a/internal/testutil/containschecker.go
+++ b/internal/testutil/containschecker.go
@@ -83,8 +83,8 @@ func (c *containsChecker) Check(params []interface{}, names []string) (result bo
 			error = fmt.Sprint(v)
 		}
 	}()
-	var container interface{} = params[0]
-	var elem interface{} = params[1]
+	container := params[0]
+	elem := params[1]
 	if commonEquals(container, elem, &result, &error) {
 		return result, error
 	}
@@ -123,8 +123,8 @@ var DeepContains check.Checker = &deepContainsChecker{
 }
 
 func (c *deepContainsChecker) Check(params []interface{}, names []string) (result bool, error string) {
-	var container interface{} = params[0]
-	var elem interface{} = params[1]
+	container := params[0]
+	elem := params[1]
 	if commonEquals(container, elem, &result, &error) {
 		return result, error
 	}

--- a/internal/timings/timings_test.go
+++ b/internal/timings/timings_test.go
@@ -58,7 +58,7 @@ func (s *timingsSuite) TearDownTest(c *C) {
 
 func (s *timingsSuite) mockDuration(c *C) {
 	// Increase duration by 1 millisecond on each call
-	s.BaseTest.AddCleanup(timings.MockTimeDuration(func(start, end time.Time) time.Duration {
+	s.AddCleanup(timings.MockTimeDuration(func(start, end time.Time) time.Duration {
 		c.Check(start.Before(end), Equals, true)
 		s.duration += time.Millisecond
 		return s.duration
@@ -79,7 +79,7 @@ func (s *timingsSuite) mockTimeNow(c *C) {
 	c.Assert(err, IsNil)
 	s.fakeTime = t
 	// Increase fakeTime by 1 millisecond on each call, and report it as current time
-	s.BaseTest.AddCleanup(timings.MockTimeNow(func() time.Time {
+	s.AddCleanup(timings.MockTimeNow(func() time.Time {
 		s.fakeTime = s.fakeTime.Add(time.Millisecond)
 		return s.fakeTime
 	}))

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -190,7 +190,7 @@ func lxdConnectionArgs() (*lxd.ConnectionArgs, error) {
 		// However, the weakness does not make PEM unsafe for our purposes as it pertains to password protection on the
 		// key file (client.key is only readable to the user in any case), so we'll ignore deprecation.
 		if x509.IsEncryptedPEMBlock(pemKey) { //nolint:staticcheck
-			return nil, fmt.Errorf("Private key is password protected and no helper was configured")
+			return nil, fmt.Errorf("private key is password protected and no helper was configured")
 		}
 
 		args.TLSClientKey = string(content)

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -225,8 +225,8 @@ func validateBinding(sdks []SdkRecord) error {
 	// All bindings must refer to the existing SDKs and meet the name validity
 	// checks (at this stage). Later, when SDK metadata will be received, the
 	// plugs must be checked again (e.g. ensure all those plugs actually exist).
-	var masters map[PlugRef][]PlugRef = make(map[PlugRef][]PlugRef)
-	var slaves map[PlugRef]PlugRef = make(map[PlugRef]PlugRef)
+	masters := make(map[PlugRef][]PlugRef)
+	slaves := make(map[PlugRef]PlugRef)
 	for _, s := range sdks {
 		for name, p := range s.Plugs {
 			if p.Bind == nil {

--- a/internal/x11/x11.go
+++ b/internal/x11/x11.go
@@ -48,7 +48,7 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 	// but it is better to convert the uid from the stat result to a
 	// string than a string into a number.
 	if fmt.Sprintf("%d", fsys.(*syscall.Stat_t).Uid) != user.Uid {
-		return fmt.Errorf("Xauthority file isn't owned by the current user %s", user.Uid)
+		return &os.PathError{Op: "open", Path: xauth, Err: syscall.EACCES}
 	}
 
 	destFile := filepath.Join(destDir, ".Xauthority")

--- a/internal/x11/x11_test.go
+++ b/internal/x11/x11_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -61,5 +62,5 @@ func (x *X11TestSuit) TestMigrateXAuthorityOwnershipFail(c *check.C) {
 
 	err = x11.MigrateXauthority(user, filepath.Join(dirs.WorkshopdRunDir, ".workshop-Xauthority"))
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "Xauthority file isn't owned by the current user "+user.Uid)
+	c.Assert(err, testutil.ErrorIs, syscall.EACCES)
 }


### PR DESCRIPTION
# Description

The `--out-format` flag no longer exists, after removing it from the workflow the output looks the same to me ([before](https://github.com/canonical/workshop/actions/runs/13914471185/job/38934893565), [after](https://github.com/canonical/workshop/actions/runs/14050360888/job/39339464598)).

I've opted out of most of the [exclusion presets](https://golangci-lint.run/usage/false-positives/#exclusion-presets). The only one that triggered was SA4011, which I fixed by importing (some of) this change from Pebble: https://github.com/canonical/pebble/pull/580/files#diff-7f043efbd77577f7522e2f457d11690b78ab671819c7d64ed69df8dfbe5e7f1c.

There are new lints for error messages; I've changed some in `cmd/workshop/warnings.go`, `internal/overlord/ifacestate/handlers.go`, `internal/workshop/lxd/lxd_base_manager.go` and `internal/x11/x11.go`.

I added `handlersetup` as an exception, so we can continue to import it using `.`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
