### PR TITLE
Temporarily restrict unix socket paths

### DIFF
--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -75,29 +75,31 @@ func (iface *desktopInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInf
 }
 
 func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	xdg := spec.Environment["XDG_RUNTIME_DIR"]
-	if xdg == "" {
-		return fmt.Errorf("XDG_RUNTIME_DIR is either empty or unset for user %q", spec.User.Username)
-	}
-
 	desktop := workshop.Desktop{}
 
 	wayland := spec.Environment["WAYLAND_DISPLAY"]
 	display := spec.Environment["DISPLAY"]
-
 	if wayland == "" && display == "" {
 		return fmt.Errorf("neither DISPLAY nor WAYLAND_DISPLAY are set for user %q", spec.User.Username)
 	}
 
 	if wayland != "" {
+		if !filepath.IsAbs(wayland) {
+			xdg := spec.Environment["XDG_RUNTIME_DIR"]
+			if xdg == "" {
+				return fmt.Errorf("XDG_RUNTIME_DIR is either empty or unset for user %q", spec.User.Username)
+			}
+			wayland = filepath.Join(xdg, wayland)
+		}
+
 		desktop.Wayland = &workshop.ProxyEntry{
 			Name: fmt.Sprintf("%s_wayland", plug.Name()),
 			Connect: workshop.ProxyTarget{
-				Address:  filepath.Join(xdg, wayland),
+				Address:  wayland,
 				Protocol: "unix",
 			},
 			Listen: workshop.ProxyTarget{
-				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, wayland),
+				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0"),
 				Protocol: "unix",
 			},
 			Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -100,7 +100,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 				Protocol: "unix",
 			},
 			Listen: workshop.ProxyTarget{
-				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0"),
+				Address:  filepath.Join("/tmp", "wayland-0"),
 				Protocol: "unix",
 			},
 			Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -27,6 +27,7 @@ import (
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -110,14 +111,26 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	// on the host. This then gives users the option to modify their xhost
 	// settings to allow connections from the container and container user.
 	if display != "" {
-		proxyTarget := workshop.ProxyTarget{
-			Address:  filepath.Join("/tmp/.X11-unix", "X"+strings.TrimPrefix(display, ":")),
-			Protocol: "unix",
+		var found bool
+		display, found = strings.CutPrefix(display, ":")
+		if !found {
+			return fmt.Errorf("desktop interface requires local X server")
 		}
+		display, _, found = strings.Cut(display, ".")
+		if found {
+			logger.Noticef("desktop interface ignores screen number")
+		}
+
 		desktop.X11 = &workshop.ProxyEntry{
-			Name:      fmt.Sprintf("%s_x11", plug.Name()),
-			Connect:   proxyTarget,
-			Listen:    proxyTarget,
+			Name: fmt.Sprintf("%s_x11", plug.Name()),
+			Connect: workshop.ProxyTarget{
+				Address:  filepath.Join("/tmp/.X11-unix", "X"+display),
+				Protocol: "unix",
+			},
+			Listen: workshop.ProxyTarget{
+				Address:  "/tmp/.X11-unix/X0",
+				Protocol: "unix",
+			},
 			Direction: workshop.WorkshopToHost,
 		}
 	}

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -127,7 +127,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 	xauth := spec.Environment["XAUTHORITY"]
 	if xauth != "" {
 		m := workshop.Mount{}
-		m.Name = plug.Sdk().Name + "-" + "xauth"
+		m.Name = fmt.Sprintf("%s_xauth", plug.Name())
 		m.Type = workshop.HostWorkshop
 		m.What = workshopdXauth
 		m.Where = filepath.Join(dirs.WorkshopRunDir, "Xauthority")

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -112,7 +112,7 @@ slots:
 }
 
 func (s *desktopSuite) TestDesktopInterfaceBoth(c *check.C) {
-	env := map[string]string{"DISPLAY": ":0", "WAYLAND_DISPLAY": "/var/run/wayland-0"}
+	env := map[string]string{"DISPLAY": ":2.0", "WAYLAND_DISPLAY": "/var/run/wayland-0"}
 	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
 		return &testuser, env, nil
 	})()
@@ -139,7 +139,7 @@ slots:
 		X11: &workshop.ProxyEntry{
 			Name: "desktop_x11",
 			Connect: workshop.ProxyTarget{
-				Address:  "/tmp/.X11-unix/X0",
+				Address:  "/tmp/.X11-unix/X2",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
 				Address:  "/tmp/.X11-unix/X0",
@@ -263,4 +263,30 @@ slots:
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "XDG_RUNTIME_DIR is either empty.*")
+}
+
+func (s *desktopSuite) TestDesktopEnvX11Fail(c *check.C) {
+	env := map[string]string{"DISPLAY": "remote:0"}
+	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
+		return &testuser, env, nil
+	})()
+
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ desktop:
+  interface: desktop
+`, s.projectId, "ws", "consumer", "desktop")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  desktop:
+`, s.projectId, "ws", "producer", "desktop")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.ErrorMatches, "desktop interface requires local X server")
 }

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -68,14 +68,14 @@ slots:
 				Address:  "/tmp/wayland-1",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/run/user/1000/wayland-1",
+				Address:  "/run/user/1000/wayland-0",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
 }
 
 func (s *desktopSuite) TestDesktopInterfaceX11(c *check.C) {
-	env := map[string]string{"XDG_RUNTIME_DIR": "/tmp", "DISPLAY": ":0"}
+	env := map[string]string{"DISPLAY": ":0"}
 	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
 		return &testuser, env, nil
 	})()
@@ -112,7 +112,7 @@ slots:
 }
 
 func (s *desktopSuite) TestDesktopInterfaceBoth(c *check.C) {
-	env := map[string]string{"XDG_RUNTIME_DIR": "/tmp", "DISPLAY": ":0", "WAYLAND_DISPLAY": "wayland-0"}
+	env := map[string]string{"DISPLAY": ":0", "WAYLAND_DISPLAY": "/var/run/wayland-0"}
 	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
 		return &testuser, env, nil
 	})()
@@ -148,7 +148,7 @@ slots:
 		Wayland: &workshop.ProxyEntry{
 			Name: "desktop_wayland",
 			Connect: workshop.ProxyTarget{
-				Address:  "/tmp/wayland-0",
+				Address:  "/var/run/wayland-0",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
 				Address:  "/run/user/1000/wayland-0",
@@ -158,7 +158,7 @@ slots:
 }
 
 func (s *desktopSuite) TestDesktopInterfaceXauth(c *check.C) {
-	env := map[string]string{"XDG_RUNTIME_DIR": "/tmp", "DISPLAY": ":0", "XAUTHORITY": "/tmp/.Xauthority"}
+	env := map[string]string{"DISPLAY": ":0", "XAUTHORITY": "/tmp/.Xauthority"}
 	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
 		return &testuser, env, nil
 	})()
@@ -186,7 +186,7 @@ slots:
 }
 
 func (s *desktopSuite) TestDesktopInterfaceXauthFail(c *check.C) {
-	env := map[string]string{"XDG_RUNTIME_DIR": "/tmp", "DISPLAY": ":0"}
+	env := map[string]string{"DISPLAY": ":0"}
 	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
 		return &testuser, env, nil
 	})()
@@ -209,12 +209,12 @@ slots:
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	_, ok := deviceSpec.Profile.Mounts["consumer-xauth"]
+	_, ok := deviceSpec.Profile.Mounts["desktop_xauth"]
 	c.Assert(!ok, check.Equals, true)
 }
 
 func (s *desktopSuite) TestDesktopEnvWaylandFail(c *check.C) {
-	env := map[string]string{"XDG_RUNTIME_DIR": "/tmp"}
+	env := map[string]string{}
 	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
 		return &testuser, env, nil
 	})()
@@ -240,7 +240,7 @@ slots:
 }
 
 func (s *desktopSuite) TestDesktopEnvXDGFail(c *check.C) {
-	env := map[string]string{"XDG_RUNTIME_DIR": ""}
+	env := map[string]string{"XDG_RUNTIME_DIR": "", "WAYLAND_DISPLAY": "wayland-7"}
 	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
 		return &testuser, env, nil
 	})()

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -181,8 +181,8 @@ slots:
 	c.Assert(err, check.IsNil)
 
 	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
-	expectedMount := &workshop.Mount{Name: "consumer-xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, "Xauthority"), Where: "/var/lib/workshop/run/Xauthority", MakeWhere: true, Type: workshop.HostWorkshop}
-	c.Assert(deviceSpec.Profile.Mounts["consumer-xauth"], check.DeepEquals, *expectedMount)
+	expectedMount := &workshop.Mount{Name: "desktop_xauth", What: filepath.Join(dirs.WorkshopdRunDir, deviceSpec.User.Uid, "Xauthority"), Where: "/var/lib/workshop/run/Xauthority", MakeWhere: true, Type: workshop.HostWorkshop}
+	c.Assert(deviceSpec.Profile.Mounts["desktop_xauth"], check.DeepEquals, *expectedMount)
 }
 
 func (s *desktopSuite) TestDesktopInterfaceXauthFail(c *check.C) {

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -68,7 +68,7 @@ slots:
 				Address:  "/tmp/wayland-1",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/run/user/1000/wayland-0",
+				Address:  "/tmp/wayland-0",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
@@ -151,7 +151,7 @@ slots:
 				Address:  "/var/run/wayland-0",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/run/user/1000/wayland-0",
+				Address:  "/tmp/wayland-0",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -353,6 +353,14 @@ func setupDesktop(fs workshop.WorkshopFs, user *user.User, env map[string]string
 		if _, err := fs.Stat(script); err == nil {
 			return errors.New("desktop interface already connected")
 		}
+
+		if next.Wayland != nil {
+			socket := next.Wayland.Listen.Address
+			link := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, filepath.Base(socket))
+			if err := fs.Symlink(socket, link); err != nil {
+				return err
+			}
+		}
 	}
 
 	envVars := desktopEnvironment(user, env, *next)
@@ -367,7 +375,13 @@ func removeDesktop(fs workshop.WorkshopFs, prev *workshop.Desktop) error {
 	script := "/etc/profile.d/workshop-desktop.sh"
 	err := fs.RemoveIfExists(script)
 	err2 := fs.RemoveIfExists("/tmp/.Xauthority")
-	return cmp.Or(err, err2)
+	var err3 error
+	if prev.Wayland != nil {
+		socket := prev.Wayland.Listen.Address
+		link := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, filepath.Base(socket))
+		err3 = fs.RemoveIfExists(link)
+	}
+	return cmp.Or(err, err2, err3)
 }
 
 func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Desktop) map[string]string {
@@ -389,8 +403,7 @@ func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Des
 	}
 
 	if dev.Wayland != nil {
-		prefix := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid) + "/"
-		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen.Address, prefix)
+		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen.Address, "/tmp/")
 	}
 
 	if dev.X11 != nil {
@@ -555,6 +568,24 @@ func cleanupProfile(conn lxd.InstanceServer, sdkRef sdk.Ref) error {
 	return cmp.Or(err, err2, err3)
 }
 
+func checkListenSocketPaths(devices map[string]map[string]string) error {
+	for _, dev := range devices {
+		if dev["type"] != "proxy" || dev["bind"] != "instance" {
+			continue
+		}
+		listen := dev["listen"]
+		if !strings.HasPrefix(listen, "unix:/") {
+			continue
+		}
+		listen = strings.TrimPrefix(listen, "unix:")
+		if strings.HasPrefix(listen, "/tmp/") || strings.HasPrefix(listen, dirs.WorkshopRunDir+"/") {
+			continue
+		}
+		return fmt.Errorf("currently unsafe to create socket %q using LXD", listen)
+	}
+	return nil
+}
+
 // Setup creates mount profile specific to a given sdk.
 func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(ctx, b.Name(), sdkRef)
@@ -562,6 +593,10 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 		return err
 	}
 	spec := s.(*Specification)
+
+	if err := checkListenSocketPaths(spec.devices); err != nil {
+		return err
+	}
 
 	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1052,7 +1052,7 @@ write_files:
     Description=Required for x11 support
 
     [Path]
-    PathChanged=/var/lib/workshop/run/
+    PathModified=/var/lib/workshop/run/Xauthority/.Xauthority
     Unit=xauth-copy.service
 
     [Install]
@@ -1064,8 +1064,8 @@ write_files:
     Description=Required for x11 support; copies Xauthority to /tmp
 
     [Service]
-    Type=simple
-    ExecStart=/bin/bash -c 'if [ -f /var/lib/workshop/run/Xauthority/.Xauthority ]; then cp -f /var/lib/workshop/run/Xauthority/.Xauthority /tmp/.Xauthority && chown workshop:workshop /tmp/.Xauthority; fi'
+    Type=oneshot
+    ExecStart=/bin/bash -c '[ ! -f /var/lib/workshop/run/Xauthority/.Xauthority ] || install --mode 600 --owner workshop --group workshop --target-directory /tmp /var/lib/workshop/run/Xauthority/.Xauthority'
 
     [Install]
     WantedBy=multi-user.target
@@ -1086,7 +1086,7 @@ runcmd:
   # Project directory is required for 'workshop exec'.
   - install --directory --mode=755 /project
   - systemctl daemon-reload
-  - systemctl enable xauth-copy.service
+  - systemctl enable --now xauth-copy.service
   - systemctl enable --now xauth-watch.path
   - systemctl restart snapd.service
   # Required to load above DHCP config.

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -98,7 +98,7 @@ execute: |
   echo "Check that the expected environment is configured inside the workshop"
   workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
-      [ "$DISPLAY" == ":1" ]
+      [ "$DISPLAY" == ":0" ]
       [ -n "$XAUTHORITY" ]
   EOF
 

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -31,7 +31,8 @@ execute: |
   echo "Check that the required mounts are configured inside the workshop"
   workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
-      [ -S "/run/user/1000/${WAYLAND_DISPLAY}" ]
+      [ -S "/tmp/${WAYLAND_DISPLAY}" ]
+      [ -L "/run/user/1000/${WAYLAND_DISPLAY}" ]
   EOF
 
   echo "Disconnect the desktop interface"


### PR DESCRIPTION
# Description

This works around https://github.com/canonical/lxd/issues/15782, which causes LXD to delete the host's wayland socket when disconnecting the desktop interface. The fix is to move the socket elsewhere and create a symlink in the usual location.

Also fixes a couple of other issues I noticed in the desktop interface:
- it now supports absolute paths in `$WAYLAND_DISPLAY`
- it's more explicit about not supporting certain forms of `$DISPLAY`
- socket paths inside the workshop are fixed and can't be influenced by the user environment
- the `XAuthority` mount is now named using the same scheme as other devices (`<SDK>_<PLUG>`)

When LXD 6.5 is available we should revert 73fdf90 but keep the other commits.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
