### PR TITLE
Improve sketch template

### DIFF
--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
+
+	"github.com/canonical/workshop/client"
 )
 
 type CmdRefresh struct {
@@ -98,6 +100,10 @@ $ workshop refresh nimble/sketch`,
 		false,
 		"Return the change ID, don't wait for the operation to finish.")
 
+	cmd.MarkFlagsMutuallyExclusive("abort", "continue")
+	cmd.MarkFlagsMutuallyExclusive("abort", "wait-on-error")
+	cmd.MarkFlagsMutuallyExclusive("continue", "wait-on-error")
+
 	return cmd
 }
 
@@ -110,43 +116,11 @@ func workshopName(name string) string {
 	return name
 }
 
-func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
-	av = strutil.Deduplicate(av)
-
-	if c.Abort && c.Continue {
-		return fmt.Errorf("cannot refresh: '--abort' incompatible with '--continue'")
-	}
-
-	if c.WaitOnError && c.Abort {
-		return fmt.Errorf("cannot refresh: '--wait-on-error' incompatible with '--abort'")
-	}
-
-	if c.WaitOnError && c.Continue {
-		return fmt.Errorf("cannot refresh: '--wait-on-error' incompatible with '--continue'")
-	}
-
+func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av []string) error {
 	// We should have no more than one argument (a single workshop) for a
 	// wait-on-error operation
 	if (c.Abort || c.Continue || c.WaitOnError) && len(av) > 1 {
 		return fmt.Errorf("cannot refresh: '--wait-on-error' incompatible with multiple workshops")
-	}
-
-	cli, err := c.root.client()
-	if err != nil {
-		return err
-	}
-
-	project, err := cli.Project(c.root.project())
-	if err != nil {
-		return err
-	}
-
-	if len(av) == 0 {
-		name, err := cli.SingleWorkshopName(project)
-		if err != nil {
-			return err
-		}
-		av = []string{name}
 	}
 
 	mode := "transactional"
@@ -179,6 +153,32 @@ To view more information: 'workshop tasks %s'`, w, w, w, changeId)
 		}
 
 		return fmt.Errorf("%v\n%s refresh aborted", err, strutil.Quoted(av))
+	}
+	return nil
+}
+
+func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
+	cli, err := c.root.client()
+	if err != nil {
+		return err
+	}
+
+	project, err := cli.Project(c.root.project())
+	if err != nil {
+		return err
+	}
+
+	av = strutil.Deduplicate(av)
+	if len(av) == 0 {
+		name, err := cli.SingleWorkshopName(project)
+		if err != nil {
+			return err
+		}
+		av = []string{name}
+	}
+
+	if err := c.RunRefresh(cli, project, av); err != nil {
+		return err
 	}
 
 	if c.Abort {

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -248,33 +248,3 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C
 	c.Assert(m.stdout.String(), check.Matches, `"ws" refreshed\n`)
 	c.Check(n, check.Equals, 3)
 }
-
-func (m *workshopRefresh) TestRefreshIncompatibleOptions(c *check.C) {
-	cmd := &CmdRefresh{root: &CmdRoot{}}
-	cmd.Abort = true
-	cmd.Continue = true
-
-	err := cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, "cannot refresh: '--abort' incompatible with '--continue'")
-
-	cmd.WaitOnError = true
-	cmd.Abort = false
-	cmd.Continue = true
-
-	err = cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, "cannot refresh: '--wait-on-error' incompatible with '--continue'")
-
-	cmd.WaitOnError = true
-	cmd.Abort = true
-	cmd.Continue = false
-
-	err = cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, "cannot refresh: '--wait-on-error' incompatible with '--abort'")
-
-	cmd.WaitOnError = true
-	cmd.Abort = false
-	cmd.Continue = false
-
-	err = cmd.Run(nil, []string{"ws", "ws-1"})
-	c.Assert(err, check.ErrorMatches, "cannot refresh: '--wait-on-error' incompatible with multiple workshops")
-}

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -80,19 +80,17 @@ var sketchTemplate = `# Sketch SDK for %s
 # Sketch SDK provides local customisation of this specific workshop.
 
 # To read more about SDKs, their components and syntax, see:
-# https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/
+# https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/sdks/#sketch-sdk
 name: sketch
 
 hooks:
   # EXAMPLE: setup-base runs once at workshop launch, use it to install some packages.
-  # See https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/hooks/
   # setup-base: |
     # apt-get update
     # apt-get install PACKAGE...
     # snap install SNAP...
 
   # EXAMPLE: check-health runs after all SDK setup completes, call 'workshopctl set-health okay' for OK.
-  # See https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/hooks/
   # check-health: |
     # if CHECK_HEALTH_COMMAND ; then
     #   workshopctl set-health okay
@@ -102,19 +100,16 @@ hooks:
 
 plugs:
   # EXAMPLE: forward your SSH agent into the workshop enabling 'git push' inside the workshop.
-  # See https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/interfaces/ssh-interface/
   # ssh-agent:
   #   interface: ssh-agent
 
   # EXAMPLE: expose well-known config file locations to the workshop
-  # See https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/interfaces/mount-interface/
   # vs-code-settings:
   #   interface: mount
   #   workshop-target: /home/workshop/.config/Code/User
 
 slots:
   # EXAMPLE: expose SDK services to the host
-  # See https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/interfaces/tunnel-interface/
   # dashboard:
   #   interface: tunnel
   #   endpoint: 8080

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -79,7 +79,7 @@ $ workshop sketch-sdk nimble --stash`,
 var sketchTemplate = `# Sketch SDK for %s
 # Sketch SDK provides local customisation of this specific workshop.
 
-# To read more about SDKs, their components and syntax, see:
+# To read more about the sketch SDK, its and syntax, see:
 # https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/sdks/#sketch-sdk
 name: sketch
 
@@ -239,8 +239,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		}
 	}
 
-	// Ensure that the workshop is Ready,
-	// aborting previous sketch if necessary.
+	// Ensure that the workshop is Ready, aborting previous sketch if necessary.
 	if wp.Status == "Waiting" {
 		cmdabort := &CmdRefresh{root: c.root, Abort: true}
 		if err = cmdabort.Run(cmd, []string{wp.Name}); err != nil {
@@ -268,12 +267,13 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		defer reverter.Fail()
 
 		cmdrefresh := &CmdRefresh{root: c.root}
-		if err = cmdrefresh.Run(cmd, []string{wp.Name}); err != nil {
+		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 			// Refresh failed, revert the stash operation so a possible subsequent
 			// "workshop refresh <WORKSHOP>/sketch" won't fail due to the lack of
 			// sketch SDK definition.
 			return err
 		}
+		fmt.Fprintf(Stdout, "%q sketch stashed\n", wp.Name)
 		reverter.Success()
 		return nil
 	}
@@ -293,7 +293,11 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		// and with --wait-on-error. Hence, there is always a possibility to
 		// workshop refresh --abort and workshop sketch-sdk --stash to restore the
 		// original stash content.
-		return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", wp.Name)})
+		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
+			return err
+		}
+		fmt.Fprintf(Stdout, "%q sketch restored\n", wp.Name)
+		return nil
 	}
 
 	if c.remove {
@@ -302,7 +306,11 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		}
 
 		cmdrefresh := &CmdRefresh{root: c.root}
-		return cmdrefresh.Run(cmd, []string{wp.Name})
+		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
+			return err
+		}
+		fmt.Fprintf(Stdout, "%q sketch removed\n", wp.Name)
+		return nil
 	}
 
 	if err = editSketchSdk(sketchdir, wp.Path); err != nil {
@@ -312,7 +320,11 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	cmdrefresh := &CmdRefresh{root: c.root}
 	cmdrefresh.WaitOnError = true
 
-	return cmdrefresh.Run(cmd, []string{fmt.Sprintf("%s/sketch", wp.Name)})
+	if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
+		return err
+	}
+	fmt.Fprintf(Stdout, "%q sketch refreshed\n", wp.Name)
+	return nil
 }
 
 func editSketchSdk(sketchdir, workshopFile string) error {

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -241,8 +241,9 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 	// Ensure that the workshop is Ready, aborting previous sketch if necessary.
 	if wp.Status == "Waiting" {
+		fmt.Fprintf(Stdout, "Reverting incomplete change for %q...\n", wp.Name)
 		cmdabort := &CmdRefresh{root: c.root, Abort: true}
-		if err = cmdabort.Run(cmd, []string{wp.Name}); err != nil {
+		if err = cmdabort.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 			return err
 		}
 	} else if wp.Status != "Ready" {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -333,18 +333,18 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 	// The API calls break down as follows:
 	// 1-2: get workshop info
 	// 3-4: refresh --wait-on-error (fails due to setup-base)
-	// 5-7: get workshop info
-	// 8-9. refresh --abort
-	// 9-11. refresh --wait-on-error
+	// 5-6: get workshop info
+	// 7-8. refresh --abort
+	// 9-10. refresh --wait-on-error
 	n := 0
 	change := 42
 	workshop := "ws"
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 5, 7:
+		case 1, 5:
 			c.Check(r.Method, check.Equals, "POST")
-			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects", check.Commentf("call: %d", n))
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
 			fmt.Fprintln(w, r)
 		case 2, 6:
@@ -357,10 +357,10 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 			case 6:
 				fmt.Fprintln(w, mockWorkshopWithSdksWaiting)
 			}
-		case 3, 8, 10:
+		case 3, 7, 9:
 			mode := "wait-on-error"
 			name := workshop
-			if n == 8 {
+			if n == 7 {
 				mode = "abort"
 			}
 
@@ -373,19 +373,19 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 				"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, response)
-		case 4, 9, 11:
+		case 4, 8, 10:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/changes/%d", change))
 			switch n {
 			case 4:
 				fmt.Fprintln(w, mockWaitChangeJSON)
-			case 9:
+			case 8:
 				fmt.Fprintln(w, mockAbortedChangeJSON)
-			case 11:
+			case 10:
 				fmt.Fprintln(w, mockReadyChangeJSON)
 			}
 		default:
-			c.Errorf("expected 11 calls, now on %d", n)
+			c.Errorf("expected 10 calls, now on %d", n)
 		}
 	})
 
@@ -425,7 +425,7 @@ hooks:
 	err = cmd.Run(cmd.Command(), []string{"ws"})
 	c.Assert(err, check.IsNil)
 
-	c.Assert(n, check.Equals, 11)
+	c.Assert(n, check.Equals, 10)
 	c.Assert(attempts, check.Equals, 2)
 }
 

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -153,7 +153,7 @@ func (m *workshopSketch) mockSketchHappyRefreshPath(c *check.C, refreshname stri
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 3:
+		case 1:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
@@ -163,19 +163,19 @@ func (m *workshopSketch) mockSketchHappyRefreshPath(c *check.C, refreshname stri
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
 			fmt.Fprintln(w, mockWorkshopWithSdksReady)
-		case 4:
+		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
 				"names": []interface{}{refreshname}, "options": map[string]interface{}{"mode": mode}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
-		case 5:
+		case 4:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
 			fmt.Fprintln(w, mockReadyChangeJSON)
 		default:
-			c.Errorf("expected 5 calls, now on %d", n)
+			c.Errorf("expected 4 calls, now on %d", n)
 		}
 	})
 }
@@ -204,7 +204,7 @@ func (m *workshopSketch) mockSketchesHappyPath(c *check.C, resp string) {
 func (m *workshopSketch) TestSketchSdkMetaOnlySuccess(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}}
 
-	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
+	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
 	sketchContent := fmt.Sprintf(sketchTemplate, "/home/project/.workshop/ws.yaml")
 	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
@@ -226,7 +226,7 @@ func (m *workshopSketch) TestSketchSdkMetaOnlySuccess(c *check.C) {
 func (m *workshopSketch) TestSketchSdkSuccess(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}}
 
-	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
+	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
 	sketchContent := `name: sketch
 base: ubuntu@22.04
@@ -249,11 +249,12 @@ hooks:
 	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
 	c.Assert(filepath.Join(current, "meta", "sdk.yaml"), testutil.FileEquals, sketchContent)
 	c.Assert(filepath.Join(current, "sdk", "hooks", "setup-base"), testutil.FileEquals, "echo \"Hello\"\n")
+	c.Assert(m.stdout.String(), check.Matches, `"ws" sketch refreshed\n`)
 }
 
 func (m *workshopSketch) TestSketchSdkUpdateHooks(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}}
-	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
+	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
 	meta, hooks := m.mockMinimalSketchSdk(c, "ws", true, []byte(`name: sketch
 base: ubuntu@22.04
@@ -294,7 +295,7 @@ hooks:
 func (m *workshopSketch) TestSketchSdkEditExistingMeta(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}}
 
-	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
+	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
 	dir := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
 	metadir := filepath.Join(dir, "meta")
@@ -331,37 +332,36 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 	// The second run should automatically abort the first refresh.
 	// The API calls break down as follows:
 	// 1-2: get workshop info
-	// 3-5: refresh --wait-on-error (fails due to setup-base)
-	// 6-7: get workshop info
-	// 8-10. refresh --abort
-	// 11-13. refresh --wait-on-error
+	// 3-4: refresh --wait-on-error (fails due to setup-base)
+	// 5-7: get workshop info
+	// 8-9. refresh --abort
+	// 9-11. refresh --wait-on-error
 	n := 0
 	change := 42
 	workshop := "ws"
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 3, 6, 8, 11:
+		case 1, 5, 7:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
 			fmt.Fprintln(w, r)
-		case 2, 7:
+		case 2, 6:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
 			switch n {
 			case 2:
 				fmt.Fprintln(w, mockWorkshopWithSdksReady)
-			case 7:
+			case 6:
 				fmt.Fprintln(w, mockWorkshopWithSdksWaiting)
 			}
-		case 4, 9, 12:
+		case 3, 8, 10:
 			mode := "wait-on-error"
-			name := fmt.Sprintf("%s/sketch", workshop)
-			if n == 9 {
+			name := workshop
+			if n == 8 {
 				mode = "abort"
-				name = workshop
 			}
 
 			change += 1
@@ -373,19 +373,19 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 				"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, response)
-		case 5, 10, 13:
+		case 4, 9, 11:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/changes/%d", change))
 			switch n {
-			case 5:
+			case 4:
 				fmt.Fprintln(w, mockWaitChangeJSON)
-			case 10:
+			case 9:
 				fmt.Fprintln(w, mockAbortedChangeJSON)
-			case 13:
+			case 11:
 				fmt.Fprintln(w, mockReadyChangeJSON)
 			}
 		default:
-			c.Errorf("expected 13 calls, now on %d", n)
+			c.Errorf("expected 11 calls, now on %d", n)
 		}
 	})
 
@@ -425,7 +425,7 @@ hooks:
 	err = cmd.Run(cmd.Command(), []string{"ws"})
 	c.Assert(err, check.IsNil)
 
-	c.Assert(n, check.Equals, 13)
+	c.Assert(n, check.Equals, 11)
 	c.Assert(attempts, check.Equals, 2)
 }
 
@@ -442,6 +442,7 @@ func (m *workshopSketch) TestSketchSdkStashOK(c *check.C) {
 
 	c.Assert(metadir, testutil.FileAbsent)
 	c.Assert(filepath.Join(restore, "meta", "sdk.yaml"), testutil.FileEquals, simpleSketchMeta)
+	c.Assert(m.stdout.String(), check.Matches, `"ws" sketch stashed\n`)
 }
 
 func (m *workshopSketch) TestSketchSdkOverwritesExistingStash(c *check.C) {
@@ -475,7 +476,7 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 3:
+		case 1:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
@@ -485,19 +486,19 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
 			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
-		case 4:
+		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
 				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "transactional"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
-		case 5:
+		case 4:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
 			fmt.Fprintln(w, mockChangeWithError)
 		default:
-			c.Errorf("expected 5 calls, now on %d", n)
+			c.Errorf("expected 4 calls, now on %d", n)
 		}
 	})
 
@@ -505,7 +506,7 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 
 	err := cmd.Run(nil, nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(n, check.Equals, 5)
+	c.Assert(n, check.Equals, 4)
 
 	c.Assert(filepath.Join(metadir, "sdk.yaml"), testutil.FileEquals, simpleSketchMeta)
 	restore := workshop.SketchSdkStash(m.userDataDir, m.prjId, "ws")
@@ -517,7 +518,7 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 func (m *workshopSketch) TestSketchSdkRestoreOK(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, restore: true}
 
-	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
+	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 	m.mockMinimalSketchSdk(c, "ws", false, []byte(simpleSketchMeta))
 
 	err := cmd.Run(nil, []string{"ws"})
@@ -525,12 +526,13 @@ func (m *workshopSketch) TestSketchSdkRestoreOK(c *check.C) {
 
 	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
 	c.Assert(filepath.Join(current, "meta", "sdk.yaml"), testutil.FileEquals, simpleSketchMeta)
+	c.Assert(m.stdout.String(), check.Matches, `"ws" sketch restored\n`)
 }
 
 func (m *workshopSketch) TestSketchSdkRestoreNoStoredSketch(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, restore: true}
 
-	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
+	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.ErrorMatches, `cannot restore: no stashed 'sketch' SDK found`)
@@ -539,7 +541,7 @@ func (m *workshopSketch) TestSketchSdkRestoreNoStoredSketch(c *check.C) {
 func (m *workshopSketch) TestSketchSdkRestoreFailsIfCurrentExists(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, restore: true}
 
-	m.mockSketchHappyRefreshPath(c, "ws/sketch", "wait-on-error")
+	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 	stored := `name: sketch
 base: ubuntu@22.04
 plugs:
@@ -566,6 +568,7 @@ func (m *workshopSketch) TestSketchSdkRemoveOK(c *check.C) {
 
 	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
 	c.Assert(current, testutil.FileAbsent)
+	c.Assert(m.stdout.String(), check.Matches, `"ws" sketch removed\n`)
 }
 
 func (m *workshopSketch) TestSketchSdkRemoveCurrentNotExist(c *check.C) {

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -139,7 +139,7 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		// progress reporting
 		for _, t := range chg.Tasks {
 			switch {
-			case t.Status != "Doing":
+			case t.Status != "Doing" && t.Status != "Undoing":
 				continue
 			case t.Progress.Total == 1:
 				pb.Spin(t.Summary)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -384,15 +384,6 @@ func newWorkshopChange(st *state.State, kind string, user, projectId, action str
 	return change
 }
 
-func newWorkshopSdkChange(st *state.State, kind string, user, projectId, action string, wp, sk string) *state.Change {
-	sdkRef := sdk.Ref{ProjectId: projectId, Workshop: wp, Sdk: sk}
-	summary := fmt.Sprintf(`%s %q SDK`, cases.Title(language.BritishEnglish).String(action), sdkRef.ShortRef())
-	change := st.NewChange(kind, summary)
-	change.Set("user", user)
-	change.Set("project-id", projectId)
-	return change
-}
-
 func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	projectId := muxVars(r)["id"]
 	state := c.d.overlord.State()
@@ -451,18 +442,6 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 	return SyncResponse(info, http.StatusOK)
 }
 
-func maybeSdkRefresh(names []string) (wp string, sk string, partial bool) {
-	if len(names) != 1 {
-		return "", "", false
-	}
-
-	parts := strings.FieldsFunc(names[0], func(r rune) bool { return r == '/' })
-	if len(parts) == 2 {
-		return parts[0], parts[1], true
-	}
-	return "", "", false
-}
-
 func actionMode(reqData *workshopReq) (conflict.Mode, error) {
 	var mode conflict.Mode
 
@@ -493,20 +472,9 @@ func actionMode(reqData *workshopReq) (conflict.Mode, error) {
 }
 
 func refresh(ctx context.Context, st *state.State, mgr *workshopstate.WorkshopManager, reqData *workshopReq, user, pid string) (*state.Change, []*state.TaskSet, error) {
-	var taskset []*state.TaskSet
-	var change *state.Change
-	var err error
+	change := newWorkshopChange(st, "refresh", user, pid, reqData.Action, reqData.Names)
+	taskset, err := mgr.RefreshMany(ctx, pid, reqData.Names)
 
-	if wp, sk, ok := maybeSdkRefresh(reqData.Names); ok {
-		change = newWorkshopSdkChange(st, "refresh", user, pid, reqData.Action, wp, sk)
-		if !sdk.IsSketch(sk) {
-			return change, taskset, fmt.Errorf(`partial refresh is supported only for "sketch" SDK`)
-		}
-		taskset, err = mgr.RefreshMany(ctx, pid, []string{wp})
-	} else {
-		change = newWorkshopChange(st, "refresh", user, pid, reqData.Action, reqData.Names)
-		taskset, err = mgr.RefreshMany(ctx, pid, reqData.Names)
-	}
 	return change, taskset, err
 }
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -3221,14 +3221,14 @@ base: ubuntu@22.04
 `)
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks/sketch"],"action":"refresh"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
 	}
 	expected = []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "refresh",
-			Summary: `Refresh "manysdks/sketch" SDK`,
+			Summary: `Refresh "manysdks" workshop`,
 		},
 	}
 
@@ -3271,14 +3271,14 @@ plugs:
 `)
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks/sketch"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
 	}
 	expected = []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "refresh",
-			Summary: `Refresh "manysdks/sketch" SDK`,
+			Summary: `Refresh "manysdks" workshop`,
 		},
 	}
 
@@ -3338,7 +3338,7 @@ base: ubuntu@22.04
 `)
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks/sketch"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
 	}
 	expected = []*expectedResp{
@@ -3346,7 +3346,7 @@ base: ubuntu@22.04
 			Type:      ResponseTypeAsync,
 			Status:    http.StatusAccepted,
 			Kind:      "refresh",
-			Summary:   `Refresh "manysdks/sketch" SDK`,
+			Summary:   `Refresh "manysdks" workshop`,
 			ChangeErr: `(?s).*\(SDK must be named "sketch" \(now: "illegal-sketch-name"\)\)`,
 		},
 		{


### PR DESCRIPTION
# Description

* Remove redundant URLs from the sketch template.
* Simplify sketch implementation and improve `sketch-sdk` info messages shown to the end-user (e.g. instead of showing a refresh operation outcome which is the underlying sketch operation, show `"<workshop>" sketch refreshed`).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
