### PR TITLE
Fix variable substitution

### DIFF
--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -179,7 +179,7 @@ Make the path nicer and shorter by contracting $HOME with a ~
 */
 func contractHomeDirectory(path string) string {
 	if home, err := os.UserHomeDir(); err == nil {
-		if strings.HasPrefix(path, home) {
+		if path == home || strings.HasPrefix(path, home+"/") {
 			return strings.Replace(path, home, "~", 1)
 		} else if strings.HasPrefix(path, "(") {
 			return "-"

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -21,6 +21,7 @@ package builtin
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -152,8 +153,21 @@ func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 		return fmt.Errorf(`mount slot "workshop-source" is not a string (found %T)`, source)
 	}
 
-	if path == "$SDK" || strings.HasPrefix(path, "$SDK/") {
-		path = strings.Replace(path, "$SDK", sdk.SdkDir(slot.Sdk.Name), 1)
+	var err error
+	path = os.Expand(path, func(s string) string {
+		switch s {
+		case "SDK":
+			return sdk.SdkDir(slot.Sdk.Name)
+		case "$":
+			// Unescape $$ -> $.
+			return "$"
+		default:
+			err = fmt.Errorf("unexpected variable %q", s)
+			return ""
+		}
+	})
+	if err != nil {
+		return err
 	}
 
 	if !filepath.IsAbs(path) {

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -152,7 +152,7 @@ func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 		return fmt.Errorf(`mount slot "workshop-source" is not a string (found %T)`, source)
 	}
 
-	if strings.HasPrefix(path, "$SDK/") {
+	if path == "$SDK" || strings.HasPrefix(path, "$SDK/") {
 		path = strings.Replace(path, "$SDK", sdk.SdkDir(slot.Sdk.Name), 1)
 	}
 

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -370,11 +370,11 @@ func expandPath(target *workshop.ProxyTarget, user *user.User) error {
 		return nil
 	}
 
-	if strings.HasPrefix(target.Address, "$HOME/") {
+	if target.Address == "$HOME" || strings.HasPrefix(target.Address, "$HOME/") {
 		target.Address = strings.Replace(target.Address, "$HOME", user.HomeDir, 1)
 		return nil
 	}
-	if strings.HasPrefix(target.Address, "$XDG_RUNTIME_DIR/") {
+	if target.Address == "$XDG_RUNTIME_DIR" || strings.HasPrefix(target.Address, "$XDG_RUNTIME_DIR/") {
 		runtimeDir := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
 		target.Address = strings.Replace(target.Address, "$XDG_RUNTIME_DIR", runtimeDir, 1)
 		return nil
@@ -398,8 +398,11 @@ func authorizePath(listen workshop.ProxyTarget, user *user.User) error {
 		return fmt.Errorf("cannot create socket %q: %w", listen.Address, err)
 	}
 
+	if realDir == user.HomeDir || strings.HasPrefix(realDir, user.HomeDir+"/") {
+		return nil
+	}
 	runtimeDir := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
-	if strings.HasPrefix(realDir, user.HomeDir) || strings.HasPrefix(realDir, runtimeDir) {
+	if realDir == runtimeDir || strings.HasPrefix(realDir, runtimeDir+"/") {
 		return nil
 	}
 

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"os/user"
 	"path/filepath"
 	"slices"
@@ -366,22 +367,27 @@ func checkListenPort(listen workshop.ProxyTarget, direction workshop.ProxyDirect
 }
 
 func expandPath(target *workshop.ProxyTarget, user *user.User) error {
-	if target.Protocol != "unix" || !strings.HasPrefix(target.Address, "$") {
+	if target.Protocol != "unix" {
 		return nil
 	}
 
-	if target.Address == "$HOME" || strings.HasPrefix(target.Address, "$HOME/") {
-		target.Address = strings.Replace(target.Address, "$HOME", user.HomeDir, 1)
-		return nil
-	}
-	if target.Address == "$XDG_RUNTIME_DIR" || strings.HasPrefix(target.Address, "$XDG_RUNTIME_DIR/") {
-		runtimeDir := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
-		target.Address = strings.Replace(target.Address, "$XDG_RUNTIME_DIR", runtimeDir, 1)
-		return nil
-	}
+	var err error
+	target.Address = os.Expand(target.Address, func(s string) string {
+		switch s {
+		case "HOME":
+			return user.HomeDir
+		case "XDG_RUNTIME_DIR":
+			return filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
+		case "$":
+			// Unescape $$ -> $.
+			return "$"
+		default:
+			err = fmt.Errorf("unexpected variable %q", s)
+			return ""
+		}
+	})
 
-	variable, _, _ := strings.Cut(target.Address[1:], "/")
-	return fmt.Errorf("unexpected variable %q", variable)
+	return err
 }
 
 // authorizePath attempts to ensure that the user is allowed to create the given socket.

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -182,8 +182,8 @@ func parseEndpoint(endpoint string) workshop.ProxyTarget {
 		return workshop.ProxyTarget{Address: endpoint, Protocol: "unix"}
 	}
 
-	if strings.HasSuffix(endpoint, "/udp") {
-		address := strings.TrimSuffix(endpoint, "/udp")
+	address, found := strings.CutSuffix(endpoint, "/udp")
+	if found {
 		return workshop.ProxyTarget{Address: address, Protocol: "udp"}
 	}
 
@@ -191,7 +191,7 @@ func parseEndpoint(endpoint string) workshop.ProxyTarget {
 		return workshop.ProxyTarget{Address: "", Protocol: endpoint}
 	}
 
-	address := strings.TrimSuffix(endpoint, "/tcp")
+	address = strings.TrimSuffix(endpoint, "/tcp")
 	return workshop.ProxyTarget{Address: address, Protocol: "tcp"}
 }
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -188,7 +188,9 @@ func (s *localStore) resolveSdks(name string, file *workshop.File, wp *workshop.
 		if !workshop.IsProjectSdk(sd.Name) {
 			continue
 		}
-		source := workshop.ProjectSdkPath("$PROJECT", strings.TrimPrefix(sd.Name, "project-"))
+		relative := workshop.ProjectSdkPath("", strings.TrimPrefix(sd.Name, "project-"))
+		escaped := strings.ReplaceAll(relative, "$", "$$")
+		source := filepath.Join("$PROJECT", escaped)
 		localSdks = append(localSdks, sdk.Setup{Name: sd.Name, Source: source})
 	}
 
@@ -240,7 +242,8 @@ func maybeSketch(userDataDir, pid, name string, launch bool) (*sdk.Setup, error)
 		return nil, nil
 	}
 
-	return &sdk.Setup{Name: sdk.Sketch, Source: sketchdir}, nil
+	escaped := strings.ReplaceAll(sketchdir, "$", "$$")
+	return &sdk.Setup{Name: sdk.Sketch, Source: escaped}, nil
 }
 
 func ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -199,8 +199,8 @@ func lxdConnectionArgs() (*lxd.ConnectionArgs, error) {
 }
 
 func connectImageServer(url string) (lxd.ImageServer, error) {
-	if strings.HasPrefix(url, "simplestreams:") {
-		server, _ := strings.CutPrefix(url, "simplestreams:")
+	server, found := strings.CutPrefix(url, "simplestreams:")
+	if found {
 		conn, err := ConnectSimpleStreams(server, nil)
 		if err != nil {
 			return nil, fmt.Errorf("image server is not available: %w", err)
@@ -208,8 +208,8 @@ func connectImageServer(url string) (lxd.ImageServer, error) {
 		return conn, err
 	}
 
-	if strings.HasPrefix(url, "lxd:") {
-		server, _ := strings.CutPrefix(url, "lxd:")
+	server, found = strings.CutPrefix(url, "lxd:")
+	if found {
 		args, err := lxdConnectionArgs()
 		if err != nil {
 			return nil, err

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -41,7 +41,7 @@ func ProjectSdkPath(project, name string) string {
 }
 
 func ExpandSdkSource(source, project string) string {
-	if strings.HasPrefix(source, "$PROJECT/") {
+	if source == "$PROJECT" || strings.HasPrefix(source, "$PROJECT/") {
 		source = strings.Replace(source, "$PROJECT", project, 1)
 	}
 	return source

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -41,10 +41,18 @@ func ProjectSdkPath(project, name string) string {
 }
 
 func ExpandSdkSource(source, project string) string {
-	if source == "$PROJECT" || strings.HasPrefix(source, "$PROJECT/") {
-		source = strings.Replace(source, "$PROJECT", project, 1)
-	}
-	return source
+	return os.Expand(source, func(s string) string {
+		switch s {
+		case "PROJECT":
+			return project
+		case "$":
+			// Unescape $$ -> $.
+			return "$"
+		default:
+			// Should never be reached because Workshop controls the source.
+			return ""
+		}
+	})
 }
 
 type PlugOrBind struct {


### PR DESCRIPTION
# Description

For the tunnel interface it makes sense to replace `$HOME/` and `$XDG_RUNTIME_DIR/` rather than `$HOME` and `$XDG_RUNTIME_DIR`, since sockets will always have at least one more component, and this avoids matching other variables e.g. `$HOME_FOO`. But I mistakenly did the same thing for `$SDK` in the mount interface.

There are a few places with similar patterns, so I updated them all to not require `/` at the end of the string.

Then I noticed the standard library already has a similar function called `os.Expand`. It is used by `snapd` but not for interfaces. This does shell-like variable parsing so avoids the `/` issue entirely. But lacks support for things like `${FOO:+bar}`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
