### PR TITLE
Enable unparam linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,10 +15,16 @@ linters:
     - errcheck
   enable:
     - nilerr
+    - unparam
   settings:
     staticcheck:
       dot-import-whitelist:
         - github.com/canonical/workshop/internal/overlord/handlersetup
+  exclusions:
+    rules:
+      - path: _test\.go$
+        linters: [unparam]
+        text: always receives (".*"|[0-9]+)$
 
 issues:
   # these values ensure that all issues will be surfaced

--- a/client/client.go
+++ b/client/client.go
@@ -344,6 +344,8 @@ func decodeInto(reader io.Reader, v interface{}) error {
 // It expects a "sync" response from the API and on success decodes the JSON
 // response payload into the given value using the "UseNumber" json decoding
 // which produces json.Numbers instead of float64 types for numbers.
+//
+//nolint:unparam // Match related function signatures for consistency.
 func (client *Client) doSync(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) (*ResultInfo, error) {
 	var rsp response
 	if err := client.do(method, path, query, headers, body, &rsp); err != nil {
@@ -368,6 +370,7 @@ func (client *Client) doSync(method, path string, query url.Values, headers map[
 	return &rsp.ResultInfo, nil
 }
 
+//nolint:unparam // Match related function signatures for consistency.
 func (client *Client) doAsync(method, path string, query url.Values, headers map[string]string, body io.Reader) (changeID string, err error) {
 	_, changeID, err = client.doAsyncFull(method, path, query, headers, body)
 	return

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -190,7 +190,7 @@ func restoreSketch(sketchdir, stashdir string) error {
 	return osutil.Rename(stashdir, sketchdir)
 }
 
-func (c *CmdSketch) inferSdkName(cmd *cobra.Command, project string) error {
+func (c *CmdSketch) inferSdkName(project string) error {
 	inferred := false
 	if c.name == "" {
 		c.name = filepath.Base(project)
@@ -443,7 +443,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 	var ejectReverter *revert.Reverter
 	if c.eject {
-		if err := c.inferSdkName(cmd, p.Path); err != nil {
+		if err := c.inferSdkName(p.Path); err != nil {
 			return fmt.Errorf("cannot eject: %w", err)
 		}
 
@@ -635,11 +635,7 @@ func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
 
 	var entries []string
 	for _, wp := range wps {
-		entry, err := stashEntry(userDataDir, wp, p)
-		if err != nil {
-			return err
-		}
-
+		entry := stashEntry(userDataDir, wp, p)
 		if entry != nil {
 			entries = append(entries, strings.Join(entry, "\t"))
 		}
@@ -655,7 +651,7 @@ func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func stashEntry(userDataDir string, w *client.WorkshopInfo, p *client.Project) ([]string, error) {
+func stashEntry(userDataDir string, w *client.WorkshopInfo, p *client.Project) []string {
 	rev := "-"
 	notes := ""
 	exists := false
@@ -678,8 +674,8 @@ func stashEntry(userDataDir string, w *client.WorkshopInfo, p *client.Project) (
 	}
 
 	if !exists {
-		return nil, nil
+		return nil
 	}
 
-	return []string{contractHomeDirectory(p.Path), w.Name, rev, notes}, nil
+	return []string{contractHomeDirectory(p.Path), w.Name, rev, notes}
 }

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -45,6 +45,7 @@ type waitMixin struct {
 var errNoWait = errors.New("no wait for op")
 var errWaitOnError = errors.New("wait-on-error")
 
+//nolint:unparam // Copied from snapd.
 func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error) {
 	if wmx.NoWait {
 		fmt.Fprintf(Stdout, "%s\n", id)

--- a/cmd/workshop/yaml_test.go
+++ b/cmd/workshop/yaml_test.go
@@ -12,6 +12,14 @@ type yamlSuite struct{}
 
 var _ = check.Suite(&yamlSuite{})
 
+func (y *yamlSuite) TestNodeRefIsUnmarshaler(c *check.C) {
+	var ref NodeRef
+	var u yaml.Unmarshaler = &ref
+	var node yaml.Node
+	c.Assert(u.UnmarshalYAML(&node), check.IsNil)
+	c.Check(ref.Node, check.Equals, &node)
+}
+
 func (y *yamlSuite) TestNodeRefField(c *check.C) {
 	var nodes struct {
 		Field NodeRef

--- a/cmd/workshopctl/main_test.go
+++ b/cmd/workshopctl/main_test.go
@@ -75,7 +75,7 @@ func (s *workshopctlSuite) SetUpTest(c *check.C) {
 }
 
 func (s *workshopctlSuite) TearDownTest(c *check.C) {
-	os.Unsetenv("WORKSHOP_COOKIE")
+	c.Assert(os.Unsetenv("WORKSHOP_COOKIE"), check.IsNil)
 	clientConfig.BaseURL = ""
 	s.server.Close()
 	os.Args = s.oldArgs

--- a/internal/asserts/header_checks.go
+++ b/internal/asserts/header_checks.go
@@ -70,6 +70,8 @@ func checkPrimaryKey(headers map[string]interface{}, primKey string) (string, er
 }
 
 // use 'defl' default if missing
+//
+//nolint:unparam // Copied from snapd.
 func checkIntWithDefault(headers map[string]interface{}, name string, defl int) (int, error) {
 	value, ok := headers[name]
 	if !ok {

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -1082,7 +1082,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsIDConstrain
 	c.Check(cstrs.SlotSdkTypes, check.DeepEquals, []string{sdk.System.String()})
 }
 
-func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.SlotConnectionConstraints, always bool) {
+func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.SlotConnectionConstraints) {
 	c.Assert(cstrs, check.HasLen, 1)
 	cstrs1 := cstrs[0]
 	if strings.HasPrefix(subrule, "deny-") {
@@ -1112,12 +1112,12 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleDefaults(c *check.C) {
 	c.Assert(rule.AllowInstallation, check.HasLen, 1)
 
 	// connection subrules
-	checkBoolSlotConnConstraints(c, "allow-connection", rule.AllowConnection, true)
-	checkBoolSlotConnConstraints(c, "deny-connection", rule.DenyConnection, false)
+	checkBoolSlotConnConstraints(c, "allow-connection", rule.AllowConnection)
+	checkBoolSlotConnConstraints(c, "deny-connection", rule.DenyConnection)
 	// auto-connection subrules
-	checkBoolSlotConnConstraints(c, "allow-auto-connection", rule.AllowAutoConnection, true)
+	checkBoolSlotConnConstraints(c, "allow-auto-connection", rule.AllowAutoConnection)
 	// ... but deny-auto-connection is on
-	checkBoolSlotConnConstraints(c, "deny-auto-connection", rule.DenyAutoConnection, true)
+	checkBoolSlotConnConstraints(c, "deny-auto-connection", rule.DenyAutoConnection)
 }
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsSideArityConstraints(c *check.C) {

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1411,7 +1411,7 @@ func mountAutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
 
 // internal helper that creates a new repository with two SDKs, one
 // has a mount plug and one a mount slot
-func makeMountConnectionTestSdks(c *C, projectId, plugMountToken, slotMountToken string) (*Repository, *sdk.Info, *sdk.Info) {
+func makeMountConnectionTestSdks(c *C, projectId, plugMountToken, slotMountToken string) *Repository {
 	repo := NewRepository()
 	err := repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "mount", AutoConnectCallback: mountAutoConnect})
 	c.Assert(err, IsNil)
@@ -1438,11 +1438,11 @@ slots:
 	err = repo.AddSdk(slotSdk)
 	c.Assert(err, IsNil)
 
-	return repo, plugSdk, slotSdk
+	return repo
 }
 
 func (s *RepositorySuite) TestAutoConnectMountInterfaceSimple(c *C) {
-	repo, _, _ := makeMountConnectionTestSdks(c, s.projectId, "mylib", "mylib")
+	repo := makeMountConnectionTestSdks(c, s.projectId, "mylib", "mylib")
 	candidateSlots := repo.AutoConnectCandidateSlots(s.projectId, "ws-importer", "mount-plug-sdk", "imported-content", mountPolicyCheck)
 	c.Assert(candidateSlots, HasLen, 1)
 	c.Check(candidateSlots[0].Name, Equals, "exported-content")
@@ -1452,7 +1452,7 @@ func (s *RepositorySuite) TestAutoConnectMountInterfaceSimple(c *C) {
 }
 
 func (s *RepositorySuite) TestAutoConnectMountInterfaceNoMatches(c *C) {
-	repo, _, _ := makeMountConnectionTestSdks(c, s.projectId, "mylib", "otherlib")
+	repo := makeMountConnectionTestSdks(c, s.projectId, "mylib", "otherlib")
 	candidateSlots := repo.AutoConnectCandidateSlots(s.projectId, "ws-importer", "mount-plug-sdk", "imported-content", mountPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)
 	candidatePlugs := repo.AutoConnectCandidatePlugs(s.projectId, "ws-exporter", "mount-slot-sdk", "exported-content", mountPolicyCheck)

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -124,7 +124,7 @@ func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]str
 	return candidates
 }
 
-func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, plugDynamic, slotDynamic map[string]map[string]interface{}) (*state.TaskSet, error) {
+func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, plugDynamic, slotDynamic map[string]map[string]interface{}) *state.TaskSet {
 
 	connectTs := state.NewTaskSet()
 	var affected = map[sdk.Ref]bool{}
@@ -165,7 +165,7 @@ func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sd
 		tsk.Set("project", wp.Project)
 	}
 
-	return connectTs, nil
+	return connectTs
 }
 
 func workshopConns(wp *workshop.Workshop) []interfaces.ConnRef {
@@ -287,11 +287,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 		}
 	}
 
-	ts, err := m.batchAutoConnectTasks(wp, info, connectRefs, plugDynamic, slotDynamic)
-	if err != nil {
-		return err
-	}
-
+	ts := m.batchAutoConnectTasks(wp, info, connectRefs, plugDynamic, slotDynamic)
 	handlersetup.InjectTasks(task, ts)
 	m.state.EnsureBefore(0)
 	task.SetStatus(state.DoneStatus)

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -74,9 +74,9 @@ func Connect(st *state.State, plugW *workshop.Workshop, slotW *workshop.Workshop
 	return ts, nil
 }
 
-func maybeAddDisconnect(st *state.State, ts *state.TaskSet, conn interfaces.ConnRef, forget bool, seen map[interfaces.ConnRef]bool) error {
+func maybeAddDisconnect(st *state.State, ts *state.TaskSet, conn interfaces.ConnRef, forget bool, seen map[interfaces.ConnRef]bool) {
 	if _, ok := seen[conn]; ok {
-		return nil
+		return
 	}
 
 	dtask := st.NewTask("disconnect", fmt.Sprintf("Disconnect %q from %q", conn.PlugRef.ShortRef(), conn.SlotRef.ShortRef()))
@@ -90,8 +90,6 @@ func maybeAddDisconnect(st *state.State, ts *state.TaskSet, conn interfaces.Conn
 	}
 	ts.AddTask(dtask)
 	seen[conn] = true
-
-	return nil
 }
 
 func disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.ConnRef, forget bool, seen map[interfaces.ConnRef]bool) (*state.TaskSet, error) {
@@ -99,15 +97,11 @@ func disconnect(st *state.State, plugW *workshop.Workshop, conn *interfaces.Conn
 	var ts = state.NewTaskSet()
 
 	cref := interfaces.ConnRef{PlugRef: master, SlotRef: conn.SlotRef}
-	if err := maybeAddDisconnect(st, ts, cref, forget, seen); err != nil {
-		return nil, err
-	}
+	maybeAddDisconnect(st, ts, cref, forget, seen)
 
 	for _, slave := range affected {
 		cref = interfaces.ConnRef{PlugRef: slave, SlotRef: conn.SlotRef}
-		if err := maybeAddDisconnect(st, ts, cref, forget, seen); err != nil {
-			return nil, err
-		}
+		maybeAddDisconnect(st, ts, cref, forget, seen)
 	}
 	return ts, nil
 }

--- a/internal/overlord/overlord_test.go
+++ b/internal/overlord/overlord_test.go
@@ -694,7 +694,7 @@ type sampleManager struct {
 	ensureCallback func()
 }
 
-func newSampleManager(s *state.State, runner *state.TaskRunner) *sampleManager {
+func newSampleManager(runner *state.TaskRunner) *sampleManager {
 	sm := &sampleManager{}
 
 	runner.AddHandler("runMgr1", func(t *state.Task, _ *tomb.Tomb) error {
@@ -756,7 +756,7 @@ func (ovs *overlordSuite) TestTrivialSettle(c *C) {
 	o := overlord.Fake()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
@@ -785,7 +785,7 @@ func (ovs *overlordSuite) TestSettleNotConverging(c *C) {
 	o := overlord.Fake()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
@@ -812,7 +812,7 @@ func (ovs *overlordSuite) TestSettleChain(c *C) {
 	o := overlord.Fake()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
@@ -846,7 +846,7 @@ func (ovs *overlordSuite) TestSettleChainWCleanup(c *C) {
 	o := overlord.Fake()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
@@ -883,7 +883,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	o := overlord.Fake()
 
 	s := o.State()
-	sm1 := newSampleManager(s, o.TaskRunner())
+	sm1 := newSampleManager(o.TaskRunner())
 	sm1.ensureCallback = func() {
 		s.Lock()
 		defer s.Unlock()

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -467,15 +467,8 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 		}
 		sdks := ordered(req.installOrder, req.storeSdks, localSdks)
 
-		plan, err := resolveRefresh(wp, req.file, sdks)
-		if err != nil {
-			return nil, err
-		}
-
-		tasks, err := refresh(w.state, plan, wp, req.file)
-		if err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
-		}
+		plan := resolveRefresh(wp, req.file, sdks)
+		tasks := refresh(w.state, plan, wp, req.file)
 		if len(tasks.Tasks()) == 0 {
 			continue
 		}
@@ -566,7 +559,7 @@ func (p refreshPlan) Remove() []sdk.Setup {
 	return ordered(revOrder, p.remove)
 }
 
-func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []sdk.Setup) (*refreshPlan, error) {
+func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []sdk.Setup) *refreshPlan {
 	plan := &refreshPlan{
 		install:        make([]sdk.Setup, 0),
 		intact:         make([]sdk.Setup, 0),
@@ -634,10 +627,10 @@ func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []s
 		plan.installOrder = append(plan.installOrder, s.Name)
 	}
 
-	return plan, nil
+	return plan
 }
 
-func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *workshop.File) (*state.TaskSet, error) {
+func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *workshop.File) *state.TaskSet {
 	refresh := state.NewTaskSet()
 	prev := (*state.TaskSet)(nil)
 	addTaskSet := func(ts *state.TaskSet) {
@@ -748,7 +741,7 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 		task.Set("project", w.Project)
 	}
 
-	return refresh, nil
+	return refresh
 }
 
 func autoconnectSdks(st *state.State, w string, sdks []sdk.Setup) *state.TaskSet {
@@ -971,26 +964,15 @@ func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projec
 		}
 	}
 
-	taskset, err := removeMany(w.state, workshops, project)
-	if err != nil {
-		return nil, err
-	}
-	return taskset, nil
-}
-
-func removeMany(st *state.State, workshops []*workshop.Workshop, project workshop.Project) ([]*state.TaskSet, error) {
 	taskset := []*state.TaskSet{}
 	for _, name := range workshops {
-		remove, err := remove(st, name, project)
-		if err != nil {
-			return nil, err
-		}
+		remove := remove(w.state, name, project)
 		taskset = append(taskset, remove)
 	}
 	return taskset, nil
 }
 
-func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*state.TaskSet, error) {
+func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *state.TaskSet {
 	removeSet := state.NewTaskSet()
 	var prevRemove *state.TaskSet
 	addTaskSet := func(ts *state.TaskSet) {
@@ -1035,7 +1017,7 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) (*s
 		task.Set("workshop", w.Name)
 		task.Set("project", project)
 	}
-	return removeSet, nil
+	return removeSet
 }
 
 func (w *WorkshopManager) Remount(ctx context.Context, st *state.State, plug sdk.PlugRef, source string) (*state.TaskSet, error) {

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -16,6 +16,7 @@ package testutil_test
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -35,16 +36,15 @@ func testInfo(c *check.C, checker check.Checker, name string, paramNames []strin
 	}
 }
 
-func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...interface{}) ([]interface{}, []string) {
+func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...interface{}) {
 	info := checker.Info()
 	if len(params) != len(info.Params) {
 		c.Fatalf("unexpected param count in test; expected %d got %d", len(info.Params), len(params))
 	}
-	names := append([]string{}, info.Params...)
+	names := slices.Clone(info.Params)
 	resultActual, errorActual := checker.Check(params, names)
 	if resultActual != result || errorActual != error {
 		c.Fatalf("%s.Check(%#v) returned (%#v, %#v) rather than (%#v, %#v)",
 			info.Name, params, resultActual, errorActual, result, error)
 	}
-	return params, names
 }

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -51,12 +51,12 @@ func (f *workshopFile) createWFile(c *check.C, name, yaml string, checkArgs ...i
 	c.Assert(err, check.IsNil, checkArgs...)
 }
 
-func (f *workshopFile) createSingleWFile(c *check.C, filename, yaml string, checkArgs ...interface{}) {
+func (f *workshopFile) createSingleWFile(c *check.C, filename, yaml string) {
 	err := os.MkdirAll(f.project.Path, os.ModePerm)
-	c.Assert(err, check.IsNil, checkArgs...)
+	c.Assert(err, check.IsNil)
 
 	err = os.WriteFile(filepath.Join(f.project.Path, filename), []byte(yaml), 0644)
-	c.Assert(err, check.IsNil, checkArgs...)
+	c.Assert(err, check.IsNil)
 }
 
 func (f *workshopFile) TestWorkshopFileParse(c *check.C) {


### PR DESCRIPTION
# Description

This caught a few remaining issues, but also some that I'd consider false positives, e.g. a test helper function always called with a `"ws"` argument, so I added an exception for those types.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
