### PR TITLE
Update workaround for snapd context canceled

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1068,10 +1068,16 @@ write_files:
     # Bypass confirmation prompts
     APT::Get::Assume-Yes "1";
   path: /etc/apt/apt.conf.d/01norecommend
+- content: |
+    # Workaround for https://bugs.launchpad.net/snapd/+bug/2104066
+    [Service]
+    Environment=SNAPD_STANDBY_WAIT=1m
+  path: /etc/systemd/system/snapd.service.d/override.conf
 runcmd:
   - systemctl daemon-reload
   - systemctl enable xauth-copy.service
   - systemctl enable --now xauth-watch.path
+  - systemctl restart snapd.service
 `
 
 	f, err := yaml.Marshal(file)

--- a/tests/lib/sdk/test-sdk-go/foxy/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/foxy/stable/sdk/hooks/setup-base
@@ -1,5 +1,3 @@
-sudo apt-get update
-sudo apt-get install xdelta3
 sudo snap install go --classic
 echo "PATH=/home/workshop/go/bin:$PATH" | tee -a /home/workshop/.profile
 

--- a/tests/lib/sdk/test-sdk-go/jammy/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/jammy/stable/sdk/hooks/setup-base
@@ -1,5 +1,3 @@
-sudo apt-get update
-sudo apt-get install xdelta3
 sudo snap install go --classic
 echo "PATH=/home/workshop/go/bin:$PATH" | tee -a /home/workshop/.profile
 

--- a/tests/lib/sdk/test-sdk-go/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/latest/stable/sdk/hooks/setup-base
@@ -1,5 +1,3 @@
-sudo apt-get update
-sudo apt-get install xdelta3
 sudo snap install go --classic
 echo "PATH=/home/workshop/go/bin:$PATH" | tee -a /home/workshop/.profile
 

--- a/tests/lib/sdk/test-sdk-go/noble/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-go/noble/stable/sdk/hooks/setup-base
@@ -1,5 +1,3 @@
-sudo apt-get update
-sudo apt-get install xdelta3
 sudo snap install go --classic
 echo "PATH=/home/workshop/go/bin:$PATH" | tee -a /home/workshop/.profile
 

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -47,10 +47,18 @@ function prepare_environment() {
     done
 
     apt-get update
-    apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)" moreutils jq xdelta3 zfsutils-linux
+    apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)" moreutils jq zfsutils-linux
+
+    mkdir -p /etc/systemd/system/snapd.service.d
+    cat <<EOF >/etc/systemd/system/snapd.service.d/override.conf
+# Workaround for https://bugs.launchpad.net/snapd/+bug/2104066
+[Service]
+Environment=SNAPD_STANDBY_WAIT=1m
+EOF
+    systemctl daemon-reload
 
     systemctl unmask snapd.service
-    systemctl start snapd.service
+    systemctl restart snapd.service
     snap wait system seed.loaded
     # The /snap directory does not exist in some environments
     [ ! -d /snap ] && ln -s /var/lib/snapd/snap /snap


### PR DESCRIPTION
# Description

Based on https://github.com/canonical/lxd-ci/pull/433.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
