### PR TITLE
Save username as a Workshop's LXD project property

### DIFF
--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -72,7 +72,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	// TODO: make filesystem operations more secure (e.g. drop privileges if possible) and easy to test.
 	actual, err := user.Current()
 	c.Assert(err, check.IsNil)
-	s.user = &user.User{Name: "testuser", Username: "testuser", HomeDir: c.MkDir(), Uid: actual.Uid, Gid: actual.Gid}
+	s.user = &user.User{Username: "testuser", HomeDir: c.MkDir(), Uid: actual.Uid, Gid: actual.Gid}
 
 	s.project = workshop.Project{
 		Path:      s.workshopDir,

--- a/internal/interfaces/builtin/all_test.go
+++ b/internal/interfaces/builtin/all_test.go
@@ -39,7 +39,6 @@ type AllSuite struct{}
 var (
 	_        = Suite(&AllSuite{})
 	testuser = user.User{
-		Name:     "testuser",
 		Username: "testuser",
 	}
 )

--- a/internal/interfaces/builtin/camera_test.go
+++ b/internal/interfaces/builtin/camera_test.go
@@ -57,7 +57,7 @@ slots:
   camera:
 `, s.projectId, "ws", "producer", "camera")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -57,7 +57,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
@@ -94,7 +94,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
@@ -131,7 +131,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
@@ -177,7 +177,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
@@ -205,7 +205,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
@@ -233,7 +233,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "neither DISPLAY nor WAYLAND_DISPLAY.*")
@@ -259,7 +259,7 @@ slots:
   desktop:
 `, s.projectId, "ws", "producer", "desktop")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "XDG_RUNTIME_DIR is either empty.*")

--- a/internal/interfaces/builtin/gpu_test.go
+++ b/internal/interfaces/builtin/gpu_test.go
@@ -58,7 +58,7 @@ slots:
 `, s.projectId, "ws", "producer", "gpu")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -335,7 +335,7 @@ slots:
 `, s.projectId, "ws", "system", "mount")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	s.env["XDG_DATA_HOME"] = ""
@@ -366,7 +366,7 @@ slots:
 `, s.projectId, "ws", "system", "mount")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	s.env["XDG_DATA_HOME"] = c.MkDir()
@@ -398,7 +398,7 @@ slots:
 `, s.projectId, "ws", "producer", "mount")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
 
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -58,7 +58,7 @@ slots:
   ssh-agent:
 `, s.projectId, "ws", "producer", "ssh-agent")
 	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
-	deviceSpec, err := lxd_device.NewSpecification(testuser.Name, "consumer")
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -86,7 +86,6 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 	var err error
 	f.pid = "42424242"
 	f.usr = &user.User{
-		Name:     "testuser",
 		Username: "testuser",
 		Uid:      "1000",
 		Gid:      "1000",

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	LxdSock               = "/var/snap/lxd/common/lxd/unix.socket"
 	storagePool           = "workshop"
 	storagePoolDriver     = "zfs"
 	storagePoolMinimalGiB = 5
@@ -111,7 +110,7 @@ func New() (*Backend, error) {
 	}
 
 	// Create LXD storage pool if it doesn't exist
-	conn, err := lxd.ConnectLXDUnixWithContext(context.Background(), LxdSock, nil)
+	conn, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {
 		return nil, ErrorWithInstallLXDPrompt(err)
 	}
@@ -290,7 +289,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			Source: api.InstanceSource{
 				Type:        "image",
 				Fingerprint: image.Fingerprint,
-				Project:     LxdProjectName(userName),
+				Project:     LxdProjectName(usr.Name),
 			},
 		}
 		op, err := conn.CreateInstance(req)
@@ -939,7 +938,7 @@ func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {
 		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
 	}
 
-	if srv, err := lxd.ConnectLXDUnixWithContext(ctx, LxdSock, nil); err != nil {
+	if srv, err := lxd.ConnectLXDUnixWithContext(ctx, "", nil); err != nil {
 		return nil, ErrorWithInstallLXDPrompt(err)
 	} else {
 		if err = InitLxdProject(srv, user); err != nil {
@@ -984,7 +983,7 @@ func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
 }
 
 func checkNvidia() (bool, error) {
-	conn, err := lxd.ConnectLXDUnixWithContext(context.Background(), LxdSock, nil)
+	conn, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {
 		return false, ErrorWithInstallLXDPrompt(err)
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -289,7 +289,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			Source: api.InstanceSource{
 				Type:        "image",
 				Fingerprint: image.Fingerprint,
-				Project:     LxdProjectName(usr.Name),
+				Project:     LxdProjectName(usr.Username),
 			},
 		}
 		op, err := conn.CreateInstance(req)

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -16,21 +16,17 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-var lxdProjectConfig = map[string]string{
-	"features.images":          "false",
-	"features.profiles":        "true",
-	"features.storage.volumes": "false",
+func lxdProjectConfig(username string) map[string]string {
+	return map[string]string{
+		"features.images":          "false",
+		"features.profiles":        "true",
+		"features.storage.volumes": "false",
+		"user.workshop.username":   username,
+	}
 }
 
 func LxdProjectName(user string) string {
 	return "workshop." + user
-}
-
-func lxdProjectUser(project string) string {
-	if strings.HasPrefix(project, "workshop.") {
-		return strings.TrimPrefix(project, "workshop.")
-	}
-	return ""
 }
 
 func LxdStashProjectName(user string) string {
@@ -42,30 +38,28 @@ func InitLxdProject(conn lxd.InstanceServer, username string) error {
 	if username == "" {
 		return fmt.Errorf("cannot init LXD project: username is empty")
 	}
-	if err := createOrLoadLxdProject(conn, LxdProjectName(username)); err != nil {
+	if err := createOrLoadLxdProject(conn, username, LxdProjectName(username)); err != nil {
 		return err
 	}
 
-	if err := createOrLoadLxdProject(conn, LxdStashProjectName(username)); err != nil {
+	if err := createOrLoadLxdProject(conn, username, LxdStashProjectName(username)); err != nil {
 		return err
 	}
 	return nil
 }
 
-func createOrLoadLxdProject(conn lxd.InstanceServer, projectName string) error {
-	if _, _, err := conn.GetProject(projectName); err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return conn.CreateProject(api.ProjectsPost{
-				ProjectPut: api.ProjectPut{
-					Config: lxdProjectConfig,
-				},
-				Name: projectName,
-			})
-		} else {
-			return err
-		}
+func createOrLoadLxdProject(conn lxd.InstanceServer, username, project string) error {
+	_, _, err := conn.GetProject(project)
+	if api.StatusErrorCheck(err, http.StatusNotFound) {
+		return conn.CreateProject(api.ProjectsPost{
+			ProjectPut: api.ProjectPut{
+				Config:      lxdProjectConfig(username),
+				Description: fmt.Sprintf(`Workshop project for "%s" user`, username),
+			},
+			Name: project,
+		})
 	}
-	return nil
+	return err
 }
 
 func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*workshop.Project, bool, error) {
@@ -125,11 +119,10 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, 
 		return map[string][]workshop.Project{user: projects}, nil
 	}
 
-	// get a default connection without preseting the LXD project as we are
-	// going over all the LXD projects to filter the ones managed by
-	// workshop and reload every interface connection for every SDK of
-	// every workshop
-	client, err := lxd.ConnectLXDUnixWithContext(ctx, LxdSock, nil)
+	// Get a default connection without preseting the LXD project as we are
+	// going over all the LXD projects to filter the ones managed by workshop
+	// and reload every interface connection for every SDK of every workshop.
+	client, err := lxd.ConnectLXDUnixWithContext(ctx, "", nil)
 	if err != nil {
 		return nil, ErrorWithInstallLXDPrompt(err)
 	}
@@ -140,14 +133,12 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, 
 	}
 	allProjects := make(map[string][]workshop.Project)
 	for _, lxdProject := range lxdProjects {
-		// if the project is created by workshop, the key must be present
-		if _, ok := lxdProject.Config["user.workshop.projects"]; !ok {
+		// If the project is created by workshop, the key must be present.
+		username, ok := lxdProject.Config["user.workshop.username"]
+		if !ok {
 			continue
 		}
-		username := lxdProjectUser(lxdProject.Name)
-		if username == "" {
-			continue
-		}
+
 		if _, err = osutil.UserLookup(username); err != nil {
 			logger.Noticef("cannot find user %q: %v", username, err)
 			continue

--- a/internal/workshop/lxd/tests/integration/project_test.go
+++ b/internal/workshop/lxd/tests/integration/project_test.go
@@ -291,7 +291,7 @@ func (f *wsProject) TestLxdBackendLoadProjectsAllUsers(c *check.C) {
 
 	restoreLookup := osutil.FakeUserLookup(func(username string) (*user.User, error) {
 		if username == f.username {
-			return &user.User{Name: username}, nil
+			return &user.User{Username: username}, nil
 		}
 		return nil, user.UnknownUserError("not found")
 	})

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -83,7 +83,6 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 	}
 
 	f.usr = &user.User{
-		Name:     "testuser",
 		Username: "testuser",
 		Uid:      "1000",
 		Gid:      "1000",

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -45,7 +45,7 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 	f.bd, err = lxdbackend.New()
 	c.Assert(err, check.IsNil)
 
-	f.usr = &user.User{Name: "testuser", Username: "testuser", Uid: "1000", Gid: "1000"}
+	f.usr = &user.User{Username: "testuser", Uid: "1000", Gid: "1000"}
 	f.project = workshop.Project{
 		ProjectId: "42424242",
 		Path:      c.MkDir(),


### PR DESCRIPTION
# Description

This is one of a series of patches we plan to get rid of passing project-id (and, possibly, username) as part of the request's context.

This is a **breaking change** as Workshop will now have to look into the project's properties for the associated username. It will not parse the project's name anymore.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
