### PR TITLE
Doc: Install caddy to /project in the tutorial

### DIFF
--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -578,7 +578,7 @@ to serve files over HTTP:
 
 .. code-block:: console
 
-   $ workshop exec dev -- go install github.com/caddyserver/caddy/v2/cmd/caddy@latest
+   $ workshop exec --env GOBIN=/project dev -- go install github.com/caddyserver/caddy/v2/cmd/caddy@latest
    $ cat <<EOF > Caddyfile
    :8080 {
            file_server
@@ -587,8 +587,8 @@ to serve files over HTTP:
    $ echo 'Hello, Workshop!' > index.html
 
 
-This installs Caddy inside the workshop under :file:`~/go/bin/`
-in the :samp:`workshop` user's home directory,
+This builds Caddy inside the workshop,
+installs it to the project directory,
 configures it to run as a file server at port 8080
 and creates an index file.
 
@@ -655,7 +655,7 @@ Then start the server at port 8080 (the slot):
 
 .. code-block:: console
 
-   $ workshop exec dev -- caddy start
+   $ workshop exec dev -- ./caddy start
 
 
 By default,


### PR DESCRIPTION
# Description

Without this it will be wiped on refresh. I've tested briefly but haven't gone through the entire tutorial.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
