### PR TITLE
Fix plug binding issues

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -34,14 +34,8 @@ type Endpoint struct {
 
 type Tunnel struct {
 	Plug PlugRef  `json:"plug"`
-	Slot SlotRef  `json:"slot"`
 	From Endpoint `json:"from"`
 	To   Endpoint `json:"to"`
-}
-
-type TunnelInfo struct {
-	Plugs []*Tunnel `json:"plugs"`
-	Slots []*Tunnel `json:"slots"`
 }
 
 type Sdk struct {
@@ -54,7 +48,7 @@ type Sdk struct {
 	InstallTime time.Time    `json:"install-time"`
 	Health      *HealthCheck `json:"health-check,omitempty"`
 	Mounts      []*Mount     `json:"mounts,omitempty"`
-	Tunnels     *TunnelInfo  `json:"tunnels,omitempty"`
+	Tunnels     []*Tunnel    `json:"tunnels,omitempty"`
 }
 
 type Workshops struct {

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -194,12 +194,12 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 				}
 			}
 
-			if sk.Tunnels != nil && len(sk.Tunnels.Plugs) > 0 {
+			if len(sk.Tunnels) > 0 {
 				fmt.Fprintf(w, "    tunnels:\n")
-				slices.SortFunc(sk.Tunnels.Plugs, func(a, b *client.Tunnel) int {
+				slices.SortFunc(sk.Tunnels, func(a, b *client.Tunnel) int {
 					return cmp.Compare(a.Plug.Name, b.Plug.Name)
 				})
-				for _, tunnel := range sk.Tunnels.Plugs {
+				for _, tunnel := range sk.Tunnels {
 					fmt.Fprintf(w, "      %s:\n", tunnel.Plug.Name)
 					fmt.Fprintf(w, "        from:\t%s\n", formatEndpoint(tunnel.From))
 					fmt.Fprintf(w, "        to:\t%s\n", formatEndpoint(tunnel.To))

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -285,58 +285,25 @@ var mockWorkshopWithTunnels = `{
       {
         "name": "system",
         "revision": "1",
-        "tunnels": {
-          "plugs": [
-            {
-              "plug": {
-                "project-id": "42ws42ws",
-                "workshop": "ws",
-                "sdk": "system",
-                "plug": "gopls"
-              },
-              "slot": {
-                "project-id": "42ws42ws",
-                "workshop": "ws",
-                "sdk": "go",
-                "slot": "gopls"
-              },
-              "from": {
-                "protocol": "tcp",
-                "host": "127.0.0.1",
-                "port": 60915
-              },
-              "to": {
-                "protocol": "unix",
-                "path": "/run/user/%s/gopls.socket"
-              }
+        "tunnels": [
+          {
+            "plug": {
+              "project-id": "42ws42ws",
+              "workshop": "ws",
+              "sdk": "system",
+              "plug": "gopls"
+            },
+            "from": {
+              "protocol": "tcp",
+              "host": "127.0.0.1",
+              "port": 60915
+            },
+            "to": {
+              "protocol": "unix",
+              "path": "/run/user/%s/gopls.socket"
             }
-          ],
-          "slots": [
-            {
-              "plug": {
-                "project-id": "42ws42ws",
-                "workshop": "ws",
-                "sdk": "go",
-                "plug": "snap-cache"
-              },
-              "slot": {
-                "project-id": "42ws42ws",
-                "workshop": "ws",
-                "sdk": "system",
-                "slot": "snap-cache"
-              },
-              "from": {
-                "protocol": "tcp",
-                "host": "0.0.0.0",
-                "port": 12345
-              },
-              "to": {
-                "protocol": "unix",
-                "path": "/run/snap-proxy.socket"
-              }
-            }
-          ]
-        }
+          }
+        ]
       },
       {
         "name": "go",
@@ -345,58 +312,25 @@ var mockWorkshopWithTunnels = `{
         "revision": "1",
         "build-time": "2017-02-19T17:23:05.592623Z",
         "install-time": "2017-03-22T09:01:00.0Z",
-        "tunnels": {
-          "plugs": [
-            {
-              "plug": {
-                "project-id": "42ws42ws",
-                "workshop": "ws",
-                "sdk": "go",
-                "plug": "snap-cache"
-              },
-              "slot": {
-                "project-id": "42ws42ws",
-                "workshop": "ws",
-                "sdk": "system",
-                "slot": "snap-cache"
-              },
-              "from": {
-                "protocol": "tcp",
-                "host": "0.0.0.0",
-                "port": 12345
-              },
-              "to": {
-                "protocol": "unix",
-                "path": "/run/snap-proxy.socket"
-              }
+        "tunnels": [
+          {
+            "plug": {
+              "project-id": "42ws42ws",
+              "workshop": "ws",
+              "sdk": "go",
+              "plug": "snap-cache"
+            },
+            "from": {
+              "protocol": "tcp",
+              "host": "0.0.0.0",
+              "port": 12345
+            },
+            "to": {
+              "protocol": "unix",
+              "path": "/run/snap-proxy.socket"
             }
-          ],
-          "slots": [
-            {
-              "plug": {
-                "project-id": "42ws42ws",
-                "workshop": "ws",
-                "sdk": "system",
-                "plug": "gopls"
-              },
-              "slot": {
-                "project-id": "42ws42ws",
-                "workshop": "ws",
-                "sdk": "go",
-                "slot": "gopls"
-              },
-              "from": {
-                "protocol": "tcp",
-                "host": "127.0.0.1",
-                "port": 60915
-              },
-              "to": {
-                "protocol": "unix",
-                "path": "/run/user/%s/gopls.socket"
-              }
-            }
-          ]
-        }
+          }
+        ]
       }
     ]
   }

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -139,8 +139,8 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 			w := workshopName(av[0])
 			return fmt.Errorf(`cannot complete launch for %q, execution is paused
 
-To proceed, resolve the issue and run 'workshop refresh --continue %s'
-To cancel and undo: 'workshop refresh --abort %s'
+To proceed, resolve the issue and run 'workshop launch --continue %s'
+To cancel and undo: 'workshop launch --abort %s'
 To view more information: 'workshop tasks %s'`, w, w, w, changeId)
 		}
 		return fmt.Errorf("%v\n%s launch aborted", err, strutil.Quoted(av))

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -88,8 +88,8 @@ func (m *workshopLaunch) TestLaunchWaitOnErrorFailed(c *check.C) {
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, "cannot complete launch for \"ws\", execution is paused\n\n"+
-		"To proceed, resolve the issue and run 'workshop refresh --continue ws'\n"+
-		"To cancel and undo: 'workshop refresh --abort ws'\n"+
+		"To proceed, resolve the issue and run 'workshop launch --continue ws'\n"+
+		"To cancel and undo: 'workshop launch --abort ws'\n"+
 		"To view more information: 'workshop tasks 42'")
 }
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -52,8 +52,8 @@ Notes:
 - The 'sketch' SDK doesn't appear in the workshop definition
   and cannot include build-time data such as parts.
 
-- In addition to hooks, the 'sketch' SDK can use interfaces,
-  define plugs, slots, connections and bindings.
+- In addition to hooks, the 'sketch' SDK can use interfaces
+  by defining plugs and slots.
 `,
 		Example: `
 Edit the sketch SDK definition for the 'nimble' workshop

--- a/docs/explanation/interfaces/concepts.rst
+++ b/docs/explanation/interfaces/concepts.rst
@@ -148,71 +148,73 @@ or simply use a singleton-like interface (:samp:`gpu` is a good example).
 
 
 As an example,
-imagine two SDKs, :samp:`pytorch` and :samp:`tensorflow`,
-that store their training data in the workshop under
-:file:`~/.cache/torchvision/datasets/` and :file:`~/.keras/datasets/`,
-respectively.
+imagine two SDKs, :samp:`torchaudio` and :samp:`torchvision`,
+that both store data in the workshop under
+:file:`~/.cache/torch/hub/`.
 The data should be persisted,
-so each SDK has a corresponding mount interface plug, :samp:`datasets`.
+so each SDK has a corresponding mount interface plug, :samp:`hub`.
 
-Now, what if our workshop includes both SDKs;
-can we leverage bindings to reuse the data?
-Here, the :samp:`datasets` plug of the :samp:`pytorch` SDK
-is bound to the :samp:`datasets` plug under :samp:`tensorflow`:
+If our workshop includes both SDKs,
+a conflict arises
+because |ws_markup| doesn't know which directory it should mount
+at the target location.
+Bindings resolve this ambiguity.
+Here, the :samp:`hub` plug of the :samp:`torchvision` SDK
+is bound to the :samp:`hub` plug under :samp:`torchaudio`:
 
 .. code-block:: yaml
    :caption: .workshop/digits.yaml
-   :emphasize-lines: 8
+   :emphasize-lines: 10
 
    name: digits
    base: ubuntu@22.04
    sdks:
-     - name: pytorch
+     - name: torchaudio
+       channel: latest/stable
+     - name: torchvision
        channel: latest/stable
        plugs:
-         datasets:
-           bind: tensorflow:datasets
-     - name: tensorflow
-       channel: latest/stable
+         hub:
+           bind: torchaudio:hub
 
 
-This binds :samp:`pytorch:datasets`
-to the location of :samp:`tensorflow:datasets`;
+This binds :samp:`torchvision:hub`
+to the location of :samp:`torchaudio:hub`;
 you benefit from sharing the data between the two frameworks,
 while simultaneously persisting it on the host.
 
 Any actions on the plug thus bound affect all its bindings.
-Here, if you remount :samp:`pytorch:datasets`,
-the :samp:`tensorflow:datasets` plug is also remounted
+Here, if you remount :samp:`torchaudio:hub`,
+the :samp:`torchvision:hub` plug is also remounted
 because they reference the same entity:
 
 .. @artefact workshop info
 
 .. code-block:: console
 
-   $ workshop remount digits/pytorch:datasets /new-mount/
+   $ mkdir -p .cache/hub
+   $ workshop remount digits/torchaudio:hub .cache/hub
    $ workshop info digits
 
      ...
      sdks:
-       pytorch:
+       system:
+         installed:  (1)
+       torchaudio:
          tracking:   latest/stable
          installed:  2.5.1  2024-11-02  (42)
          mounts:
-           datasets:
-             host-source:      /new-mount
-             workshop-target:  /home/workshop/.cache/torchvision/datasets
-       tensorflow:
+           hub:
+             host-source:      /home/user/digits/.cache/hub
+             workshop-target:  /home/workshop/.cache/torch/hub
+       torchvision:
          tracking:   latest/stable
          installed:  2.18.0  2024-10-27  (37)
          mounts:
-           data:
-             host-source:      /new-mount
-             workshop-target:  /home/workshop/.keras/datasets
+           hub:
+             host-source:      /home/user/digits/.cache/hub
+             workshop-target:  /home/workshop/.cache/torch/hub
 
-
-This avoids the need to reconfigure each mount manually,
-reducing the potential for mistakes.
 
 When you run :command:`workshop connections`,
 a bound plug will have :samp:`bind` listed under :samp:`Notes`,
@@ -224,13 +226,13 @@ along with the line number of the target plug:
 
    $ workshop connections digits
 
-     Interface  Plug                        Slot                 Notes
-     mount      digits/pytorch:datasets     digits/system:mount  bind.2
-     mount      digits/tensorflow:datasets  digits/system:mount  bind.2
+     Interface  Plug                    Slot                 Notes
+     mount      digits/torchaudio:hub   digits/system:mount  bind.1
+     mount      digits/torchvision:hub  digits/system:mount  bind.1
 
 
-Here, both plugs are listed as :samp:`bind.2`,
-pointing to :samp:`tensorflow:datasets` in the second line.
+Here, both plugs are listed as :samp:`bind.1`,
+pointing to :samp:`torchaudio:hub` in the first line.
 
 .. _exp_interfaces_cli_operations:
 

--- a/docs/reference/cli/workshop-sketch-sdk.rst
+++ b/docs/reference/cli/workshop-sketch-sdk.rst
@@ -33,8 +33,8 @@ Notes:
 - The 'sketch' SDK doesn't appear in the workshop definition
   and cannot include build-time data such as parts.
 
-- In addition to hooks, the 'sketch' SDK can use interfaces,
-  define plugs, slots, connections and bindings.
+- In addition to hooks, the 'sketch' SDK can use interfaces
+  by defining plugs and slots.
 
 
 .. rubric:: Examples

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -78,7 +78,7 @@ and includes a number of mandatory and optional keys:
        a :samp:`plug` and a :samp:`slot` from the SDKs listed under :samp:`sdks`
        (the system SDK is always implicitly included).
        Both must be strings that reference a plug and a slot
-       with the same interface in different SDKs,
+       with the same interface,
        using the :samp:`<SDK>:<PLUG>` format.
 
    * - :samp:`scripts`
@@ -135,7 +135,7 @@ Each SDK is described with the following keys:
 
        - A plug binding must name an existing plug in the SDK
          and set a single :samp:`bind` attribute
-         that references a plug of the same interface in a different SDK
+         that references a different plug of the same interface
          using the :samp:`<SDK>:<PLUG>` format.
 
        - A plug definition must specify the :samp:`interface`

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -82,7 +82,7 @@ func (s *apiSuite) workshopFile(ws string, sdks []*sdk.Info) *workshop.File {
 		file.Sdks = append(file.Sdks, workshop.SdkRecord{
 			Name:    s.Name,
 			Channel: "latest/stable",
-			Plugs:   make(map[string]workshop.Plug),
+			Plugs:   make(map[string]workshop.PlugOrBind),
 		})
 	}
 	return file
@@ -1122,8 +1122,8 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 
 	wp, err := s.b.Workshop(s.ctx, "consumer-ws")
 	c.Check(err, check.IsNil)
-	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug2"] = workshop.Plug{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}}
+	wp.File.Sdks[0].Plugs = make(map[string]workshop.PlugOrBind)
+	wp.File.Sdks[0].Plugs["plug2"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}}
 
 	d.Overlord().Loop()
 	defer d.Overlord().Stop()
@@ -1505,7 +1505,7 @@ func (s *apiSuite) TestConnectWarnOnExec(c *check.C) {
 type disconnectOpts struct {
 	auto   bool
 	forget bool
-	bind   map[string]workshop.Plug
+	bind   map[string]workshop.PlugOrBind
 }
 
 func (s *apiSuite) connect(c *check.C, plug string) *interfaces.ConnRef {
@@ -1623,7 +1623,7 @@ func (s *apiSuite) TestDisconnectPlugForgetSuccess(c *check.C) {
 
 func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 	opts := &disconnectOpts{
-		bind: map[string]workshop.Plug{
+		bind: map[string]workshop.PlugOrBind{
 			"plug2": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}
@@ -1637,7 +1637,7 @@ func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 
 func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
 	opts := &disconnectOpts{
-		bind: map[string]workshop.Plug{
+		bind: map[string]workshop.PlugOrBind{
 			"plug2": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}
@@ -1651,7 +1651,7 @@ func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
 
 func (s *apiSuite) TestDisconnectBoundPlugSlaveSuccess(c *check.C) {
 	opts := &disconnectOpts{
-		bind: map[string]workshop.Plug{
+		bind: map[string]workshop.PlugOrBind{
 			"plug2": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
 		},
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -7,17 +7,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"path/filepath"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/canonical/x-go/strutil"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/canonical/workshop/internal/metautil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -52,7 +49,7 @@ type SdkInfo struct {
 	InstallTime *time.Time       `json:"install-time,omitempty"`
 	Health      *HealthCheckInfo `json:"health-check,omitempty"`
 	Mounts      []*Mount         `json:"mounts,omitempty"`
-	Tunnels     *TunnelInfo      `json:"tunnels,omitempty"`
+	Tunnels     []*Tunnel        `json:"tunnels,omitempty"`
 }
 
 type Mount struct {
@@ -62,14 +59,8 @@ type Mount struct {
 	WorkshopTarget string      `json:"workshop-target,omitempty"`
 }
 
-type TunnelInfo struct {
-	Plugs []*Tunnel `json:"plugs,omitempty"`
-	Slots []*Tunnel `json:"slots,omitempty"`
-}
-
 type Tunnel struct {
 	Plug sdk.PlugRef `json:"plug"`
-	Slot sdk.SlotRef `json:"slot"`
 	From Endpoint    `json:"from"`
 	To   Endpoint    `json:"to"`
 }
@@ -173,6 +164,7 @@ func workshopToInfoFull(ctx context.Context, w *workshop.Workshop, health health
 	}
 
 	mnts := w.Mounts(sdks)
+	tunnels := w.Tunnels(sdks)
 
 	for _, sk := range sdks {
 		var healthInfo *HealthCheckInfo
@@ -186,6 +178,10 @@ func workshopToInfoFull(ctx context.Context, w *workshop.Workshop, health health
 
 		ref := sdk.Ref{ProjectId: info.ProjectId, Workshop: info.Name, Sdk: sk.Name}
 		mntInfos := mountInfos(ref, mnts[sk.Name])
+		tunnelInfos, err := tunnelInfos(ref, tunnels[sk.Name])
+		if err != nil {
+			return nil, err
+		}
 
 		info.Sdks = append(info.Sdks, &SdkInfo{
 			Name:        sk.Name,
@@ -197,6 +193,7 @@ func workshopToInfoFull(ctx context.Context, w *workshop.Workshop, health health
 			InstallTime: w.Sdks[sk.Name].InstallTime,
 			Health:      healthInfo,
 			Mounts:      mntInfos,
+			Tunnels:     tunnelInfos,
 		})
 	}
 
@@ -237,136 +234,48 @@ func mountInfos(sk sdk.Ref, mnts []workshop.Mount) []*Mount {
 	return infos
 }
 
-// TODO: reimplement using SDK profiles once system SDK is available.
-func tunnels(conns *connectionsJSON) (map[string]*TunnelInfo, error) {
-	var tunnels = map[string]*TunnelInfo{}
-
-	masters := map[sdk.PlugRef][]sdk.PlugRef{}
-	for _, plug := range conns.Plugs {
-		if plug.Bind == nil {
-			continue
-		}
-
-		ref := *plug.Bind
-		sref := sdk.PlugRef{ProjectId: plug.ProjectId, Workshop: plug.Workshop, Sdk: plug.Sdk, Name: plug.Name}
-		masters[ref] = append(masters[ref], sref)
+func tunnelInfos(sk sdk.Ref, tunnels []workshop.Tunnel) ([]*Tunnel, error) {
+	if tunnels == nil {
+		return nil, nil
 	}
 
-	for _, conn := range conns.Established {
-		listen, connect, err := endpoints(conn)
+	infos := make([]*Tunnel, 0, len(tunnels))
+	for _, tunnel := range tunnels {
+		pref := sdk.PlugRef{ProjectId: sk.ProjectId, Workshop: sk.Workshop, Sdk: sk.Sdk, Name: tunnel.Name}
+		listen, err := endpoint(tunnel.Listen)
 		if err != nil {
 			return nil, err
 		}
-
-		tunnel := Tunnel{
-			Plug: conn.Plug,
-			Slot: conn.Slot,
+		connect, err := endpoint(tunnel.Connect)
+		if err != nil {
+			return nil, err
+		}
+		info := &Tunnel{
+			Plug: pref,
 			From: *listen,
 			To:   *connect,
 		}
-
-		sk := conn.Plug.Sdk
-		info, ok := tunnels[sk]
-		if !ok {
-			info = &TunnelInfo{}
-			tunnels[sk] = info
-		}
-		if sk == conn.Plug.Sdk {
-			info.Plugs = append(info.Plugs, &tunnel)
-		} else {
-			info.Slots = append(info.Slots, &tunnel)
-		}
-
-		if slaves, ok := masters[conn.Plug]; ok {
-			for _, slave := range slaves {
-				t := tunnel
-				t.Plug = slave
-
-				if !sdk.IsSystem(conn.Plug.Sdk) {
-					sk = slave.Sdk
-				}
-				info, ok := tunnels[sk]
-				if !ok {
-					info = &TunnelInfo{}
-					tunnels[sk] = info
-				}
-				if sk == slave.Sdk {
-					info.Plugs = append(info.Plugs, &t)
-				} else {
-					info.Slots = append(info.Slots, &t)
-				}
-			}
-		}
+		infos = append(infos, info)
 	}
 
-	return tunnels, nil
+	return infos, nil
 }
 
-func endpoints(conn connectionJSON) (*Endpoint, *Endpoint, error) {
-	v, ok := metautil.LookupAttr(conn.PlugAttrs, nil, "endpoint")
-	if !ok {
-		return nil, nil, &sdk.AttributeNotFoundError{Attribute: "endpoint", Plug: &conn.Plug}
+func endpoint(target workshop.ProxyTarget) (*Endpoint, error) {
+	if target.Protocol == "unix" {
+		return &Endpoint{Protocol: "unix", Path: target.Address}, nil
 	}
-	var address string
-	if err := metautil.SetValueFromAttribute(v, &address); err != nil {
-		return nil, nil, fmt.Errorf("invalid attribute %q for plug %q: %w", "endpoint", conn.Plug.ShortRef(), err)
-	}
-	listen, err := parseEndpoint(address)
+
+	host, port, err := net.SplitHostPort(target.Address)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	v, ok = metautil.LookupAttr(conn.SlotAttrs, nil, "endpoint")
-	if !ok {
-		return nil, nil, &sdk.AttributeNotFoundError{Attribute: "endpoint", Slot: &conn.Slot}
-	}
-	if err := metautil.SetValueFromAttribute(v, &address); err != nil {
-		return nil, nil, fmt.Errorf("invalid attribute %q for slot %q: %w", "endpoint", conn.Slot.ShortRef(), err)
-	}
-	connect, err := parseEndpoint(address)
+	number, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if (listen.Protocol == "tcp" || listen.Protocol == "udp") && listen.Port == 0 {
-		listen.Port = connect.Port
-	}
-	if (connect.Protocol == "tcp" || connect.Protocol == "udp") && connect.Port == 0 {
-		connect.Port = listen.Port
-	}
-
-	return listen, connect, nil
-}
-
-func parseEndpoint(endpoint string) (*Endpoint, error) {
-	// Leave unix sockets untouched.
-	if filepath.IsAbs(endpoint) || strings.HasPrefix(endpoint, "@") || strings.HasPrefix(endpoint, "$") {
-		return &Endpoint{Protocol: "unix", Path: endpoint}, nil
-	}
-
-	protocol := "tcp"
-	idx := strings.LastIndexByte(endpoint, '/')
-	if idx >= 0 {
-		protocol = endpoint[idx+1:]
-		endpoint = endpoint[:idx]
-	}
-
-	host, port, err := net.SplitHostPort(endpoint)
-	if err != nil {
-		host = endpoint
-		port = ""
-	}
-
-	result := &Endpoint{Protocol: protocol, Host: host}
-	if port != "" {
-		number, err := strconv.ParseUint(port, 10, 16)
-		if err != nil {
-			return nil, err
-		}
-		result.Port = uint16(number)
-	}
-
-	return result, nil
+	return &Endpoint{Protocol: target.Protocol, Host: host, Port: uint16(number)}, nil
 }
 
 func newWorkshopChange(st *state.State, kind string, user, projectId, action string, names []string) *state.Change {
@@ -576,16 +485,6 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("workshop name required")
 	}
 
-	conns, err := collectConnections(c.d.overlord.InterfaceManager(), collectFilter{
-		projectId: projectId,
-		workshop:  name,
-		ifaceName: "tunnel",
-		connected: true,
-	})
-	if err != nil {
-		return statusInternalError("collecting connection information failed: %w", err)
-	}
-
 	state := c.d.overlord.State()
 	state.Lock()
 	defer state.Unlock()
@@ -602,14 +501,6 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	info, err := workshopToInfoFull(ctx, w, health)
 	if err != nil {
 		return statusBadRequest("%w", err)
-	}
-
-	ts, err := tunnels(conns)
-	if err != nil {
-		return statusBadRequest("%w", err)
-	}
-	for _, sk := range info.Sdks {
-		sk.Tunnels = ts[sk.Name]
 	}
 
 	files, err := wrkmgr.WorkshopFiles(ctx, projectId)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1210,7 +1210,7 @@ func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {
 
 	connection, err := repo.Connection(conns[0])
 	c.Assert(err, check.IsNil)
-	_, bound := connection.CheckBound()
+	_, bound := connection.Plug.CheckBound()
 	c.Assert(bound, check.Equals, true)
 }
 
@@ -1482,7 +1482,7 @@ func (s *apiSuite) TestWorkshopConnectionsPlugIsBoundTo(c *check.C) {
 
 	connection, err := repo.Connection(conns[0])
 	c.Assert(err, check.IsNil)
-	_, bound := connection.CheckBound()
+	_, bound := connection.Plug.CheckBound()
 	c.Assert(bound, check.Equals, true)
 }
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -516,12 +516,27 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 
 	testSDKSource := workshop.SdkMountHostSource(s.user.HomeDir, s.project.ProjectId, "tunnels", "test-sdk-2", "data")
 
-	p := workshop.NewSdkProfile("test-sdk")
+	p := workshop.NewSdkProfile("system")
+	p.Tunnels = []workshop.Tunnel{{ProxyEntry: workshop.ProxyEntry{
+		Name:      "api",
+		Connect:   workshop.ProxyTarget{Protocol: "unix", Address: "@testapi"},
+		Listen:    workshop.ProxyTarget{Protocol: "tcp", Address: "0.0.0.0:8888"},
+		Direction: workshop.HostToWorkshop,
+	}}}
+	w.Profiles["system"] = p
+
+	p = workshop.NewSdkProfile("test-sdk")
 	p.Mounts["data"] = workshop.Mount{Name: "data",
 		What:  testSDKSource,
 		Where: "/opt/data",
 		Type:  workshop.HostWorkshop,
 	}
+	p.Tunnels = []workshop.Tunnel{{ProxyEntry: workshop.ProxyEntry{
+		Name:      "dns",
+		Connect:   workshop.ProxyTarget{Protocol: "udp", Address: "127.0.0.53:5353"},
+		Listen:    workshop.ProxyTarget{Protocol: "udp", Address: "127.0.0.1:5353"},
+		Direction: workshop.WorkshopToHost,
+	}}}
 	w.Profiles["test-sdk"] = p
 
 	testSDKSource2 := workshop.SdkMountHostSource(s.user.HomeDir, s.project.ProjectId, "tunnels", "test-sdk-2", "photos")
@@ -538,25 +553,6 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 		Type:  workshop.WorkshopWorkshop,
 	}
 	w.Profiles["test-sdk-2"] = p
-
-	// TODO: extend above setup with tunnels once system SDK profile is available.
-	// Also need coverage for tunnel plug binding logic.
-	connsState := map[string]interface{}{
-		"b8639dea/tunnels/system:api b8639dea/tunnels/test-sdk-2:api": map[string]interface{}{
-			"interface":   "tunnel",
-			"plug-static": map[string]interface{}{"endpoint": "0.0.0.0:8888/tcp"},
-			"slot-static": map[string]interface{}{"endpoint": "@testapi"},
-		},
-		"b8639dea/tunnels/test-sdk:dns b8639dea/tunnels/system:dns": map[string]interface{}{
-			"interface":   "tunnel",
-			"plug-static": map[string]interface{}{"endpoint": "127.0.0.1:5353/udp"},
-			"slot-static": map[string]interface{}{"endpoint": "127.0.0.53/udp"},
-		},
-	}
-	st := s.d.Overlord().State()
-	st.Lock()
-	st.Set("conns", connsState)
-	st.Unlock()
 
 	// Get Workshop info
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}")
@@ -593,30 +589,22 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 					Name:        "system",
 					Revision:    system.SystemSdkRevision.String(),
 					InstallTime: &install1,
-					Tunnels: &TunnelInfo{
-						Plugs: []*Tunnel{
-							{
-								Plug: sdk.PlugRef{
-									ProjectId: s.project.ProjectId,
-									Workshop:  "tunnels",
-									Sdk:       "system",
-									Name:      "api",
-								},
-								Slot: sdk.SlotRef{
-									ProjectId: s.project.ProjectId,
-									Workshop:  "tunnels",
-									Sdk:       "test-sdk-2",
-									Name:      "api",
-								},
-								From: Endpoint{
-									Protocol: "tcp",
-									Host:     "0.0.0.0",
-									Port:     8888,
-								},
-								To: Endpoint{
-									Protocol: "unix",
-									Path:     "@testapi",
-								},
+					Tunnels: []*Tunnel{
+						{
+							Plug: sdk.PlugRef{
+								ProjectId: s.project.ProjectId,
+								Workshop:  "tunnels",
+								Sdk:       "system",
+								Name:      "api",
+							},
+							From: Endpoint{
+								Protocol: "tcp",
+								Host:     "0.0.0.0",
+								Port:     8888,
+							},
+							To: Endpoint{
+								Protocol: "unix",
+								Path:     "@testapi",
 							},
 						},
 					},
@@ -640,31 +628,23 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 							},
 						},
 					},
-					Tunnels: &TunnelInfo{
-						Plugs: []*Tunnel{
-							{
-								Plug: sdk.PlugRef{
-									ProjectId: s.project.ProjectId,
-									Workshop:  "tunnels",
-									Sdk:       "test-sdk",
-									Name:      "dns",
-								},
-								Slot: sdk.SlotRef{
-									ProjectId: s.project.ProjectId,
-									Workshop:  "tunnels",
-									Sdk:       "system",
-									Name:      "dns",
-								},
-								From: Endpoint{
-									Protocol: "udp",
-									Host:     "127.0.0.1",
-									Port:     5353,
-								},
-								To: Endpoint{
-									Protocol: "udp",
-									Host:     "127.0.0.53",
-									Port:     5353,
-								},
+					Tunnels: []*Tunnel{
+						{
+							Plug: sdk.PlugRef{
+								ProjectId: s.project.ProjectId,
+								Workshop:  "tunnels",
+								Sdk:       "test-sdk",
+								Name:      "dns",
+							},
+							From: Endpoint{
+								Protocol: "udp",
+								Host:     "127.0.0.1",
+								Port:     5353,
+							},
+							To: Endpoint{
+								Protocol: "udp",
+								Host:     "127.0.0.53",
+								Port:     5353,
 							},
 						},
 					},

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -206,8 +206,8 @@ sdks:
     channel: latest/stable
     plugs:
       data:
-        bind: test-sdk-2:photos
-  - name: test-sdk-2
+        bind: mount-conflict:photos
+  - name: mount-conflict
     channel: latest/stable
 `
 
@@ -268,7 +268,7 @@ sdks:
     plugs:
       training-plug:
         interface: mount
-        workshop-target: /opt
+        workshop-target: /opt/data
       data:
         bind: test-sdk:training-plug
   - name: test-sdk-2
@@ -325,7 +325,7 @@ sdks:
       photos:
         interface: mount
         workshop-source: /project/photos
-  - name: test-sdk-2
+  - name: mount-conflict
     channel: latest/stable
     plugs:
       photos:
@@ -335,7 +335,7 @@ sdks:
         interface: mount
 connections:
   - plug: test-sdk:data
-    slot: test-sdk-2:training
+    slot: mount-conflict:training
 `
 
 	testsdk = `
@@ -389,6 +389,26 @@ slots:
     interface: mount
 `
 
+	mount_conflict = `
+name: mount-conflict
+title: title
+base: ubuntu@20.04
+version: '20200401.3f3a63f'
+summary: summary
+description: SDK
+sdkcraft-started-at: '2020-05-03T22:05:35.811829Z'
+plugs:
+  photos:
+    interface: mount
+    workshop-target: /opt/data
+  gpu:
+    interface: gpu
+slots:
+  data-slot:
+    workshop-source: /mnt
+    interface: mount
+`
+
 	testsdk3 = `
 name: test-sdk-3
 title: title
@@ -406,9 +426,10 @@ type testSdk struct {
 }
 
 var apiSuiteSdks = map[string]testSdk{
-	"test-sdk":   {s: sdk.Setup{Name: "test-sdk", Revision: sdk.R(1)}, meta: testsdk},
-	"test-sdk-2": {s: sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(1)}, meta: testsdk2},
-	"test-sdk-3": {s: sdk.Setup{Name: "test-sdk-3", Revision: sdk.R(1)}, meta: testsdk3},
+	"test-sdk":       {s: sdk.Setup{Name: "test-sdk", Revision: sdk.R(1)}, meta: testsdk},
+	"test-sdk-2":     {s: sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(1)}, meta: testsdk2},
+	"mount-conflict": {s: sdk.Setup{Name: "mount-conflict", Revision: sdk.R(1)}, meta: mount_conflict},
+	"test-sdk-3":     {s: sdk.Setup{Name: "test-sdk-3", Revision: sdk.R(1)}, meta: testsdk3},
 }
 
 func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string) {
@@ -695,14 +716,14 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 	w, ok := s.b.Workshops[s.project.ProjectId]["somebound"]
 	c.Assert(ok, check.Equals, true)
 
-	testSDKSource := workshop.SdkMountHostSource(s.user.HomeDir, s.project.ProjectId, "somebound", "test-sdk-2", "photos")
-	p := workshop.NewSdkProfile("test-sdk-2")
+	testSDKSource := workshop.SdkMountHostSource(s.user.HomeDir, s.project.ProjectId, "somebound", "mount-conflict", "photos")
+	p := workshop.NewSdkProfile("mount-conflict")
 	p.Mounts["photos"] = workshop.Mount{Name: "photos",
 		What:  testSDKSource,
-		Where: "/opt/data2",
+		Where: "/opt/data",
 		Type:  workshop.HostWorkshop,
 	}
-	w.Profiles["test-sdk-2"] = p
+	w.Profiles["mount-conflict"] = p
 
 	// Get Workshop info
 	projectsCmd := apiCmd("/v1/projects/{id}/workshops/{name}")
@@ -736,6 +757,26 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 			Notes:     nil,
 			Sdks: []*SdkInfo{
 				{
+					Name:        "mount-conflict",
+					Version:     "20200401.3f3a63f",
+					Channel:     "latest/stable",
+					Revision:    "1",
+					BuildTime:   &build2,
+					InstallTime: &install2,
+					Mounts: []*Mount{
+						{
+							HostSource:     testSDKSource,
+							WorkshopTarget: "/opt/data",
+							Plug: sdk.PlugRef{
+								ProjectId: s.project.ProjectId,
+								Workshop:  "somebound",
+								Sdk:       "mount-conflict",
+								Name:      "photos",
+							},
+						},
+					},
+				},
+				{
 					Name:        "system",
 					Revision:    system.SystemSdkRevision.String(),
 					InstallTime: &install1,
@@ -750,32 +791,12 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource,
-							WorkshopTarget: "/opt/data2",
+							WorkshopTarget: "/opt/data",
 							Plug: sdk.PlugRef{
 								ProjectId: s.project.ProjectId,
 								Workshop:  "somebound",
 								Sdk:       "test-sdk",
 								Name:      "data",
-							},
-						},
-					},
-				},
-				{
-					Name:        "test-sdk-2",
-					Version:     "20200401.3f3a63f",
-					Channel:     "latest/stable",
-					Revision:    "1",
-					BuildTime:   &build2,
-					InstallTime: &install2,
-					Mounts: []*Mount{
-						{
-							HostSource:     testSDKSource,
-							WorkshopTarget: "/opt/data2",
-							Plug: sdk.PlugRef{
-								ProjectId: s.project.ProjectId,
-								Workshop:  "somebound",
-								Sdk:       "test-sdk-2",
-								Name:      "photos",
 							},
 						},
 					},
@@ -1455,7 +1476,7 @@ func (s *apiSuite) TestWorkshopConnectionsPlugIsBoundTo(c *check.C) {
 	c.Assert(conns, check.HasLen, 1)
 	c.Assert(conns[0].SlotRef.Name, check.Equals, "training")
 
-	conns, err = repo.Connected(s.project.ProjectId, "connsplugbound", "test-sdk-2", "photos")
+	conns, err = repo.Connected(s.project.ProjectId, "connsplugbound", "mount-conflict", "photos")
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
 	c.Assert(conns[0].SlotRef.Name, check.Equals, "training")
@@ -1642,19 +1663,19 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		sdks: []sdk.Setup{
 			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: "mount-conflict", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		}, connections: []string{
 			"b8639dea/somebound/test-sdk:data b8639dea/somebound/system:mount",
-			"b8639dea/somebound/test-sdk-2:photos b8639dea/somebound/system:mount",
-			"b8639dea/somebound/test-sdk-2:gpu b8639dea/somebound/system:gpu",
+			"b8639dea/somebound/mount-conflict:photos b8639dea/somebound/system:mount",
+			"b8639dea/somebound/mount-conflict:gpu b8639dea/somebound/system:gpu",
 		},
 		plugs: []string{
 			"test-sdk:data",
-			"test-sdk-2:photos",
-			"test-sdk-2:gpu",
+			"mount-conflict:photos",
+			"mount-conflict:gpu",
 		},
 		slots: []string{
-			"test-sdk-2:data-slot",
+			"mount-conflict:data-slot",
 			"system:camera",
 			"system:desktop",
 			"system:gpu",
@@ -1704,7 +1725,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 	s.checkSnapshotCalls(c, "somebound", []string{
 		"system",
 		"test-sdk",
-		"test-sdk-2",
+		"mount-conflict",
 	})
 
 	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic})

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -33,8 +33,15 @@ type Connection struct {
 	Slot *ConnectedSlot
 }
 
-func (c *Connection) CheckBound() (*ConnRef, bool) {
-	attr, _ := c.Plug.Lookup("bind")
+// ConnectedPlug represents a plug that is connected to a slot.
+type ConnectedPlug struct {
+	plugInfo     *sdk.PlugInfo
+	staticAttrs  map[string]interface{}
+	dynamicAttrs map[string]interface{}
+}
+
+func (p *ConnectedPlug) CheckBound() (*ConnRef, bool) {
+	attr, _ := p.Lookup("bind")
 	if attr == nil {
 		return nil, false
 	}
@@ -48,13 +55,6 @@ func (c *Connection) CheckBound() (*ConnRef, bool) {
 		ok = false
 	}
 	return cref, ok
-}
-
-// ConnectedPlug represents a plug that is connected to a slot.
-type ConnectedPlug struct {
-	plugInfo     *sdk.PlugInfo
-	staticAttrs  map[string]interface{}
-	dynamicAttrs map[string]interface{}
 }
 
 // ConnectedSlot represents a slot that is connected to a plug.

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -2,7 +2,6 @@ package lxd_device
 
 import (
 	"encoding/json"
-	"fmt"
 	"os/user"
 	"strconv"
 
@@ -74,18 +73,20 @@ func (s *Specification) AddConnectedPlug(iface interfaces.Interface, plug *inter
 func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 	s.Profile.Mounts[dev.Name] = dev
 
+	name := lxdbackend.DeviceName(s.Profile.Sdk, dev.Name)
+
 	if dev.Type == workshop.WorkshopWorkshop {
-		s.devices[dev.Name] = map[string]string{"type": "none"}
+		s.devices[name] = map[string]string{"type": "none"}
 		buf, err := json.Marshal(dev)
 		if err != nil {
 			return err
 		}
-		s.config[lxdbackend.DeviceConfigKey(s.Profile.Sdk, dev.Name)] = string(buf)
-		s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, dev.Name)] = "mount"
+		s.config[lxdbackend.DeviceConfigKey(name)] = string(buf)
+		s.config[lxdbackend.DeviceTypeConfigKey(name)] = "mount"
 	}
 
 	if dev.Type == workshop.HostWorkshop {
-		s.devices[dev.Name] = map[string]string{"type": "disk", "source": dev.What,
+		s.devices[name] = map[string]string{"type": "disk", "source": dev.What,
 			"path": dev.Where, "readonly": strconv.FormatBool(dev.ReadOnly)}
 	}
 
@@ -140,7 +141,8 @@ func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 	// card*/render* dri devices by LXD properly. Both will be assigned to
 	// the group provided in "gid"; there is no way to assign video to card*
 	// and render to render* devices.
-	s.devices[gpu.Name] = map[string]string{
+	name := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name)
+	s.devices[name] = map[string]string{
 		"type":    "gpu",
 		"gputype": "physical",
 		"uid":     workshop.User.Uid,
@@ -153,31 +155,32 @@ func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 func (s *Specification) SetCamera(camera workshop.Camera) error {
 	s.Profile.Camera = &camera
 
-	s.devices[camera.Name] = map[string]string{"type": "none"}
+	name := lxdbackend.DeviceName(s.Profile.Sdk, camera.Name)
+	s.devices[name] = map[string]string{"type": "none"}
 	buf, err := json.Marshal(camera)
 	if err != nil {
 		return err
 	}
-	s.config[lxdbackend.DeviceConfigKey(s.Profile.Sdk, camera.Name)] = string(buf)
-	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, camera.Name)] = "camera"
+	s.config[lxdbackend.DeviceConfigKey(name)] = string(buf)
+	s.config[lxdbackend.DeviceTypeConfigKey(name)] = "camera"
 
 	for _, subsystem := range []string{"video4linux", "media"} {
-		// This name is unique because '_' is not permitted in plug names.
-		name := fmt.Sprintf("%s_%s", camera.Name, subsystem)
+		name := lxdbackend.DeviceName(s.Profile.Sdk, camera.Name, subsystem)
 		s.devices[name] = map[string]string{
 			"type":              "unix-hotplug",
 			"subsystem":         subsystem,
 			"required":          "false",
 			"ownership.inherit": "true",
 		}
-		s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, name)] = "camera"
+		s.config[lxdbackend.DeviceTypeConfigKey(name)] = "camera"
 	}
 
 	return nil
 }
 
 func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey string) {
-	s.config[lxdbackend.DeviceTypeConfigKey(s.Profile.Sdk, entry.Name)] = configKey
+	name := lxdbackend.DeviceName(s.Profile.Sdk, entry.Name)
+	s.config[lxdbackend.DeviceTypeConfigKey(name)] = configKey
 	device := map[string]string{
 		"type":    "proxy",
 		"connect": entry.Connect.Protocol + ":" + entry.Connect.Address,
@@ -197,5 +200,5 @@ func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey stri
 			device["gid"] = s.User.Gid
 		}
 	}
-	s.devices[entry.Name] = device
+	s.devices[name] = device
 }

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -823,7 +823,7 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 			return nil, err
 		}
 		for _, conn := range r.slotPlugs[slotInfo] {
-			if _, ok := conn.CheckBound(); ok {
+			if _, ok := conn.Plug.CheckBound(); ok {
 				continue
 			}
 			if err := spec.AddConnectedSlot(iface, conn.Plug, conn.Slot); err != nil {
@@ -838,7 +838,7 @@ func (r *Repository) SdkSpecification(ctx context.Context, securitySystem Securi
 			return nil, err
 		}
 		for _, conn := range r.plugSlots[plugInfo] {
-			if _, ok := conn.CheckBound(); ok {
+			if _, ok := conn.Plug.CheckBound(); ok {
 				continue
 			}
 			if err := spec.AddConnectedPlug(iface, conn.Plug, conn.Slot); err != nil {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -198,6 +198,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 			// its master.
 			continue
 		}
+
 		candidates := m.repo.AutoConnectCandidateSlots(info.ProjectId, info.Workshop,
 			info.Name, plug.Name, autoConnectChecker(wconns))
 
@@ -207,6 +208,11 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 				slotDynamic[connRef.ID()] = make(map[string]interface{})
 			}
 
+			// remounts may be not nil when a previously existing mount
+			// interface connection (e.g. pre-refresh) needs to be recreated
+			// without changes to its 'source' attribute in the new workshop
+			// (given the new workshop also has an SDK with exactly the same
+			// plug; the target directory may change in the new workshop).
 			if src, ok := remounts[connRef.ID()]; ok {
 				slotDynamic[connRef.ID()]["host-source"] = src
 			}
@@ -235,6 +241,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 	for _, slot := range info.Slots {
 		candidates := m.repo.AutoConnectCandidatePlugs(info.ProjectId, info.Workshop,
 			info.Name, slot.Name, autoConnectChecker(wconns))
+
 		for _, plug := range candidates {
 			ref := plug.Ref()
 			master, slaves := MaybeBound(wp, ref)
@@ -243,30 +250,25 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 				// its master.
 				continue
 			}
-			connRef := interfaces.NewConnRef(plug, slot)
 
+			connRef := interfaces.NewConnRef(plug, slot)
 			if slotDynamic[connRef.ID()] == nil {
 				slotDynamic[connRef.ID()] = make(map[string]interface{})
 			}
 
+			// remounts may be not nil when a previously existing mount
+			// interface connection (e.g. pre-refresh) needs to be recreated
+			// without changes to its 'source' attribute in the new workshop
+			// (given the new workshop also has an SDK with exactly the same
+			// plug; the target directory may change in the new workshop).
 			if src, ok := remounts[connRef.ID()]; ok {
 				slotDynamic[connRef.ID()]["host-source"] = src
 			}
 
 			slotRef := slot.Ref()
+			// save associated binds as a dynamic attribute
 			for _, slave := range slaves {
 				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
-
-				slaveInfo := m.repo.Plug(slave.ProjectId, slave.Workshop, slave.Sdk, slave.Name)
-				if slaveInfo == nil {
-					return fmt.Errorf("SDK %q has no plug named %q", slave.SdkRef().ShortRef(), slave.Name)
-				}
-
-				if slaveInfo.Interface != plug.Interface {
-					return fmt.Errorf("cannot bind %q (%q interface) to %q (%q interface)",
-						slave.ShortRef(), slaveInfo.Interface, master.ShortRef(), plug.Interface)
-				}
-
 				if _, ok := conns[slref.ID()]; !ok {
 					connectRefs = append(connectRefs, slref)
 					plugDynamic[slref.ID()] = make(map[string]interface{})
@@ -275,6 +277,9 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 			}
 
 			if _, ok := conns[connRef.ID()]; ok {
+				// Suggested connection already exist (or has Undesired flag
+				// set) so don't clobber it. NOTE: we don't log anything here as
+				// this is a normal and common condition.
 				continue
 			}
 
@@ -282,11 +287,6 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 		}
 	}
 
-	// remounts may be not nil when a previously existing mount
-	// interface connection (e.g. pre-refresh) needs to be recreated
-	// without changes to its 'source' attribute in the new workshop
-	// (given the new workshop also has an SDK with exactly the same
-	// plug; the target directory may change in the new workshop).
 	ts, err := m.batchAutoConnectTasks(wp, info, connectRefs, plugDynamic, slotDynamic)
 	if err != nil {
 		return err

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -21,6 +21,37 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
+func (m *InterfaceManager) doResolveInterfaces(task *state.Task, tomb *tomb.Tomb) (err error) {
+	user, project, w, err := handlersetup.UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
+	defer cancel()
+
+	wp, err := m.backend.Workshop(ctx, w)
+	if err != nil {
+		return err
+	}
+
+	// Ensure all bound plugs exist in the repository.
+	if err = m.resolveWorkshopBindings(wp); err != nil {
+		return err
+	}
+
+	// Ensure that connections requested via the workshop file use existing and
+	// compatible plugs and slots.
+	if err = m.resolveWorkshopConnections(wp); err != nil {
+		return err
+	}
+
+	// Ensure that if the SDK is connected there will be no conflicting bind
+	// mount targets in the workshop, i.e. the situation when a two or more
+	// sources are bind mount at the same target in the workshop.
+	return m.checkConflictingMounts(wp)
+}
+
 func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err error) {
 	st := task.State()
 	user, project, w, err := handlersetup.UserProjectWorkshop(task)
@@ -62,25 +93,6 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	// if any of those are still relevant for the new workshop.
 	var remounts map[string]string
 	if err := chg.Get("remounts", &remounts); err != nil && !errors.Is(err, state.ErrNoState) {
-		return err
-	}
-
-	// Ensure that all plugs that the workshop bindings bind to actually exist
-	// in the repository.
-	if err = m.resolveWorkshopBindings(wp); err != nil {
-		return err
-	}
-
-	// Ensure that connections requested via the workshop file use existing and
-	// compatible plugs and slots.
-	if err = m.resolveWorkshopConnections(wp); err != nil {
-		return err
-	}
-
-	// Ensure that if the SDK is connected there will be no conflicting bind
-	// mount targets in the workshop, i.e. the situation when a two or more
-	// sources are bind mount at the same target in the workshop.
-	if err = m.checkConflictingTargets(info); err != nil {
 		return err
 	}
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -160,11 +160,14 @@ func (di denyAutoIface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool
 
 func (s *interfaceHandlersSuite) newAutoconnectChange() *state.Change {
 	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws", s.prj, t1)
+	t1 := s.state.NewTask("resolve-interfaces", "...")
+	t2 := s.state.NewTask("auto-connect", "...")
+	t2.Set("sdk", "consumer")
+	t2.WaitFor(t1)
+	setWorkshopProject("ws", s.prj, t1, t2)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
+	chg.AddTask(t2)
 	return chg
 }
 
@@ -368,15 +371,18 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c
 
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "conflict-1")
+	t1 := s.state.NewTask("resolve-interfaces", "...")
 	t2 := s.state.NewTask("auto-connect", "...")
-	t2.Set("sdk", "conflict-2")
+	t2.Set("sdk", "conflict-1")
 	t2.WaitFor(t1)
-	setWorkshopProject("ws", s.prj, t1, t2)
+	t3 := s.state.NewTask("auto-connect", "...")
+	t3.Set("sdk", "conflict-2")
+	t3.WaitFor(t2)
+	setWorkshopProject("ws", s.prj, t1, t2, t3)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 	chg.AddTask(t2)
+	chg.AddTask(t3)
 	s.state.Unlock()
 
 	// Execute
@@ -397,13 +403,17 @@ func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.
 	// Execute
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "consumer")
-	t2 := s.state.NewTask("error-trigger", "...")
-	setWorkshopProject("ws", s.prj, t1)
+	t1 := s.state.NewTask("resolve-interfaces", "...")
+	t2 := s.state.NewTask("auto-connect", "...")
+	t2.Set("sdk", "consumer")
+	t2.WaitFor(t1)
+	t3 := s.state.NewTask("error-trigger", "...")
+	t3.WaitFor(t2)
+	setWorkshopProject("ws", s.prj, t1, t2)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 	chg.AddTask(t2)
+	chg.AddTask(t3)
 	s.state.Unlock()
 
 	s.settle(c)
@@ -439,11 +449,14 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 	chg.Set("remounts", map[string]string{
 		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": "/old/source",
 	})
-	t1 := s.state.NewTask("auto-connect", "...")
-	t1.Set("sdk", "consumer")
-	setWorkshopProject("ws", s.prj, t1)
+	t1 := s.state.NewTask("resolve-interfaces", "...")
+	t2 := s.state.NewTask("auto-connect", "...")
+	t2.Set("sdk", "consumer")
+	t2.WaitFor(t1)
+	setWorkshopProject("ws", s.prj, t1, t2)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
+	chg.AddTask(t2)
 	s.state.Unlock()
 
 	s.settle(c)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -395,6 +395,43 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c
 	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*target "/opt" is also mounted by.*`)
 }
 
+func (s *interfaceHandlersSuite) TestAutoconnectBindResolvesMountConflicts(c *check.C) {
+	// Setup
+	wp, err := s.launchWorkshop(c, "ws", []testSdkSetup{
+		{sdk.Setup{Name: "conflict-1", Channel: "latest/stable", Revision: sdk.R(1)}, conflictingTarget1},
+		{sdk.Setup{Name: "conflict-2", Channel: "latest/stable", Revision: sdk.R(1)}, conflictingTarget2},
+	})
+	c.Assert(err, check.IsNil)
+	wp.File.Sdks[1].Plugs = map[string]workshop.PlugOrBind{}
+	wp.File.Sdks[1].Plugs["plug"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "conflict-1", Name: "plug"}}
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget1, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget2, s.prj.ProjectId, "ws")), check.IsNil)
+
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("resolve-interfaces", "...")
+	t2 := s.state.NewTask("auto-connect", "...")
+	t2.Set("sdk", "conflict-1")
+	t2.WaitFor(t1)
+	t3 := s.state.NewTask("auto-connect", "...")
+	t3.Set("sdk", "conflict-2")
+	t3.WaitFor(t2)
+	setWorkshopProject("ws", s.prj, t1, t2, t3)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	chg.AddTask(t3)
+	s.state.Unlock()
+
+	// Execute
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(chg.Err(), check.IsNil)
+}
+
 func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -69,6 +69,9 @@ plugs:
   plug-ssh:
     interface: mock-ssh-agent
     attribute: four
+  bound:
+    interface: mock-network
+    attribute: one
 `
 
 var consumer2 = `name: consumer2
@@ -227,7 +230,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 	wp, err := s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumerManyPlugs}})
 	c.Check(err, check.IsNil)
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.PlugOrBind)
-	wp.File.Sdks[0].Plugs["plug"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug2"}}
+	wp.File.Sdks[0].Plugs["bound"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}}
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
@@ -243,21 +246,20 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 
 	// Validate
 	pconns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
-	c.Check(pconns, check.HasLen, 3)
+	c.Check(pconns, check.HasLen, 4)
 	c.Check(err, check.IsNil)
 
 	ref, err := repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
-	c.Check(ref, check.HasLen, 3)
+	c.Check(ref, check.HasLen, 4)
 	c.Check(err, check.IsNil)
 
 	var conns map[string]interface{}
 	s.state.Get("conns", &conns)
 	c.Check(conns, check.DeepEquals, map[string]interface{}{
 		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
-			"interface":    "mock-network",
-			"auto":         true,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"bind": "42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot"},
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]interface{}{"attribute": "one"},
 		},
 		"42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot": map[string]interface{}{
 			"interface":   "mock-network",
@@ -268,6 +270,12 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 			"interface":   "mock-network",
 			"auto":        true,
 			"plug-static": map[string]interface{}{"attribute": "three"},
+		},
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]interface{}{
+			"interface":    "mock-network",
+			"auto":         true,
+			"plug-static":  map[string]interface{}{"attribute": "one"},
+			"plug-dynamic": map[string]interface{}{"bind": "42424242/ws/consumer:plug 42424242/ws-producer/producer:slot"},
 		},
 	})
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -223,8 +223,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 
 	wp, err := s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumerManyPlugs}})
 	c.Check(err, check.IsNil)
-	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug2"}}
+	wp.File.Sdks[0].Plugs = make(map[string]workshop.PlugOrBind)
+	wp.File.Sdks[0].Plugs["plug"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug2"}}
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
@@ -282,8 +282,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindMasterPlugNotFound(c *check.
 
 	wp, err := s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumerManyPlugs}})
 	c.Check(err, check.IsNil)
-	wp.File.Sdks[0].Plugs = make(map[string]workshop.Plug)
-	wp.File.Sdks[0].Plugs["plug"] = workshop.Plug{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "no-such-plug2"}}
+	wp.File.Sdks[0].Plugs = make(map[string]workshop.PlugOrBind)
+	wp.File.Sdks[0].Plugs["plug"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "no-such-plug2"}}
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -1267,7 +1267,7 @@ func (s *interfaceHandlersSuite) TestundoDisconnectSuccess(c *check.C) {
 
 	conn, err := repo.Connection(conns[0])
 	c.Assert(err, check.IsNil)
-	_, ok := conn.CheckBound()
+	_, ok := conn.Plug.CheckBound()
 	c.Assert(ok, check.Equals, true)
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 4)

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"slices"
 
 	"github.com/canonical/workshop/internal/dirs"
@@ -397,13 +398,29 @@ func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string
 
 func (m *InterfaceManager) resolveWorkshopBindings(w *workshop.Workshop) error {
 	for _, s := range w.File.Sdks {
-		for _, plug := range s.Plugs {
-			if plug.Bind != nil {
-				master := m.repo.Plug(w.Project.ProjectId, w.Name, plug.Bind.Sdk, plug.Bind.Name)
-				if master == nil {
-					sdkRef := sdk.Ref{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: plug.Bind.Sdk}
-					return fmt.Errorf("SDK %q has no plug named %q", sdkRef.ShortRef(), plug.Bind.Name)
-				}
+		for name, plug := range s.Plugs {
+			if plug.Bind == nil {
+				continue
+			}
+
+			master := m.repo.Plug(w.Project.ProjectId, w.Name, plug.Bind.Sdk, plug.Bind.Name)
+			if master == nil {
+				sdkRef := sdk.Ref{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: plug.Bind.Sdk}
+				return fmt.Errorf("SDK %q has no plug named %q", sdkRef.ShortRef(), plug.Bind.Name)
+			}
+
+			slave := m.repo.Plug(w.Project.ProjectId, w.Name, s.Name, name)
+			if slave == nil {
+				sdkRef := sdk.Ref{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: s.Name}
+				return fmt.Errorf("internal error: SDK %q has no plug named %q", sdkRef.ShortRef(), name)
+			}
+
+			if slave.Interface != master.Interface {
+				return fmt.Errorf("cannot bind %q (%q interface) to %q (%q interface)", slave.Ref().ShortRef(), slave.Interface, master.Ref().ShortRef(), master.Interface)
+			}
+
+			if slave.Label != master.Label || !reflect.DeepEqual(slave.Attrs, master.Attrs) {
+				return fmt.Errorf("cannot bind %q to %q: incompatible attributes", slave.Ref().ShortRef(), master.Ref().ShortRef())
 			}
 		}
 	}

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -35,6 +35,7 @@ func New(s *state.State, r *state.TaskRunner) *InterfaceManager {
 	m.backend = workshop.WorkshopBackend(s)
 	s.Unlock()
 
+	r.AddHandler("resolve-interfaces", OnDo(m.doResolveInterfaces), nil)
 	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), nil)
 	r.AddHandler("auto-disconnect", OnDo(m.doDisconnectInterfaces), nil)
 
@@ -420,31 +421,31 @@ func (m *InterfaceManager) resolveWorkshopConnections(w *workshop.Workshop) erro
 	return nil
 }
 
-func (m *InterfaceManager) checkConflictingTargets(sdkInfo *sdk.Info) error {
-	allPlugs := m.repo.AllPlugs("mount")
-
-	for _, plug := range sdkInfo.Plugs {
-		if plug.Interface != "mount" {
-			continue
+func (m *InterfaceManager) checkConflictingMounts(w *workshop.Workshop) error {
+	var plugs []*sdk.PlugInfo
+	for _, sk := range w.Sdks {
+		for _, plug := range m.repo.Plugs(w.Project.ProjectId, w.Name, sk.Name) {
+			if plug.Interface == "mount" {
+				plugs = append(plugs, plug)
+			}
 		}
+	}
+
+	for _, plug := range plugs {
 		candidateTarget, _ := plug.Lookup("workshop-target")
 
-		idx := slices.IndexFunc(allPlugs, func(pi *sdk.PlugInfo) bool {
-			// only plugs from the same workshop will be considered
-			if pi.Sdk.ProjectId != plug.Sdk.ProjectId || pi.Sdk.Workshop != plug.Sdk.Workshop {
-				return false
-			}
+		idx := slices.IndexFunc(plugs, func(pi *sdk.PlugInfo) bool {
 			// exclude oneself
-			if pi.Sdk.Ref() == plug.Sdk.Ref() && pi.Name == plug.Name {
+			if pi.Sdk.Name == plug.Sdk.Name && pi.Name == plug.Name {
 				return false
 			}
 			target, _ := pi.Lookup("workshop-target")
 			return target == candidateTarget
 		})
-		if idx != -1 {
+		if idx >= 0 {
 			return fmt.Errorf(`cannot connect %q: target %q is also mounted by %q`,
 				plug.Ref().ShortRef(), candidateTarget,
-				allPlugs[idx].Ref().ShortRef())
+				plugs[idx].Ref().ShortRef())
 		}
 	}
 	return nil

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -431,12 +431,24 @@ func (m *InterfaceManager) checkConflictingMounts(w *workshop.Workshop) error {
 		}
 	}
 
+	sdks := map[string]workshop.SdkRecord{}
+	for _, sk := range w.File.Sdks {
+		sdks[sk.Name] = sk
+	}
+
 	for _, plug := range plugs {
+		if sdks[plug.Sdk.Name].Plugs[plug.Name].Bind != nil {
+			continue
+		}
 		candidateTarget, _ := plug.Lookup("workshop-target")
 
 		idx := slices.IndexFunc(plugs, func(pi *sdk.PlugInfo) bool {
 			// exclude oneself
 			if pi.Sdk.Name == plug.Sdk.Name && pi.Name == plug.Name {
+				return false
+			}
+			// exclude bound plugs
+			if sdks[pi.Sdk.Name].Plugs[pi.Name].Bind != nil {
 				return false
 			}
 			target, _ := pi.Lookup("workshop-target")

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -406,7 +406,7 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
 	addTaskSet(state.NewTaskSet(mountProject))
 
-	connect := autoconnectSdks(st, sdks)
+	connect := autoconnectSdks(st, file.Name, sdks)
 	addTaskSet(connect)
 
 	setupProject := runHooks(st, project.ProjectId, file.Name, sdks, 0, hookstate.SetupProject)
@@ -694,7 +694,7 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", w.Project.Path))
 	addTaskSet(state.NewTaskSet(mountProject))
 
-	connect := autoconnectSdks(st, plan.InstallIntactOrRefresh())
+	connect := autoconnectSdks(st, file.Name, plan.InstallIntactOrRefresh())
 	addTaskSet(connect)
 
 	setupProject := runHooks(st, w.Project.ProjectId, file.Name, plan.InstallIntactOrRefresh(), 0, hookstate.SetupProject)
@@ -751,17 +751,19 @@ func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *worksho
 	return refresh, nil
 }
 
-func autoconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
+func autoconnectSdks(st *state.State, w string, sdks []sdk.Setup) *state.TaskSet {
 	autoconnectSet := state.NewTaskSet()
-	var prevAuto = (*state.Task)(nil)
+
+	validate := st.NewTask("resolve-interfaces", fmt.Sprintf("Resolve relations between interfaces of %q workshop", w))
+	autoconnectSet.AddTask(validate)
+
+	prev := validate
 	for _, setup := range sdks {
 		autoconnect := st.NewTask("auto-connect", fmt.Sprintf("Auto-connect interfaces of %q SDK", setup.Name))
 		autoconnect.Set("sdk", setup.Name)
 		autoconnectSet.AddTask(autoconnect)
-		if prevAuto != nil {
-			autoconnect.WaitFor(prevAuto)
-		}
-		prevAuto = autoconnect
+		autoconnect.WaitFor(prev)
+		prev = autoconnect
 	}
 	return autoconnectSet
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -94,10 +94,6 @@ func (i *Info) Ref() Ref {
 }
 
 func (i *Info) SetupPlugBinds(binds map[string]PlugRef) error {
-	if i.Type == System {
-		return nil
-	}
-
 	for name, plug := range binds {
 		if _, ok := i.Plugs[name]; ok {
 			// Check plugs that are bound. The existence of plugs that are

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -17,12 +17,16 @@ func ProfileName(pid, workshop, sdk string) string {
 	return strings.Join([]string{InstanceName(workshop, pid), sdk}, "-")
 }
 
-func DeviceConfigKey(sdk, dev string) string {
-	return fmt.Sprintf("user.workshop.%s.%s", sdk, dev)
+func DeviceName(parts ...string) string {
+	return strings.Join(parts, "_")
 }
 
-func DeviceTypeConfigKey(sdk, dev string) string {
-	return fmt.Sprintf("user.workshop.%s.%s.type", sdk, dev)
+func DeviceConfigKey(name string) string {
+	return fmt.Sprintf("user.workshop.%s", name)
+}
+
+func DeviceTypeConfigKey(name string) string {
+	return fmt.Sprintf("user.workshop.%s.type", name)
 }
 
 func Profile(conn lxd.InstanceServer, pid, wp, profile string) (workshop.SdkProfile, error) {
@@ -40,14 +44,16 @@ func Profile(conn lxd.InstanceServer, pid, wp, profile string) (workshop.SdkProf
 
 func lxdToSdkProfile(profile string, devs map[string]map[string]string, config map[string]string) (workshop.SdkProfile, error) {
 	var pr = workshop.NewSdkProfile(profile)
-	for name, dev := range devs {
+	for devname, dev := range devs {
+		name := strings.TrimPrefix(devname, DeviceName(profile, ""))
+
 		switch dev["type"] {
 		case "disk":
 			pr.Mounts[name] = workshop.Mount{Name: name, What: dev["source"], Where: dev["path"], Type: workshop.HostWorkshop}
 		case "gpu":
 			pr.Gpu = &workshop.Gpu{Name: name}
 		case "proxy":
-			devtype := config[DeviceTypeConfigKey(profile, name)]
+			devtype := config[DeviceTypeConfigKey(devname)]
 			switch devtype {
 			case "tunnel":
 				proxyEntry, err := proxyEntryFromLxdDevice(name, dev)
@@ -83,20 +89,20 @@ func lxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 				logger.Noticef("On reading %q SDK profile: unknown device type: %q", profile, devtype)
 			}
 		case "unix-hotplug":
-			devtype := config[DeviceTypeConfigKey(profile, name)]
+			devtype := config[DeviceTypeConfigKey(devname)]
 			if devtype == "camera" {
 				continue
 			}
 
 			logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
 		case "none":
-			cfg, exist := config[DeviceConfigKey(profile, name)]
+			cfg, exist := config[DeviceConfigKey(devname)]
 			if !exist {
-				logger.Noticef("On reading %q SDK profile: unknown device %q", profile, name)
+				logger.Noticef("On reading %q SDK profile: unknown device %q", profile, devname)
 				continue
 			}
 
-			devtype := config[DeviceTypeConfigKey(profile, name)]
+			devtype := config[DeviceTypeConfigKey(devname)]
 			switch devtype {
 			case "camera":
 				var camera workshop.Camera

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -92,29 +92,29 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		{
 			"sdk",
 			map[string]map[string]string{
-				"camera": {
+				"sdk_camera": {
 					"type": "none",
 				},
-				"camera_video4linux": {
+				"sdk_camera_video4linux": {
 					"type":              "unix-hotplug",
 					"subsystem":         "video4linux",
 					"required":          "false",
 					"ownership.inherit": "true",
 				},
-				"camera_media": {
+				"sdk_camera_media": {
 					"type":              "unix-hotplug",
 					"subsystem":         "media",
 					"required":          "false",
 					"ownership.inherit": "true"}},
 			map[string]string{
-				"user.workshop.sdk.camera":                  `{"name": "camera"}`,
-				"user.workshop.sdk.camera.type":             "camera",
-				"user.workshop.sdk.camera_video4linux.type": "camera",
-				"user.workshop.sdk.camera_media.type":       "camera"},
+				"user.workshop.sdk_camera":                  `{"name": "camera"}`,
+				"user.workshop.sdk_camera.type":             "camera",
+				"user.workshop.sdk_camera_video4linux.type": "camera",
+				"user.workshop.sdk_camera_media.type":       "camera"},
 		}, {
 			"sdk",
 			map[string]map[string]string{
-				"gpu": {
+				"sdk_gpu": {
 					"type":    "gpu",
 					"gputype": "physical",
 					"uid":     "1000",
@@ -123,7 +123,7 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		}, {
 			"sdk",
 			map[string]map[string]string{
-				"userdisk": {
+				"sdk_userdisk": {
 					"type":   "disk",
 					"source": "/home",
 					"path":   "/opt"}},
@@ -131,17 +131,17 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		}, {
 			"sdk",
 			map[string]map[string]string{
-				"http": {
+				"sdk_http": {
 					"type":    "proxy",
 					"connect": "tcp:127.0.0.1:8080",
 					"listen":  "tcp:0.0.0.0:8000",
 					"bind":    "host"}},
 			map[string]string{
-				"user.workshop.sdk.http.type": "tunnel"},
+				"user.workshop.sdk_http.type": "tunnel"},
 		}, {
 			"sdk",
 			map[string]map[string]string{
-				"ssh-agent": {
+				"sdk_ssh-agent": {
 					"type":    "proxy",
 					"connect": "unix:.host.socket",
 					"listen":  "unix:.workshop.socket",
@@ -149,11 +149,11 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 					"gid":     "1000",
 					"bind":    "instance"}},
 			map[string]string{
-				"user.workshop.sdk.ssh-agent.type": "ssh-agent"},
+				"user.workshop.sdk_ssh-agent.type": "ssh-agent"},
 		}, {
 			"sdk",
 			map[string]map[string]string{
-				"desktop": {
+				"sdk_desktop": {
 					"type":    "proxy",
 					"connect": "unix:.host.socket",
 					"listen":  "unix:.workshop.socket",
@@ -161,19 +161,19 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 					"gid":     "1000",
 					"bind":    "instance"}},
 			map[string]string{
-				"user.workshop.sdk.desktop.type": "desktop-wayland"},
+				"user.workshop.sdk_desktop.type": "desktop-wayland"},
 		}, {
 			"sdk",
 			map[string]map[string]string{
-				"plug": {
+				"sdk_plug": {
 					"type": "none"}},
 			map[string]string{
-				"user.workshop.sdk.plug": `{
+				"user.workshop.sdk_plug": `{
           "name": "plug",
           "what": "/var",
           "where": "/etc", 
           "type": 1}`,
-				"user.workshop.sdk.plug.type": "mount"},
+				"user.workshop.sdk_plug.type": "mount"},
 		},
 	} {
 		res, err := lxdbackend.LxdToSdkProfile(t.name, t.devs, t.cfg)

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -71,7 +71,7 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 		Name: "test",
 		Base: "ubuntu@22.04",
 		Sdks: []workshop.SdkRecord{
-			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{
+			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{
 				"one-plug":     {Bind: &workshop.PlugRef{Sdk: "two", Name: "two-plug"}},
 				"one-plug-two": {Bind: &workshop.PlugRef{Sdk: "two", Name: "two-plug"}},
 			}},

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -184,7 +184,7 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	plugs := map[string]interface{}{}
 	for name, m := range w.File.Sdks[idx].Plugs {
 		if m.Bind == nil {
-			plugs[name] = m.Attributes
+			plugs[name] = m.Plug
 		} else {
 			binds[name] = sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: m.Bind.Sdk, Name: m.Bind.Name}
 		}

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -287,6 +287,36 @@ func (w *Workshop) Mounts(sdks []*sdk.Info) map[string][]Mount {
 	return mnts
 }
 
+// Tunnels returns a map of active SDK tunnels for the workshop.
+func (w *Workshop) Tunnels(sdks []*sdk.Info) map[string][]Tunnel {
+	if sdks == nil {
+		return nil
+	}
+
+	masters := map[sdk.PlugRef][]PlugRef{}
+	for _, sk := range sdks {
+		for name, m := range sk.PlugBinds {
+			s := PlugRef{Sdk: sk.Name, Name: name}
+			masters[m] = append(masters[m], s)
+		}
+	}
+
+	tunnels := map[string][]Tunnel{}
+	for _, prof := range w.Profiles {
+		for _, tunnel := range prof.Tunnels {
+			tunnels[prof.Sdk] = append(tunnels[prof.Sdk], tunnel)
+
+			pref := sdk.PlugRef{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: prof.Sdk, Name: tunnel.Name}
+			for _, slave := range masters[pref] {
+				tunnel.Name = slave.Name
+				tunnels[slave.Sdk] = append(tunnels[slave.Sdk], tunnel)
+			}
+		}
+	}
+
+	return tunnels
+}
+
 func SnapshotId(w, sk string) string {
 	return strings.Join([]string{w, sk}, ".")
 }

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -47,9 +47,51 @@ func ExpandSdkSource(source, project string) string {
 	return source
 }
 
-type Plug struct {
-	Bind       *PlugRef               `yaml:"bind,omitempty"`
-	Attributes map[string]interface{} `yaml:",inline"`
+type PlugOrBind struct {
+	Bind *PlugRef
+	Plug interface{}
+}
+
+func (p *PlugOrBind) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		p.Bind = nil
+		return value.Decode(&p.Plug)
+	}
+
+	var plug struct {
+		Bind       *PlugRef               `yaml:"bind"`
+		Attributes map[string]interface{} `yaml:",inline"`
+	}
+	if err := value.Decode(&plug); err != nil {
+		return err
+	}
+
+	if plug.Bind == nil {
+		*p = PlugOrBind{Plug: plug.Attributes}
+		return nil
+	}
+
+	if len(plug.Attributes) > 0 {
+		return fmt.Errorf("plug is bound to %q and must not define other attributes", plug.Bind.String())
+	}
+	*p = PlugOrBind{Bind: plug.Bind}
+	return nil
+}
+
+func (p PlugOrBind) MarshalYAML() (interface{}, error) {
+	if p.Bind == nil {
+		return p.Plug, nil
+	}
+
+	if p.Plug != nil {
+		return nil, fmt.Errorf("plug is bound to %q and must not define other attributes", p.Bind.String())
+	}
+
+	bind, err := p.Bind.MarshalYAML()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"bind": bind}, nil
 }
 
 type PlugRef struct {
@@ -92,7 +134,7 @@ func (b PlugRef) MarshalYAML() (interface{}, error) {
 type SdkRecord struct {
 	Name    string                 `yaml:"name"`
 	Channel string                 `yaml:"channel"`
-	Plugs   map[string]Plug        `yaml:"plugs,omitempty"`
+	Plugs   map[string]PlugOrBind  `yaml:"plugs,omitempty"`
 	Slots   map[string]interface{} `yaml:"slots,omitempty"`
 	Hooks   map[string]string      `yaml:"hooks,omitempty"`
 }
@@ -218,13 +260,6 @@ func validateSdks(sdks []SdkRecord) error {
 		// channel.
 		if !channel.MatchString(s.Channel) {
 			return fmt.Errorf("unsupported channel %q for %q SDK", s.Channel, s.Name)
-		}
-		// A plug must either be bound or declared/extended with dynamic
-		// attributes.
-		for _, plug := range s.Plugs {
-			if plug.Bind != nil && len(plug.Attributes) > 0 {
-				return fmt.Errorf("plug %q is bound and must not define other attributes", plug.Bind.String())
-			}
 		}
 	}
 	return nil

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -276,15 +276,21 @@ func validateBinding(sdks []SdkRecord) error {
 			if p.Bind == nil {
 				continue
 			}
-			mr := PlugRef{Sdk: p.Bind.Sdk, Name: p.Bind.Name}
+			mr := *p.Bind
 			sl := PlugRef{Sdk: s.Name, Name: name}
 			masters[mr] = append(masters[mr], sl)
 			slaves[sl] = mr
 
+			if sdk.IsSystem(sl.Sdk) {
+				return fmt.Errorf("cannot bind system SDK plug %q", sl.String())
+			}
+			if sdk.IsSystem(mr.Sdk) {
+				return fmt.Errorf("cannot bind to system SDK plug %q", mr.String())
+			}
 			if !IsImplicitSdk(p.Bind.Sdk) && !slices.ContainsFunc(sdks, func(sr SdkRecord) bool { return p.Bind.Sdk == sr.Name }) {
 				return fmt.Errorf("cannot bind plug %q: SDK %q not found", p.Bind.String(), p.Bind.Sdk)
 			}
-			if p.Bind.Sdk == s.Name && p.Bind.Name == name {
+			if mr == sl {
 				return fmt.Errorf(`cannot bind plug %q to itself`, p.Bind.String())
 			}
 		}

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -369,6 +369,36 @@ sdks:
 	c.Assert(err, check.ErrorMatches, `cannot bind plug "no-sdk:cache": SDK "no-sdk" not found`)
 }
 
+func (f *workshopFile) TestBindPlugSystemSdk(c *check.C) {
+	yaml := `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  - name: system
+  - name: etl-sdk
+    channel: latest/stable
+    plugs:
+      data: 
+        bind: system:cache
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	_, err := f.project.Workshop("xbert-gpu")
+	c.Check(err, check.ErrorMatches, `cannot bind to system SDK plug "system:cache"`)
+
+	yaml = `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  - name: system
+    plugs:
+      cache: 
+        bind: etl-sdk:data
+  - name: etl-sdk
+    channel: latest/stable
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	_, err = f.project.Workshop("xbert-gpu")
+	c.Check(err, check.ErrorMatches, `cannot bind system SDK plug "system:cache"`)
+}
+
 func (f *workshopFile) TestBindPlugToItself(c *check.C) {
 	yaml := `name: xbert-gpu
 base: ubuntu@20.04

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -102,8 +102,8 @@ func (f *workshopFile) TestWorkshopFileSave(c *check.C) {
 		Name: "test-workshop",
 		Base: "ubuntu@22.04",
 		Sdks: []workshop.SdkRecord{
-			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: &workshop.PlugRef{Sdk: "two", Name: "plug"}}}},
-			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"plug": {Bind: &workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
+			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"plug": {Bind: &workshop.PlugRef{Sdk: "two", Name: "plug"}}}},
+			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"plug": {Bind: &workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
 		},
 		Scripts: map[string]workshop.Script{
 			"oneline":   "\n\n\necho one line\n",
@@ -259,6 +259,30 @@ sdks:
 	c.Assert(err, check.ErrorMatches, `unsupported channel "latest/foo" for "cuda" SDK`)
 }
 
+func (f *workshopFile) TestShortcuts(c *check.C) {
+	yaml := `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  - name: data-sdk
+    channel: latest/stable
+    plugs:
+      db: tunnel
+      tunnel:
+  - name: etl-sdk
+    channel: latest/stable
+    slots:
+      dashboard: tunnel
+      tunnel:
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	file, err := f.project.Workshop("xbert-gpu")
+	c.Assert(err, check.IsNil)
+	c.Assert(file.Sdks, check.DeepEquals, []workshop.SdkRecord{
+		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"db": {Plug: "tunnel"}, "tunnel": {}}},
+		{Name: "etl-sdk", Channel: "latest/stable", Slots: map[string]interface{}{"dashboard": "tunnel", "tunnel": nil}},
+	})
+}
+
 func (f *workshopFile) TestBindPlug(c *check.C) {
 	yaml := `name: xbert-gpu
 base: ubuntu@20.04
@@ -278,8 +302,8 @@ sdks:
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, check.DeepEquals, []workshop.SdkRecord{
-		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Bind: &workshop.PlugRef{Sdk: "etl-sdk", Name: "cache"}}}},
-		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: &workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
+		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"cache": {Bind: &workshop.PlugRef{Sdk: "etl-sdk", Name: "cache"}}}},
+		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"data": {Bind: &workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
 	})
 }
 
@@ -302,8 +326,8 @@ sdks:
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, check.DeepEquals, []workshop.SdkRecord{
-		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"cache": {Attributes: map[string]interface{}{"attr1": "val"}}}},
-		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.Plug{"data": {Bind: &workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
+		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"cache": {Plug: map[string]interface{}{"attr1": "val"}}}},
+		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"data": {Bind: &workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
 	})
 }
 
@@ -322,7 +346,7 @@ sdks:
 `
 	f.createWFile(c, "xbert-gpu", yaml)
 	_, err := f.project.Workshop("xbert-gpu")
-	c.Assert(err, check.ErrorMatches, `plug "data-sdk:aux" is bound and must not define other attributes`)
+	c.Assert(err, check.ErrorMatches, `plug is bound to "data-sdk:aux" and must not define other attributes`)
 }
 
 func (f *workshopFile) TestBindPlugNoSdk(c *check.C) {

--- a/tests/lib/sdk/test-sdk-multiple-plugs/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-multiple-plugs/latest/stable/meta/sdk.yaml
@@ -8,11 +8,11 @@ description: |
 
 sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
 plugs:
-  data:
+  one:
     interface: mount
-    workshop-target: /home/workshop/data
-  cache:
+    workshop-target: /mnt/one
+  two:
     interface: mount
-    workshop-target: /cache
+    workshop-target: /opt/two
   ssh-agent:
     interface: ssh-agent

--- a/tests/main/interface-gpu/task.yaml
+++ b/tests/main/interface-gpu/task.yaml
@@ -23,7 +23,7 @@ execute: |
   # ensure that the LXD profile contains a gpu device with a proper
   # configuration.  
   project_id=$(cat .workshop.lock)
-  lxc profile show --project workshop.ubuntu ws-gpu-"$project_id"-test-sdk-gpu | yq '.devices.gpu' > output.log
+  lxc profile show --project workshop.ubuntu ws-gpu-"$project_id"-test-sdk-gpu | yq '.devices.test-sdk-gpu_gpu' > output.log
   MATCH "type: gpu" < output.log
   MATCH "gputype: physical" < output.log
   MATCH 'uid: "1000"' < output.log

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -8,9 +8,9 @@ execute: |
   function check_original_binding() {
     MATCH "mount      -                                          ws-bind/test-sdk-mount:jobs  -" < conns.log
     MATCH "mount      ws-bind/test-sdk-mount:one                 ws-bind/system:mount         bind.2" < conns.log
-    MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         bind.4" < conns.log
-    MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      ws-bind/system:mount         bind.4" < conns.log
-    MATCH "mount      ws-bind/test-sdk-multiple-plugs:data       ws-bind/system:mount         bind.2" < conns.log
+    MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         bind.5" < conns.log
+    MATCH "mount      ws-bind/test-sdk-multiple-plugs:one        ws-bind/system:mount         bind.2" < conns.log
+    MATCH "mount      ws-bind/test-sdk-multiple-plugs:two        ws-bind/system:mount         bind.5" < conns.log
     MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -                            bind.6" < conns.log
     MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -                            bind.6" < conns.log
   }
@@ -21,26 +21,26 @@ execute: |
 
   echo "Check bound mount plugs use host directories of the plug they are bound to"
   workshop_exec info | grep -v notes > mounts.log
-  yq '.sdks["test-sdk-multiple-plugs"].mounts["data"]' < mounts.log | MATCH "^host-source:.*test-sdk-mount/one"
-  yq '.sdks["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*test-sdk-multiple-plugs/cache"
+  yq '.sdks["test-sdk-multiple-plugs"].mounts["one"]' < mounts.log | MATCH "^host-source:.*test-sdk-mount/one"
+  yq '.sdks["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*test-sdk-multiple-plugs/two"
 
   echo "Check disconnect affects all bound plugs"
-  workshop_exec disconnect ws-bind/test-sdk-multiple-plugs:cache
+  workshop_exec disconnect ws-bind/test-sdk-multiple-plugs:two
   workshop_exec connections ws-bind > conns.log
-  MATCH "mount      ws-bind/test-sdk-mount:two                 -                            bind.4" < conns.log
-  MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      -                            bind.4" < conns.log
+  MATCH "mount      ws-bind/test-sdk-mount:two                 -                            bind.5" < conns.log
+  MATCH "mount      ws-bind/test-sdk-multiple-plugs:two        -                            bind.5" < conns.log
 
   echo "Check connect affects all bound plugs"
-  workshop_exec connect ws-bind/test-sdk-multiple-plugs:cache :mount
+  workshop_exec connect ws-bind/test-sdk-multiple-plugs:two :mount
   workshop_exec connections ws-bind > conns.log
-  MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         manual,bind.4" < conns.log
-  MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      ws-bind/system:mount         manual,bind.4" < conns.log
+  MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         manual,bind.5" < conns.log
+  MATCH "mount      ws-bind/test-sdk-multiple-plugs:two        ws-bind/system:mount         manual,bind.5" < conns.log
 
   echo "Check remount affects all bound plugs"
   new_source="/home/ubuntu/remount-bound-test"
   workshop_exec remount ws-bind/test-sdk-mount:two "$new_source"
   workshop_exec info | grep -v notes > mounts.log
-  yq '.sdks["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host-source:.*$new_source"
+  yq '.sdks["test-sdk-multiple-plugs"].mounts["two"]' < mounts.log | MATCH "^host-source:.*$new_source"
   yq '.sdks["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*$new_source"
 
   echo "Check refresh respects binding"
@@ -50,11 +50,8 @@ execute: |
   check_original_binding
 
   echo "Check a plug can be unbound"
-  cat workshop.yaml | yq '.sdks[0].plugs = ~' | sponge workshop.yaml
+  cat workshop.yaml | yq 'del(.sdks[2].plugs)' | sponge workshop.yaml
   workshop_exec refresh
   workshop_exec connections ws-bind > conns.log
-  MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         -" < conns.log
-  MATCH "mount      ws-bind/test-sdk-multiple-plugs:cache      ws-bind/system:mount         -" < conns.log
-  workshop_exec info | grep -v notes > mounts.log
-  yq '.sdks["test-sdk-multiple-plugs"].mounts["cache"]' < mounts.log | MATCH "^host-source:.*$new_source"
-  yq '.sdks["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*test-sdk-mount/two"
+  MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -                            -" < conns.log
+  MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -                            -" < conns.log

--- a/tests/main/interface-plug-binding/workshop.yaml
+++ b/tests/main/interface-plug-binding/workshop.yaml
@@ -5,11 +5,11 @@ sdks:
     channel: latest/stable
     plugs:
       two:
-        bind: test-sdk-multiple-plugs:cache
+        bind: test-sdk-multiple-plugs:two
   - name: test-sdk-multiple-plugs
     channel: latest/stable
     plugs:
-      data:
+      one:
         bind: test-sdk-mount:one
   - name: test-sdk-ssh-agent
     channel: latest/stable


### PR DESCRIPTION
# Description

Limits plug binding so you can only bind identical plugs in regular SDKs. The intended use case is to resolve conflicts between mount plugs with the same `workshop-target`, but it still works for other interfaces. Tunnel interface plugs can also conflict, but since they aren't auto-connected for regular SDKs, you can just leave one disconnected instead of binding them.

There's an outstanding issue where conflicts between unix domain sockets aren't detected. If you disconnect one plug, the socket is deleted even though the other plug remains connected. Since Workshop expands environment variables in socket paths it's not easy to detect these conflicts early on. I have a fix in mind and will do it as part of the partial profile update fix.

Fixes a few other bugs:
- Conflicts between `workshop-target`s are now detected before connecting the plugs (by moving all validation to a new kind of task).
- Plugs in different SDKs with the same name can be connected simultaneously (previously the LXD device names matched, so LXD would ignore all but one of them).
- Workshop definitions now support the shortcut `name: interface` for plugs, in addition to slots. SDK definitions already supported both.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
