### PR TITLE
Fix issues related to partial SDK profile updates

### DIFF
--- a/docs/explanation/interfaces/ssh-interface.rst
+++ b/docs/explanation/interfaces/ssh-interface.rst
@@ -92,7 +92,7 @@ are available inside the workshop:
    $ workshop shell ws
    workshop@ws-8584e571$ echo $SSH_AUTH_SOCK
 
-     /var/lib/workshop/ws-ssh-agent.ssh
+     /var/lib/workshop/run/ssh-agent.sock
 
    workshop@ws-8584e571$ ssh-add -l
 

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -56,16 +56,7 @@ func (s *apiSuite) TestWorkshopRemountSuccess(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	repo := s.d.overlord.InterfaceManager().Repository()
-
 	s.launchWorkshop(c, "manysdks", manysdks)
-	ref, err := repo.Connected(s.project.ProjectId, "manysdks", "test-sdk", "data")
-	c.Assert(err, check.IsNil)
-	conn, err := repo.Connection(ref[0])
-	c.Assert(err, check.IsNil)
-	// The mock iface backend does not set this attribute as the actual one
-	// would.
-	c.Assert(conn.Slot.SetAttr("host-source", "/home/user/.local/share"), check.IsNil)
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk","plug":"data"},"host-source":%q}`, c.MkDir())),
@@ -94,11 +85,6 @@ func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
 	s.launchWorkshop(c, "manysdks", manysdks)
 	ref, err := repo.Connected(s.project.ProjectId, "manysdks", "test-sdk", "data")
 	c.Assert(err, check.IsNil)
-	conn, err := repo.Connection(ref[0])
-	c.Assert(err, check.IsNil)
-	// The mock iface backend does not set this attribute as the actual one
-	// would.
-	c.Assert(conn.Slot.SetAttr("host-source", "/home/user/.local/share"), check.IsNil)
 
 	// Setup
 	src := c.MkDir()
@@ -116,7 +102,7 @@ func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
 	}
 
 	s.runMountTest(c, "manysdks", requests, expected)
-	conn, err = repo.Connection(ref[0])
+	conn, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
 	c.Assert(conn.Slot.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"host-source": src})
 }
@@ -238,7 +224,7 @@ func (s *apiSuite) TestWorkshopRemountStaticSlotSourceFails(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "remount",
 			Summary:   `Remount workshopconns/test-sdk:data`,
-			ChangeErr: `(?s).*attribute "host-source" not found for slot "workshopconns/test-sdk-2:training".*`,
+			ChangeErr: `(?s).*source directory of connected slot "workshopconns/test-sdk-2:training" is inside the workshop.*`,
 		},
 	}
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1107,7 +1107,7 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	s.createWFile(c, "manysdks", manysdks)
 	defer s.store.SetDownloadCallback(storeDownload)()
 
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		return fmt.Errorf(`cannot assign profile to "manysdks"`)
 	}
 
@@ -3352,7 +3352,7 @@ func (s *apiSuite) TestLaunchWorkshopRefreshLaunchInProgress(c *check.C) {
 	defer s.store.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		var err error
 		errOnce.Do(func() { err = errors.New("setup failed") })
 		return err
@@ -3397,7 +3397,7 @@ func (s *apiSuite) TestLaunchWorkshopContinueSuccess(c *check.C) {
 	defer s.store.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		var err error
 		errOnce.Do(func() { err = errors.New("setup failed") })
 		return err
@@ -3478,7 +3478,7 @@ func (s *apiSuite) TestLaunchWorkshopChangeAbort(c *check.C) {
 	defer s.store.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		var err error
 		errOnce.Do(func() { err = errors.New("setup failed") })
 		return err

--- a/internal/interfaces/backend.go
+++ b/internal/interfaces/backend.go
@@ -23,7 +23,6 @@ import (
 	"context"
 
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/timings"
 )
 
 // SecurityBackend abstracts interactions between the interface system and the
@@ -40,15 +39,15 @@ type SecurityBackend interface {
 	// Setup creates and loads security artefacts specific to a given sdk.
 	// This method should be called after changing plug, slots, connections
 	// between them.
-	Setup(context context.Context, sdk sdk.Ref, repo *Repository) error
+	Setup(context context.Context, sdkRef sdk.Ref, repo *Repository) error
 
 	// Remove removes and unloads security artefacts of a given sdk.
 	//
 	// This method should be called during the process of removing an sdk.
-	Remove(context context.Context, workshop, sdkName string) error
+	Remove(context context.Context, sdkRef sdk.Ref) error
 
 	// NewSpecification returns a new specification associated with this backend.
-	NewSpecification(user string, pid, sdk string) (Specification, error)
+	NewSpecification(user string, sdk string) (Specification, error)
 }
 
 // SecurityBackendSetupMany interface may be implemented by backends that can optimize their operations
@@ -56,5 +55,5 @@ type SecurityBackend interface {
 type SecurityBackendSetupMany interface {
 	// SetupMany creates and loads apparmor profiles of multiple sdks. It tries to process all sdks and doesn't interrupt processing
 	// on errors of individual sdks.
-	SetupMany(sdks []*sdk.Info, repo *Repository, tm timings.Measurer) []error
+	SetupMany(context context.Context, sdks []*sdk.Info, repo *Repository) []error
 }

--- a/internal/interfaces/backend.go
+++ b/internal/interfaces/backend.go
@@ -49,11 +49,3 @@ type SecurityBackend interface {
 	// NewSpecification returns a new specification associated with this backend.
 	NewSpecification(user string, sdk string) (Specification, error)
 }
-
-// SecurityBackendSetupMany interface may be implemented by backends that can optimize their operations
-// when setting up multiple sdks at once.
-type SecurityBackendSetupMany interface {
-	// SetupMany creates and loads apparmor profiles of multiple sdks. It tries to process all sdks and doesn't interrupt processing
-	// on errors of individual sdks.
-	SetupMany(context context.Context, sdks []*sdk.Info, repo *Repository) []error
-}

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -131,6 +131,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 		m.Type = workshop.HostWorkshop
 		m.What = workshopdXauth
 		m.Where = filepath.Join(dirs.WorkshopRunDir, "Xauthority")
+		m.MakeWhere = true
 		spec.AddMountEntry(m)
 	}
 

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -181,7 +181,7 @@ slots:
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, "Xauthority"), Where: "/var/lib/workshop/run/Xauthority", Type: workshop.HostWorkshop}
+	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, "Xauthority"), Where: "/var/lib/workshop/run/Xauthority", MakeWhere: true, Type: workshop.HostWorkshop}
 	c.Assert(deviceSpec.Profile.Mounts["consumer-xauth"], check.DeepEquals, *expectedMount)
 }
 

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -190,20 +190,16 @@ func (iface *mountInterface) workshopSource(slot *interfaces.ConnectedSlot) (str
 	return source, nil
 }
 
-func (iface *mountInterface) hostSource(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (string, error) {
+func (iface *mountInterface) hostSource(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) (string, bool) {
 	var source string
-	err := slot.Attr("host-source", &source)
-	if err == nil {
-		return source, nil
+	if err := slot.Attr("host-source", &source); err == nil {
+		return source, false
 	}
 
 	// default dir: <sdk>/<plug>
 	userDataDir := workshop.UserDataRootDir(spec.User.HomeDir, spec.Environment)
 	source = workshop.SdkMountHostSource(userDataDir, slot.Sdk().ProjectId, slot.Sdk().Workshop, plug.Sdk().Name, plug.Name())
-	if err = slot.SetAttr("host-source", source); err != nil {
-		return "", err
-	}
-	return source, nil
+	return source, true
 }
 
 func (iface *mountInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
@@ -214,18 +210,29 @@ func (iface *mountInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo)
 // Interactions with the mount backend.
 func (iface *mountInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	if slot.Sdk().Type == sdk.System {
-		source, err := iface.hostSource(spec, plug, slot)
-		if err != nil {
-			return err
-		}
-		return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.HostWorkshop, ReadOnly: iface.readOnly(plug)})
+		source, auto := iface.hostSource(spec, plug, slot)
+		return spec.AddMountEntry(workshop.Mount{
+			Name:      plug.Name(),
+			What:      source,
+			Where:     iface.target(plug),
+			MakeWhat:  auto,
+			MakeWhere: true,
+			Type:      workshop.HostWorkshop,
+			ReadOnly:  iface.readOnly(plug),
+		})
 	}
 
 	source, err := iface.workshopSource(slot)
 	if err != nil {
 		return err
 	}
-	return spec.AddMountEntry(workshop.Mount{Name: plug.Name(), What: source, Where: iface.target(plug), Type: workshop.WorkshopWorkshop, ReadOnly: iface.readOnly(plug)})
+	return spec.AddMountEntry(workshop.Mount{
+		Name:     plug.Name(),
+		What:     source,
+		Where:    iface.target(plug),
+		Type:     workshop.WorkshopWorkshop,
+		ReadOnly: iface.readOnly(plug),
+	})
 }
 
 func init() {

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -344,7 +344,14 @@ slots:
 
 	// Validate the mount specification.
 	sourceDir := filepath.Join(testuser.HomeDir, ".local/share/workshop/id/42424242/ws/mount/consumer/mount")
-	expectedMnt := workshop.Mount{Name: plug.Name, What: sourceDir, Where: "/project/training", Type: workshop.HostWorkshop}
+	expectedMnt := workshop.Mount{
+		Name:      plug.Name,
+		What:      sourceDir,
+		Where:     "/project/training",
+		MakeWhat:  true,
+		MakeWhere: true,
+		Type:      workshop.HostWorkshop,
+	}
 	c.Assert(deviceSpec.Profile.Mounts, check.DeepEquals, map[string]workshop.Mount{plug.Name: expectedMnt})
 }
 
@@ -375,7 +382,14 @@ slots:
 
 	// Validate the mount specification.
 	sourceDir := filepath.Join(s.env["XDG_DATA_HOME"], "/workshop/id/42424242/ws/mount/consumer/mount")
-	expectedMnt := workshop.Mount{Name: plug.Name, What: sourceDir, Where: "/project/training", Type: workshop.HostWorkshop}
+	expectedMnt := workshop.Mount{
+		Name:      plug.Name,
+		What:      sourceDir,
+		Where:     "/project/training",
+		MakeWhat:  true,
+		MakeWhere: true,
+		Type:      workshop.HostWorkshop,
+	}
 	c.Assert(deviceSpec.Profile.Mounts, check.DeepEquals, map[string]workshop.Mount{plug.Name: expectedMnt})
 }
 

--- a/internal/interfaces/builtin/ssh_agent.go
+++ b/internal/interfaces/builtin/ssh_agent.go
@@ -80,7 +80,7 @@ func (iface *sshAgentInterface) MountConnectedPlug(spec *lxd_device.Specificatio
 	}
 
 	fromSocket := sock
-	toSocket := filepath.Join(dirs.WorkshopRunDir, fmt.Sprintf("%s_%s.ssh", plug.Sdk().Name, plug.Name()))
+	toSocket := filepath.Join(dirs.WorkshopRunDir, "ssh-agent.sock")
 
 	return spec.SetSshAgent(workshop.SshAgent{
 		ProxyEntry: workshop.ProxyEntry{

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -69,7 +69,7 @@ slots:
 			Protocol: "unix",
 		},
 		Listen: workshop.ProxyTarget{
-			Address:  "/var/lib/workshop/run/consumer_ssh-agent.ssh",
+			Address:  "/var/lib/workshop/run/ssh-agent.sock",
 			Protocol: "unix",
 		},
 		Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/ifacetest/backend.go
+++ b/internal/interfaces/ifacetest/backend.go
@@ -36,7 +36,7 @@ type TestSecurityBackend struct {
 	// RemoveCalls stores information about all calls to Remove
 	RemoveCalls []string
 	// SetupCallback is an callback that is optionally called in Setup
-	SetupCallback func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error
+	SetupCallback func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error
 	// RemoveCallback is a callback that is optionally called in Remove
 	RemoveCallback func(sdkName string) error
 	lock           sync.Mutex
@@ -46,8 +46,8 @@ type TestSecurityBackend struct {
 
 // TestSetupCall stores details about calls to TestSecurityBackend.Setup
 type TestSetupCall struct {
-	// SdkInfo is a copy of the sdkInfo argument to a particular call to Setup
-	SdkInfo sdk.Ref
+	// SdkInfo is a copy of the sdkRef argument to a particular call to Setup
+	SdkRef sdk.Ref
 }
 
 // Initialize does nothing.
@@ -61,35 +61,35 @@ func (b *TestSecurityBackend) Name() interfaces.SecuritySystem {
 }
 
 // Setup records information about the call and calls the setup callback if one is defined.
-func (b *TestSecurityBackend) Setup(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+func (b *TestSecurityBackend) Setup(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SdkInfo: sdkInfo})
+	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SdkRef: sdkRef})
 	if b.SetupCallback == nil {
 		return nil
 	}
-	return b.SetupCallback(context, sdkInfo, repo)
+	return b.SetupCallback(context, sdkRef, repo)
 }
 
 // Remove records information about the call and calls the remove callback if one is defined
-func (b *TestSecurityBackend) Remove(context context.Context, workshop, sdkName string) error {
+func (b *TestSecurityBackend) Remove(context context.Context, sdkRef sdk.Ref) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.RemoveCalls = append(b.RemoveCalls, sdkName)
+	b.RemoveCalls = append(b.RemoveCalls, sdkRef.Sdk)
 	if b.RemoveCallback == nil {
 		return nil
 	}
-	return b.RemoveCallback(sdkName)
+	return b.RemoveCallback(sdkRef.Sdk)
 }
 
-func (b *TestSecurityBackend) NewSpecification(user string, pid, sdk string) (interfaces.Specification, error) {
+func (b *TestSecurityBackend) NewSpecification(user string, sdk string) (interfaces.Specification, error) {
 	usr, err := osutil.UserLookup(user)
 	if err != nil {
 		return nil, err
 	}
-	return &Specification{user: usr, pid: pid, sdk: sdk}, nil
+	return &Specification{user: usr, sdk: sdk}, nil
 }
 
 func (b *TestSecurityBackend) SandboxFeatures() []string {

--- a/internal/interfaces/ifacetest/backend.go
+++ b/internal/interfaces/ifacetest/backend.go
@@ -98,28 +98,3 @@ func (b *TestSecurityBackend) SandboxFeatures() []string {
 	}
 	return b.SandboxFeaturesCallback()
 }
-
-// TestSecurityBackendSetupMany is a security backend that implements SetupMany on top of TestSecurityBackend.
-type TestSecurityBackendSetupMany struct {
-	TestSecurityBackend
-
-	// SetupManyCalls stores information about all calls to Setup
-	SetupManyCalls []TestSetupManyCall
-
-	// SetupManyCallback is an callback that is optionally called in Setup
-	SetupManyCallback func(context context.Context, sdkInfo []*sdk.Info, repo *interfaces.Repository) []error
-}
-
-// TestSetupManyCall stores details about calls to TestSecurityBackendMany.SetupMany
-type TestSetupManyCall struct {
-	// SdkInfos is a copy of the sdkInfo arguments to a particular call to SetupMany
-	SdkInfos []*sdk.Info
-}
-
-func (b *TestSecurityBackendSetupMany) SetupMany(context context.Context, sdkInfo []*sdk.Info, repo *interfaces.Repository) []error {
-	b.SetupManyCalls = append(b.SetupManyCalls, TestSetupManyCall{SdkInfos: sdkInfo})
-	if b.SetupManyCallback == nil {
-		return nil
-	}
-	return b.SetupManyCallback(context, sdkInfo, repo)
-}

--- a/internal/interfaces/ifacetest/spec.go
+++ b/internal/interfaces/ifacetest/spec.go
@@ -31,7 +31,6 @@ type Specification struct {
 	Snippets []string
 
 	user *user.User
-	pid  string
 	sdk  string
 }
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/x-go/strutil/shlex"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
@@ -196,37 +198,32 @@ func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string,
 	})
 }
 
-func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop, sdkName string) error {
-	script := fmt.Sprintf("%s_%s.sh", sdkName, dev.Name)
-	env, err := fs.Create(filepath.Join("/etc", "profile.d", script))
-	if err != nil {
-		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
+func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) (exists bool, err error) {
+	script := "/etc/profile.d/workshop-ssh-agent.sh"
+	if _, err := fs.Stat(script); err == nil {
+		exists = true
 	}
-	defer env.Close()
-
-	_, err = fmt.Fprintf(env, "export SSH_AUTH_SOCK=%s\n", dev.Listen.Address)
-	if err != nil {
-		return fmt.Errorf("cannot set SSH_AUTH_SOCK for %q: %w", workshop, err)
-	}
-	return nil
+	envVars := map[string]string{"SSH_AUTH_SOCK": dev.Listen.Address}
+	return exists, workshop.AtomicWrite(fs, script, envScript(envVars), 0644)
 }
 
-func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, sdkName string) error {
-	script := fmt.Sprintf("%s_%s.sh", sdkName, dev.Name)
-	return fs.RemoveIfExists(filepath.Join("/etc", "profile.d", script))
+func removeSshAgent(fs workshop.WorkshopFs) error {
+	return fs.RemoveIfExists("/etc/profile.d/workshop-ssh-agent.sh")
 }
 
-func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.User, env map[string]string, ws string) error {
-	backend := env["XDG_BACKEND"]
+func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.User, env map[string]string) (exists bool, err error) {
+	script := "/etc/profile.d/workshop-desktop.sh"
+	if _, err := fs.Stat(script); err == nil {
+		exists = true
+	}
+	envVars := desktopEnvironment(user, env, dev)
+	return exists, workshop.AtomicWrite(fs, script, envScript(envVars), 0644)
+}
 
+func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Desktop) map[string]string {
 	var envVars map[string]string
-	envFile, err := fs.Create("/etc/profile.d/desktop.sh")
-	if err != nil {
-		return fmt.Errorf("cannot configure required environment for %q: %w", ws, err)
-	}
-	defer envFile.Close()
-
 	// Use Wayland as the default backend in the case where it's unset
+	backend := env["XDG_BACKEND"]
 	if (backend == "wayland" || backend == "") && dev.Wayland != nil {
 		envVars = map[string]string{
 			"QT_QPA_PLATFORM":  "wayland-egl",
@@ -268,21 +265,27 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 	}
 
 	envVars["ELECTRON_OZONE_PLATFORM_HINT"] = "auto"
-
-	for key, val := range envVars {
-		_, err = envFile.WriteString("export " + key + "=" + val + "\n")
-		if err != nil {
-			return fmt.Errorf("cannot set %s for %q: %w", key, ws, err)
-		}
-	}
-
-	return nil
+	return envVars
 }
 
 func removeDesktop(fs workshop.WorkshopFs) error {
-	err := fs.RemoveIfExists("/etc/profile.d/desktop.sh")
+	err := fs.RemoveIfExists("/etc/profile.d/workshop-desktop.sh")
 	err2 := fs.RemoveIfExists("/tmp/.Xauthority")
 	return cmp.Or(err, err2)
+}
+
+type envScript map[string]string
+
+func (e envScript) WriteTo(w io.Writer) (int64, error) {
+	var n int64
+	for k, v := range e {
+		m, err := fmt.Fprintf(w, "export %s=%s\n", k, shlex.Quote(v))
+		n += int64(m)
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
 }
 
 func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error) {
@@ -339,15 +342,17 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 		}
 	}
 
+	var sshScriptExists bool
 	if spec.Profile.Agent != nil {
-		err = installSshAgent(fs, *spec.Profile.Agent, sdkRef.Workshop, sdkRef.Sdk)
+		sshScriptExists, err = installSshAgent(fs, *spec.Profile.Agent)
 		if err != nil {
 			return err
 		}
 	}
 
+	var desktopScriptExists bool
 	if spec.Profile.Desktop != nil {
-		err = installDesktop(fs, *spec.Profile.Desktop, spec.User, spec.Environment, sdkRef.Workshop)
+		desktopScriptExists, err = installDesktop(fs, *spec.Profile.Desktop, spec.User, spec.Environment)
 		if err != nil {
 			return err
 		}
@@ -372,12 +377,18 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 			}
 		}
 
+		if prevp.Agent == nil && sshScriptExists {
+			return errors.New("ssh-agent interface already connected")
+		}
 		if prevp.Agent != nil && !prevp.Agent.Equal(spec.Profile.Agent) {
-			if err = removeSshAgent(fs, *prevp.Agent, sdkRef.Sdk); err != nil {
+			if err = removeSshAgent(fs); err != nil {
 				return err
 			}
 		}
 
+		if prevp.Desktop == nil && desktopScriptExists {
+			return errors.New("desktop interface already connected")
+		}
 		if prevp.Desktop != nil && !prevp.Desktop.Equal(spec.Profile.Desktop) {
 			if err = removeDesktop(fs); err != nil {
 				return err
@@ -457,7 +468,7 @@ func (b *Backend) Remove(ctx context.Context, sdkRef sdk.Ref) error {
 	}
 
 	if prof.Agent != nil {
-		if err = removeSshAgent(fs, *prof.Agent, sdkRef.Sdk); err != nil {
+		if err = removeSshAgent(fs); err != nil {
 			return err
 		}
 	}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -72,11 +72,10 @@ func setupMounts(conn lxd.InstanceServer, fs workshop.WorkshopFs, user *user.Use
 		if mnt == prev[mnt.Name] {
 			continue
 		}
-		found, err := addMountEntry(fs, user, mounts, mnt)
-		if err != nil {
+		if err := prepareMount(fs, user, mnt); err != nil {
 			return nil, err
 		}
-		if found {
+		if addMountEntry(mounts, mnt) {
 			added = append(added, mnt.Where)
 		}
 	}
@@ -169,61 +168,69 @@ func containsWorkshopWorkshop(mounts map[string]workshop.Mount) bool {
 	return false
 }
 
-func addMountEntry(fs workshop.WorkshopFs, user *user.User, mounts *osutil.MountProfile, mnt workshop.Mount) (bool, error) {
+func prepareMount(fs workshop.WorkshopFs, user *user.User, mnt workshop.Mount) error {
 	if mnt.Type == workshop.HostWorkshop {
 		sourceExists, sourceIsDir, err := osutil.ExistsIsDir(mnt.What)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		if mnt.MakeWhat && !sourceExists {
 			uid, gid, err := osutil.UidGid(user)
 			if err != nil {
-				return false, err
+				return err
 			}
 
 			if err = osutil.MkdirAllChown(mnt.What, 0755, uid, gid); err != nil {
-				return false, err
+				return err
 			}
 		}
 
 		if !mnt.MakeWhere || !sourceIsDir {
-			return false, nil
+			return nil
 		}
 
 		if _, err := fs.Stat(mnt.Where); !osutil.IsDirNotExist(err) {
-			return false, err
+			return err
 		}
 		// FIXME: workaround LXD empty directory issue (which, if the
 		// connection was disconnected earlier, was removed by LXD).
-		return false, fs.MkdirAll(mnt.Where, os.ModePerm)
+		return fs.MkdirAll(mnt.Where, os.ModePerm)
 	}
 
 	if mnt.Type != workshop.WorkshopWorkshop {
-		return false, fmt.Errorf(`unknown device type: %v`, mnt.Type)
+		return fmt.Errorf(`unknown device type: %v`, mnt.Type)
 	}
 
 	if _, err := fs.Stat(mnt.What); osutil.IsDirNotExist(err) && mnt.MakeWhat {
 		if err := fs.MkdirAll(mnt.What, os.ModePerm); err != nil {
-			return false, err
+			return err
 		}
 	} else if err != nil {
-		return false, fmt.Errorf(`stat workshop-source %q: %v`, mnt.What, err)
+		return fmt.Errorf(`stat workshop-source %q: %v`, mnt.What, err)
 	}
 
 	if _, err := fs.Stat(mnt.Where); osutil.IsDirNotExist(err) && mnt.MakeWhere {
 		if err := fs.MkdirAll(mnt.Where, os.ModePerm); err != nil {
-			return false, err
+			return err
 		}
 	} else if err != nil {
-		return false, fmt.Errorf(`stat workshop-target %q: %v`, mnt.Where, err)
+		return fmt.Errorf(`stat workshop-target %q: %v`, mnt.Where, err)
+	}
+
+	return nil
+}
+
+func addMountEntry(mounts *osutil.MountProfile, mnt workshop.Mount) bool {
+	if mnt.Type != workshop.WorkshopWorkshop {
+		return false
 	}
 
 	check := func(me osutil.MountEntry) bool {
 		return me.Name == mnt.What && me.Dir == mnt.Where && mnt.ReadOnly == slices.Contains(me.Options, "ro")
 	}
 	if slices.ContainsFunc(mounts.Entries, check) {
-		return false, nil
+		return false
 	}
 
 	options := []string{"bind", "x-systemd.requires=/project"}
@@ -233,7 +240,7 @@ func addMountEntry(fs workshop.WorkshopFs, user *user.User, mounts *osutil.Mount
 
 	entry := osutil.MountEntry{Name: mnt.What, Dir: mnt.Where, Type: "none", Options: options}
 	mounts.Entries = append(mounts.Entries, entry)
-	return true, nil
+	return true
 }
 
 func removeMountEntry(mounts *osutil.MountProfile, mnt workshop.Mount) bool {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -45,93 +46,227 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 	return interfaces.SecurityLxdDevice
 }
 
-func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (reload bool, err error) {
-	if dev.Type == workshop.WorkshopWorkshop {
-		if _, err := fs.Stat(dev.What); osutil.IsDirNotExist(err) && dev.MakeWhat {
-			if err := fs.MkdirAll(dev.What, os.ModePerm); err != nil {
-				return false, err
-			}
-		} else if err != nil {
-			return false, fmt.Errorf(`stat workshop-source %q: %v`, dev.What, err)
-		}
-
-		if _, err := fs.Stat(dev.Where); osutil.IsDirNotExist(err) && dev.MakeWhere {
-			if err := fs.MkdirAll(dev.Where, os.ModePerm); err != nil {
-				return false, err
-			}
-		} else if err != nil {
-			return false, fmt.Errorf(`stat workshop-target %q: %v`, dev.Where, err)
-		}
-
-		mounts, err := readMountProfile(fs)
+func setupMounts(conn lxd.InstanceServer, fs workshop.WorkshopFs, user *user.User, pid, w string, prev, next map[string]workshop.Mount) (*revert.Reverter, error) {
+	var mounts *osutil.MountProfile
+	var content []byte
+	if containsWorkshopWorkshop(prev) || containsWorkshopWorkshop(next) {
+		var err error
+		mounts, content, err = readMountProfile(fs)
 		if err != nil {
-			return false, err
+			return nil, err
 		}
-
-		check := func(me osutil.MountEntry) bool {
-			return me.Name == dev.What && me.Dir == dev.Where && dev.ReadOnly == slices.Contains(me.Options, "ro")
-		}
-		if slices.ContainsFunc(mounts.Entries, check) {
-			return false, nil
-		}
-
-		options := []string{"bind", "x-systemd.requires=/project"}
-		if dev.ReadOnly {
-			options = append(options, "ro")
-		}
-
-		entry := osutil.MountEntry{Name: dev.What, Dir: dev.Where, Type: "none", Options: options}
-		mounts.Entries = append(mounts.Entries, entry)
-		if err = writeMountProfile(fs, mounts); err != nil {
-			return false, err
-		}
-		return true, nil
 	}
 
-	if dev.Type == workshop.HostWorkshop {
-		sourceExists, sourceIsDir, err := osutil.ExistsIsDir(dev.What)
+	var removed []string
+	for _, mnt := range prev {
+		if mnt == next[mnt.Name] {
+			continue
+		}
+		if removeMountEntry(mounts, mnt) {
+			removed = append(removed, mnt.Where)
+		}
+	}
+
+	var added []string
+	for _, mnt := range next {
+		if mnt == prev[mnt.Name] {
+			continue
+		}
+		found, err := addMountEntry(fs, user, mounts, mnt)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			added = append(added, mnt.Where)
+		}
+	}
+
+	rev := revert.New()
+	if len(removed) == 0 && len(added) == 0 {
+		return rev, nil
+	}
+	defer rev.Fail()
+
+	rev.Add(func() {
+		if reverr := reloadMounts(conn, pid, w); reverr != nil {
+			logger.Noticef("On setupMounts: cannot undo unmount: %v", reverr)
+		}
+	})
+
+	for _, where := range removed {
+		if err := unmount(conn, pid, w, where); err != nil {
+			logger.Noticef("On setupMounts: cannot unmount %q: %v", where, err)
+		}
+	}
+
+	if err := writeMountProfile(fs, mounts); err != nil {
+		return nil, err
+	}
+
+	rev.Add(func() {
+		for _, where := range added {
+			if reverr := unmount(conn, pid, w, where); reverr != nil {
+				logger.Noticef("On setupMounts: cannot undo mount: %v", reverr)
+			}
+		}
+		if reverr := writeMountProfile(fs, bytes.NewBuffer(content)); reverr != nil {
+			logger.Noticef("On setupMounts: cannot restore mount profile: %v", reverr)
+		}
+	})
+
+	if err := reloadMounts(conn, pid, w); err != nil {
+		return nil, err
+	}
+
+	clone := rev.Clone()
+	rev.Success()
+	return clone, nil
+}
+
+func removeMounts(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string, prev map[string]workshop.Mount) error {
+	var mounts *osutil.MountProfile
+	if containsWorkshopWorkshop(prev) {
+		var err error
+		mounts, _, err = readMountProfile(fs)
+		if err != nil {
+			return err
+		}
+	}
+
+	var removed []string
+	for _, mnt := range prev {
+		if removeMountEntry(mounts, mnt) {
+			removed = append(removed, mnt.Where)
+		}
+	}
+
+	if len(removed) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for _, where := range removed {
+		if err := unmount(conn, pid, w, where); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := writeMountProfile(fs, mounts); err != nil {
+		errs = append(errs, err)
+	} else if err := reloadMounts(conn, pid, w); err != nil {
+		errs = append(errs, err)
+	}
+
+	return cmp.Or(errs...)
+}
+
+func containsWorkshopWorkshop(mounts map[string]workshop.Mount) bool {
+	for _, mnt := range mounts {
+		if mnt.Type == workshop.WorkshopWorkshop {
+			return true
+		}
+	}
+	return false
+}
+
+func addMountEntry(fs workshop.WorkshopFs, user *user.User, mounts *osutil.MountProfile, mnt workshop.Mount) (bool, error) {
+	if mnt.Type == workshop.HostWorkshop {
+		sourceExists, sourceIsDir, err := osutil.ExistsIsDir(mnt.What)
 		if err != nil {
 			return false, err
 		}
 
-		if dev.MakeWhat && !sourceExists {
+		if mnt.MakeWhat && !sourceExists {
 			uid, gid, err := osutil.UidGid(user)
 			if err != nil {
 				return false, err
 			}
 
-			if err = osutil.MkdirAllChown(dev.What, 0755, uid, gid); err != nil {
+			if err = osutil.MkdirAllChown(mnt.What, 0755, uid, gid); err != nil {
 				return false, err
 			}
 		}
 
-		if !dev.MakeWhere || !sourceIsDir {
+		if !mnt.MakeWhere || !sourceIsDir {
 			return false, nil
 		}
 
-		if _, err := fs.Stat(dev.Where); !osutil.IsDirNotExist(err) {
+		if _, err := fs.Stat(mnt.Where); !osutil.IsDirNotExist(err) {
 			return false, err
 		}
 		// FIXME: workaround LXD empty directory issue (which, if the
 		// connection was disconnected earlier, was removed by LXD).
-		return false, fs.MkdirAll(dev.Where, os.ModePerm)
+		return false, fs.MkdirAll(mnt.Where, os.ModePerm)
 	}
-	return false, fmt.Errorf(`unknown device type: %v`, dev.Type)
+
+	if mnt.Type != workshop.WorkshopWorkshop {
+		return false, fmt.Errorf(`unknown device type: %v`, mnt.Type)
+	}
+
+	if _, err := fs.Stat(mnt.What); osutil.IsDirNotExist(err) && mnt.MakeWhat {
+		if err := fs.MkdirAll(mnt.What, os.ModePerm); err != nil {
+			return false, err
+		}
+	} else if err != nil {
+		return false, fmt.Errorf(`stat workshop-source %q: %v`, mnt.What, err)
+	}
+
+	if _, err := fs.Stat(mnt.Where); osutil.IsDirNotExist(err) && mnt.MakeWhere {
+		if err := fs.MkdirAll(mnt.Where, os.ModePerm); err != nil {
+			return false, err
+		}
+	} else if err != nil {
+		return false, fmt.Errorf(`stat workshop-target %q: %v`, mnt.Where, err)
+	}
+
+	check := func(me osutil.MountEntry) bool {
+		return me.Name == mnt.What && me.Dir == mnt.Where && mnt.ReadOnly == slices.Contains(me.Options, "ro")
+	}
+	if slices.ContainsFunc(mounts.Entries, check) {
+		return false, nil
+	}
+
+	options := []string{"bind", "x-systemd.requires=/project"}
+	if mnt.ReadOnly {
+		options = append(options, "ro")
+	}
+
+	entry := osutil.MountEntry{Name: mnt.What, Dir: mnt.Where, Type: "none", Options: options}
+	mounts.Entries = append(mounts.Entries, entry)
+	return true, nil
 }
 
-func readMountProfile(fs workshop.WorkshopFs) (*osutil.MountProfile, error) {
+func removeMountEntry(mounts *osutil.MountProfile, mnt workshop.Mount) bool {
+	if mnt.Type != workshop.WorkshopWorkshop {
+		return false
+	}
+
+	cnt := len(mounts.Entries)
+	deleter := func(me osutil.MountEntry) bool {
+		return me.Name == mnt.What && me.Dir == mnt.Where
+	}
+	mounts.Entries = slices.DeleteFunc(mounts.Entries, deleter)
+	return cnt != len(mounts.Entries)
+}
+
+func readMountProfile(fs workshop.WorkshopFs) (*osutil.MountProfile, []byte, error) {
 	fstab, err := fs.Open("/etc/fstab")
 	if errors.Is(err, os.ErrNotExist) {
-		return &osutil.MountProfile{}, nil
+		return &osutil.MountProfile{}, nil, nil
 	} else if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer fstab.Close()
 
-	return osutil.ReadMountProfile(fstab)
+	var content bytes.Buffer
+	mounts, err := osutil.ReadMountProfile(io.TeeReader(fstab, &content))
+	if err != nil {
+		return nil, nil, err
+	}
+	return mounts, content.Bytes(), nil
 }
 
-func writeMountProfile(fs workshop.WorkshopFs, mounts *osutil.MountProfile) error {
+func writeMountProfile(fs workshop.WorkshopFs, mounts io.WriterTo) error {
 	return workshop.AtomicWrite(fs, "/etc/fstab", mounts, 0644)
 }
 
@@ -150,10 +285,11 @@ func runMountCommand(conn lxd.InstanceServer, pid, w string, cmd []string) error
 		return err
 	}
 
-	if err = op.Wait(); err != nil {
-		logger.Noticef("On workshop mount: %v (%s)", err, out.String())
-	}
-	return err
+	return op.Wait()
+}
+
+func unmount(conn lxd.InstanceServer, pid, w string, where string) error {
+	return runMountCommand(conn, pid, w, []string{"umount", where})
 }
 
 // 'systemd-fstab-generator' is responsible for creating mount entries from
@@ -169,55 +305,62 @@ func reloadMounts(conn lxd.InstanceServer, pid, w string) error {
 	})
 }
 
-func removeMount(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string, mnt workshop.Mount) error {
-	if mnt.Type != workshop.WorkshopWorkshop {
+func setupSshAgent(fs workshop.WorkshopFs, prev, next *workshop.SshAgent) error {
+	if prev.Equal(next) {
 		return nil
 	}
-
-	mounts, err := readMountProfile(fs)
-	if err != nil {
-		return err
+	if next == nil {
+		return removeSshAgent(fs, prev)
 	}
 
-	cnt := len(mounts.Entries)
-	deleter := func(me osutil.MountEntry) bool {
-		return me.Name == mnt.What && me.Dir == mnt.Where
-	}
-	mounts.Entries = slices.DeleteFunc(mounts.Entries, deleter)
-	if cnt == len(mounts.Entries) {
-		return nil
-	}
-
-	if err = writeMountProfile(fs, mounts); err != nil {
-		return err
-	}
-
-	return runMountCommand(conn, pid, w, []string{
-		"umount",
-		mnt.Where,
-	})
-}
-
-func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent) (exists bool, err error) {
 	script := "/etc/profile.d/workshop-ssh-agent.sh"
-	if _, err := fs.Stat(script); err == nil {
-		exists = true
+	if prev == nil {
+		if _, err := fs.Stat(script); err == nil {
+			return errors.New("ssh-agent interface already connected")
+		}
 	}
-	envVars := map[string]string{"SSH_AUTH_SOCK": dev.Listen.Address}
-	return exists, workshop.AtomicWrite(fs, script, envScript(envVars), 0644)
+
+	envVars := map[string]string{"SSH_AUTH_SOCK": next.Listen.Address}
+	return workshop.AtomicWrite(fs, script, envScript(envVars), 0644)
 }
 
-func removeSshAgent(fs workshop.WorkshopFs) error {
-	return fs.RemoveIfExists("/etc/profile.d/workshop-ssh-agent.sh")
+func removeSshAgent(fs workshop.WorkshopFs, prev *workshop.SshAgent) error {
+	if prev == nil {
+		return nil
+	}
+
+	script := "/etc/profile.d/workshop-ssh-agent.sh"
+	return fs.RemoveIfExists(script)
 }
 
-func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.User, env map[string]string) (exists bool, err error) {
+func setupDesktop(fs workshop.WorkshopFs, user *user.User, env map[string]string, prev, next *workshop.Desktop) error {
+	if prev.Equal(next) {
+		return nil
+	}
+	if next == nil {
+		return removeDesktop(fs, prev)
+	}
+
 	script := "/etc/profile.d/workshop-desktop.sh"
-	if _, err := fs.Stat(script); err == nil {
-		exists = true
+	if prev == nil {
+		if _, err := fs.Stat(script); err == nil {
+			return errors.New("desktop interface already connected")
+		}
 	}
-	envVars := desktopEnvironment(user, env, dev)
-	return exists, workshop.AtomicWrite(fs, script, envScript(envVars), 0644)
+
+	envVars := desktopEnvironment(user, env, *next)
+	return workshop.AtomicWrite(fs, script, envScript(envVars), 0644)
+}
+
+func removeDesktop(fs workshop.WorkshopFs, prev *workshop.Desktop) error {
+	if prev == nil {
+		return nil
+	}
+
+	script := "/etc/profile.d/workshop-desktop.sh"
+	err := fs.RemoveIfExists(script)
+	err2 := fs.RemoveIfExists("/tmp/.Xauthority")
+	return cmp.Or(err, err2)
 }
 
 func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Desktop) map[string]string {
@@ -268,12 +411,6 @@ func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Des
 	return envVars
 }
 
-func removeDesktop(fs workshop.WorkshopFs) error {
-	err := fs.RemoveIfExists("/etc/profile.d/workshop-desktop.sh")
-	err2 := fs.RemoveIfExists("/tmp/.Xauthority")
-	return cmp.Or(err, err2)
-}
-
 type envScript map[string]string
 
 func (e envScript) WriteTo(w io.Writer) (int64, error) {
@@ -296,6 +433,97 @@ func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error)
 	return workshop.NewWorkshopFs(sftp), nil
 }
 
+func assignNewProfile(ctx context.Context, conn lxd.InstanceServer, sdkRef sdk.Ref, profile api.ProfilePut) error {
+	rev := revert.New()
+	defer rev.Fail()
+
+	name := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
+	if err := conn.CreateProfile(api.ProfilesPost{ProfilePut: profile, Name: name}); err != nil {
+		return err
+	}
+	rev.Add(func() {
+		if reverr := conn.DeleteProfile(name); reverr != nil {
+			logger.Noticef("On Setup: cannot remove %q SDK profile: %v", sdkRef.Sdk, reverr)
+		}
+	})
+
+	iname := lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId)
+	inst, etag, err := conn.GetInstance(iname)
+	if err != nil {
+		return err
+	}
+
+	// Assigning the profile for the first time.
+	inst.Profiles = append(inst.Profiles, name)
+	op, err := conn.UpdateInstance(iname, inst.Writable(), etag)
+	if err != nil {
+		return err
+	}
+	if err := op.WaitContext(ctx); err != nil {
+		return err
+	}
+
+	rev.Success()
+	return nil
+}
+
+func setupProfile(conn lxd.InstanceServer, user *user.User, env map[string]string, sdkRef sdk.Ref, prev, next *workshop.SdkProfile) (*revert.Reverter, error) {
+	fs, err := workshopFs(conn, sdkRef.ProjectId, sdkRef.Workshop)
+	if err != nil {
+		return nil, err
+	}
+	defer fs.Close()
+
+	rev := revert.New()
+	defer rev.Fail()
+
+	r, err := setupMounts(conn, fs, user, sdkRef.ProjectId, sdkRef.Workshop, prev.Mounts, next.Mounts)
+	if err != nil {
+		return nil, err
+	}
+	rev.AddAll(r)
+
+	if err := setupSshAgent(fs, prev.Agent, next.Agent); err != nil {
+		return nil, err
+	}
+	rev.Add(func() {
+		if reverr := setupSshAgent(fs, next.Agent, prev.Agent); reverr != nil {
+			logger.Noticef("On setupProfile: cannot undo SSH agent changes: %v", reverr)
+		}
+	})
+
+	if err := setupDesktop(fs, user, env, prev.Desktop, next.Desktop); err != nil {
+		return nil, err
+	}
+	rev.Add(func() {
+		if reverr := setupDesktop(fs, user, env, next.Desktop, prev.Desktop); reverr != nil {
+			logger.Noticef("On setupProfile: cannot undo desktop interface changes: %v", reverr)
+		}
+	})
+
+	clone := rev.Clone()
+	rev.Success()
+	return clone, nil
+}
+
+func cleanupProfile(conn lxd.InstanceServer, sdkRef sdk.Ref) error {
+	prof, err := lxdbackend.Profile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
+	if err != nil {
+		return err
+	}
+
+	fs, err := workshopFs(conn, sdkRef.ProjectId, sdkRef.Workshop)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+
+	err = removeDesktop(fs, prof.Desktop)
+	err2 := removeSshAgent(fs, prof.Agent)
+	err3 := removeMounts(conn, fs, sdkRef.ProjectId, sdkRef.Workshop, prof.Mounts)
+	return cmp.Or(err, err2, err3)
+}
+
 // Setup creates mount profile specific to a given sdk.
 func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(ctx, b.Name(), sdkRef)
@@ -304,135 +532,61 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 	}
 	spec := s.(*Specification)
 
-	name := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
-	newp := api.ProfilePut{
-		Devices:     spec.devices,
-		Config:      spec.config,
-		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkRef.Sdk, sdkRef.Workshop),
-	}
-
 	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Disconnect()
 
-	fs, err := workshopFs(conn, sdkRef.ProjectId, sdkRef.Workshop)
+	prev := workshop.NewSdkProfile(sdkRef.Sdk)
+	oldp := api.ProfilePut{
+		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkRef.Sdk, sdkRef.Workshop),
+	}
+	newp := api.ProfilePut{
+		Config:      spec.config,
+		Description: oldp.Description,
+		Devices:     spec.devices,
+	}
+
+	// Either create or update an existing LXD profile for the SDK.
+	prof, etag, err := lxdbackend.LxdProfile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
+	if errors.Is(err, workshop.ErrSdkProfileNotFound) {
+		if err := assignNewProfile(ctx, conn, sdkRef, oldp); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	} else {
+		prev, err = lxdbackend.LxdToSdkProfile(sdkRef.Sdk, prof.Devices, prof.Config)
+		if err != nil {
+			return err
+		}
+		oldp = prof.Writable()
+	}
+
+	rev, err := setupProfile(conn, spec.User, spec.Environment, sdkRef, &prev, &spec.Profile)
 	if err != nil {
 		return err
 	}
-	defer fs.Close()
+	defer rev.Fail()
 
-	reload := false
-	for _, mnt := range spec.Profile.Mounts {
-		rld, err := installMount(spec.User, fs, mnt)
-		if err != nil {
-			return err
-		}
-
-		if rld {
-			reload = true
-		}
-	}
-
-	if reload {
-		err = reloadMounts(conn, sdkRef.ProjectId, sdkRef.Workshop)
-		if err != nil {
-			return err
-		}
-	}
-
-	var sshScriptExists bool
-	if spec.Profile.Agent != nil {
-		sshScriptExists, err = installSshAgent(fs, *spec.Profile.Agent)
-		if err != nil {
-			return err
-		}
-	}
-
-	var desktopScriptExists bool
-	if spec.Profile.Desktop != nil {
-		desktopScriptExists, err = installDesktop(fs, *spec.Profile.Desktop, spec.User, spec.Environment)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Either create or update an existing LXD profile for the SDK so that later
-	// it can be assigned to the required workshop.
-	lxdp, etag, err := lxdbackend.LxdProfile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
-	if err == nil {
-		prevp, err := lxdbackend.LxdToSdkProfile(sdkRef.Sdk, lxdp.Devices, lxdp.Config)
-		if err != nil {
-			return err
-		}
-
-		// Find the difference between a set of old and new devices to detect if any
-		// clean up is required when a new profile will be assigned (updated).
-		for key, dev := range prevp.Mounts {
-			if _, exist := spec.Profile.Mounts[key]; !exist {
-				if err = removeMount(conn, fs, sdkRef.ProjectId, sdkRef.Workshop, dev); err != nil {
-					return err
-				}
+	name := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
+	if err := conn.UpdateProfile(name, newp, etag); err != nil {
+		// By design, LXD does not roll back profile changes if the update failed,
+		// so we have to do it ourselves.
+		_, etag2, err2 := conn.GetProfile(name)
+		if err2 != nil {
+			logger.Noticef("cannot get updated profile: %v", err2)
+		} else if etag2 != etag {
+			if err2 := conn.UpdateProfile(name, oldp, etag2); err2 != nil {
+				logger.Noticef("cannot restore original profile: %v", err2)
 			}
 		}
-
-		if prevp.Agent == nil && sshScriptExists {
-			return errors.New("ssh-agent interface already connected")
-		}
-		if prevp.Agent != nil && !prevp.Agent.Equal(spec.Profile.Agent) {
-			if err = removeSshAgent(fs); err != nil {
-				return err
-			}
-		}
-
-		if prevp.Desktop == nil && desktopScriptExists {
-			return errors.New("desktop interface already connected")
-		}
-		if prevp.Desktop != nil && !prevp.Desktop.Equal(spec.Profile.Desktop) {
-			if err = removeDesktop(fs); err != nil {
-				return err
-			}
-		}
-
-		if err := conn.UpdateProfile(name, newp, etag); err != nil {
-			// By design, LXD does not roll back profile changes if the update failed,
-			// so we have to do it ourselves.
-			_, etag2, err2 := conn.GetProfile(name)
-			if err2 != nil {
-				logger.Noticef("cannot get updated profile: %v", err2)
-			} else if etag2 != etag {
-				if err2 := conn.UpdateProfile(name, lxdp.Writable(), etag2); err2 != nil {
-					logger.Noticef("cannot restore original profile: %v", err2)
-				}
-			}
-			return err
-		}
-		return nil
+		return err
 	}
 
-	if errors.Is(err, workshop.ErrSdkProfileNotFound) {
-		if err = conn.CreateProfile(api.ProfilesPost{ProfilePut: newp, Name: name}); err != nil {
-			return err
-		}
-
-		iname := lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId)
-		inst, etag, err := conn.GetInstance(iname)
-		if err != nil {
-			return err
-		}
-
-		// Assigning the profile for the first time.
-		inst.Profiles = append(inst.Profiles, name)
-		op, err := conn.UpdateInstance(iname, inst.Writable(), etag)
-		if err != nil {
-			return err
-		}
-
-		return op.WaitContext(ctx)
-	}
-
-	return err
+	rev.Success()
+	return nil
 }
 
 // Remove removes profile of a given sdk.
@@ -445,45 +599,18 @@ func (b *Backend) Remove(ctx context.Context, sdkRef sdk.Ref) error {
 	}
 	defer conn.Disconnect()
 
-	fs, err := workshopFs(conn, sdkRef.ProjectId, sdkRef.Workshop)
-	if err != nil {
-		return err
-	}
-	defer fs.Close()
-
-	inst, etag, err := conn.GetInstance(lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId))
-	if err != nil {
-		return err
-	}
-
-	prof, err := lxdbackend.Profile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
-	if err != nil {
-		return err
-	}
-
-	for _, dev := range prof.Mounts {
-		if err = removeMount(conn, fs, sdkRef.ProjectId, sdkRef.Workshop, dev); err != nil {
-			return err
-		}
-	}
-
-	if prof.Agent != nil {
-		if err = removeSshAgent(fs); err != nil {
-			return err
-		}
-	}
-
-	if prof.Desktop != nil {
-		if err = removeDesktop(fs); err != nil {
-			return err
-		}
-	}
-
 	// 1. Unassign the profile from the workshop
+	iname := lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId)
+	inst, etag, err := conn.GetInstance(iname)
+	if err != nil {
+		return err
+	}
+
 	lxdname := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
-	if idx := slices.Index(inst.Profiles, lxdname); idx != -1 {
+	if idx := slices.Index(inst.Profiles, lxdname); idx >= 0 {
 		inst.Profiles = slices.Delete(inst.Profiles, idx, idx+1)
-		op, err := conn.UpdateInstance(lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId), inst.Writable(), etag)
+
+		op, err := conn.UpdateInstance(iname, inst.Writable(), etag)
 		if err != nil {
 			return err
 		}
@@ -492,7 +619,9 @@ func (b *Backend) Remove(ctx context.Context, sdkRef sdk.Ref) error {
 		}
 	}
 
-	return conn.DeleteProfile(lxdname)
+	err = cleanupProfile(conn, sdkRef)
+	err2 := conn.DeleteProfile(lxdname)
+	return cmp.Or(err, err2)
 }
 
 // NewSpecification returns a new mount specification.

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -505,7 +505,7 @@ func setupProfile(conn lxd.InstanceServer, user *user.User, env map[string]strin
 	if err != nil {
 		return nil, err
 	}
-	rev.AddAll(r)
+	revert.Copy(rev, r)
 
 	if err := setupSshAgent(fs, prev.Agent, next.Agent); err != nil {
 		return nil, err
@@ -595,7 +595,7 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 		if err != nil {
 			return err
 		}
-		rev.AddAll(r)
+		revert.Copy(rev, r)
 	}
 
 	prof := api.ProfilePut{

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -45,11 +45,19 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 
 func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (reload bool, err error) {
 	if dev.Type == workshop.WorkshopWorkshop {
-		if _, err = fs.Stat(dev.What); err != nil {
+		if _, err := fs.Stat(dev.What); osutil.IsDirNotExist(err) && dev.MakeWhat {
+			if err := fs.MkdirAll(dev.What, os.ModePerm); err != nil {
+				return false, err
+			}
+		} else if err != nil {
 			return false, fmt.Errorf(`stat workshop-source %q: %v`, dev.What, err)
 		}
 
-		if _, err = fs.Stat(dev.Where); err != nil {
+		if _, err := fs.Stat(dev.Where); osutil.IsDirNotExist(err) && dev.MakeWhere {
+			if err := fs.MkdirAll(dev.Where, os.ModePerm); err != nil {
+				return false, err
+			}
+		} else if err != nil {
 			return false, fmt.Errorf(`stat workshop-target %q: %v`, dev.Where, err)
 		}
 
@@ -79,14 +87,12 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 	}
 
 	if dev.Type == workshop.HostWorkshop {
-		// We cannot infer what the user intended to mount if the source doesn't
-		// exist. In this case - inline with the above - we create a directory.
 		sourceExists, sourceIsDir, err := osutil.ExistsIsDir(dev.What)
 		if err != nil {
 			return false, err
 		}
 
-		if !sourceExists {
+		if dev.MakeWhat && !sourceExists {
 			uid, gid, err := osutil.UidGid(user)
 			if err != nil {
 				return false, err
@@ -97,7 +103,7 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 			}
 		}
 
-		if !sourceIsDir {
+		if !dev.MakeWhere || !sourceIsDir {
 			return false, nil
 		}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -79,22 +79,13 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 	}
 
 	if dev.Type == workshop.HostWorkshop {
-		// Ensure that the source path exists here. LXD allows to
-		// require the source attribute when updating an instance
-		// configuration but it would fail and still save changes to the
-		// instace profile even if the source does not exist. For
-		// Workshop that would mean that the interface connection would
-		// fail but there will still be changes made to the instance
-		// configuration which is not acceptable.
-		// The dir is being dynamically created (no source attribute
-		// provided by the slot).
+		// We cannot infer what the user intended to mount if the source doesn't
+		// exist. In this case - inline with the above - we create a directory.
 		sourceExists, sourceIsDir, err := osutil.ExistsIsDir(dev.What)
 		if err != nil {
 			return false, err
 		}
 
-		// We cannot infer what the user intended to mount if the source doesn't
-		// exist. In this case - inline with the above - we create a directory.
 		if !sourceExists {
 			uid, gid, err := osutil.UidGid(user)
 			if err != nil {
@@ -110,17 +101,12 @@ func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (
 			return false, nil
 		}
 
-		_, err = fs.Stat(dev.Where)
-		if !osutil.IsDirNotExist(err) {
+		if _, err := fs.Stat(dev.Where); !osutil.IsDirNotExist(err) {
 			return false, err
-		} else {
-			// FIXME: workaround LXD empty directory issue (which, if the
-			// connection was disconnected earlier, was removed by LXD).
-			if err = fs.MkdirAll(dev.Where, os.ModePerm); err != nil {
-				return false, err
-			}
 		}
-		return false, nil
+		// FIXME: workaround LXD empty directory issue (which, if the
+		// connection was disconnected earlier, was removed by LXD).
+		return false, fs.MkdirAll(dev.Where, os.ModePerm)
 	}
 	return false, fmt.Errorf(`unknown device type: %v`, dev.Type)
 }
@@ -371,8 +357,13 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 
 	// Either create or update an existing LXD profile for the SDK so that later
 	// it can be assigned to the required workshop.
-	prevp, err := lxdbackend.Profile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
+	lxdp, etag, err := lxdbackend.LxdProfile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
 	if err == nil {
+		prevp, err := lxdbackend.LxdToSdkProfile(sdkRef.Sdk, lxdp.Devices, lxdp.Config)
+		if err != nil {
+			return err
+		}
+
 		// Find the difference between a set of old and new devices to detect if any
 		// clean up is required when a new profile will be assigned (updated).
 		for key, dev := range prevp.Mounts {
@@ -395,7 +386,20 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 			}
 		}
 
-		return conn.UpdateProfile(name, newp, "")
+		if err := conn.UpdateProfile(name, newp, etag); err != nil {
+			// By design, LXD does not roll back profile changes if the update failed,
+			// so we have to do it ourselves.
+			_, etag2, err2 := conn.GetProfile(name)
+			if err2 != nil {
+				logger.Noticef("cannot get updated profile: %v", err2)
+			} else if etag2 != etag {
+				if err2 := conn.UpdateProfile(name, lxdp.Writable(), etag2); err2 != nil {
+					logger.Noticef("cannot restore original profile: %v", err2)
+				}
+			}
+			return err
+		}
+		return nil
 	}
 
 	if errors.Is(err, workshop.ErrSdkProfileNotFound) {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -433,13 +433,19 @@ func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error)
 	return workshop.NewWorkshopFs(sftp), nil
 }
 
-func assignNewProfile(ctx context.Context, conn lxd.InstanceServer, sdkRef sdk.Ref, profile api.ProfilePut) error {
+func assignNewProfile(ctx context.Context, conn lxd.InstanceServer, sdkRef sdk.Ref) (*revert.Reverter, error) {
 	rev := revert.New()
 	defer rev.Fail()
 
 	name := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
-	if err := conn.CreateProfile(api.ProfilesPost{ProfilePut: profile, Name: name}); err != nil {
-		return err
+	description := fmt.Sprintf("%q SDK profile for %q workshop", sdkRef.Sdk, sdkRef.Workshop)
+	lxdp := api.ProfilesPost{
+		ProfilePut: api.ProfilePut{Description: description},
+		Name:       name,
+	}
+
+	if err := conn.CreateProfile(lxdp); err != nil {
+		return nil, err
 	}
 	rev.Add(func() {
 		if reverr := conn.DeleteProfile(name); reverr != nil {
@@ -450,24 +456,42 @@ func assignNewProfile(ctx context.Context, conn lxd.InstanceServer, sdkRef sdk.R
 	iname := lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId)
 	inst, etag, err := conn.GetInstance(iname)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Assigning the profile for the first time.
 	inst.Profiles = append(inst.Profiles, name)
 	op, err := conn.UpdateInstance(iname, inst.Writable(), etag)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := op.WaitContext(ctx); err != nil {
-		return err
+		return nil, err
 	}
+	rev.Add(func() {
+		inst, etag, reverr := conn.GetInstance(iname)
+		if reverr != nil {
+			logger.Noticef("On Setup: cannot unassign %q SDK profile: %v", sdkRef.Sdk, reverr)
+			return
+		}
+		inst.Profiles = slices.DeleteFunc(inst.Profiles, func(n string) bool { return n == name })
 
+		op, reverr := conn.UpdateInstance(iname, inst.Writable(), etag)
+		if reverr != nil {
+			logger.Noticef("On Setup: cannot unassign %q SDK profile: %v", sdkRef.Sdk, reverr)
+			return
+		}
+		if reverr := op.WaitContext(ctx); reverr != nil {
+			logger.Noticef("On Setup: cannot unassign %q SDK profile: %v", sdkRef.Sdk, reverr)
+		}
+	})
+
+	clone := rev.Clone()
 	rev.Success()
-	return nil
+	return clone, nil
 }
 
-func setupProfile(conn lxd.InstanceServer, user *user.User, env map[string]string, sdkRef sdk.Ref, prev, next *workshop.SdkProfile) (*revert.Reverter, error) {
+func setupProfile(conn lxd.InstanceServer, user *user.User, env map[string]string, sdkRef sdk.Ref, prev, next workshop.SdkProfile) (*revert.Reverter, error) {
 	fs, err := workshopFs(conn, sdkRef.ProjectId, sdkRef.Workshop)
 	if err != nil {
 		return nil, err
@@ -538,49 +562,65 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 	}
 	defer conn.Disconnect()
 
+	name := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
 	prev := workshop.NewSdkProfile(sdkRef.Sdk)
-	oldp := api.ProfilePut{
-		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkRef.Sdk, sdkRef.Workshop),
-	}
-	newp := api.ProfilePut{
-		Config:      spec.config,
-		Description: oldp.Description,
-		Devices:     spec.devices,
-	}
 
-	// Either create or update an existing LXD profile for the SDK.
-	prof, etag, err := lxdbackend.LxdProfile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
-	if errors.Is(err, workshop.ErrSdkProfileNotFound) {
-		if err := assignNewProfile(ctx, conn, sdkRef, oldp); err != nil {
+	// Load previous profile, if in use.
+	lxdp, etag, err := lxdbackend.LxdProfile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
+	if err != nil {
+		if !errors.Is(err, workshop.ErrSdkProfileNotFound) {
 			return err
 		}
-	} else if err != nil {
-		return err
+		lxdp, etag = nil, ""
+	} else if len(lxdp.UsedBy) == 0 {
+		if err := conn.DeleteProfile(name); err != nil {
+			return err
+		}
+		lxdp, etag = nil, ""
 	} else {
-		prev, err = lxdbackend.LxdToSdkProfile(sdkRef.Sdk, prof.Devices, prof.Config)
+		prev, err = lxdbackend.LxdToSdkProfile(sdkRef.Sdk, lxdp.Devices, lxdp.Config)
 		if err != nil {
 			return err
 		}
-		oldp = prof.Writable()
 	}
 
-	rev, err := setupProfile(conn, spec.User, spec.Environment, sdkRef, &prev, &spec.Profile)
+	rev, err := setupProfile(conn, spec.User, spec.Environment, sdkRef, prev, spec.Profile)
 	if err != nil {
 		return err
 	}
 	defer rev.Fail()
 
-	name := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
-	if err := conn.UpdateProfile(name, newp, etag); err != nil {
+	if lxdp == nil {
+		r, err := assignNewProfile(ctx, conn, sdkRef)
+		if err != nil {
+			return err
+		}
+		rev.AddAll(r)
+	}
+
+	prof := api.ProfilePut{
+		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkRef.Sdk, sdkRef.Workshop),
+		Config:      spec.config,
+		Devices:     spec.devices,
+	}
+	if err := conn.UpdateProfile(name, prof, etag); err != nil {
+		if lxdp == nil {
+			return err
+		}
+
 		// By design, LXD does not roll back profile changes if the update failed,
 		// so we have to do it ourselves.
 		_, etag2, err2 := conn.GetProfile(name)
 		if err2 != nil {
 			logger.Noticef("cannot get updated profile: %v", err2)
-		} else if etag2 != etag {
-			if err2 := conn.UpdateProfile(name, oldp, etag2); err2 != nil {
-				logger.Noticef("cannot restore original profile: %v", err2)
-			}
+			return err
+		}
+		if etag2 == etag {
+			return err
+		}
+
+		if err2 := conn.UpdateProfile(name, lxdp.Writable(), etag2); err2 != nil {
+			logger.Noticef("cannot restore original profile: %v", err2)
 		}
 		return err
 	}

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -2,6 +2,7 @@ package lxd_device
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/spf13/afero"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
@@ -213,7 +213,7 @@ func installSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, workshop, sd
 
 func removeSshAgent(fs workshop.WorkshopFs, dev workshop.SshAgent, sdkName string) error {
 	script := fmt.Sprintf("%s_%s.sh", sdkName, dev.Name)
-	return fs.Remove(filepath.Join("/etc", "profile.d", script))
+	return fs.RemoveIfExists(filepath.Join("/etc", "profile.d", script))
 }
 
 func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.User, env map[string]string, ws string) error {
@@ -280,17 +280,9 @@ func installDesktop(fs workshop.WorkshopFs, dev workshop.Desktop, user *user.Use
 }
 
 func removeDesktop(fs workshop.WorkshopFs) error {
-	if err := fs.Remove("/etc/profile.d/desktop.sh"); err != nil {
-		return err
-	}
-
-	// The Xauth cookie may not always exist. Ignore any errors relating to this
-	if err := fs.Remove("/tmp/.Xauthority"); err != nil {
-		if !errors.Is(err, afero.ErrFileNotFound) {
-			return err
-		}
-	}
-	return nil
+	err := fs.RemoveIfExists("/etc/profile.d/desktop.sh")
+	err2 := fs.RemoveIfExists("/tmp/.Xauthority")
+	return cmp.Or(err, err2)
 }
 
 func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error) {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -310,18 +310,18 @@ func sftpFs(conn lxd.InstanceServer, pid, w string) (workshop.WorkshopFs, error)
 }
 
 // Setup creates mount profile specific to a given sdk.
-func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
-	s, err := repo.SdkSpecification(ctx, b.Name(), sdkInfo)
+func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
+	s, err := repo.SdkSpecification(ctx, b.Name(), sdkRef)
 	if err != nil {
 		return err
 	}
 	spec := s.(*Specification)
 
-	name := lxdbackend.ProfileName(sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Sdk)
+	name := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
 	newp := api.ProfilePut{
 		Devices:     spec.devices,
 		Config:      spec.config,
-		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkInfo.Sdk, sdkInfo.Workshop),
+		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkRef.Sdk, sdkRef.Workshop),
 	}
 
 	conn, err := lxdbackend.ConnectLxd(ctx)
@@ -330,7 +330,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 	}
 	defer conn.Disconnect()
 
-	fs, err := workshopFs(conn, sdkInfo.ProjectId, sdkInfo.Workshop)
+	fs, err := workshopFs(conn, sdkRef.ProjectId, sdkRef.Workshop)
 	if err != nil {
 		return err
 	}
@@ -349,21 +349,21 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 	}
 
 	if reload {
-		err = reloadMounts(conn, sdkInfo.ProjectId, sdkInfo.Workshop)
+		err = reloadMounts(conn, sdkRef.ProjectId, sdkRef.Workshop)
 		if err != nil {
 			return err
 		}
 	}
 
 	if spec.Profile.Agent != nil {
-		err = installSshAgent(fs, *spec.Profile.Agent, sdkInfo.Workshop, sdkInfo.Sdk)
+		err = installSshAgent(fs, *spec.Profile.Agent, sdkRef.Workshop, sdkRef.Sdk)
 		if err != nil {
 			return err
 		}
 	}
 
 	if spec.Profile.Desktop != nil {
-		err = installDesktop(fs, *spec.Profile.Desktop, spec.User, spec.Environment, sdkInfo.Workshop)
+		err = installDesktop(fs, *spec.Profile.Desktop, spec.User, spec.Environment, sdkRef.Workshop)
 		if err != nil {
 			return err
 		}
@@ -371,20 +371,20 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 
 	// Either create or update an existing LXD profile for the SDK so that later
 	// it can be assigned to the required workshop.
-	prevp, err := lxdbackend.Profile(conn, sdkInfo.ProjectId, sdkInfo.Workshop, sdkInfo.Sdk)
+	prevp, err := lxdbackend.Profile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
 	if err == nil {
 		// Find the difference between a set of old and new devices to detect if any
 		// clean up is required when a new profile will be assigned (updated).
 		for key, dev := range prevp.Mounts {
 			if _, exist := spec.Profile.Mounts[key]; !exist {
-				if err = removeMount(conn, fs, sdkInfo.ProjectId, sdkInfo.Workshop, dev); err != nil {
+				if err = removeMount(conn, fs, sdkRef.ProjectId, sdkRef.Workshop, dev); err != nil {
 					return err
 				}
 			}
 		}
 
 		if prevp.Agent != nil && !prevp.Agent.Equal(spec.Profile.Agent) {
-			if err = removeSshAgent(fs, *prevp.Agent, sdkInfo.Sdk); err != nil {
+			if err = removeSshAgent(fs, *prevp.Agent, sdkRef.Sdk); err != nil {
 				return err
 			}
 		}
@@ -403,7 +403,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 			return err
 		}
 
-		iname := lxdbackend.InstanceName(sdkInfo.Workshop, sdkInfo.ProjectId)
+		iname := lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId)
 		inst, etag, err := conn.GetInstance(iname)
 		if err != nil {
 			return err
@@ -425,42 +425,37 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 // Remove removes profile of a given sdk.
 //
 // This method should be called after removing a sdk.
-func (b *Backend) Remove(ctx context.Context, w, profile string) error {
+func (b *Backend) Remove(ctx context.Context, sdkRef sdk.Ref) error {
 	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Disconnect()
 
-	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
-	if !ok {
-		return fmt.Errorf("context key project-id not found")
-	}
-
-	fs, err := workshopFs(conn, projectId, w)
+	fs, err := workshopFs(conn, sdkRef.ProjectId, sdkRef.Workshop)
 	if err != nil {
 		return err
 	}
 	defer fs.Close()
 
-	inst, etag, err := conn.GetInstance(lxdbackend.InstanceName(w, projectId))
+	inst, etag, err := conn.GetInstance(lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId))
 	if err != nil {
 		return err
 	}
 
-	prof, err := lxdbackend.Profile(conn, projectId, w, profile)
+	prof, err := lxdbackend.Profile(conn, sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
 	if err != nil {
 		return err
 	}
 
 	for _, dev := range prof.Mounts {
-		if err = removeMount(conn, fs, projectId, w, dev); err != nil {
+		if err = removeMount(conn, fs, sdkRef.ProjectId, sdkRef.Workshop, dev); err != nil {
 			return err
 		}
 	}
 
 	if prof.Agent != nil {
-		if err = removeSshAgent(fs, *prof.Agent, profile); err != nil {
+		if err = removeSshAgent(fs, *prof.Agent, sdkRef.Sdk); err != nil {
 			return err
 		}
 	}
@@ -472,10 +467,10 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 	}
 
 	// 1. Unassign the profile from the workshop
-	lxdname := lxdbackend.ProfileName(projectId, w, profile)
+	lxdname := lxdbackend.ProfileName(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
 	if idx := slices.Index(inst.Profiles, lxdname); idx != -1 {
 		inst.Profiles = slices.Delete(inst.Profiles, idx, idx+1)
-		op, err := conn.UpdateInstance(lxdbackend.InstanceName(w, projectId), inst.Writable(), etag)
+		op, err := conn.UpdateInstance(lxdbackend.InstanceName(sdkRef.Workshop, sdkRef.ProjectId), inst.Writable(), etag)
 		if err != nil {
 			return err
 		}
@@ -488,7 +483,7 @@ func (b *Backend) Remove(ctx context.Context, w, profile string) error {
 }
 
 // NewSpecification returns a new mount specification.
-func (b *Backend) NewSpecification(user string, pid, sdk string) (interfaces.Specification, error) {
+func (b *Backend) NewSpecification(user string, sdk string) (interfaces.Specification, error) {
 	return NewSpecification(user, sdk)
 }
 

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -86,8 +86,14 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 	}
 
 	if dev.Type == workshop.HostWorkshop {
-		s.devices[name] = map[string]string{"type": "disk", "source": dev.What,
-			"path": dev.Where, "readonly": strconv.FormatBool(dev.ReadOnly)}
+		s.devices[name] = map[string]string{
+			"type":             "disk",
+			"source":           dev.What,
+			"path":             dev.Where,
+			"user.make-source": strconv.FormatBool(dev.MakeWhat),
+			"user.make-path":   strconv.FormatBool(dev.MakeWhere),
+			"readonly":         strconv.FormatBool(dev.ReadOnly),
+		}
 	}
 
 	return nil

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -389,12 +389,12 @@ func (f *backendDeviceSuite) TestSetupSshAgent(c *check.C) {
 	c.Check(prof.Agent.Name, check.Equals, "ssh-agent")
 	c.Check(prof.Agent.Connect.Address, check.Equals, "/run/.workshop.socket")
 	c.Check(prof.Agent.Connect.Protocol, check.Equals, "unix")
-	c.Check(prof.Agent.Listen.Address, check.Equals, "/run/consumer_ssh-agent.ssh")
+	c.Check(prof.Agent.Listen.Address, check.Equals, "/run/ssh-agent.sock")
 	c.Check(prof.Agent.Listen.Protocol, check.Equals, "unix")
 	c.Check(prof.Agent.Direction, check.Equals, workshop.WorkshopToHost)
 
-	buf := f.readWorkshopFile(c, "/etc/profile.d/consumer_ssh-agent.sh")
-	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/consumer_ssh-agent.ssh\n")
+	buf := f.readWorkshopFile(c, "/etc/profile.d/workshop-ssh-agent.sh")
+	c.Check(buf, check.Equals, "export SSH_AUTH_SOCK=/run/ssh-agent.sock\n")
 
 	f.repo.DisconnectAll([]*interfaces.ConnRef{connref})
 
@@ -404,7 +404,7 @@ func (f *backendDeviceSuite) TestSetupSshAgent(c *check.C) {
 
 	fs, err := f.be.WorkshopFs(f.ctx, "test")
 	c.Assert(err, check.IsNil)
-	_, err = fs.Stat("/etc/profile.d/consumer_ssh-agent.sh")
+	_, err = fs.Stat("/etc/profile.d/workshop-ssh-agent.sh")
 	c.Assert(osutil.IsDirNotExist(err), check.Equals, true)
 }
 
@@ -468,18 +468,18 @@ func (f *backendDeviceSuite) TestSetupMultipleInterfaces(c *check.C) {
 		// Validate Filesystem
 		fs, err := f.be.WorkshopFs(f.ctx, "test")
 		c.Assert(err, check.IsNil)
-		_, err = fs.Stat("/etc/profile.d/consumer_ssh-agent.sh")
+		_, err = fs.Stat("/etc/profile.d/workshop-ssh-agent.sh")
 		c.Assert(err, check.IsNil)
-		_, err = fs.Stat("/etc/profile.d/desktop.sh")
+		_, err = fs.Stat("/etc/profile.d/workshop-desktop.sh")
 		c.Assert(err, check.IsNil)
 
 		// Disconnect and setup
 		f.repo.DisconnectAll([]*interfaces.ConnRef{sshConnRef, desktopConnRef})
 		err = b.Setup(f.ctx, cref, f.repo)
 		c.Assert(err, check.IsNil)
-		_, err = fs.Stat("/etc/profile.d/consumer_ssh-agent.sh")
+		_, err = fs.Stat("/etc/profile.d/workshop-ssh-agent.sh")
 		c.Assert(err, check.NotNil)
-		_, err = fs.Stat("/etc/profile.d/desktop.sh")
+		_, err = fs.Stat("/etc/profile.d/workshop-desktop.sh")
 		c.Assert(err, check.NotNil)
 	}
 

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -74,10 +74,11 @@ func (f *backendDeviceSuite) readWorkshopFile(c *check.C, fname string) string {
 func defaultTestDevices(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
 	cwd, _ := os.Getwd()
 	mounts := []workshop.Mount{{
-		Name:  workshop.ConfigProjectPathDevice,
-		What:  cwd,
-		Where: workshop.WorkshopProjectPath,
-		Type:  workshop.HostWorkshop,
+		Name:      workshop.ConfigProjectPathDevice,
+		What:      cwd,
+		Where:     workshop.WorkshopProjectPath,
+		MakeWhere: true,
+		Type:      workshop.HostWorkshop,
 	}}
 	return mounts, nil
 }
@@ -207,11 +208,17 @@ func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
 	c.Check(prof.Mounts["one"].Name, check.Equals, "one")
 	c.Check(prof.Mounts["one"].What, check.Equals, "/usr/local")
 	c.Check(prof.Mounts["one"].Where, check.Equals, "/opt")
+	c.Check(prof.Mounts["one"].MakeWhat, check.Equals, false)
+	c.Check(prof.Mounts["one"].MakeWhere, check.Equals, false)
 	c.Check(prof.Mounts["one"].Type, check.Equals, workshop.WorkshopWorkshop)
+	c.Check(prof.Mounts["one"].ReadOnly, check.Equals, false)
 	c.Check(prof.Mounts["two"].Name, check.Equals, "two")
 	c.Check(prof.Mounts["two"].What, check.Equals, "/home")
 	c.Check(prof.Mounts["two"].Where, check.Equals, "/mnt")
+	c.Check(prof.Mounts["two"].MakeWhat, check.Equals, false)
+	c.Check(prof.Mounts["two"].MakeWhere, check.Equals, false)
 	c.Check(prof.Mounts["two"].Type, check.Equals, workshop.WorkshopWorkshop)
+	c.Check(prof.Mounts["two"].ReadOnly, check.Equals, false)
 
 	// Check /etc/fstab and mount
 	fstab := f.readWorkshopFile(c, "/etc/fstab")
@@ -295,7 +302,10 @@ func (f *backendDeviceSuite) TestSetupHostWorkshopMounts(c *check.C) {
 	c.Check(prof.Mounts["one"].Name, check.Equals, "one")
 	c.Check(prof.Mounts["one"].What, check.Equals, filepath.Join(f.usr.HomeDir, ".local/share/workshop/id/42424242/test/mount/consumer/one"))
 	c.Check(prof.Mounts["one"].Where, check.Equals, "/opt")
+	c.Check(prof.Mounts["one"].MakeWhat, check.Equals, true)
+	c.Check(prof.Mounts["one"].MakeWhere, check.Equals, true)
 	c.Check(prof.Mounts["one"].Type, check.Equals, workshop.HostWorkshop)
+	c.Check(prof.Mounts["one"].ReadOnly, check.Equals, false)
 }
 
 func (f *backendDeviceSuite) TestSetupUpdateProfile(c *check.C) {

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -241,7 +241,7 @@ func (f *backendDeviceSuite) TestSetupWorkshopMounts(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Check the LXD profile is removed
-	err = b.Remove(f.ctx, "test", "consumer")
+	err = b.Remove(f.ctx, sdk.Ref{ProjectId: f.pid, Workshop: "test", Sdk: "consumer"})
 	c.Assert(err, check.IsNil)
 	_, err = lxdbackend.Profile(f.client, f.pid, "test", "consumer")
 	c.Assert(err, testutil.ErrorIs, workshop.ErrSdkProfileNotFound)

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -789,12 +789,7 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 		return nil, fmt.Errorf("internal error: context key %s not found", workshop.ContextUser)
 	}
 
-	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
-	if !ok {
-		return nil, fmt.Errorf("context key project-id not found")
-	}
-
-	spec, err := backend.NewSpecification(user, projectId, sdkInfo.Sdk)
+	spec, err := backend.NewSpecification(user, sdkInfo.Sdk)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -116,7 +116,7 @@ func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]str
 		}
 		if conn.Interface() == "mount" {
 			attrs := conn.Slot.DynamicAttrs()
-			if attrs != nil && attrs["host-source"] != nil {
+			if attrs["host-source"] != nil {
 				candidates[cref.ID()] = attrs["host-source"].(string)
 			}
 		}
@@ -995,11 +995,28 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 		return err
 	}
 
+	if connection.Slot.Sdk().Type != sdk.System {
+		return fmt.Errorf("source directory of connected slot %q is inside the workshop", connRef.SlotRef.ShortRef())
+	}
+
 	var oldSource string
-	if err := connection.Slot.Attr("host-source", &oldSource); err != nil {
+	var attrError *sdk.AttributeNotFoundError
+	if err := connection.Slot.Attr("host-source", &oldSource); errors.As(err, &attrError) {
+		user, ok := ctx.Value(workshop.ContextUser).(string)
+		if !ok {
+			return fmt.Errorf("internal error: context key %s not found", workshop.ContextUser)
+		}
+		usr, env, err := osutil.UserAndEnv(user)
+		if err != nil {
+			return err
+		}
+		userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
+		oldSource = workshop.SdkMountHostSource(userDataDir, plug.ProjectId, plug.Workshop, plug.Sdk, plug.Name)
+	} else if err != nil {
 		return err
 	}
 
+	oldDynamicAttrs := maps.Clone(connection.Slot.DynamicAttrs())
 	if err := connection.Slot.SetAttr("host-source", source); err != nil {
 		return err
 	}
@@ -1013,16 +1030,35 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 	}
 
 	revert.Add(func() {
-		_ = connection.Slot.SetAttr("host-source", oldSource)
 		if _, err := m.repo.Connect(connRef, connection.Plug.StaticAttrs(),
-			connection.Plug.DynamicAttrs(), connection.Slot.StaticAttrs(), connection.Slot.DynamicAttrs(), nil); err != nil {
+			connection.Plug.DynamicAttrs(), connection.Slot.StaticAttrs(), oldDynamicAttrs, nil); err != nil {
 			logger.Debugf("On doRemount: cannot reconnect %q plug on a failed remount", plug.ShortRef())
 		}
 	})
 
-	_, err = os.Stat(oldSource)
-	if osutil.IsDirNotExist(err) {
-		task.State().Warnf("cannot find source %q for %q; will attempt to recreate", oldSource, plug.ShortRef())
+	if _, err := os.Stat(oldSource); osutil.IsDirNotExist(err) {
+		if _, err := os.Stat(source); osutil.IsDirNotExist(err) {
+			username, ok := ctx.Value(workshop.ContextUser).(string)
+			if !ok {
+				return fmt.Errorf("internal error: context key %s not found", workshop.ContextUser)
+			}
+			user, err := osutil.UserLookup(username)
+			if err != nil {
+				return err
+			}
+			uid, gid, err := osutil.UidGid(user)
+			if err != nil {
+				return err
+			}
+			if err = osutil.MkdirAllChown(source, 0755, uid, gid); err != nil {
+				return err
+			}
+			task.State().Warnf("cannot find source %q for %q; created directory %q", oldSource, plug.ShortRef(), source)
+		} else if err != nil {
+			return err
+		} else {
+			task.State().Warnf("cannot find source %q for %q; using existing directory %q", oldSource, plug.ShortRef(), source)
+		}
 	} else if err != nil {
 		return err
 	} else {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -855,10 +855,8 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 				return err
 			}
 
-			ref := ref
-			backend := backend
 			rev.Add(func() {
-				if err1 := backend.Remove(ctx, ref.Workshop, ref.Sdk); err1 != nil {
+				if err1 := backend.Remove(ctx, ref); err1 != nil {
 					logger.Noticef(`On doSetupProfiles: Failed to clean up %q SDK backend setup`, ref.ShortRef())
 				}
 			})
@@ -901,7 +899,7 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 					return err
 				}
 			} else {
-				if err := backend.Remove(ctx, w, sdkRef.Sdk); err != nil {
+				if err := backend.Remove(ctx, sdkRef); err != nil {
 					return err
 				}
 			}
@@ -935,7 +933,8 @@ func (m *InterfaceManager) doRemoveProfiles(task *state.Task, tomb *tomb.Tomb) e
 	for _, backend := range m.repo.Backends() {
 		// If there are not plugs or slots declared by the SDK the profile does
 		// not neccessarily exist for the SDK.
-		if err := backend.Remove(ctx, w, s); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
+		ref := sdk.Ref{ProjectId: p.ProjectId, Workshop: w, Sdk: s}
+		if err := backend.Remove(ctx, ref); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
 			return err
 		}
 	}

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -417,7 +417,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c
 	defer s.state.Unlock()
 
 	// Validate
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target "/opt" is also mounted by.*`)
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*cannot connect "ws/conflict-[12]:plug" without binding to "ws/conflict-[12]:plug": unbound plugs cannot share target "/opt".*`)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectBindResolvesMountConflicts(c *check.C) {

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -333,7 +333,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 	// One of the SDKs setup fails, we need to make sure that any partial
 	// progress will be aborted (i.e. previously created profiles for other SDKs
 	// will be removed).
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		if n > 0 {
 			return errors.New("cannot finish backend setup")
 		}
@@ -659,8 +659,8 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 
 	c.Assert(oldSource, testutil.FileAbsent)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
-	c.Assert(s.secBackend.SetupCalls[0].SdkInfo.Sdk, check.Equals, "consumer")
-	c.Assert(s.secBackend.SetupCalls[0].SdkInfo.Workshop, check.Equals, "ws-consumer")
+	c.Assert(s.secBackend.SetupCalls[0].SdkRef.Sdk, check.Equals, "consumer")
+	c.Assert(s.secBackend.SetupCalls[0].SdkRef.Workshop, check.Equals, "ws-consumer")
 
 	// ensure the global conns state was updated correctly
 	conns, err := ifacestate.GetConns(s.state)
@@ -789,7 +789,7 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	s.launchRemountWorkshop(c, oldSource)
 	change := s.newRemountChange(newSource)
 
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		return errors.New("cannot setup LXD profile")
 	}
 	defer func() { s.secBackend.SetupCallback = nil }()
@@ -1479,7 +1479,7 @@ func (s *interfaceHandlersSuite) TestConnectDisconnectsIfBackedSetupFailed(c *ch
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
 
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		return errors.New("cannot finish backend setup")
 	}
 	defer func() { s.secBackend.SetupCallback = nil }()
@@ -1517,7 +1517,7 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	tsk.Set("delayed-setup-profile", false)
 	s.state.Unlock()
 
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		conns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
 		c.Check(err, check.IsNil)
 		conn, err := repo.Connection(conns[0])
@@ -1847,7 +1847,7 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Force the disconnect to fail
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		return fmt.Errorf("setup failed")
 	}
 
@@ -1922,7 +1922,7 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailureAuto(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Force the disconnect to fail
-	s.secBackend.SetupCallback = func(context context.Context, sdkInfo sdk.Ref, repo *interfaces.Repository) error {
+	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		return fmt.Errorf("setup failed")
 	}
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -27,9 +27,11 @@ import (
 type interfaceHandlersSuite struct {
 	interfaceManagerSuite
 	mgr                      *ifacestate.InterfaceManager
+	user                     *user.User
 	restoreSimple            func()
 	restoreDeny              func()
 	restoreSecurtityBackends func()
+	restoreUserEnv           func()
 	restoreUserLookup        func()
 }
 
@@ -123,8 +125,22 @@ func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 	err := s.o.StartUp()
 	c.Assert(err, check.IsNil)
 
+	// Real UID and GID are required to create source directories on remount.
+	// TODO: make filesystem operations more secure (e.g. drop privileges if possible) and easy to test.
+	actual, err := user.Current()
+	c.Assert(err, check.IsNil)
+	s.user = &user.User{Username: "testuser", HomeDir: c.MkDir(), Uid: actual.Uid, Gid: actual.Gid}
+	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
+		if name != "testuser" {
+			return nil, nil, user.UnknownUserError("not found")
+		}
+		return s.user, nil, nil
+	})
 	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
-		return &user.User{HomeDir: c.MkDir()}, nil
+		if name != "testuser" {
+			return nil, user.UnknownUserError("not found")
+		}
+		return s.user, nil
 	})
 }
 
@@ -132,6 +148,7 @@ func (s *interfaceHandlersSuite) TearDownTest(c *check.C) {
 	s.restoreSimple()
 	s.restoreDeny()
 	s.restoreSecurtityBackends()
+	s.restoreUserEnv()
 	s.restoreUserLookup()
 }
 
@@ -569,13 +586,17 @@ slots:
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, systemYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
+	dynamic := map[string]interface{}{}
+	if source != "" {
+		dynamic["host-source"] = source
+	}
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
 		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount": map[string]interface{}{
 			"interface":    "mount",
 			"auto":         true,
 			"plug-static":  map[string]interface{}{"workshop-target": "/opt"},
-			"slot-dynamic": map[string]interface{}{"host-source": source},
+			"slot-dynamic": dynamic,
 		},
 	})
 	_, err = ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws-consumer", "consumer")
@@ -810,7 +831,6 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 
 	connection, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
-	c.Assert(err, check.IsNil)
 	var src string
 	c.Assert(connection.Slot.Attr("host-source", &src), check.IsNil)
 	c.Assert(src, check.Equals, oldSource)
@@ -823,9 +843,8 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 
 func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C) {
 	// Setup
-	oldSource := "/does/not/exist"
 	newSource := c.MkDir()
-	s.launchRemountWorkshop(c, oldSource)
+	s.launchRemountWorkshop(c, "")
 	change := s.newRemountChange(newSource)
 
 	// Execute
@@ -838,7 +857,40 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C)
 
 	warnings := s.state.AllWarnings()
 	c.Check(warnings, check.HasLen, 1)
-	c.Check(warnings[0].String(), check.Equals, `cannot find source "/does/not/exist" for "ws-consumer/consumer:plug"; will attempt to recreate`)
+	c.Check(warnings[0].String(), check.Matches, `cannot find source ".*/id/42424242/ws-consumer/mount/consumer/plug" for "ws-consumer/consumer:plug"; using existing directory ".*"`)
+
+	repo := s.mgr.Repository()
+	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	connection, err := repo.Connection(ref[0])
+	c.Assert(err, check.IsNil)
+	var src string
+	c.Assert(connection.Slot.Attr("host-source", &src), check.IsNil)
+	c.Assert(src, check.Equals, newSource)
+
+	c.Assert(newSource, testutil.FilePresent)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
+}
+
+func (s *interfaceHandlersSuite) TestRemountWorksIfNeitherSourceExists(c *check.C) {
+	// Setup
+	newSource := filepath.Join(c.MkDir(), "new")
+	s.launchRemountWorkshop(c, "")
+	change := s.newRemountChange(newSource)
+
+	// Execute
+	s.settle(c)
+
+	// Validate
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(change.Status(), check.Equals, state.DoneStatus)
+
+	warnings := s.state.AllWarnings()
+	c.Check(warnings, check.HasLen, 1)
+	c.Check(warnings[0].String(), check.Matches, `cannot find source ".*/id/42424242/ws-consumer/mount/consumer/plug" for "ws-consumer/consumer:plug"; created directory ".*"`)
 
 	repo := s.mgr.Repository()
 	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
@@ -947,6 +999,33 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	c.Assert(attrs, check.HasLen, 1)
 	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount"],
 		check.DeepEquals, source)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
+}
+
+func (s *interfaceHandlersSuite) TestAutoDisconnectIgnoresAutoConnections(c *check.C) {
+	// Setup
+	// Create an already installed workshop with an auto-connected mount plug
+	s.launchRemountWorkshop(c, "")
+
+	// Execute
+	s.state.Lock()
+	chg := s.newDisconnectInterfacesChange("consumer")
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	var stateConns map[string]interface{}
+	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
+	c.Assert(stateConns, check.HasLen, 0)
+
+	var attrs map[string]interface{}
+	c.Assert(chg.Get("remounts", &attrs), check.NotNil)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -472,9 +472,9 @@ func (m *InterfaceManager) checkConflictingMounts(w *workshop.Workshop) error {
 			return target == candidateTarget
 		})
 		if idx >= 0 {
-			return fmt.Errorf(`cannot connect %q: target %q is also mounted by %q`,
-				plug.Ref().ShortRef(), candidateTarget,
-				plugs[idx].Ref().ShortRef())
+			return fmt.Errorf(`cannot connect %q without binding to %q: unbound plugs cannot share target %q`,
+				plug.Ref().ShortRef(), plugs[idx].Ref().ShortRef(),
+				candidateTarget)
 		}
 	}
 	return nil

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -164,7 +164,7 @@ func (m *SdkManager) mountSdk(ctx context.Context, user string, project *worksho
 	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
 	what := workshop.LocalSdkRevision(userDataDir, project.ProjectId, w, sdkSetup.Name, sdkSetup.Revision)
 
-	mnt := workshop.Mount{Name: name, What: what, Where: sdkPath, Type: workshop.HostWorkshop, ReadOnly: true}
+	mnt := workshop.Mount{Name: name, What: what, Where: sdkPath, MakeWhere: true, Type: workshop.HostWorkshop, ReadOnly: true}
 	return m.backend.AddWorkshopMount(ctx, w, mnt)
 }
 

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -218,10 +218,11 @@ func (m *WorkshopManager) doMountProject(task *state.Task, tomb *tomb.Tomb) erro
 
 	// Configure workshop core properties: project directory
 	var prjMount = workshop.Mount{
-		Name:  workshop.ConfigProjectPathDevice,
-		What:  prj.Path,
-		Where: workshop.WorkshopProjectPath,
-		Type:  workshop.HostWorkshop,
+		Name:      workshop.ConfigProjectPathDevice,
+		What:      prj.Path,
+		Where:     workshop.WorkshopProjectPath,
+		MakeWhere: true,
+		Type:      workshop.HostWorkshop,
 	}
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()

--- a/internal/revert/revert.go
+++ b/internal/revert/revert.go
@@ -19,6 +19,15 @@ func (r *Reverter) Add(f Hook) {
 	r.revertFuncs = append(r.revertFuncs, f)
 }
 
+// AddAll steals every revert function from another Reverter.
+func (r *Reverter) AddAll(other *Reverter) {
+	if other == nil {
+		return
+	}
+	r.revertFuncs = append(r.revertFuncs, other.revertFuncs...)
+	other.Success()
+}
+
 // Fail runs any revert functions in the reverse order they were added.
 // Should be used with defer or when a task has encountered an error and needs to be reverted.
 func (r *Reverter) Fail() {

--- a/internal/revert/revert.go
+++ b/internal/revert/revert.go
@@ -19,15 +19,6 @@ func (r *Reverter) Add(f Hook) {
 	r.revertFuncs = append(r.revertFuncs, f)
 }
 
-// AddAll steals every revert function from another Reverter.
-func (r *Reverter) AddAll(other *Reverter) {
-	if other == nil {
-		return
-	}
-	r.revertFuncs = append(r.revertFuncs, other.revertFuncs...)
-	other.Success()
-}
-
 // Fail runs any revert functions in the reverse order they were added.
 // Should be used with defer or when a task has encountered an error and needs to be reverted.
 func (r *Reverter) Fail() {
@@ -54,3 +45,12 @@ func (r *Reverter) Clone() *Reverter {
 
 	return rNew
 }
+
+// Copy adds the revert functions of the source reverter to the target reverter.
+func Copy(target, source *Reverter) {
+	if source == nil {
+		return
+	}
+	target.revertFuncs = append(target.revertFuncs, source.revertFuncs...)
+}
+

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -48,11 +48,13 @@ type Camera struct {
 }
 
 type Mount struct {
-	Name     string    `json:"name"`
-	What     string    `json:"what"`
-	Where    string    `json:"where"`
-	Type     MountType `json:"type"`
-	ReadOnly bool      `json:"readonly"`
+	Name      string    `json:"name"`
+	What      string    `json:"what"`
+	Where     string    `json:"where"`
+	MakeWhat  bool      `json:"make-what,omitempty"`
+	MakeWhere bool      `json:"make-where,omitempty"`
+	Type      MountType `json:"type"`
+	ReadOnly  bool      `json:"readonly"`
 }
 
 type Tunnel struct {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -258,8 +258,10 @@ func (f *FakeWorkshopBackend) AddWorkshopMount(ctx context.Context, name string,
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(mnt), 0755); err != nil {
-		return err
+	if mount.MakeWhere {
+		if err := os.MkdirAll(filepath.Dir(mnt), 0755); err != nil {
+			return err
+		}
 	}
 
 	if err := os.Symlink(mount.What, mnt); err != nil {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -675,7 +675,7 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, 
 	defer fs.Close()
 
 	// Remove project mount
-	if err := fs.Remove(workshop.WorkshopProjectPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := fs.RemoveIfExists(workshop.WorkshopProjectPath); err != nil {
 		return err
 	}
 
@@ -724,6 +724,13 @@ func NewWorkshopFs(baseDir string) (*FakeInstanceFs, error) {
 	}
 	fs.Fs = afero.NewBasePathFs(osfs, wfspath)
 	return &fs, nil
+}
+
+func (w *FakeInstanceFs) RemoveIfExists(name string) error {
+	if err := w.Remove(name); !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 func (w *FakeInstanceFs) Symlink(source, target string) error {

--- a/internal/workshop/lxd/export_test.go
+++ b/internal/workshop/lxd/export_test.go
@@ -5,7 +5,6 @@ var (
 	ReadProjects       = readProjects
 	SaveProjects       = saveProjects
 	HandleLaunchUpdate = handleLaunchUpdate
-	LxdToSdkProfile    = lxdToSdkProfile
 )
 
 func MockNvidiaRuntime(f func() (bool, error)) func() {

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -30,19 +30,27 @@ func DeviceTypeConfigKey(name string) string {
 }
 
 func Profile(conn lxd.InstanceServer, pid, wp, profile string) (workshop.SdkProfile, error) {
-	name := ProfileName(pid, wp, profile)
-	lxdp, _, err := conn.GetProfile(name)
+	lxdp, _, err := LxdProfile(conn, pid, wp, profile)
 	if err != nil {
-		if api.StatusErrorCheck(err, http.StatusNotFound) {
-			return workshop.SdkProfile{}, workshop.ErrSdkProfileNotFound
-		}
-		return workshop.SdkProfile{}, fmt.Errorf("cannot load %q profile (%w)", profile, err)
+		return workshop.SdkProfile{}, err
 	}
 
-	return lxdToSdkProfile(profile, lxdp.Devices, lxdp.Config)
+	return LxdToSdkProfile(profile, lxdp.Devices, lxdp.Config)
 }
 
-func lxdToSdkProfile(profile string, devs map[string]map[string]string, config map[string]string) (workshop.SdkProfile, error) {
+func LxdProfile(conn lxd.InstanceServer, pid, wp, profile string) (*api.Profile, string, error) {
+	name := ProfileName(pid, wp, profile)
+	lxdp, etag, err := conn.GetProfile(name)
+	if err != nil {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return nil, "", workshop.ErrSdkProfileNotFound
+		}
+		return nil, "", fmt.Errorf("cannot load %q profile (%w)", profile, err)
+	}
+	return lxdp, etag, nil
+}
+
+func LxdToSdkProfile(profile string, devs map[string]map[string]string, config map[string]string) (workshop.SdkProfile, error) {
 	var pr = workshop.NewSdkProfile(profile)
 	for devname, dev := range devs {
 		name := strings.TrimPrefix(devname, DeviceName(profile, ""))

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	lxd "github.com/canonical/lxd/client"
@@ -57,7 +58,27 @@ func LxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 
 		switch dev["type"] {
 		case "disk":
-			pr.Mounts[name] = workshop.Mount{Name: name, What: dev["source"], Where: dev["path"], Type: workshop.HostWorkshop}
+			makeWhat, err := boolFromString(dev["user.make-source"])
+			if err != nil {
+				return pr, err
+			}
+			makeWhere, err := boolFromString(dev["user.make-path"])
+			if err != nil {
+				return pr, err
+			}
+			readOnly, err := boolFromString(dev["readonly"])
+			if err != nil {
+				return pr, err
+			}
+			pr.Mounts[name] = workshop.Mount{
+				Name:      name,
+				What:      dev["source"],
+				Where:     dev["path"],
+				MakeWhat:  makeWhat,
+				MakeWhere: makeWhere,
+				Type:      workshop.HostWorkshop,
+				ReadOnly:  readOnly,
+			}
 		case "gpu":
 			pr.Gpu = &workshop.Gpu{Name: name}
 		case "proxy":
@@ -132,6 +153,13 @@ func LxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 		}
 	}
 	return pr, nil
+}
+
+func boolFromString(s string) (bool, error) {
+	if s == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(s)
 }
 
 // Constructs a ProxyEntry from an LXD device entry

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -27,10 +27,11 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 			Sdk: "sdk",
 			Mounts: map[string]workshop.Mount{
 				"userdisk": {
-					Name:  "userdisk",
-					What:  "/home",
-					Where: "/opt",
-					Type:  workshop.HostWorkshop}},
+					Name:      "userdisk",
+					What:      "/home",
+					Where:     "/opt",
+					MakeWhere: true,
+					Type:      workshop.HostWorkshop}},
 		}, {
 			Sdk:    "sdk",
 			Mounts: map[string]workshop.Mount{},
@@ -124,9 +125,11 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 			"sdk",
 			map[string]map[string]string{
 				"sdk_userdisk": {
-					"type":   "disk",
-					"source": "/home",
-					"path":   "/opt"}},
+					"type":             "disk",
+					"source":           "/home",
+					"path":             "/opt",
+					"user.make-source": "false",
+					"user.make-path":   "true"}},
 			map[string]string{},
 		}, {
 			"sdk",

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -370,10 +370,11 @@ func (s *Backend) updateProjectMounts(conn lxd.InstanceServer, ctx context.Conte
 
 	for _, i := range workshops {
 		mount := workshop.Mount{
-			Name:  workshop.ConfigProjectPathDevice,
-			What:  project.Path,
-			Where: workshop.WorkshopProjectPath,
-			Type:  workshop.HostWorkshop,
+			Name:      workshop.ConfigProjectPathDevice,
+			What:      project.Path,
+			Where:     workshop.WorkshopProjectPath,
+			MakeWhere: true,
+			Type:      workshop.HostWorkshop,
 		}
 		err = s.AddWorkshopMount(projectCtx, workshop.WorkshopName(i.Name), mount)
 		if err != nil {

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -43,10 +43,11 @@ var _ = check.Suite(&wsExec{})
 
 func execTestDevices(projectDir string) func(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
 	mounts := []workshop.Mount{{
-		Name:  workshop.ConfigProjectPathDevice,
-		What:  projectDir,
-		Where: workshop.WorkshopProjectPath,
-		Type:  workshop.HostWorkshop,
+		Name:      workshop.ConfigProjectPathDevice,
+		What:      projectDir,
+		Where:     workshop.WorkshopProjectPath,
+		MakeWhere: true,
+		Type:      workshop.HostWorkshop,
 	}}
 	return func(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry) {
 		return mounts, nil

--- a/internal/workshop/workshop_fs.go
+++ b/internal/workshop/workshop_fs.go
@@ -1,6 +1,7 @@
 package workshop
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 type WorkshopFs interface {
 	afero.Fs
+	RemoveIfExists(name string) error
 	Symlink(old, new string) error
 	ReadLink(p string) (string, error)
 	Close()
@@ -32,8 +34,19 @@ type InstanceFs struct {
 	client *sftp.Client
 }
 
+func (w *InstanceFs) RemoveIfExists(name string) error {
+	if err := w.Remove(name); !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
 func (w *InstanceFs) RemoveAll(path string) error {
-	return w.client.RemoveAll(path)
+	// The os and afero packages ignore ErrNotExist in RemoveAll, but sftp doesn't.
+	if err := w.client.RemoveAll(path); !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 func (w *InstanceFs) Rename(oldname, newname string) error {

--- a/tests/main/interface-tunnel/task.yaml
+++ b/tests/main/interface-tunnel/task.yaml
@@ -46,15 +46,7 @@ execute: |
 
   echo "Check that plugs cannot bind to same address"
   (! workshop_exec connect ws-tunnel/test-sdk-tunnel:conflict :unused) | MATCH 'listen tcp 127.0.0.1:5432: bind: address already in use'
-  # FIXME: device is still in LXD profile; reconnect to enable disconnect (which removes the profile)
-  if workshop_exec connect ws-tunnel/test-sdk-tunnel:conflict :unused; then
-    workshop_exec disconnect ws-tunnel/test-sdk-tunnel:conflict
-  fi
   (! workshop_exec connect ws-tunnel/system:conflict ws-tunnel/test-sdk-tunnel:unused) | MATCH 'listen tcp 0.0.0.0:8000: bind: address already in use'
-  # FIXME: device is still in LXD profile; reconnect to enable disconnect (which removes the profile)
-  if workshop_exec connect ws-tunnel/system:conflict ws-tunnel/test-sdk-tunnel:unused; then
-    workshop_exec disconnect ws-tunnel/system:conflict
-  fi
 
   echo "Check that unix sockets have correct permissions"
   usermod --append --groups ubuntu --gid games ubuntu

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -42,23 +42,26 @@ execute: |
   workshop_exec stop
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path"
   workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$otherfs_path"
+  workshop_exec remount ws-remount/test-sdk-mount:two "$new_source"
+  workshop_exec start
 
   echo "Remount: old source removed"
   workshop_exec remount ws-remount/test-sdk-mount:two "${new_source}.1"
   rmdir "${new_source}.1"
   workshop_exec remount ws-remount/test-sdk-mount:two "${new_source}.2" | MATCH "^WARNING: There is 1 new warning. See 'workshop warnings'.$"
   rmdir "${new_source}.2"
+  mkdir "$new_source"
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source" | MATCH "^WARNING: There are 2 new warnings. See 'workshop warnings'.$"
   workshop_exec list | MATCH "^WARNING: There are 2 new warnings. See 'workshop warnings'.$"
   workshop_exec warnings |
     tr -d '\n' | # remove newlines
     sed -e 's,\s\+, ,g' | # rename any extra spaces
-    MATCH 'cannot find source "/home/ubuntu/two\.1" for "ws-remount/test-sdk-mount:two"; will attempt to recreate'
+    MATCH 'cannot find source "/home/ubuntu/two\.1" for "ws-remount/test-sdk-mount:two"; created directory "/home/ubuntu/two\.2"'
   workshop_exec list | NOMATCH "new warning"
   workshop_exec warnings |
     tr -d '\n' | # remove newlines
     sed -e 's,\s\+, ,g' | # rename any extra spaces
-    MATCH 'cannot find source "/home/ubuntu/two\.2" for "ws-remount/test-sdk-mount:two"; will attempt to recreate'
+    MATCH 'cannot find source "/home/ubuntu/two\.2" for "ws-remount/test-sdk-mount:two"; using existing directory "/home/ubuntu/two"'
   workshop_exec okay
   workshop_exec warnings | MATCH '^No further warnings.$'
 


### PR DESCRIPTION
# Description

Works around the LXD issue where updating a profile takes effect even if an error occurs. In this case, we roll back the profile update. Other changes to the workshop (e.g. creating scripts in `/etc/profile.d`) are also rolled back if an error occurs later on.

Since it's now harder to get into an invalid state, we can be a bit more relaxed about creating directories before setting up a mount interface connection. I don't think the effects of this change are visible in practice though.

Disconnecting desktop and ssh-agent interfaces is now more relaxed, and no error occurs when removing a file which has already been deleted. On the other hand, if such files already exist when connecting the interface, an error occurs. This prevents connecting more than one plug of these types, which I think is what we want anyway.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
