### PR TITLE
Rework LxdProjectName to accommodate non-POSIX usernames

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -260,16 +260,16 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	username, err := LookupUserId(strconv.FormatUint(uint64(uid), 10))
+	usr, err := LookupUserId(strconv.FormatUint(uint64(uid), 10))
 	if err != nil {
 		statusInternalError("cannot get an associated user name: %w", err).ServeHTTP(w, r)
 		return
 	}
 
-	userCtx := context.WithValue(r.Context(), workshop.ContextUser, username.Username)
+	ctx := context.WithValue(r.Context(), workshop.ContextUser, usr.Username)
 
 	if rspf != nil {
-		rsp = rspf(c, r.WithContext(userCtx), user)
+		rsp = rspf(c, r.WithContext(ctx), user)
 	}
 
 	if rsp, ok := rsp.(*resp); ok {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -43,20 +43,6 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 	return interfaces.SecurityLxdDevice
 }
 
-func lxdClient(ctx context.Context) (lxd.InstanceServer, error) {
-	user, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
-	}
-
-	srv, err := lxd.ConnectLXDUnixWithContext(ctx, LxdSock, nil)
-	if err != nil {
-		return nil, lxdbackend.ErrorWithInstallLXDPrompt(err)
-	}
-
-	return srv.UseProject("workshop." + user), nil
-}
-
 func installMount(user *user.User, fs workshop.WorkshopFs, dev workshop.Mount) (reload bool, err error) {
 	if dev.Type == workshop.WorkshopWorkshop {
 		if _, err = fs.Stat(dev.What); err != nil {
@@ -338,7 +324,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 		Description: fmt.Sprintf("%q SDK profile for %q workshop", sdkInfo.Sdk, sdkInfo.Workshop),
 	}
 
-	conn, err := lxdClient(ctx)
+	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {
 		return err
 	}
@@ -440,7 +426,7 @@ func (b *Backend) Setup(ctx context.Context, sdkInfo sdk.Ref, repo *interfaces.R
 //
 // This method should be called after removing a sdk.
 func (b *Backend) Remove(ctx context.Context, w, profile string) error {
-	conn, err := lxdClient(ctx)
+	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -118,8 +118,8 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 
 func (f *backendDeviceSuite) TearDownTest(c *check.C) {
 	helper.RemoveTestWorkshop(c, f.ctx, f.be)
-	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdProjectName(f.usr.Username))
-	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdStashProjectName(f.usr.Username))
+	helper.CleanupLxdProject(c, f.client, "workshop."+f.usr.Username)
+	helper.CleanupLxdProject(c, f.client, "workshop-stash."+f.usr.Username)
 	f.restoreNewId()
 	f.restoreEnv()
 	f.restoreUser()

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -63,8 +63,8 @@ func (w *WorkshopManager) Workshop(ctx context.Context, name, pId string) (*work
 	return workshop, nil
 }
 
-// Returns latest file for a workshop. The state must be locked,
-// as listing projects can update project metadata.
+// Returns latest file for a workshop. The state must be locked, as listing
+// projects can update project metadata.
 func (w *WorkshopManager) WorkshopFile(ctx context.Context, name, pId string) (*workshop.File, error) {
 	user, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
@@ -85,8 +85,8 @@ func (w *WorkshopManager) WorkshopFile(ctx context.Context, name, pId string) (*
 	return p.Workshop(name)
 }
 
-// Returns all workshop files for a project. The state must be locked,
-// as listing projects can update project metadata.
+// Returns all workshop files for a project. The state must be locked, as
+// listing projects can update project metadata.
 func (w *WorkshopManager) WorkshopFiles(ctx context.Context, pId string) (map[string]string, error) {
 	user, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -317,7 +317,7 @@ func installSdks(st *state.State, pid, w string, sdks []sdk.Setup, retrieveTasks
 	return all
 }
 
-func launchWorkshop(st *state.State, file *workshop.File, project workshop.Project) *state.TaskSet {
+func launchWorkshop(st *state.State, file *workshop.File) *state.TaskSet {
 	construct := state.NewTaskSet()
 
 	var prev *state.Task
@@ -397,7 +397,7 @@ func launch(st *state.State, file *workshop.File, sdks []sdk.Setup, project work
 	createDirs := st.NewTask("create-workshop-storage", fmt.Sprintf("Create %q storage directories", file.Name))
 	addTaskSet(state.NewTaskSet(createDirs))
 
-	create := launchWorkshop(st, file, project)
+	create := launchWorkshop(st, file)
 	addTaskSet(create)
 
 	install := installSdks(st, project.ProjectId, file.Name, sdks, rmap)
@@ -472,7 +472,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 			return nil, err
 		}
 
-		tasks, err := refresh(ctx, w.state, plan, wp, req.file)
+		tasks, err := refresh(w.state, plan, wp, req.file)
 		if err != nil {
 			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}
@@ -637,7 +637,7 @@ func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []s
 	return plan, nil
 }
 
-func refresh(ctx context.Context, st *state.State, plan *refreshPlan, w *workshop.Workshop, file *workshop.File) (*state.TaskSet, error) {
+func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *workshop.File) (*state.TaskSet, error) {
 	refresh := state.NewTaskSet()
 	prev := (*state.TaskSet)(nil)
 	addTaskSet := func(ts *state.TaskSet) {

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -60,8 +60,6 @@ type WorkshopConfigValue struct {
 	Value string
 }
 
-var StashNamePrefix string = "stash-"
-
 type Stash interface {
 	// Make a stash of the workshop. The workshop will be stopped and will not
 	// be available to other workshop operations, e.g. list, stop, start and so

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -457,10 +457,10 @@ func (s *FakeWorkshopBackend) RemoveWorkshopStash(ctx context.Context, name stri
 	s.workshopLock.Lock()
 	defer s.workshopLock.Unlock()
 
-	if s.StashedWorkshops[projectId][workshop.StashNamePrefix+name] == nil {
+	if s.StashedWorkshops[projectId]["stash-"+name] == nil {
 		return fmt.Errorf("stashed workshop %q not found", name)
 	}
-	delete(s.StashedWorkshops[projectId], workshop.StashNamePrefix+name)
+	delete(s.StashedWorkshops[projectId], "stash-"+name)
 	return nil
 }
 
@@ -473,7 +473,7 @@ func (s *FakeWorkshopBackend) UnstashWorkshop(ctx context.Context, name string) 
 	s.workshopLock.Lock()
 	defer s.workshopLock.Unlock()
 
-	wp := s.StashedWorkshops[projectId][workshop.StashNamePrefix+name]
+	wp := s.StashedWorkshops[projectId]["stash-"+name]
 	if wp == nil {
 		return fmt.Errorf("stashed workshop %q not found", name)
 	}
@@ -506,9 +506,9 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	wcpy := *wp.Workshop
 	stashed := *wp
 	stashed.Workshop = &wcpy
-	stashed.Name = workshop.StashNamePrefix + name
+	stashed.Name = "stash-" + name
 
-	s.StashedWorkshops[projectId][workshop.StashNamePrefix+name] = &stashed
+	s.StashedWorkshops[projectId][stashed.Name] = &stashed
 	return nil
 }
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -113,22 +113,26 @@ func New() (*Backend, error) {
 		imageServer = srv
 	}
 
-	// Create LXD storage pool if it doesn't exist
+	// TODO: run this logic for a specific user. The code below implies the
+	// default project activated for the connection. As we have seen, every user
+	// has to create its own storage pool to avoid issues with id mapping of a
+	// volume with the same name (e.g. both users have system-1 volume for the
+	// system SDK that cannot be successfully mounted for another user).
 	conn, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {
 		return nil, ErrorLxdBackend(err)
 	}
 	defer conn.Disconnect()
 
+	// Create LXD storage pool if it doesn't exist.
 	pools, err := conn.GetStoragePools()
 	if err != nil {
 		return nil, err
 	}
-	// Workshop does not require an existing storage pool.
-	// However, once the workshop storage pool exists,
-	// `lxd init --auto` won't add another one,
-	// and non-Workshop LXD containers can't be launched
-	// without further manual configuration.
+	// Workshop does not require an existing storage pool. However, once the
+	// workshop storage pool exists, `lxd init --auto` won't add another one,
+	// and non-Workshop LXD containers can't be launched without further manual
+	// configuration.
 	if len(pools) == 0 {
 		return nil, errors.New(`LXD not initialized
 
@@ -139,11 +143,10 @@ To initialize LXD: 'lxd init --auto'`)
 	if err != nil {
 		return nil, err
 	}
-	// Workshop does not require an existing network.
-	// However, once the workshopbr0 network pool exists,
-	// `lxd init --auto` won't add another one,
-	// and non-Workshop LXD containers won't have network access
-	// without further manual configuration.
+	// Workshop does not require an existing network. However, once the
+	// workshopbr0 network pool exists, `lxd init --auto` won't add another one,
+	// and non-Workshop LXD containers won't have network access without further
+	// manual configuration.
 	if len(networks) == 0 {
 		return nil, errors.New(`LXD not initialized
 
@@ -936,17 +939,26 @@ func (s *Backend) WorkshopFs(ctx context.Context, name string) (workshop.Worksho
 }
 
 func ConnectLxd(ctx context.Context) (lxd.InstanceServer, error) {
-	user, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
-	}
-
 	conn, err := lxd.ConnectLXDUnixWithContext(ctx, "", nil)
 	if err != nil {
 		return nil, ErrorLxdBackend(err)
 	}
 
-	return switchLxdProject(conn, user)
+	user, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
+	}
+
+	project, err := lxdProjectName(user)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = initLxdProject(conn, project, user); err != nil {
+		return nil, err
+	}
+
+	return conn.UseProject(project), err
 }
 
 func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -78,11 +78,15 @@ func InstanceName(name string, project_id string) string {
 	return fmt.Sprintf("%s-%s", name, project_id)
 }
 
+func instanceStashName(name string, pid string) string {
+	return "stash-" + InstanceName(name, pid)
+}
+
 func ImageAlias(name string) string {
 	return fmt.Sprintf("workshop-%s-%s", name, runtime.GOARCH)
 }
 
-func ErrorWithInstallLXDPrompt(err error) error {
+func ErrorLxdBackend(err error) error {
 	switch {
 	case errors.Is(err, unix.ECONNREFUSED):
 		return fmt.Errorf(`cannot connect to LXD: %w
@@ -112,7 +116,7 @@ func New() (*Backend, error) {
 	// Create LXD storage pool if it doesn't exist
 	conn, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {
-		return nil, ErrorWithInstallLXDPrompt(err)
+		return nil, ErrorLxdBackend(err)
 	}
 	defer conn.Disconnect()
 
@@ -241,7 +245,12 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 	}
 	defer conn.Disconnect()
 
-	userName, ok := ctx.Value(workshop.ContextUser).(string)
+	info, err := conn.GetConnectionInfo()
+	if err != nil {
+		return err
+	}
+
+	username, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
 		return fmt.Errorf("context key user not found")
 	}
@@ -251,7 +260,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	// Check if we have the base image stored locally
+	// Check if we have the base image stored locally.
 	alias, _, err := conn.GetImageAlias(ImageAlias(file.Base))
 	if err != nil {
 		return err
@@ -262,7 +271,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		return err
 	}
 
-	usr, err := osutil.UserLookup(userName)
+	usr, err := osutil.UserLookup(username)
 	if err != nil {
 		return err
 	}
@@ -289,7 +298,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			Source: api.InstanceSource{
 				Type:        "image",
 				Fingerprint: image.Fingerprint,
-				Project:     LxdProjectName(usr.Username),
+				Project:     info.Project,
 			},
 		}
 		op, err := conn.CreateInstance(req)
@@ -299,7 +308,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 
 		return op.Wait()
 	default:
-		// Rebuild the existing workshop
+		// Rebuild the existing workshop.
 		for _, snapshot := range inst.Snapshots {
 			op, err := conn.DeleteInstanceSnapshot(inst.Name, snapshot.Name)
 			if err != nil {
@@ -318,7 +327,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			return err
 		}
 
-		// Get an updated instance configuration
+		// Get an updated instance configuration.
 		rebuilt, etag, err := conn.GetInstance(inst.Name)
 		if err != nil {
 			return err
@@ -926,20 +935,22 @@ func (s *Backend) WorkshopFs(ctx context.Context, name string) (workshop.Worksho
 	return workshop.NewWorkshopFs(sftp), nil
 }
 
-func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {
+func ConnectLxd(ctx context.Context) (lxd.InstanceServer, error) {
 	user, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
 		return nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
 	}
 
-	if srv, err := lxd.ConnectLXDUnixWithContext(ctx, "", nil); err != nil {
-		return nil, ErrorWithInstallLXDPrompt(err)
-	} else {
-		if err = InitLxdProject(srv, user); err != nil {
-			return nil, err
-		}
-		return srv.UseProject(LxdProjectName(user)), nil
+	conn, err := lxd.ConnectLXDUnixWithContext(ctx, "", nil)
+	if err != nil {
+		return nil, ErrorLxdBackend(err)
 	}
+
+	return switchLxdProject(conn, user)
+}
+
+func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {
+	return ConnectLxd(ctx)
 }
 
 func defaultDevices(pid, w string) map[string]map[string]string {
@@ -979,7 +990,7 @@ func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
 func checkNvidia() (bool, error) {
 	conn, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {
-		return false, ErrorWithInstallLXDPrompt(err)
+		return false, ErrorLxdBackend(err)
 	}
 	defer conn.Disconnect()
 

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -2,10 +2,12 @@ package lxdbackend
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
+	"regexp"
+	"slices"
 	"strings"
 
 	lxd "github.com/canonical/lxd/client"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -25,41 +28,82 @@ func lxdProjectConfig(username string) map[string]string {
 	}
 }
 
-func LxdProjectName(user string) string {
-	return "workshop." + user
+// Checks if a user name can be used in a LXD project name.
+var isValidUsername = regexp.MustCompile(`^[a-zA-Z0-9-._]*$`).MatchString
+
+func projectName(prefix, user string) (string, error) {
+	if isValidUsername(user) {
+		return prefix + user, nil
+	}
+
+	u, err := osutil.UserLookup(user)
+	if err != nil {
+		return "", err
+	}
+	return prefix + u.Uid, nil
 }
 
-func LxdStashProjectName(user string) string {
-	return "workshop-stash." + user
+func lxdProjectName(user string) (string, error) {
+	return projectName("workshop.", user)
+}
+
+func lxdStashProjectName(user string) (string, error) {
+	return projectName("workshop-stash.", user)
 }
 
 // Initialise the Workshop project namespace.
-func InitLxdProject(conn lxd.InstanceServer, username string) error {
-	if username == "" {
-		return fmt.Errorf("cannot init LXD project: username is empty")
-	}
-	if err := createOrLoadLxdProject(conn, username, LxdProjectName(username)); err != nil {
-		return err
+func switchLxdProject(conn lxd.InstanceServer, username string) (lxd.InstanceServer, error) {
+	project, err := lxdProjectName(username)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := createOrLoadLxdProject(conn, username, LxdStashProjectName(username)); err != nil {
-		return err
+	if err = initLxdProject(conn, project, username); err != nil {
+		return nil, err
 	}
-	return nil
+
+	return conn.UseProject(project), err
 }
 
-func createOrLoadLxdProject(conn lxd.InstanceServer, username, project string) error {
-	_, _, err := conn.GetProject(project)
-	if api.StatusErrorCheck(err, http.StatusNotFound) {
-		return conn.CreateProject(api.ProjectsPost{
+// Create LXD projects (regular and stash) for the user.
+func initLxdProject(conn lxd.InstanceServer, project, username string) error {
+	names, err := conn.GetProjectNames()
+	if err != nil {
+		return err
+	}
+
+	if !slices.Contains(names, project) {
+		stash, err := lxdStashProjectName(username)
+		if err != nil {
+			return err
+		}
+
+		err1 := conn.CreateProject(api.ProjectsPost{
 			ProjectPut: api.ProjectPut{
 				Config:      lxdProjectConfig(username),
 				Description: fmt.Sprintf(`Workshop project for "%s" user`, username),
 			},
 			Name: project,
 		})
+
+		rev := revert.New()
+		rev.Add(func() { _ = conn.DeleteProject(project) })
+
+		err2 := conn.CreateProject(api.ProjectsPost{
+			ProjectPut: api.ProjectPut{
+				Config:      lxdProjectConfig(username),
+				Description: fmt.Sprintf(`Workshop stash project for "%s" user`, username),
+			},
+			Name: stash,
+		})
+
+		if err = cmp.Or(err1, err2); err != nil {
+			return err
+		}
+		rev.Success()
 	}
-	return err
+
+	return nil
 }
 
 func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*workshop.Project, bool, error) {
@@ -69,12 +113,12 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 	}
 	defer client.Disconnect()
 
-	user, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return nil, false, fmt.Errorf("context key %s not found", workshop.ContextUser)
+	info, err := client.GetConnectionInfo()
+	if err != nil {
+		return nil, false, err
 	}
 
-	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
+	lxdPrj, etag, err := client.GetProject(info.Project)
 	if err != nil {
 		return nil, false, err
 	}
@@ -112,7 +156,7 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 
 func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, error) {
 	if user, ok := ctx.Value(workshop.ContextUser).(string); ok {
-		projects, err := s.userProjects(ctx, user)
+		projects, err := s.userProjects(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +168,7 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, 
 	// and reload every interface connection for every SDK of every workshop.
 	client, err := lxd.ConnectLXDUnixWithContext(ctx, "", nil)
 	if err != nil {
-		return nil, ErrorWithInstallLXDPrompt(err)
+		return nil, ErrorLxdBackend(err)
 	}
 	// list all projects for all users if the user is not provided
 	lxdProjects, err := client.GetProjects()
@@ -145,7 +189,7 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, 
 		}
 
 		prjctx := context.WithValue(ctx, workshop.ContextUser, username)
-		projects, err := s.userProjects(prjctx, username)
+		projects, err := s.userProjects(prjctx)
 		if err != nil {
 			return nil, err
 		}
@@ -155,14 +199,19 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, 
 	return allProjects, nil
 }
 
-func (s *Backend) userProjects(ctx context.Context, user string) ([]workshop.Project, error) {
+func (s *Backend) userProjects(ctx context.Context) ([]workshop.Project, error) {
 	client, err := s.LxdClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer client.Disconnect()
 
-	lxdPrj, etag, err := client.GetProject(LxdProjectName(user))
+	info, err := client.GetConnectionInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	lxdPrj, etag, err := client.GetProject(info.Project)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -2,7 +2,6 @@ package lxdbackend
 
 import (
 	"bytes"
-	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,14 +28,14 @@ func lxdProjectConfig(username string) map[string]string {
 }
 
 // Checks if a user name can be used in a LXD project name.
-var isValidUsername = regexp.MustCompile(`^[a-zA-Z0-9-._]*$`).MatchString
+var isValidProjectSuffix = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z0-9._]*$`).MatchString
 
-func projectName(prefix, user string) (string, error) {
-	if isValidUsername(user) {
-		return prefix + user, nil
+func projectName(prefix, username string) (string, error) {
+	if isValidProjectSuffix(username) {
+		return prefix + username, nil
 	}
 
-	u, err := osutil.UserLookup(user)
+	u, err := osutil.UserLookup(username)
 	if err != nil {
 		return "", err
 	}
@@ -51,21 +50,7 @@ func lxdStashProjectName(user string) (string, error) {
 	return projectName("workshop-stash.", user)
 }
 
-// Initialise the Workshop project namespace.
-func switchLxdProject(conn lxd.InstanceServer, username string) (lxd.InstanceServer, error) {
-	project, err := lxdProjectName(username)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = initLxdProject(conn, project, username); err != nil {
-		return nil, err
-	}
-
-	return conn.UseProject(project), err
-}
-
-// Create LXD projects (regular and stash) for the user.
+// Create regular and stash LXD projects for the user if they don't exist.
 func initLxdProject(conn lxd.InstanceServer, project, username string) error {
 	names, err := conn.GetProjectNames()
 	if err != nil {
@@ -73,36 +58,40 @@ func initLxdProject(conn lxd.InstanceServer, project, username string) error {
 	}
 
 	if !slices.Contains(names, project) {
-		stash, err := lxdStashProjectName(username)
-		if err != nil {
-			return err
-		}
-
-		err1 := conn.CreateProject(api.ProjectsPost{
+		err = conn.CreateProject(api.ProjectsPost{
 			ProjectPut: api.ProjectPut{
 				Config:      lxdProjectConfig(username),
 				Description: fmt.Sprintf(`Workshop project for "%s" user`, username),
 			},
 			Name: project,
 		})
+		if err != nil {
+			return err
+		}
+	}
 
-		rev := revert.New()
-		rev.Add(func() { _ = conn.DeleteProject(project) })
+	rev := revert.New()
+	defer rev.Fail()
+	rev.Add(func() { _ = conn.DeleteProject(project) })
 
-		err2 := conn.CreateProject(api.ProjectsPost{
+	stash, err := lxdStashProjectName(username)
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(names, stash) {
+		err = conn.CreateProject(api.ProjectsPost{
 			ProjectPut: api.ProjectPut{
 				Config:      lxdProjectConfig(username),
 				Description: fmt.Sprintf(`Workshop stash project for "%s" user`, username),
 			},
 			Name: stash,
 		})
-
-		if err = cmp.Or(err1, err2); err != nil {
+		if err != nil {
 			return err
 		}
-		rev.Success()
 	}
 
+	rev.Success()
 	return nil
 }
 

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -1,6 +1,7 @@
 package lxdbackend
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/http"
@@ -27,8 +28,6 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	instance := InstanceName(name, projectId)
-	stashedInsance := workshop.StashNamePrefix + instance
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -45,7 +44,16 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		}
 	})
 
-	if err = s.copyInstance(conn, instance, stashedInsance, LxdProjectName(user), LxdStashProjectName(user)); err != nil {
+	instance := InstanceName(name, projectId)
+	stashed := instanceStashName(name, projectId)
+
+	sourceProject, err1 := lxdProjectName(user)
+	targetProject, err2 := lxdStashProjectName(user)
+	if err = cmp.Or(err1, err2); err != nil {
+		return err
+	}
+
+	if err = s.copyInstance(conn, instance, stashed, sourceProject, targetProject); err != nil {
 		return err
 	}
 
@@ -64,22 +72,29 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	instance := InstanceName(name, projectId)
-	stashedInsance := workshop.StashNamePrefix + instance
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Disconnect()
 
-	if err := s.copyInstance(conn, stashedInsance, instance, LxdStashProjectName(user), LxdProjectName(user)); err != nil {
+	instance := InstanceName(name, projectId)
+	stash := instanceStashName(name, projectId)
+
+	sourceProject, err1 := lxdStashProjectName(user)
+	targetProject, err2 := lxdProjectName(user)
+	if err = cmp.Or(err1, err2); err != nil {
+		return err
+	}
+
+	if err := s.copyInstance(conn, stash, instance, sourceProject, targetProject); err != nil {
 		return err
 	}
 
 	return s.startWorkshop(conn, ctx, name)
 }
 
-// Moves the instance between LXD projects.
+// Copies the instance between LXD projects.
 func (s *Backend) copyInstance(conn lxd.InstanceServer, srcName, dstName, sourceProject, targetProject string) error {
 	conn = conn.UseProject(sourceProject)
 	instance, _, err := conn.GetInstance(srcName)
@@ -118,8 +133,13 @@ func (s *Backend) RemoveWorkshopStash(ctx context.Context, name string) error {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	conn = conn.UseProject(LxdStashProjectName(user))
-	iname := workshop.StashNamePrefix + InstanceName(name, projectId)
+	stash, err := lxdStashProjectName(user)
+	if err != nil {
+		return err
+	}
+
+	conn = conn.UseProject(stash)
+	iname := instanceStashName(name, projectId)
 
 	op, err := conn.DeleteInstance(iname)
 	if err != nil {

--- a/internal/workshop/lxd/lxd_backend_stash.go
+++ b/internal/workshop/lxd/lxd_backend_stash.go
@@ -18,16 +18,6 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	rev := revert.New()
 	defer rev.Fail()
 
-	user, ok := ctx.Value(workshop.ContextUser).(string)
-	if !ok {
-		return fmt.Errorf("context key %s not found", workshop.ContextUser)
-	}
-
-	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
-	if !ok {
-		return fmt.Errorf("context key project-id not found")
-	}
-
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -43,6 +33,16 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 			logger.Debugf("On StashWorkshop: Cannot restart %q workshop after failed stash operation: %v", name, rerr)
 		}
 	})
+
+	user, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return fmt.Errorf("context key %s not found", workshop.ContextUser)
+	}
+
+	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
+	if !ok {
+		return fmt.Errorf("context key project-id not found")
+	}
 
 	instance := InstanceName(name, projectId)
 	stashed := instanceStashName(name, projectId)

--- a/internal/workshop/lxd/tests/integration/project_test.go
+++ b/internal/workshop/lxd/tests/integration/project_test.go
@@ -5,6 +5,7 @@ package lxdbackend_integration_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -44,8 +45,8 @@ func (f *wsProject) SetUpTest(c *check.C) {
 }
 
 func (f *wsProject) TearDownTest(c *check.C) {
-	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdProjectName(f.username))
-	helper.CleanupLxdProject(c, f.client, lxdbackend.LxdStashProjectName(f.username))
+	helper.CleanupLxdProject(c, f.client, "workshop."+f.username)
+	helper.CleanupLxdProject(c, f.client, "workshop-stash."+f.username)
 }
 
 func TestWorkshopBackendIntegration(t *testing.T) { check.TestingT(t) }
@@ -97,7 +98,7 @@ func (f *wsProject) TestLxdBackendCreateProject(c *check.C) {
 	c.Assert(prj.Path, check.Equals, projectDir)
 	c.Assert(err, check.IsNil)
 
-	lxdProject, _, _ := f.client.GetProject(lxdbackend.LxdProjectName("testuser"))
+	lxdProject, _, _ := f.client.GetProject("workshop." + f.username)
 	c.Assert(workshop.LockPath(projectDir), testutil.FilePresent)
 	c.Assert(lxdProject.Config["user.workshop.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, projectDir))
 
@@ -107,7 +108,7 @@ func (f *wsProject) TestLxdBackendCreateProject(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Validate
-	lxdProject, _, _ = f.client.GetProject(lxdbackend.LxdProjectName("testuser"))
+	lxdProject, _, _ = f.client.GetProject("workshop." + f.username)
 	c.Assert(workshop.LockPath(projectDir2), testutil.FilePresent)
 	c.Assert(lxdProject.Config["user.workshop.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"b8639dea"},{"path":"%s","id":"d4352dea"}]`, projectDir, projectDir2))
 }
@@ -134,7 +135,7 @@ func (f *wsProject) TestLxdBackendReconcileProjectIfNotRecovered(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(projects[f.username], check.HasLen, 0)
 
-	lxdProject, _, _ := f.client.GetProject(lxdbackend.LxdProjectName("testuser"))
+	lxdProject, _, _ := f.client.GetProject("workshop." + f.username)
 	c.Assert(lxdProject.Config["user.workshop.projects"], check.DeepEquals, `[]`)
 }
 
@@ -161,7 +162,7 @@ func (f *wsProject) TestLxdBackendLoadProject(c *check.C) {
 	c.Assert(prj.Path, check.Equals, projectDir)
 	c.Assert(err, check.IsNil)
 	c.Assert(created, check.Equals, false)
-	lxdProject, _, _ := f.client.GetProject(lxdbackend.LxdProjectName("testuser"))
+	lxdProject, _, _ := f.client.GetProject("workshop." + f.username)
 
 	c.Assert(lxdProject.Config["user.workshop.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, projectDir))
 }
@@ -174,16 +175,17 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryMoved(c *check.C) {
 	be := lxdbackend.Backend{}
 	projectDir := c.MkDir()
 	newDir := projectDir + "_moved"
-	f.client.UpdateProject(lxdbackend.LxdProjectName(f.username),
+	err := f.client.UpdateProject("workshop."+f.username,
 		api.ProjectPut{
 			Config: map[string]string{
 				"user.workshop.projects": fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, projectDir),
 			},
 		}, "")
+	c.Assert(err, check.IsNil)
 
 	createWFile(c, projectDir, "test", workshopMock)
 	os.WriteFile(filepath.Join(projectDir, ".workshop.lock"), []byte("b8639dea"), 0644)
-	err := os.Rename(projectDir, newDir)
+	err = os.Rename(projectDir, newDir)
 	c.Assert(err, check.IsNil)
 
 	prj, created, err := be.CreateOrLoadProject(f.ctx, newDir)
@@ -191,7 +193,7 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryMoved(c *check.C) {
 	c.Assert(prj.Path, check.Equals, newDir)
 	c.Assert(err, check.IsNil)
 	c.Assert(created, check.Equals, false)
-	lxdProject, _, _ := f.client.GetProject(lxdbackend.LxdProjectName(f.username))
+	lxdProject, _, _ := f.client.GetProject("workshop." + f.username)
 	c.Assert(lxdProject.Config["user.workshop.projects"], check.DeepEquals, fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, newDir))
 }
 
@@ -205,12 +207,13 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryCopied(c *check.C) {
 	defer restore()
 	projectDir := c.MkDir()
 	newDir := c.MkDir()
-	f.client.UpdateProject(lxdbackend.LxdProjectName(f.username),
+	err := f.client.UpdateProject("workshop."+f.username,
 		api.ProjectPut{
 			Config: map[string]string{
 				"user.workshop.projects": fmt.Sprintf(`[{"path":"%s","id":"b8639dea"}]`, projectDir),
 			},
 		}, "")
+	c.Assert(err, check.IsNil)
 
 	createWFile(c, projectDir, "test", workshopMock)
 	createWFile(c, newDir, "test", workshopMock)
@@ -223,7 +226,7 @@ func (f *wsProject) TestLxdBackendLoadProjectDirectoryCopied(c *check.C) {
 	c.Assert(prj.Path, check.Equals, newDir)
 	c.Assert(created, check.Equals, true)
 	c.Assert(filepath.Join(newDir, ".workshop.lock"), testutil.FileEquals, "abcdefgi")
-	lxdProject, _, _ := f.client.GetProject(lxdbackend.LxdProjectName(f.username))
+	lxdProject, _, _ := f.client.GetProject("workshop." + f.username)
 	c.Assert(lxdProject.Config["user.workshop.projects"], check.Matches, fmt.Sprintf(`.*{"path":"%s","id":"abcdefgi"}.*`, newDir))
 }
 
@@ -315,8 +318,8 @@ func (f *wsProject) TestLxdBackendLoadProjectsAllUsers(c *check.C) {
 }
 
 func (f *wsProject) TestLxdBackendLoadProjectAsDifferentUser(c *check.C) {
-	defer helper.CleanupLxdProject(c, f.client, lxdbackend.LxdProjectName("anotheruser"))
-	defer helper.CleanupLxdProject(c, f.client, lxdbackend.LxdStashProjectName("anotheruser"))
+	defer helper.CleanupLxdProject(c, f.client, "workshop.anotheruser")
+	defer helper.CleanupLxdProject(c, f.client, "workshop-stash.anotheruser")
 
 	// Setup
 	be := lxdbackend.Backend{}
@@ -342,4 +345,46 @@ func (f *wsProject) TestLxdBackendLoadProjectAsDifferentUser(c *check.C) {
 	c.Assert(created, check.Equals, true)
 	c.Assert(prj, check.NotNil)
 	c.Assert(prj.Path, check.Equals, projectDir)
+}
+
+func (f *wsProject) TestPosixUsername(c *check.C) {
+	restore := osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		if name != "ubuntu" {
+			return nil, errors.New("unexpected username!")
+		}
+		return &user.User{
+			Username: "ubuntu",
+			Uid:      "1001",
+		}, nil
+	})
+	defer restore()
+	ctx := context.WithValue(context.Background(), workshop.ContextUser, "ubuntu")
+
+	p, err := lxdbackend.ConnectLxd(ctx)
+	c.Assert(err, check.IsNil)
+
+	props, err := p.GetConnectionInfo()
+	c.Assert(err, check.IsNil)
+	c.Assert(props.Project, check.Equals, "workshop.ubuntu")
+}
+
+func (f *wsProject) TestNonPosixUsername(c *check.C) {
+	restore := osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		if name != "ubuntu@canonical.com" {
+			return nil, errors.New("unexpected username!")
+		}
+		return &user.User{
+			Username: "ubuntu@canonical.com",
+			Uid:      "1001",
+		}, nil
+	})
+	defer restore()
+	ctx := context.WithValue(context.Background(), workshop.ContextUser, "ubuntu@canonical.com")
+
+	p, err := lxdbackend.ConnectLxd(ctx)
+	c.Assert(err, check.IsNil)
+
+	props, err := p.GetConnectionInfo()
+	c.Assert(err, check.IsNil)
+	c.Assert(props.Project, check.Equals, "workshop.1001")
 }

--- a/internal/workshop/lxd/tests/integration/project_test.go
+++ b/internal/workshop/lxd/tests/integration/project_test.go
@@ -347,28 +347,62 @@ func (f *wsProject) TestLxdBackendLoadProjectAsDifferentUser(c *check.C) {
 	c.Assert(prj.Path, check.Equals, projectDir)
 }
 
-func (f *wsProject) TestPosixUsername(c *check.C) {
+func (f *wsProject) TestInitLxdProjectFails(c *check.C) {
+	count := 0
 	restore := osutil.FakeUserLookup(func(name string) (*user.User, error) {
-		if name != "ubuntu" {
+		count++
+		if name != "test@user" {
 			return nil, errors.New("unexpected username!")
 		}
+		if count == 2 {
+			return nil, errors.New("test error: unknown user")
+		}
 		return &user.User{
-			Username: "ubuntu",
+			Username: "test@user",
 			Uid:      "1001",
 		}, nil
 	})
 	defer restore()
-	ctx := context.WithValue(context.Background(), workshop.ContextUser, "ubuntu")
+	ctx := context.WithValue(context.Background(), workshop.ContextUser, "test@user")
 
-	p, err := lxdbackend.ConnectLxd(ctx)
+	be := lxdbackend.Backend{}
+	_, err := be.LxdClient(ctx)
+	c.Assert(err, check.ErrorMatches, "test error: unknown user")
+
+	projects, err := f.client.GetProjectNames()
+	c.Assert(err, check.IsNil)
+	c.Assert(projects, check.Not(testutil.Contains), "workshop.test@user")
+	c.Assert(projects, check.Not(testutil.Contains), "workshop-stash.test@user")
+}
+
+func (f *wsProject) TestPosixUsernameAsProjectSuffix(c *check.C) {
+	restore := osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		if name != "testuser0" {
+			return nil, errors.New("unexpected username!")
+		}
+		return &user.User{
+			Username: "testuser0",
+			Uid:      "1001",
+		}, nil
+	})
+	defer restore()
+	ctx := context.WithValue(context.Background(), workshop.ContextUser, "testuser0")
+
+	be := lxdbackend.Backend{}
+	p, err := be.LxdClient(ctx)
 	c.Assert(err, check.IsNil)
 
 	props, err := p.GetConnectionInfo()
 	c.Assert(err, check.IsNil)
-	c.Assert(props.Project, check.Equals, "workshop.ubuntu")
+	c.Assert(props.Project, check.Equals, "workshop.testuser0")
+
+	projects, err := p.GetProjectNames()
+	c.Assert(err, check.IsNil)
+	c.Assert(projects, testutil.Contains, "workshop.testuser0")
+	c.Assert(projects, testutil.Contains, "workshop-stash.testuser0")
 }
 
-func (f *wsProject) TestNonPosixUsername(c *check.C) {
+func (f *wsProject) TestNonPosixUsernameAsProjectSuffix(c *check.C) {
 	restore := osutil.FakeUserLookup(func(name string) (*user.User, error) {
 		if name != "ubuntu@canonical.com" {
 			return nil, errors.New("unexpected username!")
@@ -381,10 +415,16 @@ func (f *wsProject) TestNonPosixUsername(c *check.C) {
 	defer restore()
 	ctx := context.WithValue(context.Background(), workshop.ContextUser, "ubuntu@canonical.com")
 
-	p, err := lxdbackend.ConnectLxd(ctx)
+	be := lxdbackend.Backend{}
+	p, err := be.LxdClient(ctx)
 	c.Assert(err, check.IsNil)
 
 	props, err := p.GetConnectionInfo()
 	c.Assert(err, check.IsNil)
 	c.Assert(props.Project, check.Equals, "workshop.1001")
+
+	projects, err := p.GetProjectNames()
+	c.Assert(err, check.IsNil)
+	c.Assert(projects, testutil.Contains, "workshop.1001")
+	c.Assert(projects, testutil.Contains, "workshop-stash.1001")
 }

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -90,8 +90,7 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 
 	f.ctx = helper.CreateTestContext(f.usr.Username, f.project.ProjectId)
 
-	f.lxdClient, _ = f.be.(*lxdbackend.Backend).LxdClient(f.ctx)
-	err = lxdbackend.InitLxdProject(f.lxdClient, f.usr.Username)
+	f.lxdClient, err = f.be.(*lxdbackend.Backend).LxdClient(f.ctx)
 	c.Check(err, check.IsNil)
 
 	f.lookupUserRestore = osutil.FakeUserLookup(func(name string) (*user.User, error) {
@@ -120,8 +119,8 @@ func (f *wsExec) TearDownSuite(c *check.C) {
 	f.newProjectidRestore()
 	f.restoreImageServer()
 	f.restoreDevices()
-	helper.CleanupLxdProject(c, f.lxdClient, lxdbackend.LxdProjectName(f.usr.Username))
-	helper.CleanupLxdProject(c, f.lxdClient, lxdbackend.LxdStashProjectName(f.usr.Username))
+	helper.CleanupLxdProject(c, f.lxdClient, "workshop."+f.usr.Username)
+	helper.CleanupLxdProject(c, f.lxdClient, "workshop-stash."+f.usr.Username)
 }
 
 func (f *wsExec) exec(stdin string, workshop, projectId string, opts *client.ExecOptions) (stdout, stderr string, waitErr error) {

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -66,8 +66,8 @@ func (f *wsOps) TearDownSuite(c *check.C) {
 	lxdclient, err := f.bd.LxdClient(f.ctx)
 	c.Check(err, check.IsNil)
 
-	helper.CleanupLxdProject(c, lxdclient, lxdbackend.LxdProjectName(f.usr.Username))
-	helper.CleanupLxdProject(c, lxdclient, lxdbackend.LxdStashProjectName(f.usr.Username))
+	helper.CleanupLxdProject(c, lxdclient, "workshop."+f.usr.Username)
+	helper.CleanupLxdProject(c, lxdclient, "workshop-stash."+f.usr.Username)
 	f.restoreLookupUsr()
 	f.restoreNewId()
 


### PR DESCRIPTION
# Description

If a username is not POSIX-compliant, it can cause issues. For example, including an '@' character in the username breaks snapshot logic, as the LXD snapshot mechanism interprets '@' as a separator when using the project name. To prevent such conflicts, only alphanumeric usernames are allowed. If the username contains unsupported characters, the user's UID will be used as the LXD project name suffix instead.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
