### PR TITLE
Fix various naming issues

### DIFF
--- a/docs/reference/definition-files/schema.json
+++ b/docs/reference/definition-files/schema.json
@@ -8,8 +8,8 @@
     "name": {
       "type": "string",
       "description": "Name of the workshop.",
-      "pattern": "^[a-z][a-z0-9-]*$",
-      "errorMessage": "A workshop's name must start with a letter and can only include digits, lowercase letters, and hyphens."
+      "pattern": "^[a-z](-?[a-z0-9])*$",
+      "errorMessage": "A workshop's name must start with a letter and can only include digits, lowercase letters, and hyphens joining them."
     },
     "base": {
       "type": "string",
@@ -30,8 +30,8 @@
           "name": {
             "type": "string",
             "description": "Name of the SDK.",
-            "pattern": "^(?!agent$)[a-z][a-z0-9-]*$",
-            "errorMessage": "An SDK's name must start with a letter, can only include digits, lowercase letters, and hyphens, and cannot be 'agent'."
+            "pattern": "^(?!agent$)([a-z0-9]-?)*[a-z](-?[a-z0-9])*$",
+            "errorMessage": "An SDK's name must contain a letter, can only include digits, lowercase letters, and hyphens joining them, and cannot be 'agent'."
           },
           "channel": {
             "type": "string",
@@ -53,7 +53,7 @@
                   "bind": {
                     "type": "string",
                     "description": "Reference to a plug in the form [<sdk>:]<plug>. If omitted, the SDK is 'system'.",
-                    "pattern": "^(?:[a-z][a-z0-9-]*)?:[a-z_][a-z0-9_-]*$",
+                    "pattern": "^(([a-z0-9]-?)*[a-z](-?[a-z0-9])*)?:[a-z](-?[a-z0-9])*$",
                     "errorMessage": "Bind reference must follow the pattern [<sdk>:]<plug> (SDK optional)."
                   },
                   "attributes": {
@@ -130,13 +130,13 @@
           "plug": {
             "type": "string",
             "description": "Reference to a plug in the form [<sdk>:]<plug>. If omitted, the SDK is 'system'.",
-            "pattern": "^(?:[a-z][a-z0-9-]*)?:[a-z_][a-z0-9_-]*$",
+            "pattern": "^(([a-z0-9]-?)*[a-z](-?[a-z0-9])*)?:[a-z](-?[a-z0-9])*$",
             "errorMessage": "Plug reference must follow the pattern [<sdk>:]<plug> (SDK optional)."
           },
           "slot": {
             "type": "string",
             "description": "Reference to a slot in the form [<sdk>:]<slot>. If omitted, the SDK is 'system'.",
-            "pattern": "^(?:[a-z][a-z0-9-]*)?:[a-z_][a-z0-9_-]*$",
+            "pattern": "^(([a-z0-9]-?)*[a-z](-?[a-z0-9])*)?:[a-z](-?[a-z0-9])*$",
             "errorMessage": "Slot reference must follow the pattern [<sdk>:]<slot> (SDK optional)."
           }
         },
@@ -156,7 +156,7 @@
       "type": "object",
       "description": "List of scripts to be run in the workshop.",
       "patternProperties": {
-        "^[a-z][a-z0-9-]*$": {
+        "^[a-z](-?[a-z0-9])*$": {
           "type": "string",
           "description": "Shell script."
         }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -3310,7 +3310,7 @@ func (s *apiSuite) TestRefreshPartialConflictChange(c *check.C) {
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
 	s.mockSdkVolumes(c, apiSuiteSdks)
-	s.mockSketchSdk(c, "manysdks", `name: illegal%
+	s.mockSketchSdk(c, "manysdks", `name: illegal-sketch-name
 base: ubuntu@22.04
 `)
 	defer s.store.SetDownloadCallback(storeDownload)()

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -92,6 +92,9 @@ func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sd
 				actError.errors[act.Name] = err
 				continue
 			}
+			if info.Name != act.Name {
+				return nil, fmt.Errorf("SDK must be named %q (now: %q)", act.Name, info.Name)
+			}
 			if act.Base != info.Base {
 				return nil, fmt.Errorf("%q SDK from %q has %q base; required: %q", act.Name, act.Channel, info.Base, act.Base)
 			}

--- a/internal/fakestore/store_test.go
+++ b/internal/fakestore/store_test.go
@@ -71,7 +71,7 @@ func (s *storeSuite) TestSdkActionInstallCannotParseSdkInfo(c *check.C) {
 				Revision: sdk.Revision{N: 123},
 				SdkYAML:  `incorrect yaml: -`,
 			},
-			"test-sdk-valid": {
+			"test-sdk": {
 				Name:     "test-sdk",
 				Channel:  channel,
 				Revision: sdk.Revision{N: 123},
@@ -95,7 +95,7 @@ func (s *storeSuite) TestSdkActionInstallCannotParseSdkInfo(c *check.C) {
 		ProjectId: "24242424",
 		Workshop:  "test-workshop",
 		Action:    sdk.Install,
-		Name:      "test-sdk-valid",
+		Name:      "test-sdk",
 		Base:      "ubuntu@20.04",
 		Channel:   "latest/stable",
 	}}

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -91,7 +91,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 
 	if wayland != "" {
 		desktop.Wayland = &workshop.ProxyEntry{
-			Name: plug.Sdk().Name + "-" + "wayland",
+			Name: fmt.Sprintf("%s_wayland", plug.Name()),
 			Connect: workshop.ProxyTarget{
 				Address:  filepath.Join(xdg, wayland),
 				Protocol: "unix",
@@ -113,7 +113,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 			Protocol: "unix",
 		}
 		desktop.X11 = &workshop.ProxyEntry{
-			Name:      plug.Sdk().Name + "-" + "x11",
+			Name:      fmt.Sprintf("%s_x11", plug.Name()),
 			Connect:   proxyTarget,
 			Listen:    proxyTarget,
 			Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -181,7 +181,7 @@ slots:
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, "Xauthority"), Where: "/var/lib/workshop/run/Xauthority"}
+	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, "Xauthority"), Where: "/var/lib/workshop/run/Xauthority", Type: workshop.HostWorkshop}
 	c.Assert(deviceSpec.Profile.Mounts["consumer-xauth"], check.DeepEquals, *expectedMount)
 }
 

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -63,7 +63,7 @@ slots:
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 	expectedProxy := &workshop.Desktop{
 		Wayland: &workshop.ProxyEntry{
-			Name: "consumer-wayland",
+			Name: "desktop_wayland",
 			Connect: workshop.ProxyTarget{
 				Address:  "/tmp/wayland-1",
 				Protocol: "unix"},
@@ -100,7 +100,7 @@ slots:
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 	expectedProxy := &workshop.Desktop{
 		X11: &workshop.ProxyEntry{
-			Name: "consumer-x11",
+			Name: "desktop_x11",
 			Connect: workshop.ProxyTarget{
 				Address:  "/tmp/.X11-unix/X0",
 				Protocol: "unix"},
@@ -137,7 +137,7 @@ slots:
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 	expectedProxy := &workshop.Desktop{
 		X11: &workshop.ProxyEntry{
-			Name: "consumer-x11",
+			Name: "desktop_x11",
 			Connect: workshop.ProxyTarget{
 				Address:  "/tmp/.X11-unix/X0",
 				Protocol: "unix"},
@@ -146,7 +146,7 @@ slots:
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost},
 		Wayland: &workshop.ProxyEntry{
-			Name: "consumer-wayland",
+			Name: "desktop_wayland",
 			Connect: workshop.ProxyTarget{
 				Address:  "/tmp/wayland-0",
 				Protocol: "unix"},

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -152,7 +152,7 @@ plugs:
 }
 
 func (s *mountSuite) TestSanitizeSlotSystem(c *check.C) {
-	const mockSdkYaml = `name: mount-slot-sdk
+	const mockSdkYaml = `name: system
 base: ubuntu@22.04
 type: system
 slots:
@@ -165,7 +165,7 @@ slots:
 }
 
 func (s *mountSuite) TestSanitizeSlotSystemWorkshopSource(c *check.C) {
-	const mockSdkYaml = `name: mount-slot-sdk
+	const mockSdkYaml = `name: system
 base: ubuntu@22.04
 type: system
 slots:
@@ -179,7 +179,7 @@ slots:
 }
 
 func (s *mountSuite) TestSanitizeSlotSystemHostSource(c *check.C) {
-	const mockSdkYaml = `name: mount-slot-sdk
+	const mockSdkYaml = `name: system
 base: ubuntu@22.04
 type: system
 slots:

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -79,14 +79,12 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 		return fmt.Errorf(`cannot access ssh-agent for user %q: environment variable "SSH_AUTH_SOCK" not found`, spec.User.Username)
 	}
 
-	name := plug.Sdk().Name + "-" + plug.Name()
-
 	fromSocket := sock
-	toSocket := filepath.Join(dirs.WorkshopRunDir, name+".ssh")
+	toSocket := filepath.Join(dirs.WorkshopRunDir, fmt.Sprintf("%s_%s.ssh", plug.Sdk().Name, plug.Name()))
 
 	return spec.SetSshAgent(workshop.SshAgent{
 		ProxyEntry: workshop.ProxyEntry{
-			Name: name,
+			Name: plug.Name(),
 			Connect: workshop.ProxyTarget{
 				Address:  fromSocket,
 				Protocol: "unix",

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -63,13 +63,13 @@ slots:
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
 	expectedProxy := &workshop.SshAgent{ProxyEntry: workshop.ProxyEntry{
-		Name: "consumer-" + plug.Name,
+		Name: plug.Name,
 		Connect: workshop.ProxyTarget{
 			Address:  "/tmp/dir/ssh",
 			Protocol: "unix",
 		},
 		Listen: workshop.ProxyTarget{
-			Address:  "/var/lib/workshop/run/consumer-ssh-agent.ssh",
+			Address:  "/var/lib/workshop/run/consumer_ssh-agent.ssh",
 			Protocol: "unix",
 		},
 		Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -217,8 +217,9 @@ func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string,
 	})
 }
 
-func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop string) error {
-	env, err := fs.Create(filepath.Join("/etc/profile.d", dev.Name+".sh"))
+func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop, sdkName string) error {
+	script := fmt.Sprintf("%s_%s.sh", sdkName, dev.Name)
+	env, err := fs.Create(filepath.Join("/etc", "profile.d", script))
 	if err != nil {
 		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
 	}
@@ -231,15 +232,16 @@ func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop str
 	return nil
 }
 
-func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) error {
-	return fs.Remove(filepath.Join("/etc/profile.d", dev.Name+".sh"))
+func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, sdkName string) error {
+	script := fmt.Sprintf("%s_%s.sh", sdkName, dev.Name)
+	return fs.Remove(filepath.Join("/etc", "profile.d", script))
 }
 
 func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.User, env map[string]string, ws string) error {
 	backend := env["XDG_BACKEND"]
 
 	var envVars map[string]string
-	envFile, err := fs.Create(filepath.Join("/etc/profile.d", "desktop"+".sh"))
+	envFile, err := fs.Create("/etc/profile.d/desktop.sh")
 	if err != nil {
 		return fmt.Errorf("cannot configure required environment for %q: %w", ws, err)
 	}
@@ -367,7 +369,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 	}
 
 	if spec.Profile.Agent != nil {
-		err = installSshAgent(fs, *spec.Profile.Agent, sdkInfo.Workshop)
+		err = installSshAgent(fs, *spec.Profile.Agent, sdkInfo.Workshop, sdkInfo.Sdk)
 		if err != nil {
 			return err
 		}
@@ -395,7 +397,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		}
 
 		if prevp.Agent != nil && !prevp.Agent.Equal(spec.Profile.Agent) {
-			if err = removeSshAgent(fs, *prevp.Agent); err != nil {
+			if err = removeSshAgent(fs, *prevp.Agent, sdkInfo.Sdk); err != nil {
 				return err
 			}
 		}
@@ -471,7 +473,7 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 	}
 
 	if prof.Agent != nil {
-		if err = removeSshAgent(fs, *prof.Agent); err != nil {
+		if err = removeSshAgent(fs, *prof.Agent, profile); err != nil {
 			return err
 		}
 	}

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -162,8 +162,8 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, camera.Name)] = "camera"
 
 	for _, subsystem := range []string{"video4linux", "media"} {
-		// This name is unique because '/' is not permitted in plug names.
-		name := fmt.Sprintf("%s/%s", camera.Name, subsystem)
+		// This name is unique because '_' is not permitted in plug names.
+		name := fmt.Sprintf("%s_%s", camera.Name, subsystem)
 		s.devices[name] = map[string]string{
 			"type":              "unix-hotplug",
 			"subsystem":         subsystem,

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -113,7 +113,7 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 
 func (f *backendDeviceSuite) TearDownTest(c *check.C) {
 	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdProjectName(f.usr.Username))
-	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdSystemProjectName(f.usr.Username))
+	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdStashProjectName(f.usr.Username))
 	f.restoreEnv()
 	f.client.Disconnect()
 }

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -368,15 +368,15 @@ func (f *backendDeviceSuite) TestSetupSshAgent(c *check.C) {
 	prof, err := lxdbackend.Profile(f.client, f.pid, "test", "consumer")
 	c.Assert(err, check.IsNil)
 	c.Assert(prof.Agent, check.NotNil)
-	c.Check(prof.Agent.Name, check.Equals, "consumer-ssh-agent")
+	c.Check(prof.Agent.Name, check.Equals, "ssh-agent")
 	c.Check(prof.Agent.Connect.Address, check.Equals, "/run/.workshop.socket")
 	c.Check(prof.Agent.Connect.Protocol, check.Equals, "unix")
-	c.Check(prof.Agent.Listen.Address, check.Equals, "/run/consumer-ssh-agent.ssh")
+	c.Check(prof.Agent.Listen.Address, check.Equals, "/run/consumer_ssh-agent.ssh")
 	c.Check(prof.Agent.Listen.Protocol, check.Equals, "unix")
 	c.Check(prof.Agent.Direction, check.Equals, workshop.WorkshopToHost)
 
-	buf := f.readWorkshopFile(c, "/etc/profile.d/consumer-ssh-agent.sh")
-	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/consumer-ssh-agent.ssh\n")
+	buf := f.readWorkshopFile(c, "/etc/profile.d/consumer_ssh-agent.sh")
+	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/consumer_ssh-agent.ssh\n")
 
 	f.repo.DisconnectAll([]*interfaces.ConnRef{connref})
 
@@ -386,7 +386,7 @@ func (f *backendDeviceSuite) TestSetupSshAgent(c *check.C) {
 
 	fs, err := f.be.WorkshopFs(f.ctx, "test")
 	c.Assert(err, check.IsNil)
-	_, err = fs.Stat("/etc/profile.d/consumer-ssh-agent.sh")
+	_, err = fs.Stat("/etc/profile.d/consumer_ssh-agent.sh")
 	c.Assert(osutil.IsDirNotExist(err), check.Equals, true)
 }
 
@@ -450,7 +450,7 @@ func (f *backendDeviceSuite) TestSetupMultipleInterfaces(c *check.C) {
 		// Validate Filesystem
 		fs, err := f.be.WorkshopFs(f.ctx, "test")
 		c.Assert(err, check.IsNil)
-		_, err = fs.Stat("/etc/profile.d/consumer-ssh-agent.sh")
+		_, err = fs.Stat("/etc/profile.d/consumer_ssh-agent.sh")
 		c.Assert(err, check.IsNil)
 		_, err = fs.Stat("/etc/profile.d/desktop.sh")
 		c.Assert(err, check.IsNil)
@@ -459,7 +459,7 @@ func (f *backendDeviceSuite) TestSetupMultipleInterfaces(c *check.C) {
 		f.repo.DisconnectAll([]*interfaces.ConnRef{sshConnRef, desktopConnRef})
 		err = b.Setup(f.ctx, cref, f.repo)
 		c.Assert(err, check.IsNil)
-		_, err = fs.Stat("/etc/profile.d/consumer-ssh-agent.sh")
+		_, err = fs.Stat("/etc/profile.d/consumer_ssh-agent.sh")
 		c.Assert(err, check.NotNil)
 		_, err = fs.Stat("/etc/profile.d/desktop.sh")
 		c.Assert(err, check.NotNil)

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -79,12 +79,16 @@ plugs:
 
 func (s *baseDeclSuite) installSlotCand(c *check.C, iface string, sdkType sdk.Type, yaml string) *policy.InstallCandidate {
 	if yaml == "" {
-		yaml = fmt.Sprintf(`name: install-slot-sdk
+		name := "install-slot-sdk"
+		if sdkType == sdk.System {
+			name = "system"
+		}
+		yaml = fmt.Sprintf(`name: %s
 base: ubuntu@22.04
 type: %s
 slots:
   %s:
-`, sdkType, iface)
+`, name, sdkType, iface)
 	}
 	sdk := sdk.MockInfo(c, yaml, "mock424242", "ws")
 	return &policy.InstallCandidate{
@@ -144,7 +148,7 @@ func (s *baseDeclSuite) TestManualConnection(c *check.C) {
 }
 
 func (s *baseDeclSuite) TestMountAutoConnection(c *check.C) {
-	slotYaml := `name: slot-sdk
+	slotYaml := `name: system
 base: ubuntu@22.04
 type: system
 slots:
@@ -204,7 +208,7 @@ func (s *baseDeclSuite) TestDoesNotPanic(c *check.C) {
 }
 
 func (s *baseDeclSuite) TestSlotPlugFromSameWorkshop(c *check.C) {
-	slotYaml := `name: slot-sdk
+	slotYaml := `name: system
 base: ubuntu@22.04
 type: system
 slots:
@@ -218,7 +222,7 @@ slots:
 }
 
 func (s *baseDeclSuite) TestSlotPlugDifferentProjects(c *check.C) {
-	slotYaml := `name: slot-sdk
+	slotYaml := `name: system
 base: ubuntu@22.04
 type: system
 slots:
@@ -238,7 +242,7 @@ plugs:
 }
 
 func (s *baseDeclSuite) TestSlotPlugDifferentWorkshop(c *check.C) {
-	slotYaml := `name: slot-sdk
+	slotYaml := `name: system
 base: ubuntu@22.04
 type: system
 slots:

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1661,7 +1661,7 @@ slots:
 	c.Assert(r.AddSdk(s2), IsNil)
 
 	s3 := sdk.MockInfo(c, `
-name: s3
+name: system
 base: ubuntu@22.04
 type: system
 slots:
@@ -1687,7 +1687,7 @@ plugs:
 	c.Assert(err, IsNil)
 	_, err = r.Connect(&ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s1", Name: "i2"},
-		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "s3", Name: "i2"}}, nil, nil, nil, nil, nil)
+		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "system", Name: "i2"}}, nil, nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	// Without any names or options we get the summary of all the interfaces.

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -300,8 +300,12 @@ func (m *InterfaceManager) recreateInternalMounts(pctx context.Context, w string
 	// Recreate workshopctl bind mount, this has to be done if, for example,
 	// workshopctl was updated to a new version and is shown as /deleted in a
 	// workshop.
-	workshopctl := workshop.Mount{Name: "workshop.workshopctl", What: filepath.Join(dirs.ExecDir, "workshopctl"),
-		Where: "/usr/bin/workshopctl"}
+	workshopctl := workshop.Mount{
+		Name:  "workshop.workshopctl",
+		What:  filepath.Join(dirs.ExecDir, "workshopctl"),
+		Where: "/usr/bin/workshopctl",
+		Type:  workshop.HostWorkshop,
+	}
 
 	_ = m.backend.RemoveWorkshopMount(pctx, w, workshopctl.Name)
 

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -177,7 +177,12 @@ func (m *WorkshopManager) doMountProject(task *state.Task, tomb *tomb.Tomb) erro
 	}
 
 	// Configure workshop core properties: project directory
-	var prjMount = workshop.Mount{Name: workshop.ConfigProjectPathDevice, What: prj.Path, Where: workshop.WorkshopProjectPath}
+	var prjMount = workshop.Mount{
+		Name:  workshop.ConfigProjectPathDevice,
+		What:  prj.Path,
+		Where: workshop.WorkshopProjectPath,
+		Type:  workshop.HostWorkshop,
+	}
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
 

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -169,11 +169,14 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 	var sdkYaml sdkYaml
 	err := yaml.Unmarshal(yamlData, &sdkYaml)
 	if err != nil {
-		return &Info{}, err
+		return nil, err
 	}
 
 	if sdkYaml.Type == "" {
 		sdkYaml.Type = Regular.String()
+	}
+	if sdkYaml.Type == System.String() && !IsSystem(sdkYaml.Name) {
+		return nil, fmt.Errorf("SDK %q has type %q but is not the system SDK", sdkYaml.Name, sdkYaml.Type)
 	}
 
 	sdkInfo := &Info{

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -11,13 +11,13 @@ import (
 
 var (
 	AllowedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
-	sdkName      = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+	SdkName      = regexp.MustCompile(`^(?:[a-z0-9]-?)*[a-z](?:-?[a-z0-9])*$`)
 	// Regular expression describing correct plug, slot and interface names.
 	validPlugSlotIface = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 )
 
 func Validate(sdk *Info) error {
-	if !sdkName.MatchString(sdk.Name) {
+	if !SdkName.MatchString(sdk.Name) {
 		return fmt.Errorf("invalid SDK name %q", sdk.Name)
 	}
 

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -93,7 +93,7 @@ type VolumeManager interface {
 	ImportVolume(ctx context.Context, name string, tarball string) error
 
 	// Attach the volume to the workshop. The volume must be created before.
-	AttachVolume(ctx context.Context, wp, name, what string, ro bool) error
+	AttachVolume(ctx context.Context, wp, name, where string, ro bool) error
 
 	// Detach the volume from the workshop.
 	DetachVolume(ctx context.Context, wp, name string) error
@@ -185,10 +185,10 @@ type Backend interface {
 	StopWorkshop(ctx context.Context, name string, force bool) error
 
 	// Adds a workshop mount described by the properties.
-	AddWorkshopMount(ctx context.Context, name string, device Mount) error
+	AddWorkshopMount(ctx context.Context, name string, mount Mount) error
 
 	// Removes a workshop mount.
-	RemoveWorkshopMount(ctx context.Context, name string, device string) error
+	RemoveWorkshopMount(ctx context.Context, name, mount string) error
 
 	// TODO: these methods are too generic and should be wrapped with a proper
 	// interface method where required. We should not let the client to change

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -257,7 +257,7 @@ func (s *FakeWorkshopBackend) StopWorkshop(ctx context.Context, name string, for
 	return nil
 }
 
-func (f *FakeWorkshopBackend) AddWorkshopMount(ctx context.Context, name string, props workshop.Mount) error {
+func (f *FakeWorkshopBackend) AddWorkshopMount(ctx context.Context, name string, mount workshop.Mount) error {
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -266,12 +266,12 @@ func (f *FakeWorkshopBackend) AddWorkshopMount(ctx context.Context, name string,
 	f.workshopLock.Lock()
 	defer f.workshopLock.Unlock()
 
-	f.Workshops[projectId][name].Devices[props.Name] = map[string]string{"type": "disk", "source": props.What,
-		"path": props.Where}
+	f.Workshops[projectId][name].Devices[mount.Name] = map[string]string{"type": "disk", "source": mount.What,
+		"path": mount.Where}
 	return nil
 }
 
-func (f *FakeWorkshopBackend) RemoveWorkshopMount(ctx context.Context, name string, device string) error {
+func (f *FakeWorkshopBackend) RemoveWorkshopMount(ctx context.Context, name, mount string) error {
 	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -280,7 +280,7 @@ func (f *FakeWorkshopBackend) RemoveWorkshopMount(ctx context.Context, name stri
 	f.workshopLock.Lock()
 	defer f.workshopLock.Unlock()
 
-	delete(f.Workshops[projectId][name].Devices, device)
+	delete(f.Workshops[projectId][name].Devices, mount)
 	return nil
 }
 
@@ -507,7 +507,7 @@ func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, name string) err
 	return nil
 }
 
-func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, what string, ro bool) error {
+func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, where string, ro bool) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
@@ -519,7 +519,7 @@ func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, what s
 	}
 	defer wfs.Close()
 
-	mnt, err := wfs.(*FakeInstanceFs).Fs.(*afero.BasePathFs).RealPath(what)
+	mnt, err := wfs.(*FakeInstanceFs).Fs.(*afero.BasePathFs).RealPath(where)
 	if err != nil {
 		return err
 	}
@@ -537,7 +537,7 @@ func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, what s
 		return err
 	}
 
-	s.WorkshopVolumeMountPoints[name] = what
+	s.WorkshopVolumeMountPoints[name] = where
 	return nil
 }
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -487,7 +487,7 @@ func (s *Backend) RemoveWorkshopConfig(ctx context.Context, name string, key str
 	return op.Wait()
 }
 
-func (s *Backend) AddWorkshopMount(ctx context.Context, name string, device workshop.Mount) error {
+func (s *Backend) AddWorkshopMount(ctx context.Context, name string, mount workshop.Mount) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -503,16 +503,18 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, device work
 	if err != nil {
 		return err
 	}
-	if device.Type == workshop.Volume {
-		inst.Devices[device.Name] = map[string]string{"type": "disk",
-			"pool":     storagePool,
-			"path":     device.What,
-			"source":   device.Where,
-			"readonly": fmt.Sprint(device.ReadOnly)}
-	} else {
-		inst.Devices[device.Name] = map[string]string{"type": "disk", "source": device.What,
-			"path": device.Where, "readonly": fmt.Sprint(device.ReadOnly)}
+
+	device := map[string]string{
+		"type":     "disk",
+		"source":   mount.What,
+		"path":     mount.Where,
+		"readonly": fmt.Sprint(mount.ReadOnly),
 	}
+	if mount.Type == workshop.Volume {
+		device["pool"] = storagePool
+	}
+	inst.Devices[mount.Name] = device
+
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
 	if err != nil {
 		return err
@@ -521,7 +523,7 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, device work
 	return op.WaitContext(ctx)
 }
 
-func (s *Backend) RemoveWorkshopMount(ctx context.Context, name string, device string) error {
+func (s *Backend) RemoveWorkshopMount(ctx context.Context, name, mount string) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -538,7 +540,7 @@ func (s *Backend) RemoveWorkshopMount(ctx context.Context, name string, device s
 		return err
 	}
 
-	delete(inst.Devices, device)
+	delete(inst.Devices, mount)
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
 	if err != nil {
 		return err

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -95,13 +95,13 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 				"camera": {
 					"type": "none",
 				},
-				"camera/video4linux": {
+				"camera_video4linux": {
 					"type":              "unix-hotplug",
 					"subsystem":         "video4linux",
 					"required":          "false",
 					"ownership.inherit": "true",
 				},
-				"camera/media": {
+				"camera_media": {
 					"type":              "unix-hotplug",
 					"subsystem":         "media",
 					"required":          "false",
@@ -109,8 +109,8 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 			map[string]string{
 				"user.workshop.sdk.camera":                  `{"name": "camera"}`,
 				"user.workshop.sdk.camera.type":             "camera",
-				"user.workshop.sdk.camera/video4linux.type": "camera",
-				"user.workshop.sdk.camera/media.type":       "camera"},
+				"user.workshop.sdk.camera_video4linux.type": "camera",
+				"user.workshop.sdk.camera_media.type":       "camera"},
 		}, {
 			"sdk",
 			map[string]map[string]string{

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -340,7 +340,12 @@ func (s *Backend) updateProjectMounts(conn lxd.InstanceServer, ctx context.Conte
 	}
 
 	for _, i := range workshops {
-		mount := workshop.Mount{Name: workshop.ConfigProjectPathDevice, What: project.Path, Where: workshop.WorkshopProjectPath}
+		mount := workshop.Mount{
+			Name:  workshop.ConfigProjectPathDevice,
+			What:  project.Path,
+			Where: workshop.WorkshopProjectPath,
+			Type:  workshop.HostWorkshop,
+		}
 		err = s.AddWorkshopMount(projectCtx, workshop.WorkshopName(i.Name), mount)
 		if err != nil {
 			return fmt.Errorf("cannot update workshop %q project directory: %w", i.Name, err)

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -33,8 +33,8 @@ func lxdProjectUser(project string) string {
 	return ""
 }
 
-func LxdSystemProjectName(user string) string {
-	return LxdProjectName(user) + ".stash"
+func LxdStashProjectName(user string) string {
+	return "workshop-stash." + user
 }
 
 // Initialise the Workshop project namespace.
@@ -46,7 +46,7 @@ func InitLxdProject(conn lxd.InstanceServer, username string) error {
 		return err
 	}
 
-	if err := createOrLoadLxdProject(conn, LxdSystemProjectName(username)); err != nil {
+	if err := createOrLoadLxdProject(conn, LxdStashProjectName(username)); err != nil {
 		return err
 	}
 	return nil

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -45,7 +45,7 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		}
 	})
 
-	if err = s.copyInstance(conn, instance, stashedInsance, LxdProjectName(user), LxdSystemProjectName(user)); err != nil {
+	if err = s.copyInstance(conn, instance, stashedInsance, LxdProjectName(user), LxdStashProjectName(user)); err != nil {
 		return err
 	}
 
@@ -72,7 +72,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 	}
 	defer conn.Disconnect()
 
-	if err := s.copyInstance(conn, stashedInsance, instance, LxdSystemProjectName(user), LxdProjectName(user)); err != nil {
+	if err := s.copyInstance(conn, stashedInsance, instance, LxdStashProjectName(user), LxdProjectName(user)); err != nil {
 		return err
 	}
 
@@ -118,7 +118,7 @@ func (s *Backend) RemoveWorkshopStash(ctx context.Context, name string) error {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	conn = conn.UseProject(LxdSystemProjectName(user))
+	conn = conn.UseProject(LxdStashProjectName(user))
 	iname := workshop.StashNamePrefix + InstanceName(name, projectId)
 
 	op, err := conn.DeleteInstance(iname)

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -223,8 +223,8 @@ func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string)
 		}}, "")
 }
 
-func (s *Backend) AttachVolume(ctx context.Context, wp, name, what string, ro bool) error {
-	return s.AddWorkshopMount(ctx, wp, workshop.Mount{Name: name, What: what, Where: name, Type: workshop.Volume, ReadOnly: ro})
+func (s *Backend) AttachVolume(ctx context.Context, wp, name, where string, ro bool) error {
+	return s.AddWorkshopMount(ctx, wp, workshop.Mount{Name: name, What: name, Where: where, Type: workshop.Volume, ReadOnly: ro})
 }
 
 func (s *Backend) DetachVolume(ctx context.Context, wp, name string) error {

--- a/internal/workshop/lxd/tests/integration/project_test.go
+++ b/internal/workshop/lxd/tests/integration/project_test.go
@@ -45,7 +45,7 @@ func (f *wsProject) SetUpTest(c *check.C) {
 
 func (f *wsProject) TearDownTest(c *check.C) {
 	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdProjectName(f.username))
-	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdSystemProjectName(f.username))
+	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdStashProjectName(f.username))
 }
 
 func TestWorkshopBackendIntegration(t *testing.T) { check.TestingT(t) }
@@ -316,7 +316,7 @@ func (f *wsProject) TestLxdBackendLoadProjectsAllUsers(c *check.C) {
 
 func (f *wsProject) TestLxdBackendLoadProjectAsDifferentUser(c *check.C) {
 	defer helper.CleanupLxdProject(c, f.client, lxdbackend.LxdProjectName("anotheruser"))
-	defer helper.CleanupLxdProject(c, f.client, lxdbackend.LxdSystemProjectName("anotheruser"))
+	defer helper.CleanupLxdProject(c, f.client, lxdbackend.LxdStashProjectName("anotheruser"))
 
 	// Setup
 	be := lxdbackend.Backend{}

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -118,7 +118,7 @@ func (f *wsExec) TearDownSuite(c *check.C) {
 	f.restoreImageServer()
 	f.restoreDevices()
 	helper.CleanupLxdProject(c, f.lxdClient, lxdbackend.LxdProjectName(f.usr.Username))
-	helper.CleanupLxdProject(c, f.lxdClient, lxdbackend.LxdSystemProjectName(f.usr.Username))
+	helper.CleanupLxdProject(c, f.lxdClient, lxdbackend.LxdStashProjectName(f.usr.Username))
 }
 
 func (f *wsExec) exec(stdin string, workshop, projectId string, opts *client.ExecOptions) (stdout, stderr string, waitErr error) {

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -64,7 +64,7 @@ func (f *wsOps) TearDownSuite(c *check.C) {
 	c.Check(err, check.IsNil)
 
 	helper.CleanupLxdProject(c, lxdclient, lxdbackend.LxdProjectName(f.usr.Username))
-	helper.CleanupLxdProject(c, lxdclient, lxdbackend.LxdSystemProjectName(f.usr.Username))
+	helper.CleanupLxdProject(c, lxdclient, lxdbackend.LxdStashProjectName(f.usr.Username))
 	f.restoreLookupUsr()
 	f.restoreNewId()
 

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -222,6 +222,10 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 		return nil, err
 	}
 
+	if info.Name != sdkName {
+		return nil, fmt.Errorf("SDK must be named %q (now: %q)", sdkName, info.Name)
+	}
+
 	// system SDK will always have its workshop's base.
 	if info.Type == sdk.System {
 		info.Base = w.Base

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -20,8 +20,9 @@ var (
 	SupportedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
 	sdkBlocklist   = []string{"agent"}
 
-	workshopName = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
-	channel      = regexp.MustCompile(`^(?P<track>[a-zA-Z0-9\.-]+)/(?P<risk>(stable|candidate|beta|edge))$`)
+	workshopName = regexp.MustCompile(`^[a-z](?:-?[a-z0-9])*$`)
+	channel      = regexp.MustCompile(`^(?:[a-zA-Z0-9\.-]+/(?:stable|candidate|beta|edge)|)$`)
+	scriptName   = workshopName
 
 	Directory = ".workshop"
 	Filenames = []string{"workshop.yaml", ".workshop.yaml"}
@@ -64,7 +65,7 @@ func (b *PlugRef) UnmarshalYAML(value *yaml.Node) error {
 	if len(parts[0]) == 0 {
 		parts[0] = sdk.System.String()
 	}
-	if !workshopName.MatchString(parts[0]) {
+	if !sdk.SdkName.MatchString(parts[0]) {
 		return fmt.Errorf("%q is not a valid plug or slot reference (%q is an invalid SDK name)", refStr, parts[0])
 	}
 
@@ -164,7 +165,7 @@ func readWorkshop(path string) (*File, error) {
 	}
 
 	if !workshopName.MatchString(file.Name) {
-		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) only include digits, lowercase letters, and hyphens")
+		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) only include digits, lowercase letters, and hyphens joining them")
 	}
 
 	if !slices.Contains(SupportedBases, file.Base) {
@@ -204,10 +205,7 @@ func validateSdks(sdks []SdkRecord) error {
 
 		// An SDK installed from a local source (e.g. system SDK) does not have a
 		// channel.
-		if s.Channel == "" {
-			continue
-		}
-		if matches := channel.FindStringSubmatch(s.Channel); matches == nil {
+		if !channel.MatchString(s.Channel) {
 			return fmt.Errorf("unsupported channel %q for %q SDK", s.Channel, s.Name)
 		}
 		// A plug must either be bound or declared/extended with dynamic
@@ -300,8 +298,8 @@ func validateConnections(wfile *File) error {
 
 func validateScripts(wfile *File) error {
 	for name := range wfile.Scripts {
-		if !workshopName.MatchString(name) {
-			return fmt.Errorf("script name %q must: (1) start with a letter, (2) only include digits, lowercase letters, and hyphens", name)
+		if !scriptName.MatchString(name) {
+			return fmt.Errorf("script name %q must: (1) start with a letter, (2) only include digits, lowercase letters, and hyphens joining them", name)
 		}
 	}
 	return nil

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -198,7 +198,7 @@ base: ubuntu@20.04
 	f.createWFile(c, "99-xbert", yaml)
 	file, err := f.project.Workshop("99-xbert")
 	c.Assert(file, check.IsNil)
-	c.Assert(err, check.ErrorMatches, `a workshop's name must: \(1\) start with a letter, \(2\) only include digits, lowercase letters, and hyphens`)
+	c.Assert(err, check.ErrorMatches, `a workshop's name must: \(1\) start with a letter, \(2\) only include digits, lowercase letters, and hyphens joining them`)
 }
 
 func (f *workshopFile) TestWorkshopUnsupportedBase(c *check.C) {

--- a/snap/local/hooks/lxc-utils
+++ b/snap/local/hooks/lxc-utils
@@ -4,7 +4,7 @@ run_lxc() {
 }
 
 get_projects() {
-  run_lxc project list -f compact | awk '$1 ~ /^workshop\..*/ {print $1}'
+  run_lxc project list -f compact | awk '$1 ~ /^workshop(-stash)?\..*/ {print $1}'
 }
 
 remove_instances() {

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -49,6 +49,6 @@ execute: |
   workshop_exec warnings |
     tr -d '\n' | # remove newlines
     sed -e 's,\s\+, ,g' | # rename any extra spaces
-    MATCH "invalid file \".*/new-project/.workshop.yaml\": a workshop's name must: \\(1\\) start with a letter, \\(2\\) only include digits, lowercase letters, and hyphens"
+    MATCH "invalid file \".*/new-project/.workshop.yaml\": a workshop's name must: \\(1\\) start with a letter, \\(2\\) only include digits, lowercase letters, and hyphens joining them"
 
   workshop_exec remove --project $(pwd)/new-project ws


### PR DESCRIPTION
# Description

This brings workshop and SDK names in line with restrictions imposed by SDKcraft. Also requires SDK YAML to match the name in the store (and the system SDK must be named `system`). Might technically be a breaking change, if you have workshops or SDKs with weird names. Only implication for documentation that I know of is the schema.

The next change is to swap `what` and `where` for volume mounts, bringing them in line with the other mount types. Shouldn't change anything visible.

Renames some files and devices associated with the desktop and ssh-agent interfaces, to avoid clashing with tunnel plugs (which can have arbitrary names). This is likely a breaking change for users which are actively using these interfaces.

LXD doesn't support slashes in tunnel names, so I replaced slashes with underscores in the camera interface devices for consistency. I avoided dots because the device config keys use them as delimiters. The filenames don't have to use underscores, but it makes things consistent.

Renames the stash project to `workshop-stash.<USER>`, to avoid potentially conflicting with `workshop.<USER>` (although this seems unlikely). Shouldn't be a breaking change, but I made no attempt to clean up the old `workshop.<USER>.stash` project. I think the snap hook still takes care of that anyway.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
