### PR TITLE
Update golangci-lint pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.64.5
+    rev: v2.0.2
     hooks:
       - id: golangci-lint
       - id: golangci-lint


### PR DESCRIPTION
Forgot about this the other day. The old one still seems to work but it doesn't format the code anymore.