### PR TITLE
Add verbose mode for hooks

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -61,8 +61,9 @@ type Task struct {
 	Log      []string     `json:"log,omitempty"`
 	Progress TaskProgress `json:"progress"`
 
-	SpawnTime time.Time `json:"spawn-time,omitempty"`
-	ReadyTime time.Time `json:"ready-time,omitempty"`
+	SpawnTime time.Time     `json:"spawn-time,omitempty"`
+	ReadyTime time.Time     `json:"ready-time,omitempty"`
+	DoingTime time.Duration `json:"doing-time,omitempty"`
 
 	Data map[string]*json.RawMessage
 }

--- a/client/changes.go
+++ b/client/changes.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -88,9 +89,12 @@ type changeAndData struct {
 }
 
 // Change fetches information about a Change given its ID.
-func (client *Client) Change(id string) (*Change, error) {
+func (client *Client) Change(id string, verbose bool) (*Change, error) {
 	var chgd changeAndData
-	_, err := client.doSync("GET", "/v1/changes/"+id, nil, nil, nil, &chgd)
+	query := url.Values{}
+	query.Set("verbose", strconv.FormatBool(verbose))
+
+	_, err := client.doSync("GET", "/v1/changes/"+id, query, nil, nil, &chgd)
 	if err != nil {
 		return nil, err
 	}

--- a/client/changes_test.go
+++ b/client/changes_test.go
@@ -34,7 +34,7 @@ func (cs *clientSuite) TestClientChange(c *check.C) {
   "ready": false,
   "spawn-time": "2016-04-21T01:02:03Z",
   "ready-time": "2016-04-21T01:02:04Z",
-  "tasks": [{"kind": "bar", "summary": "...", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z"}]
+  "tasks": [{"kind": "bar", "summary": "...", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z", "doing-time":242401344}]
 }}`
 
 	chg, err := cs.cli.Change("uno", false)
@@ -51,6 +51,7 @@ func (cs *clientSuite) TestClientChange(c *check.C) {
 			Progress:  client.TaskProgress{Done: 0, Total: 1},
 			SpawnTime: time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC),
 			ReadyTime: time.Date(2016, 04, 21, 1, 2, 4, 0, time.UTC),
+			DoingTime: 242401344,
 		}},
 
 		SpawnTime: time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC),

--- a/client/changes_test.go
+++ b/client/changes_test.go
@@ -37,7 +37,7 @@ func (cs *clientSuite) TestClientChange(c *check.C) {
   "tasks": [{"kind": "bar", "summary": "...", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z"}]
 }}`
 
-	chg, err := cs.cli.Change("uno")
+	chg, err := cs.cli.Change("uno", false)
 	c.Assert(err, check.IsNil)
 	c.Check(chg, check.DeepEquals, &client.Change{
 		ID:      "uno",
@@ -111,7 +111,7 @@ func (cs *clientSuite) TestClientChangeData(c *check.C) {
   "data": {"n": 42}
 }}`
 
-	chg, err := cs.cli.Change("uno")
+	chg, err := cs.cli.Change("uno", false)
 	c.Assert(err, check.IsNil)
 	var n int
 	err = chg.Get("n", &n)
@@ -133,7 +133,7 @@ func (cs *clientSuite) TestClientChangeRestartingState(c *check.C) {
  "maintenance": {"kind": "system-restart", "message": "system is restarting"}
 }`
 
-	chg, err := cs.cli.Change("uno")
+	chg, err := cs.cli.Change("uno", false)
 	c.Check(chg, check.NotNil)
 	c.Check(chg.ID, check.Equals, "uno")
 	c.Check(err, check.IsNil)
@@ -151,7 +151,7 @@ func (cs *clientSuite) TestClientChangeError(c *check.C) {
   "err": "error message"
 }}`
 
-	chg, err := cs.cli.Change("uno")
+	chg, err := cs.cli.Change("uno", false)
 	c.Assert(err, check.IsNil)
 	c.Check(chg, check.DeepEquals, &client.Change{
 		ID:      "uno",

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -72,30 +72,17 @@ $ workshop launch`,
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
 		false,
 		"Return the change ID, don't wait for the operation to finish.")
+	cmd.PersistentFlags().BoolVar(&c.verbose, "verbose",
+		false,
+		"Combine stdout and stderr output from hooks.")
+
+	cmd.MarkFlagsMutuallyExclusive("abort", "continue", "wait-on-error")
 
 	return cmd
 }
 
 func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	av = strutil.Deduplicate(av)
-
-	if c.Abort && c.Continue {
-		return fmt.Errorf("cannot launch: '--abort' incompatible with '--continue'")
-	}
-
-	if c.WaitOnError && c.Abort {
-		return fmt.Errorf("cannot launch: '--wait-on-error' incompatible with '--abort'")
-	}
-
-	if c.WaitOnError && c.Continue {
-		return fmt.Errorf("cannot launch: '--wait-on-error' incompatible with '--continue'")
-	}
-
-	// We should have no more than one argument (a single workshop) for a
-	// wait-on-error operation
-	if (c.Abort || c.Continue || c.WaitOnError) && len(av) > 1 {
-		return fmt.Errorf("cannot launch: '--wait-on-error' incompatible with multiple workshops")
-	}
 
 	cli, err := c.root.client()
 	if err != nil {

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -161,36 +161,6 @@ func (m *workshopLaunch) TestLaunchWaitOnErrorContinuedSuccessfully(c *check.C) 
 	c.Assert(m.stdout.String(), check.Matches, `"ws" launched\n`)
 }
 
-func (m *workshopLaunch) TestLaunchIncompatibleOptions(c *check.C) {
-	cmd := &CmdLaunch{root: &CmdRoot{}}
-	cmd.Abort = true
-	cmd.Continue = true
-
-	err := cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, "cannot launch: '--abort' incompatible with '--continue'")
-
-	cmd.WaitOnError = true
-	cmd.Abort = false
-	cmd.Continue = true
-
-	err = cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, "cannot launch: '--wait-on-error' incompatible with '--continue'")
-
-	cmd.WaitOnError = true
-	cmd.Abort = true
-	cmd.Continue = false
-
-	err = cmd.Run(nil, []string{"ws"})
-	c.Assert(err, check.ErrorMatches, "cannot launch: '--wait-on-error' incompatible with '--abort'")
-
-	cmd.WaitOnError = true
-	cmd.Abort = false
-	cmd.Continue = false
-
-	err = cmd.Run(nil, []string{"ws", "ws-1"})
-	c.Assert(err, check.ErrorMatches, "cannot launch: '--wait-on-error' incompatible with multiple workshops")
-}
-
 func (m *workshopLaunch) TestLaunchCompletions(c *check.C) {
 	wsInfo := []*client.WorkshopInfo{
 		{

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -96,6 +96,9 @@ $ workshop refresh --continue`,
 	cmd.PersistentFlags().BoolVar(&c.NoWait, "no-wait",
 		false,
 		"Return the change ID, don't wait for the operation to finish.")
+	cmd.PersistentFlags().BoolVar(&c.verbose, "verbose",
+		false,
+		"Combine stdout and stderr output from hooks.")
 
 	cmd.MarkFlagsMutuallyExclusive("abort", "continue", "wait-on-error")
 
@@ -112,12 +115,6 @@ func workshopName(name string) string {
 }
 
 func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av []string) error {
-	// We should have no more than one argument (a single workshop) for a
-	// wait-on-error operation
-	if (c.Abort || c.Continue || c.WaitOnError) && len(av) > 1 {
-		return fmt.Errorf("cannot refresh: '--wait-on-error' incompatible with multiple workshops")
-	}
-
 	mode := "transactional"
 	if c.WaitOnError {
 		mode = "wait-on-error"

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -488,6 +488,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 	cmdrefresh := &CmdRefresh{root: c.root}
 	cmdrefresh.WaitOnError = true
+	cmdrefresh.verbose = true
 
 	if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 		return err

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -190,7 +190,7 @@ func restoreSketch(sketchdir, stashdir string) error {
 	return osutil.Rename(stashdir, sketchdir)
 }
 
-func (c *CmdSketch) inferSdkName(cmd *cobra.Command, project string) error {
+func (c *CmdSketch) inferSdkName(project string) error {
 	inferred := false
 	if c.name == "" {
 		c.name = filepath.Base(project)
@@ -443,7 +443,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 	var ejectReverter *revert.Reverter
 	if c.eject {
-		if err := c.inferSdkName(cmd, p.Path); err != nil {
+		if err := c.inferSdkName(p.Path); err != nil {
 			return fmt.Errorf("cannot eject: %w", err)
 		}
 

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -96,7 +95,16 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 
 		if len(tasks) > 0 {
 			w := tabWriter()
-			fmt.Fprintf(w, "Status\tDuration\tSummary\n")
+
+			maxDur := len("Duration")
+			for _, tsk := range tasks {
+				dur := len(tsk.DoingTime.Round(time.Millisecond).String())
+				if dur > maxDur {
+					maxDur = dur
+				}
+			}
+
+			fmt.Fprintf(w, "Status\t%*s\tSummary\n", maxDur, "Duration")
 
 			for _, tsk := range tasks {
 				duration := tsk.DoingTime.Round(time.Millisecond).String()
@@ -104,10 +112,11 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 					duration = "-"
 				}
 
-				fmt.Fprintln(w, strings.Join([]string{
+				fmt.Fprintf(w, "%s\t%*s\t%s\n",
 					tsk.Status,
+					maxDur,
 					duration,
-					tsk.Summary}, "\t"))
+					tsk.Summary)
 			}
 			w.Flush()
 

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
 	"github.com/canonical/workshop/client"
-	"github.com/canonical/workshop/internal/timeutil"
 )
 
 type CmdTasks struct {
@@ -96,20 +96,17 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 
 		if len(tasks) > 0 {
 			w := tabWriter()
-			fmt.Fprintf(w, "ID\tStatus\tSpawn\tReady\tSummary\n")
+			fmt.Fprintf(w, "Status\tDuration\tSummary\n")
 
 			for _, tsk := range tasks {
-				spawnTime := timeutil.Human(tsk.SpawnTime)
-				readyTime := timeutil.Human(tsk.ReadyTime)
-				if tsk.ReadyTime.IsZero() {
-					readyTime = "-"
+				duration := tsk.DoingTime.Round(time.Millisecond).String()
+				if tsk.DoingTime == 0 {
+					duration = "-"
 				}
 
 				fmt.Fprintln(w, strings.Join([]string{
-					tsk.ID,
 					tsk.Status,
-					spawnTime,
-					readyTime,
+					duration,
 					tsk.Summary}, "\t"))
 			}
 			w.Flush()

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -63,7 +63,7 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 
 	var change *client.Change
 	if len(av) > 0 {
-		change, err = cli.Change(av[0])
+		change, err = cli.Change(av[0], false)
 		if err != nil {
 			return err
 		}

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -40,6 +40,7 @@ var (
 type waitMixin struct {
 	NoWait    bool
 	skipAbort bool
+	verbose   bool
 }
 
 var errNoWait = errors.New("no wait for op")
@@ -81,10 +82,10 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 	tMax := time.Time{}
 
 	var lastID string
-	lastLog := map[string]string{}
+	seenLog := map[string]int{}
 	for {
 		var rebootingErr error
-		chg, err := cli.Change(id)
+		chg, err := cli.Change(id, wmx.verbose)
 		if err != nil {
 			// a client.Error means we were able to communicate with
 			// the server (got an answer)
@@ -114,14 +115,6 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 			tMax = time.Time{}
 		}
 
-		maybeShowLog := func(t *client.Task) {
-			nowLog := lastLogStr(t.Log)
-			if lastLog[t.ID] != nowLog {
-				pb.Notify(nowLog)
-				lastLog[t.ID] = nowLog
-			}
-		}
-
 		// Tasks in "wait" state communicate the wait reason
 		// via the log mechanism. So make sure the log is
 		// visible even if the normal progress reporting
@@ -131,7 +124,6 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		// the messages: "Task set to wait until a manual system restart allows to continue"
 		for _, t := range chg.Tasks {
 			if t.Status == "Wait" {
-				maybeShowLog(t)
 				return nil, errWaitOnError
 			}
 		}
@@ -142,6 +134,14 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 			case t.Status != "Doing" && t.Status != "Undoing":
 				continue
 			case t.Progress.Total == 1:
+				if wmx.verbose {
+					cur := seenLog[t.ID]
+
+					for ; cur < len(t.Log); cur++ {
+						pb.Notify(t.Log[cur])
+					}
+					seenLog[t.ID] = cur
+				}
 				pb.Spin(t.Summary)
 			case t.ID == lastID:
 				pb.Set(float64(t.Progress.Done))
@@ -171,11 +171,4 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		// 100ms.
 		time.Sleep(pollTime)
 	}
-}
-
-func lastLogStr(logs []string) string {
-	if len(logs) == 0 {
-		return ""
-	}
-	return logs[len(logs)-1]
 }

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"slices"
 	"time"
 
 	"github.com/canonical/x-go/i18n"
@@ -40,7 +41,9 @@ var (
 type waitMixin struct {
 	NoWait    bool
 	skipAbort bool
-	verbose   bool
+
+	verbose bool
+	colorMixin
 }
 
 var errNoWait = errors.New("no wait for op")
@@ -51,11 +54,14 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		fmt.Fprintf(Stdout, "%s\n", id)
 		return nil, errNoWait
 	}
-	// Intercept sigint
+	wmx.Color = "auto"
+
+	// Intercept sigint.
 	c := make(chan os.Signal, 2)
 
 	signal.Notify(c, os.Interrupt)
 	go func() {
+
 		sig := <-c
 		if sig != nil && wmx.skipAbort {
 			fmt.Fprintln(Stdout, "cannot interrupt: it may break the workshop, please wait until the operation is finished")
@@ -70,7 +76,12 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		}
 	}()
 
-	pb := progress.MakeProgressBar()
+	var pb progress.Meter
+	if wmx.verbose {
+		pb = progress.MakeProgressBar(progress.NotifierRaw)
+	} else {
+		pb = progress.MakeProgressBar(progress.NotifierQuiet)
+	}
 	defer func() {
 		pb.Finished()
 		// next two not strictly needed for CLI, but without
@@ -82,7 +93,6 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 	tMax := time.Time{}
 
 	var lastID string
-	seenLog := map[string]int{}
 	for {
 		var rebootingErr error
 		chg, err := cli.Change(id, wmx.verbose)
@@ -128,25 +138,20 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 			}
 		}
 
-		// progress reporting
+		wmx.maybeShowLogs(pb, chg)
+
+		// Report progress.
+		countPrefix := fmtDoneCount(chg)
 		for _, t := range chg.Tasks {
 			switch {
 			case t.Status != "Doing" && t.Status != "Undoing":
 				continue
 			case t.Progress.Total == 1:
-				if wmx.verbose {
-					cur := seenLog[t.ID]
-
-					for ; cur < len(t.Log); cur++ {
-						pb.Notify(t.Log[cur])
-					}
-					seenLog[t.ID] = cur
-				}
-				pb.Spin(t.Summary)
+				pb.Spin(countPrefix + t.Summary)
 			case t.ID == lastID:
 				pb.Set(float64(t.Progress.Done))
 			default:
-				pb.Start(t.Summary, float64(t.Progress.Total))
+				pb.Start(countPrefix+t.Summary, float64(t.Progress.Total))
 				lastID = t.ID
 			}
 			break
@@ -171,4 +176,59 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		// 100ms.
 		time.Sleep(pollTime)
 	}
+}
+
+var (
+	seenLines     = map[string]int{}
+	summarisedIds = map[string]bool{}
+)
+
+var sortByReady = func(a, b *client.Task) int {
+	if a.ReadyTime.IsZero() {
+		return 1
+	}
+	if b.ReadyTime.IsZero() {
+		return -1
+	}
+	return a.ReadyTime.Compare(b.ReadyTime)
+}
+
+func (wmx waitMixin) maybeShowLogs(pb progress.Meter, chg *client.Change) {
+	if !wmx.verbose {
+		return
+	}
+
+	tasks := slices.Clone(chg.Tasks)
+	slices.SortFunc(tasks, sortByReady)
+
+	esc := wmx.getEscapes()
+	for _, t := range tasks {
+		if t.Status == "Doing" || t.Status == "Done" {
+			cur := seenLines[t.ID]
+
+			for ; cur < len(t.Log); cur++ {
+				pb.Notify(t.Log[cur])
+			}
+
+			seenLines[t.ID] = cur
+
+			_, summarised := summarisedIds[t.ID]
+			// We have shown all the task's logs and since it's in Done,
+			// there'll be now new lines.
+			if !summarised && t.Status == "Done" {
+				pb.Notify(esc.green + esc.tick + esc.end + " " + t.Summary)
+				summarisedIds[t.ID] = true
+			}
+		}
+	}
+}
+
+func fmtDoneCount(chg *client.Change) string {
+	done := 0
+	for _, t := range chg.Tasks {
+		if t.Status == "Done" {
+			done++
+		}
+	}
+	return fmt.Sprintf("(%d/%d) ", done, len(chg.Tasks))
 }

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -141,17 +141,18 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		wmx.maybeShowLogs(pb, chg)
 
 		// Report progress.
-		countPrefix := fmtDoneCount(chg)
 		for _, t := range chg.Tasks {
 			switch {
 			case t.Status != "Doing" && t.Status != "Undoing":
 				continue
 			case t.Progress.Total == 1:
-				pb.Spin(countPrefix + t.Summary)
+				summary := wmx.fmtTaskSummary(chg, t)
+				pb.Spin(summary)
 			case t.ID == lastID:
 				pb.Set(float64(t.Progress.Done))
 			default:
-				pb.Start(countPrefix+t.Summary, float64(t.Progress.Total))
+				summary := wmx.fmtTaskSummary(chg, t)
+				pb.Start(summary, float64(t.Progress.Total))
 				lastID = t.ID
 			}
 			break
@@ -203,7 +204,7 @@ func (wmx waitMixin) maybeShowLogs(pb progress.Meter, chg *client.Change) {
 
 	esc := wmx.getEscapes()
 	for _, t := range tasks {
-		if t.Status == "Doing" || t.Status == "Done" {
+		if t.Status == "Doing" || t.Status == "Done" || t.Status == "Error" {
 			cur := seenLines[t.ID]
 
 			for ; cur < len(t.Log); cur++ {
@@ -223,12 +224,33 @@ func (wmx waitMixin) maybeShowLogs(pb progress.Meter, chg *client.Change) {
 	}
 }
 
-func fmtDoneCount(chg *client.Change) string {
-	done := 0
-	for _, t := range chg.Tasks {
-		if t.Status == "Done" {
-			done++
+func (wmx waitMixin) fmtTaskSummary(chg *client.Change, t *client.Task) string {
+	countPrefix := ""
+	if wmx.verbose {
+		countPrefix = fmtFinishedCount(chg)
+	}
+	return countPrefix + t.Summary
+}
+
+func fmtFinishedCount(chg *client.Change) string {
+	finished, total := 0, len(chg.Tasks)
+
+	if chg.Status == "Doing" {
+		for _, t := range chg.Tasks {
+			if t.Status == "Done" {
+				finished++
+			}
 		}
 	}
-	return fmt.Sprintf("(%d/%d) ", done, len(chg.Tasks))
+
+	if chg.Status == "Undoing" {
+		for _, t := range chg.Tasks {
+			// Reverse counting back to 0 if undoing.
+			if t.Status == "Undo" || t.Status == "Undoing" {
+				finished++
+			}
+		}
+	}
+
+	return fmt.Sprintf("(%d/%d) ", finished, total)
 }

--- a/internal/daemon/api_changes.go
+++ b/internal/daemon/api_changes.go
@@ -17,11 +17,13 @@ package daemon
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"golang.org/x/exp/slices"
 
+	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 )
 
@@ -62,7 +64,7 @@ type taskInfoProgress struct {
 	Total int    `json:"total"`
 }
 
-func change2changeInfo(chg *state.Change) *changeInfo {
+func change2changeInfo(chg *state.Change, verbose bool) *changeInfo {
 	status := chg.Status()
 	chgInfo := &changeInfo{
 		ID:      chg.ID(),
@@ -86,12 +88,32 @@ func change2changeInfo(chg *state.Change) *changeInfo {
 	for j, t := range tasks {
 		label, done, total := t.Progress()
 
+		var taskLog []string
+		// Only hooks support verbose output.
+		if verbose && t.Kind() == "run-hook" {
+			cached := chg.State().Cached(hookstate.HookLogKey(t.ID()))
+			hookLog, ok := cached.(*hookstate.HookLog)
+			if ok && hookLog != nil {
+				rawout := hookLog.Output()
+				for {
+					line, err := rawout.ReadString('\n')
+					if err != nil {
+						break
+					}
+					line = strings.TrimRight(line, "\n")
+					taskLog = append(taskLog, line)
+				}
+			}
+		} else {
+			taskLog = t.Log()
+		}
+
 		taskInfo := &taskInfo{
 			ID:      t.ID(),
 			Kind:    t.Kind(),
 			Summary: t.Summary(),
 			Status:  t.Status().String(),
-			Log:     t.Log(),
+			Log:     taskLog,
 			Progress: taskInfoProgress{
 				Label: label,
 				Done:  done,
@@ -186,12 +208,23 @@ func v1GetChanges(c *Command, r *http.Request, _ *userState) Response {
 		if !filter(chg) {
 			continue
 		}
-		chgInfos = append(chgInfos, change2changeInfo(chg))
+		chgInfos = append(chgInfos, change2changeInfo(chg, false))
 	}
 	return SyncResponse(chgInfos, http.StatusOK)
 }
 
 func v1GetChange(c *Command, r *http.Request, _ *userState) Response {
+	query := r.URL.Query()
+
+	var err error
+	var verbose bool
+	if val := query.Get("verbose"); len(val) > 0 {
+		verbose, err = strconv.ParseBool(val)
+		if err != nil {
+			return statusBadRequest(`invalid "verbose" parameter: %v`, err)
+		}
+	}
+
 	changeID := muxVars(r)["id"]
 	st := c.d.overlord.State()
 	st.Lock()
@@ -201,11 +234,12 @@ func v1GetChange(c *Command, r *http.Request, _ *userState) Response {
 		return statusNotFound("cannot find change with id %q", changeID)
 	}
 
-	return SyncResponse(change2changeInfo(chg), http.StatusOK)
+	return SyncResponse(change2changeInfo(chg, verbose), http.StatusOK)
 }
 
 func v1PostChange(c *Command, r *http.Request, _ *userState) Response {
 	chID := muxVars(r)["id"]
+
 	state := c.d.overlord.State()
 	state.Lock()
 	defer state.Unlock()
@@ -237,7 +271,7 @@ func v1PostChange(c *Command, r *http.Request, _ *userState) Response {
 	// actually ask to proceed with the abort
 	stateEnsureBefore(state, 0)
 
-	return SyncResponse(change2changeInfo(chg), http.StatusOK)
+	return SyncResponse(change2changeInfo(chg, false), http.StatusOK)
 }
 
 func v1GetChangeWait(c *Command, r *http.Request, _ *userState) Response {
@@ -278,5 +312,5 @@ func v1GetChangeWait(c *Command, r *http.Request, _ *userState) Response {
 
 	st.Lock()
 	defer st.Unlock()
-	return SyncResponse(change2changeInfo(change), http.StatusOK)
+	return SyncResponse(change2changeInfo(change, false), http.StatusOK)
 }

--- a/internal/daemon/api_changes.go
+++ b/internal/daemon/api_changes.go
@@ -52,8 +52,9 @@ type taskInfo struct {
 	Log      []string         `json:"log,omitempty"`
 	Progress taskInfoProgress `json:"progress"`
 
-	SpawnTime time.Time  `json:"spawn-time,omitempty"`
-	ReadyTime *time.Time `json:"ready-time,omitempty"`
+	SpawnTime time.Time     `json:"spawn-time,omitempty"`
+	ReadyTime *time.Time    `json:"ready-time,omitempty"`
+	DoingTime time.Duration `json:"doing-time,omitempty"`
 
 	Data map[string]*json.RawMessage `json:"data,omitempty"`
 }
@@ -62,6 +63,30 @@ type taskInfoProgress struct {
 	Label string `json:"label"`
 	Done  int    `json:"done"`
 	Total int    `json:"total"`
+}
+
+func getTaskLog(tsk *state.Task, verbose bool) []string {
+	taskLog := []string{}
+	st := tsk.State()
+	// Only hooks support verbose output.
+	if verbose && tsk.Kind() == "run-hook" {
+		cached := st.Cached(hookstate.HookLogKey(tsk.ID()))
+		hookLog, ok := cached.(*hookstate.HookLog)
+		if ok && hookLog != nil {
+			rawout := hookLog.Output()
+			for {
+				line, err := rawout.ReadString('\n')
+				if err != nil {
+					break
+				}
+				line = strings.TrimRight(line, "\n")
+				taskLog = append(taskLog, line)
+			}
+		}
+	} else {
+		taskLog = tsk.Log()
+	}
+	return taskLog
 }
 
 func change2changeInfo(chg *state.Change, verbose bool) *changeInfo {
@@ -88,25 +113,7 @@ func change2changeInfo(chg *state.Change, verbose bool) *changeInfo {
 	for j, t := range tasks {
 		label, done, total := t.Progress()
 
-		var taskLog []string
-		// Only hooks support verbose output.
-		if verbose && t.Kind() == "run-hook" {
-			cached := chg.State().Cached(hookstate.HookLogKey(t.ID()))
-			hookLog, ok := cached.(*hookstate.HookLog)
-			if ok && hookLog != nil {
-				rawout := hookLog.Output()
-				for {
-					line, err := rawout.ReadString('\n')
-					if err != nil {
-						break
-					}
-					line = strings.TrimRight(line, "\n")
-					taskLog = append(taskLog, line)
-				}
-			}
-		} else {
-			taskLog = t.Log()
-		}
+		taskLog := getTaskLog(t, verbose)
 
 		taskInfo := &taskInfo{
 			ID:      t.ID(),
@@ -120,6 +127,7 @@ func change2changeInfo(chg *state.Change, verbose bool) *changeInfo {
 				Total: total,
 			},
 			SpawnTime: t.SpawnTime(),
+			DoingTime: t.DoingTime(),
 		}
 		readyTime := t.ReadyTime()
 		if !readyTime.IsZero() {

--- a/internal/daemon/api_changes_test.go
+++ b/internal/daemon/api_changes_test.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/exp/slices"
 	"gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -226,6 +227,80 @@ func (s *apiSuite) TestStateChangesForWorkshop(c *check.C) {
 
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
+}
+
+func (s *apiSuite) TestStateChangeDoingTimes(c *check.C) {
+	restore := state.MockTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	defer restore()
+
+	d := s.daemon(c)
+
+	d.Overlord().Loop()
+	defer d.Overlord().Stop()
+
+	d.overlord.TaskRunner().AddHandler("doing-test", func(task *state.Task, tomb *tomb.Tomb) error {
+		time.Sleep(50 * time.Microsecond)
+		return nil
+	}, nil)
+
+	st := d.Overlord().State()
+	st.Lock()
+	task := st.NewTask("doing-test", "...")
+	chg := st.NewChange("doing", "launch...")
+	chg.AddTask(task)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+
+	<-chg.Ready()
+
+	st.Lock()
+	err := chg.Err()
+	st.Unlock()
+	c.Assert(err, check.IsNil)
+
+	stateChangeCmd := apiCmd("/v1/changes/{id}")
+
+	// Execute
+	req, err := http.NewRequest("GET", "/v1/change/"+chg.ID(), nil)
+	c.Assert(err, check.IsNil)
+	s.vars = map[string]string{"id": chg.ID()}
+	rsp := v1GetChange(stateChangeCmd, req, nil).(*resp)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+
+	// Verify
+	c.Check(rec.Code, check.Equals, 200)
+	c.Check(rsp.Status, check.Equals, 200)
+	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Result, check.NotNil)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	st.Lock()
+	doingTime := float64(task.DoingTime().Nanoseconds())
+	st.Unlock()
+	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+		"id":         chg.ID(),
+		"kind":       "doing",
+		"summary":    "launch...",
+		"status":     "Done",
+		"ready":      true,
+		"spawn-time": "2016-04-21T01:02:03Z",
+		"ready-time": "2016-04-21T01:02:03Z",
+		"tasks": []interface{}{
+			map[string]interface{}{
+				"id":         task.ID(),
+				"kind":       "doing-test",
+				"summary":    "...",
+				"status":     "Done",
+				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},
+				"spawn-time": "2016-04-21T01:02:03Z",
+				"ready-time": "2016-04-21T01:02:03Z",
+				"doing-time": doingTime,
+			},
+		},
+	})
 }
 
 func (s *apiSuite) TestStateChange(c *check.C) {

--- a/internal/daemon/api_changes_test.go
+++ b/internal/daemon/api_changes_test.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/exp/slices"
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 )
 
@@ -35,7 +36,7 @@ func setupChanges(st *state.State) []string {
 	chg1.Set("workshop", "one")
 	chg1.Set("project-id", "123")
 	t1 := st.NewTask("create-workshop", "1...")
-	t2 := st.NewTask("start-workshop", "2...")
+	t2 := st.NewTask("run-hook", "2...")
 	chg1.AddAll(state.NewTaskSet(t1, t2))
 	t1.Logf("l11")
 	t1.Logf("l12")
@@ -246,7 +247,7 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 	stateChangeCmd := apiCmd("/v1/changes/{id}")
 
 	// Execute
-	req, err := http.NewRequest("POST", "/v1/change/"+ids[0], nil)
+	req, err := http.NewRequest("GET", "/v1/change/"+ids[0], nil)
 	c.Assert(err, check.IsNil)
 	rsp := v1GetChange(stateChangeCmd, req, nil).(*resp)
 	rec := httptest.NewRecorder()
@@ -284,11 +285,86 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 			},
 			map[string]interface{}{
 				"id":         ids[3],
-				"kind":       "start-workshop",
+				"kind":       "run-hook",
 				"summary":    "2...",
 				"status":     "Do",
 				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
+			},
+		},
+		"data": map[string]interface{}{
+			"n": float64(42),
+		},
+	})
+}
+
+func (s *apiSuite) TestStateChangeVerbose(c *check.C) {
+	restore := state.MockTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	defer restore()
+
+	// Setup
+	d := s.daemon(c)
+	st := d.overlord.State()
+	st.Lock()
+	ids := setupChanges(st)
+	chg := st.Change(ids[0])
+	chg.Set("api-data", map[string]int{"n": 42})
+	task := chg.Tasks()[0]
+	task.Set("api-data", map[string]string{"foo": "bar"})
+	hl := hookstate.NewHookLog()
+	_, err := hl.Write([]byte("verbose task output line\nsecond line\nunfinished line"))
+	c.Assert(err, check.IsNil)
+	st.Cache(hookstate.HookLogKey(chg.Tasks()[1].ID()), hl)
+	st.Unlock()
+	s.vars = map[string]string{"id": ids[0]}
+
+	stateChangeCmd := apiCmd("/v1/changes/{id}")
+
+	// Execute
+	req, err := http.NewRequest("GET", "/v1/change/"+ids[0]+"?verbose=true", nil)
+	c.Assert(err, check.IsNil)
+	rsp := v1GetChange(stateChangeCmd, req, nil).(*resp)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+
+	// Verify
+	c.Check(rec.Code, check.Equals, 200)
+	c.Check(rsp.Status, check.Equals, 200)
+	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Result, check.NotNil)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(err, check.IsNil)
+	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+		"id":         ids[0],
+		"kind":       "launch",
+		"summary":    "launch...",
+		"status":     "Do",
+		"ready":      false,
+		"spawn-time": "2016-04-21T01:02:03Z",
+		"project-id": "123",
+		"tasks": []interface{}{
+			map[string]interface{}{
+				"id":         ids[2],
+				"kind":       "create-workshop",
+				"summary":    "1...",
+				"status":     "Do",
+				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"spawn-time": "2016-04-21T01:02:03Z",
+				"data": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			map[string]interface{}{
+				"id":         ids[3],
+				"kind":       "run-hook",
+				"summary":    "2...",
+				"status":     "Do",
+				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"spawn-time": "2016-04-21T01:02:03Z",
+				"log":        []interface{}{"verbose task output line", "second line"},
 			},
 		},
 		"data": map[string]interface{}{
@@ -360,7 +436,7 @@ func (s *apiSuite) TestStateChangeAbort(c *check.C) {
 			},
 			map[string]interface{}{
 				"id":         ids[3],
-				"kind":       "start-workshop",
+				"kind":       "run-hook",
 				"summary":    "2...",
 				"status":     "Hold",
 				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -1,12 +1,14 @@
 package hookstate
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
+	"sync"
 
+	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/afero"
 	"gopkg.in/tomb.v2"
 
@@ -17,6 +19,11 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
+)
+
+const (
+	hookRawOutputBufferSize = 1024 * 1024 * 10
+	hookTaskLogSize         = 1024 * 64
 )
 
 func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
@@ -83,7 +90,7 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 			return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
 		}
 
-		return h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs)
+		return h.executeHook(ctx, task, &hook, execArgs)
 	case RestoreState:
 		fs, err := h.backend.WorkshopFs(ctx, w)
 		if err != nil {
@@ -99,9 +106,9 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: state storage path is not a directory", hook.Sdk)
 		}
 
-		return h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs)
+		return h.executeHook(ctx, task, &hook, execArgs)
 	case SetupBase:
-		if err = h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs); err != nil {
+		if err = h.executeHook(ctx, task, &hook, execArgs); err != nil {
 			return err
 		}
 		return h.backend.Snapshot(ctx, w, workshop.SnapshotId(w, hook.Sdk))
@@ -133,16 +140,62 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		xdgRuntimeDir := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid)
 		execArgs.Environment["XDG_RUNTIME_DIR"] = xdgRuntimeDir
 		execArgs.Environment["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=" + filepath.Join(xdgRuntimeDir, "bus")
-		return h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs)
+		return h.executeHook(ctx, task, &hook, execArgs)
 	default:
-		return h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs)
+		return h.executeHook(ctx, task, &hook, execArgs)
 	}
 }
 
-func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, projectId string, hook *HookSetup, execArgs *workshop.ExecArgs) error {
+type HookLogKey string
+
+type HookLog struct {
+	l   sync.Mutex
+	buf *strutil.LimitedBuffer
+}
+
+func NewHookLog() *HookLog {
+	return &HookLog{
+		buf: strutil.NewLimitedBuffer(-1, hookRawOutputBufferSize),
+	}
+}
+
+func (h *HookLog) Output() *bytes.Buffer {
+	h.l.Lock()
+	defer h.l.Unlock()
+
+	return bytes.NewBuffer(h.buf.Bytes())
+}
+
+func (h *HookLog) taskLog() []byte {
+	h.l.Lock()
+	defer h.l.Unlock()
+
+	// 10 lines per task log to be stored in the state as a sensible default
+	// (see task.Logf).
+	return strutil.TruncateOutput(h.buf.Bytes(), 10, hookTaskLogSize)
+}
+
+func (h *HookLog) Write(buf []byte) (n int, err error) {
+	h.l.Lock()
+	defer h.l.Unlock()
+
+	return h.buf.Write(buf)
+}
+
+func (h *HookLog) flush() {
+	h.l.Lock()
+	defer h.l.Unlock()
+
+	buf := h.buf.Bytes()
+	if len(buf) > 0 && buf[len(buf)-1] != '\n' {
+		_, _ = h.buf.Write([]byte{'\n'})
+	}
+}
+
+func (h *HookManager) executeHook(ctx context.Context, task *state.Task, hook *HookSetup, execArgs *workshop.ExecArgs) error {
 	hookPath := sdk.SdkHookPath(hook.Sdk, hook.Type())
 
-	wsFs, err := h.backend.WorkshopFs(ctx, w)
+	wsFs, err := h.backend.WorkshopFs(ctx, hook.Workshop)
 	if err != nil {
 		return err
 	}
@@ -174,67 +227,38 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, proj
 		return err
 	}
 
-	// create a memory out/err to log the hook output into the task's log
-	memfs := afero.NewMemMapFs()
-	stdout, err := memfs.Create(fmt.Sprintf("%s-%s-%s-stdout", w, projectId, hook.Type()))
-	if err != nil {
-		return err
-	}
-	defer stdout.Close()
+	hookOutErr := NewHookLog()
 
-	stderr, err := memfs.Create(fmt.Sprintf("%s-%s-%s-stderr", w, projectId, hook.Type()))
-	if err != nil {
-		return err
-	}
-	defer stderr.Close()
+	st := task.State()
+	st.Lock()
+	st.Cache(HookLogKey(task.ID()), hookOutErr)
+	st.Unlock()
 
 	execArgs.Environment["WORKSHOP_COOKIE"] = hookCtx.ID()
 	args := workshop.Execution{
 		ExecArgs: *execArgs,
 		ExecControls: workshop.ExecControls{
 			Stdin:  nil,
-			Stdout: stdout,
-			Stderr: stderr,
+			Stdout: hookOutErr,
+			Stderr: hookOutErr,
 		},
 	}
 
-	exectx, err := h.backend.Exec(ctx, w, &args)
+	exectx, err := h.backend.Exec(ctx, hook.Workshop, &args)
 	// Handle errors that are unrelated to the command, for example, LXD-related
 	// issues. An error here means the execution has not started at all.
 	if err != nil {
 		return err
 	}
+
 	err = exectx.WaitExecution(ctx)
 
-	st := task.State()
-	isNewLine := func(r rune) bool { return r == '\n' }
-	outlog, _ := afero.ReadFile(memfs, stdout.Name())
-	if len(outlog) > 0 {
-		lines := strings.FieldsFunc(string(outlog), isNewLine)
-		st.Lock()
-		for _, line := range lines {
-			task.Logf("%s", line)
-		}
-		st.Unlock()
-	}
+	hookOutErr.flush()
+	taskLog := hookOutErr.taskLog()
 
-	errlog, _ := afero.ReadFile(memfs, stderr.Name())
-	if err != nil {
-		lines := strings.FieldsFunc(string(errlog), isNewLine)
+	if len(taskLog) > 0 {
 		st.Lock()
-		for i, line := range lines {
-			if i == len(lines)-1 {
-				if exerr, isCmdError := err.(*workshop.ErrExec); isCmdError {
-					// If it's an exec error, the return value would only
-					// contain the status code which is often useless to return
-					// to the upper level. We'll attempt to return the last
-					// known error line for better claririty.
-					err = fmt.Errorf("%s (exit code: %d)", line, exerr.Status)
-				}
-			} else {
-				task.Errorf("%s", line)
-			}
-		}
+		task.Logf(string(taskLog))
 		st.Unlock()
 	}
 
@@ -263,6 +287,13 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, proj
 	}
 
 	return err
+}
+
+func (h *HookManager) doHookCleanup(task *state.Task, tomb *tomb.Tomb) error {
+	h.state.Lock()
+	h.state.Cache(HookLogKey(task.ID()), nil)
+	h.state.Unlock()
+	return nil
 }
 
 func createHookContext(task *state.Task, repo *repository, hook *HookSetup) (*Context, error) {

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -163,7 +163,7 @@ func (h *HookLog) Output() *bytes.Buffer {
 	h.l.Lock()
 	defer h.l.Unlock()
 
-	return bytes.NewBuffer(h.buf.Bytes())
+	return bytes.NewBuffer(bytes.Clone(h.buf.Bytes()))
 }
 
 func (h *HookLog) taskLog() []byte {
@@ -172,7 +172,7 @@ func (h *HookLog) taskLog() []byte {
 
 	// 10 lines per task log to be stored in the state as a sensible default
 	// (see task.Logf).
-	return strutil.TruncateOutput(h.buf.Bytes(), 10, hookTaskLogSize)
+	return bytes.Clone(strutil.TruncateOutput(h.buf.Bytes(), 10, hookTaskLogSize))
 }
 
 func (h *HookLog) Write(buf []byte) (n int, err error) {
@@ -292,6 +292,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, hook *H
 func (h *HookManager) doHookCleanup(task *state.Task, tomb *tomb.Tomb) error {
 	h.state.Lock()
 	h.state.Cache(HookLogKey(task.ID()), nil)
+	logger.Debugf("On HookManager.doHookCleanup: cleaned up logs for task %s", task.ID())
 	h.state.Unlock()
 	return nil
 }

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -542,3 +542,52 @@ func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
 	_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.FakeHook.String()))
 	c.Check(err, check.IsNil)
 }
+
+func (s *hookSuite) TestExecCombinedHookOutputStoredInLogs(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.FakeHook)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.launchWorkshop(c, "one")
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+		return workshop.ExecContext{
+			WaitExecution: func(ctx context.Context) error {
+				_, err := args.Stdout.Write([]byte("hello from hook!\n"))
+				c.Assert(err, check.IsNil)
+				_, err = args.Stdout.Write([]byte("stdout message\n"))
+				c.Assert(err, check.IsNil)
+				_, err = args.Stderr.Write([]byte("\terror message\n"))
+				c.Assert(err, check.IsNil)
+				return &workshop.ErrExec{Status: 1}
+			},
+		}, nil
+	}
+	defer func() {
+		s.backend.ExecCallback = fakebackend.DoExecDefault
+	}()
+
+	s.state.Unlock()
+	err := s.se.Ensure()
+	c.Assert(err, check.IsNil)
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Check(t1.Log(), check.HasLen, 2)
+	c.Assert(t1.Log()[0], check.Matches, ".*hello from hook!\nstdout message\n\terror message\n$")
+	c.Assert(t1.Log()[1], check.Matches, ".* ERROR command exit code 1$")
+
+	cached := s.state.Cached(hookstate.HookLogKey(t1.ID()))
+	hookOutErr, ok := cached.(*hookstate.HookLog)
+	c.Assert(ok, check.Equals, true)
+	c.Assert(hookOutErr.Output().String(), check.Equals, "hello from hook!\nstdout message\n\terror message\n")
+
+	c.Check(s.mockHandler.BeforeCalled, check.Equals, true)
+	c.Check(s.mockHandler.DoneCalled, check.Equals, false)
+	c.Check(s.mockHandler.ErrorCalled, check.Equals, true)
+}

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -78,6 +78,7 @@ func New(s *state.State, runner *state.TaskRunner) *HookManager {
 	s.Unlock()
 
 	runner.AddHandler("run-hook", handlersetup.OnDo(manager.doRunHook), nil)
+	runner.AddCleanup("run-hook", manager.doHookCleanup)
 
 	setupHooks(manager)
 

--- a/internal/progress/ansimeter.go
+++ b/internal/progress/ansimeter.go
@@ -27,14 +27,38 @@ import (
 
 var stdout io.Writer = os.Stdout
 
+type notifyer interface {
+	Notify(msg string)
+}
+
+func NewANSIMeter(nt NotifyerType) *ANSIMeter {
+	switch nt {
+	case NotifierQuiet:
+		return &ANSIMeter{
+			notifier: &nilNotifier{},
+		}
+	case NotifierRaw:
+		return &ANSIMeter{
+			notifier: &rawPrintNotifier{},
+		}
+	case NotifierLimitedWindow:
+		return &ANSIMeter{
+			notifier: newLimitedWindowNotifier(defaultNotificationLines),
+		}
+	default:
+		panic("unknown notifier type for ANSIMeter")
+	}
+}
+
 // ANSIMeter is a progress.Meter that uses ANSI escape codes to make
 // better use of the available horizontal space.
 type ANSIMeter struct {
-	label   []rune
-	total   float64
-	written float64
-	spin    int
-	t0      time.Time
+	label    []rune
+	total    float64
+	written  float64
+	spin     int
+	t0       time.Time
+	notifier notifyer
 }
 
 // these are the bits of the ANSI escapes (beyond \r) that we use
@@ -42,6 +66,7 @@ type ANSIMeter struct {
 var (
 	// clear to end of line
 	clrEOL = "\033[K"
+	clrEOS = "\033[0J"
 	// make cursor invisible
 	cursorInvisible = "\033[?25l"
 	// make cursor visible
@@ -50,7 +75,92 @@ var (
 	enterReverseMode = "\033[7m"
 	// go back to normal video
 	exitAttributeMode = "\033[0m"
+	// move cursor %d lines up
+	moveCursorUp = "\033[%dA"
 )
+
+const defaultNotificationLines = 5
+
+type nilNotifier struct{}
+
+func (*nilNotifier) Notify(string) {}
+
+// limitedWindowNotifier manages a scrolling fixed-size window for notifications.
+type limitedWindowNotifier struct {
+	history  []string
+	numLines int
+}
+
+func newLimitedWindowNotifier(numLines int) *limitedWindowNotifier {
+	if numLines <= 0 {
+		numLines = defaultNotificationLines
+	}
+	return &limitedWindowNotifier{
+		history:  make([]string, 0, numLines),
+		numLines: numLines,
+	}
+}
+
+// Notify adds a message and displays the updated window to stdout.
+// New messages effectively appear at the bottom of the window, and old messages scroll off the top.
+func (lwn *limitedWindowNotifier) Notify(msg string) {
+	lwn.history = append(lwn.history, msg)
+
+	if len(lwn.history) > lwn.numLines {
+		lwn.history = lwn.history[len(lwn.history)-lwn.numLines:]
+	}
+
+	linesToPrint := len(lwn.history)
+
+	if linesToPrint > 0 {
+		fmt.Fprint(stdout, "\n")
+		fmt.Fprint(stdout, clrEOS)
+
+		for i := 0; i < linesToPrint; i++ {
+			fmt.Fprint(stdout, "\r", exitAttributeMode, clrEOL)
+			fmt.Fprint(stdout, lwn.history[i])
+
+			if i < linesToPrint-1 { // For all but the last line printed
+				fmt.Fprint(stdout, "\n")
+			}
+		}
+		fmt.Fprintf(stdout, moveCursorUp, linesToPrint)
+		fmt.Fprint(stdout, "\r")
+	}
+}
+
+type rawPrintNotifier struct {
+}
+
+func (*rawPrintNotifier) Notify(msgstr string) {
+	col := termWidth()
+	// Clear the current line, reset attributes, and move cursor to the beginning.
+	fmt.Fprint(stdout, "\r", exitAttributeMode, clrEOL)
+
+	msg := []rune(msgstr)
+	var breakPoint int
+	// Word wrap the message if it's longer than the terminal width.
+	for len(msg) > col {
+		breakPoint = col // Default break point if no space is found within the first `col` characters.
+		// Find the last space within the column width to break the line.
+		// Search from right to left within the available width.
+		for searchIdx := col - 1; searchIdx >= 0; searchIdx-- {
+			if unicode.IsSpace(msg[searchIdx]) {
+				breakPoint = searchIdx
+				break // Found a suitable space.
+			}
+		}
+
+		if breakPoint == col { // No space found (or space is beyond `col`), hard break at `col`.
+			fmt.Fprintln(stdout, string(msg[:col]))
+			msg = msg[col:]
+		} else { // Space found at breakPoint (0 <= breakPoint < col).
+			fmt.Fprintln(stdout, string(msg[:breakPoint])) // Print up to the space.
+			msg = msg[breakPoint+1:]                       // Continue with the rest, skipping the space.
+		}
+	}
+	fmt.Fprintln(stdout, string(msg)) // Print the remaining part of the message.
+}
 
 var termWidth = func() int {
 	col, _, _ := term.GetSize(0)
@@ -166,29 +276,8 @@ func (*ANSIMeter) Finished() {
 	fmt.Fprint(stdout, "\r", exitAttributeMode, cursorVisible, clrEOL)
 }
 
-func (*ANSIMeter) Notify(msgstr string) {
-	col := termWidth()
-	fmt.Fprint(stdout, "\r", exitAttributeMode, clrEOL)
-
-	msg := []rune(msgstr)
-	var i int
-	for len(msg) > col {
-		for i = col; i >= 0; i-- {
-			if unicode.IsSpace(msg[i]) {
-				break
-			}
-		}
-		if i < 1 {
-			// didn't find anything; print the whole thing and try again
-			fmt.Fprintln(stdout, string(msg[:col]))
-			msg = msg[col:]
-		} else {
-			// found a space; print up to but not including it, and skip it
-			fmt.Fprintln(stdout, string(msg[:i]))
-			msg = msg[i+1:]
-		}
-	}
-	fmt.Fprintln(stdout, string(msg))
+func (p *ANSIMeter) Notify(msgstr string) {
+	p.notifier.Notify(msgstr)
 }
 
 func (p *ANSIMeter) Write(bs []byte) (n int, err error) {

--- a/internal/progress/ansimeter.go
+++ b/internal/progress/ansimeter.go
@@ -31,7 +31,7 @@ type notifyer interface {
 	Notify(msg string)
 }
 
-func NewANSIMeter(nt NotifyerType) *ANSIMeter {
+func NewANSIMeter(nt NotifierType) *ANSIMeter {
 	switch nt {
 	case NotifierQuiet:
 		return &ANSIMeter{

--- a/internal/progress/ansimeter_test.go
+++ b/internal/progress/ansimeter_test.go
@@ -189,7 +189,7 @@ func (ansiSuite) TestNotify(c *check.C) {
 	defer progress.MockSimpleEscapes()()
 	defer progress.MockTermWidth(func() int { return width })()
 
-	p := &progress.ANSIMeter{}
+	p := progress.NewANSIMeter(progress.NotifierRaw)
 	p.Start("working", 1e300)
 
 	width = 10

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -22,6 +22,14 @@ import (
 	"golang.org/x/term"
 )
 
+type NotifyerType uint8
+
+const (
+	NotifierQuiet NotifyerType = iota
+	NotifierRaw
+	NotifierLimitedWindow
+)
+
 // Meter is an interface to show progress to the user
 type Meter interface {
 	// Start progress with max "total" steps
@@ -88,12 +96,12 @@ var inTesting bool = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test") 
 //   - otherwise, an ANSIMeter is returned.
 //
 // TODO: instead of making the pivot at creation time, do it at every call.
-func MakeProgressBar() Meter {
+func MakeProgressBar(nt NotifyerType) Meter {
 	if testMeter != nil {
 		return testMeter
 	}
-	if !inTesting && term.IsTerminal(int(os.Stdin.Fd())) {
-		return &ANSIMeter{}
+	if !inTesting && term.IsTerminal(int(os.Stdout.Fd())) {
+		return NewANSIMeter(nt)
 	}
 
 	return QuietMeter{}

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -22,10 +22,10 @@ import (
 	"golang.org/x/term"
 )
 
-type NotifyerType uint8
+type NotifierType uint8
 
 const (
-	NotifierQuiet NotifyerType = iota
+	NotifierQuiet NotifierType = iota
 	NotifierRaw
 	NotifierLimitedWindow
 )
@@ -96,7 +96,7 @@ var inTesting bool = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test") 
 //   - otherwise, an ANSIMeter is returned.
 //
 // TODO: instead of making the pivot at creation time, do it at every call.
-func MakeProgressBar(nt NotifyerType) Meter {
+func MakeProgressBar(nt NotifierType) Meter {
 	if testMeter != nil {
 		return testMeter
 	}

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -50,7 +50,7 @@ func (ts *ProgressTestSuite) TestQuietNotify(c *C) {
 
 func (ts *ProgressTestSuite) TestANSINotify(c *C) {
 	expected := fmt.Sprint("\r", progress.ExitAttributeMode, progress.ClrEOL, "blah blah\n")
-	ts.testNotify(c, &progress.ANSIMeter{}, "ansi", expected)
+	ts.testNotify(c, progress.NewANSIMeter(progress.NotifierRaw), "ansi", expected)
 }
 
 func (ts *ProgressTestSuite) TestTestingNotify(c *C) {


### PR DESCRIPTION
# Description

* Implement verbose mode for `launch` and `refresh`.
* Show tasks duration in `workshop tasks` instead of spawn and ready times that often do not bear any useful information as `SpawnTime` is the time when a task was created for the change (not when it was scheduled for running). Thus, it's difficult to conclude when each task has actually started.

## Considerations and assumptions made for the implementation

- Minimise changes to the client and API.

- The client needs to be significantly extended to support chunked streaming or websockets for the functionality like 
verbose logs streaming and it is unclear whether such an  investment will pay off in our use case which I define as "occasional usage of verbose output for progress tracking and debugging".

- The final task log must be limited so that logs do not accumulate in the state file which leads to performance issues quite quickly as it has been seen in pebble.

- The combined stdout and stderr streams from hooks are stored in the state's cache. These are available in the `/v1/change/<id>?verbose=true` response for the duration of the change execution and up until the next ensure pass. After that, the cache will be invalidated and only a truncated version of the output streams remain available in the task's log (stored in state).

- The `state.Task` stores logs as `[]string`; the client also expects logs as `[]string`. Thus, the API will send the combined output as lines which means buffering for the output data that wasn't finished with a new line.

- There are possible strategies to optimise the verbose mode performance, and extend the lifetime of verbose logs (e.g. store in a temporary file up until the time the associated change is pruned, extend the cache's expiration if it was requested after the change has finished and so on). These were considered as premature to be implemented now.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
