### PR TITLE
Only refresh requested workshops

### DIFF
--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1460,7 +1460,10 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 	c.Assert(err, check.IsNil)
 	c.Assert(got, check.HasLen, len(want), check.Commentf("expected %d workshops, got %d", len(want), len(got)))
 
-	for idx, w := range got {
+	for _, w := range got {
+		idx := slices.IndexFunc(want, func(ws expectedWorkshop) bool { return ws.name == w.Name })
+		c.Assert(idx >= 0, check.Equals, true)
+
 		wantws := want[idx]
 		c.Assert(w.Name, check.Equals, wantws.name)
 		c.Assert(w.Base, check.Equals, wantws.base)
@@ -1524,27 +1527,154 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 }
 
 func (s *apiSuite) checkSnapshotCalls(c *check.C, name string, sdks []string) {
-	c.Assert(s.b.SnapshotCalls, check.HasLen, len(sdks))
+	wpCalls := []fakebackend.SnapshotCall{}
+	for _, sc := range s.b.SnapshotCalls {
+		if sc.Workshop == name {
+			wpCalls = append(wpCalls, sc)
+		}
+	}
+
+	c.Assert(wpCalls, check.HasLen, len(sdks))
 
 	for i, sk := range sdks {
-		c.Assert(s.b.SnapshotCalls[i].Snapid, check.Equals, workshop.SnapshotId(name, sk))
-		c.Assert(s.b.SnapshotCalls[i].Workshop, check.Equals, name)
+		c.Assert(wpCalls[i].Snapid, check.Equals, workshop.SnapshotId(name, sk))
 	}
 }
 
 func (s *apiSuite) checkRestoreCalls(c *check.C, name string, sdks []string, files []string) {
-	c.Assert(s.b.RestoreCalls, check.HasLen, len(sdks))
-	c.Assert(s.b.RestoreCalls, check.HasLen, len(files))
+	wpCalls := []fakebackend.RestoreCall{}
+	for _, sc := range s.b.RestoreCalls {
+		if sc.Workshop == name {
+			wpCalls = append(wpCalls, sc)
+		}
+	}
+
+	c.Assert(wpCalls, check.HasLen, len(sdks))
 
 	for i, sk := range sdks {
-		c.Assert(s.b.RestoreCalls[i].Snapid, check.Equals, workshop.SnapshotId(name, sk))
-		c.Assert(s.b.RestoreCalls[i].Workshop, check.Equals, name)
+		c.Assert(wpCalls[i].Snapid, check.Equals, workshop.SnapshotId(name, sk))
 
 		var f workshop.File
 		err := yaml.Unmarshal([]byte(files[i]), &f)
 		c.Assert(err, check.IsNil)
-		c.Assert(s.b.RestoreCalls[i].File, check.DeepEquals, &f)
+		c.Assert(wpCalls[i].File, check.DeepEquals, &f)
 	}
+}
+
+func (s *apiSuite) TestRefreshMany(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+	// Setup
+	s.createWFile(c, "basic", basic)
+	s.createWFile(c, "manysdks", manysdks)
+	s.createWFile(c, "somebound", somebound)
+
+	s.mockSdkVolumes(c, apiSuiteSdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic", "manysdks", "somebound"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic", "manysdks", "somebound" workshops`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.createWFile(c, "manysdks", manysdks_allremoved)
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic", "manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "basic", "manysdks" workshops`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "somebound",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+		}, connections: []string{
+			"b8639dea/somebound/test-sdk:data b8639dea/somebound/system:mount",
+			"b8639dea/somebound/test-sdk-2:photos b8639dea/somebound/system:mount",
+			"b8639dea/somebound/test-sdk-2:gpu b8639dea/somebound/system:gpu",
+		},
+		plugs: []string{
+			"test-sdk:data",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
+		},
+		slots: []string{
+			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}, {
+		name: "basic",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+		},
+		slots: []string{
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}, {
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+		},
+		slots: []string{
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+
+	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "basic", []string{
+		"system",
+	})
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkSnapshotCalls(c, "somebound", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic})
+	s.checkRestoreCalls(c, "somebound", []string{}, []string{})
+	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_allremoved})
 }
 
 func (s *apiSuite) TestRefreshAddSdk(c *check.C) {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -304,7 +304,7 @@ type refreshWorkshopReq struct {
 	infos []sdk.SdkResult
 }
 
-func (w *WorkshopManager) prepareRefresh(ctx context.Context, wps []*workshop.Workshop) ([]refreshWorkshopReq, error) {
+func (w *WorkshopManager) prepareRefresh(ctx context.Context, wps []*workshop.Workshop, names []string) ([]refreshWorkshopReq, error) {
 	sto := sdk.StoreService(w.state)
 
 	// Not an error, the state is locked; unlock it to let other requests to be
@@ -312,18 +312,24 @@ func (w *WorkshopManager) prepareRefresh(ctx context.Context, wps []*workshop.Wo
 	w.state.Unlock()
 	defer w.state.Lock()
 
-	refreshReqs := make([]refreshWorkshopReq, 0, len(wps))
-	for _, w := range wps {
-		file, err := w.Project.Workshop(w.Name)
+	refreshReqs := make([]refreshWorkshopReq, 0, len(names))
+	for _, name := range names {
+		idx := slices.IndexFunc(wps, func(wp *workshop.Workshop) bool { return wp.Name == name })
+		if idx == -1 {
+			return nil, fmt.Errorf("cannot refresh %q: %w", name, workshop.ErrWorkshopNotLaunched)
+		}
+		wp := wps[idx]
+
+		file, err := wp.Project.Workshop(wp.Name)
 		if err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", w.Name, err)
+			return nil, fmt.Errorf("cannot refresh %q: %w", wp.Name, err)
 		}
 
-		infos, err := sdkInfos(sto, ctx, w.Project.ProjectId, file)
+		infos, err := sdkInfos(sto, ctx, wp.Project.ProjectId, file)
 		if err != nil {
 			return nil, err
 		}
-		refreshReqs = append(refreshReqs, refreshWorkshopReq{w: w, file: file, infos: infos})
+		refreshReqs = append(refreshReqs, refreshWorkshopReq{w: wp, file: file, infos: infos})
 	}
 	return refreshReqs, nil
 }
@@ -334,22 +340,16 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 		return nil, err
 	}
 
-	refreshReqs, err := w.prepareRefresh(ctx, all)
+	refreshReqs, err := w.prepareRefresh(ctx, all, names)
 	if err != nil {
 		return nil, err
 	}
 
 	allowed := []healthstate.Status{healthstate.ReadyStatus}
-	for _, name := range names {
-		idx := slices.IndexFunc(all, func(w *workshop.Workshop) bool { return w.Name == name })
-		if idx == -1 {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, workshop.ErrWorkshopNotLaunched)
+	for _, req := range refreshReqs {
+		if err = healthstate.CheckWorkshopHealth(w.state, req.w, allowed); err != nil {
+			return nil, fmt.Errorf("cannot refresh %q: %w", req.w.Name, err)
 		}
-
-		if err = healthstate.CheckWorkshopHealth(w.state, all[idx], allowed); err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
-		}
-
 	}
 
 	taskset := make([]*state.TaskSet, 0, len(refreshReqs))


### PR DESCRIPTION
# Description

At the moment all workshops in the current project are refreshed, even if you only request one. It won't show up in `workshop changes`, but will in the server logs.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
