### PR TITLE
Improve error messaging for --wait-on-error scenarios

### DIFF
--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -136,9 +136,12 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 			return nil
 		}
 		if err == errWaitOnError {
-			return fmt.Errorf("cannot launch; fix the errors reported,\n"+
-				"then run \"workshop launch --continue %s\".\n"+
-				"To abort and revert, run \"workshop launch --abort %s\"", workshopName(av[0]), workshopName(av[0]))
+			w := workshopName(av[0])
+			return fmt.Errorf(`cannot complete launch for %q, execution is paused
+
+To proceed, resolve the issue and run 'workshop refresh --continue %s'
+To cancel and undo: 'workshop refresh --abort %s'
+To view more information: 'workshop tasks %s'`, w, w, w, changeId)
 		}
 		return fmt.Errorf("%v\n%s launch aborted", err, strutil.Quoted(av))
 	}

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -87,7 +87,10 @@ func (m *workshopLaunch) TestLaunchWaitOnErrorFailed(c *check.C) {
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot launch; fix the errors reported,\nthen run "workshop launch --continue ws".\nTo abort and revert, run "workshop launch --abort ws"`)
+	c.Assert(err, check.ErrorMatches, "cannot complete launch for \"ws\", execution is paused\n\n"+
+		"To proceed, resolve the issue and run 'workshop refresh --continue ws'\n"+
+		"To cancel and undo: 'workshop refresh --abort ws'\n"+
+		"To view more information: 'workshop tasks 42'")
 }
 
 func (m *workshopLaunch) TestLaunchWaitOnErrorAbortedSuccessfully(c *check.C) {

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -167,9 +167,12 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 			return nil
 		}
 		if err == errWaitOnError {
-			return fmt.Errorf("cannot refresh; fix the errors reported,\n"+
-				"then run \"workshop refresh --continue %s\".\n"+
-				"To abort and revert, run \"workshop refresh --abort %s\"", workshopName(av[0]), workshopName(av[0]))
+			w := workshopName(av[0])
+			return fmt.Errorf(`cannot complete refresh for %q, execution is paused
+
+To proceed, resolve the issue and run 'workshop refresh --continue %s'
+To cancel and undo: 'workshop refresh --abort %s'
+To view more information: 'workshop tasks %s'`, w, w, w, changeId)
 		}
 
 		return fmt.Errorf("%v\n%s refresh aborted", err, strutil.Quoted(av))

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -172,7 +172,10 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 
 	err := cmd.Run(nil, nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot refresh; fix the errors reported,\nthen run "workshop refresh --continue ws".\nTo abort and revert, run "workshop refresh --abort ws"`)
+	c.Assert(err, check.ErrorMatches, "cannot complete refresh for \"ws\", execution is paused\n\n"+
+		"To proceed, resolve the issue and run 'workshop refresh --continue ws'\n"+
+		"To cancel and undo: 'workshop refresh --abort ws'\n"+
+		"To view more information: 'workshop tasks 42'")
 	c.Check(n, check.Equals, 4)
 }
 

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -398,7 +398,10 @@ hooks:
 	defer restore()
 
 	err := cmd.Run(cmd.Command(), []string{"ws"})
-	c.Assert(err, check.ErrorMatches, `cannot refresh; fix the errors reported,\nthen run "workshop refresh --continue ws".\nTo abort and revert, run "workshop refresh --abort ws"`)
+	c.Assert(err, check.ErrorMatches, "cannot complete refresh for \"ws\", execution is paused\n\n"+
+		"To proceed, resolve the issue and run 'workshop refresh --continue ws'\n"+
+		"To cancel and undo: 'workshop refresh --abort ws'\n"+
+		"To view more information: 'workshop tasks 43'")
 
 	err = cmd.Run(cmd.Command(), []string{"ws"})
 	c.Assert(err, check.IsNil)

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -182,10 +182,10 @@ func ResumeAfterWait(st *state.State,
 			case ChangeContinue:
 				waited := tsk.WaitedStatus()
 				tsk.SetStatus(waited)
-				tsk.Logf("Continuing for workshop %q...", workshop)
+				tsk.Logf("Continuing %q for workshop %q...", chg.Kind(), workshop)
 			case ChangeAbort:
 				tsk.SetStatus(state.DoStatus)
-				tsk.Logf("Aborting for workshop %q...", workshop)
+				tsk.Logf("Aborting %q for workshop %q...", chg.Kind(), workshop)
 			}
 		}
 	}

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -46,7 +46,6 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 				}
 
 				if mode == conflict.ChangeWaitOnError {
-					task.Logf("Setting the task to wait until the operation is either aborted or continued...")
 					task.Errorf(err.Error())
 					return &state.Wait{
 						WaitedStatus: state.DoingStatus,

--- a/internal/overlord/handlersetup/handler_setup_test.go
+++ b/internal/overlord/handlersetup/handler_setup_test.go
@@ -58,9 +58,8 @@ func (s *CommonStateFuncs) TestChangeWaitOnError(c *check.C) {
 	expected := state.Wait{Reason: "wait on error: task failed", WaitedStatus: state.DoingStatus}
 	c.Assert(err, check.ErrorMatches, expected.Error())
 	s.state.Lock()
-	c.Assert(task.Log(), check.HasLen, 2)
-	c.Assert(task.Log()[0], check.Matches, ".*Setting the task to wait until the operation is either aborted or continued...")
-	c.Assert(task.Log()[1], check.Matches, ".*task failed")
+	c.Assert(task.Log(), check.HasLen, 1)
+	c.Assert(task.Log()[0], check.Matches, ".*task failed")
 	s.state.Unlock()
 
 }

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/afero"
 	"gopkg.in/tomb.v2"
@@ -123,12 +124,18 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, proj
 	}
 
 	// create a memory out/err to log the hook output into the task's log
-	memFs := afero.NewMemMapFs()
-	out, err := memFs.Create(fmt.Sprintf("%s-%s", w, projectId))
+	memfs := afero.NewMemMapFs()
+	stdout, err := memfs.Create(fmt.Sprintf("%s-%s-%s-stdout", w, projectId, hook.Type()))
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer stdout.Close()
+
+	stderr, err := memfs.Create(fmt.Sprintf("%s-%s-%s-stderr", w, projectId, hook.Type()))
+	if err != nil {
+		return err
+	}
+	defer stderr.Close()
 
 	hook.Environment["WORKSHOP_COOKIE"] = hookCtx.ID()
 	args := workshop.Execution{
@@ -148,8 +155,8 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, proj
 		},
 		ExecControls: workshop.ExecControls{
 			Stdin:  nil,
-			Stdout: out,
-			Stderr: out,
+			Stdout: stdout,
+			Stderr: stderr,
 		},
 	}
 
@@ -162,10 +169,34 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, proj
 	err = exectx.WaitExecution(ctx)
 
 	st := task.State()
-	hookLog, _ := afero.ReadFile(memFs, out.Name())
-	if len(hookLog) > 0 {
+	isNewLine := func(r rune) bool { return r == '\n' }
+	outlog, _ := afero.ReadFile(memfs, stdout.Name())
+	if len(outlog) > 0 {
+		lines := strings.FieldsFunc(string(outlog), isNewLine)
 		st.Lock()
-		task.Logf("%s", string(hookLog))
+		for _, line := range lines {
+			task.Logf("%s", line)
+		}
+		st.Unlock()
+	}
+
+	errlog, _ := afero.ReadFile(memfs, stderr.Name())
+	if err != nil {
+		lines := strings.FieldsFunc(string(errlog), isNewLine)
+		st.Lock()
+		for i, line := range lines {
+			if i == len(lines)-1 {
+				if exerr, isCmdError := err.(*workshop.ErrExec); isCmdError {
+					// If it's an exec error, the return value would only
+					// contain the status code which is often useless to return
+					// to the upper level. We'll attempt to return the last
+					// known error line for better claririty.
+					err = fmt.Errorf("%s (exit code: %d)", line, exerr.Status)
+				}
+			} else {
+				task.Errorf("%s", line)
+			}
+		}
 		st.Unlock()
 	}
 

--- a/tests/main/launch-abort/task.yaml
+++ b/tests/main/launch-abort/task.yaml
@@ -12,7 +12,7 @@ execute: |
   workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-abort[[:space:]]+Off[[:space:]]+-$"
 
   echo "Validate the task output from the launch attempt"
-  workshop_exec tasks | tail -1 | MATCH ".*Aborting for workshop \"ws-launch-abort\"..."
+  workshop_exec tasks | tail -1 | MATCH ".*Aborting \"launch\" for workshop \"ws-launch-abort\"..."
 
   echo "Ensure SDKs are unlinked successfully during abort"
   echo "Update the workshop file to use test-sdk-mount-broken"

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -21,4 +21,4 @@ execute: |
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-abort[[:space:]]+Ready[[:space:]]+-$"
 
   echo "Validate the task output from the refresh attempt"
-  workshop_exec tasks | tail -1 | MATCH ".*Aborting for workshop \"ws-refresh-abort\"..."
+  workshop_exec tasks | tail -1 | MATCH ".*Aborting \"refresh\" for workshop \"ws-refresh-abort\"..."


### PR DESCRIPTION
# Description

This solves cryptic `command exit code: 1` error messages if a `setup-base` or other hooks failed during the `refresh` or `launch` with `--wait-on-error`. We will show the latest known error log line to indicate a possible cue and suggest the next steps.

Also, hooks will not store its entire output in the task log. This is ruthless to the json state file to keep all the logs around. For now, it will be limited by the 9 lines of logs that is hard-coded by the state package. When a raw mode will be introduced for the hooks, it shall store full logs somewhere else.

An example of the new error message:

```
2025-03-27T11:52:08+13:00 ERROR cp: cannot stat './not-found' : No such file or directory (exit code: 1)
error: cannot complete refresh for "dev", execution is paused

To proceed, resolve the issue and run 'workshop refresh --continue dev'
To cancel and undo: 'workshop refresh --abort dev'
To view more information: 'workshop tasks 1077'
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
