### PR TITLE
Track revisions for sketch SDK and bind-mount them in the workshop

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -48,6 +48,7 @@ type Sdk struct {
 	Name        string       `json:"name"`
 	Version     string       `json:"version,omitempty"`
 	Channel     string       `json:"channel"`
+	Source      string       `json:"source"`
 	Revision    string       `json:"revision"`
 	BuildTime   time.Time    `json:"build-time"`
 	InstallTime time.Time    `json:"install-time"`

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -16,7 +16,6 @@ import (
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/workshop"
 )
 
 type CmdInfo struct {
@@ -144,19 +143,22 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		for _, sk := range workshop.Sdks {
 			fmt.Fprintf(w, "  %s:\n", sk.Name)
 
-			if sdk.IsSketch(sk.Name) {
-				sk.Channel = sketchSdkChannel(project.Id, workshop.Name)
-				if sk.BuildTime.IsZero() {
-					sk.BuildTime = sk.InstallTime
-				}
-			} else if sk.Channel == "" {
-				sk.Channel = "~"
-			}
-
 			// Tracking info is always the same for the system SDK. Omit it to
 			// highlight the difference between it and a regular type SDK.
 			if !sdk.IsSystem(sk.Name) {
-				fmt.Fprintf(w, "    tracking:\t%s\n", sk.Channel)
+				tracking := sk.Channel
+				revision, err := sdk.ParseRevision(sk.Revision)
+				if err == nil && revision.Local() {
+					tracking = contractHomeDirectory(sk.Source)
+					if sk.BuildTime.IsZero() {
+						sk.BuildTime = sk.InstallTime
+					}
+				}
+				if tracking == "" {
+					tracking = "-"
+				}
+
+				fmt.Fprintf(w, "    tracking:\t%s\n", tracking)
 			}
 
 			var buildTime string
@@ -209,16 +211,6 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	w.Flush()
 
 	return nil
-}
-
-func sketchSdkChannel(projectId, w string) string {
-	user, env, err := osutil.CurrentUserAndEnv()
-	if err != nil {
-		return "~"
-	}
-
-	userDataDir := workshop.UserDataRootDir(user.HomeDir, env)
-	return contractHomeDirectory(workshop.SketchSdkDir(userDataDir, projectId, w))
 }
 
 func formatEndpoint(endpoint client.Endpoint) string {

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -143,21 +143,21 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		for _, sk := range workshop.Sdks {
 			fmt.Fprintf(w, "  %s:\n", sk.Name)
 
+			tracking := sk.Channel
+			revision, err := sdk.ParseRevision(sk.Revision)
+			if err == nil && revision.Local() {
+				tracking = contractHomeDirectory(sk.Source)
+				if sk.BuildTime.IsZero() {
+					sk.BuildTime = sk.InstallTime
+				}
+			}
+			if tracking == "" {
+				tracking = "-"
+			}
+
 			// Tracking info is always the same for the system SDK. Omit it to
 			// highlight the difference between it and a regular type SDK.
 			if !sdk.IsSystem(sk.Name) {
-				tracking := sk.Channel
-				revision, err := sdk.ParseRevision(sk.Revision)
-				if err == nil && revision.Local() {
-					tracking = contractHomeDirectory(sk.Source)
-					if sk.BuildTime.IsZero() {
-						sk.BuildTime = sk.InstallTime
-					}
-				}
-				if tracking == "" {
-					tracking = "-"
-				}
-
 				fmt.Fprintf(w, "    tracking:\t%s\n", tracking)
 			}
 

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -284,7 +284,7 @@ var mockWorkshopWithTunnels = `{
     "sdks": [
       {
         "name": "system",
-        "revision": "x1",
+        "revision": "1",
         "tunnels": {
           "plugs": [
             {
@@ -437,7 +437,7 @@ status:   ready
 notes:    -
 sdks:
   system:
-    installed:  \(x1\)
+    installed:  \(1\)
     tunnels:
       gopls:
         from:  127.0.0.1:60915/tcp

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -38,7 +38,7 @@ var mockWorkshopWithSdks = `{"type":"sync","status-code":200,"status":"OK","resu
       "install-time":"2017-03-22T09:01:00.0Z"
     },{  
       "name":"sketch",
-      "channel":"",
+      "source":"%s/.local/share/workshop/id/42424242/ws/sdk/sketch/current",
       "revision":"x1",
       "install-time":"2017-03-22T09:01:00.0Z"
     }],
@@ -51,6 +51,8 @@ var mockWorkshopWithSdks = `{"type":"sync","status-code":200,"status":"OK","resu
 func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
 	cmd := &CmdInfo{root: &CmdRoot{}}
 	workshop := "ws"
+	home, err := os.UserHomeDir()
+	c.Assert(err, check.IsNil)
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -69,13 +71,13 @@ func (m *workshopInfo) TestWorkshopInfo(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
-			fmt.Fprintln(w, mockWorkshopWithSdks)
+			fmt.Fprintln(w, fmt.Sprintf(mockWorkshopWithSdks, home))
 		default:
 			c.Errorf("expected 3 calls, now on %d", n)
 		}
 	})
 
-	err := cmd.Run(cmd.Command(), nil)
+	err = cmd.Run(cmd.Command(), nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`name:     ws
 base:     ubuntu@22.04
@@ -87,7 +89,7 @@ sdks:
     tracking:   latest/edge
     installed:  1.8.0  2017-02-19  \(1\)
   sketch:
-    tracking:   ~/.local/share/workshop/id/42424242/ws/sdk/sketch
+    tracking:   ~/.local/share/workshop/id/42424242/ws/sdk/sketch/current
     installed:  2017-03-22  \(x1\)
 `, m.prjDir))
 	c.Check(n, check.Equals, 3)

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -26,7 +26,7 @@ type BaseWorkshopSuite struct {
 	stderr *bytes.Buffer
 }
 
-func TestMain(t *testing.T) { check.TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 func (s *BaseWorkshopSuite) SetUpTest(c *check.C) {
 	dirs.SetRootDir(c.MkDir())

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -126,8 +125,6 @@ var (
 )
 
 func stashSketch(sketchdir, stashdir string) (*revert.Reverter, error) {
-	reverter := revert.New()
-
 	recs, err := os.ReadDir(sketchdir)
 	if err != nil && !osutil.IsDirNotExist(err) {
 		return nil, err
@@ -137,20 +134,43 @@ func stashSketch(sketchdir, stashdir string) (*revert.Reverter, error) {
 		return nil, fmt.Errorf(`cannot stash: the 'sketch' SDK doesn't exist`)
 	}
 
-	if err := os.MkdirAll(stashdir, 0755); err != nil {
+	// Ensure stashdir exists but is empty.
+	if err := clearStash(stashdir); err != nil {
 		return nil, err
 	}
+
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	if err := osutil.Exchange(sketchdir, stashdir); err != nil {
 		return nil, err
 	}
 	reverter.Add(func() { _ = osutil.Exchange(stashdir, sketchdir) })
 
-	if err := os.RemoveAll(sketchdir); err != nil {
+	if err := os.Remove(sketchdir); err != nil {
 		return nil, err
 	}
 	reverter.Add(func() { _ = os.MkdirAll(sketchdir, 0755) })
-	return reverter, nil
+
+	clone := reverter.Clone()
+	reverter.Success()
+	return clone, nil
+}
+
+func clearStash(stashdir string) error {
+	temp, err := os.MkdirTemp(filepath.Dir(stashdir), "stash-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temp)
+	if err := os.Chmod(temp, 0755); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(stashdir, 0755); err != nil {
+		return err
+	}
+	return osutil.Exchange(stashdir, temp)
 }
 
 func restoreSketch(sketchdir, stashdir string) error {
@@ -185,7 +205,20 @@ func removeSketch(sketchdir string) error {
 		return fmt.Errorf(`cannot remove: the 'sketch' SDK doesn't exist`)
 	}
 
-	return os.RemoveAll(sketchdir)
+	temp, err := os.MkdirTemp(filepath.Dir(sketchdir), "sketch-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temp)
+	if err := os.Chmod(temp, 0755); err != nil {
+		return err
+	}
+
+	if err := osutil.Exchange(sketchdir, temp); err != nil {
+		return err
+	}
+
+	return os.Remove(sketchdir)
 }
 
 func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
@@ -254,17 +287,17 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		cmdrefresh := &CmdRefresh{root: c.root}
 		cmdrefresh.WaitOnError = true
 
-		storedir := workshop.SketchSdkStash(userDataDir, p.Id, wp.Name)
+		stashdir := workshop.SketchSdkStash(userDataDir, p.Id, wp.Name)
 
-		if err = restoreSketch(sketchdir, storedir); err != nil {
+		if err = restoreSketch(sketchdir, stashdir); err != nil {
 			return err
 		}
 
-		// Run refresh with the stored sketch SDK. We do not revert dirs exchange
+		// Run refresh with the stashed sketch SDK. We do not revert dirs exchange
 		// on a failed refresh here as it is run with the content from "stored"
 		// and with --wait-on-error. Hence, there is always a possibility to
-		// workshop refresh --abort and workshop sketch-sdk --restore to restore the
-		// original sketch content.
+		// workshop refresh --abort and workshop sketch-sdk --stash to restore the
+		// original stash content.
 		return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", wp.Name)})
 	}
 
@@ -277,38 +310,8 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		return cmdrefresh.Run(cmd, []string{wp.Name})
 	}
 
-	metafile := filepath.Join(sketchdir, "meta", "sdk.yaml")
-
-	// Format sketch SDK template header.
-	boilerplate := fmt.Sprintf(sketchTemplate, wp.Path)
-
-	if osutil.FileExists(metafile) {
-		old, err := os.ReadFile(metafile)
-		if err != nil {
-			return err
-		}
-
-		new, err := runTextEditor(metafile, []byte{})
-		if err != nil {
-			return err
-		}
-
-		if bytes.Equal(old, new) {
-			return nil
-		}
-
-		if err = writeSketchSdk(sketchdir, new); err != nil {
-			return err
-		}
-	} else {
-		res, err := runTextEditor("", []byte(boilerplate))
-		if err != nil {
-			return err
-		}
-
-		if err = writeSketchSdk(sketchdir, res); err != nil {
-			return err
-		}
+	if err = editSketchSdk(sketchdir, wp.Path); err != nil {
+		return err
 	}
 
 	cmdrefresh := &CmdRefresh{root: c.root}
@@ -317,11 +320,52 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", wp.Name)})
 }
 
-func writeSketchSdk(sketchdir string, content []byte) error {
-	var rec workshop.SdkRecord
-	r := revert.New()
-	defer r.Fail()
+func editSketchSdk(sketchdir, workshopFile string) error {
+	content, err := os.ReadFile(filepath.Join(sketchdir, "meta", "sdk.yaml"))
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(sketchdir, 0755); err != nil {
+			return err
+		}
 
+		// Format sketch SDK template header.
+		content = []byte(fmt.Sprintf(sketchTemplate, workshopFile))
+	} else if err != nil {
+		return err
+	}
+
+	temp, err := os.MkdirTemp(filepath.Dir(sketchdir), "current-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temp)
+	if err := os.Chmod(temp, 0755); err != nil {
+		return err
+	}
+
+	target := filepath.Join(temp, "meta", "sdk.yaml")
+	if err := writeSketchSdk(target, content); err != nil {
+		return err
+	}
+	content, err = runTextEditor(target, content)
+	if err != nil {
+		return err
+	}
+	if err := writeSketchHooks(temp, content); err != nil {
+		return err
+	}
+
+	return osutil.Exchange(temp, sketchdir)
+}
+
+func writeSketchSdk(path string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, 0644)
+}
+
+func writeSketchHooks(sketchdir string, content []byte) error {
+	var rec workshop.SdkRecord
 	if err := yaml.Unmarshal(content, &rec); err != nil {
 		return err
 	}
@@ -330,37 +374,22 @@ func writeSketchSdk(sketchdir string, content []byte) error {
 		return fmt.Errorf("cannot sketch: SDK must be named %q (now: %q)", sdk.Sketch, rec.Name)
 	}
 
-	metadir := filepath.Join(sketchdir, "meta")
-	metapath := filepath.Join(metadir, "sdk.yaml")
-	if err := os.MkdirAll(metadir, 0755); err != nil {
-		return err
-	}
-	r.Add(func() { os.RemoveAll(metadir) })
-	if err := os.WriteFile(metapath, content, 0644); err != nil {
-		return err
-	}
-
 	hooksdir := filepath.Join(sketchdir, "hooks")
 	if len(rec.Hooks) > 0 {
 		if err := os.MkdirAll(hooksdir, 0755); err != nil {
 			return err
 		}
-		r.Add(func() { os.RemoveAll(hooksdir) })
 	}
+
 	for _, hook := range []string{"setup-base", "save-state", "restore-state", "check-health"} {
 		hookpath := filepath.Join(hooksdir, hook)
 		if script := rec.Hooks[hook]; len(script) > 0 {
 			if err := os.WriteFile(hookpath, []byte(script+"\n"), 0644); err != nil {
 				return err
 			}
-		} else {
-			if err := os.Remove(hookpath); err != nil && !errors.Is(err, os.ErrNotExist) {
-				return err
-			}
 		}
 	}
 
-	r.Success()
 	return nil
 }
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -89,6 +89,7 @@ hooks:
   # EXAMPLE: setup-base runs once at workshop launch, use it to install some packages.
   # See https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/hooks/
   # setup-base: |
+    # apt-get update
     # apt-get install PACKAGE...
     # snap install SNAP...
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -83,7 +83,6 @@ var sketchTemplate = `# Sketch SDK for %s
 # To read more about SDKs, their components and syntax, see:
 # https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/
 name: sketch
-base: %s
 
 hooks:
   # EXAMPLE: setup-base runs once at workshop launch, use it to install some packages.
@@ -281,7 +280,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	metafile := filepath.Join(sketchdir, "meta", "sdk.yaml")
 
 	// Format sketch SDK template header.
-	boilerplate := fmt.Sprintf(sketchTemplate, wp.Path, wp.Base)
+	boilerplate := fmt.Sprintf(sketchTemplate, wp.Path)
 
 	if osutil.FileExists(metafile) {
 		old, err := os.ReadFile(metafile)

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -374,7 +374,7 @@ func writeSketchHooks(sketchdir string, content []byte) error {
 		return fmt.Errorf("cannot sketch: SDK must be named %q (now: %q)", sdk.Sketch, rec.Name)
 	}
 
-	hooksdir := filepath.Join(sketchdir, "hooks")
+	hooksdir := filepath.Join(sketchdir, "sdk", "hooks")
 	if len(rec.Hooks) > 0 {
 		if err := os.MkdirAll(hooksdir, 0755); err != nil {
 			return err

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -139,7 +139,7 @@ func (m *workshopSketch) mockMinimalSketchSdk(c *check.C, ws string, current boo
 	}
 
 	metadir := filepath.Join(sketchDir, "meta")
-	hooksdir := filepath.Join(sketchDir, "hooks")
+	hooksdir := filepath.Join(sketchDir, "sdk", "hooks")
 
 	c.Assert(writeSketchSdk(filepath.Join(metadir, "sdk.yaml"), meta), check.IsNil)
 	c.Assert(writeSketchHooks(sketchDir, meta), check.IsNil)
@@ -248,7 +248,7 @@ hooks:
 
 	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
 	c.Assert(filepath.Join(current, "meta", "sdk.yaml"), testutil.FileEquals, sketchContent)
-	c.Assert(filepath.Join(current, "hooks", "setup-base"), testutil.FileEquals, "echo \"Hello\"\n")
+	c.Assert(filepath.Join(current, "sdk", "hooks", "setup-base"), testutil.FileEquals, "echo \"Hello\"\n")
 }
 
 func (m *workshopSketch) TestSketchSdkUpdateHooks(c *check.C) {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -38,7 +38,7 @@ var mockWorkshopWithSdksReady = `{"type":"sync","status-code":200,"status":"OK",
       "install-time":"2017-03-22T09:01:00.0Z"
     },{
       "name":"sketch",
-      "channel":"",
+      "source":"/home/.local/share/workshop/id/42424242/ws/sdk/sketch/current",
       "revision":"x1",
       "install-time":"2017-03-22T09:01:00.0Z"
     }],
@@ -60,7 +60,7 @@ var mockWorkshopWithSdksWaiting = `{"type":"sync","status-code":200,"status":"OK
       "install-time":"2017-03-22T09:01:00.0Z"
     },{
       "name":"sketch",
-      "channel":"",
+      "source":"/home/.local/share/workshop/id/42424242/ws/sdk/sketch/current",
       "revision":"x2",
       "install-time":"2017-03-22T09:01:00.0Z"
     }],
@@ -75,7 +75,7 @@ var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK
         "status":"Ready",
         "sdks":[{
             "name":"sketch",
-            "channel":"",
+            "source":"/home/.local/share/workshop/id/42424242/ws/sdk/sketch/current",
             "revision":"x1",
             "install-time":"2017-03-22T09:01:00.0Z"
         }]
@@ -91,7 +91,7 @@ var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK
         "status":"Ready",
         "sdks":[{
             "name":"sketch",
-            "channel":"",
+            "source":"/home/.local/share/workshop/id/42424242/both/sdk/sketch/current",
             "revision":"x3",
             "install-time":"2017-03-22T09:01:00.0Z"
         }]

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -205,7 +205,7 @@ func (m *workshopSketch) TestSketchSdkMetaOnlySuccess(c *check.C) {
 
 	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
 
-	sketchContent := fmt.Sprintf(sketchTemplate, "/home/project/.workshop/ws.yaml", "ubuntu@22.04")
+	sketchContent := fmt.Sprintf(sketchTemplate, "/home/project/.workshop/ws.yaml")
 	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
 		return []byte(inContent), nil
 	})

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -138,10 +138,11 @@ func (m *workshopSketch) mockMinimalSketchSdk(c *check.C, ws string, current boo
 		sketchDir = workshop.SketchSdkStash(m.userDataDir, m.prjId, ws)
 	}
 
-	err := writeSketchSdk(sketchDir, meta)
-	c.Assert(err, check.IsNil)
 	metadir := filepath.Join(sketchDir, "meta")
 	hooksdir := filepath.Join(sketchDir, "hooks")
+
+	c.Assert(writeSketchSdk(filepath.Join(metadir, "sdk.yaml"), meta), check.IsNil)
+	c.Assert(writeSketchHooks(sketchDir, meta), check.IsNil)
 
 	return metadir, hooksdir
 }
@@ -207,7 +208,10 @@ func (m *workshopSketch) TestSketchSdkMetaOnlySuccess(c *check.C) {
 
 	sketchContent := fmt.Sprintf(sketchTemplate, "/home/project/.workshop/ws.yaml")
 	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
-		return []byte(inContent), nil
+		if inPath != "" {
+			c.Assert(writeSketchSdk(inPath, inContent), check.IsNil)
+		}
+		return inContent, nil
 	})
 	defer restore()
 
@@ -232,6 +236,9 @@ hooks:
         echo "Hello"
 `
 	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
+		if inPath != "" {
+			c.Assert(writeSketchSdk(inPath, []byte(sketchContent)), check.IsNil)
+		}
 		return []byte(sketchContent), nil
 	})
 	defer restore()
@@ -268,6 +275,9 @@ hooks:
         # restores state
 `
 	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
+		if inPath != "" {
+			c.Assert(writeSketchSdk(inPath, []byte(sketchContent)), check.IsNil)
+		}
 		return []byte(sketchContent), nil
 	})
 	defer restore()
@@ -300,6 +310,9 @@ plugs:
     interface: gpu
 `
 	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
+		if inPath != "" {
+			c.Assert(writeSketchSdk(inPath, []byte(sketchContent)), check.IsNil)
+		}
 		return []byte(sketchContent), nil
 	})
 	defer restore()
@@ -385,15 +398,21 @@ hooks:
         %s
 `
 	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
+		var content string
 		attempts += 1
 		switch attempts {
 		case 1:
-			return []byte(fmt.Sprintf(sketchSetup, "false")), nil
+			content = fmt.Sprintf(sketchSetup, "false")
 		case 2:
-			return []byte(fmt.Sprintf(sketchSetup, "true")), nil
+			content = fmt.Sprintf(sketchSetup, "true")
 		default:
 			return nil, fmt.Errorf("expected 2 attempts, now on %d", attempts)
 		}
+
+		if inPath != "" {
+			c.Assert(writeSketchSdk(inPath, []byte(content)), check.IsNil)
+		}
+		return []byte(content), nil
 	})
 	defer restore()
 

--- a/docs/how-to/ros2/ros2-design-sdk.rst
+++ b/docs/how-to/ros2/ros2-design-sdk.rst
@@ -253,7 +253,7 @@ Run-time behaviour
 At run-time, SDK revisions are available inside the workshop;
 under :file:`/var/lib/workshop/sdk/ros2/`,
 you can see all SDK content that was packed, published and installed.
-There, :file:`current/` always maps to the latest installed revision:
+The directory always maps to the latest installed revision:
 
 .. @artefact workshop shell
 .. @artefact SDK revision
@@ -261,7 +261,7 @@ There, :file:`current/` always maps to the latest installed revision:
 .. code-block:: console
 
    $ workshop shell ros2-jazzy
-   workshop@ros2-jazzy-8584e57d$ ls /var/lib/workshop/sdk/ros2/current
+   workshop@ros2-jazzy-8584e57d$ ls /var/lib/workshop/sdk/ros2
 
    meta  sdk
 

--- a/docs/how-to/use-workshops/debug-workshop-issues.rst
+++ b/docs/how-to/use-workshops/debug-workshop-issues.rst
@@ -48,7 +48,7 @@ run :command:`workshop tasks` without arguments:
 
    $ workshop tasks
 
-     ID    Status  Spawn                Ready                Summary
+     ID    Status  Spawn           Ready           Summary
      ...
 
 
@@ -60,9 +60,9 @@ by listing all *changes* in the workshop to find the one that failed:
 
    $ workshop changes
 
-     ID  Status  Spawn                Ready                Summary
+     ID  Status  Spawn           Ready           Summary
      ...
-     81  Error   today at 12:20       today at 12:23       Refresh workshops "dev-volatile"
+     81  Error   today at 12:20  today at 12:21  Refresh workshops "dev-volatile"
 
 
 When you have found the problematic change,
@@ -73,22 +73,40 @@ this time supplying the change ID as the argument:
 
    $ workshop tasks 81
 
-     ID    Status  Spawn                Ready                Summary
-     ...
-     1392  Error   today at 12:17       today at 12:18       Run hook "setup-base" for "go" SDK
+     ID    Status  Spawn           Ready           Summary
+     1390  Undone  today at 12:20  today at 12:21  Create SDK state storage
+     1391  Done    today at 12:20  today at 12:21  Run hook "save-state" for "go" SDK
+     1392  Done    today at 12:20  today at 12:21  Disconnect interfaces of "go" SDK
+     1393  Done    today at 12:20  today at 12:21  Disconnect interfaces of "system" SDK
+     1394  Undone  today at 12:20  today at 12:21  Unregister "go" SDK plugs and slots
+     1395  Undone  today at 12:20  today at 12:21  Stash previous "dev-volatile" workshop
+     1396  Undone  today at 12:20  today at 12:21  Restore "dev-volatile" workshop from "system" snapshot
+     1397  Undone  today at 12:20  today at 12:21  Start "dev-volatile" workshop
+     1398  Undone  today at 12:20  today at 12:21  Install "go" SDK
+     1399  Undone  today at 12:20  today at 12:21  Register "go" SDK plugs and slots
+     1400  Error   today at 12:20  today at 12:21  Run hook "setup-base" for "go" SDK
+     1401  Hold    today at 12:20  today at 12:21  Auto-connect interfaces of "system" SDK
+     1402  Hold    today at 12:20  today at 12:21  Auto-connect interfaces of "go" SDK
+     1403  Hold    today at 12:20  today at 12:21  Run hook "restore-state" for "go" SDK
+     1404  Hold    today at 12:20  today at 12:21  Run hook "check-health" for "system" SDK
+     1405  Hold    today at 12:20  today at 12:21  Run hook "check-health" for "go" SDK
+     1406  Hold    today at 12:20  today at 12:21  Remove SDK state storage
+     1407  Hold    today at 12:20  today at 12:21  Remove "dev-volatile" workshop from stash
+     1408  Done    today at 12:20  today at 12:21  Remove "go" SDK profile
+     1409  Done    today at 12:20  today at 12:21  Remove "system" SDK profile
 
      ......................................................................
      Run hook "save-state" for "go" SDK
 
-     2023-07-24T12:17:37+12:00 INFO latest/beta save-state: preserving ~/.config/pretrained-config.conf
+     2023-07-24T12:21:37 INFO GOBIN='/home/workshop/.local/bin'
+
      ......................................................................
      Run hook "setup-base" for "go" SDK
-     ...
-     Traceback (most recent call last):
-         File "<string>", line 1, in <module>
-         File "/home/user/.local/lib/python3.9/site-packages/tensorrt/__init__.py", line 36, in <module>
-             from .tensorrt import *
-     ModuleNotFoundError: No module named 'tensorrt.tensorrt'
+
+     2023-07-24T12:21:37 ERROR error: cannot install "go": cannot get nonce from store: persistent network
+     2023-07-24T12:21:37 ERROR        error: Post "https://api.snapcraft.io/api/v1/snaps/auth/nonces": dial
+     2023-07-24T12:21:37 ERROR        tcp: lookup api.snapcraft.io: Temporary failure in name resolution (exit code: 1)
+
 
 The SDK-specific reason can be addressed individually.
 

--- a/docs/how-to/use-workshops/sketch-sdk.rst
+++ b/docs/how-to/use-workshops/sketch-sdk.rst
@@ -66,15 +66,20 @@ This defines all SDK components in a single file named :file:`sdk.yaml`:
    $ workshop sketch-sdk
 
 
-The editor presents a minimal setup with :samp:`name`, :samp:`base`,
-and empty :samp:`hooks` and :samp:`plugs`:
+The editor presents a minimal setup
+with empty :samp:`hooks`, :samp:`plugs` and :samp:`slots`:
 
 .. code-block:: yaml
    :caption: sdk.yaml
 
    name: sketch
-   base: ubuntu@22.04
-   # ...
+
+   hooks:
+    # ...
+   plugs:
+    # ...
+   slots:
+    # ...
 
 
 .. note::
@@ -92,7 +97,6 @@ Uncomment :samp:`setup-base` and add the installation commands for our tools:
    :caption: sdk.yaml
 
    name: sketch
-   base: ubuntu@22.04
 
    hooks:
      setup-base: |

--- a/docs/how-to/use-workshops/sketch-sdk.rst
+++ b/docs/how-to/use-workshops/sketch-sdk.rst
@@ -134,7 +134,7 @@ After the refresh, the output of :command:`workshop info` should look like this
 .. code-block:: console
 
    sketch:
-     tracking:   ~/.local/share/workshop/project/b5b0f128/sdk/sketch/dev
+     tracking:   ~/.local/share/workshop/id/b5b0f128/dev/sdk/sketch/current
      installed:  2025-02-24  (x1)
 
 

--- a/docs/reference/workshops.rst
+++ b/docs/reference/workshops.rst
@@ -75,6 +75,10 @@ At the container launch, |ws_markup| does the following:
 - Fetches the required images and SDKs from the image server and the Store,
   if they aren't already cached locally.
 
+- Reads definitions of local SDKs,
+  such as the sketch SDK,
+  and copies them to a read-only location.
+
 - Spins up the container with mapped user and group IDs,
   configures basic devices like the root disk and network bridge.
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -333,34 +333,20 @@ pass the ID of the change to the :command:`workshop tasks` command:
      ID   Status  Spawn               Ready               Summary
      132  Done    today at 11:32 GMT  today at 11:32 GMT  Retrieve "system" SDK
      133  Done    today at 11:32 GMT  today at 11:32 GMT  Retrieve "go" SDK from channel "latest/stable"
-     134  Done    today at 11:32 GMT  today at 11:32 GMT  Create apt cache for "dev"
-     135  Done    today at 11:32 GMT  today at 11:32 GMT  Download "ubuntu@22.04" base image
-     136  Done    today at 11:32 GMT  today at 11:32 GMT  Create new "dev" workshop
-     137  Done    today at 11:32 GMT  today at 11:32 GMT  Mount project directory "/home/user/hello-workshop"
-     138  Done    today at 11:32 GMT  today at 11:33 GMT  Start "dev" workshop
-     139  Done    today at 11:33 GMT  today at 11:33 GMT  Install "system" SDK
-     140  Done    today at 11:33 GMT  today at 11:33 GMT  Link "system" SDK
-     141  Done    today at 11:33 GMT  today at 11:33 GMT  Run hook "setup-base" for "system" SDK
-     142  Done    today at 11:33 GMT  today at 11:33 GMT  Install "go" SDK
-     143  Done    today at 11:33 GMT  today at 11:33 GMT  Link "go" SDK
-     144  Done    today at 11:33 GMT  today at 11:34 GMT  Run hook "setup-base" for "go" SDK
-     145  Done    today at 11:34 GMT  today at 11:34 GMT  Auto-connect interfaces of "system" SDK
-     146  Done    today at 11:34 GMT  today at 11:34 GMT  Auto-connect interfaces of "go" SDK
-     147  Done    today at 11:34 GMT  today at 11:34 GMT  Run hook "check-health" for "system" SDK
-     148  Done    today at 11:34 GMT  today at 11:34 GMT  Run hook "check-health" for "go" SDK
-     149  Done    today at 11:34 GMT  today at 11:34 GMT  Connect "dev/go:mod-cache" to "dev/system:mount"
-     150  Done    today at 11:34 GMT  today at 11:34 GMT  Connect "dev/go:bin" to "dev/system:mount"
-     151  Done    today at 11:34 GMT  today at 11:34 GMT  Setup "system" SDK profile
+     ...
+     144  Done    today at 11:32 GMT  today at 11:33 GMT  Run hook "setup-base" for "go" SDK
+     ...
 
      ......................................................................
      Run hook "setup-base" for "go" SDK
 
      2024-08-25T11:34:53+00:00 INFO go 1.23.0 from Canonical** installed
-     2024-08-25T11:34:53+00:00 INFO PATH=/home/workshop/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 
 
-
-Here, the following happens:
+This displays a list of all the tasks
+which comprise launching the workshop,
+and logs for some of the tasks.
+For launch, the following happens:
 
 - The :samp:`ubuntu@22.04` base image from the definition is retrieved.
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -331,17 +331,40 @@ pass the ID of the change to the :command:`workshop tasks` command:
    $ workshop tasks 34
 
      ID   Status  Spawn               Ready               Summary
-     133  Done    today at 11:32 GMT  today at 11:32 GMT  Create new "dev" workshop
-     134  Done    today at 11:32 GMT  today at 11:32 GMT  Mount project directory "hello-workshop"
-     135  Done    today at 11:32 GMT  today at 11:32 GMT  Start "dev" workshop
-     136  Done    today at 11:32 GMT  today at 11:32 GMT  Retrieve "go" SDK from channel "latest/stable"
-     137  Done    today at 11:32 GMT  today at 11:32 GMT  Install "go" SDK
-     138  Done    today at 11:32 GMT  today at 11:33 GMT  Link "go" SDK
-     139  Done    today at 11:33 GMT  today at 11:33 GMT  Run hook "setup-base" for "go" SDK
-     140  Done    today at 11:33 GMT  today at 11:33 GMT  Auto-connect interfaces of "go" SDK
+     132  Done    today at 11:32 GMT  today at 11:32 GMT  Retrieve "system" SDK
+     133  Done    today at 11:32 GMT  today at 11:32 GMT  Retrieve "go" SDK from channel "latest/stable"
+     134  Done    today at 11:32 GMT  today at 11:32 GMT  Create apt cache for "dev"
+     135  Done    today at 11:32 GMT  today at 11:32 GMT  Download "ubuntu@22.04" base image
+     136  Done    today at 11:32 GMT  today at 11:32 GMT  Create new "dev" workshop
+     137  Done    today at 11:32 GMT  today at 11:32 GMT  Mount project directory "/home/user/hello-workshop"
+     138  Done    today at 11:32 GMT  today at 11:33 GMT  Start "dev" workshop
+     139  Done    today at 11:33 GMT  today at 11:33 GMT  Install "system" SDK
+     140  Done    today at 11:33 GMT  today at 11:33 GMT  Link "system" SDK
+     141  Done    today at 11:33 GMT  today at 11:33 GMT  Run hook "setup-base" for "system" SDK
+     142  Done    today at 11:33 GMT  today at 11:33 GMT  Install "go" SDK
+     143  Done    today at 11:33 GMT  today at 11:33 GMT  Link "go" SDK
+     144  Done    today at 11:33 GMT  today at 11:34 GMT  Run hook "setup-base" for "go" SDK
+     145  Done    today at 11:34 GMT  today at 11:34 GMT  Auto-connect interfaces of "system" SDK
+     146  Done    today at 11:34 GMT  today at 11:34 GMT  Auto-connect interfaces of "go" SDK
+     147  Done    today at 11:34 GMT  today at 11:34 GMT  Run hook "check-health" for "system" SDK
+     148  Done    today at 11:34 GMT  today at 11:34 GMT  Run hook "check-health" for "go" SDK
+     149  Done    today at 11:34 GMT  today at 11:34 GMT  Connect "dev/go:mod-cache" to "dev/system:mount"
+     150  Done    today at 11:34 GMT  today at 11:34 GMT  Connect "dev/go:bin" to "dev/system:mount"
+     151  Done    today at 11:34 GMT  today at 11:34 GMT  Setup "system" SDK profile
+
+     ......................................................................
+     Run hook "setup-base" for "go" SDK
+
+     2024-08-25T11:34:53+00:00 INFO go 1.23.0 from Canonical** installed
+     2024-08-25T11:34:53+00:00 INFO PATH=/home/workshop/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+
 
 
 Here, the following happens:
+
+- The :samp:`ubuntu@22.04` base image from the definition is retrieved.
+
+- A cache is created for apt packages.
 
 - The :ref:`project directory <tut_define>`
   is mounted inside the workshop
@@ -350,10 +373,12 @@ Here, the following happens:
 
 - The workshop is *started*, or brought online.
 
+- The :ref:`system SDK <exp_system_sdk>` is installed.
+
 - The :samp:`go` SDK from the definition is retrieved,
   installed and set up inside the workshop.
 
-- The interfaces of the SDK are connected.
+- The interfaces of the SDKs are connected.
 
 
 You only need to launch a workshop once after defining it;

--- a/internal/daemon/api_changes_test.go
+++ b/internal/daemon/api_changes_test.go
@@ -42,10 +42,10 @@ func setupChanges(st *state.State) []string {
 	chg2 := st.NewChange("remove", "remove...")
 	chg2.Set("workshop", "two")
 	chg2.Set("project-id", "123")
-	t3 := st.NewTask("unlink-sdk", "1...")
+	t3 := st.NewTask("unregister-sdk", "1...")
 	chg2.AddTask(t3)
 	t3.SetStatus(state.ErrorStatus)
-	t3.Errorf("unlink failed")
+	t3.Errorf("unregister failed")
 
 	return []string{chg1.ID(), chg2.ID(), t1.ID(), t2.ID(), t3.ID()}
 }
@@ -102,7 +102,7 @@ func (s *apiSuite) TestStateChangesDefaultToAll(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"launch","summary":"launch...","status":"Do","tasks":\[{"id":"\w+","kind":"create-workshop","summary":"1...","status":"Do","log":\["2016-04-21T01:02:03Z INFO l11","2016-04-21T01:02:03Z INFO l12"],"progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}.*],"ready":false,"spawn-time":"2016-04-21T01:02:03Z","project-id":"123"}.*`)
-	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unlink-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unlink failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
+	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unregister-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unregister failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
 }
 
 func (s *apiSuite) TestStateChangesInProgress(c *check.C) {
@@ -160,7 +160,7 @@ func (s *apiSuite) TestStateChangesAll(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"launch","summary":"launch...","status":"Do","tasks":\[{"id":"\w+","kind":"create-workshop","summary":"1...","status":"Do","log":\["2016-04-21T01:02:03Z INFO l11","2016-04-21T01:02:03Z INFO l12"],"progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}.*],"ready":false,"spawn-time":"2016-04-21T01:02:03Z","project-id":"123"}.*`)
-	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unlink-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unlink failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
+	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unregister-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unregister failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
 }
 
 func (s *apiSuite) TestStateChangesReady(c *check.C) {
@@ -188,7 +188,7 @@ func (s *apiSuite) TestStateChangesReady(c *check.C) {
 	res, err := rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
 
-	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unlink-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unlink failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
+	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unregister-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unregister failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
 }
 
 func (s *apiSuite) TestStateChangesForWorkshop(c *check.C) {

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -109,7 +109,7 @@ func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop
 	c.Assert(err, check.IsNil)
 	s.writeSDKMetaFile(c, wfs, info.Name, yaml)
 
-	err = wp.LinkSdk(s.ctx, sdk.Setup{Name: info.Name, Channel: info.Channel, Revision: info.Revision})
+	err = wp.LinkSdk(s.ctx, sdk.Setup{Name: info.Name, Channel: info.Channel, Source: info.Source, Revision: info.Revision})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -32,7 +32,6 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/client"
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/builtin"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
@@ -90,7 +89,7 @@ func (s *apiSuite) workshopFile(ws string, sdks []*sdk.Info) *workshop.File {
 }
 
 func (s *apiSuite) writeSDKMetaFile(c *check.C, fs workshop.WorkshopFs, name, yaml string) {
-	sdkPath := filepath.Join(dirs.WorkshopSdksDir, name, "0", "meta")
+	sdkPath := sdk.SdkMetaDir(name)
 	c.Assert(fs.MkdirAll(sdkPath, 0755), check.IsNil)
 	metaPath := filepath.Join(sdkPath, "sdk.yaml")
 	c.Assert(afero.WriteFile(fs, metaPath, []byte(yaml), 0644), check.IsNil)
@@ -109,7 +108,7 @@ func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop
 	c.Assert(err, check.IsNil)
 	s.writeSDKMetaFile(c, wfs, info.Name, yaml)
 
-	err = wp.LinkSdk(s.ctx, sdk.Setup{Name: info.Name, Channel: info.Channel, Source: info.Source, Revision: info.Revision})
+	err = wp.AddSdk(s.ctx, sdk.Setup{Name: info.Name, Channel: info.Channel, Source: info.Source, Revision: info.Revision})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -65,7 +65,11 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	s.restoreMuxVars = FakeMuxVars(s.muxVars)
 	s.workshopDir = c.MkDir()
 
-	s.user = &user.User{Name: "testuser", Username: "testuser", HomeDir: c.MkDir()}
+	// Real UID and GID are required to copy local SDKs.
+	// TODO: implement unprivileged operations properly and mock them separately.
+	actual, err := user.Current()
+	c.Assert(err, check.IsNil)
+	s.user = &user.User{Name: "testuser", Username: "testuser", HomeDir: c.MkDir(), Uid: actual.Uid, Gid: actual.Gid}
 
 	s.project = workshop.Project{
 		Path:      s.workshopDir,
@@ -74,7 +78,6 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 
 	s.store = &sdk.FakeStore{}
 
-	var err error
 	s.b, err = fakebackend.New(c.MkDir())
 	c.Check(err, check.IsNil)
 

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	"github.com/canonical/workshop/internal/workshop/fakebackend"
@@ -52,6 +53,7 @@ type apiSuite struct {
 	vars map[string]string
 
 	restoreMuxVars    func()
+	restoreRetrieve   func()
 	restoreProjectId  func()
 	restoreUserEnv    func()
 	restoreTime       func()
@@ -77,6 +79,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	}
 
 	s.store = &sdk.FakeStore{}
+	s.restoreRetrieve = system.FakeRetrieveSystemSdk(s.store.RetrieveSystemSdk)
 
 	s.b, err = fakebackend.New(c.MkDir())
 	c.Check(err, check.IsNil)
@@ -107,6 +110,7 @@ func (s *apiSuite) TearDownTest(c *check.C) {
 	s.d = nil
 	s.workshopDir = ""
 	s.restoreMuxVars()
+	s.restoreRetrieve()
 	s.restoreProjectId()
 	s.restoreUserEnv()
 	s.restoreTime()

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -45,7 +45,8 @@ type HealthCheckInfo struct {
 type SdkInfo struct {
 	Name        string           `json:"name"`
 	Version     string           `json:"version,omitempty"`
-	Channel     string           `json:"channel"`
+	Channel     string           `json:"channel,omitempty"`
+	Source      string           `json:"source,omitempty"`
 	Revision    string           `json:"revision"`
 	BuildTime   *time.Time       `json:"build-time,omitempty"`
 	InstallTime *time.Time       `json:"install-time,omitempty"`
@@ -142,6 +143,7 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) *Works
 		info.Sdks = append(info.Sdks, &SdkInfo{
 			Name:        sk.Name,
 			Channel:     sk.Channel,
+			Source:      sk.Source,
 			Revision:    sk.Revision.String(),
 			InstallTime: sk.InstallTime,
 			Health:      healthInfo,
@@ -189,6 +191,7 @@ func workshopToInfoFull(ctx context.Context, w *workshop.Workshop, health health
 			Name:        sk.Name,
 			Version:     sk.Version,
 			Channel:     sk.Channel,
+			Source:      sk.Source,
 			Revision:    sk.Revision.String(),
 			BuildTime:   sk.BuildTime,
 			InstallTime: w.Sdks[sk.Name].InstallTime,

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -2907,9 +2907,9 @@ func (s *apiSuite) TestValidateActionModeInputs(c *check.C) {
 		}, {
 			cmd: "refresh",
 			result: map[string]string{
-				"":              `cannot refresh "basic": workshop not launched`,
-				"transactional": `cannot refresh "basic": workshop not launched`,
-				"wait-on-error": `cannot refresh "basic": workshop not launched`,
+				"":              `cannot refresh "basic": workshop definition .*`,
+				"transactional": `cannot refresh "basic": workshop definition .*`,
+				"wait-on-error": `cannot refresh "basic": workshop definition .*`,
 				"continue":      "cannot continue: no wait in progress",
 				"abort":         "cannot abort: no wait in progress",
 				"invalid-mode":  `cannot refresh: "invalid-mode" is not a valid mode`,
@@ -3191,13 +3191,6 @@ func (s *apiSuite) TestRefreshPartialOK(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	s.mockSketchSdk(c, "manysdks", `name: sketch
-base: ubuntu@22.04
-plugs:
-  sketch-plug:
-    interface: mount
-    workshop-target: /etc
-`)
 	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
@@ -3212,6 +3205,14 @@ plugs:
 		},
 	}
 	s.runActionTest(c, requests, expected)
+
+	s.mockSketchSdk(c, "manysdks", `name: sketch
+base: ubuntu@22.04
+plugs:
+  sketch-plug:
+    interface: mount
+    workshop-target: /etc
+`)
 
 	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks/sketch"],"action":"refresh"}`),
@@ -3270,9 +3271,6 @@ func (s *apiSuite) TestRefreshPartialConflictChange(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	s.mockSketchSdk(c, "manysdks", `name: illegal-sketch-name
-base: ubuntu@22.04
-`)
 	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
@@ -3287,6 +3285,10 @@ base: ubuntu@22.04
 		},
 	}
 	s.runActionTest(c, requests, expected)
+
+	s.mockSketchSdk(c, "manysdks", `name: illegal-sketch-name
+base: ubuntu@22.04
+`)
 
 	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks/sketch"],"action":"refresh","options": {"mode":"wait-on-error"}}`),

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	"github.com/canonical/workshop/internal/workshop/fakebackend"
@@ -462,7 +463,7 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 		Sdks: []*SdkInfo{
 			{
 				Name:        "system",
-				Revision:    "x1",
+				Revision:    system.SystemSdkRevision.String(),
 				InstallTime: &install1,
 			},
 			{
@@ -479,7 +480,7 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 		Status:    "Ready",
 		Sdks: []*SdkInfo{{
 			Name:        "system",
-			Revision:    "x1",
+			Revision:    system.SystemSdkRevision.String(),
 			InstallTime: &install1,
 		}},
 	}})
@@ -583,7 +584,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 			Sdks: []*SdkInfo{
 				{
 					Name:        "system",
-					Revision:    "x1",
+					Revision:    system.SystemSdkRevision.String(),
 					InstallTime: &install1,
 					Tunnels: &TunnelInfo{
 						Plugs: []*Tunnel{
@@ -749,7 +750,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 			Sdks: []*SdkInfo{
 				{
 					Name:        "system",
-					Revision:    "x1",
+					Revision:    system.SystemSdkRevision.String(),
 					InstallTime: &install1,
 				},
 				{
@@ -923,6 +924,10 @@ func storeDownload(ctx context.Context, setup sdk.Setup, report *progress.Report
 	if err != nil {
 		return err
 	}
+
+	if sdk.IsSystem(setup.Name) {
+		return os.CopyFS(sdkdir, system.SystemSdkFs)
+	}
 	return mockSdkVolume(sdkdir, apiSuiteSdks[setup.Name].meta)
 }
 
@@ -975,6 +980,7 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 	// Setup
 	s.createWFile(c, "basic", basic)
 	s.createWFile(c, "basic-invalid", basic_invalid)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic", "basic", "basic"],"action":"launch"}`),
@@ -1579,7 +1585,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "somebound",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		}, connections: []string{
@@ -1604,7 +1610,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 		},
 		slots: []string{
 			"system:camera",
@@ -1617,7 +1623,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 		},
 		slots: []string{
 			"system:camera",
@@ -1657,6 +1663,7 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -1675,7 +1682,6 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		"system"})
 
 	s.createWFile(c, "basic", basic_refreshed)
-	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"refresh"}`),
@@ -1695,7 +1701,7 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -1771,7 +1777,7 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-3", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
@@ -1852,7 +1858,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
 		connections: []string{
@@ -1922,7 +1928,7 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/edge", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2012,7 +2018,7 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(2), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2089,7 +2095,7 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2165,7 +2171,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2245,7 +2251,7 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
 		connections: []string{
@@ -2318,7 +2324,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2394,7 +2400,7 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2470,7 +2476,7 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@24.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2549,7 +2555,7 @@ func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
 		connections: []string{
@@ -2620,7 +2626,7 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 		},
 		slots: []string{
 			"system:camera",
@@ -2684,7 +2690,7 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2725,6 +2731,7 @@ func (s *apiSuite) TestRefreshNoRefreshInProgress(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -2759,6 +2766,7 @@ func (s *apiSuite) TestRefreshContinue(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
 	s.secBackend.RemoveCallback = func(sdkName string) error {
@@ -2783,7 +2791,6 @@ func (s *apiSuite) TestRefreshContinue(c *check.C) {
 	s.runActionTest(c, requests, expected)
 
 	s.createWFile(c, "basic", basic_refreshed)
-	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
@@ -2823,6 +2830,7 @@ func (s *apiSuite) TestRefreshAbort(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
 	s.secBackend.RemoveCallback = func(sdkName string) error {
@@ -3110,6 +3118,7 @@ func (s *apiSuite) TestLaunchWorkshopNoRefreshInProgress(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -3232,7 +3241,7 @@ base: ubuntu@22.04
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "sketch", Source: sketchdir, Revision: sdk.R(-1), InstallTime: &s.installTime},
 		},
@@ -3279,7 +3288,7 @@ plugs:
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "sketch", Source: sketchdir, Revision: sdk.R(-2), InstallTime: &s.installTime},
 		},
@@ -3383,6 +3392,7 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	s2 := apiSuiteSdks["test-sdk-2"].s
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
+		{Workshop: "manysdks", Name: sdk.VolumeName(sdk.System.String(), system.SystemSdkRevision)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s2.Name, s2.Revision)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s1.Name, s1.Revision)},
 	})
@@ -3406,6 +3416,7 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	s.runActionTest(c, requests, expected)
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
+		{Workshop: "manysdks", Name: sdk.VolumeName(sdk.System.String(), system.SystemSdkRevision)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s1.Name, s1.Revision)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s2.Name, s2.Revision)},
 	})
@@ -3417,7 +3428,8 @@ func (s *apiSuite) TestStartWorkshop(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
-	// Setup
+	defer s.store.SetDownloadCallback(storeDownload)()
+
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
 
@@ -3467,6 +3479,7 @@ func (s *apiSuite) TestStopWorkshop(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -17,7 +17,6 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
@@ -1031,7 +1030,6 @@ line 1: cannot unmarshal !!seq into string`,
 
 	volume := workshop.AptCacheVolumeName("basic", wp.Project.ProjectId)
 	c.Assert(s.b.WorkshopVolumes[volume], check.Equals, true)
-	c.Assert(s.b.WorkshopVolumeMountPoints[volume], check.Equals, dirs.AptCachePath)
 
 	c.Assert(wp.Running, check.Equals, true)
 
@@ -3345,7 +3343,6 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	s2 := apiSuiteSdks["test-sdk-2"].s
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
-		{Workshop: "manysdks", Name: workshop.AptCacheVolumeName("manysdks", s.project.ProjectId)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s2.Name, s2.Revision)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s1.Name, s1.Revision)},
 	})
@@ -3369,7 +3366,6 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	s.runActionTest(c, requests, expected)
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
-		{Workshop: "manysdks", Name: workshop.AptCacheVolumeName("manysdks", s.project.ProjectId)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s1.Name, s1.Revision)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s2.Name, s2.Revision)},
 	})

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -3206,6 +3206,53 @@ func (s *apiSuite) TestRefreshPartialOK(c *check.C) {
 	}
 	s.runActionTest(c, requests, expected)
 
+	s.createWFile(c, "manysdks", manysdks_minusone)
+	s.mockSketchSdk(c, "manysdks", `name: sketch
+base: ubuntu@22.04
+`)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks/sketch"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks/sketch" SDK`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
+	sketchdir := workshop.SketchSdkCurrent(userDataDir, s.project.ProjectId, "manysdks")
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: "sketch", Source: sketchdir, Revision: sdk.R(-1), InstallTime: &s.installTime},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
+		},
+		plugs: []string{
+			"test-sdk:data",
+		},
+		slots: []string{
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+
+	s.ensureWorskhops(c, want)
+
 	s.mockSketchSdk(c, "manysdks", `name: sketch
 base: ubuntu@22.04
 plugs:
@@ -3215,7 +3262,6 @@ plugs:
 `)
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks/sketch"],"action":"refresh"}`),
 		bytes.NewBufferString(`{"names":["manysdks/sketch"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
 	}
 	expected = []*expectedResp{
@@ -3225,24 +3271,17 @@ plugs:
 			Kind:    "refresh",
 			Summary: `Refresh "manysdks/sketch" SDK`,
 		},
-		{
-			Type:    ResponseTypeAsync,
-			Status:  http.StatusAccepted,
-			Kind:    "refresh",
-			Summary: `Refresh "manysdks/sketch" SDK`,
-		},
 	}
 
-	s.createWFile(c, "manysdks", manysdks_minusone)
 	s.runActionTest(c, requests, expected)
 
-	want := []expectedWorkshop{{
+	want = []expectedWorkshop{{
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
 			{Name: sdk.System.String(), Revision: sdk.R(-1), InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "sketch", Channel: "", Revision: sdk.R(-2), InstallTime: &s.installTime},
+			{Name: "sketch", Source: sketchdir, Revision: sdk.R(-2), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/manysdks/sketch:sketch-plug b8639dea/manysdks/system:mount",
@@ -3262,7 +3301,6 @@ plugs:
 	}}
 
 	s.ensureWorskhops(c, want)
-
 }
 
 func (s *apiSuite) TestRefreshPartialConflictChange(c *check.C) {

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -59,9 +59,9 @@ func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
 	err := s.DownloadSdk(context.Background(), setup, r)
 	c.Assert(err, check.IsNil)
 	c.Assert(setup.Filepath(), testutil.FilePresent)
-	c.Check(done > 0, check.Equals, true)
-	c.Check(total > 0, check.Equals, true)
-	c.Check(done == total, check.Equals, true)
+	c.Check(done, testutil.IntGreaterThan, 0)
+	c.Check(total, testutil.IntGreaterThan, 0)
+	c.Check(done, check.Equals, total)
 	c.Assert(os.Remove(setup.Filepath()), check.IsNil)
 }
 

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -153,7 +153,7 @@ func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 	}
 
 	if strings.HasPrefix(path, "$SDK/") {
-		path = strings.Replace(path, "$SDK", sdk.SdkCurrentPath(slot.Sdk.Name), 1)
+		path = strings.Replace(path, "$SDK", sdk.SdkDir(slot.Sdk.Name), 1)
 	}
 
 	if !filepath.IsAbs(path) {
@@ -185,7 +185,7 @@ func (iface *mountInterface) workshopSource(slot *interfaces.ConnectedSlot) (str
 	}
 
 	if strings.HasPrefix(source, "$SDK/") {
-		return strings.Replace(source, "$SDK", sdk.SdkCurrentPath(slot.Sdk().Name), 1), nil
+		return strings.Replace(source, "$SDK", sdk.SdkDir(slot.Sdk().Name), 1), nil
 	}
 	return source, nil
 }

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -404,7 +404,7 @@ slots:
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 
 	// Validate the mount specification.
-	expectedMnt := workshop.Mount{Name: plug.Name, What: "/var/lib/workshop/sdk/producer/current/training", Where: "/project/training", Type: workshop.WorkshopWorkshop}
+	expectedMnt := workshop.Mount{Name: plug.Name, What: "/var/lib/workshop/sdk/producer/training", Where: "/project/training", Type: workshop.WorkshopWorkshop}
 	c.Assert(deviceSpec.Profile.Mounts, check.DeepEquals, map[string]workshop.Mount{plug.Name: expectedMnt})
 }
 

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -30,14 +30,15 @@ import (
 )
 
 type backendDeviceSuite struct {
-	ctx         context.Context
-	be          *lxdbackend.Backend
-	client      lxd.InstanceServer
-	repo        *interfaces.Repository
-	usr         *user.User
-	pid         string
-	restoreUser func()
-	restoreEnv  func()
+	ctx          context.Context
+	be           *lxdbackend.Backend
+	client       lxd.InstanceServer
+	repo         *interfaces.Repository
+	usr          *user.User
+	pid          string
+	restoreUser  func()
+	restoreEnv   func()
+	restoreNewId func()
 }
 
 var _ = check.Suite(&backendDeviceSuite{})
@@ -70,13 +71,15 @@ func (f *backendDeviceSuite) readWorkshopFile(c *check.C, fname string) string {
 	return string(buf)
 }
 
-func defaultTestDevices() map[string]map[string]string {
+func defaultTestDevices(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
 	cwd, _ := os.Getwd()
-	return map[string]map[string]string{
-		"root":             {"type": "disk", "pool": "workshop", "path": "/"},
-		"project":          {"type": "disk", "source": cwd, "path": "/project"},
-		"workshop.network": {"type": "nic", "network": "workshopbr0", "name": "eth0"},
-	}
+	mounts := []workshop.Mount{{
+		Name:  workshop.ConfigProjectPathDevice,
+		What:  cwd,
+		Where: workshop.WorkshopProjectPath,
+		Type:  workshop.HostWorkshop,
+	}}
+	return mounts, nil
 }
 
 func (f *backendDeviceSuite) SetUpTest(c *check.C) {
@@ -97,6 +100,9 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 	f.restoreEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil
 	})
+	f.restoreNewId = testutil.FakeFunc(func() (string, error) {
+		return f.pid, nil
+	}, &workshop.NewProjectId)
 
 	f.ctx = helper.CreateTestContext(f.usr.Username, "42424242")
 
@@ -107,14 +113,17 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 
 	f.setupRepo(c)
 
-	defer lxdbackend.FakeDefaultDevices(defaultTestDevices)()
+	defer workshop.FakeDefaultDevices(defaultTestDevices)()
 	helper.LaunchTestWorkshop(c, f.ctx, f.be, c.MkDir())
 }
 
 func (f *backendDeviceSuite) TearDownTest(c *check.C) {
+	helper.RemoveTestWorkshop(c, f.ctx, f.be)
 	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdProjectName(f.usr.Username))
 	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdStashProjectName(f.usr.Username))
+	f.restoreNewId()
 	f.restoreEnv()
+	f.restoreUser()
 	f.client.Disconnect()
 }
 

--- a/internal/metautil/normalize_test.go
+++ b/internal/metautil/normalize_test.go
@@ -32,7 +32,7 @@ type normalizeTestSuite struct {
 
 var _ = Suite(&normalizeTestSuite{})
 
-func TestMain(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { TestingT(t) }
 
 func (s *normalizeTestSuite) TestNormalize(c *C) {
 	for _, tc := range []struct {

--- a/internal/osutil/cmp.go
+++ b/internal/osutil/cmp.go
@@ -1,0 +1,103 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+const defaultChunkSize = 16 * 1024
+
+func filesAreEqualChunked(a, b string, chunkSize int) bool {
+	fa, err := os.Open(a)
+	if err != nil {
+		return false
+	}
+	defer fa.Close()
+
+	fb, err := os.Open(b)
+	if err != nil {
+		return false
+	}
+	defer fb.Close()
+
+	fia, err := fa.Stat()
+	if err != nil {
+		return false
+	}
+
+	fib, err := fb.Stat()
+	if err != nil {
+		return false
+	}
+
+	if fia.Size() != fib.Size() {
+		return false
+	}
+
+	return streamsEqualChunked(fa, fb, chunkSize)
+}
+
+// FilesAreEqual compares the two files' contents and returns whether
+// they are the same.
+func FilesAreEqual(a, b string) bool {
+	return filesAreEqualChunked(a, b, 0)
+}
+
+func streamsEqualChunked(a, b io.Reader, chunkSize int) bool {
+	if a == b {
+		return true
+	}
+	if chunkSize <= 0 {
+		chunkSize = defaultChunkSize
+	}
+	bufa := make([]byte, chunkSize)
+	bufb := make([]byte, chunkSize)
+	for {
+		ra, erra := io.ReadAtLeast(a, bufa, chunkSize)
+		rb, errb := io.ReadAtLeast(b, bufb, chunkSize)
+		if erra == io.EOF && errb == io.EOF {
+			return true
+		}
+		if erra != nil || errb != nil {
+			// if both files finished in the middle of a
+			// ReadAtLeast, (returning io.ErrUnexpectedEOF), then we
+			// still need to check what was read to know whether
+			// they're equal.  Otherwise, we know they're not equal
+			// (because we count any read error as a being non-equal
+			// also).
+			tailMightBeEqual := erra == io.ErrUnexpectedEOF && errb == io.ErrUnexpectedEOF
+			if !tailMightBeEqual {
+				return false
+			}
+		}
+		if !bytes.Equal(bufa[:ra], bufb[:rb]) {
+			return false
+		}
+	}
+}
+
+// StreamsEqual compares two streams and returns true if both
+// have the same content.
+func StreamsEqual(a, b io.Reader) bool {
+	return streamsEqualChunked(a, b, 0)
+}

--- a/internal/osutil/cmp.go
+++ b/internal/osutil/cmp.go
@@ -23,6 +23,8 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
+	"slices"
 )
 
 const defaultChunkSize = 16 * 1024
@@ -100,4 +102,97 @@ func streamsEqualChunked(a, b io.Reader, chunkSize int) bool {
 // have the same content.
 func StreamsEqual(a, b io.Reader) bool {
 	return streamsEqualChunked(a, b, 0)
+}
+
+// DirsAreEqual compares the two directories' contents and returns whether
+// they are the same. Ignores non-regular files, and the mode of the given
+// directories. Follows symlinks, but returns false if a cycle is detected.
+func DirsAreEqual(a, b string) bool {
+	return dirsAreEqualRecursive(a, b, nil)
+}
+
+func dirsAreEqualRecursive(a, b string, prev []os.FileInfo) bool {
+	na, fia, err := regularFilesAndDirs(a)
+	if err != nil {
+		return false
+	}
+	nb, fib, err := regularFilesAndDirs(b)
+	if err != nil {
+		return false
+	}
+
+	if !slices.Equal(na, nb) {
+		return false
+	}
+	if !slices.EqualFunc(fia, fib, maybeFilesAreEqual) {
+		return false
+	}
+
+	for i, info := range fia {
+		pa := filepath.Join(a, na[i])
+		pb := filepath.Join(b, nb[i])
+
+		if info.IsDir() {
+			// Prevent infinite recursion from symlink loops. As long as each branch never repeats `a`,
+			// the recursion depth is bounded by the number of distinct directories.
+			if slices.ContainsFunc(prev, func(fi os.FileInfo) bool { return os.SameFile(fi, info) }) {
+				return false
+			}
+
+			prev = append(prev, info)
+			if !dirsAreEqualRecursive(pa, pb, prev) {
+				return false
+			}
+			prev = prev[:len(prev)-1]
+		} else if !FilesAreEqual(pa, pb) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func regularFilesAndDirs(path string) ([]string, []os.FileInfo, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	infos, err := DirInfos(entries)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	names := make([]string, 0, len(infos))
+	resolved := make([]os.FileInfo, 0, len(infos))
+
+	for _, info := range infos {
+		name := info.Name()
+		if info.Mode()&os.ModeSymlink != 0 {
+			var err error
+			info, err = os.Stat(filepath.Join(path, name))
+			if err != nil {
+				return names, resolved, err
+			}
+		}
+
+		if info.IsDir() || info.Mode().IsRegular() {
+			names = append(names, name)
+			resolved = append(resolved, info)
+		}
+	}
+
+	return names, resolved, nil
+}
+
+func maybeFilesAreEqual(a, b os.FileInfo) bool {
+	switch {
+	case a.IsDir() != b.IsDir():
+		return false
+	case a.Mode().Perm() != b.Mode().Perm():
+		return false
+	case a.Mode().IsRegular() && b.Mode().IsRegular() && a.Size() != b.Size():
+		return false
+	default:
+		return true
+	}
 }

--- a/internal/osutil/cmp_test.go
+++ b/internal/osutil/cmp_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	. "gopkg.in/check.v1"
 
@@ -152,4 +153,104 @@ func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
 		eq = osutil.StreamsEqualChunked(readerB, readerA, chunkSize)
 		c.Check(eq, Equals, false, comment)
 	}
+}
+
+func (s *CmpTestSuite) TestDirsAreEqual(c *C) {
+	// Empty directory
+	a := c.MkDir()
+	b := c.MkDir()
+	c.Check(osutil.DirsAreEqual(a, a), Equals, true)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, true)
+
+	// Add empty subdirectory
+	c.Assert(os.Mkdir(filepath.Join(a, "dir"), os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(a, a), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	c.Assert(os.Mkdir(filepath.Join(b, "dir"), os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, true)
+
+	// Add empty file, with initially different permissions.
+	c.Assert(os.WriteFile(filepath.Join(a, "file"), nil, 0600), IsNil)
+	c.Check(osutil.DirsAreEqual(a, a), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	c.Assert(os.WriteFile(filepath.Join(b, "file"), nil, os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	c.Assert(os.Chmod(filepath.Join(b, "file"), 0600), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, true)
+
+	// Add named pipe
+	c.Assert(syscall.Mkfifo(filepath.Join(b, "pipe"), uint32(os.ModePerm)), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, true)
+
+	// Add files with different names and contents
+	c.Assert(os.WriteFile(filepath.Join(a, "dir", "file"), []byte("foo"), os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(a, a), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	c.Assert(os.WriteFile(filepath.Join(b, "dir", "file"), nil, os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	c.Assert(os.WriteFile(filepath.Join(b, "dir", "file"), []byte("bar"), os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	c.Assert(os.Remove(filepath.Join(b, "dir", "file")), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Assert(os.WriteFile(filepath.Join(b, "dir", "file2"), []byte("foo"), os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	c.Assert(os.Rename(filepath.Join(b, "dir", "file2"), filepath.Join(b, "dir", "file")), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, true)
+
+	// Add subdirectory and a regular file
+	c.Assert(os.Mkdir(filepath.Join(a, "dir", "dir"), os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(a, a), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	c.Assert(os.WriteFile(filepath.Join(b, "dir", "dir"), nil, os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+
+	// Add symlink to subdirectory
+	c.Assert(os.Remove(filepath.Join(b, "dir", "dir")), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Assert(os.Symlink(filepath.Join(a, "dir", "dir"), filepath.Join(b, "dir", "dir")), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, true)
+
+	// Add file in shared subdirectory
+	c.Assert(os.WriteFile(filepath.Join(a, "dir", "dir", "file"), nil, os.ModePerm), IsNil)
+	c.Check(osutil.DirsAreEqual(a, a), Equals, true)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, true)
+
+	// Edit top-level directory permissions
+	c.Check(osutil.DirsAreEqual(filepath.Join(a, "dir"), filepath.Join(b, "dir")), Equals, true)
+	c.Assert(os.Chmod(filepath.Join(b, "dir"), 0700), IsNil)
+	c.Check(osutil.DirsAreEqual(b, b), Equals, true)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
+	c.Check(osutil.DirsAreEqual(filepath.Join(a, "dir"), filepath.Join(b, "dir")), Equals, true)
+}
+
+func (s *CmpTestSuite) TestDirsAreEqualTerminates(c *C) {
+	loop := filepath.Join(c.MkDir(), "loop")
+	c.Assert(os.Symlink("loop", loop), IsNil)
+	c.Check(osutil.DirsAreEqual(loop, loop), Equals, false)
+
+	a := c.MkDir()
+	b := c.MkDir()
+	c.Assert(os.Symlink(a, filepath.Join(b, "a")), IsNil)
+	c.Assert(os.Symlink(b, filepath.Join(a, "b")), IsNil)
+	c.Check(osutil.DirsAreEqual(a, b), Equals, false)
 }

--- a/internal/osutil/cmp_test.go
+++ b/internal/osutil/cmp_test.go
@@ -1,0 +1,155 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil"
+)
+
+type CmpTestSuite struct{}
+
+var _ = Suite(&CmpTestSuite{})
+
+func (ts *CmpTestSuite) TestCmp(c *C) {
+	tmpdir := c.MkDir()
+
+	foo := filepath.Join(tmpdir, "foo")
+	f, err := os.Create(foo)
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	// test FilesAreEqual for various sizes:
+	// - bufsz not exceeded
+	// - bufsz matches file size
+	// - bufsz exceeds file size
+	canary := "1234567890123456"
+	for _, n := range []int{1, 128 / len(canary), (128 / len(canary)) + 1} {
+		for i := 0; i < n; i++ {
+			// Pick a smaller buffer size so that the test can complete quicker
+			c.Assert(osutil.FilesAreEqualChunked(foo, foo, 128), Equals, true)
+			_, err := f.WriteString(canary)
+			c.Assert(err, IsNil)
+			c.Assert(f.Sync(), IsNil)
+		}
+	}
+}
+
+func (ts *CmpTestSuite) TestCmpEmptyNeqMissing(c *C) {
+	tmpdir := c.MkDir()
+
+	foo := filepath.Join(tmpdir, "foo")
+	bar := filepath.Join(tmpdir, "bar")
+	f, err := os.Create(foo)
+	c.Assert(err, IsNil)
+	defer f.Close()
+	c.Assert(osutil.FilesAreEqual(foo, bar), Equals, false)
+	c.Assert(osutil.FilesAreEqual(bar, foo), Equals, false)
+}
+
+func (ts *CmpTestSuite) TestCmpEmptyNeqNonEmpty(c *C) {
+	tmpdir := c.MkDir()
+
+	foo := filepath.Join(tmpdir, "foo")
+	bar := filepath.Join(tmpdir, "bar")
+	f, err := os.Create(foo)
+	c.Assert(err, IsNil)
+	defer f.Close()
+	c.Assert(os.WriteFile(bar, []byte("x"), 0644), IsNil)
+	c.Assert(osutil.FilesAreEqual(foo, bar), Equals, false)
+	c.Assert(osutil.FilesAreEqual(bar, foo), Equals, false)
+}
+
+func (ts *CmpTestSuite) TestCmpStreams(c *C) {
+	for _, x := range []struct {
+		a string
+		b string
+		r bool
+	}{
+		{"hello", "hello", true},
+		{"hello", "world", false},
+		{"hello", "hell", false},
+	} {
+		c.Assert(osutil.StreamsEqual(strings.NewReader(x.a), strings.NewReader(x.b)), Equals, x.r)
+	}
+}
+
+func (s *CmpTestSuite) TestStreamsEqualChunked(c *C) {
+	text := "marry had a little lamb"
+
+	// Passing the same stream twice is not mishandled.
+	readerA := bytes.NewReader([]byte(text))
+	readerB := readerA
+	eq := osutil.StreamsEqualChunked(readerA, readerB, 0)
+	c.Check(eq, Equals, true)
+
+	// Passing two streams with the same content works as expected. Note that
+	// we are using different block sizes to check for additional edge cases.
+	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
+		readerA = bytes.NewReader([]byte(text))
+		readerB = bytes.NewReader([]byte(text))
+		eq := osutil.StreamsEqualChunked(readerA, readerB, chunkSize)
+		c.Check(eq, Equals, true, Commentf("chunk size %d", chunkSize))
+	}
+
+	// Passing two streams with unequal contents but equal length works as
+	// expected.
+	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
+		comment := Commentf("chunk size %d", chunkSize)
+		readerA = bytes.NewReader([]byte(strings.ToLower(text)))
+		readerB = bytes.NewReader([]byte(strings.ToUpper(text)))
+		eq = osutil.StreamsEqualChunked(readerA, readerB, chunkSize)
+		c.Check(eq, Equals, false, comment)
+	}
+
+	// Passing two streams which differer by tail only also works as expected.
+	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
+		textWithChangedTail := text[:len(text)-1] + strings.ToUpper(text[len(text)-1:])
+		c.Assert(textWithChangedTail, Not(Equals), text)
+		c.Assert(len(textWithChangedTail), Equals, len(text))
+		comment := Commentf("chunk size %d", chunkSize)
+		readerA = bytes.NewReader([]byte(text))
+		readerB = bytes.NewReader([]byte(textWithChangedTail))
+		eq = osutil.StreamsEqualChunked(readerA, readerB, chunkSize)
+		c.Check(eq, Equals, false, comment)
+	}
+
+	// Passing two streams with different length works as expected.
+	// Note that this is not used by EnsureDirState in practice.
+	for _, chunkSize := range []int{0, 1, len(text) / 2, len(text), len(text) + 1} {
+		comment := Commentf("A: %q, B: %q, chunk size %d", text, text[:len(text)/2], chunkSize)
+		readerA = bytes.NewReader([]byte(text))
+		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
+		eq = osutil.StreamsEqualChunked(readerA, readerB, chunkSize)
+		c.Check(eq, Equals, false, comment)
+
+		// Readers passed the other way around.
+		readerA = bytes.NewReader([]byte(text))
+		readerB = bytes.NewReader([]byte(text[:len(text)/2]))
+		eq = osutil.StreamsEqualChunked(readerB, readerA, chunkSize)
+		c.Check(eq, Equals, false, comment)
+	}
+}

--- a/internal/osutil/cp.go
+++ b/internal/osutil/cp.go
@@ -25,6 +25,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"syscall"
+
+	"github.com/canonical/workshop/internal/osutil/sys"
+	"github.com/canonical/workshop/internal/revert"
 )
 
 // CopyFlag is used to tweak the behaviour of CopyFile
@@ -168,4 +173,149 @@ func (e CopySpecialFileError) Error() string {
 	}
 
 	return fmt.Sprintf("failed to %s: %q (%v)", e.desc, e.output, e.err)
+}
+
+// CopyDirOnBehalf copies a directory into a new location, owned by the provided user.
+// It ignores non-regular files, resolves symlinks, preserves permissions and syncs to disk.
+// FIXME: the chown behaviour is not currently tested. The plan is to simplify this function
+// and run it as the actual user, once we have decided on a uniform approach for this.
+func CopyDirOnBehalf(src, dst string, uid sys.UserID, gid sys.GroupID) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if err := checkOwner(uid, info, src); err != nil {
+		return err
+	}
+
+	dst, err = filepath.Abs(dst)
+	if err != nil {
+		return err
+	}
+
+	// Fail early and also check dst != "/".
+	if FileExists(dst) {
+		return &os.PathError{Op: "mkdir", Path: dst, Err: syscall.EEXIST}
+	}
+	parent := filepath.Dir(dst)
+
+	rev := revert.New()
+	defer rev.Fail()
+
+	temp, err := os.MkdirTemp(parent, "copy-*")
+	if err != nil {
+		return err
+	}
+	rev.Add(func() { _ = os.RemoveAll(temp) })
+
+	if err := os.Chmod(temp, info.Mode().Perm()); err != nil {
+		return err
+	}
+
+	if err := chownCopyAndSync(uid, gid, src, temp, []os.FileInfo{info}); err != nil {
+		return err
+	}
+
+	if err = os.Rename(temp, dst); err != nil {
+		return err
+	}
+
+	d, err := os.OpenFile(parent, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		return err
+	}
+
+	rev.Success()
+	return nil
+}
+
+func checkOwner(uid sys.UserID, info os.FileInfo, path string) error {
+	fuid, _, err := sys.FileOwner(info)
+	if err != nil {
+		return &os.PathError{Op: "stat", Path: path, Err: err}
+	}
+	if fuid != uid {
+		return &os.PathError{Op: "open", Path: path, Err: syscall.EPERM}
+	}
+	return nil
+}
+
+func chownCopyAndSync(uid sys.UserID, gid sys.GroupID, src, dst string, prev []os.FileInfo) error {
+	d, err := os.OpenFile(dst, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	if err := sys.Chown(d, uid, gid); err != nil {
+		return &os.PathError{Op: "chown", Path: dst, Err: err}
+	}
+
+	names, infos, err := regularFilesAndDirs(src)
+	if err != nil {
+		return err
+	}
+
+	for i, info := range infos {
+		from := filepath.Join(src, names[i])
+		to := filepath.Join(dst, names[i])
+
+		if err := checkOwner(uid, info, from); err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			if err := copyDirOnBehalf(uid, gid, from, to, info, prev); err != nil {
+				return err
+			}
+		} else if err := copyFileOnBehalf(uid, gid, from, to, info); err != nil {
+			return err
+		}
+	}
+
+	return d.Sync()
+}
+
+func copyDirOnBehalf(uid sys.UserID, gid sys.GroupID, src, dst string, info os.FileInfo, prev []os.FileInfo) error {
+	if err := os.Mkdir(dst, info.Mode().Perm()); err != nil {
+		return err
+	}
+
+	if slices.ContainsFunc(prev, func(fi os.FileInfo) bool { return os.SameFile(fi, info) }) {
+		return fmt.Errorf("directory %q contains a symlink cycle", dst)
+	}
+	prev = append(prev, info)
+	if err := chownCopyAndSync(uid, gid, src, dst, prev); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copyFileOnBehalf(uid sys.UserID, gid sys.GroupID, src, dst string, info os.FileInfo) error {
+	r, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	w, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	if err := sys.Chown(w, uid, gid); err != nil {
+		return &os.PathError{Op: "chown", Path: dst, Err: err}
+	}
+
+	if err := copyfile(r, w, info); err != nil {
+		return fmt.Errorf("copy %q to %q: %w", src, dst, err)
+	}
+
+	return w.Sync()
 }

--- a/internal/osutil/cp_test.go
+++ b/internal/osutil/cp_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -31,6 +32,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/osutil/sys"
 	"github.com/canonical/workshop/internal/testutil"
 )
 
@@ -295,4 +297,108 @@ func (s *cpSuite) TestCopyPreserveAllSyncSyncFailure(c *C) {
 		{"cp", "-av", src, dst},
 		{"sync"},
 	})
+}
+
+// To check file ownership properly, run:
+// $ go test -c ./internal/osutil
+// $ sudo ./osutil.test -check.f TestCopyDirOnBehalf
+func (s *cpSuite) TestCopyDirOnBehalf(c *C) {
+	root := c.MkDir()
+
+	c.Assert(os.Mkdir(filepath.Join(root, "a"), 0755), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(root, "a", "dir"), 0700), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "a", "file"), []byte("foo"), 0640), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "a", "script"), []byte("#!/bin/sh\n"), 0705), IsNil)
+	c.Assert(syscall.Mkfifo(filepath.Join(root, "a", "pipe"), 0644), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(root, "target"), 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "target", "file"), []byte("bar"), 0644), IsNil)
+	c.Assert(os.Symlink(filepath.Join(root, "target"), filepath.Join(root, "a", "link")), IsNil)
+
+	u, err := osutil.UserMaybeSudoUser()
+	c.Assert(err, IsNil)
+	uid, gid, err := osutil.UidGid(u)
+	c.Assert(err, IsNil)
+
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		return os.Lchown(path, int(uid), int(gid))
+	})
+	c.Assert(err, IsNil)
+
+	b := filepath.Join(c.MkDir(), "b")
+	c.Assert(osutil.CopyDirOnBehalf(filepath.Join(root, "a"), b, uid, gid), IsNil)
+
+	c.Check(filepath.Dir(b), testutil.DirEquals, []string{"drwxr-xr-x b"})
+	c.Check(b, testutil.DirEquals, []string{
+		"drwx------ dir",
+		"-rw-r----- file",
+		"drwxr-xr-x link",
+		"-rwx---r-x script"})
+	c.Check(filepath.Join(b, "file"), testutil.FileEquals, "foo")
+	c.Check(filepath.Join(b, "dir"), testutil.DirEquals, []string{})
+	c.Check(filepath.Join(b, "link"), testutil.DirEquals, []string{"-rw-r--r-- file"})
+	c.Check(filepath.Join(b, "link", "file"), testutil.FileEquals, "bar")
+	c.Check(filepath.Join(b, "script"), testutil.FileEquals, "#!/bin/sh\n")
+
+	err = filepath.WalkDir(b, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		fuid, fgid, err := sys.FileOwner(info)
+		if err != nil {
+			return err
+		}
+
+		c.Check(fuid, Equals, uid)
+		c.Check(fgid, Equals, gid)
+		return nil
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *cpSuite) TestCopyDirOnBehalfNoSource(c *C) {
+	root := c.MkDir()
+
+	u, err := user.Current()
+	c.Assert(err, IsNil)
+	uid, gid, err := osutil.UidGid(u)
+	c.Assert(err, IsNil)
+	err = osutil.CopyDirOnBehalf(filepath.Join(root, "a"), filepath.Join(root, "b"), uid, gid)
+	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
+}
+
+func (s *cpSuite) TestCopyDirOnBehalfTargetExists(c *C) {
+	root := c.MkDir()
+
+	c.Assert(os.Mkdir(filepath.Join(root, "a"), os.ModePerm), IsNil)
+	c.Assert(os.Mkdir(filepath.Join(root, "b"), os.ModePerm), IsNil)
+
+	u, err := user.Current()
+	c.Assert(err, IsNil)
+	uid, gid, err := osutil.UidGid(u)
+	c.Assert(err, IsNil)
+	err = osutil.CopyDirOnBehalf(filepath.Join(root, "a"), filepath.Join(root, "b"), uid, gid)
+	c.Check(err, testutil.ErrorIs, os.ErrExist)
+}
+
+func (s *cpSuite) TestCopyDirOnBehalfNoParent(c *C) {
+	root := c.MkDir()
+
+	c.Assert(os.Mkdir(filepath.Join(root, "a"), os.ModePerm), IsNil)
+
+	u, err := user.Current()
+	c.Assert(err, IsNil)
+	uid, gid, err := osutil.UidGid(u)
+	c.Assert(err, IsNil)
+	err = osutil.CopyDirOnBehalf(filepath.Join(root, "a"), filepath.Join(root, "b", "c"), uid, gid)
+	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
 }

--- a/internal/osutil/export_test.go
+++ b/internal/osutil/export_test.go
@@ -28,8 +28,10 @@ import (
 )
 
 var (
-	ParseRawEnvironment = parseRawEnvironment
-	DoCopyFile          = doCopyFile
+	FilesAreEqualChunked = filesAreEqualChunked
+	StreamsEqualChunked  = streamsEqualChunked
+	ParseRawEnvironment  = parseRawEnvironment
+	DoCopyFile           = doCopyFile
 )
 
 // ParseRawExpandableEnv returns a new expandable environment parsed from key=value strings.

--- a/internal/osutil/stat.go
+++ b/internal/osutil/stat.go
@@ -122,3 +122,20 @@ func ExistsIsDir(fn string) (exists bool, isDir bool, err error) {
 	}
 	return true, st.IsDir(), nil
 }
+
+// DirInfos converts directory entries into file info.
+func DirInfos(entries []os.DirEntry) ([]os.FileInfo, error) {
+	if entries == nil {
+		return nil, nil
+	}
+
+	infos := make([]os.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return infos, err
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
+}

--- a/internal/osutil/sys/syscall.go
+++ b/internal/osutil/sys/syscall.go
@@ -20,6 +20,7 @@
 package sys
 
 import (
+	"errors"
 	"os"
 	"syscall"
 	"unsafe"
@@ -106,4 +107,12 @@ func FcntlGetFl(fd int) (int, error) {
 		return 0, errno
 	}
 	return int(flags), nil
+}
+
+func FileOwner(info os.FileInfo) (UserID, GroupID, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, errors.New("user and group unavailable")
+	}
+	return UserID(stat.Uid), GroupID(stat.Gid), nil
 }

--- a/internal/osutil/user_test.go
+++ b/internal/osutil/user_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"syscall"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -30,6 +31,12 @@ import (
 
 type userSuite struct {
 	testutil.BaseTest
+}
+
+func TestMain(m *testing.M) {
+	// Ensure consistent file permissions for profileSuite and StatTestSuite.
+	syscall.Umask(0002)
+	m.Run()
 }
 
 func TestOsUtil(t *testing.T) { check.TestingT(t) }

--- a/internal/osutil/user_test.go
+++ b/internal/osutil/user_test.go
@@ -34,7 +34,7 @@ type userSuite struct {
 }
 
 func TestMain(m *testing.M) {
-	// Ensure consistent file permissions for profileSuite and StatTestSuite.
+	// Ensure consistent file permissions for CmpTestSuite, profileSuite and StatTestSuite.
 	syscall.Umask(0002)
 	m.Run()
 }

--- a/internal/osutil/user_test.go
+++ b/internal/osutil/user_test.go
@@ -34,7 +34,7 @@ type userSuite struct {
 }
 
 func TestMain(m *testing.M) {
-	// Ensure consistent file permissions for CmpTestSuite, profileSuite and StatTestSuite.
+	// Ensure consistent file permissions for CmpTestSuite, cpSuite, profileSuite and StatTestSuite.
 	syscall.Umask(0002)
 	m.Run()
 }

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -135,7 +135,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	c.Assert(chg.Err(), check.IsNil)
 	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 
 	// Ensure that the save-state handler has created the required state
 	// directory (reattach the volume to the workshop to check).
@@ -152,7 +152,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 2)
@@ -192,7 +192,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/restore-state"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 2)
@@ -235,7 +235,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/save-state"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
@@ -275,7 +275,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/current/sdk/hooks/fake-hook"})
+		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
 
@@ -71,13 +70,6 @@ func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-func (s *interfaceManagerSuite) writeSDKMetaFile(c *check.C, fs workshop.WorkshopFs, setup sdk.Setup, yaml string) {
-	sdkPath := filepath.Join(dirs.WorkshopSdksDir, setup.Name, setup.Revision.String(), "meta")
-	c.Assert(fs.MkdirAll(sdkPath, 0755), check.IsNil)
-	metaPath := filepath.Join(sdkPath, "sdk.yaml")
-	c.Assert(afero.WriteFile(fs, metaPath, []byte(yaml), 0644), check.IsNil)
-}
-
 type testSdkSetup struct {
 	sdk.Setup
 	yaml string
@@ -103,8 +95,9 @@ func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sd
 	s.state.Lock()
 	be := s.o.WorkshopBackend()
 	s.state.Unlock()
-	err = be.ImportVolume(s.ctx, sdk.VolumeName(name, rev), vfs)
-	c.Assert(err, check.IsNil)
+	if err := be.ImportVolume(s.ctx, sdk.VolumeName(name, rev), vfs); err != nil {
+		c.Assert(err, testutil.ErrorIs, workshop.ErrVolumeAlreadyExists)
+	}
 }
 
 func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []testSdkSetup) (*workshop.Workshop, error) {
@@ -127,24 +120,21 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	c.Assert(err, check.IsNil)
 	defer wsfs.Close()
 
-	c.Assert(wsfs.MkdirAll(filepath.Join(dirs.WorkshopSdksDir, sdk.System.String(), "x1", "meta"), 0755), check.IsNil)
-	s.writeSDKMetaFile(c, wsfs, sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}}, systemYaml)
+	allsdks := []testSdkSetup{{Setup: sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(1)}, yaml: systemYaml}}
+	allsdks = append(allsdks, sdks...)
 
-	for _, setup := range sdks {
+	for _, setup := range allsdks {
 		s.mockSdk(c, setup.Name, setup.yaml, setup.Revision)
 	}
 
 	w, err := s.wsbackend.Workshop(ctx, ws)
 	c.Assert(err, check.IsNil)
 
-	err = w.LinkSdk(ctx, sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}})
-	c.Assert(err, check.IsNil)
-
 	s.state.Lock()
 	be := s.o.WorkshopBackend()
 	s.state.Unlock()
 
-	for _, sk := range sdks {
+	for _, sk := range allsdks {
 		err = be.AttachVolume(ctx, ws, sdk.VolumeName(sk.Name, sk.Revision), filepath.Join(dirs.WorkshopSdksDir, sk.Name, sk.Revision.String()), true)
 		c.Assert(err, check.IsNil)
 		err = w.LinkSdk(ctx, sk.Setup)

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
 	"github.com/canonical/workshop/internal/overlord"
@@ -135,9 +134,9 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	s.state.Unlock()
 
 	for _, sk := range allsdks {
-		err = be.AttachVolume(ctx, ws, sdk.VolumeName(sk.Name, sk.Revision), filepath.Join(dirs.WorkshopSdksDir, sk.Name, sk.Revision.String()), true)
+		err = be.AttachVolume(ctx, ws, sdk.VolumeName(sk.Name, sk.Revision), sdk.SdkDir(sk.Name), true)
 		c.Assert(err, check.IsNil)
-		err = w.LinkSdk(ctx, sk.Setup)
+		err = w.AddSdk(ctx, sk.Setup)
 		c.Assert(err, check.IsNil)
 	}
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -1,9 +1,9 @@
 package sdkstate
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	"gopkg.in/tomb.v2"
 
@@ -110,7 +110,7 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	// Directory: /var/lib/workshop/sdk/<name>/<revision>/
+	// Directory: /var/lib/workshop/sdk/<name>/
 	fs, err := m.backend.WorkshopFs(ctx, w)
 	if err != nil {
 		return err
@@ -120,9 +120,38 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	wp, err := m.backend.Workshop(ctx, w)
+	if err != nil {
+		return err
+	}
+
+	rev := revert.New()
+	defer rev.Fail()
+
+	if err := m.mountSdk(ctx, user, project, w, sdkSetup); err != nil {
+		return err
+	}
+	st := task.State()
+	rev.Add(func() {
+		if reverr := m.unmountSdk(ctx, w, sdkSetup); reverr != nil {
+			st.Lock()
+			task.Logf("Install SDK cleanup: could not unmount %q SDK: %v", sdkSetup.Name, reverr)
+			st.Unlock()
+		}
+	})
+
+	if err = wp.AddSdk(ctx, sdkSetup); err != nil {
+		return err
+	}
+
+	rev.Success()
+	return nil
+}
+
+func (m *SdkManager) mountSdk(ctx context.Context, user string, project *workshop.Project, w string, sdkSetup sdk.Setup) error {
 	// Mount the SDK content at the workshop location.
 	name := sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision)
-	sdkPath := filepath.Join(dirs.WorkshopSdksDir, sdkSetup.Name, sdkSetup.Revision.String())
+	sdkPath := sdk.SdkDir(sdkSetup.Name)
 
 	if sdkSetup.Revision.Store() {
 		return m.backend.AttachVolume(ctx, w, name, sdkPath, true)
@@ -153,6 +182,19 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	wp, err := m.backend.Workshop(ctx, w)
+	if err != nil {
+		return err
+	}
+
+	if err := wp.RemoveSdk(ctx, sdkSetup.Name); err != nil {
+		return err
+	}
+
+	return m.unmountSdk(ctx, w, sdkSetup)
+}
+
+func (m *SdkManager) unmountSdk(ctx context.Context, w string, sdkSetup sdk.Setup) error {
 	name := sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision)
 	if sdkSetup.Revision.Store() {
 		return m.backend.DetachVolume(ctx, w, name)
@@ -160,7 +202,7 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return m.backend.RemoveWorkshopMount(ctx, w, name)
 }
 
-func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
+func (m *SdkManager) doRegisterSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
@@ -178,22 +220,6 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 	if err != nil {
 		return err
 	}
-
-	if err = wp.LinkSdk(ctx, setup); err != nil {
-		return err
-	}
-
-	rev := revert.New()
-	defer rev.Fail()
-
-	st := task.State()
-	rev.Add(func() {
-		if reverr := wp.UnlinkSdk(ctx, setup.Name); reverr != nil {
-			st.Lock()
-			task.Logf("Link SDK cleanup: could not unlink %q SDK: %v", setup.Name, reverr)
-			st.Unlock()
-		}
-	})
 
 	info, err := wp.SdkInfo(ctx, setup.Name)
 	if err != nil {
@@ -209,34 +235,17 @@ func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	// add SDK's plugs and slots
-	if err := m.repo.AddSdk(info); err != nil {
-		return err
-	}
-
-	rev.Success()
-	return nil
+	return m.repo.AddSdk(info)
 }
 
-func (m *SdkManager) doUnlinkSdk(task *state.Task, tomb *tomb.Tomb) error {
-	user, project, w, err := UserProjectWorkshop(task)
+func (m *SdkManager) doUnregisterSdk(task *state.Task, tomb *tomb.Tomb) error {
+	_, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		return err
 	}
 
 	setup, err := SdkSetup(task)
 	if err != nil {
-		return err
-	}
-
-	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
-	defer cancel()
-
-	wp, err := m.backend.Workshop(ctx, w)
-	if err != nil {
-		return err
-	}
-
-	if err = wp.UnlinkSdk(ctx, setup.Name); err != nil {
 		return err
 	}
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -110,21 +110,18 @@ func (m *SdkManager) doInstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error 
 		return err
 	}
 
-	switch sdkSetup.Name {
-	case sdk.System.String():
+	if sdk.IsSystem(sdkSetup.Name) {
 		return wp.InstallLocalSdk(ctx, sdkSetup.Name, sdkSetup.Revision.String(), system.SystemSdkFs)
-	case sdk.Sketch:
-		usr, env, err := osutil.UserAndEnv(user)
-		if err != nil {
-			return err
-		}
-		userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
-		sketchdir := workshop.SketchSdkCurrent(userDataDir, project.ProjectId, w)
-
-		return wp.InstallLocalSdk(ctx, sdkSetup.Name, sdkSetup.Revision.String(), os.DirFS(sketchdir))
-	default:
-		return fmt.Errorf("unknown type of the local SDK")
 	}
+
+	usr, env, err := osutil.UserAndEnv(user)
+	if err != nil {
+		return err
+	}
+	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
+	sdkdir := workshop.LocalSdkRevision(userDataDir, project.ProjectId, w, sdkSetup.Name, sdkSetup.Revision)
+
+	return wp.InstallLocalSdk(ctx, sdkSetup.Name, sdkSetup.Revision.String(), os.DirFS(sdkdir))
 }
 
 func (m *SdkManager) doUninstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -65,10 +65,6 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	st.Lock()
-	store := sdk.StoreService(st)
-	st.Unlock()
-
 	reporter := &progress.Reporter{
 		Name: task.ID(),
 		Report: func(label string, done, total int) {
@@ -78,8 +74,18 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		},
 	}
 
-	if err = store.DownloadSdk(ctx, rec, reporter); err != nil {
-		return err
+	if sdk.IsSystem(rec.Name) {
+		if err := system.RetrieveSystemSdk(rec, reporter); err != nil {
+			return err
+		}
+	} else {
+		st.Lock()
+		store := sdk.StoreService(st)
+		st.Unlock()
+
+		if err = store.DownloadSdk(ctx, rec, reporter); err != nil {
+			return err
+		}
 	}
 
 	err = m.backend.ImportVolume(ctx, sdk.VolumeName(rec.Name, rec.Revision), rec.Filepath())
@@ -108,10 +114,6 @@ func (m *SdkManager) doInstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error 
 	wp, err := m.backend.Workshop(ctx, w)
 	if err != nil {
 		return err
-	}
-
-	if sdk.IsSystem(sdkSetup.Name) {
-		return wp.InstallLocalSdk(ctx, sdkSetup.Name, sdkSetup.Revision.String(), system.SystemSdkFs)
 	}
 
 	usr, env, err := osutil.UserAndEnv(user)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -3,7 +3,6 @@ package sdkstate
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"gopkg.in/tomb.v2"
@@ -97,58 +96,6 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return err
 }
 
-func (m *SdkManager) doInstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error {
-	user, project, w, err := UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	sdkSetup, err := SdkSetup(task)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
-	defer cancel()
-
-	wp, err := m.backend.Workshop(ctx, w)
-	if err != nil {
-		return err
-	}
-
-	usr, env, err := osutil.UserAndEnv(user)
-	if err != nil {
-		return err
-	}
-	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
-	sdkdir := workshop.LocalSdkRevision(userDataDir, project.ProjectId, w, sdkSetup.Name, sdkSetup.Revision)
-
-	return wp.InstallLocalSdk(ctx, sdkSetup.Name, sdkSetup.Revision.String(), os.DirFS(sdkdir))
-}
-
-func (m *SdkManager) doUninstallLocalSdk(task *state.Task, tomb *tomb.Tomb) error {
-	user, project, w, err := UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	sdkSetup, err := SdkSetup(task)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
-	defer cancel()
-
-	wfs, err := m.backend.WorkshopFs(ctx, w)
-	if err != nil {
-		return err
-	}
-	defer wfs.Close()
-
-	return wfs.RemoveAll(sdk.SdkRevPath(sdkSetup.Name, sdkSetup.Revision.String()))
-}
-
 func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {
@@ -174,9 +121,22 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	// Mount the SDK content at the workshop location.
+	name := sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision)
 	sdkPath := filepath.Join(dirs.WorkshopSdksDir, sdkSetup.Name, sdkSetup.Revision.String())
 
-	return m.backend.AttachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), sdkPath, true)
+	if sdkSetup.Revision.Store() {
+		return m.backend.AttachVolume(ctx, w, name, sdkPath, true)
+	}
+
+	usr, env, err := osutil.UserAndEnv(user)
+	if err != nil {
+		return err
+	}
+	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
+	what := workshop.LocalSdkRevision(userDataDir, project.ProjectId, w, sdkSetup.Name, sdkSetup.Revision)
+
+	mnt := workshop.Mount{Name: name, What: what, Where: sdkPath, Type: workshop.HostWorkshop, ReadOnly: true}
+	return m.backend.AddWorkshopMount(ctx, w, mnt)
 }
 
 func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -193,7 +153,11 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	return m.backend.DetachVolume(ctx, w, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+	name := sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision)
+	if sdkSetup.Revision.Store() {
+		return m.backend.DetachVolume(ctx, w, name)
+	}
+	return m.backend.RemoveWorkshopMount(ctx, w, name)
 }
 
 func (m *SdkManager) doLinkSdk(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -270,7 +270,7 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 func (s *sdkStateSuite) TestDoInstallSystemSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: sdk.System.String(), Revision: sdk.Revision{N: -1}}
+	newSdk := sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-local-sdk", "test")
@@ -298,7 +298,7 @@ func (s *sdkStateSuite) TestDoInstallSystemSdkSuccess(c *check.C) {
 func (s *sdkStateSuite) TestUndoInstallSystemSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: sdk.System.String()}
+	newSdk := sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-local-sdk", "test")

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -43,6 +44,12 @@ type sdkStateSuite struct {
 }
 
 var _ = check.Suite(&sdkStateSuite{})
+
+func TestMain(m *testing.M) {
+	// Ensure consistent file permissions for sdkStateSuite.
+	syscall.Umask(0002)
+	m.Run()
+}
 
 func Test(t *testing.T) { check.TestingT(t) }
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -1,9 +1,11 @@
 package sdkstate_test
 
 import (
+	"archive/tar"
 	"context"
 	"errors"
-	"io/fs"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -22,6 +24,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	"github.com/canonical/workshop/internal/workshop/fakebackend"
@@ -267,65 +270,56 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 0)
 }
 
-func (s *sdkStateSuite) TestDoInstallSystemSdkSuccess(c *check.C) {
+func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
+	sdk.ReplaceStore(s.state, sdk.NewFakeStore())
+
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)}
-	t := s.state.NewTask("fake-task", "retrieve")
+
+	newSdk := sdk.Setup{Name: sdk.System.String(), Revision: system.SystemSdkRevision}
+	t := s.state.NewTask("retrieve-sdk", "retrieve")
 	t.Set("sdk-setup", newSdk)
-	t1 := s.state.NewTask("install-local-sdk", "test")
-	t1.Set("sdk-retrieve-task", t.ID())
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t, t1)
+	setWorkshopProject("ws", s.project, t)
 	chg.Set("user", "testuser")
-	chg.AddTask(t1)
 	chg.AddTask(t)
 
 	s.state.Unlock()
-	s.se.Ensure()
+	c.Assert(s.se.Ensure(), check.IsNil)
 	s.se.Wait()
 	s.state.Lock()
 
 	c.Check(chg.Err(), check.IsNil)
-	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
+
+	f, err := os.Open(newSdk.Filepath())
 	c.Assert(err, check.IsNil)
-	info, err := wfs.Stat("/var/lib/workshop/sdk/system/x1/meta/sdk.yaml")
-	c.Assert(err, check.IsNil)
-	c.Assert(info.Mode().Perm(), check.Equals, fs.FileMode(0644))
-}
+	defer f.Close()
 
-func (s *sdkStateSuite) TestUndoInstallSystemSdkSuccess(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)}
-	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", newSdk)
-	t1 := s.state.NewTask("install-local-sdk", "test")
-	t1.Set("sdk-retrieve-task", t.ID())
+	tr := tar.NewReader(f)
+	var entries []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		c.Assert(err, check.IsNil)
 
-	terr := s.state.NewTask("error-trigger", "provoking total undo")
-	terr.WaitFor(t1)
+		info := hdr.FileInfo()
+		if info.IsDir() {
+			continue
+		}
 
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t, t1, terr)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-	chg.AddTask(t)
-	chg.AddTask(terr)
+		entry := fmt.Sprintf("%s %s", info.Mode().Perm(), hdr.Name)
+		entries = append(entries, entry)
 
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
-		s.se.Wait()
+		r, err := system.SystemSdkFs.Open(hdr.Name)
+		c.Assert(err, check.IsNil)
+		c.Check(osutil.StreamsEqual(r, tr), check.Equals, true)
+		r.Close()
 	}
-	s.state.Lock()
 
-	c.Check(chg.Err(), check.NotNil)
-	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
-	c.Assert(err, check.IsNil)
-	_, err = wfs.Stat("/var/lib/workshop/sdk/system/x1")
-	c.Assert(osutil.IsDirNotExist(err), check.Equals, true)
+	c.Check(entries, check.DeepEquals, []string{"-r--r--r-- meta/sdk.yaml"})
 }
 
 func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -174,8 +174,11 @@ func (s *sdkStateSuite) TearDownTest(c *check.C) {
 func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
-	s.mockSdk(c, "test-2", sdkYaml, sdk.R(2))
+
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	newSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
+	s.mockSdk(c, "test", sdkYaml, sdk.R(2))
 
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
@@ -197,38 +200,17 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	c.Check(chg.Status(), check.Equals, state.DoneStatus)
 
 	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 1)
-	c.Assert(s.backend.WorkshopVolumeMountPoints["test-2-2"], check.Equals, "/var/lib/workshop/sdk/test-2/2")
-}
+	c.Assert(s.backend.WorkshopVolumeMountPoints["test-2"], check.Equals, "/var/lib/workshop/sdk/test")
 
-func (s *sdkStateSuite) TestDoInstallSdkWhenVolumeExists(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
-	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", newSdk)
-	t1 := s.state.NewTask("install-sdk", "test")
-	t1.Set("sdk-retrieve-task", t.ID())
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-	chg.AddTask(t)
-
-	err := s.backend.CreateVolume(s.ctx, sdk.VolumeName(newSdk.Name, newSdk.Revision))
+	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	defer func() { _ = s.backend.DeleteVolume(s.ctx, sdk.VolumeName(newSdk.Name, newSdk.Revision)) }()
+	info := props.Sdks
+	c.Check(info["test"], check.DeepEquals, newSdk)
 
-	s.state.Unlock()
-	s.se.Ensure()
-	s.se.Wait()
-	s.state.Lock()
-
-	c.Check(chg.Err(), check.IsNil)
-	c.Check(chg.Status(), check.Equals, state.DoneStatus)
-
-	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 1)
-	c.Assert(s.backend.WorkshopVolumeMountPoints["test-2-2"], check.Equals, "/var/lib/workshop/sdk/test-2/2")
+	sdkInfo, err := props.SdkInfo(s.ctx, "test")
+	c.Assert(err, check.IsNil)
+	c.Assert(sdkInfo.Plugs, check.HasLen, 2)
+	c.Assert(sdkInfo.Slots, check.HasLen, 0)
 }
 
 func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
@@ -322,7 +304,7 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 	c.Check(entries, check.DeepEquals, []string{"-r--r--r-- meta/sdk.yaml"})
 }
 
-func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {
+func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -335,7 +317,7 @@ func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {
 	t.Set("sdk-setup", testSdk)
 	t1 := s.state.NewTask("install-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
-	t2 := s.state.NewTask("link-sdk", "test")
+	t2 := s.state.NewTask("register-sdk", "test")
 	t2.Set("sdk-retrieve-task", t.ID())
 	t2.WaitFor(t1)
 
@@ -354,22 +336,13 @@ func (s *sdkStateSuite) TestDoLinkSdkSuccess(c *check.C) {
 	s.state.Lock()
 
 	c.Check(chg.Err(), check.Equals, nil)
-	props, err := s.backend.Workshop(s.ctx, "ws")
-	c.Assert(err, check.IsNil)
-	info := props.Sdks
-	c.Check(info["test"], check.DeepEquals, testSdk)
-
-	sdkInfo, err := props.SdkInfo(s.ctx, info["test"].Name)
-	c.Assert(err, check.IsNil)
-	c.Assert(sdkInfo.Plugs, check.HasLen, 2)
-	c.Assert(sdkInfo.Slots, check.HasLen, 0)
 
 	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 2)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.NotNil)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.NotNil)
 }
 
-func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
+func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -382,7 +355,7 @@ func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
 	t.Set("sdk-setup", testSdk)
 	t1 := s.state.NewTask("install-sdk", "...")
 	t1.Set("sdk-retrieve-task", t.ID())
-	t2 := s.state.NewTask("link-sdk", "test-broken")
+	t2 := s.state.NewTask("register-sdk", "test-broken")
 	t2.Set("sdk-retrieve-task", t.ID())
 	t2.WaitFor(t1)
 
@@ -405,7 +378,7 @@ func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
 	// not in the fs (removed)
 	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	_, err = wfs.Stat(sdk.SdkCurrentPath("test-broken"))
+	_, err = wfs.Stat(sdk.SdkDir("test-broken"))
 	c.Check(osutil.IsDirNotExist(err), check.Equals, true)
 
 	// not in the SDK list (unlinked)
@@ -419,29 +392,29 @@ func (s *sdkStateSuite) TestDoLinkSdkFailedPolicyCheck(c *check.C) {
 	c.Check(s.repo.Slots(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
 }
 
-func (s *sdkStateSuite) TestUndoLinkSdk(c *check.C) {
+func (s *sdkStateSuite) TestDoUnregisterSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 
-	newSdk := sdk.Info{Workshop: "ws", Name: "test", Revision: sdk.Revision{N: 1}}
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "...")
 	t1.Set("sdk-retrieve-task", t.ID())
-	link := s.state.NewTask("link-sdk", "test")
-	link.Set("sdk-retrieve-task", t.ID())
-	link.WaitFor(t1)
+	register := s.state.NewTask("register-sdk", "test")
+	register.Set("sdk-retrieve-task", t.ID())
+	register.WaitFor(t1)
 
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
-	terr.WaitFor(link)
+	terr.WaitFor(register)
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, link, t, t1)
+	setWorkshopProject("ws", s.project, register, t, t1)
 
 	chg.Set("user", "testuser")
-	chg.AddTask(link)
+	chg.AddTask(register)
 	chg.AddTask(t)
 	chg.AddTask(terr)
 	chg.AddTask(t1)
@@ -452,42 +425,39 @@ func (s *sdkStateSuite) TestUndoLinkSdk(c *check.C) {
 		s.se.Wait()
 	}
 	s.state.Lock()
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*provoking total undo \(error out\)`)
 
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
 	_, ok := props.Sdks["test"]
 	c.Check(ok, check.Equals, false)
-	c.Check(link.Status(), check.Equals, state.UndoneStatus)
+	c.Check(register.Status(), check.Equals, state.UndoneStatus)
 
 	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
 }
 
-func (s *sdkStateSuite) TestLinkSdkBadInterfacesFound(c *check.C) {
+func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 
-	newSdk := sdk.Info{Workshop: "ws", Name: "test", Revision: sdk.Revision{N: 1}}
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "...")
 	t1.Set("sdk-retrieve-task", t.ID())
-	link := s.state.NewTask("link-sdk", "test")
-	link.Set("sdk-retrieve-task", t.ID())
-	link.WaitFor(t1)
-
-	terr := s.state.NewTask("error-trigger", "provoking total undo")
-	terr.WaitFor(link)
+	register := s.state.NewTask("register-sdk", "test")
+	register.Set("sdk-retrieve-task", t.ID())
+	register.WaitFor(t1)
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, link, t, t1)
+	setWorkshopProject("ws", s.project, register, t, t1)
 
 	chg.Set("user", "testuser")
-	chg.AddTask(link)
+	chg.AddTask(register)
 	chg.AddTask(t)
-	chg.AddTask(terr)
 	chg.AddTask(t1)
 
 	s.state.Unlock()

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -21,8 +21,8 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
 	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.doUninstallSdk)
-	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.doUnlinkSdk)
-	runner.AddHandler("unlink-sdk", OnDo(manager.doUnlinkSdk), manager.doLinkSdk)
+	runner.AddHandler("register-sdk", OnDo(manager.doRegisterSdk), manager.doUnregisterSdk)
+	runner.AddHandler("unregister-sdk", OnDo(manager.doUnregisterSdk), manager.doRegisterSdk)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -24,7 +24,6 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	runner.AddHandler("install-local-sdk", OnDo(manager.doInstallLocalSdk), manager.doUninstallLocalSdk)
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.doUnlinkSdk)
 	runner.AddHandler("unlink-sdk", OnDo(manager.doUnlinkSdk), manager.doLinkSdk)
-	runner.AddHandler("remove-sdk", OnDo(manager.doUninstallSdk), nil)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -21,7 +21,6 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
 	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), manager.doUninstallSdk)
-	runner.AddHandler("install-local-sdk", OnDo(manager.doInstallLocalSdk), manager.doUninstallLocalSdk)
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.doUnlinkSdk)
 	runner.AddHandler("unlink-sdk", OnDo(manager.doUnlinkSdk), manager.doLinkSdk)
 

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -3,7 +3,6 @@ package sdkstate
 import (
 	"fmt"
 
-	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 )
@@ -19,31 +18,28 @@ func Retrieve(st *state.State, s sdk.Setup) *state.Task {
 	return download
 }
 
-func InstallLocalSdk(st *state.State, pid, w string, setup sdk.Setup) *state.TaskSet {
+func InstallLocalSdk(st *state.State, setup sdk.Setup) *state.Task {
 	install := st.NewTask("install-sdk", fmt.Sprintf("Install %q SDK", setup.Name))
 	install.Set("sdk-setup", setup)
 	install.Set("sdk-retrieve-task", install.ID())
-
-	link := st.NewTask("link-sdk", fmt.Sprintf("Link %q SDK", setup.Name))
-	link.Set("sdk-retrieve-task", install.ID())
-	link.WaitFor(install)
-
-	hook := hookstate.Hook(st, pid, w, setup.Name, 0, hookstate.SetupBase)
-	hook.WaitFor(link)
-
-	return state.NewTaskSet(install, link, hook)
+	return install
 }
 
-func Install(st *state.State, pid, w, sdk, retrieveId string) *state.TaskSet {
+func Install(st *state.State, sdk, retrieveId string) *state.Task {
 	install := st.NewTask("install-sdk", fmt.Sprintf("Install %q SDK", sdk))
 	install.Set("sdk-retrieve-task", retrieveId)
+	return install
+}
 
-	link := st.NewTask("link-sdk", fmt.Sprintf("Link %q SDK", sdk))
-	link.Set("sdk-retrieve-task", retrieveId)
-	link.WaitFor(install)
+func Register(st *state.State, sdk, retrieveId string) *state.Task {
+	register := st.NewTask("register-sdk", fmt.Sprintf("Register %q SDK plugs and slots", sdk))
+	register.Set("sdk-retrieve-task", retrieveId)
+	return register
+}
 
-	hook := hookstate.Hook(st, pid, w, sdk, 0, hookstate.SetupBase)
-	hook.WaitFor(link)
-
-	return state.NewTaskSet(install, link, hook)
+func Unregister(st *state.State, setup sdk.Setup) *state.Task {
+	unregister := st.NewTask("unregister-sdk", fmt.Sprintf("Unregister %q SDK plugs and slots", setup.Name))
+	unregister.Set("sdk-retrieve-task", unregister.ID())
+	unregister.Set("sdk-setup", setup)
+	return unregister
 }

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -9,7 +9,12 @@ import (
 )
 
 func Retrieve(st *state.State, s sdk.Setup) *state.Task {
-	download := st.NewTask("retrieve-sdk", fmt.Sprintf("Retrieve %q SDK from channel %q", s.Name, s.Channel))
+	summary := fmt.Sprintf("Retrieve %q SDK from channel %q", s.Name, s.Channel)
+	if sdk.IsSystem(s.Name) {
+		summary = fmt.Sprintf("Retrieve %q SDK", s.Name)
+	}
+
+	download := st.NewTask("retrieve-sdk", summary)
 	download.Set("sdk-setup", s)
 	return download
 }

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -3,6 +3,7 @@ package sdkstate
 import (
 	"fmt"
 
+	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 )
@@ -13,7 +14,7 @@ func Retrieve(st *state.State, s sdk.Setup) *state.Task {
 	return download
 }
 
-func InstallLocalSdk(st *state.State, setup sdk.Setup) *state.TaskSet {
+func InstallLocalSdk(st *state.State, pid, w string, setup sdk.Setup) *state.TaskSet {
 	install := st.NewTask("install-local-sdk", fmt.Sprintf("Install %q SDK", setup.Name))
 	install.Set("sdk-setup", setup)
 	install.Set("sdk-retrieve-task", install.ID())
@@ -22,10 +23,13 @@ func InstallLocalSdk(st *state.State, setup sdk.Setup) *state.TaskSet {
 	link.Set("sdk-retrieve-task", install.ID())
 	link.WaitFor(install)
 
-	return state.NewTaskSet(install, link)
+	hook := hookstate.Hook(st, pid, w, setup.Name, 0, hookstate.SetupBase)
+	hook.WaitFor(link)
+
+	return state.NewTaskSet(install, link, hook)
 }
 
-func Install(st *state.State, sdk string, retrieveId string) *state.TaskSet {
+func Install(st *state.State, pid, w, sdk, retrieveId string) *state.TaskSet {
 	install := st.NewTask("install-sdk", fmt.Sprintf("Install %q SDK", sdk))
 	install.Set("sdk-retrieve-task", retrieveId)
 
@@ -33,5 +37,8 @@ func Install(st *state.State, sdk string, retrieveId string) *state.TaskSet {
 	link.Set("sdk-retrieve-task", retrieveId)
 	link.WaitFor(install)
 
-	return state.NewTaskSet(install, link)
+	hook := hookstate.Hook(st, pid, w, sdk, 0, hookstate.SetupBase)
+	hook.WaitFor(link)
+
+	return state.NewTaskSet(install, link, hook)
 }

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -20,7 +20,7 @@ func Retrieve(st *state.State, s sdk.Setup) *state.Task {
 }
 
 func InstallLocalSdk(st *state.State, pid, w string, setup sdk.Setup) *state.TaskSet {
-	install := st.NewTask("install-local-sdk", fmt.Sprintf("Install %q SDK", setup.Name))
+	install := st.NewTask("install-sdk", fmt.Sprintf("Install %q SDK", setup.Name))
 	install.Set("sdk-setup", setup)
 	install.Set("sdk-retrieve-task", install.ID())
 

--- a/internal/overlord/sdkstate/request_test.go
+++ b/internal/overlord/sdkstate/request_test.go
@@ -25,19 +25,13 @@ func (i *SdkStateTasks) TestInstall(c *check.C) {
 
 	sdk := workshop.SdkRecord{Name: "sdk"}
 
-	tasks := sdkstate.Install(i.state, "42424242", "ws", sdk.Name, "retrieve").Tasks()
+	task := sdkstate.Install(i.state, sdk.Name, "retrieve")
 
-	c.Check(tasks, check.HasLen, 3)
-	c.Check(tasks[1].WaitTasks(), check.HasLen, 1)
-	c.Check(tasks[2].WaitTasks(), check.HasLen, 1)
 	var id string
-	tasks[0].Get("sdk-retrieve-task", &id)
-	c.Check(tasks[0].Summary(), check.Equals, `Install "sdk" SDK`)
+	c.Assert(task.Get("sdk-retrieve-task", &id), check.IsNil)
 	c.Check(id, check.Equals, "retrieve")
-	tasks[1].Get("sdk-retrieve-task", &id)
-	c.Check(tasks[1].Summary(), check.Equals, `Link "sdk" SDK`)
-	c.Check(id, check.Equals, "retrieve")
-	c.Check(tasks[2].Summary(), check.Equals, `Run hook "setup-base" for "sdk" SDK`)
+	c.Check(task.Kind(), check.Equals, "install-sdk")
+	c.Check(task.Summary(), check.Equals, `Install "sdk" SDK`)
 }
 
 func (i *SdkStateTasks) TestRetrieve(c *check.C) {
@@ -49,7 +43,7 @@ func (i *SdkStateTasks) TestRetrieve(c *check.C) {
 	task := sdkstate.Retrieve(i.state, rec)
 
 	var s sdk.Setup
-	task.Get("sdk-setup", &s)
+	c.Assert(task.Get("sdk-setup", &s), check.IsNil)
 	c.Check(s, check.DeepEquals, rec)
 	c.Check(task.Kind(), check.Equals, "retrieve-sdk")
 	c.Check(task.Summary(), check.Equals, "Retrieve \"sdk\" SDK from channel \"latest/stable\"")

--- a/internal/overlord/sdkstate/request_test.go
+++ b/internal/overlord/sdkstate/request_test.go
@@ -25,17 +25,19 @@ func (i *SdkStateTasks) TestInstall(c *check.C) {
 
 	sdk := workshop.SdkRecord{Name: "sdk"}
 
-	tasks := sdkstate.Install(i.state, sdk.Name, "retrieve").Tasks()
+	tasks := sdkstate.Install(i.state, "42424242", "ws", sdk.Name, "retrieve").Tasks()
 
-	c.Check(tasks, check.HasLen, 2)
+	c.Check(tasks, check.HasLen, 3)
 	c.Check(tasks[1].WaitTasks(), check.HasLen, 1)
+	c.Check(tasks[2].WaitTasks(), check.HasLen, 1)
 	var id string
 	tasks[0].Get("sdk-retrieve-task", &id)
-	c.Check(tasks[0].Summary(), check.Equals, "Install \"sdk\" SDK")
+	c.Check(tasks[0].Summary(), check.Equals, `Install "sdk" SDK`)
 	c.Check(id, check.Equals, "retrieve")
 	tasks[1].Get("sdk-retrieve-task", &id)
-	c.Check(tasks[1].Summary(), check.Equals, "Link \"sdk\" SDK")
+	c.Check(tasks[1].Summary(), check.Equals, `Link "sdk" SDK`)
 	c.Check(id, check.Equals, "retrieve")
+	c.Check(tasks[2].Summary(), check.Equals, `Run hook "setup-base" for "sdk" SDK`)
 }
 
 func (i *SdkStateTasks) TestRetrieve(c *check.C) {

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -194,24 +194,6 @@ func (m *WorkshopManager) undoMountProject(task *state.Task, tomb *tomb.Tomb) er
 	return nil
 }
 
-func (m *WorkshopManager) doMountAptCache(task *state.Task, tomb *tomb.Tomb) error {
-	user, prj, w, err := UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
-	defer cancel()
-
-	volume := workshop.AptCacheVolumeName(w, prj.ProjectId)
-	return m.backend.AttachVolume(ctx, w, volume, dirs.AptCachePath, false)
-}
-
-func (m *WorkshopManager) undoMountAptCache(task *state.Task, tomb *tomb.Tomb) error {
-	// No need to undo because the mount will be removed with the workshop
-	return nil
-}
-
 func (m *WorkshopManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -402,24 +401,6 @@ func (s *workshopHandlers) TestAptCache(c *check.C) {
 
 	volume := workshop.AptCacheVolumeName("ws", s.project.ProjectId)
 	c.Assert(s.backend.WorkshopVolumes[volume], check.Equals, true)
-
-	// Mount apt cache
-	chg = s.state.NewChange("sample", "...")
-	t1 = s.state.NewTask("mount-apt-cache", "...")
-	setWorkshopProject("ws", s.project, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
-		s.se.Wait()
-	}
-	s.state.Lock()
-
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
-
-	c.Assert(s.backend.WorkshopVolumeMountPoints[volume], check.Equals, dirs.AptCachePath)
 
 	// Remove volume for apt cache
 	chg = s.state.NewChange("sample", "...")

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -33,7 +33,6 @@ func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	runner.AddHandler("mount-project", OnDo(manager.doMountProject), manager.undoMountProject)
 	runner.AddHandler("create-apt-cache", OnDo(manager.doCreateAptCache), manager.doRemoveAptCache)
 	runner.AddHandler("remove-apt-cache", OnDo(manager.doRemoveAptCache), nil)
-	runner.AddHandler("mount-apt-cache", OnDo(manager.doMountAptCache), manager.undoMountAptCache)
 	runner.AddHandler("remove-workshop-stash", OnDo(manager.doRemoveWorkshopStash), nil)
 	runner.AddHandler("stash-workshop", OnDo(manager.doStashWorkshop), manager.undoStashWorkshop)
 	runner.AddHandler("create-state-storage", OnDo(manager.doCreateStateStorage), manager.doRemoveStateStorage)

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -126,7 +126,10 @@ func (s *managerSuite) TestRefreshRequireWorkshopExistence(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	s.launchWorkshopWithSDKs(c, "test-1", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
+	workshop2 := s.launchWorkshopWithSDKs(c, "test-2", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
+	err := s.backend.RemoveWorkshop(s.ctx, workshop2.Name)
+	c.Assert(err, check.IsNil)
 
-	_, err := s.manager.RefreshMany(s.ctx, s.project.ProjectId, []string{"test-1", "test-2"})
+	_, err = s.manager.RefreshMany(s.ctx, s.project.ProjectId, []string{"test-1", "test-2"})
 	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop not launched`)
 }

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -69,7 +69,6 @@ func (s *managerSuite) TestAddHandlers(c *check.C) {
 		"mount-project",
 		"create-apt-cache",
 		"remove-apt-cache",
-		"mount-apt-cache",
 		"remove-workshop-stash",
 		"stash-workshop",
 		"create-state-storage",

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/cmdstate"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
@@ -196,13 +195,9 @@ func launchWorkshop(st *state.State, file *workshop.File, project workshop.Proje
 	addTask(create)
 	create.Set("workshop-file", file)
 
-	// We're rebuilding the workshop from base, which means, the mounts will
-	// be removed too.
+	// TODO: move this after snapshots are taken; also for refresh.
 	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
 	addTask(mountProject)
-
-	mountAptCache := st.NewTask("mount-apt-cache", fmt.Sprintf("Mount apt cache directory %q", dirs.AptCachePath))
-	addTask(mountAptCache)
 
 	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", file.Name))
 	addTask(start)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/cmdstate"
+	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
@@ -86,6 +87,9 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, fmt.Errorf("cannot launch %q: workshop exists", name)
 		} else if !errors.Is(err, workshop.ErrWorkshopNotLaunched) {
 			return nil, fmt.Errorf("cannot launch %q, failed to check whether the workshop exists: %w", name, err)
+		}
+		if err := conflict.CheckChangeConflict(w.state, projectId, name, nil); err != nil {
+			return nil, fmt.Errorf("cannot launch %q: other changes in progress", name)
 		}
 
 		localSdks, err := resolveLocalSdks(usr, userDataDir, projectId, name, nil)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -19,7 +19,6 @@ import (
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -54,17 +53,32 @@ func (w *WorkshopManager) loadProject(ctx context.Context, id string) (workshop.
 }
 
 func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
-	sto := sdk.StoreService(w.state)
+	username, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key user not found")
+	}
+
+	usr, env, err := osutil.UserAndEnv(username)
+	if err != nil {
+		return nil, err
+	}
+	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
 
 	project, err := w.loadProject(ctx, projectId)
 	if err != nil {
 		return nil, err
 	}
 
+	reqs, err := w.resolveWorkshops(ctx, project, names, "launch")
+	if err != nil {
+		return nil, err
+	}
+
 	taskset := make([]*state.TaskSet, 0, len(names))
-	var sdks []sdk.SdkResult
-	for _, name := range names {
+	for _, req := range reqs {
+		name := req.file.Name
 		// Make sure the workshop doesn't exist.
+		// Has to happen after calling resolveWorkshops (because it unlocks the state).
 		_, err := w.Workshop(ctx, name, projectId)
 		if err == nil {
 			return nil, fmt.Errorf("cannot launch %q: workshop exists", name)
@@ -72,41 +86,64 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, fmt.Errorf("cannot launch %q, failed to check whether the workshop exists: %w", name, err)
 		}
 
-		file, err := project.Workshop(name)
+		localSdks, err := resolveLocalSdks(userDataDir, projectId, name, nil)
 		if err != nil {
 			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
+		sdks := ordered(req.installOrder, req.storeSdks, localSdks)
 
-		sdks, err = sdkInfos(sto, ctx, projectId, file)
-		if err != nil {
-			return nil, err
-		}
-
-		candidates := make([]sdk.Setup, 0, len(sdks))
-		for _, s := range sdks {
-			candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
-		}
-
-		tasks := launch(w.state, file, candidates, project)
+		tasks := launch(w.state, req.file, sdks, project)
 		taskset = append(taskset, tasks)
 	}
 	return taskset, nil
 }
 
-func systemSdkInfo(pid, wname string) (sdk.SdkResult, error) {
-	ybuf, err := system.SystemSdkFs.ReadFile(system.SdkMeta)
-	if err != nil {
-		return sdk.SdkResult{}, err
-	}
-	info, err := sdk.ReadSdkInfo(ybuf, pid, wname)
-	if err != nil {
-		return sdk.SdkResult{}, err
-	}
-	info.Revision = sdk.R(-1)
-	return sdk.SdkResult{Info: info}, nil
+type workshopReq struct {
+	// Up to date workshop definitions from the project directory.
+	file *workshop.File
+	// All possible SDKs (including sketch) in installation order.
+	installOrder []string
+	// Up to date SDK setups from the store.
+	storeSdks []sdk.Setup
 }
 
-func sdkInfos(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.SdkResult, error) {
+func (w *WorkshopManager) resolveWorkshops(ctx context.Context, project workshop.Project, names []string, action string) ([]workshopReq, error) {
+	sto := sdk.StoreService(w.state)
+	reqs := make([]workshopReq, 0, len(names))
+
+	// Not an error, the state is locked; unlock it to let other requests to be
+	// processed while we are getting the store info sorted.
+	// This code can be concurrent with other changes,
+	// so we avoid interacting with local SDKs.
+	w.state.Unlock()
+	defer w.state.Lock()
+
+	for _, name := range names {
+		file, err := project.Workshop(name)
+		if err != nil {
+			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
+		}
+
+		installOrder := make([]string, 1, len(file.Sdks)+2)
+		installOrder[0] = sdk.System.String()
+		for _, sk := range file.Sdks {
+			if !workshop.IsImplicitSdk(sk.Name) {
+				installOrder = append(installOrder, sk.Name)
+			}
+		}
+		installOrder = append(installOrder, sdk.Sketch)
+
+		storeSdks, err := resolveStoreSdks(sto, ctx, project.ProjectId, file)
+		if err != nil {
+			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
+		}
+		reqs = append(reqs, workshopReq{file: file, installOrder: installOrder, storeSdks: storeSdks})
+	}
+
+	return reqs, nil
+}
+
+func resolveStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.Setup, error) {
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
 		if workshop.IsImplicitSdk(sd.Name) {
@@ -121,13 +158,73 @@ func sdkInfos(sto sdk.Store, ctx context.Context, projectid string, file *worksh
 		return nil, err
 	}
 
-	sinfo, err := systemSdkInfo(projectid, file.Name)
+	setups := make([]sdk.Setup, 0, len(infos))
+	for _, s := range infos {
+		setups = append(setups, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
+	}
+
+	return setups, nil
+}
+
+func resolveLocalSdks(userDataDir, pid, name string, wp *workshop.Workshop) ([]sdk.Setup, error) {
+	localSdks := []sdk.Setup{{Name: sdk.System.String(), Revision: sdk.R(-1)}}
+
+	sketch, err := maybeSketch(userDataDir, pid, name, wp)
+	if err != nil {
+		return nil, err
+	}
+	if sketch != nil {
+		localSdks = append(localSdks, *sketch)
+	}
+
+	return localSdks, nil
+}
+
+func maybeSketch(userDataDir, pid, name string, wp *workshop.Workshop) (*sdk.Setup, error) {
+	sketchdir := workshop.SketchSdkCurrent(userDataDir, pid, name)
+
+	recs, err := os.ReadDir(sketchdir)
+	// no Sketch SDK exists for the workshop and it is not an error.
+	if (err == nil && len(recs) == 0) || osutil.IsDirNotExist(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	infos = slices.Insert(infos, 0, sinfo)
-	return infos, nil
+	if wp == nil {
+		// Old sketches might exist because the snap remove hook doesn't remove them.
+		// No workshop exists currently; including the sketch SDK would be unexpected.
+		// We remove it (but keep the stash) to prevent future refreshes from including it.
+		if err = os.RemoveAll(sketchdir); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	revision := sdk.R(-1)
+	if installed, ok := wp.Sdks[sdk.Sketch]; ok {
+		revision = sdk.Revision{N: installed.Revision.N - 1}
+	}
+
+	return &sdk.Setup{Name: sdk.Sketch, Revision: revision}, nil
+}
+
+func ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {
+	ordered := make([]sdk.Setup, 0, len(order))
+
+	for _, sk := range order {
+		for _, setup := range setups {
+			contains := func(sp sdk.Setup) bool { return sk == sp.Name }
+
+			idx := slices.IndexFunc(setup, contains)
+			if idx != -1 {
+				ordered = append(ordered, setup[idx])
+				break
+			}
+		}
+	}
+	return ordered
 }
 
 func retrieveSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string]string) {
@@ -287,73 +384,57 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	return all
 }
 
-type refreshWorkshopReq struct {
-	// Existing workshop that will be refreshed.
-	w *workshop.Workshop
-	// Up to date workshop definitions from the project directory.
-	file *workshop.File
-	// Up to date SDK infos (from the store or a local source).
-	infos []sdk.SdkResult
-}
-
-func (w *WorkshopManager) prepareRefresh(ctx context.Context, wps []*workshop.Workshop, names []string) ([]refreshWorkshopReq, error) {
-	sto := sdk.StoreService(w.state)
-
-	// Not an error, the state is locked; unlock it to let other requests to be
-	// processed while we are getting the store info sorted.
-	w.state.Unlock()
-	defer w.state.Lock()
-
-	refreshReqs := make([]refreshWorkshopReq, 0, len(names))
-	for _, name := range names {
-		idx := slices.IndexFunc(wps, func(wp *workshop.Workshop) bool { return wp.Name == name })
-		if idx == -1 {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, workshop.ErrWorkshopNotLaunched)
-		}
-		wp := wps[idx]
-
-		file, err := wp.Project.Workshop(wp.Name)
-		if err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", wp.Name, err)
-		}
-
-		infos, err := sdkInfos(sto, ctx, wp.Project.ProjectId, file)
-		if err != nil {
-			return nil, err
-		}
-		refreshReqs = append(refreshReqs, refreshWorkshopReq{w: wp, file: file, infos: infos})
-	}
-	return refreshReqs, nil
-}
-
 func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, names []string) ([]*state.TaskSet, error) {
-	all, err := w.Workshops(ctx, projectId)
+	username, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key user not found")
+	}
+
+	usr, env, err := osutil.UserAndEnv(username)
+	if err != nil {
+		return nil, err
+	}
+	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
+
+	project, err := w.loadProject(ctx, projectId)
 	if err != nil {
 		return nil, err
 	}
 
-	refreshReqs, err := w.prepareRefresh(ctx, all, names)
+	reqs, err := w.resolveWorkshops(ctx, project, names, "refresh")
 	if err != nil {
 		return nil, err
 	}
 
+	taskset := make([]*state.TaskSet, 0, len(reqs))
 	allowed := []healthstate.Status{healthstate.ReadyStatus}
-	for _, req := range refreshReqs {
-		if err = healthstate.CheckWorkshopHealth(w.state, req.w, allowed); err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", req.w.Name, err)
+	for _, req := range reqs {
+		name := req.file.Name
+		wp, err := w.Workshop(ctx, name, projectId)
+		if err != nil {
+			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}
-	}
 
-	taskset := make([]*state.TaskSet, 0, len(refreshReqs))
-	for _, req := range refreshReqs {
-		plan, err := resolveRefresh(ctx, req.w, req.file, req.infos)
+		// Check for conflicting changes.
+		// Has to happen after calling resolveWorkshops (because it unlocks the state).
+		if err := healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+		}
+
+		localSdks, err := resolveLocalSdks(userDataDir, projectId, name, wp)
+		if err != nil {
+			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+		}
+		sdks := ordered(req.installOrder, req.storeSdks, localSdks)
+
+		plan, err := resolveRefresh(wp, req.file, sdks)
 		if err != nil {
 			return nil, err
 		}
 
-		tasks, err := refresh(ctx, w.state, plan, req.w, req.file)
+		tasks, err := refresh(ctx, w.state, plan, wp, req.file)
 		if err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", req.w.Name, err)
+			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}
 		if len(tasks.Tasks()) == 0 {
 			continue
@@ -389,31 +470,6 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 	return taskset, nil
 }
 
-func maybeSketch(ctx context.Context, pid, wp string) (bool, error) {
-	username, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return false, fmt.Errorf("context key user not found")
-	}
-
-	usr, env, err := osutil.UserAndEnv(username)
-	if err != nil {
-		return false, err
-	}
-
-	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
-	sketchdir := workshop.SketchSdkCurrent(userDataDir, pid, wp)
-
-	recs, err := os.ReadDir(sketchdir)
-	// no Sketch SDK exists for the workshop and it is not an error.
-	if len(recs) == 0 || osutil.IsDirNotExist(err) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
 func maybeRefresh(installed, candidate sdk.Setup) bool {
 	return installed.Channel != candidate.Channel || installed.Revision != candidate.Revision
 }
@@ -445,49 +501,32 @@ type refreshPlan struct {
 	installedOrder []string
 }
 
-func (p refreshPlan) ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {
-	ordered := make([]sdk.Setup, 0, len(order))
-
-	for _, sk := range order {
-		for _, setup := range setups {
-			contains := func(sp sdk.Setup) bool { return sk == sp.Name }
-
-			idx := slices.IndexFunc(setup, contains)
-			if idx != -1 {
-				ordered = append(ordered, setup[idx])
-				break
-			}
-		}
-	}
-	return ordered
-}
-
 func (p refreshPlan) InstallOrRefresh() []sdk.Setup {
-	return p.ordered(p.installOrder, p.install, p.refresh)
+	return ordered(p.installOrder, p.install, p.refresh)
 }
 
 func (p refreshPlan) IntactOrRemove() []sdk.Setup {
 	revOrder := slices.Clone(p.installedOrder)
 	slices.Reverse(revOrder)
-	ordered := p.ordered(revOrder, p.intact, p.remove)
+	ordered := ordered(revOrder, p.intact, p.remove)
 	return ordered
 }
 
 func (p refreshPlan) InstallIntactOrRefresh() []sdk.Setup {
-	return p.ordered(p.installOrder, p.install, p.refresh, p.intact)
+	return ordered(p.installOrder, p.install, p.refresh, p.intact)
 }
 
 func (p refreshPlan) Refresh() []sdk.Setup {
-	return p.ordered(p.installOrder, p.refresh)
+	return ordered(p.installOrder, p.refresh)
 }
 
 func (p refreshPlan) Remove() []sdk.Setup {
 	revOrder := slices.Clone(p.installedOrder)
 	slices.Reverse(revOrder)
-	return p.ordered(revOrder, p.remove)
+	return ordered(revOrder, p.remove)
 }
 
-func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop.File, newinfos []sdk.SdkResult) (*refreshPlan, error) {
+func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []sdk.Setup) (*refreshPlan, error) {
 	plan := &refreshPlan{
 		install:        make([]sdk.Setup, 0),
 		intact:         make([]sdk.Setup, 0),
@@ -495,11 +534,6 @@ func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop
 		remove:         make([]sdk.Setup, 0),
 		installOrder:   make([]string, 0),
 		installedOrder: make([]string, 0),
-	}
-
-	candidates := make([]sdk.Setup, 0, len(newinfos))
-	for _, s := range newinfos {
-		candidates = append(candidates, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 	}
 
 	// Restore the order of SDKs installed in the running workshop.
@@ -560,23 +594,6 @@ func resolveRefresh(ctx context.Context, w *workshop.Workshop, newfile *workshop
 		plan.installOrder = append(plan.installOrder, s.Name)
 	}
 
-	sketchFound, err := maybeSketch(ctx, w.Project.ProjectId, w.Name)
-	if err != nil {
-		return nil, err
-	}
-	if sketchFound {
-		plan.installOrder = append(plan.installOrder, sdk.Sketch)
-
-		if installed, exist := w.Sdks[sdk.Sketch]; exist {
-			plan.refresh = append(plan.refresh, sdk.Setup{
-				Name:     sdk.Sketch,
-				Revision: sdk.Revision{N: installed.Revision.N - 1},
-			})
-		} else {
-			plan.install = append(plan.install,
-				sdk.Setup{Name: sdk.Sketch, Revision: sdk.Revision{N: -1}})
-		}
-	}
 	return plan, nil
 }
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -143,7 +143,7 @@ func retrieveSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string
 	return retrieve, retrieveMap
 }
 
-func installSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
+func installSdks(st *state.State, pid, w string, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
 	var prevInstall *state.TaskSet
 	all := state.NewTaskSet()
 	addTaskSet := func(ts *state.TaskSet) {
@@ -165,9 +165,9 @@ func installSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]str
 		// guarantee safety of concurrent installations.
 		var install *state.TaskSet
 		if setup.Revision.Local() {
-			install = sdkstate.InstallLocalSdk(st, setup)
+			install = sdkstate.InstallLocalSdk(st, pid, w, setup)
 		} else {
-			install = sdkstate.Install(st, setup.Name, retrieveTasks[setup.Name])
+			install = sdkstate.Install(st, pid, w, setup.Name, retrieveTasks[setup.Name])
 		}
 
 		addTaskSet(install)
@@ -270,11 +270,8 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	create := launchWorkshop(st, file, project)
 	addTaskSet(create)
 
-	install := installSdks(st, sdks, rmap)
+	install := installSdks(st, project.ProjectId, file.Name, sdks, rmap)
 	addTaskSet(install)
-
-	setup := runHooks(st, project.ProjectId, file.Name, sdks, 0, hookstate.SetupBase)
-	addTaskSet(setup)
 
 	connect := autoconnectSdks(st, sdks)
 	addTaskSet(connect)
@@ -626,22 +623,9 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	rebuild := rebuildWorkshop(st, file, plan.sdkSnapshot)
 	addTaskSet(rebuild)
 
-	// Detach (uninstall) volumes of the SDKs from the restored snapshot. If the
-	// refresh fails, a copy of the workshop will be restored that had SDKs
-	// installed previously.
-	// We do not uninstall the SDKs that were installed locally and are to be
-	// removed here as those will not present in the recovered snapshot (as
-	// those are simply copied over into the workshop). These tasks will uninstall
-	// SDKs that were installed from the store as SDK volumes.
-	uninstall := uninstallSdks(st, plan.Remove())
-	addTaskSet(uninstall)
-
 	// Install and link updated SDKs to the rebuilt workshop.
-	install := installSdks(st, plan.InstallOrRefresh(), rmap)
+	install := installSdks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), rmap)
 	addTaskSet(install)
-
-	setup := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), 0, hookstate.SetupBase)
-	addTaskSet(setup)
 
 	connect := autoconnectSdks(st, plan.InstallIntactOrRefresh())
 	addTaskSet(connect)
@@ -710,32 +694,6 @@ func autoconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 		prevAuto = autoconnect
 	}
 	return autoconnectSet
-}
-
-func uninstallSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
-	var prevRemove *state.Task
-	all := state.NewTaskSet()
-	addTask := func(ts *state.Task) {
-		if prevRemove != nil {
-			ts.WaitFor(prevRemove)
-		}
-		prevRemove = ts
-
-		all.AddTask(ts)
-	}
-
-	for _, setup := range sdks {
-		// The install task sets must not run concurrently as exec ops are not
-		// allowed by LXD to be run concurrently and in general case we cannot
-		// guarantee safety of concurrent installations.
-		if setup.Revision.Store() {
-			install := st.NewTask("remove-sdk", fmt.Sprintf("Remove %q SDK", setup.Name))
-			install.Set("sdk-retrieve-task", install.ID())
-			install.Set("sdk-setup", setup)
-			addTask(install)
-		}
-	}
-	return all
 }
 
 func unlinkSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -20,6 +20,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -159,7 +160,8 @@ func resolveStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file
 		return nil, err
 	}
 
-	setups := make([]sdk.Setup, 0, len(infos))
+	setups := make([]sdk.Setup, 1, len(infos)+1)
+	setups[0] = sdk.Setup{Name: "system", Revision: system.SystemSdkRevision}
 	for _, s := range infos {
 		setups = append(setups, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
 	}
@@ -168,7 +170,7 @@ func resolveStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file
 }
 
 func resolveLocalSdks(usr *user.User, userDataDir, pid, name string, wp *workshop.Workshop) ([]sdk.Setup, error) {
-	localSdks := []sdk.Setup{{Name: sdk.System.String(), Revision: sdk.R(-1)}}
+	var localSdks []sdk.Setup
 
 	sketch, err := maybeSketch(userDataDir, pid, name, wp == nil)
 	if err != nil {
@@ -179,11 +181,6 @@ func resolveLocalSdks(usr *user.User, userDataDir, pid, name string, wp *worksho
 	}
 
 	for i, sk := range localSdks {
-		if i == 0 {
-			// Skip system SDK.
-			continue
-		}
-
 		var installed sdk.Revision
 		if wp != nil {
 			installed = wp.Sdks[sk.Name].Revision

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -252,33 +252,39 @@ func retrieveSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string
 }
 
 func installSdks(st *state.State, pid, w string, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
-	var prevInstall *state.TaskSet
 	all := state.NewTaskSet()
-	addTaskSet := func(ts *state.TaskSet) {
-		if len(ts.Tasks()) == 0 {
-			return
-		}
 
-		if prevInstall != nil {
-			ts.WaitAll(prevInstall)
+	var prev *state.Task
+	addTask := func(t *state.Task) {
+		all.AddTask(t)
+		if prev != nil {
+			t.WaitFor(prev)
 		}
-		prevInstall = ts
-
-		all.AddAll(ts)
+		prev = t
 	}
 
+	// Run setup-base after installing each SDK, rather than all at once.
+	// This means each SDK snapshot only contains the relevant SDKs.
 	for _, setup := range sdks {
 		// The install task sets must not run concurrently as exec ops are not
 		// allowed by LXD to be run concurrently and in general case we cannot
 		// guarantee safety of concurrent installations.
-		var install *state.TaskSet
+		var install *state.Task
+		var retrieveTask string
 		if setup.Revision.Local() {
-			install = sdkstate.InstallLocalSdk(st, pid, w, setup)
+			install = sdkstate.InstallLocalSdk(st, setup)
+			retrieveTask = install.ID()
 		} else {
-			install = sdkstate.Install(st, pid, w, setup.Name, retrieveTasks[setup.Name])
+			retrieveTask = retrieveTasks[setup.Name]
+			install = sdkstate.Install(st, setup.Name, retrieveTask)
 		}
+		addTask(install)
 
-		addTaskSet(install)
+		register := sdkstate.Register(st, setup.Name, retrieveTask)
+		addTask(register)
+
+		hook := hookstate.Hook(st, pid, w, setup.Name, 0, hookstate.SetupBase)
+		addTask(hook)
 	}
 	return all
 }
@@ -639,11 +645,10 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	disconnect := disconnectSdks(st, plan.IntactOrRemove())
 	addTaskSet(disconnect)
 
-	// Unlink and remove SDKs from interfaces repository. If refresh fails, the
-	// SDKs will be linked back and returned to the repository. This is the
-	// reason unlink has to happen before stashing.
-	unlink := unlinkSdks(st, plan.Remove())
-	addTaskSet(unlink)
+	// Remove SDKs from interfaces repository. If refresh fails, the SDKs will be returned
+	// to the repository after restoring the stashed workshop (with the SDKs installed).
+	unregister := unregisterSdks(st, plan.Remove())
+	addTaskSet(unregister)
 
 	stash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
 	addTaskSet(state.NewTaskSet(stash))
@@ -651,7 +656,7 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	rebuild := rebuildWorkshop(st, file, plan.sdkSnapshot)
 	addTaskSet(rebuild)
 
-	// Install and link updated SDKs to the rebuilt workshop.
+	// Install updated SDKs to the rebuilt workshop.
 	install := installSdks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), rmap)
 	addTaskSet(install)
 
@@ -724,21 +729,19 @@ func autoconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	return autoconnectSet
 }
 
-func unlinkSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
+func unregisterSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	prev := (*state.Task)(nil)
-	unlinkSet := state.NewTaskSet()
+	unregisterSet := state.NewTaskSet()
 	for _, s := range sdks {
-		unlink := st.NewTask("unlink-sdk", fmt.Sprintf("Unlink %q SDK", s.Name))
-		unlink.Set("sdk-retrieve-task", unlink.ID())
-		unlink.Set("sdk-setup", s)
-		unlinkSet.AddTask(unlink)
+		unregister := sdkstate.Unregister(st, s)
+		unregisterSet.AddTask(unregister)
 
 		if prev != nil {
-			unlink.WaitFor(prev)
+			unregister.WaitFor(prev)
 		}
-		prev = unlink
+		prev = unregister
 	}
-	return unlinkSet
+	return unregisterSet
 }
 
 func disconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
@@ -965,8 +968,8 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*s
 	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", w.Name))
 	addTaskSet(state.NewTaskSet(discard))
 
-	unlink := unlinkSdks(st, slices.Collect(maps.Values(w.Sdks)))
-	addTaskSet(unlink)
+	unregister := unregisterSdks(st, slices.Collect(maps.Values(w.Sdks)))
+	addTaskSet(unregister)
 
 	remove := st.NewTask("remove-workshop", fmt.Sprintf("Remove %q workshop", w.Name))
 	addTaskSet(state.NewTaskSet(remove))

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -666,7 +666,7 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	restoreState := runHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), 0, hookstate.RestoreState)
 	addTaskSet(restoreState)
 
-	checkHealth := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), 0, hookstate.CheckHealth)
+	checkHealth := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallIntactOrRefresh(), 0, hookstate.CheckHealth)
 	addTaskSet(checkHealth)
 
 	length := len(refresh.Tasks())

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"os/user"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -86,7 +87,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, fmt.Errorf("cannot launch %q, failed to check whether the workshop exists: %w", name, err)
 		}
 
-		localSdks, err := resolveLocalSdks(userDataDir, projectId, name, nil)
+		localSdks, err := resolveLocalSdks(usr, userDataDir, projectId, name, nil)
 		if err != nil {
 			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
@@ -166,10 +167,10 @@ func resolveStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file
 	return setups, nil
 }
 
-func resolveLocalSdks(userDataDir, pid, name string, wp *workshop.Workshop) ([]sdk.Setup, error) {
+func resolveLocalSdks(usr *user.User, userDataDir, pid, name string, wp *workshop.Workshop) ([]sdk.Setup, error) {
 	localSdks := []sdk.Setup{{Name: sdk.System.String(), Revision: sdk.R(-1)}}
 
-	sketch, err := maybeSketch(userDataDir, pid, name, wp)
+	sketch, err := maybeSketch(userDataDir, pid, name, wp == nil)
 	if err != nil {
 		return nil, err
 	}
@@ -177,10 +178,28 @@ func resolveLocalSdks(userDataDir, pid, name string, wp *workshop.Workshop) ([]s
 		localSdks = append(localSdks, *sketch)
 	}
 
+	for i, sk := range localSdks {
+		if i == 0 {
+			// Skip system SDK.
+			continue
+		}
+
+		var installed sdk.Revision
+		if wp != nil {
+			installed = wp.Sdks[sk.Name].Revision
+		}
+
+		sdkdir := workshop.LocalSdkDir(userDataDir, pid, name, sk.Name)
+		localSdks[i].Revision, err = sdk.CommitRevision(usr, sk.Source, sdkdir, installed)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return localSdks, nil
 }
 
-func maybeSketch(userDataDir, pid, name string, wp *workshop.Workshop) (*sdk.Setup, error) {
+func maybeSketch(userDataDir, pid, name string, launch bool) (*sdk.Setup, error) {
 	sketchdir := workshop.SketchSdkCurrent(userDataDir, pid, name)
 
 	recs, err := os.ReadDir(sketchdir)
@@ -192,7 +211,7 @@ func maybeSketch(userDataDir, pid, name string, wp *workshop.Workshop) (*sdk.Set
 		return nil, err
 	}
 
-	if wp == nil {
+	if launch {
 		// Old sketches might exist because the snap remove hook doesn't remove them.
 		// No workshop exists currently; including the sketch SDK would be unexpected.
 		// We remove it (but keep the stash) to prevent future refreshes from including it.
@@ -202,12 +221,7 @@ func maybeSketch(userDataDir, pid, name string, wp *workshop.Workshop) (*sdk.Set
 		return nil, nil
 	}
 
-	revision := sdk.R(-1)
-	if installed, ok := wp.Sdks[sdk.Sketch]; ok {
-		revision = sdk.Revision{N: installed.Revision.N - 1}
-	}
-
-	return &sdk.Setup{Name: sdk.Sketch, Revision: revision}, nil
+	return &sdk.Setup{Name: sdk.Sketch, Source: sketchdir}, nil
 }
 
 func ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {
@@ -421,7 +435,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}
 
-		localSdks, err := resolveLocalSdks(userDataDir, projectId, name, wp)
+		localSdks, err := resolveLocalSdks(usr, userDataDir, projectId, name, wp)
 		if err != nil {
 			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/afero"
 	"gopkg.in/check.v1"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
@@ -61,7 +60,7 @@ base: ubuntu@20.04
 `
 
 func (s *requestSuite) writeSDKMetaFile(c *check.C, fs workshop.WorkshopFs, name, yaml string) {
-	sdkPath := filepath.Join(dirs.WorkshopSdksDir, name, "0", "meta")
+	sdkPath := sdk.SdkMetaDir(name)
 	c.Assert(fs.MkdirAll(sdkPath, 0755), check.IsNil)
 	metaPath := filepath.Join(sdkPath, "sdk.yaml")
 	c.Assert(afero.WriteFile(fs, metaPath, []byte(yaml), 0644), check.IsNil)
@@ -94,7 +93,7 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 
 	for _, sd := range sdks {
 		s.writeSDKMetaFile(c, wfs, sd.Name, fmt.Sprintf(sdkTemplate, sd.Name))
-		c.Assert(w.LinkSdk(s.ctx, sdk.Setup{Name: sd.Name, Channel: sd.Channel}), check.IsNil)
+		c.Assert(w.AddSdk(s.ctx, sdk.Setup{Name: sd.Name, Channel: sd.Channel}), check.IsNil)
 	}
 
 	return w

--- a/internal/sdk/local.go
+++ b/internal/sdk/local.go
@@ -1,0 +1,123 @@
+package sdk
+
+import (
+	"cmp"
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/exp/slices"
+
+	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/osutil"
+)
+
+// CommitRevision copies the source SDK into a subdirectory of the target, reusing an existing
+// subdirectory if possible. The subdirectory name is a local revision number, e.g. x123 for -123.
+// If no local revision matches the source, the new revision is one less than the lowest existing
+// revision, e.g. -124. After creating a new revision, all but the three most recently installed
+// revisions will be removed. The currently installed revision can be passed as an argument,
+// to avoid relying too heavily on directory timestamps.
+func CommitRevision(u *user.User, source, target string, installed Revision) (Revision, error) {
+	revisions, err := listRevisions(target)
+	if err != nil {
+		return Revision{}, err
+	}
+
+	revision, exists := nextRevision(source, target, revisions)
+	if exists {
+		return revision, nil
+	}
+
+	uid, gid, err := osutil.UidGid(u)
+	if err != nil {
+		return Revision{}, err
+	}
+	if err := osutil.MkdirAllChown(target, os.ModePerm, uid, gid); err != nil {
+		return Revision{}, err
+	}
+	if err := osutil.CopyDirOnBehalf(source, filepath.Join(target, revision.String()), uid, gid); err != nil {
+		return Revision{}, err
+	}
+
+	remove := len(revisions) - 2
+	revisions = slices.DeleteFunc(revisions, func(rev Revision) bool { return rev == installed })
+	removeOldRevisions(target, revisions, remove)
+
+	return revision, nil
+}
+
+func listRevisions(path string) ([]Revision, error) {
+	recs, err := os.ReadDir(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	revisions := make([]Revision, 0, len(recs))
+	for _, rec := range recs {
+		name := rec.Name()
+		revision, err := ParseRevision(name)
+		if err == nil && revision.Local() && revision.String() == name {
+			revisions = append(revisions, revision)
+		}
+	}
+	return revisions, nil
+}
+
+func nextRevision(source, target string, revisions []Revision) (Revision, bool) {
+	if len(revisions) == 0 {
+		return R(-1), false
+	}
+
+	for _, revision := range revisions {
+		dir := filepath.Join(target, revision.String())
+		// FIXME: should drop privileges for this. There's a (small) chance that
+		// unauthorised users can brute force the source directory contents.
+		if osutil.DirsAreEqual(source, dir) {
+			// Extend revision lifetime.
+			if err := os.Chtimes(dir, time.Time{}, time.Now()); err != nil {
+				logger.Noticef("Cannot update revision timestamp: %v", err)
+			}
+			return revision, true
+		}
+	}
+
+	revision := slices.MinFunc(revisions, func(a, b Revision) int { return cmp.Compare(a.N, b.N) })
+	return Revision{N: revision.N - 1}, false
+}
+
+func removeOldRevisions(path string, revisions []Revision, remove int) {
+	if remove <= 0 {
+		return
+	}
+
+	times := make([]revTime, 0, len(revisions))
+	for _, revision := range revisions {
+		var modTime time.Time
+		info, err := os.Stat(filepath.Join(path, revision.String()))
+		if err != nil {
+			// Broken revision, use zero modTime so it is removed first.
+			logger.Noticef("Cannot read revision timestamp: %v", err)
+		} else {
+			modTime = info.ModTime()
+		}
+		times = append(times, revTime{revision, modTime})
+	}
+
+	slices.SortFunc(times, func(a, b revTime) int { return a.modTime.Compare(b.modTime) })
+	times = times[:remove]
+	for _, time := range times {
+		if err := os.RemoveAll(filepath.Join(path, time.revision.String())); err != nil {
+			logger.Noticef("Cannot remove old revision: %v", err)
+		}
+	}
+}
+
+type revTime struct {
+	revision Revision
+	modTime  time.Time
+}

--- a/internal/sdk/local_test.go
+++ b/internal/sdk/local_test.go
@@ -1,0 +1,167 @@
+package sdk_test
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/osutil/sys"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+type localSdk struct {
+	target string
+	user   *user.User
+	uid    sys.UserID
+	gid    sys.GroupID
+}
+
+var _ = check.Suite(&localSdk{})
+
+func (s *localSdk) SetUpTest(c *check.C) {
+	s.target = c.MkDir()
+
+	var err error
+	s.user, err = user.Current()
+	c.Assert(err, check.IsNil)
+
+	s.uid, s.gid, err = osutil.UidGid(s.user)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *localSdk) createSource(c *check.C, contents string) string {
+	source := filepath.Join(c.MkDir(), "source")
+	c.Assert(os.Mkdir(source, 0755), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(source, "contents"), []byte(contents), 0644), check.IsNil)
+	return source
+}
+
+func (s *localSdk) createRevision(c *check.C, revision, contents string) {
+	c.Assert(os.Mkdir(filepath.Join(s.target, revision), 0755), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.target, revision, "contents"), []byte(contents), 0644), check.IsNil)
+}
+
+func (s *localSdk) TestCommitSuccess(c *check.C) {
+	one := s.createSource(c, "1")
+	revision, err := sdk.CommitRevision(s.user, one, s.target, sdk.Revision{})
+	c.Assert(err, check.IsNil)
+	c.Check(revision, check.Equals, sdk.R(-1))
+
+	checkRev1 := func() {
+		c.Check(filepath.Join(s.target, "x1"), testutil.DirEquals, []string{"-rw-r--r-- contents"})
+		c.Check(filepath.Join(s.target, "x1", "contents"), testutil.FileEquals, "1")
+	}
+	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x1"})
+	checkRev1()
+
+	two := s.createSource(c, "2")
+	revision, err = sdk.CommitRevision(s.user, two, s.target, revision)
+	c.Assert(err, check.IsNil)
+	c.Check(revision, check.Equals, sdk.R(-2))
+
+	checkRev2 := func() {
+		c.Check(filepath.Join(s.target, "x2"), testutil.DirEquals, []string{"-rw-r--r-- contents"})
+		c.Check(filepath.Join(s.target, "x2", "contents"), testutil.FileEquals, "2")
+	}
+	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x1", "drwxr-xr-x x2"})
+	checkRev1()
+	checkRev2()
+
+	oneAgain := s.createSource(c, "1")
+	revision, err = sdk.CommitRevision(s.user, oneAgain, s.target, revision)
+	c.Assert(err, check.IsNil)
+	c.Check(revision, check.Equals, sdk.R(-1))
+
+	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x1", "drwxr-xr-x x2"})
+	checkRev1()
+	checkRev2()
+}
+
+func (s *localSdk) TestCommitIncreasesRevision(c *check.C) {
+	s.createRevision(c, "x11", "11")
+	s.createRevision(c, "x111", "111")
+	s.createRevision(c, "x1111", "1111")
+
+	source := s.createSource(c, "1112")
+	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-111))
+	c.Assert(err, check.IsNil)
+	c.Check(revision, check.Equals, sdk.R(-1112))
+}
+
+func (s *localSdk) TestCommitIgnoresUnusualRevisions(c *check.C) {
+	s.createRevision(c, "10", "10")
+	s.createRevision(c, "-11", "11")
+	s.createRevision(c, "x+12", "12")
+	s.createRevision(c, "x013", "13")
+
+	source := s.createSource(c, "1")
+	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.Revision{})
+	c.Assert(err, check.IsNil)
+	c.Check(revision, check.Equals, sdk.R(-1))
+}
+
+func (s *localSdk) TestCommitRemovesOldRevisions(c *check.C) {
+	s.createRevision(c, "x42", "42")
+	s.createRevision(c, "x43", "43")
+	s.createRevision(c, "x44", "44")
+
+	t3 := time.Now()
+	t2 := t3.Add(-time.Minute)
+	t1 := t2.Add(-time.Minute)
+	c.Assert(os.Chtimes(filepath.Join(s.target, "x42"), time.Time{}, t2), check.IsNil)
+	c.Assert(os.Chtimes(filepath.Join(s.target, "x43"), time.Time{}, t1), check.IsNil)
+	c.Assert(os.Chtimes(filepath.Join(s.target, "x44"), time.Time{}, t3), check.IsNil)
+
+	source := s.createSource(c, "45")
+	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-44))
+	c.Assert(err, check.IsNil)
+	c.Check(revision, check.Equals, sdk.R(-45))
+	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x42", "drwxr-xr-x x44", "drwxr-xr-x x45"})
+}
+
+func (s *localSdk) TestCommitKeepsInstalled(c *check.C) {
+	s.createRevision(c, "x42", "42")
+	s.createRevision(c, "x43", "43")
+	s.createRevision(c, "x44", "44")
+
+	t3 := time.Now()
+	t2 := t3.Add(-time.Minute)
+	t1 := t2.Add(-time.Minute)
+	c.Assert(os.Chtimes(filepath.Join(s.target, "x42"), time.Time{}, t2), check.IsNil)
+	c.Assert(os.Chtimes(filepath.Join(s.target, "x43"), time.Time{}, t1), check.IsNil)
+	c.Assert(os.Chtimes(filepath.Join(s.target, "x44"), time.Time{}, t3), check.IsNil)
+
+	source := s.createSource(c, "45")
+	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-43))
+	c.Assert(err, check.IsNil)
+	c.Check(revision, check.Equals, sdk.R(-45))
+	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x43", "drwxr-xr-x x44", "drwxr-xr-x x45"})
+}
+
+func (s *localSdk) TestCommitExistingUpdatesTimestamp(c *check.C) {
+	s.createRevision(c, "x41", "41")
+	s.createRevision(c, "x42", "42")
+	s.createRevision(c, "x43", "43")
+	s.createRevision(c, "x44", "44")
+
+	old := time.Now().Add(-time.Minute)
+	c.Assert(os.Chtimes(filepath.Join(s.target, "x43"), time.Time{}, old), check.IsNil)
+	info, err := os.Stat(filepath.Join(s.target, "x43"))
+	c.Assert(err, check.IsNil)
+	c.Check(info.ModTime().Compare(old), check.Equals, 0)
+
+	source := s.createSource(c, "43")
+	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-44))
+	c.Assert(err, check.IsNil)
+	c.Check(revision, check.Equals, sdk.R(-43))
+	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x41", "drwxr-xr-x x42", "drwxr-xr-x x43", "drwxr-xr-x x44"})
+
+	info, err = os.Stat(filepath.Join(s.target, "x43"))
+	c.Assert(err, check.IsNil)
+	c.Check(info.ModTime().Compare(old), check.Equals, 1)
+}

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -443,20 +443,12 @@ func (ref PlugRef) SortsBefore(other PlugRef) bool {
 	return ref.Name < other.Name
 }
 
-func SdkRootPath(sdkName string) string {
+func SdkDir(sdkName string) string {
 	return filepath.Join(dirs.WorkshopSdksDir, sdkName)
 }
 
-func SdkRevPath(sdkName string, rev string) string {
-	return filepath.Join(SdkRootPath(sdkName), rev)
-}
-
-func SdkCurrentPath(sdkName string) string {
-	return filepath.Join(SdkRootPath(sdkName), "current")
-}
-
 func SdkMetaDir(sdkName string) string {
-	return filepath.Join(SdkCurrentPath(sdkName), "meta")
+	return filepath.Join(SdkDir(sdkName), "meta")
 }
 
 func SdkMetaPath(sdkName string) string {
@@ -464,7 +456,7 @@ func SdkMetaPath(sdkName string) string {
 }
 
 func SdkHooksDir(sdkName string) string {
-	return filepath.Join(SdkCurrentPath(sdkName), "sdk", "hooks")
+	return filepath.Join(SdkDir(sdkName), "sdk", "hooks")
 }
 
 func SdkHookPath(sdkName, hookName string) string {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -17,7 +17,8 @@ import (
 
 type Setup struct {
 	Name        string     `json:"name"`
-	Channel     string     `json:"channel"`
+	Channel     string     `json:"channel,omitempty"`
+	Source      string     `json:"source,omitempty"`
 	Revision    Revision   `json:"revision"`
 	InstallTime *time.Time `json:"install-time"`
 }
@@ -74,6 +75,7 @@ type Info struct {
 	Type      Type
 	Revision  Revision
 	Channel   string
+	Source    string
 	BuildTime *time.Time
 
 	Plugs     map[string]*PlugInfo

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -125,3 +125,15 @@ func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progre
 	}
 	return nil
 }
+
+func (f *FakeStore) RetrieveSystemSdk(setup Setup, report *progress.Reporter) error {
+	f.downloadLock.Lock()
+	defer f.downloadLock.Unlock()
+	f.DownloadCalls = append(f.DownloadCalls, TestDownloadCall{
+		Setup: setup,
+	})
+	if f.DownloadCallback != nil {
+		return f.DownloadCallback(nil, setup, report)
+	}
+	return nil
+}

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -1,10 +1,87 @@
 package system
 
 import (
+	"archive/tar"
 	"embed"
+	"fmt"
+	"os"
+
+	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/progress"
+	"github.com/canonical/workshop/internal/revert"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
-//go:embed meta/*
-var SystemSdkFs embed.FS
+var (
+	//go:embed meta/*
+	SystemSdkFs embed.FS
 
-const SdkMeta = "meta/sdk.yaml"
+	SystemSdkRevision = sdk.R(1)
+
+	RetrieveSystemSdk = retrieveSystemSdk
+)
+
+func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) error {
+	fl, err := sdk.OpenLock(setup.Name)
+	if err != nil {
+		return err
+	}
+	if err = fl.Lock(); err != nil {
+		return err
+	}
+	defer fl.Close()
+
+	target := setup.Filepath()
+	if osutil.FileExists(target) {
+		logger.Debugf("System SDK on Retrieve: SDK found locally: %s", target)
+		return nil
+	}
+
+	if setup.Revision != SystemSdkRevision {
+		return fmt.Errorf("system SDK (%s) not available", setup.Revision)
+	}
+
+	r := revert.New()
+	defer r.Fail()
+
+	// TODO: remove old system SDKs when no longer in use.
+	file, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	r.Add(func() {
+		if err1 := os.Remove(target); err1 != nil {
+			logger.Noticef("System SDK on Retrieve: Cannot remove %q on a failed download: %v", target, err1)
+		}
+	})
+
+	writer := tar.NewWriter(file)
+	if err := writer.AddFS(SystemSdkFs); err != nil {
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+
+	if report != nil {
+		size := 1
+		info, err := file.Stat()
+		if err != nil {
+			logger.Noticef("System SDK on Retrieve: %v", err)
+		} else {
+			size = int(info.Size())
+		}
+		report.Report("download", size, size)
+	}
+
+	r.Success()
+	return nil
+}
+
+func FakeRetrieveSystemSdk(f func(setup sdk.Setup, report *progress.Reporter) error) func() {
+	oldRetrieveSystemSdk := RetrieveSystemSdk
+	RetrieveSystemSdk = f
+	return func() { RetrieveSystemSdk = oldRetrieveSystemSdk }
+}

--- a/internal/sdk/system/system_test.go
+++ b/internal/sdk/system/system_test.go
@@ -1,0 +1,74 @@
+package system_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/progress"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdk/system"
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+type systemSdk struct {
+	oldRoot string
+}
+
+var _ = check.Suite(&systemSdk{})
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+func (f *systemSdk) SetUpSuite(c *check.C) {
+	f.oldRoot = dirs.BaseDir
+	dirs.SetRootDir(c.MkDir())
+	c.Assert(dirs.CreateDirs(), check.IsNil)
+}
+
+func (f *systemSdk) TearDownSuite(c *check.C) {
+	dirs.SetRootDir(f.oldRoot)
+}
+
+// Update this hash with new SDK revision numbers.
+const systemSdkHash = "8836e6d5a7a5fd6d16e9b74028d572518002105251af0f17e4bcd50870ea7cf1"
+
+func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
+	done, total := 0, 0
+	report := &progress.Reporter{Name: "1", Report: func(label string, d, t int) {
+		done = d
+		total = t
+	}}
+	setup := sdk.Setup{Name: sdk.System.String(), Revision: system.SystemSdkRevision}
+	c.Assert(system.RetrieveSystemSdk(setup, report), check.IsNil)
+	c.Check(done, testutil.IntGreaterThan, 0)
+	c.Check(total, testutil.IntGreaterThan, 0)
+	c.Check(done, check.Equals, total)
+
+	r, err := os.Open(setup.Filepath())
+	c.Assert(err, check.IsNil)
+	defer r.Close()
+
+	w := sha256.New()
+	_, err = io.Copy(w, r)
+	c.Assert(err, check.IsNil)
+
+	hash := hex.EncodeToString(w.Sum(nil))
+	c.Check(hash, check.Equals, systemSdkHash, check.Commentf("system SDK revision needs updating"))
+	c.Check(system.SystemSdkRevision, check.Equals, sdk.R(1))
+}
+
+func (s *systemSdk) TestRetrieveSystemSdkWrongRevision(c *check.C) {
+	setup := sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(system.SystemSdkRevision.N - 1)}
+	err := system.RetrieveSystemSdk(setup, nil)
+	c.Check(err, check.ErrorMatches, fmt.Sprintf(`system SDK \(%s\) not available`, setup.Revision))
+
+	setup.Revision.N += 2
+	err = system.RetrieveSystemSdk(setup, nil)
+	c.Check(err, check.ErrorMatches, fmt.Sprintf(`system SDK \(%s\) not available`, setup.Revision))
+}

--- a/internal/testutil/dircontentchecker.go
+++ b/internal/testutil/dircontentchecker.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2014-2020 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package testutil
+
+import (
+	"cmp"
+	"fmt"
+	"io/fs"
+	"os"
+	"slices"
+
+	"github.com/spf13/afero"
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil"
+)
+
+type dirContentChecker struct {
+	*check.CheckerInfo
+}
+
+// DirEquals verifies that the given directory contains exactly the given contents.
+// Contents should be a slice of strings of the form "drwxr-xr-x filename".
+var DirEquals check.Checker = &dirContentChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "DirEquals", Params: []string{"directory", "contents"}},
+}
+
+func (c *dirContentChecker) Check(params []interface{}, names []string) (bool, string) {
+	var infos []os.FileInfo
+	switch dir := params[0].(type) {
+	case string:
+		recs, err := os.ReadDir(dir)
+		if err != nil {
+			return false, fmt.Sprintf("Cannot read directory %q: %v", dir, err)
+		}
+		infos, err = osutil.DirInfos(recs)
+		if err != nil {
+			return false, fmt.Sprintf("Cannot read directory %q: %v", dir, err)
+		}
+	case fs.ReadDirFile:
+		recs, err := dir.ReadDir(-1)
+		if err != nil {
+			info, err1 := dir.Stat()
+			if err1 != nil {
+				return false, fmt.Sprintf("Cannot read directory: %v", err)
+			}
+			return false, fmt.Sprintf("Cannot read directory %q: %v", info.Name(), err)
+		}
+		infos, err = osutil.DirInfos(recs)
+		if err != nil {
+			return false, fmt.Sprintf("Cannot read directory %q: %v", dir, err)
+		}
+		slices.SortFunc(infos, func(a, b os.FileInfo) int { return cmp.Compare(a.Name(), b.Name()) })
+	case afero.Fs:
+		var err error
+		infos, err = afero.ReadDir(dir, "/")
+		if err != nil {
+			return false, fmt.Sprintf("Cannot read directory %q: %v", dir.Name(), err)
+		}
+	case afero.File:
+		var err error
+		infos, err = dir.Readdir(-1)
+		if err != nil {
+			return false, fmt.Sprintf("Cannot read directory %q: %v", dir.Name(), err)
+		}
+		slices.SortFunc(infos, func(a, b os.FileInfo) int { return cmp.Compare(a.Name(), b.Name()) })
+	default:
+		return false, "Directory must be a string or afero.Fs"
+	}
+
+	obtained := make([]string, 0, len(infos))
+	for _, info := range infos {
+		obtained = append(obtained, fmt.Sprintf("%s %s", info.Mode().String(), info.Name()))
+	}
+
+	return check.DeepEquals.Check([]interface{}{obtained, params[1]}, names)
+}

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -1,5 +1,13 @@
 package workshop
 
+import (
+	"path/filepath"
+
+	"github.com/canonical/workshop/internal/dirs"
+)
+
+var DefaultDevices = defaultDevices
+
 type MountType int
 
 const (
@@ -96,4 +104,35 @@ func NewSdkProfile(sdkName string) SdkProfile {
 		Sdk:    sdkName,
 		Mounts: make(map[string]Mount),
 	}
+}
+
+func defaultDevices(pid, w string) ([]Mount, []ProxyEntry) {
+	mounts := []Mount{{
+		Name:  "workshop.workshopctl",
+		What:  filepath.Join(dirs.ExecDir, "workshopctl"),
+		Where: "/usr/bin/workshopctl",
+		Type:  HostWorkshop,
+	}, {
+		Name:  "cache.apt",
+		What:  AptCacheVolumeName(w, pid),
+		Where: dirs.AptCachePath,
+		Type:  Volume,
+	}}
+
+	socketHost := dirs.SocketPath + ".untrusted"
+	socketWorkshop := filepath.Join(dirs.WorkshopRunDir, filepath.Base(socketHost))
+	proxies := []ProxyEntry{{
+		Name:      "workshop.socket",
+		Connect:   ProxyTarget{Address: socketHost, Protocol: "unix"},
+		Listen:    ProxyTarget{Address: socketWorkshop, Protocol: "unix"},
+		Direction: WorkshopToHost,
+	}}
+
+	return mounts, proxies
+}
+
+func FakeDefaultDevices(f func(pid, w string) ([]Mount, []ProxyEntry)) func() {
+	oldDefault := DefaultDevices
+	DefaultDevices = f
+	return func() { DefaultDevices = oldDefault }
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -243,6 +243,29 @@ func (s *FakeWorkshopBackend) StopWorkshop(ctx context.Context, name string, for
 }
 
 func (f *FakeWorkshopBackend) AddWorkshopMount(ctx context.Context, name string, mount workshop.Mount) error {
+	if mount.Type != workshop.HostWorkshop {
+		return errors.New("fake backend only supports HostWorkshop mounts")
+	}
+
+	wfs, err := f.WorkshopFs(ctx, name)
+	if err != nil {
+		return err
+	}
+	defer wfs.Close()
+
+	mnt, err := wfs.(*FakeInstanceFs).Fs.(*afero.BasePathFs).RealPath(mount.Where)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(mnt), 0755); err != nil {
+		return err
+	}
+
+	if err := os.Symlink(mount.What, mnt); err != nil {
+		return err
+	}
+
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -263,10 +286,25 @@ func (f *FakeWorkshopBackend) RemoveWorkshopMount(ctx context.Context, name, mou
 	}
 
 	f.workshopLock.Lock()
-	defer f.workshopLock.Unlock()
-
+	device, ok := f.Workshops[projectId][name].Devices[mount]
 	delete(f.Workshops[projectId][name].Devices, mount)
-	return nil
+	f.workshopLock.Unlock()
+	if !ok {
+		return fmt.Errorf("mount %q not found", mount)
+	}
+
+	wfs, err := f.WorkshopFs(ctx, name)
+	if err != nil {
+		return err
+	}
+	defer wfs.Close()
+
+	where, err := wfs.(*FakeInstanceFs).Fs.(*afero.BasePathFs).RealPath(device["path"])
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(where)
 }
 
 func (f *FakeWorkshopBackend) AddWorkshopConfig(ctx context.Context, name string, item *workshop.WorkshopConfigValue) error {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -662,15 +662,8 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, 
 		return err
 	}
 
-	sdks := []string{sdk.System.String()}
-	for _, sk := range wp.File.Sdks {
-		if !workshop.IsImplicitSdk(sk.Name) {
-			sdks = append(sdks, sk.Name)
-		}
-	}
-	sdks = append(sdks, sdk.Sketch)
-
-	lastIntact := slices.IndexFunc(sdks, func(s string) bool { return workshop.SnapshotId(name, s) == snapid })
+	sdks := wp.SdksByInstallOrder()
+	lastIntact := slices.IndexFunc(sdks, func(s sdk.Setup) bool { return workshop.SnapshotId(name, s.Name) == snapid })
 	if lastIntact < 0 {
 		return fmt.Errorf("invalid snapshot %q", snapid)
 	}
@@ -682,9 +675,18 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, 
 		return err
 	}
 	for _, sk := range unwantedSdks {
-		if err = fs.RemoveAll(sdk.SdkRootPath(sk)); err != nil {
+		if err = fs.RemoveAll(sdk.SdkDir(sk.Name)); err != nil {
 			return err
 		}
+		delete(wp.Sdks, sk.Name)
+	}
+	value, err := json.Marshal(wp.Sdks)
+	if err != nil {
+		return err
+	}
+	item := &workshop.WorkshopConfigValue{Name: workshop.ConfigWorkshopSdks, Value: string(value)}
+	if err := s.AddWorkshopConfig(ctx, name, item); err != nil {
+		return err
 	}
 
 	wp.File = file

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -173,25 +173,9 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 
 	if wpe, ok := f.Workshops[projectId][file.Name]; ok {
 		// rebuild the workshop
-
 		ws = wpe
 		ws.File = file
 		ws.Base = file.Base
-		fs := ws.WorkshopFilesystem
-
-		// TODO: Remove locally installed SDKs. These should be removed in a
-		// more elegant way, i.e. unmounted from the workshop in a similar
-		// fashion to regular SDKs installed from the store. Thus, it will make
-		// SDKs "independent" of the workshop, which means that changes will
-		// have to take care of unmounting them from the workshop at the right
-		// time.
-		// NOTE: RemoveAll ignores E_NOENT.
-		if err = fs.RemoveAll(sdk.SdkRootPath("system")); err != nil {
-			return err
-		}
-		if err = fs.RemoveAll(sdk.SdkRootPath("sketch")); err != nil {
-			return err
-		}
 	} else {
 		ws.Workshop = &workshop.Workshop{Backend: f,
 			Name:    file.Name,
@@ -200,11 +184,12 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 			Base:    file.Base,
 			File:    file,
 		}
-		ws.WorkshopFilesystem, err = NewWorkshopFs(f.BaseDir)
-		if err != nil {
-			return err
-		}
 		f.Workshops[projectId][file.Name] = ws
+	}
+
+	ws.WorkshopFilesystem, err = NewWorkshopFs(f.BaseDir)
+	if err != nil {
+		return err
 	}
 
 	ws.Config = make(map[string]string)
@@ -634,21 +619,37 @@ func (s *FakeWorkshopBackend) Snapshot(ctx context.Context, name, snapid string)
 }
 
 func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, file *workshop.File) error {
-	user, projectId, err := s.userProject(ctx)
+	wp, err := s.Workshop(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	prj := s.project(user, projectId)
-
-	s.workshopLock.Lock()
-	if wp, ok := s.Workshops[prj.ProjectId][name]; !ok {
-		defer s.workshopLock.Unlock()
-		return workshop.ErrWorkshopNotLaunched
-	} else {
-		wp.File = file
+	sdks := []string{sdk.System.String()}
+	for _, sk := range wp.File.Sdks {
+		if !workshop.IsImplicitSdk(sk.Name) {
+			sdks = append(sdks, sk.Name)
+		}
 	}
-	s.workshopLock.Unlock()
+	sdks = append(sdks, sdk.Sketch)
+
+	lastIntact := slices.IndexFunc(sdks, func(s string) bool { return workshop.SnapshotId(name, s) == snapid })
+	if lastIntact < 0 {
+		return fmt.Errorf("invalid snapshot %q", snapid)
+	}
+	unwantedSdks := sdks[lastIntact+1:]
+
+	// Remove SDKs from after the snapshot.
+	fs, err := s.WorkshopFs(ctx, name)
+	if err != nil {
+		return err
+	}
+	for _, sk := range unwantedSdks {
+		if err = fs.RemoveAll(sdk.SdkRootPath(sk)); err != nil {
+			return err
+		}
+	}
+
+	wp.File = file
 
 	s.snapshotLock.Lock()
 	defer s.snapshotLock.Unlock()

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -889,8 +889,6 @@ func (s *Backend) Restore(ctx context.Context, name, snapid string, file *worksh
 		return err
 	}
 
-	// The restored snapshot will have an updated file and empty profiles.
-	// Similar to how a launched workshop is associated with its definition.
 	restored, etag, err := conn.GetInstance(InstanceName(name, projectId))
 	if err != nil {
 		return err
@@ -901,14 +899,9 @@ func (s *Backend) Restore(ctx context.Context, name, snapid string, file *worksh
 		return err
 	}
 
-	// Restore from a snapshot also restores the workshop configuration at the
-	// time the snapshot was made. We need the restored configuration to have
-	// the current instance's configuration as it reflects the installed SDKs
-	// list, for example.
-	// Reset it to the actual configuration of the instance.
-	restored.Config["user.workshop.sdks"] = instPut.Config["user.workshop.sdks"]
-	restored.Config["user.workshop.file"] = string(f)
-	restored.Profiles = []string{"default"}
+	// The restored snapshot will have an updated file.
+	// Similar to how a launched workshop is associated with its definition.
+	restored.Config[workshop.ConfigWorkshopFile] = string(f)
 
 	op, err = conn.UpdateInstance(inst.Name, restored.Writable(), etag)
 	if err != nil {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"net/http"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -21,7 +20,6 @@ import (
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
@@ -40,7 +38,6 @@ const (
 )
 
 var (
-	defaultDevices      = createDefaultDevices
 	checkNvidiaRuntime  = checkNvidia
 	startCommandTimeout = 1 * time.Minute
 )
@@ -275,7 +272,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 	if err != nil {
 		return err
 	}
-	devices := defaultDevices()
+	devices := defaultDevices(projectId, file.Name)
 
 	inst, _, err := conn.GetInstanceFull(InstanceName(file.Name, projectId))
 	switch {
@@ -529,6 +526,17 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, mount works
 		return err
 	}
 
+	inst.Devices[mount.Name] = mountToLxdDisk(mount)
+
+	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
+	if err != nil {
+		return err
+	}
+
+	return op.WaitContext(ctx)
+}
+
+func mountToLxdDisk(mount workshop.Mount) map[string]string {
 	device := map[string]string{
 		"type":     "disk",
 		"source":   mount.What,
@@ -538,14 +546,7 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, mount works
 	if mount.Type == workshop.Volume {
 		device["pool"] = storagePool
 	}
-	inst.Devices[mount.Name] = device
-
-	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
-	if err != nil {
-		return err
-	}
-
-	return op.WaitContext(ctx)
+	return device
 }
 
 func (s *Backend) RemoveWorkshopMount(ctx context.Context, name, mount string) error {
@@ -948,16 +949,38 @@ func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {
 	}
 }
 
-func createDefaultDevices() map[string]map[string]string {
-	// configure .untrusted socket mount
-	shostpath := dirs.SocketPath + ".untrusted"
-	swspath := filepath.Join(dirs.WorkshopRunDir, filepath.Base(shostpath))
-	return map[string]map[string]string{
-		"root":                 {"type": "disk", "pool": storagePool, "path": "/"},
-		"workshop.network":     {"type": "nic", "network": networkName, "name": "eth0"},
-		"workshop.socket":      {"type": "proxy", "connect": "unix:" + shostpath, "listen": "unix:" + swspath, "bind": "instance", "mode": "0666"},
-		"workshop.workshopctl": {"type": "disk", "source": filepath.Join(dirs.ExecDir, "workshopctl"), "path": "/usr/bin/workshopctl"},
+func defaultDevices(pid, w string) map[string]map[string]string {
+	devices := map[string]map[string]string{
+		"root":             {"type": "disk", "pool": storagePool, "path": "/"},
+		"workshop.network": {"type": "nic", "network": networkName, "name": "eth0"},
 	}
+
+	mounts, proxies := workshop.DefaultDevices(pid, w)
+	for _, mount := range mounts {
+		devices[mount.Name] = mountToLxdDisk(mount)
+	}
+
+	for _, proxy := range proxies {
+		devices[proxy.Name] = proxyToLxdDevice(proxy)
+	}
+
+	return devices
+}
+
+func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
+	device := map[string]string{
+		"type":    "proxy",
+		"connect": proxy.Connect.Protocol + ":" + proxy.Connect.Address,
+		"listen":  proxy.Listen.Protocol + ":" + proxy.Listen.Address,
+		"mode":    "0666",
+	}
+	switch proxy.Direction {
+	case workshop.WorkshopToHost:
+		device["bind"] = "instance"
+	case workshop.HostToWorkshop:
+		device["bind"] = "host"
+	}
+	return device
 }
 
 func checkNvidia() (bool, error) {
@@ -1056,13 +1079,32 @@ runcmd:
 		return map[string]string{}, err
 	}
 
+	nvidiaRuntime, err := checkNvidiaRuntime()
+	if err != nil {
+		return nil, err
+	}
+
+	// nvidia.* properties must be set at launch as otherwise it requires a
+	// container restart to take effect.
+	cfgNvidiaDriverCapabilities := ""
+	cfgNvidiaRuntime := ""
+	if nvidiaRuntime {
+		cfgNvidiaDriverCapabilities = "all"
+		cfgNvidiaRuntime = "true"
+	}
+
+	// Include all options we might change, even those with default values,
+	// so that workshops can be rebuilt.
 	cfg := map[string]string{
-		"raw.idmap":                fmt.Sprintf("uid %s %s\ngid %s %s", userid, workshop.User.Uid, groupid, workshop.User.Gid),
-		"security.nesting":         "true",
-		"user.workshop.project-id": projectId,
-		"user.user-data":           cloudInitConfig,
-		"user.workshop.file":       string(f),
-		"user.workshop.sdks":       "{}",
+		"boot.autostart":             "false",
+		"raw.idmap":                  fmt.Sprintf("uid %s %s\ngid %s %s", userid, workshop.User.Uid, groupid, workshop.User.Gid),
+		"security.nesting":           "true",
+		"user.workshop.project-id":   projectId,
+		"user.user-data":             cloudInitConfig,
+		"user.workshop.file":         string(f),
+		"user.workshop.sdks":         "{}",
+		"nvidia.driver.capabilities": cfgNvidiaDriverCapabilities,
+		"nvidia.runtime":             cfgNvidiaRuntime,
 		// LXC appears to have a race condition wherein a proxy device mounted in
 		// a dynamically created directory has the potential to be 'masked' by this
 		// directory. We create an explicit mount for /tmp here (one such dymanic
@@ -1070,25 +1112,7 @@ runcmd:
 		// See: https://github.com/lxc/lxc/issues/434
 		"raw.lxc": "lxc.mount.entry = tmpfs tmp tmpfs defaults",
 	}
-
-	nvidiaRuntime, err := checkNvidiaRuntime()
-	if err != nil {
-		return nil, err
-	}
-
-	if nvidiaRuntime {
-		// nvidia.* properties must be set at launch as otherwise it requires a
-		// container restart to take effect.
-		cfg["nvidia.driver.capabilities"] = "all"
-		cfg["nvidia.runtime"] = "true"
-	}
 	return cfg, nil
-}
-
-func FakeDefaultDevices(f func() map[string]map[string]string) func() {
-	oldDefault := defaultDevices
-	defaultDevices = f
-	return func() { defaultDevices = oldDefault }
 }
 
 func FakeStartCommand(script string) func() {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -325,7 +325,14 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			return err
 		}
 
+		// TODO: Run mount-project after snapshots, and delete this workaround.
+		projectPathDevice, ok := rebuilt.Devices[workshop.ConfigProjectPathDevice]
+		if ok {
+			devices[workshop.ConfigProjectPathDevice] = projectPathDevice
+		}
+
 		maps.Copy(rebuilt.Config, config)
+		clear(rebuilt.Devices)
 		maps.Copy(rebuilt.Devices, devices)
 
 		op, err := conn.UpdateInstance(rebuilt.Name, rebuilt.Writable(), etag)

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"gopkg.in/check.v1"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -29,11 +28,8 @@ scripts:
 
 var MinimalImageServer = "simplestreams:https://cloud-images.ubuntu.com/minimal/releases/"
 
-func DefaultTestDevices() map[string]map[string]string {
-	return map[string]map[string]string{
-		"root":             {"type": "disk", "pool": "workshop", "path": "/"},
-		"workshop.network": {"type": "nic", "network": "workshopbr0", "name": "eth0"},
-	}
+func DefaultTestDevices(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
+	return nil, nil
 }
 
 func CleanupLxdProject(c *check.C, client lxd.InstanceServer, project string) {
@@ -127,8 +123,6 @@ printf '%s\n' "$@"
 
 	volume := workshop.AptCacheVolumeName(wf.Name, prj.ProjectId)
 	err = bd.CreateVolume(ctx, volume)
-	c.Assert(err, check.IsNil)
-	err = bd.AttachVolume(ctx, wf.Name, volume, dirs.AptCachePath, false)
 	c.Assert(err, check.IsNil)
 
 	err = bd.StartWorkshop(ctx, "test")

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -41,11 +41,15 @@ type wsExec struct {
 
 var _ = check.Suite(&wsExec{})
 
-func execTestDevices(projectDir string) func() map[string]map[string]string {
-	conf := helper.DefaultTestDevices()
-	conf["workshop.project"] = map[string]string{"type": "disk", "source": projectDir, "path": "/project"}
-	return func() map[string]map[string]string {
-		return conf
+func execTestDevices(projectDir string) func(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
+	mounts := []workshop.Mount{{
+		Name:  workshop.ConfigProjectPathDevice,
+		What:  projectDir,
+		Where: workshop.WorkshopProjectPath,
+		Type:  workshop.HostWorkshop,
+	}}
+	return func(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
+		return mounts, nil
 	}
 }
 
@@ -99,7 +103,7 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 		return f.usr, nil
 	}, &daemon.LookupUserId)
 
-	f.restoreDevices = lxdbackend.FakeDefaultDevices(execTestDevices(c.MkDir()))
+	f.restoreDevices = workshop.FakeDefaultDevices(execTestDevices(c.MkDir()))
 
 	f.newProjectidRestore = testutil.FakeFunc(func() (string, error) {
 		return f.project.ProjectId, nil

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"os"
 	"os/user"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 
@@ -421,7 +420,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
 	w, err := f.bd.Workshop(f.ctx, "test")
-	c.Check(err, check.IsNil)
+	c.Assert(err, check.IsNil)
 
 	setup := sdk.Setup{Name: sdk.System.String(), Revision: system.SystemSdkRevision}
 	err = system.RetrieveSystemSdk(setup, nil)
@@ -431,12 +430,11 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	err = f.bd.ImportVolume(f.ctx, volume, setup.Filepath())
 	c.Assert(err, check.IsNil)
 
-	sdkPath := filepath.Join(dirs.WorkshopSdksDir, setup.Name, setup.Revision.String())
-	err = f.bd.AttachVolume(f.ctx, "test", volume, sdkPath, true)
+	err = f.bd.AttachVolume(f.ctx, "test", volume, sdk.SdkDir(setup.Name), true)
 	c.Assert(err, check.IsNil)
 
-	err = w.LinkSdk(f.ctx, setup)
-	c.Check(err, check.IsNil)
+	err = w.AddSdk(f.ctx, setup)
+	c.Assert(err, check.IsNil)
 	c.Check(w.Sdks, check.HasLen, 1)
 
 	err = f.bd.StopWorkshop(f.ctx, "test", true)
@@ -445,24 +443,31 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	err = f.bd.Snapshot(f.ctx, "test", "snapshot-1")
 	c.Assert(err, check.IsNil)
 
+	err = f.bd.AttachVolume(f.ctx, "test", volume, sdk.SdkDir("sdk"), true)
+	c.Assert(err, check.IsNil)
+
+	err = w.AddSdk(f.ctx, sdk.Setup{Name: "sdk", Revision: sdk.R(5)})
+	c.Assert(err, check.IsNil)
+	c.Check(w.Sdks, check.HasLen, 2)
+
 	wf := &workshop.File{
 		Name: "test",
 		Base: "ubuntu@24.04",
 	}
-	// The instance's configuration does not have any SDK in user.workshop.sdks
-	// after this.
-	err = w.UnlinkSdk(f.ctx, setup.Name)
-	c.Check(err, check.IsNil)
-
+	// The instance's configuration only has the system SDK after this.
 	err = f.bd.Restore(f.ctx, "test", "snapshot-1", wf)
 	c.Assert(err, check.IsNil)
 
 	w, err = f.bd.Workshop(f.ctx, "test")
-	c.Check(err, check.IsNil)
+	c.Assert(err, check.IsNil)
 	c.Check(w.Running, check.Equals, false)
-	// Check that restore did not restore previous version of
-	// "user.workshop.sdks" or "user.workshop.file" and uses the instance's
-	// configuration, not the snapshot's.
+	// Check that Restore uses the provided "user.workshop.file" and removes "sdk".
 	c.Check(w.File, check.DeepEquals, wf)
-	c.Check(w.Sdks, check.HasLen, 0)
+	c.Check(w.Sdks, check.HasLen, 1)
+
+	fs, err := f.bd.WorkshopFs(f.ctx, "test")
+	c.Assert(err, check.IsNil)
+	defer fs.Close()
+	_, err = fs.Stat(sdk.SdkDir("sdk"))
+	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
 }

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -49,7 +49,7 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 	}
 	f.ctx = helper.CreateTestContext(f.usr.Username, "42424242")
 
-	f.restoreDevices = lxdbackend.FakeDefaultDevices(helper.DefaultTestDevices)
+	f.restoreDevices = workshop.FakeDefaultDevices(helper.DefaultTestDevices)
 	f.restoreImageServer = lxdbackend.FakeImageServer(helper.MinimalImageServer)
 	f.restoreLookupUsr = osutil.FakeUserLookup(func(name string) (*user.User, error) {
 		return f.usr, nil

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"os"
 	"os/user"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
@@ -37,6 +39,8 @@ type wsOps struct {
 var _ = check.Suite(&wsOps{})
 
 func (f *wsOps) SetUpSuite(c *check.C) {
+	c.Assert(dirs.CreateDirs(), check.IsNil)
+
 	var err error
 
 	f.bd, err = lxdbackend.New()
@@ -418,9 +422,20 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 
 	w, err := f.bd.Workshop(f.ctx, "test")
 	c.Check(err, check.IsNil)
-	err = w.InstallLocalSdk(f.ctx, sdk.System.String(), "x1", system.SystemSdkFs)
-	c.Check(err, check.IsNil)
-	err = w.LinkSdk(f.ctx, sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(-1)})
+
+	setup := sdk.Setup{Name: sdk.System.String(), Revision: system.SystemSdkRevision}
+	err = system.RetrieveSystemSdk(setup, nil)
+	c.Assert(err, check.IsNil)
+
+	volume := sdk.VolumeName(setup.Name, setup.Revision)
+	err = f.bd.ImportVolume(f.ctx, volume, setup.Filepath())
+	c.Assert(err, check.IsNil)
+
+	sdkPath := filepath.Join(dirs.WorkshopSdksDir, setup.Name, setup.Revision.String())
+	err = f.bd.AttachVolume(f.ctx, "test", volume, sdkPath, true)
+	c.Assert(err, check.IsNil)
+
+	err = w.LinkSdk(f.ctx, setup)
 	c.Check(err, check.IsNil)
 	c.Check(w.Sdks, check.HasLen, 1)
 
@@ -436,7 +451,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	}
 	// The instance's configuration does not have any SDK in user.workshop.sdks
 	// after this.
-	err = w.UnlinkSdk(f.ctx, sdk.System.String())
+	err = w.UnlinkSdk(f.ctx, setup.Name)
 	c.Check(err, check.IsNil)
 
 	err = f.bd.Restore(f.ctx, "test", "snapshot-1", wf)

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -9,10 +9,10 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"syscall"
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/osutil/sys"
 )
 
 var (
@@ -341,13 +341,12 @@ func (w *Project) updateLock() error {
 		return err
 	}
 
-	uid, gid := 0, 0
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		uid = int(stat.Uid)
-		gid = int(stat.Gid)
+	uid, gid, err := sys.FileOwner(info)
+	if err != nil {
+		return err
 	}
 
-	if err = os.Chown(LockPath(w.Path), uid, gid); err != nil {
+	if err = sys.Chown(lock, uid, gid); err != nil {
 		return err
 	}
 

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -218,8 +218,8 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 		return nil, fmt.Errorf("SDK must be named %q (now: %q)", sdkName, info.Name)
 	}
 
-	// system SDK will always have its workshop's base.
-	if info.Type == sdk.System {
+	// Local SDKs will always have the workshop's base.
+	if setup.Revision.Local() {
 		info.Base = w.Base
 	}
 	info.Revision = setup.Revision

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -3,7 +3,6 @@ package workshop
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -14,7 +13,6 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/internal/osutil"
-	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 )
 
@@ -43,103 +41,43 @@ type Workshop struct {
 	Profiles map[string]SdkProfile
 }
 
-// Associate an SDK with the workshop by creating a 'current' symlink and adding
-// the SDK to the Sdks field.
-func (w *Workshop) LinkSdk(ctx context.Context, s sdk.Setup) error {
-	fs, err := w.Backend.WorkshopFs(ctx, w.Name)
-	if err != nil {
-		return err
-	}
-	defer fs.Close()
-
-	// Update the current link to point out to the newly installed SDK.
-	sdkrev := sdk.SdkRevPath(s.Name, s.Revision.String())
-	current := sdk.SdkCurrentPath(s.Name)
-
-	rev := revert.New()
-	defer rev.Fail()
-
-	oldcur, err := fs.ReadLink(current)
-	if err != nil && !osutil.IsDirNotExist(err) {
-		return err
-	}
-	if err == nil {
-		// The link could already be existing (e.g. there is a previous
-		// revision).
-		if err = fs.Remove(current); err != nil {
-			return err
-		}
-		rev.Add(func() { _ = fs.Symlink(oldcur, current) })
-	}
-
-	if err = fs.Symlink(sdkrev, current); err != nil {
-		return err
-	}
-	rev.Add(func() { _ = fs.Remove(current) })
-
+// Associate an SDK with the workshop by adding the SDK to the Sdks field.
+func (w *Workshop) AddSdk(ctx context.Context, s sdk.Setup) error {
 	now := InstallTimeNow()
 	s.InstallTime = &now
 
 	_, exist := w.Sdks[s.Name]
 	if exist {
-		return fmt.Errorf("%q SDK is already linked", s.Name)
+		return fmt.Errorf("%q SDK is already installed", s.Name)
 	} else {
 		w.Sdks[s.Name] = s
 	}
 
-	sequenceValue, err := json.Marshal(w.Sdks)
+	value, err := json.Marshal(w.Sdks)
 	if err != nil {
 		return err
 	}
 
-	err = w.Backend.AddWorkshopConfig(ctx, w.Name,
-		&WorkshopConfigValue{
-			Name:  ConfigWorkshopSdks,
-			Value: string(sequenceValue),
-		})
-
-	if err != nil {
-		return err
+	item := &WorkshopConfigValue{
+		Name:  ConfigWorkshopSdks,
+		Value: string(value),
 	}
-
-	rev.Success()
-	return nil
+	return w.Backend.AddWorkshopConfig(ctx, w.Name, item)
 }
 
-// Stops associating an SDK with the workshop by removing a 'current' symlink and
-// removing the SDK from the workshop "installed" SDKs if there are no more
-// revisions left.
-func (w *Workshop) UnlinkSdk(ctx context.Context, name string) error {
+// Stops associating an SDK with the workshop by removing the SDK from the Sdks field.
+func (w *Workshop) RemoveSdk(ctx context.Context, name string) error {
 	delete(w.Sdks, name)
-	newSequence, err := json.Marshal(w.Sdks)
+	value, err := json.Marshal(w.Sdks)
 	if err != nil {
 		return err
 	}
 
-	err = w.Backend.AddWorkshopConfig(ctx, w.Name,
-		&WorkshopConfigValue{
-			Name:  ConfigWorkshopSdks,
-			Value: string(newSequence),
-		})
-	if err != nil {
-		return err
+	item := &WorkshopConfigValue{
+		Name:  ConfigWorkshopSdks,
+		Value: string(value),
 	}
-
-	// Update the 'current' link
-	fs, err := w.Backend.WorkshopFs(ctx, w.Name)
-	if err != nil {
-		return err
-	}
-	defer fs.Close()
-
-	// No revisions left in the sequence, remove the 'current' link.
-	// This will be the case during a launch operation that fails, therefore it's
-	// possible for there to be no current revision to remove.
-	if err = fs.Remove(sdk.SdkCurrentPath(name)); errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-
-	return err
+	return w.Backend.AddWorkshopConfig(ctx, w.Name, item)
 }
 
 func WorkshopName(instance string) string {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/afero"
-
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
@@ -177,15 +175,22 @@ func (w *Workshop) metaFromVolume(ctx context.Context, setup sdk.Setup) (string,
 	return meta, nil
 }
 
-func (w *Workshop) metaFromFs(ctx context.Context, setup sdk.Setup) (string, error) {
-	fs, err := w.Backend.WorkshopFs(ctx, w.Name)
+func (w *Workshop) metaFromFile(ctx context.Context, setup sdk.Setup) (string, error) {
+	username, ok := ctx.Value(ContextUser).(string)
+	if !ok {
+		return "", fmt.Errorf("context key %s not found", ContextUser)
+	}
+
+	usr, env, err := osutil.UserAndEnv(username)
 	if err != nil {
 		return "", err
 	}
-	defer fs.Close()
+	userDataDir := UserDataRootDir(usr.HomeDir, env)
 
-	metapath := sdk.SdkMetaPath(setup.Name)
-	meta, err := afero.ReadFile(fs, metapath)
+	rev := LocalSdkRevision(userDataDir, w.Project.ProjectId, w.Name, setup.Name, setup.Revision)
+	metapath := filepath.Join(rev, "meta", "sdk.yaml")
+
+	meta, err := os.ReadFile(metapath)
 	return string(meta), err
 }
 
@@ -199,7 +204,7 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	var err error
 	var meta string
 	if setup.Revision.Local() {
-		meta, err = w.metaFromFs(ctx, setup)
+		meta, err = w.metaFromFile(ctx, setup)
 	} else {
 		meta, err = w.metaFromVolume(ctx, setup)
 	}

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -20,7 +20,6 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/sdk/system"
 )
 
 var (
@@ -218,8 +217,8 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 		return nil, fmt.Errorf("SDK must be named %q (now: %q)", sdkName, info.Name)
 	}
 
-	// Local SDKs will always have the workshop's base.
-	if setup.Revision.Local() {
+	// Local and system SDKs will always have the workshop's base.
+	if setup.Revision.Local() || info.Type == sdk.System {
 		info.Base = w.Base
 	}
 	info.Revision = setup.Revision
@@ -382,7 +381,7 @@ func (w *Workshop) InstallLocalSdk(ctx context.Context, name string, rev string,
 	defer reverter.Fail()
 
 	// meta: /var/lib/workshop/sdk/<name>/<rev>/meta
-	metasrc := system.SdkMeta
+	metasrc := filepath.Join("meta", "sdk.yaml")
 	metadst := filepath.Join(sdk.SdkRevPath(name, rev), "meta", "sdk.yaml")
 
 	if err = install(wfs, src, metasrc, metadst, 0644); err != nil {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -349,74 +347,6 @@ func (w *Workshop) Mounts(sdks []*sdk.Info) map[string][]Mount {
 	}
 
 	return mnts
-}
-
-func install(wfs WorkshopFs, srcfs fs.FS, src, dst string, perm fs.FileMode) error {
-	filesrc, err := srcfs.Open(src)
-	if err != nil {
-		return err
-	}
-	defer filesrc.Close()
-
-	dstdir := filepath.Dir(dst)
-	if err := wfs.MkdirAll(dstdir, 0755); err != nil {
-		return err
-	}
-
-	filedst, err := wfs.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, perm)
-	if err != nil {
-		return err
-	}
-	defer filedst.Close()
-
-	if _, err = io.Copy(filedst, filesrc); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (w *Workshop) InstallLocalSdk(ctx context.Context, name string, rev string, src fs.FS) error {
-	wfs, err := w.Backend.WorkshopFs(ctx, w.Name)
-	if err != nil {
-		return err
-	}
-	defer wfs.Close()
-
-	reverter := revert.New()
-	defer reverter.Fail()
-
-	// meta: /var/lib/workshop/sdk/<name>/<rev>/meta
-	metasrc := filepath.Join("meta", "sdk.yaml")
-	metadst := filepath.Join(sdk.SdkRevPath(name, rev), "meta", "sdk.yaml")
-
-	if err = install(wfs, src, metasrc, metadst, 0644); err != nil {
-		return err
-	}
-	reverter.Add(func() { _ = wfs.RemoveAll(filepath.Dir(metadst)) })
-
-	// hooks: /var/lib/workshop/sdk/<name>/<rev>/sdk/hooks
-	hooksdir := filepath.Join(sdk.SdkRevPath(name, rev), "sdk", "hooks")
-	reverter.Add(func() { _ = wfs.RemoveAll(hooksdir) })
-
-	for _, hook := range []string{"setup-base", "save-state", "restore-state", "check-health"} {
-		hooksrc := filepath.Join("hooks", hook)
-		hookdst := filepath.Join(hooksdir, hook)
-
-		// Hooks are optional.
-		if _, err := src.Open(hooksrc); err != nil {
-			if !osutil.IsDirNotExist(err) {
-				return err
-			}
-			continue
-		}
-
-		if err = install(wfs, src, hooksrc, hookdst, 0755); err != nil {
-			return err
-		}
-	}
-
-	reverter.Success()
-	return nil
 }
 
 func SnapshotId(w, sk string) string {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -224,6 +224,7 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	}
 	info.Revision = setup.Revision
 	info.Channel = setup.Channel
+	info.Source = setup.Source
 
 	// Now add changes defined for this SDK in the workshop file (e.g. plug
 	// binds, slots).

--- a/internal/workshop/workshop_dirs.go
+++ b/internal/workshop/workshop_dirs.go
@@ -2,6 +2,8 @@ package workshop
 
 import (
 	"path/filepath"
+
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 func UserDataRootDir(homedir string, env map[string]string) string {
@@ -36,8 +38,16 @@ func SdkMountHostSource(userDataDir, pid, w, sdk, plug string) string {
 	return filepath.Join(SdkMountDir(userDataDir, pid, w, sdk), plug)
 }
 
+func LocalSdkDir(userDataDir, pid, w, name string) string {
+	return filepath.Join(UserData(userDataDir, pid, w), "sdk", name)
+}
+
+func LocalSdkRevision(userDataDir, pid, w, name string, revision sdk.Revision) string {
+	return filepath.Join(LocalSdkDir(userDataDir, pid, w, name), revision.String())
+}
+
 func SketchSdkDir(userDataDir, pid, w string) string {
-	return filepath.Join(UserData(userDataDir, pid, w), "sdk", "sketch")
+	return LocalSdkDir(userDataDir, pid, w, sdk.Sketch)
 }
 
 func SketchSdkCurrent(userDataDir, pid, w string) string {

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -27,7 +27,7 @@ var _ = check.Suite(&workshopFile{})
 func TestWorkshop(t *testing.T) { check.TestingT(t) }
 
 func TestMain(m *testing.M) {
-	// Ensure consistent file permissions for workshopSuite and workshopFsSuite.
+	// Ensure consistent file permissions for workshopSuite, workshopFsSuite and localSdk.
 	syscall.Umask(0002)
 	m.Run()
 }

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -24,6 +25,12 @@ type workshopFile struct {
 var _ = check.Suite(&workshopFile{})
 
 func TestWorkshop(t *testing.T) { check.TestingT(t) }
+
+func TestMain(m *testing.M) {
+	// Ensure consistent file permissions for workshopSuite and workshopFsSuite.
+	syscall.Umask(0002)
+	m.Run()
+}
 
 func (f *workshopFile) SetUpTest(c *check.C) {
 	f.fs = afero.NewMemMapFs()

--- a/internal/workshop/workshop_fs_test.go
+++ b/internal/workshop/workshop_fs_test.go
@@ -27,53 +27,37 @@ func (f *workshopFsSuite) SetUpTest(c *check.C) {
 }
 
 func (f *workshopFsSuite) TestAtomicWrite(c *check.C) {
-	c.Assert(workshop.AtomicWrite(f.fs, "/file", strings.NewReader("content"), 0200), check.IsNil)
+	c.Assert(workshop.AtomicWrite(f.fs, "/file", strings.NewReader("content"), 0400), check.IsNil)
 
-	info, err := f.fs.Stat("/file")
+	c.Check(f.fs, testutil.DirEquals, []string{"-r-------- file"})
+	content, err := afero.ReadFile(f.fs, "/file")
 	c.Assert(err, check.IsNil)
-	c.Check(info.Name(), check.Equals, "file")
-	c.Check(info.Size(), check.Equals, int64(7))
-	c.Check(info.Mode().Perm(), check.Equals, os.FileMode(0200))
-	c.Check(info.IsDir(), check.Equals, false)
+	c.Check(string(content), check.Equals, "content")
 
-	infos, err := afero.ReadDir(f.fs, "/")
+	c.Assert(workshop.AtomicWrite(f.fs, "/file", strings.NewReader("new"), 0500), check.IsNil)
+	c.Check(f.fs, testutil.DirEquals, []string{"-r-x------ file"})
+	content, err = afero.ReadFile(f.fs, "/file")
 	c.Assert(err, check.IsNil)
-	c.Assert(infos, check.HasLen, 1)
-	c.Check(infos[0].Name(), check.Equals, "file")
-
-	c.Assert(workshop.AtomicWrite(f.fs, "/file", strings.NewReader("new"), 0100), check.IsNil)
-
-	info, err = f.fs.Stat("/file")
-	c.Assert(err, check.IsNil)
-	c.Check(info.Name(), check.Equals, "file")
-	c.Check(info.Size(), check.Equals, int64(3))
-	c.Check(info.Mode().Perm(), check.Equals, os.FileMode(0100))
-	c.Check(info.IsDir(), check.Equals, false)
-
-	infos, err = afero.ReadDir(f.fs, "/")
-	c.Assert(err, check.IsNil)
-	c.Assert(infos, check.HasLen, 1)
-	c.Check(infos[0].Name(), check.Equals, "file")
+	c.Check(string(content), check.Equals, "new")
 }
 
 func (f *workshopFsSuite) TestAtomicWriteNameOnly(c *check.C) {
 	err := workshop.AtomicWrite(f.fs, "file", strings.NewReader("content"), 0644)
 	c.Check(err, check.ErrorMatches, `parent directory not found for "file"`)
+	c.Check(f.fs, testutil.DirEquals, []string{})
 }
 
 func (f *workshopFsSuite) TestAtomicWriteNoDirectory(c *check.C) {
 	err := workshop.AtomicWrite(f.fs, "/var/tmp/file", strings.NewReader("content"), 0644)
 	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
+	c.Check(f.fs, testutil.DirEquals, []string{})
 }
 
 func (f *workshopFsSuite) TestAtomicWriteSourceError(c *check.C) {
 	expected := errors.New("fake error")
 	err := workshop.AtomicWrite(f.fs, "/file", &ErrorSource{expected}, 0644)
 	c.Check(err, testutil.ErrorIs, expected)
-
-	infos, err := afero.ReadDir(f.fs, "/")
-	c.Assert(err, check.IsNil)
-	c.Assert(infos, check.HasLen, 0)
+	c.Check(f.fs, testutil.DirEquals, []string{})
 }
 
 type ErrorSource struct {
@@ -89,12 +73,7 @@ func (f *workshopFsSuite) TestAtomicWriteRenameFailed(c *check.C) {
 	err := workshop.AtomicWrite(f.fs, "/file", strings.NewReader("content"), 0644)
 	c.Check(err, testutil.ErrorIs, os.ErrExist)
 
-	infos, err := afero.ReadDir(f.fs, "/")
-	c.Assert(err, check.IsNil)
-	c.Assert(infos, check.HasLen, 1)
-	c.Check(infos[0].Name(), check.Equals, "file")
-
-	infos, err = afero.ReadDir(f.fs, "/file")
-	c.Assert(err, check.IsNil)
-	c.Assert(infos, check.HasLen, 0)
+	c.Check(f.fs, testutil.DirEquals, []string{"drwxrwxr-x file"})
+	dir := afero.NewBasePathFs(f.fs, "/file")
+	c.Check(dir, testutil.DirEquals, []string{})
 }

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -162,13 +162,13 @@ func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
 	w.Sdks = map[string]sdk.Setup{
 		"test-sdk-1": {Name: "test-sdk-1", Revision: sdk.R(1), Channel: "latest/stable"},
 		"test-sdk-2": {Name: "test-sdk-2", Revision: sdk.R(1), Channel: "latest/edge"},
-		"system":     {Name: "system", Revision: sdk.R(-1)},
+		"system":     {Name: "system", Revision: sdk.R(1)},
 		"sketch":     {Name: "sketch", Revision: sdk.R(-3)},
 	}
 
 	sdks := w.SdksByInstallOrder()
 	c.Assert(sdks, check.DeepEquals, []sdk.Setup{
-		{Name: "system", Revision: sdk.R(-1)},
+		{Name: "system", Revision: sdk.R(1)},
 		{Name: "test-sdk-1", Revision: sdk.R(1), Channel: "latest/stable"},
 		{Name: "test-sdk-2", Revision: sdk.R(1), Channel: "latest/edge"},
 		{Name: "sketch", Revision: sdk.R(-3)},

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -1,26 +1,17 @@
 package workshop_test
 
 import (
-	"context"
-	"io/fs"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"gopkg.in/check.v1"
 
-	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
-	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
 
 type workshopSuite struct {
-	bend *fakebackend.FakeWorkshopBackend
-	ctx  context.Context
-	p    workshop.Project
-
-	restoreUserLookup func()
+	project workshop.Project
 }
 
 var _ = check.Suite(&workshopSuite{})
@@ -36,31 +27,10 @@ sdks:
 `)
 
 func (f *workshopSuite) SetUpTest(c *check.C) {
-	var err error
-	f.bend, err = fakebackend.New(c.MkDir())
-	c.Assert(err, check.IsNil)
-
-	f.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
-		return &user.User{HomeDir: c.MkDir()}, nil
-	})
-
-	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser")
-
-	p, _, err := f.bend.CreateOrLoadProject(ctx, c.MkDir())
-	c.Assert(err, check.IsNil)
-	f.p = *p
-
-	f.ctx = createTestContext("testuser", f.p.ProjectId)
-}
-
-func (f *workshopSuite) TearDownTest(c *check.C) {
-	f.restoreUserLookup()
-}
-
-func createTestContext(username, projectId string) context.Context {
-	ctx := context.WithValue(context.Background(), workshop.ContextUser, username)
-	ctx = context.WithValue(ctx, workshop.ContextProjectId, projectId)
-	return ctx
+	f.project = workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "b8639dea",
+	}
 }
 
 func writeFile(c *check.C, path string, content string) {
@@ -68,92 +38,8 @@ func writeFile(c *check.C, path string, content string) {
 	c.Assert(os.WriteFile(path, []byte(content), 0644), check.IsNil)
 }
 
-func (f *workshopSuite) TestInstallLocalSdkMetaOnlyOK(c *check.C) {
-	wpath := filepath.Join(f.p.Path, "workshop.yaml")
-	writeFile(c, wpath, string(workshopyaml))
-	file, err := workshop.ReadWorkshop(wpath)
-	c.Assert(err, check.IsNil)
-
-	err = f.bend.LaunchOrRebuildWorkshop(f.ctx, file)
-	c.Assert(err, check.IsNil)
-
-	w, err := f.bend.Workshop(f.ctx, "test-workshop")
-	c.Assert(err, check.IsNil)
-
-	localdir := c.MkDir()
-	writeFile(c, filepath.Join(localdir, "meta/sdk.yaml"), `name: local
-base: ubuntu@22.04`)
-	localsdkFs := os.DirFS(localdir)
-
-	err = w.InstallLocalSdk(f.ctx, "local", "x1", localsdkFs)
-	c.Assert(err, check.IsNil)
-
-	wfs, err := f.bend.WorkshopFs(f.ctx, "test-workshop")
-	c.Assert(err, check.IsNil)
-
-	_, err = wfs.Stat("/var/lib/workshop/sdk/local/x1/meta/sdk.yaml")
-	c.Assert(err, check.IsNil)
-}
-
-func (f *workshopSuite) TestInstallLocalSdkNoMetaFails(c *check.C) {
-	wpath := filepath.Join(f.p.Path, "workshop.yaml")
-	writeFile(c, wpath, string(workshopyaml))
-	file, err := workshop.ReadWorkshop(wpath)
-	c.Assert(err, check.IsNil)
-
-	err = f.bend.LaunchOrRebuildWorkshop(f.ctx, file)
-	c.Assert(err, check.IsNil)
-
-	w, err := f.bend.Workshop(f.ctx, "test-workshop")
-	c.Assert(err, check.IsNil)
-
-	localdir := c.MkDir()
-	localsdkFs := os.DirFS(localdir)
-
-	err = w.InstallLocalSdk(f.ctx, "local", "x1", localsdkFs)
-	c.Assert(err, check.ErrorMatches, `open meta/sdk.yaml: no such file or directory`)
-
-	wfs, err := f.bend.WorkshopFs(f.ctx, "test-workshop")
-	c.Assert(err, check.IsNil)
-
-	_, err = wfs.Stat("/var/lib/workshop/sdk/local/x1/meta")
-	c.Assert(osutil.IsDirNotExist(err), check.Equals, true)
-}
-
-func (f *workshopSuite) TestInstallLocalSdkWithHooksOK(c *check.C) {
-	wpath := filepath.Join(f.p.Path, "workshop.yaml")
-	writeFile(c, wpath, string(workshopyaml))
-	file, err := workshop.ReadWorkshop(wpath)
-	c.Assert(err, check.IsNil)
-
-	err = f.bend.LaunchOrRebuildWorkshop(f.ctx, file)
-	c.Assert(err, check.IsNil)
-
-	w, err := f.bend.Workshop(f.ctx, "test-workshop")
-	c.Assert(err, check.IsNil)
-
-	localdir := c.MkDir()
-	writeFile(c, filepath.Join(localdir, "meta/sdk.yaml"), `name: local	
-base: ubuntu@22.04`)
-	writeFile(c, filepath.Join(localdir, "hooks/setup-base"), "")
-	localsdkFs := os.DirFS(localdir)
-
-	err = w.InstallLocalSdk(f.ctx, "local", "x1", localsdkFs)
-	c.Assert(err, check.IsNil)
-
-	wfs, err := f.bend.WorkshopFs(f.ctx, "test-workshop")
-	c.Assert(err, check.IsNil)
-
-	_, err = wfs.Stat("/var/lib/workshop/sdk/local/x1/meta/sdk.yaml")
-	c.Assert(err, check.IsNil)
-
-	info, err := wfs.Stat("/var/lib/workshop/sdk/local/x1/sdk/hooks/setup-base")
-	c.Assert(err, check.IsNil)
-	c.Check(info.Mode().Perm(), check.Equals, fs.FileMode(0755))
-}
-
 func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
-	wpath := filepath.Join(f.p.Path, "workshop.yaml")
+	wpath := filepath.Join(f.project.Path, "workshop.yaml")
 	writeFile(c, wpath, string(workshopyaml))
 	file, err := workshop.ReadWorkshop(wpath)
 	c.Assert(err, check.IsNil)

--- a/internal/x11/x11.go
+++ b/internal/x11/x11.go
@@ -27,6 +27,11 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 		return err
 	}
 
+	uid, gid, err := osutil.UidGid(user)
+	if err != nil {
+		return err
+	}
+
 	// We are performing a Stat() here to ensure that the user can't steal
 	// another user's Xauthority file. Note that while Stat() uses fstat() on the
 	// file descriptor created during Open(), the file might have changed
@@ -40,24 +45,16 @@ func MigrateXauthority(user *user.User, xauth string) (err error) {
 	if err != nil {
 		return err
 	}
-	fsys := f.Sys()
-	if fsys == nil {
-		return fmt.Errorf("cannot validate owner of file %s", f.Name())
+	fuid, _, err := sys.FileOwner(f)
+	if err != nil {
+		return &os.PathError{Op: "stat", Path: xauth, Err: err}
 	}
-	// cheap comparison as the current uid is only available as a string
-	// but it is better to convert the uid from the stat result to a
-	// string than a string into a number.
-	if fmt.Sprintf("%d", fsys.(*syscall.Stat_t).Uid) != user.Uid {
+	if fuid != uid {
 		return &os.PathError{Op: "open", Path: xauth, Err: syscall.EACCES}
 	}
 
 	destFile := filepath.Join(destDir, ".Xauthority")
 	err = osutil.CopyFile(xauth, filepath.Join(destDir, ".Xauthority"), osutil.CopyFlagOverwrite)
-	if err != nil {
-		return err
-	}
-
-	uid, gid, err := osutil.UidGid(user)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

In preparation for other types of local SDKs, revisions for sketch SDKs are now tracked on the host instead of inside the workshop. These revisions are immutable (without user misbehaviour) and are mounted read-only inside the workshop, similar to store SDKs. All SDKs are mounted at `/var/lib/workshop/sdk/<NAME>` with no revision numbers or `current` symlink.

If the user runs `sketch-sdk` and makes no changes to the YAML, the subsequent refresh will trigger, but won't do much work. Same with manual refreshes while a sketch SDK is installed.

Editing the sketch SDK is now more robust to potential concurrent edits, e.g. we don't assume the user's editor saves files atomically.

The sketch SDK template now includes `apt-get update` - when testing I forgot to put this in there a couple of times, and I suspect our users will too. It also doesn't have a `base` since this can be inferred from the workshop. Going forward, only store SDKs are likely to require a specific `base`.

The system SDK is now treated more like a store SDK, mounted from a volume (which is populated from the metadata embedded in `workshopd`). This will become important when we start allowing users to upgrade the workshop snap without removing their existing workshops. There's currently no cleanup of old system SDK "downloads", because it's not possible to recover old versions. All store SDKs could benefit from improved lifecycle management, so we can address this issue when we get to that.

Snapshots are now taken after each SDK is installed, so restoring from a snapshot doesn't require SDKs to be unmounted. Rebuilt workshops will also lose their SDKs, to be more consistent with newly launched workshops. They will retain the `/project` mount, but we plan to mount this later on and it won't be preserved during a rebuild. See https://github.com/canonical/workshop/pull/364 for more details.

Launch and refresh share more behaviour now, e.g. refresh only queries at the relevant projects/workshops and launch unlocks the state while reading workshop definition files and querying the store. I'll do some tests soon to confirm that this doesn't have a negative impact on latency. Launch will delete the sketch SDK if it finds one (left over from a snap reinstall).

Workshop will read local SDK info from the host filesystem instead of the workshop. I don't think this is necessary but it's more in line with how store SDKs work.

The tasks for installing SDKs are split into `install-sdk` and `register-sdk`. The former mounts the SDK and adds it to the instance config. The task is automatically undone when removing, restoring or rebuilding a workshop. On the other hand `register-sdk` updates the interface repo and needs to be undone before removing, restoring or rebuilding.

This breaks quite a few things, e.g. `workshop remove` will probably struggle to remove existing workshops after updating the daemon.

The documentation probably needs another pass, I'll take a look soon.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
