### PR TITLE
Use start and stop implementations for stashed workshops

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -39,8 +39,9 @@ const (
 )
 
 var (
-	defaultDevices     = createDefaultDevices
-	checkNvidiaRuntime = checkNvidia
+	defaultDevices      = createDefaultDevices
+	checkNvidiaRuntime  = checkNvidia
+	startCommandTimeout = 1 * time.Minute
 )
 
 type volumeGuard struct {
@@ -354,6 +355,10 @@ func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
 	}
 	defer conn.Disconnect()
 
+	return s.startWorkshop(conn, ctx, name)
+}
+
+func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, name string) error {
 	rev := revert.New()
 	defer rev.Fail()
 
@@ -373,12 +378,12 @@ func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
 		}
 	})
 
-	if err = s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
+	if err := s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
 		return err
 	}
 
 	// Workshop started, enable autostart.
-	if err = s.addWorkshopConfig(conn, ctx, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "true"}); err != nil {
+	if err := s.addWorkshopConfig(conn, ctx, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "true"}); err != nil {
 		return err
 	}
 
@@ -390,6 +395,7 @@ func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
 				"bash", "-euc", startCommand,
 			},
 			WorkDir: "/",
+			Timeout: startCommandTimeout,
 		},
 	}
 
@@ -413,8 +419,12 @@ func (s *Backend) StopWorkshop(ctx context.Context, name string, force bool) err
 	}
 	defer conn.Disconnect()
 
-	// Workshop stopped, disable autostart
-	if err = s.addWorkshopConfig(conn, ctx, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "false"}); err != nil {
+	return s.stopWorkshop(conn, ctx, name, force)
+}
+
+func (s *Backend) stopWorkshop(conn lxd.InstanceServer, ctx context.Context, name string, force bool) error {
+	// Workshop stopped, disable autostart.
+	if err := s.addWorkshopConfig(conn, ctx, name, &workshop.WorkshopConfigValue{Name: "boot.autostart", Value: "false"}); err != nil {
 		return err
 	}
 
@@ -783,7 +793,7 @@ func (s *Backend) RemoveWorkshop(ctx context.Context, name string) (err error) {
 	}
 
 	// ignore possible errors (e.g. container is already stopped)
-	if err = s.updateInstanceState(conn, ctx, name, "stop", true); err != nil {
+	if err = s.stopWorkshop(conn, ctx, name, true); err != nil {
 		logger.Noticef("On RemoveWorkshop: failed to stop %q workshop: %v", name, err)
 	}
 

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -35,14 +35,13 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	}
 	defer conn.Disconnect()
 
-	if err := s.updateInstanceState(conn, ctx, name, "stop", true); err != nil {
+	if err := s.stopWorkshop(conn, ctx, name, true); err != nil {
 		return err
 	}
 
 	rev.Add(func() {
-		err := s.updateInstanceState(conn, ctx, name, "start", false)
-		if err != nil {
-			logger.Debugf("Cannot restart %q workshop after failed stash operation", name)
+		if rerr := s.startWorkshop(conn, ctx, name); rerr != nil {
+			logger.Debugf("On StashWorkshop: Cannot restart %q workshop after failed stash operation: %v", name, rerr)
 		}
 	})
 
@@ -77,10 +76,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 		return err
 	}
 
-	if err := s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
-		return err
-	}
-	return nil
+	return s.startWorkshop(conn, ctx, name)
 }
 
 // Moves the instance between LXD projects.


### PR DESCRIPTION
# Description
This prevents stashed workshops from auto-start on a LXD daemon reload.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
