### PR TITLE
Remove listener closing race in daemon

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -579,16 +579,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	restartSocket := d.restartSocket
 	d.mu.Unlock()
 
-	d.generalListener.Close()
 	d.standbyOpinions.Stop()
-
-	if d.untrustedListener != nil {
-		d.untrustedListener.Close()
-	}
-
-	if d.httpListener != nil {
-		d.httpListener.Close()
-	}
 
 	if restartSystem {
 		// give time to polling clients to notice restart


### PR DESCRIPTION
# Description

A double close was observed in https://github.com/canonical/workshop/actions/runs/14392632930/job/40362618518?pr=368.

Fixed by importing changes from https://github.com/canonical/pebble/pull/253.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
