### PR TITLE
Doc: Add LXD debugging instructions

### DIFF
--- a/docs/how-to/use-workshops/troubleshoot.rst
+++ b/docs/how-to/use-workshops/troubleshoot.rst
@@ -99,7 +99,24 @@ Or, you can shell into the container to recover its data:
 
 .. code-block:: console
 
-   $ sudo lxc exec nimble-ec275767 --project workshop.user -- /bin/bash
+   $ sudo lxc shell nimble-ec275767 --project workshop.user
+
+
+If the container fails to start,
+use :command:`lxc info` to view the latest log entries:
+
+.. code-block:: console
+
+   $ sudo lxc info --show-log nimble-ec275767 --project workshop.user
+
+
+To increase log verbosity,
+you can reconfigure LXD with :program:`snap`:
+
+.. code-block:: console
+
+   $ sudo snap set lxd daemon.debug=true
+   $ sudo snap restart lxd.daemon
 
 
 Use other relevant `LXC`_ commands to continue your investigation.


### PR DESCRIPTION
# Description

For example if the NVIDIA driver is out of sync with the userspace libraries or initramfs, the error messages are pretty obtuse without additional logging.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
