### PR TITLE
Support wayland for snaps

### DIFF
--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -100,7 +100,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 				Protocol: "unix",
 			},
 			Listen: workshop.ProxyTarget{
-				Address:  filepath.Join("/tmp", "wayland-0"),
+				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0"),
 				Protocol: "unix",
 			},
 			Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -100,7 +100,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 				Protocol: "unix",
 			},
 			Listen: workshop.ProxyTarget{
-				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0"),
+				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0-inside-workshop"),
 				Protocol: "unix",
 			},
 			Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -68,7 +68,7 @@ slots:
 				Address:  "/tmp/wayland-1",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/tmp/wayland-0",
+				Address:  "/run/user/1000/wayland-0",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
@@ -151,7 +151,7 @@ slots:
 				Address:  "/var/run/wayland-0",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/tmp/wayland-0",
+				Address:  "/run/user/1000/wayland-0",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -68,7 +68,7 @@ slots:
 				Address:  "/tmp/wayland-1",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/run/user/1000/wayland-0",
+				Address:  "/run/user/1000/wayland-0-inside-workshop",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
@@ -151,7 +151,7 @@ slots:
 				Address:  "/var/run/wayland-0",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/run/user/1000/wayland-0",
+				Address:  "/run/user/1000/wayland-0-inside-workshop",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -555,6 +555,27 @@ func cleanupProfile(conn lxd.InstanceServer, sdkRef sdk.Ref) error {
 	return cmp.Or(err, err2, err3)
 }
 
+func checkListenSocketPaths(devices map[string]map[string]string) error {
+	for _, dev := range devices {
+		if dev["type"] != "proxy" || dev["bind"] != "instance" {
+			continue
+		}
+		listen := dev["listen"]
+		if !strings.HasPrefix(listen, "unix:/") {
+			continue
+		}
+		listen = strings.TrimPrefix(listen, "unix:")
+		if strings.HasPrefix(listen, "/tmp/") || strings.HasPrefix(listen, dirs.WorkshopRunDir+"/") {
+			continue
+		}
+		if listen == filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0-inside-workshop") {
+			continue
+		}
+		return fmt.Errorf("currently unsafe to create socket %q using LXD", listen)
+	}
+	return nil
+}
+
 // Setup creates mount profile specific to a given sdk.
 func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(ctx, b.Name(), sdkRef)
@@ -562,6 +583,10 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 		return err
 	}
 	spec := s.(*Specification)
+
+	if err := checkListenSocketPaths(spec.devices); err != nil {
+		return err
+	}
 
 	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -353,14 +353,6 @@ func setupDesktop(fs workshop.WorkshopFs, user *user.User, env map[string]string
 		if _, err := fs.Stat(script); err == nil {
 			return errors.New("desktop interface already connected")
 		}
-
-		if next.Wayland != nil {
-			socket := next.Wayland.Listen.Address
-			link := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, filepath.Base(socket))
-			if err := fs.Symlink(socket, link); err != nil {
-				return err
-			}
-		}
 	}
 
 	envVars := desktopEnvironment(user, env, *next)
@@ -375,13 +367,7 @@ func removeDesktop(fs workshop.WorkshopFs, prev *workshop.Desktop) error {
 	script := "/etc/profile.d/workshop-desktop.sh"
 	err := fs.RemoveIfExists(script)
 	err2 := fs.RemoveIfExists("/tmp/.Xauthority")
-	var err3 error
-	if prev.Wayland != nil {
-		socket := prev.Wayland.Listen.Address
-		link := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, filepath.Base(socket))
-		err3 = fs.RemoveIfExists(link)
-	}
-	return cmp.Or(err, err2, err3)
+	return cmp.Or(err, err2)
 }
 
 func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Desktop) map[string]string {
@@ -403,7 +389,8 @@ func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Des
 	}
 
 	if dev.Wayland != nil {
-		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen.Address, "/tmp/")
+		prefix := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid) + "/"
+		envVars["WAYLAND_DISPLAY"] = strings.TrimPrefix(dev.Wayland.Listen.Address, prefix)
 	}
 
 	if dev.X11 != nil {
@@ -568,24 +555,6 @@ func cleanupProfile(conn lxd.InstanceServer, sdkRef sdk.Ref) error {
 	return cmp.Or(err, err2, err3)
 }
 
-func checkListenSocketPaths(devices map[string]map[string]string) error {
-	for _, dev := range devices {
-		if dev["type"] != "proxy" || dev["bind"] != "instance" {
-			continue
-		}
-		listen := dev["listen"]
-		if !strings.HasPrefix(listen, "unix:/") {
-			continue
-		}
-		listen = strings.TrimPrefix(listen, "unix:")
-		if strings.HasPrefix(listen, "/tmp/") || strings.HasPrefix(listen, dirs.WorkshopRunDir+"/") {
-			continue
-		}
-		return fmt.Errorf("currently unsafe to create socket %q using LXD", listen)
-	}
-	return nil
-}
-
 // Setup creates mount profile specific to a given sdk.
 func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(ctx, b.Name(), sdkRef)
@@ -593,10 +562,6 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 		return err
 	}
 	spec := s.(*Specification)
-
-	if err := checkListenSocketPaths(spec.devices); err != nil {
-		return err
-	}
 
 	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {

--- a/tests/main/interface-desktop/task.yaml
+++ b/tests/main/interface-desktop/task.yaml
@@ -31,8 +31,7 @@ execute: |
   echo "Check that the required mounts are configured inside the workshop"
   workshop_exec exec ws-desktop sudo -Hiu workshop /bin/bash -s <<"EOF"
       set -e
-      [ -S "/tmp/${WAYLAND_DISPLAY}" ]
-      [ -L "/run/user/1000/${WAYLAND_DISPLAY}" ]
+      [ -S "/run/user/1000/${WAYLAND_DISPLAY}" ]
   EOF
 
   echo "Disconnect the desktop interface"


### PR DESCRIPTION
# Description

After reading through https://github.com/canonical/workshop/pull/329 I realised there's an issue with my recent PR https://github.com/canonical/workshop/pull/407. The symlink created for the wayland socket doesn't survive `workshop stop`, since `systemd` removes the parent directory.

Also, the Wayland socket in `/tmp` is not restored on `workshop start`, even though the X11 socket is fine. I considered moving it to `/var/lib/workshop/run` to avoid issues with `/tmp`, but the firefox snap is unable to access that directory.

It turns out the `wayland` interface in `snapd` uses `/run/user/[0-9]*/wayland-[0-9]*` for the socket path. Since this is a glob, not a regex, we could either create a new directory `/run/user/0something` or rename the socket to `wayland-0something`. I opted for the latter.

Now I don't really see a way to fix the issue mentioned in https://github.com/canonical/workshop/pull/329 without changing how LXD does things. I wasn't able to reproduce the issue after 100 restarts anyway.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
