### PR TITLE
Remove workaround for snap context canceled

### DIFF
--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -159,6 +159,7 @@ func (c *CmdRoot) Command() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&c.prj, "project", "p", c.cwd, "Specify the project's directory path.")
 	cmd.PersistentFlags().BoolP("help", "h", false, "Print the help message for the command.")
+	cmd.PersistentFlags().BoolP("version", "v", false, "Print Workshop version.")
 
 	cmd.DisableAutoGenTag = true
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -411,7 +411,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	if !slices.Contains(validActions, reqData.Action) {
-		return statusBadRequest(fmt.Sprintf("unknown action %q", reqData.Action))
+		return statusBadRequest("unknown action %q", reqData.Action)
 	}
 
 	mode, err := actionMode(&reqData)

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -66,7 +66,7 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 				}
 
 				if mode == conflict.ChangeWaitOnError {
-					task.Errorf(err.Error())
+					task.Errorf("%v", err)
 					return &state.Wait{
 						WaitedStatus: state.DoingStatus,
 						Reason:       fmt.Sprintf("wait on error: %v", err),

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -258,7 +258,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, hook *H
 
 	if len(taskLog) > 0 {
 		st.Lock()
-		task.Logf(string(taskLog))
+		task.Logf("%s", string(taskLog))
 		st.Unlock()
 	}
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1071,11 +1071,6 @@ write_files:
     WantedBy=multi-user.target
   path: /etc/systemd/system/xauth-copy.service
 - content: |
-    # Workaround for https://bugs.launchpad.net/snapd/+bug/2104066
-    [Service]
-    Environment=SNAPD_STANDBY_WAIT=1m
-  path: /etc/systemd/system/snapd.service.d/override.conf
-- content: |
     [DHCPv4]
     SendRelease=false
 
@@ -1088,7 +1083,6 @@ runcmd:
   - systemctl daemon-reload
   - systemctl enable --now xauth-copy.service
   - systemctl enable --now xauth-watch.path
-  - systemctl restart snapd.service
   # Required to load above DHCP config.
   - networkctl reload
 `

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -49,16 +49,8 @@ function prepare_environment() {
     apt-get update
     apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)" moreutils jq zfsutils-linux
 
-    mkdir -p /etc/systemd/system/snapd.service.d
-    cat <<EOF >/etc/systemd/system/snapd.service.d/override.conf
-# Workaround for https://bugs.launchpad.net/snapd/+bug/2104066
-[Service]
-Environment=SNAPD_STANDBY_WAIT=1m
-EOF
-    systemctl daemon-reload
-
     systemctl unmask snapd.service
-    systemctl restart snapd.service
+    systemctl start snapd.service
     snap wait system seed.loaded
     # The /snap directory does not exist in some environments
     [ ! -d /snap ] && ln -s /var/lib/snapd/snap /snap


### PR DESCRIPTION
# Description

Removes a workaround that isn't needed now that snapd 2.70 is stable.

https://bugs.launchpad.net/snapstore-server/+bug/2104066

Also fixes a couple of minor formatting issues I noticed recently.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
