### PR TITLE
Run setup-base hook and snapshot right after installing SDK

### DIFF
--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -17,7 +17,6 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
@@ -1031,7 +1030,6 @@ line 1: cannot unmarshal !!seq into string`,
 
 	volume := workshop.AptCacheVolumeName("basic", wp.Project.ProjectId)
 	c.Assert(s.b.WorkshopVolumes[volume], check.Equals, true)
-	c.Assert(s.b.WorkshopVolumeMountPoints[volume], check.Equals, dirs.AptCachePath)
 
 	c.Assert(wp.Running, check.Equals, true)
 
@@ -3345,7 +3343,6 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	s2 := apiSuiteSdks["test-sdk-2"].s
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
-		{Workshop: "manysdks", Name: workshop.AptCacheVolumeName("manysdks", s.project.ProjectId)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s2.Name, s2.Revision)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s1.Name, s1.Revision)},
 	})
@@ -3369,7 +3366,6 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	s.runActionTest(c, requests, expected)
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
-		{Workshop: "manysdks", Name: workshop.AptCacheVolumeName("manysdks", s.project.ProjectId)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s1.Name, s1.Revision)},
 		{Workshop: "manysdks", Name: sdk.VolumeName(s2.Name, s2.Revision)},
 	})

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -30,14 +30,15 @@ import (
 )
 
 type backendDeviceSuite struct {
-	ctx         context.Context
-	be          *lxdbackend.Backend
-	client      lxd.InstanceServer
-	repo        *interfaces.Repository
-	usr         *user.User
-	pid         string
-	restoreUser func()
-	restoreEnv  func()
+	ctx          context.Context
+	be           *lxdbackend.Backend
+	client       lxd.InstanceServer
+	repo         *interfaces.Repository
+	usr          *user.User
+	pid          string
+	restoreUser  func()
+	restoreEnv   func()
+	restoreNewId func()
 }
 
 var _ = check.Suite(&backendDeviceSuite{})
@@ -70,13 +71,15 @@ func (f *backendDeviceSuite) readWorkshopFile(c *check.C, fname string) string {
 	return string(buf)
 }
 
-func defaultTestDevices() map[string]map[string]string {
+func defaultTestDevices(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
 	cwd, _ := os.Getwd()
-	return map[string]map[string]string{
-		"root":             {"type": "disk", "pool": "workshop", "path": "/"},
-		"project":          {"type": "disk", "source": cwd, "path": "/project"},
-		"workshop.network": {"type": "nic", "network": "workshopbr0", "name": "eth0"},
-	}
+	mounts := []workshop.Mount{{
+		Name:  workshop.ConfigProjectPathDevice,
+		What:  cwd,
+		Where: workshop.WorkshopProjectPath,
+		Type:  workshop.HostWorkshop,
+	}}
+	return mounts, nil
 }
 
 func (f *backendDeviceSuite) SetUpTest(c *check.C) {
@@ -97,6 +100,9 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 	f.restoreEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil
 	})
+	f.restoreNewId = testutil.FakeFunc(func() (string, error) {
+		return f.pid, nil
+	}, &workshop.NewProjectId)
 
 	f.ctx = helper.CreateTestContext(f.usr.Username, "42424242")
 
@@ -107,14 +113,17 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 
 	f.setupRepo(c)
 
-	defer lxdbackend.FakeDefaultDevices(defaultTestDevices)()
+	defer workshop.FakeDefaultDevices(defaultTestDevices)()
 	helper.LaunchTestWorkshop(c, f.ctx, f.be, c.MkDir())
 }
 
 func (f *backendDeviceSuite) TearDownTest(c *check.C) {
+	helper.RemoveTestWorkshop(c, f.ctx, f.be)
 	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdProjectName(f.usr.Username))
 	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdStashProjectName(f.usr.Username))
+	f.restoreNewId()
 	f.restoreEnv()
+	f.restoreUser()
 	f.client.Disconnect()
 }
 

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -24,7 +24,6 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	runner.AddHandler("install-local-sdk", OnDo(manager.doInstallLocalSdk), manager.doUninstallLocalSdk)
 	runner.AddHandler("link-sdk", OnDo(manager.doLinkSdk), manager.doUnlinkSdk)
 	runner.AddHandler("unlink-sdk", OnDo(manager.doUnlinkSdk), manager.doLinkSdk)
-	runner.AddHandler("remove-sdk", OnDo(manager.doUninstallSdk), nil)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -3,6 +3,7 @@ package sdkstate
 import (
 	"fmt"
 
+	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 )
@@ -13,7 +14,7 @@ func Retrieve(st *state.State, s sdk.Setup) *state.Task {
 	return download
 }
 
-func InstallLocalSdk(st *state.State, setup sdk.Setup) *state.TaskSet {
+func InstallLocalSdk(st *state.State, pid, w string, setup sdk.Setup) *state.TaskSet {
 	install := st.NewTask("install-local-sdk", fmt.Sprintf("Install %q SDK", setup.Name))
 	install.Set("sdk-setup", setup)
 	install.Set("sdk-retrieve-task", install.ID())
@@ -22,10 +23,13 @@ func InstallLocalSdk(st *state.State, setup sdk.Setup) *state.TaskSet {
 	link.Set("sdk-retrieve-task", install.ID())
 	link.WaitFor(install)
 
-	return state.NewTaskSet(install, link)
+	hook := hookstate.Hook(st, pid, w, setup.Name, 0, hookstate.SetupBase)
+	hook.WaitFor(link)
+
+	return state.NewTaskSet(install, link, hook)
 }
 
-func Install(st *state.State, sdk string, retrieveId string) *state.TaskSet {
+func Install(st *state.State, pid, w, sdk, retrieveId string) *state.TaskSet {
 	install := st.NewTask("install-sdk", fmt.Sprintf("Install %q SDK", sdk))
 	install.Set("sdk-retrieve-task", retrieveId)
 
@@ -33,5 +37,8 @@ func Install(st *state.State, sdk string, retrieveId string) *state.TaskSet {
 	link.Set("sdk-retrieve-task", retrieveId)
 	link.WaitFor(install)
 
-	return state.NewTaskSet(install, link)
+	hook := hookstate.Hook(st, pid, w, sdk, 0, hookstate.SetupBase)
+	hook.WaitFor(link)
+
+	return state.NewTaskSet(install, link, hook)
 }

--- a/internal/overlord/sdkstate/request_test.go
+++ b/internal/overlord/sdkstate/request_test.go
@@ -25,17 +25,19 @@ func (i *SdkStateTasks) TestInstall(c *check.C) {
 
 	sdk := workshop.SdkRecord{Name: "sdk"}
 
-	tasks := sdkstate.Install(i.state, sdk.Name, "retrieve").Tasks()
+	tasks := sdkstate.Install(i.state, "42424242", "ws", sdk.Name, "retrieve").Tasks()
 
-	c.Check(tasks, check.HasLen, 2)
+	c.Check(tasks, check.HasLen, 3)
 	c.Check(tasks[1].WaitTasks(), check.HasLen, 1)
+	c.Check(tasks[2].WaitTasks(), check.HasLen, 1)
 	var id string
 	tasks[0].Get("sdk-retrieve-task", &id)
-	c.Check(tasks[0].Summary(), check.Equals, "Install \"sdk\" SDK")
+	c.Check(tasks[0].Summary(), check.Equals, `Install "sdk" SDK`)
 	c.Check(id, check.Equals, "retrieve")
 	tasks[1].Get("sdk-retrieve-task", &id)
-	c.Check(tasks[1].Summary(), check.Equals, "Link \"sdk\" SDK")
+	c.Check(tasks[1].Summary(), check.Equals, `Link "sdk" SDK`)
 	c.Check(id, check.Equals, "retrieve")
+	c.Check(tasks[2].Summary(), check.Equals, `Run hook "setup-base" for "sdk" SDK`)
 }
 
 func (i *SdkStateTasks) TestRetrieve(c *check.C) {

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -194,24 +194,6 @@ func (m *WorkshopManager) undoMountProject(task *state.Task, tomb *tomb.Tomb) er
 	return nil
 }
 
-func (m *WorkshopManager) doMountAptCache(task *state.Task, tomb *tomb.Tomb) error {
-	user, prj, w, err := UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
-	defer cancel()
-
-	volume := workshop.AptCacheVolumeName(w, prj.ProjectId)
-	return m.backend.AttachVolume(ctx, w, volume, dirs.AptCachePath, false)
-}
-
-func (m *WorkshopManager) undoMountAptCache(task *state.Task, tomb *tomb.Tomb) error {
-	// No need to undo because the mount will be removed with the workshop
-	return nil
-}
-
 func (m *WorkshopManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, w, err := UserProjectWorkshop(task)
 	if err != nil {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -402,24 +401,6 @@ func (s *workshopHandlers) TestAptCache(c *check.C) {
 
 	volume := workshop.AptCacheVolumeName("ws", s.project.ProjectId)
 	c.Assert(s.backend.WorkshopVolumes[volume], check.Equals, true)
-
-	// Mount apt cache
-	chg = s.state.NewChange("sample", "...")
-	t1 = s.state.NewTask("mount-apt-cache", "...")
-	setWorkshopProject("ws", s.project, t1)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
-		s.se.Wait()
-	}
-	s.state.Lock()
-
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
-
-	c.Assert(s.backend.WorkshopVolumeMountPoints[volume], check.Equals, dirs.AptCachePath)
 
 	// Remove volume for apt cache
 	chg = s.state.NewChange("sample", "...")

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -33,7 +33,6 @@ func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	runner.AddHandler("mount-project", OnDo(manager.doMountProject), manager.undoMountProject)
 	runner.AddHandler("create-apt-cache", OnDo(manager.doCreateAptCache), manager.doRemoveAptCache)
 	runner.AddHandler("remove-apt-cache", OnDo(manager.doRemoveAptCache), nil)
-	runner.AddHandler("mount-apt-cache", OnDo(manager.doMountAptCache), manager.undoMountAptCache)
 	runner.AddHandler("remove-workshop-stash", OnDo(manager.doRemoveWorkshopStash), nil)
 	runner.AddHandler("stash-workshop", OnDo(manager.doStashWorkshop), manager.undoStashWorkshop)
 	runner.AddHandler("create-state-storage", OnDo(manager.doCreateStateStorage), manager.doRemoveStateStorage)

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -69,7 +69,6 @@ func (s *managerSuite) TestAddHandlers(c *check.C) {
 		"mount-project",
 		"create-apt-cache",
 		"remove-apt-cache",
-		"mount-apt-cache",
 		"remove-workshop-stash",
 		"stash-workshop",
 		"create-state-storage",

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/cmdstate"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
@@ -196,13 +195,9 @@ func launchWorkshop(st *state.State, file *workshop.File, project workshop.Proje
 	addTask(create)
 	create.Set("workshop-file", file)
 
-	// We're rebuilding the workshop from base, which means, the mounts will
-	// be removed too.
+	// TODO: move this after snapshots are taken; also for refresh.
 	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
 	addTask(mountProject)
-
-	mountAptCache := st.NewTask("mount-apt-cache", fmt.Sprintf("Mount apt cache directory %q", dirs.AptCachePath))
-	addTask(mountAptCache)
 
 	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", file.Name))
 	addTask(start)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -143,7 +143,7 @@ func retrieveSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string
 	return retrieve, retrieveMap
 }
 
-func installSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
+func installSdks(st *state.State, pid, w string, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
 	var prevInstall *state.TaskSet
 	all := state.NewTaskSet()
 	addTaskSet := func(ts *state.TaskSet) {
@@ -165,9 +165,9 @@ func installSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]str
 		// guarantee safety of concurrent installations.
 		var install *state.TaskSet
 		if setup.Revision.Local() {
-			install = sdkstate.InstallLocalSdk(st, setup)
+			install = sdkstate.InstallLocalSdk(st, pid, w, setup)
 		} else {
-			install = sdkstate.Install(st, setup.Name, retrieveTasks[setup.Name])
+			install = sdkstate.Install(st, pid, w, setup.Name, retrieveTasks[setup.Name])
 		}
 
 		addTaskSet(install)
@@ -270,11 +270,8 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	create := launchWorkshop(st, file, project)
 	addTaskSet(create)
 
-	install := installSdks(st, sdks, rmap)
+	install := installSdks(st, project.ProjectId, file.Name, sdks, rmap)
 	addTaskSet(install)
-
-	setup := runHooks(st, project.ProjectId, file.Name, sdks, 0, hookstate.SetupBase)
-	addTaskSet(setup)
 
 	connect := autoconnectSdks(st, sdks)
 	addTaskSet(connect)
@@ -626,22 +623,9 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	rebuild := rebuildWorkshop(st, file, plan.sdkSnapshot)
 	addTaskSet(rebuild)
 
-	// Detach (uninstall) volumes of the SDKs from the restored snapshot. If the
-	// refresh fails, a copy of the workshop will be restored that had SDKs
-	// installed previously.
-	// We do not uninstall the SDKs that were installed locally and are to be
-	// removed here as those will not present in the recovered snapshot (as
-	// those are simply copied over into the workshop). These tasks will uninstall
-	// SDKs that were installed from the store as SDK volumes.
-	uninstall := uninstallSdks(st, plan.Remove())
-	addTaskSet(uninstall)
-
 	// Install and link updated SDKs to the rebuilt workshop.
-	install := installSdks(st, plan.InstallOrRefresh(), rmap)
+	install := installSdks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), rmap)
 	addTaskSet(install)
-
-	setup := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), 0, hookstate.SetupBase)
-	addTaskSet(setup)
 
 	connect := autoconnectSdks(st, plan.InstallIntactOrRefresh())
 	addTaskSet(connect)
@@ -710,32 +694,6 @@ func autoconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 		prevAuto = autoconnect
 	}
 	return autoconnectSet
-}
-
-func uninstallSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
-	var prevRemove *state.Task
-	all := state.NewTaskSet()
-	addTask := func(ts *state.Task) {
-		if prevRemove != nil {
-			ts.WaitFor(prevRemove)
-		}
-		prevRemove = ts
-
-		all.AddTask(ts)
-	}
-
-	for _, setup := range sdks {
-		// The install task sets must not run concurrently as exec ops are not
-		// allowed by LXD to be run concurrently and in general case we cannot
-		// guarantee safety of concurrent installations.
-		if setup.Revision.Store() {
-			install := st.NewTask("remove-sdk", fmt.Sprintf("Remove %q SDK", setup.Name))
-			install.Set("sdk-retrieve-task", install.ID())
-			install.Set("sdk-setup", setup)
-			addTask(install)
-		}
-	}
-	return all
 }
 
 func unlinkSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -1,5 +1,13 @@
 package workshop
 
+import (
+	"path/filepath"
+
+	"github.com/canonical/workshop/internal/dirs"
+)
+
+var DefaultDevices = defaultDevices
+
 type MountType int
 
 const (
@@ -96,4 +104,35 @@ func NewSdkProfile(sdkName string) SdkProfile {
 		Sdk:    sdkName,
 		Mounts: make(map[string]Mount),
 	}
+}
+
+func defaultDevices(pid, w string) ([]Mount, []ProxyEntry) {
+	mounts := []Mount{{
+		Name:  "workshop.workshopctl",
+		What:  filepath.Join(dirs.ExecDir, "workshopctl"),
+		Where: "/usr/bin/workshopctl",
+		Type:  HostWorkshop,
+	}, {
+		Name:  "cache.apt",
+		What:  AptCacheVolumeName(w, pid),
+		Where: dirs.AptCachePath,
+		Type:  Volume,
+	}}
+
+	socketHost := dirs.SocketPath + ".untrusted"
+	socketWorkshop := filepath.Join(dirs.WorkshopRunDir, filepath.Base(socketHost))
+	proxies := []ProxyEntry{{
+		Name:      "workshop.socket",
+		Connect:   ProxyTarget{Address: socketHost, Protocol: "unix"},
+		Listen:    ProxyTarget{Address: socketWorkshop, Protocol: "unix"},
+		Direction: WorkshopToHost,
+	}}
+
+	return mounts, proxies
+}
+
+func FakeDefaultDevices(f func(pid, w string) ([]Mount, []ProxyEntry)) func() {
+	oldDefault := DefaultDevices
+	DefaultDevices = f
+	return func() { DefaultDevices = oldDefault }
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -173,25 +173,9 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 
 	if wpe, ok := f.Workshops[projectId][file.Name]; ok {
 		// rebuild the workshop
-
 		ws = wpe
 		ws.File = file
 		ws.Base = file.Base
-		fs := ws.WorkshopFilesystem
-
-		// TODO: Remove locally installed SDKs. These should be removed in a
-		// more elegant way, i.e. unmounted from the workshop in a similar
-		// fashion to regular SDKs installed from the store. Thus, it will make
-		// SDKs "independent" of the workshop, which means that changes will
-		// have to take care of unmounting them from the workshop at the right
-		// time.
-		// NOTE: RemoveAll ignores E_NOENT.
-		if err = fs.RemoveAll(sdk.SdkRootPath("system")); err != nil {
-			return err
-		}
-		if err = fs.RemoveAll(sdk.SdkRootPath("sketch")); err != nil {
-			return err
-		}
 	} else {
 		ws.Workshop = &workshop.Workshop{Backend: f,
 			Name:    file.Name,
@@ -200,11 +184,12 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 			Base:    file.Base,
 			File:    file,
 		}
-		ws.WorkshopFilesystem, err = NewWorkshopFs(f.BaseDir)
-		if err != nil {
-			return err
-		}
 		f.Workshops[projectId][file.Name] = ws
+	}
+
+	ws.WorkshopFilesystem, err = NewWorkshopFs(f.BaseDir)
+	if err != nil {
+		return err
 	}
 
 	ws.Config = make(map[string]string)
@@ -634,21 +619,37 @@ func (s *FakeWorkshopBackend) Snapshot(ctx context.Context, name, snapid string)
 }
 
 func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, file *workshop.File) error {
-	user, projectId, err := s.userProject(ctx)
+	wp, err := s.Workshop(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	prj := s.project(user, projectId)
-
-	s.workshopLock.Lock()
-	if wp, ok := s.Workshops[prj.ProjectId][name]; !ok {
-		defer s.workshopLock.Unlock()
-		return workshop.ErrWorkshopNotLaunched
-	} else {
-		wp.File = file
+	sdks := []string{sdk.System.String()}
+	for _, sk := range wp.File.Sdks {
+		if !workshop.IsImplicitSdk(sk.Name) {
+			sdks = append(sdks, sk.Name)
+		}
 	}
-	s.workshopLock.Unlock()
+	sdks = append(sdks, sdk.Sketch)
+
+	lastIntact := slices.IndexFunc(sdks, func(s string) bool { return workshop.SnapshotId(name, s) == snapid })
+	if lastIntact < 0 {
+		return fmt.Errorf("invalid snapshot %q", snapid)
+	}
+	unwantedSdks := sdks[lastIntact+1:]
+
+	// Remove SDKs from after the snapshot.
+	fs, err := s.WorkshopFs(ctx, name)
+	if err != nil {
+		return err
+	}
+	for _, sk := range unwantedSdks {
+		if err = fs.RemoveAll(sdk.SdkRootPath(sk)); err != nil {
+			return err
+		}
+	}
+
+	wp.File = file
 
 	s.snapshotLock.Lock()
 	defer s.snapshotLock.Unlock()

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"net/http"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -21,7 +20,6 @@ import (
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
@@ -40,7 +38,6 @@ const (
 )
 
 var (
-	defaultDevices      = createDefaultDevices
 	checkNvidiaRuntime  = checkNvidia
 	startCommandTimeout = 1 * time.Minute
 )
@@ -275,7 +272,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 	if err != nil {
 		return err
 	}
-	devices := defaultDevices()
+	devices := defaultDevices(projectId, file.Name)
 
 	inst, _, err := conn.GetInstanceFull(InstanceName(file.Name, projectId))
 	switch {
@@ -529,6 +526,17 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, mount works
 		return err
 	}
 
+	inst.Devices[mount.Name] = mountToLxdDisk(mount)
+
+	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
+	if err != nil {
+		return err
+	}
+
+	return op.WaitContext(ctx)
+}
+
+func mountToLxdDisk(mount workshop.Mount) map[string]string {
 	device := map[string]string{
 		"type":     "disk",
 		"source":   mount.What,
@@ -538,14 +546,7 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, mount works
 	if mount.Type == workshop.Volume {
 		device["pool"] = storagePool
 	}
-	inst.Devices[mount.Name] = device
-
-	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
-	if err != nil {
-		return err
-	}
-
-	return op.WaitContext(ctx)
+	return device
 }
 
 func (s *Backend) RemoveWorkshopMount(ctx context.Context, name, mount string) error {
@@ -948,16 +949,38 @@ func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {
 	}
 }
 
-func createDefaultDevices() map[string]map[string]string {
-	// configure .untrusted socket mount
-	shostpath := dirs.SocketPath + ".untrusted"
-	swspath := filepath.Join(dirs.WorkshopRunDir, filepath.Base(shostpath))
-	return map[string]map[string]string{
-		"root":                 {"type": "disk", "pool": storagePool, "path": "/"},
-		"workshop.network":     {"type": "nic", "network": networkName, "name": "eth0"},
-		"workshop.socket":      {"type": "proxy", "connect": "unix:" + shostpath, "listen": "unix:" + swspath, "bind": "instance", "mode": "0666"},
-		"workshop.workshopctl": {"type": "disk", "source": filepath.Join(dirs.ExecDir, "workshopctl"), "path": "/usr/bin/workshopctl"},
+func defaultDevices(pid, w string) map[string]map[string]string {
+	devices := map[string]map[string]string{
+		"root":             {"type": "disk", "pool": storagePool, "path": "/"},
+		"workshop.network": {"type": "nic", "network": networkName, "name": "eth0"},
 	}
+
+	mounts, proxies := workshop.DefaultDevices(pid, w)
+	for _, mount := range mounts {
+		devices[mount.Name] = mountToLxdDisk(mount)
+	}
+
+	for _, proxy := range proxies {
+		devices[proxy.Name] = proxyToLxdDevice(proxy)
+	}
+
+	return devices
+}
+
+func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
+	device := map[string]string{
+		"type":    "proxy",
+		"connect": proxy.Connect.Protocol + ":" + proxy.Connect.Address,
+		"listen":  proxy.Listen.Protocol + ":" + proxy.Listen.Address,
+		"mode":    "0666",
+	}
+	switch proxy.Direction {
+	case workshop.WorkshopToHost:
+		device["bind"] = "instance"
+	case workshop.HostToWorkshop:
+		device["bind"] = "host"
+	}
+	return device
 }
 
 func checkNvidia() (bool, error) {
@@ -1056,13 +1079,32 @@ runcmd:
 		return map[string]string{}, err
 	}
 
+	nvidiaRuntime, err := checkNvidiaRuntime()
+	if err != nil {
+		return nil, err
+	}
+
+	// nvidia.* properties must be set at launch as otherwise it requires a
+	// container restart to take effect.
+	cfgNvidiaDriverCapabilities := ""
+	cfgNvidiaRuntime := ""
+	if nvidiaRuntime {
+		cfgNvidiaDriverCapabilities = "all"
+		cfgNvidiaRuntime = "true"
+	}
+
+	// Include all options we might change, even those with default values,
+	// so that workshops can be rebuilt.
 	cfg := map[string]string{
-		"raw.idmap":                fmt.Sprintf("uid %s %s\ngid %s %s", userid, workshop.User.Uid, groupid, workshop.User.Gid),
-		"security.nesting":         "true",
-		"user.workshop.project-id": projectId,
-		"user.user-data":           cloudInitConfig,
-		"user.workshop.file":       string(f),
-		"user.workshop.sdks":       "{}",
+		"boot.autostart":             "false",
+		"raw.idmap":                  fmt.Sprintf("uid %s %s\ngid %s %s", userid, workshop.User.Uid, groupid, workshop.User.Gid),
+		"security.nesting":           "true",
+		"user.workshop.project-id":   projectId,
+		"user.user-data":             cloudInitConfig,
+		"user.workshop.file":         string(f),
+		"user.workshop.sdks":         "{}",
+		"nvidia.driver.capabilities": cfgNvidiaDriverCapabilities,
+		"nvidia.runtime":             cfgNvidiaRuntime,
 		// LXC appears to have a race condition wherein a proxy device mounted in
 		// a dynamically created directory has the potential to be 'masked' by this
 		// directory. We create an explicit mount for /tmp here (one such dymanic
@@ -1070,25 +1112,7 @@ runcmd:
 		// See: https://github.com/lxc/lxc/issues/434
 		"raw.lxc": "lxc.mount.entry = tmpfs tmp tmpfs defaults",
 	}
-
-	nvidiaRuntime, err := checkNvidiaRuntime()
-	if err != nil {
-		return nil, err
-	}
-
-	if nvidiaRuntime {
-		// nvidia.* properties must be set at launch as otherwise it requires a
-		// container restart to take effect.
-		cfg["nvidia.driver.capabilities"] = "all"
-		cfg["nvidia.runtime"] = "true"
-	}
 	return cfg, nil
-}
-
-func FakeDefaultDevices(f func() map[string]map[string]string) func() {
-	oldDefault := defaultDevices
-	defaultDevices = f
-	return func() { defaultDevices = oldDefault }
 }
 
 func FakeStartCommand(script string) func() {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -325,7 +325,14 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			return err
 		}
 
+		// TODO: Run mount-project after snapshots, and delete this workaround.
+		projectPathDevice, ok := rebuilt.Devices[workshop.ConfigProjectPathDevice]
+		if ok {
+			devices[workshop.ConfigProjectPathDevice] = projectPathDevice
+		}
+
 		maps.Copy(rebuilt.Config, config)
+		clear(rebuilt.Devices)
 		maps.Copy(rebuilt.Devices, devices)
 
 		op, err := conn.UpdateInstance(rebuilt.Name, rebuilt.Writable(), etag)

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"gopkg.in/check.v1"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -29,11 +28,8 @@ scripts:
 
 var MinimalImageServer = "simplestreams:https://cloud-images.ubuntu.com/minimal/releases/"
 
-func DefaultTestDevices() map[string]map[string]string {
-	return map[string]map[string]string{
-		"root":             {"type": "disk", "pool": "workshop", "path": "/"},
-		"workshop.network": {"type": "nic", "network": "workshopbr0", "name": "eth0"},
-	}
+func DefaultTestDevices(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
+	return nil, nil
 }
 
 func CleanupLxdProject(c *check.C, client lxd.InstanceServer, project string) {
@@ -127,8 +123,6 @@ printf '%s\n' "$@"
 
 	volume := workshop.AptCacheVolumeName(wf.Name, prj.ProjectId)
 	err = bd.CreateVolume(ctx, volume)
-	c.Assert(err, check.IsNil)
-	err = bd.AttachVolume(ctx, wf.Name, volume, dirs.AptCachePath, false)
 	c.Assert(err, check.IsNil)
 
 	err = bd.StartWorkshop(ctx, "test")

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -41,11 +41,15 @@ type wsExec struct {
 
 var _ = check.Suite(&wsExec{})
 
-func execTestDevices(projectDir string) func() map[string]map[string]string {
-	conf := helper.DefaultTestDevices()
-	conf["workshop.project"] = map[string]string{"type": "disk", "source": projectDir, "path": "/project"}
-	return func() map[string]map[string]string {
-		return conf
+func execTestDevices(projectDir string) func(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
+	mounts := []workshop.Mount{{
+		Name:  workshop.ConfigProjectPathDevice,
+		What:  projectDir,
+		Where: workshop.WorkshopProjectPath,
+		Type:  workshop.HostWorkshop,
+	}}
+	return func(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
+		return mounts, nil
 	}
 }
 
@@ -99,7 +103,7 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 		return f.usr, nil
 	}, &daemon.LookupUserId)
 
-	f.restoreDevices = lxdbackend.FakeDefaultDevices(execTestDevices(c.MkDir()))
+	f.restoreDevices = workshop.FakeDefaultDevices(execTestDevices(c.MkDir()))
 
 	f.newProjectidRestore = testutil.FakeFunc(func() (string, error) {
 		return f.project.ProjectId, nil

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -49,7 +49,7 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 	}
 	f.ctx = helper.CreateTestContext(f.usr.Username, "42424242")
 
-	f.restoreDevices = lxdbackend.FakeDefaultDevices(helper.DefaultTestDevices)
+	f.restoreDevices = workshop.FakeDefaultDevices(helper.DefaultTestDevices)
 	f.restoreImageServer = lxdbackend.FakeImageServer(helper.MinimalImageServer)
 	f.restoreLookupUsr = osutil.FakeUserLookup(func(name string) (*user.User, error) {
 		return f.usr, nil


### PR DESCRIPTION
# Description

Previously, Workshop made an effort to remove existing SDKs after
restoring from a snapshot. However, the removed SDKs are based on the
current refresh. Future refreshes won't know about these SDKs, but
volumes are still mounted in the snapshot.

Example:
```console
$ cat <<EOF >workshop.yaml
name: dev
base: ubuntu@22.04
sdks:
  - name: test-sdk-basic
    channel: latest/stable
EOF
$ workshop launch
"dev" launched
$ cat <<EOF >workshop.yaml
name: dev
base: ubuntu@22.04
EOF
$ workshop refresh
"dev" refreshed
$ workshop exec -- ls -l /var/lib/workshop/sdk/test-sdk-basic
total 1
lrwxrwxrwx 1 root root 40 Apr  4 04:25 current -> /var/lib/workshop/sdk/test-sdk-basic/696
$ workshop refresh
$ workshop exec -- ls -l /var/lib/workshop/sdk/test-sdk-basic
total 1
drwx--x--x 4 root root  4 Apr  4 04:24 696
lrwxrwxrwx 1 root root 40 Apr  4 04:25 current -> /var/lib/workshop/sdk/test-sdk-basic/696
```

This PR restores earlier behaviour, where setup-base is run after
installing the associated SDK, and before other SDKs are mounted.

Other SDKs no longer need to be removed from the workshop after
restoring a snapshot. This means `FakeWorkshopBackend.Restore` needs to
be a bit smarter at restoring snapshots. Rather than copying the
WorkshopFs on each snapshot, it's enough for now to just remove the SDKs
that were installed after the current snapshot.

Also, rebuilt workshops will no longer include any SDK mounts, in line with freshly launched workshops.

This might break things when refreshing a workshop from an old-style snapshot.

# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
