### PR TITLE
Eject option for sketch SDK command

### DIFF
--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -100,9 +100,7 @@ $ workshop refresh nimble/sketch`,
 		false,
 		"Return the change ID, don't wait for the operation to finish.")
 
-	cmd.MarkFlagsMutuallyExclusive("abort", "continue")
-	cmd.MarkFlagsMutuallyExclusive("abort", "wait-on-error")
-	cmd.MarkFlagsMutuallyExclusive("continue", "wait-on-error")
+	cmd.MarkFlagsMutuallyExclusive("abort", "continue", "wait-on-error")
 
 	return cmd
 }

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -20,7 +20,7 @@ type CmdRefresh struct {
 
 func (c *CmdRefresh) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "refresh [--abort|--continue|--wait-on-error] <WORKSHOP>[/<SDK>]...",
+		Use:   "refresh [--abort|--continue|--wait-on-error] <WORKSHOP>...",
 		Short: "Update workshops according to their definitions",
 		Long: `
 This command updates the workshops listed as arguments by going over their
@@ -79,10 +79,7 @@ $ workshop refresh --abort
 
 After refresh paused on error and the workshop was fixed,
 continue the operation:
-$ workshop refresh --continue
-
-Refresh the sketch SDK in the 'nimble' workshop:
-$ workshop refresh nimble/sketch`,
+$ workshop refresh --continue`,
 		RunE:              c.Run,
 		ValidArgsFunction: c.root.completeWorkshopNames([]string{"Ready", "Waiting"}),
 	}

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -54,9 +54,6 @@ Notes:
 
 - In addition to hooks, the 'sketch' SDK can use interfaces,
   define plugs, slots, connections and bindings.
-
-- You can partially refresh the workshop, targeting the 'sketch' SDK
-  with the 'workshop refresh <WORKSHOP>/sketch' command.
 `,
 		Example: `
 Edit the sketch SDK definition for the 'nimble' workshop
@@ -410,8 +407,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		cmdrefresh := &CmdRefresh{root: c.root}
 		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 			// Refresh failed, revert the stash operation so a possible subsequent
-			// "workshop refresh <WORKSHOP>/sketch" won't fail due to the lack of
-			// sketch SDK definition.
+			// refresh won't fail due to the lack of a sketch SDK definition.
 			return err
 		}
 		fmt.Fprintf(Stdout, "%q sketch stashed\n", wp.Name)

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -82,14 +82,12 @@ var sketchTemplate = `# Sketch SDK for %s
 # To read more about the sketch SDK, its and syntax, see:
 # https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/sdks/#sketch-sdk
 name: sketch
-
 hooks:
   # EXAMPLE: setup-base runs once at workshop launch, use it to install some packages.
   # setup-base: |
     # apt-get update
     # apt-get install PACKAGE...
     # snap install SNAP...
-
   # EXAMPLE: check-health runs after all SDK setup completes, call 'workshopctl set-health okay' for OK.
   # check-health: |
     # if CHECK_HEALTH_COMMAND ; then
@@ -97,17 +95,14 @@ hooks:
     # else
     #   workshopctl set-health --code=installation-failed error "Installation failed"
     # fi
-
 plugs:
   # EXAMPLE: forward your SSH agent into the workshop enabling 'git push' inside the workshop.
   # ssh-agent:
   #   interface: ssh-agent
-
   # EXAMPLE: expose well-known config file locations to the workshop
   # vs-code-settings:
   #   interface: mount
   #   workshop-target: /home/workshop/.config/Code/User
-
 slots:
   # EXAMPLE: expose SDK services to the host
   # dashboard:

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -523,6 +523,9 @@ func editSketchSdk(sketchdir, workshopFile string) error {
 		return err
 	}
 	if err := writeSketchHooks(temp, content); err != nil {
+		// If writeSketchHooks failed, we don't want to refresh
+		// but we do want to remember the user's edits for next time.
+		_ = osutil.Exchange(temp, sketchdir)
 		return err
 	}
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -190,30 +190,36 @@ func restoreSketch(sketchdir, stashdir string) error {
 	return nil
 }
 
-func removeSketch(sketchdir string) error {
+func hideSketch(sketchdir string) (string, *revert.Reverter, error) {
 	_, err := os.Stat(sketchdir)
 	if err != nil && !osutil.IsDirNotExist(err) {
-		return err
+		return "", nil, err
 	}
 	if osutil.IsDirNotExist(err) {
 		// Nothing to do.
-		return fmt.Errorf(`cannot remove: the 'sketch' SDK doesn't exist`)
+		return "", nil, fmt.Errorf(`cannot remove: the 'sketch' SDK doesn't exist`)
 	}
+
+	reverter := revert.New()
+	defer reverter.Fail()
 
 	temp, err := os.MkdirTemp(filepath.Dir(sketchdir), "sketch-*")
 	if err != nil {
-		return err
+		return "", nil, err
 	}
-	defer os.RemoveAll(temp)
+	reverter.Add(func() { _ = os.RemoveAll(temp) })
 	if err := os.Chmod(temp, 0755); err != nil {
-		return err
+		return "", nil, err
 	}
 
 	if err := osutil.Exchange(sketchdir, temp); err != nil {
-		return err
+		return "", nil, err
 	}
+	reverter.Add(func() { _ = osutil.Exchange(temp, sketchdir) })
 
-	return os.Remove(sketchdir)
+	clone := reverter.Clone()
+	reverter.Success()
+	return temp, clone, nil
 }
 
 func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
@@ -302,14 +308,20 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	if c.remove {
-		if err := removeSketch(sketchdir); err != nil {
+		temp, reverter, err := hideSketch(sketchdir)
+		if err != nil {
 			return err
 		}
+		defer reverter.Fail()
 
 		cmdrefresh := &CmdRefresh{root: c.root}
 		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 			return err
 		}
+
+		reverter.Success()
+		_ = os.RemoveAll(temp)
+
 		fmt.Fprintf(Stdout, "%q sketch removed\n", wp.Name)
 		return nil
 	}

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -126,7 +126,7 @@ func stashSketch(sketchdir, stashdir string) (*revert.Reverter, error) {
 	}
 	if len(recs) == 0 {
 		// Nothing to do.
-		return nil, fmt.Errorf(`cannot stash: the 'sketch' SDK doesn't exist`)
+		return nil, errors.New(`"sketch" SDK not found`)
 	}
 
 	// Ensure stashdir exists but is empty.
@@ -175,19 +175,16 @@ func restoreSketch(sketchdir, stashdir string) error {
 	}
 	if len(recs) == 0 || osutil.IsDirNotExist(err) {
 		// Nothing in stored.
-		return fmt.Errorf(`cannot restore: no stashed 'sketch' SDK found`)
+		return errors.New(`stashed "sketch" SDK not found`)
 	}
 
 	// We don't overwrite current sketch SDK as opposed to overwriting stashed
 	// sketch SDK.
 	if _, err = os.Stat(sketchdir); err == nil {
-		return fmt.Errorf(`cannot restore: the 'sketch' SDK exists; run 'workshop sketch-sdk --remove' to remove it from the workshop`)
+		return errors.New(`"sketch" SDK exists; run 'workshop sketch-sdk --remove' to remove it from the workshop`)
 	}
 
-	if err = osutil.Rename(stashdir, sketchdir); err != nil {
-		return err
-	}
-	return nil
+	return osutil.Rename(stashdir, sketchdir)
 }
 
 func hideSketch(sketchdir string) (string, *revert.Reverter, error) {
@@ -197,7 +194,7 @@ func hideSketch(sketchdir string) (string, *revert.Reverter, error) {
 	}
 	if osutil.IsDirNotExist(err) {
 		// Nothing to do.
-		return "", nil, fmt.Errorf(`cannot remove: the 'sketch' SDK doesn't exist`)
+		return "", nil, fmt.Errorf(`"sketch" SDK not found`)
 	}
 
 	reverter := revert.New()
@@ -253,7 +250,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 			return err
 		}
 	} else if wp.Status != "Ready" {
-		return fmt.Errorf(`error: cannot sketch %q: workshop currently %q, must be "Ready"`, wp.Name, wp.Status)
+		return fmt.Errorf(`cannot sketch: workshop %q currently %q, must be "Ready"`, wp.Name, wp.Status)
 	}
 
 	user, env, err := osutil.CurrentUserAndEnv()
@@ -269,7 +266,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 		reverter, err := stashSketch(sketchdir, stashdir)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot stash: %w", err)
 		}
 		defer reverter.Fail()
 
@@ -292,7 +289,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		stashdir := workshop.SketchSdkStash(userDataDir, p.Id, wp.Name)
 
 		if err = restoreSketch(sketchdir, stashdir); err != nil {
-			return err
+			return fmt.Errorf("cannot restore: %w", err)
 		}
 
 		// Run refresh with the stashed sketch SDK. We do not revert dirs exchange
@@ -310,7 +307,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	if c.remove {
 		temp, reverter, err := hideSketch(sketchdir)
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot remove: %w", err)
 		}
 		defer reverter.Fail()
 
@@ -327,7 +324,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	if err = editSketchSdk(sketchdir, wp.Path); err != nil {
-		return err
+		return fmt.Errorf("cannot sketch: %w", err)
 	}
 
 	cmdrefresh := &CmdRefresh{root: c.root}
@@ -348,7 +345,7 @@ func editSketchSdk(sketchdir, workshopFile string) error {
 		}
 
 		// Format sketch SDK template header.
-		content = []byte(fmt.Sprintf(sketchTemplate, workshopFile))
+		content = fmt.Appendf(nil, sketchTemplate, workshopFile)
 	} else if err != nil {
 		return err
 	}
@@ -391,7 +388,7 @@ func writeSketchHooks(sketchdir string, content []byte) error {
 	}
 
 	if !sdk.IsSketch(rec.Name) {
-		return fmt.Errorf("cannot sketch: SDK must be named %q (now: %q)", sdk.Sketch, rec.Name)
+		return fmt.Errorf("SDK must be named %q (now: %q)", sdk.Sketch, rec.Name)
 	}
 
 	hooksdir := filepath.Join(sketchdir, "hooks")

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -23,12 +24,14 @@ type CmdSketch struct {
 	root    *CmdRoot
 	stash   bool
 	restore bool
+	eject   bool
+	name    string
 	remove  bool
 }
 
 func (c *CmdSketch) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "sketch-sdk [--stash|--restore|--remove] [<WORKSHOP>]",
+		Use:   "sketch-sdk [--stash|--restore|--eject|--remove] [<WORKSHOP>]",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Edit the sketch SDK and graft it onto the workshop",
 		Long: `
@@ -40,6 +43,8 @@ which installs the configured 'sketch' SDK in the workshop.
 
 The '--stash' and '--restore' options respectively stash the SDK,
 reversing the changes, and quickly restore it to the workshop.
+The '--eject' option moves the SDK definition into the project directory,
+so it can be added to multiple workshops or shared with others.
 The '--remove' option removes the SDK permanently.
 
 Notes:
@@ -69,9 +74,11 @@ $ workshop sketch-sdk nimble --stash`,
 
 	cmd.Flags().BoolVar(&c.stash, "stash", false, "Stash the sketch SDK and remove it from the workshop.")
 	cmd.Flags().BoolVar(&c.restore, "restore", false, "Return the previously stashed SDK to the workshop.")
+	cmd.Flags().BoolVar(&c.eject, "eject", false, "Promote the sketch SDK to an in-project SDK.")
+	cmd.Flags().StringVar(&c.name, "name", "", "Name for the ejected SDK.")
 	cmd.Flags().BoolVar(&c.remove, "remove", false, "Remove the sketch SDK from the workshop.")
 
-	cmd.MarkFlagsMutuallyExclusive("stash", "restore", "remove")
+	cmd.MarkFlagsMutuallyExclusive("stash", "restore", "eject", "remove")
 
 	return cmd
 }
@@ -182,6 +189,137 @@ func restoreSketch(sketchdir, stashdir string) error {
 	return osutil.Rename(stashdir, sketchdir)
 }
 
+func (c *CmdSketch) inferSdkName(cmd *cobra.Command, project string) error {
+	inferred := false
+	if c.name == "" {
+		c.name = filepath.Base(project)
+		inferred = true
+	}
+
+	if sdk.SdkName.MatchString(c.name) {
+		return nil
+	}
+
+	err := fmt.Errorf("invalid SDK name %q", c.name)
+	if inferred {
+		err = fmt.Errorf("flag --name required: %w", err)
+	}
+	return err
+}
+
+func ejectSketch(project, sketchdir string, name string) (*revert.Reverter, error) {
+	target := workshop.ProjectSdkPath(project, name)
+	if osutil.FileExists(target) {
+		return nil, &os.PathError{Op: "mkdir", Path: target, Err: os.ErrExist}
+	}
+
+	content, err := os.ReadFile(filepath.Join(sketchdir, "sdk.yaml"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, errors.New(`"sketch" SDK not found`)
+	} else if err != nil {
+		return nil, err
+	}
+	var document yaml.Node
+	if err := yaml.Unmarshal(content, &document); err != nil {
+		return nil, err
+	}
+
+	var rec workshop.SdkRecord
+	if err := document.Decode(&rec); err != nil {
+		return nil, err
+	}
+	rec.Name = name
+
+	if err := sketchToProjectSdk(&document, name); err != nil {
+		return nil, err
+	}
+	if err := validateProjectSdk(&document, &rec); err != nil {
+		return nil, err
+	}
+
+	// This won't be cleaned up on failure. In most cases the user
+	// is likely to retry the eject after fixing the underlying issue.
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return nil, err
+	}
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	temp, err := os.MkdirTemp(filepath.Dir(target), name+"-*")
+	if err != nil {
+		return nil, err
+	}
+	reverter.Add(func() { _ = os.RemoveAll(temp) })
+
+	f, err := os.OpenFile(filepath.Join(temp, "sdk.yaml"), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	encoder := yaml.NewEncoder(f)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&document); err != nil {
+		return nil, err
+	}
+	if err := writeHooks(temp, rec); err != nil {
+		return nil, err
+	}
+
+	if err := os.Rename(temp, target); err != nil {
+		return nil, err
+	}
+
+	reverter.Success()
+
+	ejectReverter := revert.New()
+	ejectReverter.Add(func() { _ = os.RemoveAll(target) })
+	return ejectReverter, nil
+}
+
+func sketchToProjectSdk(document *yaml.Node, name string) error {
+	var nodes struct {
+		Name  NodeRef `yaml:"name"`
+		Hooks NodeRef `yaml:"hooks"`
+	}
+	if err := document.Decode(&nodes); err != nil {
+		return err
+	}
+
+	if nodes.Name.Node == nil {
+		return errors.New(`"sketch" SDK name not found`)
+	}
+	nodes.Name.Node.Value = name
+
+	if nodes.Hooks.Node != nil {
+		RemoveNodes(document, nodes.Hooks.Node)
+	}
+
+	return nil
+}
+
+func validateProjectSdk(document *yaml.Node, expected *workshop.SdkRecord) error {
+	var actual workshop.SdkRecord
+	if err := document.Decode(&actual); err != nil {
+		return err
+	}
+
+	if actual.Name != expected.Name {
+		return fmt.Errorf("internal error: sketch SDK renamed %q (expected %q)", actual.Name, expected.Name)
+	}
+	if !reflect.DeepEqual(expected.Plugs, actual.Plugs) {
+		return errors.New("internal error: sketch SDK plugs not preserved")
+	}
+	if !reflect.DeepEqual(actual.Slots, actual.Slots) {
+		return errors.New("internal error: sketch SDK slots not preserved")
+	}
+	if len(actual.Hooks) > 0 {
+		return errors.New("internal error: hooks not ejected from sketch SDK")
+	}
+
+	return nil
+}
+
 func hideSketch(sketchdir string) (string, *revert.Reverter, error) {
 	_, err := os.Stat(sketchdir)
 	if err != nil && !osutil.IsDirNotExist(err) {
@@ -215,6 +353,10 @@ func hideSketch(sketchdir string) (string, *revert.Reverter, error) {
 }
 
 func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
+	if c.name != "" && !c.eject {
+		return errors.New("flag --name requires --eject")
+	}
+
 	cli, err := c.root.client()
 	if err != nil {
 		return err
@@ -299,7 +441,20 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		return nil
 	}
 
-	if c.remove {
+	var ejectReverter *revert.Reverter
+	if c.eject {
+		if err := c.inferSdkName(cmd, p.Path); err != nil {
+			return fmt.Errorf("cannot eject: %w", err)
+		}
+
+		ejectReverter, err = ejectSketch(p.Path, sketchdir, c.name)
+		if err != nil {
+			return fmt.Errorf("cannot eject: %w", err)
+		}
+		defer ejectReverter.Fail()
+	}
+
+	if c.eject || c.remove {
 		temp, reverter, err := hideSketch(sketchdir)
 		if err != nil {
 			return fmt.Errorf("cannot remove: %w", err)
@@ -312,9 +467,18 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		}
 
 		reverter.Success()
+		if ejectReverter != nil {
+			ejectReverter.Success()
+		}
 		_ = os.RemoveAll(temp)
 
-		fmt.Fprintf(Stdout, "%q sketch removed\n", wp.Name)
+		if c.remove {
+			fmt.Fprintf(Stdout, "%q sketch removed\n", wp.Name)
+		} else {
+			fmt.Fprintf(Stdout, "%q sketch ejected to %q\n", wp.Name, workshop.ProjectSdkPath("", c.name))
+			fmt.Fprintf(Stdout, "To use it, add %q to the list of SDKs and run 'workshop refresh %s'\n", "project-"+c.name, wp.Name)
+		}
+
 		return nil
 	}
 
@@ -386,7 +550,11 @@ func writeSketchHooks(sketchdir string, content []byte) error {
 		return fmt.Errorf("SDK must be named %q (now: %q)", sdk.Sketch, rec.Name)
 	}
 
-	hooksdir := filepath.Join(sketchdir, "hooks")
+	return writeHooks(sketchdir, rec)
+}
+
+func writeHooks(sdkdir string, rec workshop.SdkRecord) error {
+	hooksdir := filepath.Join(sdkdir, "hooks")
 	if len(rec.Hooks) > 0 {
 		if err := os.MkdirAll(hooksdir, 0755); err != nil {
 			return err
@@ -396,7 +564,10 @@ func writeSketchHooks(sketchdir string, content []byte) error {
 	for _, hook := range []string{"setup-base", "save-state", "restore-state", "check-health"} {
 		hookpath := filepath.Join(hooksdir, hook)
 		if script := rec.Hooks[hook]; len(script) > 0 {
-			if err := os.WriteFile(hookpath, []byte(script+"\n"), 0644); err != nil {
+			if !strings.HasSuffix(script, "\n") {
+				script += "\n"
+			}
+			if err := os.WriteFile(hookpath, []byte(script), 0644); err != nil {
 				return err
 			}
 		}

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -531,7 +531,7 @@ func (m *workshopSketch) TestSketchSdkRestoreNoStoredSketch(c *check.C) {
 	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
 	err := cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, `cannot restore: no stashed 'sketch' SDK found`)
+	c.Assert(err, check.ErrorMatches, `cannot restore: stashed "sketch" SDK not found`)
 }
 
 func (m *workshopSketch) TestSketchSdkRestoreFailsIfCurrentExists(c *check.C) {
@@ -550,7 +550,7 @@ plugs:
 	m.mockMinimalSketchSdk(c, "ws", false, []byte(stored))
 
 	err := cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, `cannot restore: the 'sketch' SDK exists; run 'workshop sketch-sdk --remove' to remove it from the workshop`)
+	c.Assert(err, check.ErrorMatches, `cannot restore: "sketch" SDK exists; run 'workshop sketch-sdk --remove' to remove it from the workshop`)
 }
 
 func (m *workshopSketch) TestSketchSdkRemoveOK(c *check.C) {
@@ -573,7 +573,7 @@ func (m *workshopSketch) TestSketchSdkRemoveCurrentNotExist(c *check.C) {
 	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
 
 	err := cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, `cannot remove: the 'sketch' SDK doesn't exist`)
+	c.Assert(err, check.ErrorMatches, `cannot remove: "sketch" SDK not found`)
 }
 
 func (m *workshopSketch) TestSketchSdkRemoveRevertOnFail(c *check.C) {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -106,7 +106,6 @@ var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK
 "warning-count":1}`
 
 var simpleSketchMeta = `name: sketch
-base: ubuntu@22.04
 `
 
 func (m *workshopSketch) SetUpTest(c *check.C) {
@@ -226,7 +225,6 @@ func (m *workshopSketch) TestSketchSdkSuccess(c *check.C) {
 	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
 	sketchContent := `name: sketch
-base: ubuntu@22.04
 
 hooks:
     setup-base: |-
@@ -254,7 +252,6 @@ func (m *workshopSketch) TestSketchSdkUpdateHooks(c *check.C) {
 	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
 	meta, hooks := m.mockMinimalSketchSdk(c, "ws", true, []byte(`name: sketch
-base: ubuntu@22.04
 
 hooks:
   setup-base: |-
@@ -264,7 +261,6 @@ hooks:
 `))
 
 	sketchContent := `name: sketch
-base: ubuntu@22.04
 
 hooks:
     save-state: |-
@@ -301,7 +297,6 @@ func (m *workshopSketch) TestSketchSdkEditExistingMeta(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	sketchContent := `name: sketch
-base: ubuntu@22.04
 plugs:
   gpu:
     interface: gpu
@@ -387,7 +382,6 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 
 	attempts := 0
 	sketchSetup := `name: sketch
-base: ubuntu@22.04
 
 hooks:
     setup-base: |
@@ -445,7 +439,6 @@ func (m *workshopSketch) TestSketchSdkOverwritesExistingStash(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
 	stash := workshop.SketchSdkStash(m.userDataDir, m.prjId, "ws")
 	_, stashedhooks := m.mockMinimalSketchSdk(c, "ws", false, []byte(`name: sketch
-base: ubuntu@18.04
 hooks:
     setup-base: |
         touch /home/workshop/stash
@@ -539,7 +532,6 @@ func (m *workshopSketch) TestSketchSdkRestoreFailsIfCurrentExists(c *check.C) {
 
 	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 	stored := `name: sketch
-base: ubuntu@22.04
 plugs:
   gpu:
     interface: gpu

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -315,6 +315,59 @@ plugs:
 	c.Assert(filepath.Join(dir, "sdk.yaml"), testutil.FileEquals, sketchContent)
 }
 
+func (m *workshopSketch) TestSketchSdkPreserveBadEdits(c *check.C) {
+	cmd := &CmdSketch{root: &CmdRoot{}}
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1, 3:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2, 4:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithSdksReady)
+		default:
+			c.Errorf("expected 4 calls, now on %d", n)
+		}
+	})
+
+	sketchContent := `name: sketch
+hooks:
+  setup-base:
+    check-health:
+  # comment
+      save-state:
+`
+	checked := false
+	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
+		if n >= 4 {
+			checked = true
+			c.Check(string(inContent), check.Equals, sketchContent)
+		}
+		if inPath != "" {
+			c.Assert(writeSketchSdk(inPath, []byte(sketchContent)), check.IsNil)
+		}
+		return []byte(sketchContent), nil
+	})
+	defer restore()
+
+	err := cmd.Run(cmd.Command(), []string{"ws"})
+	c.Assert(err, check.NotNil)
+	dir := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
+	c.Check(filepath.Join(dir, "sdk.yaml"), testutil.FileEquals, sketchContent)
+
+	err = cmd.Run(cmd.Command(), []string{"ws"})
+	c.Assert(err, check.NotNil)
+	c.Check(checked, check.Equals, true)
+	c.Check(n, check.Equals, 4)
+}
+
 func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}}
 

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -563,7 +563,7 @@ func (m *workshopSketch) TestSketchSdkRemoveOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
-	c.Assert(current, testutil.FileAbsent)
+	c.Assert(current, testutil.DirEquals, []string{})
 	c.Assert(m.stdout.String(), check.Matches, `"ws" sketch removed\n`)
 }
 
@@ -574,6 +574,48 @@ func (m *workshopSketch) TestSketchSdkRemoveCurrentNotExist(c *check.C) {
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.ErrorMatches, `cannot remove: the 'sketch' SDK doesn't exist`)
+}
+
+func (m *workshopSketch) TestSketchSdkRemoveRevertOnFail(c *check.C) {
+	cmd := &CmdSketch{root: &CmdRoot{}, remove: true}
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
+		case 3:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
+				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "transactional"}})
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 4:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, "/v1/changes/42")
+			fmt.Fprintln(w, mockChangeWithError)
+		default:
+			c.Errorf("expected 4 calls, now on %d", n)
+		}
+	})
+
+	metadir, _ := m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
+
+	err := cmd.Run(nil, nil)
+	c.Assert(err, check.NotNil)
+	c.Assert(n, check.Equals, 4)
+
+	c.Assert(filepath.Join(metadir, "sdk.yaml"), testutil.FileEquals, simpleSketchMeta)
 }
 
 func (m *workshopSketch) TestSketchesOK(c *check.C) {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -420,14 +420,17 @@ hooks:
 }
 
 func (m *workshopSketch) TestSketchSdkStashOK(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdStash := cmd.Command()
+	cmd.stash = true
+
 	restore := workshop.SketchSdkStash(m.userDataDir, m.prjId, "ws")
 	c.Assert(filepath.Join(restore, "sdk.yaml"), testutil.FileAbsent)
 
 	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
 	metadir, _ := m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(cmdStash, []string{"ws"})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(metadir, testutil.FileAbsent)
@@ -436,7 +439,10 @@ func (m *workshopSketch) TestSketchSdkStashOK(c *check.C) {
 }
 
 func (m *workshopSketch) TestSketchSdkOverwritesExistingStash(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdStash := cmd.Command()
+	cmd.stash = true
+
 	stash := workshop.SketchSdkStash(m.userDataDir, m.prjId, "ws")
 	_, stashedhooks := m.mockMinimalSketchSdk(c, "ws", false, []byte(`name: sketch
 hooks:
@@ -449,7 +455,7 @@ hooks:
 	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
 	metadir, _ := m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(cmdStash, []string{"ws"})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(metadir, testutil.FileAbsent)
@@ -459,7 +465,9 @@ hooks:
 }
 
 func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdStash := cmd.Command()
+	cmd.stash = true
 
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -493,7 +501,7 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 
 	metadir, _ := m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
-	err := cmd.Run(nil, nil)
+	err := cmd.Run(cmdStash, nil)
 	c.Assert(err, check.NotNil)
 	c.Assert(n, check.Equals, 4)
 
@@ -505,12 +513,14 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 }
 
 func (m *workshopSketch) TestSketchSdkRestoreOK(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, restore: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdRestore := cmd.Command()
+	cmd.restore = true
 
 	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 	m.mockMinimalSketchSdk(c, "ws", false, []byte(simpleSketchMeta))
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(cmdRestore, []string{"ws"})
 	c.Assert(err, check.IsNil)
 
 	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
@@ -519,16 +529,20 @@ func (m *workshopSketch) TestSketchSdkRestoreOK(c *check.C) {
 }
 
 func (m *workshopSketch) TestSketchSdkRestoreNoStoredSketch(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, restore: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdRestore := cmd.Command()
+	cmd.restore = true
 
 	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(cmdRestore, []string{"ws"})
 	c.Assert(err, check.ErrorMatches, `cannot restore: stashed "sketch" SDK not found`)
 }
 
 func (m *workshopSketch) TestSketchSdkRestoreFailsIfCurrentExists(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, restore: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdRestore := cmd.Command()
+	cmd.restore = true
 
 	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 	stored := `name: sketch
@@ -541,17 +555,150 @@ plugs:
 	// stored
 	m.mockMinimalSketchSdk(c, "ws", false, []byte(stored))
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(cmdRestore, []string{"ws"})
 	c.Assert(err, check.ErrorMatches, `cannot restore: "sketch" SDK exists; run 'workshop sketch-sdk --remove' to remove it from the workshop`)
 }
 
+func (m *workshopSketch) TestSketchSdkEjectOK(c *check.C) {
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdEject := cmd.Command()
+	cmd.eject = true
+	cmd.name = "notsketch"
+
+	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
+	m.mockMinimalSketchSdk(c, "ws", true, []byte(`name: sketch
+
+hooks:
+  # comment1
+  setup-base: |
+    echo "Hello"
+# comment2
+  check-health: |-
+    workshopctl set-health okay
+
+plugs:
+  ssh-agent:
+   # comment3
+    interface: ssh-agent
+     # comment4
+
+slots:
+  tunnel:
+    interface: tunnel
+    endpoint: 1234
+    # comment5
+`))
+
+	err := cmd.Run(cmdEject, []string{"ws"})
+	c.Assert(err, check.IsNil)
+
+	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
+	c.Check(current, testutil.DirEquals, []string{})
+
+	notsketch := workshop.ProjectSdkPath(m.prjDir, "notsketch")
+	c.Check(filepath.Join(notsketch, "sdk.yaml"), testutil.FileEquals, `name: notsketch
+plugs:
+  ssh-agent:
+    # comment3
+    interface: ssh-agent
+    # comment4
+slots:
+  tunnel:
+    interface: tunnel
+    endpoint: 1234
+    # comment5
+`)
+	c.Check(filepath.Join(notsketch, "hooks", "setup-base"), testutil.FileEquals, `echo "Hello"
+`)
+	c.Check(filepath.Join(notsketch, "hooks", "check-health"), testutil.FileEquals, `workshopctl set-health okay
+`)
+	c.Check(m.stdout.String(), check.Equals, `"ws" sketch ejected to ".workshop/notsketch"
+To use it, add "project-notsketch" to the list of SDKs and run 'workshop refresh ws'
+`)
+}
+
+func (m *workshopSketch) TestSketchSdkEjectInferName(c *check.C) {
+	m.prjDir = filepath.Join(m.prjDir, "myproject")
+	c.Assert(os.Mkdir(m.prjDir, os.ModePerm), check.IsNil)
+
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdEject := cmd.Command()
+	cmd.eject = true
+
+	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
+	m.mockMinimalSketchSdk(c, "ws", true, []byte(`name: sketch
+`))
+
+	err := cmd.Run(cmdEject, []string{"ws"})
+	c.Assert(err, check.IsNil)
+
+	myproject := workshop.ProjectSdkPath(m.prjDir, "myproject")
+	c.Check(filepath.Join(myproject, "sdk.yaml"), testutil.FileEquals, `name: myproject
+`)
+}
+
+func (m *workshopSketch) TestSketchSdkEjectCannotInferName(c *check.C) {
+	m.prjDir = filepath.Join(m.prjDir, "_____")
+
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdEject := cmd.Command()
+	cmd.eject = true
+
+	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
+
+	err := cmd.Run(cmdEject, []string{"ws"})
+	c.Check(err, check.ErrorMatches, `cannot eject: flag --name required: invalid SDK name "_____"`)
+}
+
+func (m *workshopSketch) TestSketchSdkEjectPreservesExisting(c *check.C) {
+	c.Assert(os.MkdirAll(workshop.ProjectSdkPath(m.prjDir, "name"), os.ModePerm), check.IsNil)
+
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdEject := cmd.Command()
+	cmd.eject = true
+	cmd.name = "name"
+
+	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
+
+	err := cmd.Run(cmdEject, []string{"ws"})
+	c.Check(err, testutil.ErrorIs, os.ErrExist)
+}
+
+func (m *workshopSketch) TestSketchSdkEjectCurrentNotExist(c *check.C) {
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdEject := cmd.Command()
+	cmd.eject = true
+	cmd.name = "name"
+
+	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
+
+	err := cmd.Run(cmdEject, []string{"ws"})
+	c.Assert(err, check.ErrorMatches, `cannot eject: "sketch" SDK not found`)
+}
+
+func (m *workshopSketch) TestSketchSdkEjectNoName(c *check.C) {
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdEject := cmd.Command()
+	cmd.eject = true
+	cmd.name = "name"
+
+	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
+	sketchDir := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
+	c.Assert(writeSketchSdk(filepath.Join(sketchDir, "sdk.yaml"), []byte("{}")), check.IsNil)
+
+	err := cmd.Run(cmdEject, []string{"ws"})
+	c.Assert(err, check.ErrorMatches, `cannot eject: "sketch" SDK name not found`)
+}
+
 func (m *workshopSketch) TestSketchSdkRemoveOK(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, remove: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdRemove := cmd.Command()
+	cmd.remove = true
 
 	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
 	m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(cmdRemove, []string{"ws"})
 	c.Assert(err, check.IsNil)
 
 	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
@@ -560,16 +707,20 @@ func (m *workshopSketch) TestSketchSdkRemoveOK(c *check.C) {
 }
 
 func (m *workshopSketch) TestSketchSdkRemoveCurrentNotExist(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, remove: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdRemove := cmd.Command()
+	cmd.remove = true
 
 	m.mockSketchHappyRefreshPath(c, "ws", "transactional")
 
-	err := cmd.Run(nil, []string{"ws"})
+	err := cmd.Run(cmdRemove, []string{"ws"})
 	c.Assert(err, check.ErrorMatches, `cannot remove: "sketch" SDK not found`)
 }
 
 func (m *workshopSketch) TestSketchSdkRemoveRevertOnFail(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, remove: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdRemove := cmd.Command()
+	cmd.remove = true
 
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -603,7 +754,7 @@ func (m *workshopSketch) TestSketchSdkRemoveRevertOnFail(c *check.C) {
 
 	metadir, _ := m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 
-	err := cmd.Run(nil, nil)
+	err := cmd.Run(cmdRemove, nil)
 	c.Assert(err, check.NotNil)
 	c.Assert(n, check.Equals, 4)
 
@@ -640,7 +791,9 @@ func (m *workshopSketch) TestSketchesEmpty(c *check.C) {
 }
 
 func (m *workshopSketch) TestSketchSdkWorkshopStatusNotReady(c *check.C) {
-	cmd := &CmdSketch{root: &CmdRoot{}, stash: true}
+	cmd := &CmdSketch{root: &CmdRoot{}}
+	cmdStash := cmd.Command()
+	cmd.stash = true
 
 	status := []string{"Pending", "Error", "Stopped"}
 
@@ -664,7 +817,7 @@ func (m *workshopSketch) TestSketchSdkWorkshopStatusNotReady(c *check.C) {
 	})
 
 	for i := 1; i <= len(status); i++ {
-		err := cmd.Run(nil, nil)
+		err := cmd.Run(cmdStash, nil)
 		c.Assert(err, check.NotNil)
 		c.Assert(n, check.Equals, i*2)
 	}

--- a/cmd/workshop/yaml.go
+++ b/cmd/workshop/yaml.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+// NodeRef can be used to extract a pointer to the node which
+// corresponds to a struct field or slice element.
+type NodeRef struct {
+	Node *yaml.Node
+}
+
+func (n *NodeRef) UnmarshalYAML(value *yaml.Node) error {
+	n.Node = value
+	return nil
+}
+
+// RemoveNodes removes the given nodes from the document.
+func RemoveNodes(root *yaml.Node, nodes ...*yaml.Node) {
+	r := &nodeRemover{nodes}
+	for len(r.nodes) > 0 {
+		last := len(r.nodes) - 1
+		node := r.nodes[last]
+		r.nodes = r.nodes[:last]
+		r.remove(root, node)
+	}
+}
+
+type nodeRemover struct {
+	nodes []*yaml.Node
+}
+
+func (r *nodeRemover) remove(root, node *yaml.Node) {
+	switch root.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		root.Content = slices.DeleteFunc(root.Content, func(n *yaml.Node) bool { return n == node })
+	case yaml.MappingNode:
+		if idx := slices.Index(root.Content, node); idx >= 0 {
+			if idx&1 == 0 {
+				r.nodes = append(r.nodes, root.Content[idx+1])
+			} else {
+				idx -= 1
+				r.nodes = append(r.nodes, root.Content[idx])
+			}
+			root.Content = slices.Delete(root.Content, idx, idx+2)
+		}
+	case yaml.AliasNode:
+		if root.Alias == node {
+			r.nodes = append(r.nodes, root)
+		}
+		return
+	default:
+		return
+	}
+
+	for _, child := range root.Content {
+		r.remove(child, node)
+	}
+}

--- a/cmd/workshop/yaml_test.go
+++ b/cmd/workshop/yaml_test.go
@@ -1,0 +1,449 @@
+package main
+
+import (
+	"slices"
+	"strings"
+
+	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
+)
+
+type yamlSuite struct{}
+
+var _ = check.Suite(&yamlSuite{})
+
+func (y *yamlSuite) TestNodeRefField(c *check.C) {
+	var nodes struct {
+		Field NodeRef
+	}
+
+	document := unmarshalAndDecode(c, &nodes, `field: data
+`)
+	c.Check(nodes.Field.Node.Value, check.Equals, "data")
+	c.Check(contains(document, nodes.Field.Node), check.Equals, true)
+}
+
+func (y *yamlSuite) TestNodeRefAlias(c *check.C) {
+	var nodes struct {
+		Field NodeRef
+	}
+
+	document := unmarshalAndDecode(c, &nodes, `x-field: &f data
+field: *f
+`)
+	c.Check(nodes.Field.Node.Value, check.Equals, "data")
+	c.Check(contains(document, nodes.Field.Node), check.Equals, true)
+}
+
+func (y *yamlSuite) TestNodeRefSlice(c *check.C) {
+	var nodes struct {
+		Slice []NodeRef
+	}
+
+	document := unmarshalAndDecode(c, &nodes, `slice: [1, 2, 3]
+`)
+	c.Check(nodes.Slice, check.HasLen, 3)
+	c.Check(contains(document, nodes.Slice[0].Node), check.Equals, true)
+	c.Check(contains(document, nodes.Slice[1].Node), check.Equals, true)
+	c.Check(contains(document, nodes.Slice[2].Node), check.Equals, true)
+}
+
+func (y *yamlSuite) TestNodeRefNested(c *check.C) {
+	var nodes struct {
+		One struct {
+			Nest struct {
+				A NodeRef
+				B NodeRef
+				C NodeRef
+			}
+		}
+		Two struct {
+			A NodeRef
+			B NodeRef
+		}
+	}
+
+	document := unmarshalAndDecode(c, &nodes, `two: &t
+  a: aa
+  b: bb
+one:
+  nest:
+    <<: *t
+    c: cc
+`)
+	c.Check(nodes.One.Nest.A.Node.Value, check.Equals, "aa")
+	c.Check(nodes.One.Nest.B.Node.Value, check.Equals, "bb")
+	c.Check(nodes.One.Nest.C.Node.Value, check.Equals, "cc")
+	c.Check(nodes.One.Nest.A.Node, check.Equals, nodes.Two.A.Node)
+	c.Check(nodes.One.Nest.B.Node, check.Equals, nodes.Two.B.Node)
+	c.Check(contains(document, nodes.One.Nest.A.Node), check.Equals, true)
+	c.Check(contains(document, nodes.One.Nest.B.Node), check.Equals, true)
+	c.Check(contains(document, nodes.One.Nest.C.Node), check.Equals, true)
+}
+
+func unmarshalAndDecode(c *check.C, v interface{}, content string) *yaml.Node {
+	var document yaml.Node
+	c.Assert(yaml.Unmarshal([]byte(content), &document), check.IsNil)
+	c.Assert(document.Decode(v), check.IsNil)
+	return &document
+}
+
+func contains(root, node *yaml.Node) bool {
+	if root == node {
+		return true
+	}
+
+	switch root.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode, yaml.MappingNode:
+		return slices.ContainsFunc(root.Content, func(n *yaml.Node) bool { return contains(n, node) })
+	default:
+		return false
+	}
+}
+
+func (y *yamlSuite) TestRemoveNodesMapping(c *check.C) {
+	var nodes struct {
+		Field NodeRef
+	}
+
+	before := `field: f
+`
+	after := `{}
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+
+	before = `field: f
+after: a
+`
+	after = `after: a
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+
+	before = `before: b
+field: f
+`
+	after = `before: b
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+
+	before = `before: b
+field: f
+after: a
+`
+	after = `before: b
+after: a
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+}
+
+func (y *yamlSuite) TestRemoveNodesSequence(c *check.C) {
+	var one [1]NodeRef
+	before := `- b
+`
+	after := `[]
+`
+	checkRemoveNodes(c, before, after, &one, &one[0])
+
+	var two [2]NodeRef
+	before = `- b
+- c
+`
+	after = `- c
+`
+	checkRemoveNodes(c, before, after, &two, &two[0])
+
+	before = `- a
+- b
+`
+	after = `- a
+`
+	checkRemoveNodes(c, before, after, &two, &two[1])
+
+	var three [3]NodeRef
+	before = `- a
+- b
+- c
+`
+	after = `- a
+- c
+`
+	checkRemoveNodes(c, before, after, &three, &three[1])
+}
+
+func (y *yamlSuite) TestRemoveNodesFlowStyle(c *check.C) {
+	var nodes struct {
+		Field NodeRef
+	}
+	before := `{"before": "b", "field": "f", "after": "a"}
+`
+	after := `{"before": "b", "after": "a"}
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+
+	var items [3]NodeRef
+	before = `["a", "b", "c"]
+`
+	after = `["a", "c"]
+`
+	checkRemoveNodes(c, before, after, &items, &items[1])
+}
+
+func (y *yamlSuite) TestRemoveNodesWithComments(c *check.C) {
+	var nodes struct {
+		Field NodeRef
+	}
+
+	before := `# document head
+
+# field head
+field: f # f line
+# field foot
+
+# document foot
+`
+	after := `# document head
+
+{}
+
+# document foot
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+
+	before = `# document head
+
+# field head
+field: f # f line
+# field foot
+
+# after head
+after: a # a line
+# after foot
+
+# document foot
+`
+	after = `# document head
+
+# after head
+after: a # a line
+# after foot
+
+# document foot
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+
+	before = `# document head
+
+# before head
+before: b # b line
+# before foot
+
+# field head
+field: f # f line
+# field foot
+
+# document foot
+`
+	after = `# document head
+
+# before head
+before: b # b line
+# before foot
+
+# document foot
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+
+	before = `# document head
+
+# before head
+before: b # b line
+# before foot
+
+# field head
+field: f # f line
+# field foot
+
+# after head
+after: a # a line
+# after foot
+
+# document foot
+`
+	after = `# document head
+
+# before head
+before: b # b line
+# before foot
+
+# after head
+after: a # a line
+# after foot
+
+# document foot
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+
+	var nested struct {
+		Nodes struct {
+			Field NodeRef
+		}
+	}
+	before = `# document head
+
+# nodes head
+nodes:
+  # field head
+  field: f # f line
+  # field foot
+# nodes foot
+
+# document foot
+`
+	after = `# document head
+
+# nodes head
+nodes: {}
+# nodes foot
+
+# document foot
+`
+	checkRemoveNodes(c, before, after, &nested, &nested.Nodes.Field)
+}
+
+func (y *yamlSuite) TestRemoveNodesAliases(c *check.C) {
+	var nodes struct {
+		Field NodeRef
+	}
+
+	before := `x-field: &f data
+field: *f
+`
+	after := `{}
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.Field)
+}
+
+func (y *yamlSuite) TestRemoveNodesMultiple(c *check.C) {
+	var nodes struct {
+		One NodeRef
+		Two NodeRef
+	}
+
+	before := `zero: 0
+one: 1
+two: 2
+three: 3
+`
+	after := `zero: 0
+three: 3
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.One, &nodes.Two)
+
+	before = `zero: 0
+one: 1
+three: 3
+two: 2
+`
+	after = `zero: 0
+three: 3
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.One, &nodes.Two)
+
+	before = `one: 1
+zero: 0
+two: 2
+three: 3
+`
+	after = `zero: 0
+three: 3
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.One, &nodes.Two)
+
+	before = `one: 1
+zero: 0
+three: 3
+two: 2
+`
+	after = `zero: 0
+three: 3
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.One, &nodes.Two)
+}
+
+func (y *yamlSuite) TestRemoveNodesMerged(c *check.C) {
+	var nodes struct {
+		A struct {
+			One NodeRef
+			Two NodeRef
+		}
+		B struct {
+			One   NodeRef
+			Two   NodeRef
+			Three NodeRef
+		}
+	}
+
+	before := `a: &a
+  one: 1
+  two: 2
+b:
+  <<: *a
+  three: 3
+`
+	after := `a: &a
+  two: 2
+b:
+  !!merge <<: *a
+  three: 3
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.A.One)
+
+	after = `a: &a
+  one: 1
+b:
+  !!merge <<: *a
+  three: 3
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.A.Two)
+
+	after = `a: &a
+  one: 1
+  two: 2
+b:
+  !!merge <<: *a
+`
+	checkRemoveNodes(c, before, after, &nodes, &nodes.B.Three)
+
+	var maps struct {
+		A NodeRef
+		B NodeRef
+	}
+
+	after = `b:
+  three: 3
+`
+	checkRemoveNodes(c, before, after, &maps, &maps.A)
+
+	after = `a: &a
+  one: 1
+  two: 2
+`
+	checkRemoveNodes(c, before, after, &maps, &maps.B)
+}
+
+func checkRemoveNodes(c *check.C, before, after string, v interface{}, nodeRefs ...*NodeRef) {
+	document := unmarshalAndDecode(c, v, before)
+
+	nodes := make([]*yaml.Node, 0, len(nodeRefs))
+	for _, n := range nodeRefs {
+		nodes = append(nodes, n.Node)
+	}
+	RemoveNodes(document, nodes...)
+
+	var builder strings.Builder
+	e := yaml.NewEncoder(&builder)
+	e.SetIndent(2)
+	c.Assert(e.Encode(document), check.IsNil)
+
+	c.Check(builder.String(), check.Equals, after)
+}

--- a/docs/.coverage.yaml
+++ b/docs/.coverage.yaml
@@ -146,6 +146,11 @@
     - SK020
     - SK031
 
+"in-project SDK":
+  category: project
+  type: concept
+  specs: []
+
 "installation":
   category: "workshop (CLI)"
   type: action

--- a/docs/how-to/use-workshops/sketch-sdk.rst
+++ b/docs/how-to/use-workshops/sketch-sdk.rst
@@ -222,13 +222,48 @@ Stashing does not delete the SDK,
 allowing you to restore and continue working later.
 
 
-Craft the SDK (optional)
+Eject the SDK (optional)
 ------------------------
 
+.. @artefact in-project SDK
+.. @artefact SDK Store
+
 If you're satisfied with the sketch to a degree
-where think others may benefit from it as well,
-the next possible step is to refine it into a permanent SDK for publishing.
-For details, see the |sdk_markup| :ref:`how-to guide <how_sdkcraft>`.
+where others may benefit from it,
+you can either add it to your project
+or publish it in the SDK Store.
+
+The first step is to *eject* the SDK:
+
+.. code-block:: console
+
+   $ workshop sketch-sdk --eject
+
+     "dev" sketch ejected to ".workshop/hello-workshop"
+     To use it, add "project-hello-workshop" to the list of SDKs and run 'workshop refresh dev'
+
+
+This moves the SDK definition files
+into the :file:`.workshop/` subdirectory of the project
+and removes the sketch from the running workshop.
+|ws_markup| can pull SDKs from this directory,
+bypassing the SDK Store.
+
+If you'd rather publish the SDK for other projects to use,
+|sdk_markup| can help.
+For details, see the :ref:`how-to guide <how_sdkcraft>`.
+
+The new SDK is named after the project directory by default;
+use the :option:`!--name` option to change this:
+
+.. code-block:: console
+
+   $ workshop sketch-sdk --eject --name tools
+
+     "dev" sketch ejected to ".workshop/tools"
+     To use it, add "project-tools" to the list of SDKs and run 'workshop refresh dev'
+
+
 
 
 Clean up

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -107,11 +107,14 @@ Each SDK is described with the following keys:
 
    * - :samp:`name` (required)
      - string
-     - Name of an existing SDK
-       that is available from the SDK store,
-       or :samp:`system` for the :ref:`system SDK <ref_system_sdk>`.
+     - Name of an existing SDK,
+       typically from the SDK Store.
 
-   * - :samp:`channel` (required)
+       The :ref:`system SDK <ref_system_sdk>` is named :samp:`system`.
+
+       :ref:`In-project SDKs <ref_in_project_sdk>` should be prefixed by :samp:`project-`.
+
+   * - :samp:`channel`
      - string
      - SDK version to retrieve during
        :ref:`launch <ref_workshop_launch>`
@@ -124,7 +127,7 @@ Each SDK is described with the following keys:
        of :samp:`<TRACK>/<RISK>`
        without the :samp:`<BRANCH>` part.
 
-       Not required for the :ref:`system SDK <ref_system_sdk>`.
+       Required for SDKs from the Store.
 
    * - :samp:`plugs`
      - object
@@ -154,7 +157,7 @@ System SDK
 
 The system SDK is built into every workshop
 to expose resources provided by the host system in a consistent way.
-It's not available in the SDK store,
+It's not available in the SDK Store,
 so :samp:`channel` isn't relevant and can be omitted.
 
 Technically, the system SDK is of :samp:`system` type,
@@ -177,6 +180,24 @@ largely due to security considerations,
 because the system SDK exposes sensitive host system resources.
 To the contrary, plugs added under the system SDK can be auto-connected
 because they expose workshop internals.
+
+
+.. _ref_in_project_sdk:
+
+In-project SDKs
+~~~~~~~~~~~~~~~
+
+.. @artefact in-project SDK
+
+Projects can define their own SDKs
+to configure the workshop in a project-specific way.
+These SDKs are defined by files named like :file:`.workshop/<NAME>/sdk.yaml`,
+relative to the project directory.
+Accordingly, SDK hooks are stored under :file:`.workshop/<NAME>/hooks/`.
+
+Workshops within the project consume these SDKs
+using names like :samp:`project-<NAME>`;
+a :samp:`channel` is not required in this case.
 
 
 Camera interface
@@ -419,8 +440,9 @@ and some useful scripts:
 
 
 This YAML file defines a :samp:`go-dev` workshop
-that uses two SDKs, :samp:`go` and :samp:`dev-tunnel`;
-the :samp:`data` plug defined by the :samp:`dev-tunnel` SDK
+that uses the :samp:`go` SDK from the Store
+and an :ref:`in-project SDK <ref_in_project_sdk>` named :samp:`tunnel`;
+the :samp:`data` plug defined by the :samp:`tunnel` SDK
 is bound to the :samp:`mod-cache` plug of the :samp:`go` SDK:
 
 .. code-block:: yaml
@@ -431,8 +453,7 @@ is bound to the :samp:`mod-cache` plug of the :samp:`go` SDK:
    sdks:
      - name: go
        channel: latest/candidate
-     - name: dev-tunnel
-       channel: latest/edge
+     - name: project-tunnel
        plugs:
          data:
            bind: go:mod-cache

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -77,7 +77,7 @@ func (b *PlugRef) UnmarshalYAML(value *yaml.Node) error {
 		parts[0] = sdk.System.String()
 	}
 	if !sdk.SdkName.MatchString(parts[0]) {
-		return fmt.Errorf("%q is not a valid plug or slot reference (%q is an invalid SDK name)", refStr, parts[0])
+		return fmt.Errorf("%q is not a valid plug or slot reference: invalid SDK name %q", refStr, parts[0])
 	}
 
 	b.Sdk = parts[0]

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -83,3 +83,7 @@ execute: |
 
   echo "Abort the change"
   workshop_exec refresh --abort
+
+  echo "Eject the sketch"
+  workshop_exec sketch-sdk --eject --name broken
+  [ -f .workshop/broken/sdk.yaml ]


### PR DESCRIPTION
# Description

Adds `sketch-sdk --eject [--name <NAME>]`, which is like `sketch-sdk --remove` but copies the sketch SDK files into `.workshop/<NAME>/` first. It renames the SDK to `<NAME>` and extracts hooks from `sdk.yaml`. The default SDK name is the project directory name. The output looks like:
```console
$ workshop sketch-sdk --eject dev
"dev" sketch ejected to ".workshop/myproject"
To use it, add "project-myproject" to the list of SDKs and run 'workshop refresh dev'
```

The main part I'm not too happy with is that transforming `sdk.yaml` changes the formatting. This seems to be due to how `yaml` parses certain comments. In particular, something like:
```yaml
foo:
  # comment
```
is treated like:
```yaml
foo: null
  # comment
```
and so the comment is attached to the next node, or the document itself, rather than `foo`. This affects the sketch template pretty badly but should be less of an issue for cleaner SDK definitions.

If the refresh fails for `sketch-sdk --remove`, the sketch SDK files are not removed. Subsequent attempts to remove the sketch SDK will work as expected (once the issue causing refresh failure is fixed). The output in this case looks like:
```console
$ workshop sketch-sdk --remove
error: cannot perform the following tasks:
- Run hook "setup-base" for "project-tools" SDK (command exit code 1)
"dev" refresh aborted
Restoring "dev" sketch
```

I made a first pass on the docs, will probably revisit again when I've updated SDKcraft to make our SDK definitions more consistent.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
