### PR TITLE
Remove artificial dependency on lxd init

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -454,7 +454,7 @@ then initialise LXD:
 
 .. code-block:: console
 
-   lxd init --minimal
+   lxd init
 
 
 Publish the release

--- a/docs/how-to/use-workshops/troubleshoot.rst
+++ b/docs/how-to/use-workshops/troubleshoot.rst
@@ -32,12 +32,11 @@ Install and start LXD
 ---------------------
 
 A major prerequisite for |ws_markup| is `LXD`_;
-ensure it's installed, initialised and running:
+ensure it's installed and running:
 
 .. code-block:: console
 
    $ sudo snap install lxd
-   $ sudo lxd init --auto
    $ sudo snap start --enable lxd.daemon
    $ sudo snap services lxd
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -82,7 +82,7 @@ To refresh an existing installation:
    and your distribution's manuals for guidance.
 
 
-With LXD properly installed, initialised and started,
+With LXD properly installed and started,
 proceed to installing |ws_markup|.
 
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -99,7 +99,6 @@ To restart the workshop daemon: 'sudo snap restart workshop'`, err)
 
 Maybe LXD isn't installed?
 To install LXD: 'sudo snap install lxd'
-To initialize LXD: 'lxd init --auto'
 To restart the workshop daemon: 'sudo snap restart workshop'`, err)
 	default:
 		return err
@@ -129,43 +128,7 @@ func New() (*Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Workshop does not require an existing storage pool. However, once the
-	// workshop storage pool exists, `lxd init --auto` won't add another one,
-	// and non-Workshop LXD containers can't be launched without further manual
-	// configuration.
-	if len(pools) == 0 {
-		return nil, errors.New(`LXD not initialized
-
-To initialize LXD: 'lxd init --auto'`)
-	}
-
-	networks, err := conn.GetNetworks()
-	if err != nil {
-		return nil, err
-	}
-	// Workshop does not require an existing network. However, once the
-	// workshopbr0 network pool exists, `lxd init --auto` won't add another one,
-	// and non-Workshop LXD containers won't have network access without further
-	// manual configuration.
-	if len(networks) == 0 {
-		return nil, errors.New(`LXD not initialized
-
-To initialize LXD: 'lxd init --auto'`)
-	}
-
-	poolExists := false
-	for _, pool := range pools {
-		if pool.Name == storagePool {
-			if pool.Driver != storagePoolDriver {
-				return nil, fmt.Errorf("storage pool %q already exists with a different driver: %q", storagePool, pool.Driver)
-			}
-
-			poolExists = true
-			break
-		}
-	}
-
-	if !poolExists {
+	if idx := slices.IndexFunc(pools, func(p api.StoragePool) bool { return p.Name == storagePool }); idx < 0 {
 		req := api.StoragePoolsPost{
 			Name:   storagePool,
 			Driver: storagePoolDriver,
@@ -204,21 +167,15 @@ To initialize LXD: 'lxd init --auto'`)
 			}
 			logger.Noticef("On Backend.New: set storage pool to the minimal size: %dGiB", storagePoolMinimalGiB)
 		}
+	} else if pools[idx].Driver != storagePoolDriver {
+		return nil, fmt.Errorf("storage pool %q already exists with a different driver: %q", storagePool, pools[idx].Driver)
 	}
 
-	networkExists := false
-	for _, network := range networks {
-		if network.Name == networkName {
-			if network.Type != networkType {
-				return nil, fmt.Errorf("network %q already exists with a different type: %q", networkName, network.Type)
-			}
-
-			networkExists = true
-			break
-		}
+	networks, err := conn.GetNetworks()
+	if err != nil {
+		return nil, err
 	}
-
-	if !networkExists {
+	if idx := slices.IndexFunc(networks, func(n api.Network) bool { return n.Name == networkName }); idx < 0 {
 		req := api.NetworksPost{
 			Name: networkName,
 			Type: networkType,
@@ -233,6 +190,8 @@ To initialize LXD: 'lxd init --auto'`)
 		if err := conn.CreateNetwork(req); err != nil {
 			return nil, err
 		}
+	} else if networks[idx].Type != networkType {
+		return nil, fmt.Errorf("network %q already exists with a different type: %q", networkName, networks[idx].Type)
 	}
 
 	return &server, nil


### PR DESCRIPTION
# Description

This simplifies the tutorial and GitHub Action at the cost of LXD not working normally if a user installs Workshop and later wants to start using LXD directly. The default LXD storage pool and network can still be created using `lxd init` without `--auto` and accepting all the default settings.

It's also possible to use this hack:
```console
# yes '' | lxd init
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
