### PR TITLE
Improve LXD device error messages

### DIFF
--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -53,7 +53,7 @@ func setupMounts(conn lxd.InstanceServer, fs workshop.WorkshopFs, user *user.Use
 		var err error
 		mounts, content, err = readMountProfile(fs)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read filesystem table: %w", err)
 		}
 	}
 
@@ -88,13 +88,13 @@ func setupMounts(conn lxd.InstanceServer, fs workshop.WorkshopFs, user *user.Use
 
 	rev.Add(func() {
 		if reverr := reloadMounts(conn, pid, w); reverr != nil {
-			logger.Noticef("On setupMounts: cannot undo unmount: %v", reverr)
+			logger.Noticef("On setupMounts: cannot undo unmount in workshop %q: %v", w, reverr)
 		}
 	})
 
 	for _, where := range removed {
 		if err := unmount(conn, pid, w, where); err != nil {
-			logger.Noticef("On setupMounts: cannot unmount %q: %v", where, err)
+			logger.Noticef("On setupMounts: cannot unmount in workshop %q: %v", w, err)
 		}
 	}
 
@@ -105,7 +105,7 @@ func setupMounts(conn lxd.InstanceServer, fs workshop.WorkshopFs, user *user.Use
 	rev.Add(func() {
 		for _, where := range added {
 			if reverr := unmount(conn, pid, w, where); reverr != nil {
-				logger.Noticef("On setupMounts: cannot undo mount: %v", reverr)
+				logger.Noticef("On setupMounts: cannot undo mount in workshop %q: %v", w, reverr)
 			}
 		}
 		if reverr := writeMountProfile(fs, bytes.NewBuffer(content)); reverr != nil {
@@ -128,7 +128,7 @@ func removeMounts(conn lxd.InstanceServer, fs workshop.WorkshopFs, pid, w string
 		var err error
 		mounts, _, err = readMountProfile(fs)
 		if err != nil {
-			return err
+			return fmt.Errorf("read filesystem table: %w", err)
 		}
 	}
 
@@ -278,21 +278,32 @@ func writeMountProfile(fs workshop.WorkshopFs, mounts io.WriterTo) error {
 }
 
 func runMountCommand(conn lxd.InstanceServer, pid, w string, cmd []string) error {
-	var out bytes.Buffer
-
 	c := api.InstanceExecPost{
 		Command:     cmd,
 		Interactive: false,
 	}
 
-	args := lxd.InstanceExecArgs{Stderr: &out}
+	args := lxd.InstanceExecArgs{}
 
 	op, err := conn.ExecInstance(lxdbackend.InstanceName(w, pid), c, &args)
 	if err != nil {
 		return err
 	}
+	if err := op.Wait(); err != nil {
+		switch err.Error() {
+		case "Command not executable", "Command not found":
+			// Usually a nonzero exit status is not an error,
+			// but LXD translates 126 and 127 into the above messages.
+		default:
+			return fmt.Errorf("%s: %w", strings.Join(cmd, " "), err)
+		}
+	}
 
-	return op.Wait()
+	if status := int(op.Get().Metadata["return"].(float64)); status != 0 {
+		err := &workshop.ErrExec{Status: status}
+		return fmt.Errorf("%s: %w", strings.Join(cmd, " "), err)
+	}
+	return nil
 }
 
 func unmount(conn lxd.InstanceServer, pid, w string, where string) error {
@@ -305,11 +316,10 @@ func unmount(conn lxd.InstanceServer, pid, w string, where string) error {
 // newly-creaed units by restarting a downstream target (ie. local-fs) see:
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html
 func reloadMounts(conn lxd.InstanceServer, pid, w string) error {
-	return runMountCommand(conn, pid, w, []string{
-		"/bin/bash",
-		"-c",
-		"systemctl daemon-reload && systemctl restart local-fs.target",
-	})
+	if err := runMountCommand(conn, pid, w, []string{"systemctl", "daemon-reload"}); err != nil {
+		return err
+	}
+	return runMountCommand(conn, pid, w, []string{"systemctl", "restart", "local-fs.target"})
 }
 
 func setupSshAgent(fs workshop.WorkshopFs, prev, next *workshop.SshAgent) error {


### PR DESCRIPTION
# Description

Some stuff I noticed while testing https://github.com/canonical/workshop/pull/394 but didn't make it in time.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.