### PR TITLE
Add setup-project hooks

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -30,6 +31,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/ptyutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -447,13 +449,14 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 	// user. This is created due to enabling lingering for this user during the
 	// workshop start script and will not exist for other users. See:
 	// https://github.com/systemd/systemd/blob/7419291670dd4066594350cce585031f60bc4f0a/src/login/pam_systemd.c#L1288
-	env["XDG_RUNTIME_DIR"] = "/run/user/" + strconv.Itoa(flags.UserId)
+	xdgRuntimeDir := filepath.Join(dirs.XdgRuntimeDirBase, strconv.Itoa(flags.UserId))
+	env["XDG_RUNTIME_DIR"] = xdgRuntimeDir
 
 	// The session bus address is often determined programatically, however some
 	// programs rely on an explicit environment variable. We set that here. Like
 	// the runtime dir above, we only guarantee that the bus exists for the
 	// workshop user.
-	env["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/run/user/" + strconv.Itoa(flags.UserId) + "/bus"
+	env["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=" + filepath.Join(xdgRuntimeDir, "bus")
 
 	for _, kv := range flags.Env {
 		parts := strings.SplitN(kv, "=", 2)

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -92,6 +92,10 @@ hooks:
     # apt-get update
     # apt-get install PACKAGE...
     # snap install SNAP...
+  # EXAMPLE: setup-project runs after connecting plugs and slots, use it to install the project environment.
+  # setup-project: |
+    # go mod download
+    # uv sync
   # EXAMPLE: check-health runs after all SDK setup completes, call 'workshopctl set-health okay' for OK.
   # check-health: |
     # if CHECK_HEALTH_COMMAND ; then
@@ -560,7 +564,7 @@ func writeHooks(sdkdir string, rec workshop.SdkRecord) error {
 		}
 	}
 
-	for _, hook := range []string{"setup-base", "save-state", "restore-state", "check-health"} {
+	for _, hook := range []string{"setup-base", "setup-project", "save-state", "restore-state", "check-health"} {
 		hookpath := filepath.Join(hooksdir, hook)
 		if script := rec.Hooks[hook]; len(script) > 0 {
 			if !strings.HasSuffix(script, "\n") {

--- a/docs/.coverage.yaml
+++ b/docs/.coverage.yaml
@@ -234,6 +234,11 @@
   specs:
     - SK005
 
+"setup-project":
+  category: SDK
+  type: action
+  specs: []
+
 "sketch SDK":
   category: SDK
   type: concept

--- a/docs/explanation/sdks/concepts.rst
+++ b/docs/explanation/sdks/concepts.rst
@@ -67,7 +67,7 @@ Each hook is a shell script with domain-aware actions
 that |ws_markup| runs in the workshop
 at a particular life cycle stage
 to ensure that the SDK stays functional.
-Specific examples include :samp:`setup-base`,
+Specific examples include :samp:`setup-base`, :samp:`setup-project`,
 :samp:`save-state` and :samp:`restore-state`.
 
 You may see individual hooks mentioned in the output of

--- a/docs/explanation/sdks/hooks.rst
+++ b/docs/explanation/sdks/hooks.rst
@@ -11,6 +11,7 @@ SDK hooks
 .. @artefact restore-state
 .. @artefact save-state
 .. @artefact setup-base
+.. @artefact setup-project
 
 |ws_markup| and |sdk_markup| enable optional life cycle *hooks*
 that control and extend the behaviour of an SDK.
@@ -19,7 +20,7 @@ Each hook is a shell script
 that performs SDK-specific, domain-oriented actions in the workshop
 at a particular life cycle stage
 to ensure that the SDK stays functional.
-Specific examples include :samp:`setup-base`,
+Specific examples include :samp:`setup-base`, :samp:`setup-project`,
 :samp:`save-state` and :samp:`restore-state`.
 
 When you define an SDK,

--- a/docs/how-to/craft-sdks.rst
+++ b/docs/how-to/craft-sdks.rst
@@ -278,8 +278,11 @@ named :file:`hooks/`:
 This directory stores all the hooks for an SDK.
 
 
-Build: setup base
-~~~~~~~~~~~~~~~~~
+Build: setup base and project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. @artefact setup-base
+.. @artefact setup-project
 
 Under :file:`go/hooks/`,
 create a file
@@ -289,7 +292,6 @@ named :file:`setup-base`:
    :caption: setup-base
 
    snap install --classic go
-   echo "PATH=/home/workshop/go/bin:$PATH" | tee -a /home/workshop/.profile
    
    # Create a mod cache directory to be mounted using the mount interface
    cache=$(sudo -u workshop -- go env GOMODCACHE)
@@ -297,13 +299,31 @@ named :file:`setup-base`:
 
 
 It runs when the workshop is launched or refreshed,
-installing the prerequisites and preparing it for use.
+installing system packages and preparing the workshop for use.
 
 .. note::
 
    For workshops,
    :command:`apt` is configured to exclude recommended or suggested packages
    and answer 'yes' to all confirmation prompts.
+
+
+In the same directory,
+create a file named :file:`setup-project`:
+
+.. code-block:: shell
+   :caption: setup-project
+
+   go mod download
+
+   echo "PATH=/home/workshop/go/bin:$PATH" | tee -a /home/workshop/.profile
+
+
+It runs after :file:`setup-base`,
+once the project directory is mounted
+and interfaces are connected.
+This can be used to install project-specific packages
+or setup the :samp:`workshop` user's environment.
 
 
 Persist: save and restore

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -87,7 +87,7 @@ and includes a number of mandatory and optional keys:
 
        These are copied into the workshop
        before being executed by :command:`bash`.
-       The options :samp:`errexit`, :samp:`pipefail` and :samp:`nounset`
+       The options :samp:`errexit` and :samp:`pipefail`
        are set by default.
 
 

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -326,6 +326,7 @@ which can be defined when the SDK is built using |sdk_markup|:
 .. @artefact SDK base image
 .. @artefact setup-base
 .. @artefact workshop base image
+.. @artefact setup-project
 
 .. list-table::
    :header-rows: 1
@@ -336,26 +337,24 @@ which can be defined when the SDK is built using |sdk_markup|:
      - When |ws_markup| runs it
      - What it does
 
-   * - :samp:`check-health`
-     - At :ref:`ref_workshop_launch`:
-       after running :samp:`setup-base` hooks for *all* SDKs.
+   * - :samp:`setup-base`
 
-       At :ref:`ref_workshop_refresh`:
-       after running :samp:`restore-state` hooks for *all* SDKs.
+     - At :ref:`ref_workshop_launch`, :ref:`ref_workshop_refresh`:
+       after unpacking the base image
+       and starting the workshop,
+       but before mounting the project directory
+       and connecting plugs and slots.
 
-     - Sets the state of the SDK
-       (:samp:`okay`, :samp:`waiting` or :samp:`error`)
-       using :ref:`workshopctl <ref_workshopctl>`,
-       which affects the :ref:`status <ref_workshop_status>` of the workshop.
+     - Configures system packages and services required by the SDK.
 
-   * - :samp:`restore-state`
+   * - :samp:`setup-project`
 
-     - At :ref:`ref_workshop_refresh`:
-       after launching the new workshop
-       and running the :samp:`setup-base` hook for the SDK.
+     - At :ref:`ref_workshop_launch`, :ref:`ref_workshop_refresh`:
+       after mounting the project directory
+       and connecting plugs and slots
+       but before the workshop is set to *Ready*.
 
-     - Restores SDK-specific data from the :ref:`state directory <ref_sdk_state>`.
-       The hook itself comes from the *new* SDK revision.
+     - Configures the user environment for the SDK to become operational.
 
    * - :samp:`save-state`
 
@@ -365,20 +364,37 @@ which can be defined when the SDK is built using |sdk_markup|:
      - Saves SDK-specific data to the :ref:`state directory <ref_sdk_state>`.
        The hook itself comes from the *old* SDK revision.
 
-   * - :samp:`setup-base`
+   * - :samp:`restore-state`
 
-     - At :ref:`ref_workshop_launch`, :ref:`ref_workshop_refresh`:
-       after unpacking the base image
-       and starting the workshop,
-       but before setting its status to *Ready*.
+     - At :ref:`ref_workshop_refresh`:
+       after running :samp:`setup-project` hooks for *all* SDKs.
 
-     - Configures the base image for the SDK to become operational.
+     - Restores SDK-specific data from the :ref:`state directory <ref_sdk_state>`.
+       The hook itself comes from the *new* SDK revision.
+
+   * - :samp:`check-health`
+     - At :ref:`ref_workshop_launch`:
+       after running :samp:`setup-project` hooks for *all* SDKs.
+
+       At :ref:`ref_workshop_refresh`:
+       after running :samp:`restore-state` hooks for *all* SDKs.
+
+     - Sets the state of the SDK
+       (:samp:`okay`, :samp:`waiting` or :samp:`error`)
+       using :ref:`workshopctl <ref_workshopctl>`,
+       which affects the :ref:`status <ref_workshop_status>` of the workshop.
 
 
-Each hook is defined in a text file of the same name
+Each hook is defined as a :program:`bash` script of the same name
 under :samp:`hooks/` in the :ref:`source directory <ref_sdk_directory>`.
-At run-time, they are executed by :command:`bash`
-as :samp:`root` inside the workshop.
+Inside the workshop,
+the SDK is mounted at :file:`/var/lib/workshop/sdk/<SDK>/`
+and hooks are stored in the :file:`sdk/hooks/` subdirectory.
+Most hooks run as :samp:`root`
+and use that subdirectory as the working directory.
+The exception is :samp:`setup-project`,
+which runs as the :samp:`workshop` user
+in the :file:`/project/` directory.
 
 A hook can signal an error by returning a non-zero exit code;
 a zero code indicates success.

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -316,7 +316,7 @@ SDK hooks
 ---------
 
 |ws_markup| supports the following life cycle hooks,
-which can be defined when the SDK's is built using |sdk_markup|:
+which can be defined when the SDK is built using |sdk_markup|:
 
 .. @artefact workshopctl
 .. @artefact check-health
@@ -399,7 +399,7 @@ SDK state
 
 .. @artefact SDK state
 
-An SDK cat store any data specific to it within the workshop.
+An SDK can store any data specific to it within the workshop.
 For this purpose, an environment variable named :envvar:`$SDK_STATE_DIR`
 is exposed by |ws_markup| at run-time;
 it resolves to an internal directory in the workshop,

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
+	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
@@ -919,6 +920,17 @@ func (s *apiSuite) createWFile(c *check.C, name, yaml string) {
 	c.Assert(err, check.IsNil)
 }
 
+func storeDownloadWithSaveRestore(ctx context.Context, setup sdk.Setup, report *progress.Reporter) error {
+	if err := storeDownload(ctx, setup, report); err != nil || sdk.IsSystem(setup.Name) {
+		return err
+	}
+	hooksdir := filepath.Join(setup.Filepath(), "sdk", "hooks")
+	if err := os.WriteFile(filepath.Join(hooksdir, "save-state"), nil, 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(hooksdir, "restore-state"), nil, 0o644)
+}
+
 func storeDownload(ctx context.Context, setup sdk.Setup, report *progress.Reporter) error {
 	// Emulate store action behaviour which would reuse the existing SDK if
 	// present.
@@ -1589,6 +1601,23 @@ func (s *apiSuite) checkRestoreCalls(c *check.C, name string, sdks []string, fil
 	}
 }
 
+func (s *apiSuite) checkHookCalls(c *check.C, name string, sdks []string, hooks []hookstate.WorkshopHookType) {
+	wpCalls := []*fakebackend.ExecCall{}
+	for _, ec := range s.b.ExecCalls {
+		if ec.Name == name {
+			wpCalls = append(wpCalls, ec)
+		}
+	}
+
+	c.Assert(wpCalls, check.HasLen, len(sdks))
+
+	for i, sk := range sdks {
+		c.Check(wpCalls[i].Args.WorkDir, check.Equals, sdk.SdkHooksDir(sk))
+		command := wpCalls[i].Args.Command
+		c.Check(command[len(command)-1], check.Equals, sdk.SdkHookPath(sk, hooks[i].String()))
+	}
+}
+
 func (s *apiSuite) TestRefreshMany(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
@@ -2099,6 +2128,138 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks})
+}
+
+func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	defer s.store.SetDownloadCallback(storeDownloadWithSaveRestore)()
+
+	// Launch
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.checkHookCalls(c, "manysdks", nil, nil)
+
+	// Refresh saves and restores state for intact SDKs
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	s.checkHookCalls(c, "manysdks", []string{
+		"test-sdk",
+		"test-sdk-2",
+		"test-sdk",
+		"test-sdk-2",
+	}, []hookstate.WorkshopHookType{
+		hookstate.SaveState,
+		hookstate.SaveState,
+		hookstate.RestoreState,
+		hookstate.RestoreState,
+	})
+	s.b.ExecCalls = nil
+
+	// Refresh saves and restores state for updated SDKs
+	defer updateSdkStoreRev("test-sdk", 2, testsdk_r2)()
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	s.checkHookCalls(c, "manysdks", []string{
+		"test-sdk",
+		"test-sdk-2",
+		"test-sdk",
+		"test-sdk-2",
+	}, []hookstate.WorkshopHookType{
+		hookstate.SaveState,
+		hookstate.SaveState,
+		hookstate.RestoreState,
+		hookstate.RestoreState,
+	})
+	s.b.ExecCalls = nil
+
+	// Refresh doesn't save or restore state for removed SDKs
+	s.createWFile(c, "manysdks", manysdks_minusone)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.checkHookCalls(c, "manysdks", []string{
+		"test-sdk",
+		"test-sdk",
+	}, []hookstate.WorkshopHookType{
+		hookstate.SaveState,
+		hookstate.RestoreState,
+	})
+	s.b.ExecCalls = nil
+
+	// Refresh doesn't save or restore state for installed SDKs
+	s.createWFile(c, "manysdks", manysdks)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.checkHookCalls(c, "manysdks", []string{
+		"test-sdk",
+		"test-sdk",
+	}, []hookstate.WorkshopHookType{
+		hookstate.SaveState,
+		hookstate.RestoreState,
+	})
 }
 
 func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -97,7 +97,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 				Protocol: "unix",
 			},
 			Listen: workshop.ProxyTarget{
-				Address:  filepath.Join("/run/user", workshop.User.Uid, wayland),
+				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, wayland),
 				Protocol: "unix",
 			},
 			Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
 	"github.com/canonical/workshop/internal/logger"
@@ -374,7 +375,7 @@ func expandPath(target *workshop.ProxyTarget, user *user.User) error {
 		return nil
 	}
 	if strings.HasPrefix(target.Address, "$XDG_RUNTIME_DIR/") {
-		runtimeDir := filepath.Join("/run/user", user.Uid)
+		runtimeDir := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
 		target.Address = strings.Replace(target.Address, "$XDG_RUNTIME_DIR", runtimeDir, 1)
 		return nil
 	}
@@ -397,7 +398,7 @@ func authorizePath(listen workshop.ProxyTarget, user *user.User) error {
 		return fmt.Errorf("cannot create socket %q: %w", listen.Address, err)
 	}
 
-	runtimeDir := filepath.Join("/run/user", user.Uid)
+	runtimeDir := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
 	if strings.HasPrefix(realDir, user.HomeDir) || strings.HasPrefix(realDir, runtimeDir) {
 		return nil
 	}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/spf13/afero"
 
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
@@ -263,7 +264,7 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	}
 
 	if dev.Wayland != nil {
-		prefix := filepath.Join("/run/user", workshop.User.Uid) + "/"
+		prefix := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid) + "/"
 		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen.Address, prefix)
 	}
 

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -144,8 +144,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, proj
 			GroupId: 0,
 			Command: []string{
 				"bash",
-				"-ue",
-				"-o",
+				"-eo",
 				"pipefail",
 				hookPath,
 			},

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
@@ -35,7 +37,26 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	hookPath := sdk.SdkHookPath(hook.Sdk, hook.Type())
+	stateDir := filepath.Join(dirs.WorkshopStateDir, "sdk", hook.Sdk)
+
+	execArgs := &workshop.ExecArgs{
+		UserId:  0,
+		GroupId: 0,
+		Command: []string{
+			"bash",
+			"-eo",
+			"pipefail",
+			hookPath,
+		},
+		Environment: map[string]string{},
+		WorkDir:     sdk.SdkHooksDir(hook.Sdk),
+		Timeout:     hook.Timeout,
+	}
+
 	if hook.HookType == SaveState || hook.HookType == RestoreState {
+		execArgs.Environment["SDK_STATE_DIR"] = stateDir
+
 		volume := workshop.WorkshopStateVolumeName(w, prj.ProjectId)
 		if err := h.backend.AttachVolume(ctx, w, volume, dirs.WorkshopStateDir, false); err != nil {
 			return fmt.Errorf("cannot run hook %q for SDK %q: %w", hook.Type(), hook.Sdk, err)
@@ -54,20 +75,19 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		if err != nil {
 			return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
 		}
-		err = fs.MkdirAll(hook.Environment["SDK_STATE_DIR"], 0755)
+		err = fs.MkdirAll(stateDir, 0755)
 		fs.Close()
 		if err != nil {
 			return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
 		}
 
-		return h.executeHook(ctx, task, w, prj.ProjectId, &hook)
+		return h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs)
 	case RestoreState:
-
 		fs, err := h.backend.WorkshopFs(ctx, w)
 		if err != nil {
 			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
 		}
-		info, err := fs.Stat(hook.Environment["SDK_STATE_DIR"])
+		info, err := fs.Stat(stateDir)
 		fs.Close()
 		if err != nil {
 			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
@@ -77,18 +97,47 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: state storage path is not a directory", hook.Sdk)
 		}
 
-		return h.executeHook(ctx, task, w, prj.ProjectId, &hook)
+		return h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs)
 	case SetupBase:
-		if err = h.executeHook(ctx, task, w, prj.ProjectId, &hook); err != nil {
+		if err = h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs); err != nil {
 			return err
 		}
 		return h.backend.Snapshot(ctx, w, workshop.SnapshotId(w, hook.Sdk))
+	case SetupProject:
+		execArgs.Command = []string{
+			"sudo",
+			"-u",
+			"#" + workshop.User.Uid,
+			"-g",
+			"#" + workshop.User.Gid,
+			"--preserve-env",
+			"--",
+			"bash",
+			"-elo",
+			"pipefail",
+			hookPath,
+		}
+
+		uid, gid, err := osutil.UidGid(&workshop.User)
+		if err != nil {
+			return err
+		}
+		execArgs.UserId = int(uid)
+		execArgs.GroupId = int(gid)
+
+		execArgs.WorkDir = workshop.WorkshopProjectPath
+
+		execArgs.Environment["HOME"] = workshop.User.HomeDir
+		xdgRuntimeDir := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid)
+		execArgs.Environment["XDG_RUNTIME_DIR"] = xdgRuntimeDir
+		execArgs.Environment["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=" + filepath.Join(xdgRuntimeDir, "bus")
+		return h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs)
 	default:
-		return h.executeHook(ctx, task, w, prj.ProjectId, &hook)
+		return h.executeHook(ctx, task, w, prj.ProjectId, &hook, execArgs)
 	}
 }
 
-func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, projectId string, hook *HookSetup) error {
+func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, projectId string, hook *HookSetup, execArgs *workshop.ExecArgs) error {
 	hookPath := sdk.SdkHookPath(hook.Sdk, hook.Type())
 
 	wsFs, err := h.backend.WorkshopFs(ctx, w)
@@ -137,21 +186,9 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w, proj
 	}
 	defer stderr.Close()
 
-	hook.Environment["WORKSHOP_COOKIE"] = hookCtx.ID()
+	execArgs.Environment["WORKSHOP_COOKIE"] = hookCtx.ID()
 	args := workshop.Execution{
-		ExecArgs: workshop.ExecArgs{
-			UserId:  0,
-			GroupId: 0,
-			Command: []string{
-				"bash",
-				"-eo",
-				"pipefail",
-				hookPath,
-			},
-			Environment: hook.Environment,
-			WorkDir:     sdk.SdkHooksDir(hook.Sdk),
-			Timeout:     hook.Timeout,
-		},
+		ExecArgs: *execArgs,
 		ExecControls: workshop.ExecControls{
 			Stdin:  nil,
 			Stdout: stdout,

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -49,9 +49,11 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 			"pipefail",
 			hookPath,
 		},
-		Environment: map[string]string{},
-		WorkDir:     sdk.SdkHooksDir(hook.Sdk),
-		Timeout:     hook.Timeout,
+		Environment: map[string]string{
+			"SDK": sdk.SdkDir(hook.Sdk),
+		},
+		WorkDir: sdk.SdkHooksDir(hook.Sdk),
+		Timeout: hook.Timeout,
 	}
 
 	if hook.HookType == SaveState || hook.HookType == RestoreState {

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -108,6 +108,29 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 	c.Check(t1.Status(), check.Equals, state.DoneStatus)
 }
 
+func (s *hookSuite) TestExecSetupProject(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, s.project.ProjectId, "ws", "one", 0, hookstate.SetupProject)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.launchWorkshop(c, "one")
+
+	s.state.Unlock()
+	c.Assert(s.se.Ensure(), check.IsNil)
+	s.se.Wait()
+	s.state.Lock()
+	c.Assert(chg.Err(), check.IsNil)
+	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
+	c.Check(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
+		[]string{"sudo", "-u", "#1000", "-g", "#1000", "--preserve-env", "--", "bash", "-elo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/setup-project"})
+	c.Check(s.backend.ExecCalls[0].Args.WorkDir, check.Equals, "/project")
+}
+
 func (s *hookSuite) TestExecSaveState(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -513,6 +536,8 @@ func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
 	_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.RestoreState.String()))
 	c.Check(err, check.IsNil)
 	_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.SetupBase.String()))
+	c.Check(err, check.IsNil)
+	_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.SetupProject.String()))
 	c.Check(err, check.IsNil)
 	_, err = ws.Create(sdk.SdkHookPath(newsdk, hookstate.FakeHook.String()))
 	c.Check(err, check.IsNil)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/canonical/workshop/internal/overlord/hookstate/hooktest"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	"github.com/canonical/workshop/internal/workshop/fakebackend"
 )
@@ -134,8 +133,8 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	s.state.Lock()
 	c.Assert(chg.Err(), check.IsNil)
 	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
-	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
+		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 
 	// Ensure that the save-state handler has created the required state
 	// directory (reattach the volume to the workshop to check).
@@ -151,8 +150,8 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	c.Check(t1.Status(), check.Equals, state.DoneStatus)
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
-	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
+		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 2)
@@ -191,8 +190,8 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	c.Check(t1.Status(), check.Equals, state.DoneStatus)
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
-	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
+	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
+		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 2)
@@ -234,8 +233,8 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 	s.state.Lock()
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
-	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
+		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
@@ -274,8 +273,8 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 	s.state.Lock()
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
-	c.Assert(s.backend.ExecCalls[0].Args.Command, testutil.DeepUnsortedMatches,
-		[]string{"bash", "-ue", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
+	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
+		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -177,7 +177,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
-	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 2)
+	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
 }
 
 func (s *hookSuite) TestExecRestoreState(c *check.C) {
@@ -217,7 +217,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
-	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 2)
+	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
 }
 
 func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -29,19 +29,19 @@ type Handler interface {
 type HandlerGenerator func(*Context) Handler
 
 type HookSetup struct {
-	ProjectId   string            `json:"project-id"`
-	Workshop    string            `json:"workshop"`
-	Sdk         string            `json:"sdk"`
-	HookType    WorkshopHookType  `json:"type"`
-	Environment map[string]string `json:"environment"`
-	Timeout     time.Duration     `json:"timeout"`
-	IgnoreError bool              `json:"bool"`
+	ProjectId   string           `json:"project-id"`
+	Workshop    string           `json:"workshop"`
+	Sdk         string           `json:"sdk"`
+	HookType    WorkshopHookType `json:"type"`
+	Timeout     time.Duration    `json:"timeout"`
+	IgnoreError bool             `json:"bool"`
 }
 
 type WorkshopHookType int
 
 const (
 	SetupBase WorkshopHookType = iota
+	SetupProject
 	SaveState
 	RestoreState
 	CheckHealth
@@ -50,7 +50,7 @@ const (
 )
 
 func (s WorkshopHookType) String() string {
-	return [...]string{"setup-base", "save-state", "restore-state", "check-health", "fake-hook"}[s]
+	return [...]string{"setup-base", "setup-project", "save-state", "restore-state", "check-health", "fake-hook"}[s]
 }
 
 func (h *HookSetup) Type() string {
@@ -148,6 +148,7 @@ func setupHooks(hookMgr *HookManager) {
 	}
 
 	hookMgr.Register(regexp.MustCompile("^setup-base$"), handlerGenerator)
+	hookMgr.Register(regexp.MustCompile("^setup-project$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^save-state$"), handlerGenerator)
 	hookMgr.Register(regexp.MustCompile("^restore-state$"), handlerGenerator)
 }

--- a/internal/overlord/hookstate/request.go
+++ b/internal/overlord/hookstate/request.go
@@ -2,20 +2,14 @@ package hookstate
 
 import (
 	"fmt"
-	"path/filepath"
 	"time"
 
-	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/overlord/state"
 )
 
 func Hook(st *state.State, pid, workshop, sdk string, timeout time.Duration, hook WorkshopHookType) *state.Task {
 	setup_hook := st.NewTask("run-hook", fmt.Sprintf("Run hook %q for %q SDK", hook.String(), sdk))
-	setup := HookSetup{HookType: hook, ProjectId: pid, Workshop: workshop, Sdk: sdk, Environment: map[string]string{}}
-	if hook == SaveState || hook == RestoreState {
-		setup.Environment["SDK_STATE_DIR"] = filepath.Join(dirs.WorkshopStateDir, "sdk", sdk)
-	}
-	setup.Timeout = timeout
+	setup := HookSetup{HookType: hook, ProjectId: pid, Workshop: workshop, Sdk: sdk, Timeout: timeout}
 	setup_hook.Set("hook-setup", &setup)
 	return setup_hook
 }

--- a/internal/overlord/hookstate/request_test.go
+++ b/internal/overlord/hookstate/request_test.go
@@ -27,26 +27,20 @@ func (s *hooksRequestSuite) TestCreateHook(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	envs := []map[string]string{
-		{},
-		{"SDK_STATE_DIR": "/var/lib/workshop/state/sdk/go"},
-		{"SDK_STATE_DIR": "/var/lib/workshop/state/sdk/go"},
-	}
-
-	for num, i := range []hookstate.WorkshopHookType{
+	for _, hook := range []hookstate.WorkshopHookType{
 		hookstate.SetupBase,
+		hookstate.SetupProject,
 		hookstate.SaveState,
 		hookstate.RestoreState,
 	} {
-		task := hookstate.Hook(s.state, s.project.ProjectId, "test", "go", 0, i)
+		task := hookstate.Hook(s.state, s.project.ProjectId, "test", "go", 0, hook)
 
 		var hookSetup hookstate.HookSetup
 		err := task.Get("hook-setup", &hookSetup)
 		c.Assert(err, check.IsNil)
-		c.Assert(hookSetup.Type(), check.Equals, i.String())
+		c.Assert(hookSetup.Type(), check.Equals, hook.String())
 		c.Assert(hookSetup.Workshop, check.DeepEquals, "test")
 		c.Assert(hookSetup.Sdk, check.DeepEquals, "go")
-		c.Assert(hookSetup.Environment, check.DeepEquals, envs[num])
 		c.Check(task.Summary(), check.Equals, fmt.Sprintf("Run hook %q for \"go\" SDK", hookSetup.Type()))
 	}
 }
@@ -61,7 +55,6 @@ func (s *hooksRequestSuite) TestCreateHookWithTimeout(c *check.C) {
 	c.Assert(hookSetup.Type(), check.Equals, "check-health")
 	c.Assert(hookSetup.Workshop, check.DeepEquals, "test")
 	c.Assert(hookSetup.Sdk, check.DeepEquals, "go")
-	c.Assert(hookSetup.Environment, check.HasLen, 0)
 	c.Assert(hookSetup.Timeout, check.Equals, 5*time.Second)
 	c.Check(task.Summary(), check.Equals, fmt.Sprintf("Run hook %q for \"go\" SDK", hookSetup.Type()))
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -333,10 +333,6 @@ func launchWorkshop(st *state.State, file *workshop.File, project workshop.Proje
 	addTask(create)
 	create.Set("workshop-file", file)
 
-	// TODO: move this after snapshots are taken; also for refresh.
-	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
-	addTask(mountProject)
-
 	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", file.Name))
 	addTask(start)
 
@@ -406,6 +402,9 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 
 	install := installSdks(st, project.ProjectId, file.Name, sdks, rmap)
 	addTaskSet(install)
+
+	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
+	addTaskSet(state.NewTaskSet(mountProject))
 
 	connect := autoconnectSdks(st, sdks)
 	addTaskSet(connect)
@@ -691,6 +690,9 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	// Install updated SDKs to the rebuilt workshop.
 	install := installSdks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), rmap)
 	addTaskSet(install)
+
+	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", w.Project.Path))
+	addTaskSet(state.NewTaskSet(mountProject))
 
 	connect := autoconnectSdks(st, plan.InstallIntactOrRefresh())
 	addTaskSet(connect)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -410,6 +410,9 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	connect := autoconnectSdks(st, sdks)
 	addTaskSet(connect)
 
+	setupProject := runHooks(st, project.ProjectId, file.Name, sdks, 0, hookstate.SetupProject)
+	addTaskSet(setupProject)
+
 	checkHealth := runHooks(st, project.ProjectId, file.Name, sdks, checkHealthTimeout, hookstate.CheckHealth)
 	addTaskSet(checkHealth)
 
@@ -691,6 +694,9 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 
 	connect := autoconnectSdks(st, plan.InstallIntactOrRefresh())
 	addTaskSet(connect)
+
+	setupProject := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallIntactOrRefresh(), 0, hookstate.SetupProject)
+	addTaskSet(setupProject)
 
 	restoreState := runHooks(st, w.Project.ProjectId, file.Name, plan.IntactOrRefresh(), 0, hookstate.RestoreState)
 	addTaskSet(restoreState)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -543,6 +543,10 @@ func (p refreshPlan) InstallOrRefresh() []sdk.Setup {
 	return ordered(p.installOrder, p.install, p.refresh)
 }
 
+func (p refreshPlan) IntactOrRefresh() []sdk.Setup {
+	return ordered(p.installOrder, p.intact, p.refresh)
+}
+
 func (p refreshPlan) IntactOrRemove() []sdk.Setup {
 	revOrder := slices.Clone(p.installedOrder)
 	slices.Reverse(revOrder)
@@ -552,10 +556,6 @@ func (p refreshPlan) IntactOrRemove() []sdk.Setup {
 
 func (p refreshPlan) InstallIntactOrRefresh() []sdk.Setup {
 	return ordered(p.installOrder, p.install, p.refresh, p.intact)
-}
-
-func (p refreshPlan) Refresh() []sdk.Setup {
-	return ordered(p.installOrder, p.refresh)
 }
 
 func (p refreshPlan) Remove() []sdk.Setup {
@@ -661,14 +661,14 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	}
 	addTaskSet(retrieve)
 
-	if len(plan.Refresh()) > 0 {
+	if len(plan.IntactOrRefresh()) > 0 {
 		stateStorage := st.NewTask("create-state-storage", "Create SDK state storage")
 		addTaskSet(state.NewTaskSet(stateStorage))
 	}
 
 	// Call save-state hooks for the SDKs that are installed and will not be
 	// removed after this refresh.
-	saveState := runHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), 0, hookstate.SaveState)
+	saveState := runHooks(st, w.Project.ProjectId, file.Name, plan.IntactOrRefresh(), 0, hookstate.SaveState)
 	addTaskSet(saveState)
 
 	disconnect := disconnectSdks(st, plan.IntactOrRemove())
@@ -692,7 +692,7 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	connect := autoconnectSdks(st, plan.InstallIntactOrRefresh())
 	addTaskSet(connect)
 
-	restoreState := runHooks(st, w.Project.ProjectId, file.Name, plan.Refresh(), 0, hookstate.RestoreState)
+	restoreState := runHooks(st, w.Project.ProjectId, file.Name, plan.IntactOrRefresh(), 0, hookstate.RestoreState)
 	addTaskSet(restoreState)
 
 	checkHealth := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallIntactOrRefresh(), 0, hookstate.CheckHealth)
@@ -704,7 +704,7 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 
 	cleanupLane := st.NewLane()
 
-	if len(plan.Refresh()) > 0 {
+	if len(plan.IntactOrRefresh()) > 0 {
 		removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
 		removeStateStorage.WaitFor(last)
 		removeStateStorage.JoinLane(cleanupLane)

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -669,11 +669,18 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, 
 	}
 	unwantedSdks := sdks[lastIntact+1:]
 
-	// Remove SDKs from after the snapshot.
 	fs, err := s.WorkshopFs(ctx, name)
 	if err != nil {
 		return err
 	}
+	defer fs.Close()
+
+	// Remove project mount
+	if err := fs.Remove(workshop.WorkshopProjectPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	// Remove SDKs from after the snapshot.
 	for _, sk := range unwantedSdks {
 		if err = fs.RemoveAll(sdk.SdkDir(sk.Name)); err != nil {
 			return err

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -324,12 +324,6 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			return err
 		}
 
-		// TODO: Run mount-project after snapshots, and delete this workaround.
-		projectPathDevice, ok := rebuilt.Devices[workshop.ConfigProjectPathDevice]
-		if ok {
-			devices[workshop.ConfigProjectPathDevice] = projectPathDevice
-		}
-
 		maps.Copy(rebuilt.Config, config)
 		clear(rebuilt.Devices)
 		maps.Copy(rebuilt.Devices, devices)
@@ -1073,6 +1067,8 @@ write_files:
     Environment=SNAPD_STANDBY_WAIT=1m
   path: /etc/systemd/system/snapd.service.d/override.conf
 runcmd:
+  # Project directory is required for 'workshop exec'.
+  - install --directory --mode=755 /project
   - systemctl daemon-reload
   - systemctl enable xauth-copy.service
   - systemctl enable --now xauth-watch.path

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1030,6 +1030,18 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
     groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video,render
     shell: /bin/bash
+apt:
+  conf: |
+    # Installed by workshop
+    
+    # Don't automatically install recommended packages
+    APT::Install-Recommends "0";
+
+    # Don't automatically install suggested packages
+    APT::Install-Suggests "0";
+
+    # Bypass confirmation prompts
+    APT::Get::Assume-Yes "1";
 write_files:
 - content: |
     # Managed by workshop, do not remove
@@ -1055,18 +1067,6 @@ write_files:
     [Install]
     WantedBy=multi-user.target
   path: /etc/systemd/system/xauth-copy.service
-- content: |
-    # Installed by workshop
-    
-    # Don't automatically install recommended packages
-    APT::Install-Recommends "0";
-
-    # Don't automatically install suggested packages
-    APT::Install-Suggests "0";
-
-    # Bypass confirmation prompts
-    APT::Get::Assume-Yes "1";
-  path: /etc/apt/apt.conf.d/01norecommend
 - content: |
     # Workaround for https://bugs.launchpad.net/snapd/+bug/2104066
     [Service]

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -224,22 +224,7 @@ func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string)
 }
 
 func (s *Backend) AttachVolume(ctx context.Context, wp, name, where string, ro bool) error {
-	mount := workshop.Mount{Name: name, What: name, Where: where, Type: workshop.Volume, ReadOnly: ro}
-	if err := s.AddWorkshopMount(ctx, wp, mount); err != nil {
-		return err
-	}
-
-	// Workaround for https://github.com/canonical/lxd/issues/14507
-	fs, err := s.WorkshopFs(ctx, wp)
-	if err != nil {
-		logger.Noticef("Cannot chmod volume root: %v", err)
-		return nil
-	}
-	defer fs.Close()
-	if err := fs.Chmod(where, 0755); err != nil {
-		logger.Noticef("Cannot chmod volume root: %v", err)
-	}
-	return nil
+	return s.AddWorkshopMount(ctx, wp, workshop.Mount{Name: name, What: name, Where: where, Type: workshop.Volume, ReadOnly: ro})
 }
 
 func (s *Backend) DetachVolume(ctx context.Context, wp, name string) error {

--- a/tests/main/launch/.workshop/ws-20.yaml
+++ b/tests/main/launch/.workshop/ws-20.yaml
@@ -6,6 +6,6 @@ scripts:
       sudo apt-get -o 'Debug::NoLocking=true' -o 'APT::Get::Assume-Yes=0' --assume-no "$@" install gnome
     }
 
-    [ -f /etc/apt/apt.conf.d/01norecommend ]
+    [ -f /etc/apt/apt.conf.d/94cloud-init-config ]
     sudo apt-get update
     diff <(dry_run --no-install-recommends --no-install-suggests) <(dry_run)

--- a/tests/main/launch/.workshop/ws-22.yaml
+++ b/tests/main/launch/.workshop/ws-22.yaml
@@ -6,6 +6,6 @@ scripts:
       sudo apt-get -o 'Debug::NoLocking=true' -o 'APT::Get::Assume-Yes=0' --assume-no "$@" install gnome
     }
 
-    [ -f /etc/apt/apt.conf.d/01norecommend ]
+    [ -f /etc/apt/apt.conf.d/94cloud-init-config ]
     sudo apt-get update
     diff <(dry_run --no-install-recommends --no-install-suggests) <(dry_run)

--- a/tests/main/launch/.workshop/ws-24.yaml
+++ b/tests/main/launch/.workshop/ws-24.yaml
@@ -6,6 +6,6 @@ scripts:
       sudo apt-get -o 'Debug::NoLocking=true' -o 'APT::Get::Assume-Yes=0' --assume-no "$@" install gnome
     }
 
-    [ -f /etc/apt/apt.conf.d/01norecommend ]
+    [ -f /etc/apt/apt.conf.d/94cloud-init-config ]
     sudo apt-get update
     diff <(dry_run --no-install-recommends --no-install-suggests) <(dry_run)

--- a/tests/main/project-sdks/project/.workshop/one/hooks/setup-project
+++ b/tests/main/project-sdks/project/.workshop/one/hooks/setup-project
@@ -6,4 +6,5 @@ set -x
 [ "$HOME" = '/home/workshop' ]
 [ "$USER" = 'workshop' ]
 [ "$LANG" = 'C.UTF-8' ]
+[ "$SDK" = '/var/lib/workshop/sdk/project-one' ]
 sudo touch /setup-project.log

--- a/tests/main/project-sdks/project/.workshop/one/hooks/setup-project
+++ b/tests/main/project-sdks/project/.workshop/one/hooks/setup-project
@@ -1,0 +1,9 @@
+set -x
+[ -d /one/two/three ]
+[ "$(id -un)" = 'workshop' ]
+[ "$(id -gn)" = 'workshop' ]
+[ "$(pwd)" = '/project' ]
+[ "$HOME" = '/home/workshop' ]
+[ "$USER" = 'workshop' ]
+[ "$LANG" = 'C.UTF-8' ]
+sudo touch /setup-project.log

--- a/tests/main/project-sdks/project/.workshop/three/hooks/restore-state
+++ b/tests/main/project-sdks/project/.workshop/three/hooks/restore-state
@@ -1,0 +1,2 @@
+[ "$SDK_STATE_DIR" = '/var/lib/workshop/state/sdk/project-three' ]
+cp "${SDK_STATE_DIR}/saved" /restored-state

--- a/tests/main/project-sdks/project/.workshop/three/hooks/save-state
+++ b/tests/main/project-sdks/project/.workshop/three/hooks/save-state
@@ -1,0 +1,2 @@
+[ "$SDK_STATE_DIR" = '/var/lib/workshop/state/sdk/project-three' ]
+touch "${SDK_STATE_DIR}/saved"

--- a/tests/main/project-sdks/task.yaml
+++ b/tests/main/project-sdks/task.yaml
@@ -43,6 +43,7 @@ execute: |
   echo false >> .workshop/two/sdk/hooks/setup-base
   ! workshop_exec refresh
   workshop_exec exec -- test -d /one/two/three
+  workshop_exec exec -- test ! -f /restored-state
 
   workshop_exec info | grep -v notes | yq '.sdks["project-two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
   workshop_exec info | grep -v notes | yq '.sdks["project-two"].installed' | MATCH '\(x1\)$'
@@ -52,6 +53,7 @@ execute: |
   workshop_exec refresh
   workshop_exec exec -- test -d /one/two/three
   workshop_exec exec -- test -d /two
+  workshop_exec exec -- test -f /restored-state
 
   workshop_exec info | grep -v notes | yq '.sdks["project-one"].installed' | MATCH '\(x1\)$'
   workshop_exec info | grep -v notes | yq '.sdks["project-two"].installed' | MATCH '\(x3\)$'

--- a/tests/main/project-sdks/task.yaml
+++ b/tests/main/project-sdks/task.yaml
@@ -9,6 +9,7 @@ execute: |
   cd project
   workshop_exec launch
   workshop_exec exec -- test -d /one/two/three
+  workshop_exec exec -- test -f /setup-project.log
 
   workshop_exec connections dev | MATCH "^ssh-agent.+dev/project-one:ssh-agent.+\-.+\-$"
   workshop_exec connections dev | MATCH "^tunnel.+\-.+dev/project-two:http.+\-$"

--- a/tests/main/project-sdks/task.yaml
+++ b/tests/main/project-sdks/task.yaml
@@ -35,11 +35,6 @@ execute: |
   workshop_exec info | grep -v notes | yq '.sdks["project-three"].tracking' | MATCH "^$PWD/\\.workshop/three\$"
   workshop_exec info | grep -v notes | yq '.sdks["project-three"].installed' | MATCH '\(x1\)$'
 
-  # TODO: don't move back, to provide coverage for refresh (currently broken due to /project mount)
-  cd ..
-  mv moved project
-  cd project
-
   echo "Break second SDK"
   echo false >> .workshop/two/sdk/hooks/setup-base
   ! workshop_exec refresh


### PR DESCRIPTION
# Description

Adds the `setup-project` hook, which runs after interfaces are connected. This allows it to take advantage of cache mounts (e.g. for `pip`) and access the project directory. The project directory is now mounted after all SDKs are installed, so the post-`setup-base` snapshots can't be influenced by the contents of the project.

Some tangentially related changes:
- Workshop runs save and restore state hooks for all SDKs that remain in the refreshed workshop, not just those which were refreshed.
- Hooks are run without the `nounset` bash option (I noticed in `setup-project` there are scripts in `/etc/profile.d` which don't respect this option).
- Attaching volumes won't modify the permissions of the root directory. This workaround is no longer needed for the apt cache, and SDKs are mounted read-only so there's no point changing it for them.
- Non-test code uses `dirs.XdgRuntimeDirBase` instead of hard coding `"/run/user"`.
- The cloud-init config uses the `apt` module instead of creating a config file manually.

This will break SDKs which currently use `/project` in `setup-base`. Only one I'm aware of is ROS

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
