### PR TITLE
Fix formatting

### DIFF
--- a/internal/daemon/api_json.go
+++ b/internal/daemon/api_json.go
@@ -32,7 +32,7 @@ type plugJSON struct {
 	Interface string                 `json:"interface,omitempty"`
 	Attrs     map[string]interface{} `json:"attrs,omitempty"`
 	Label     string                 `json:"label,omitempty"`
-	Bind      *sdk.PlugRef    `json:"bind,omitempty"`
+	Bind      *sdk.PlugRef           `json:"bind,omitempty"`
 	// Connections are synthesized, they are not on the original type.
 	Connections []sdk.SlotRef `json:"connections,omitempty"`
 }
@@ -61,8 +61,8 @@ type interfaceAction struct {
 // connectionsJSON aids in marshalling information about a single connection
 // into JSON
 type connectionJSON struct {
-	Slot      sdk.SlotRef     `json:"slot"`
-	Plug      sdk.PlugRef     `json:"plug"`
+	Slot      sdk.SlotRef            `json:"slot"`
+	Plug      sdk.PlugRef            `json:"plug"`
 	Interface string                 `json:"interface"`
 	Manual    bool                   `json:"manual,omitempty"`
 	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`

--- a/internal/revert/revert.go
+++ b/internal/revert/revert.go
@@ -53,4 +53,3 @@ func Copy(target, source *Reverter) {
 	}
 	target.revertFuncs = append(target.revertFuncs, source.revertFuncs...)
 }
-


### PR DESCRIPTION
# Description

Versions of golangci-lint older than 2.2 have a bug [1] which causes files with few/no imports to not be formatted.

[1] https://github.com/golangci/golangci-lint/pull/5893

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
