### PR TITLE
Fix deadlock in TestConnectWarnOnExec

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,9 +15,6 @@ jobs:
       - name: Build
         run: go build -v ./...
 
-      - name: Check for races
-        run: go test -race ./...
-
       - name: Test
         run: mkdir -p ${{ github.workspace }}.cover/unit/cover && go test -cover ./... -args -test.gocoverdir=${{ github.workspace }}.cover/unit/cover
 
@@ -27,3 +24,15 @@ jobs:
         with:
           name: code-coverage-unit
           path: ${{ github.workspace }}.cover/
+  race:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Check for races
+        run: go test -race ./...

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1445,6 +1445,9 @@ func (s *apiSuite) TestConnectWarnOnExec(c *check.C) {
 	d.Overlord().Loop()
 	defer d.Overlord().Stop()
 
+	// Prevent the exec task from finishing before connect.
+	s.d.Overlord().TaskRunner().AddBlocked(func(t *state.Task, running []*state.Task) bool { return t.Kind() == "exec" })
+
 	action := &client.InterfaceAction{
 		Action: "connect",
 		Plugs:  []client.Plug{{ProjectId: "b8639dea", Workshop: "consumer-ws", Sdk: "consumer", Name: "plug"}},
@@ -1458,7 +1461,6 @@ func (s *apiSuite) TestConnectWarnOnExec(c *check.C) {
 	chg.AddTask(tsk)
 	tsk.Set("workshop", "producer-ws")
 	chg.Set("project-id", "b8639dea")
-	s.d.overlord.TaskRunner().AddBlocked(func(t *state.Task, running []*state.Task) bool { return t.ID() == tsk.ID() })
 	st.Unlock()
 
 	text, err := json.Marshal(action)

--- a/internal/interfaces/ifacetest/backend.go
+++ b/internal/interfaces/ifacetest/backend.go
@@ -37,9 +37,9 @@ type TestSecurityBackend struct {
 	RemoveCalls []string
 	// SetupCallback is an callback that is optionally called in Setup
 	SetupCallback func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error
-	setupLock     sync.Mutex
 	// RemoveCallback is a callback that is optionally called in Remove
 	RemoveCallback func(sdkName string) error
+	lock           sync.Mutex
 	// SandboxFeaturesCallback is a callback that is optionally called in SandboxFeatures
 	SandboxFeaturesCallback func() []string
 }
@@ -62,8 +62,8 @@ func (b *TestSecurityBackend) Name() interfaces.SecuritySystem {
 
 // Setup records information about the call and calls the setup callback if one is defined.
 func (b *TestSecurityBackend) Setup(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-	b.setupLock.Lock()
-	defer b.setupLock.Unlock()
+	b.lock.Lock()
+	defer b.lock.Unlock()
 
 	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SdkInfo: sdkInfo})
 	if b.SetupCallback == nil {
@@ -74,6 +74,9 @@ func (b *TestSecurityBackend) Setup(context context.Context, sdkInfo sdk.Ref, re
 
 // Remove records information about the call and calls the remove callback if one is defined
 func (b *TestSecurityBackend) Remove(context context.Context, workshop, sdkName string) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
 	b.RemoveCalls = append(b.RemoveCalls, sdkName)
 	if b.RemoveCallback == nil {
 		return nil


### PR DESCRIPTION
# Description

Fixes a deadlock caused by locking the `TaskRunner` while the state is already locked (in other places, e.g. `Ensure`, the runner is locked first).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
