### PR TITLE
Optimise refresh plan if only plugs or slots were changed

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -16,7 +16,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: mkdir -p ${{ github.workspace }}.cover/unit/cover && go test -cover ./... -args -test.gocoverdir=${{ github.workspace }}.cover/unit/cover
+        run: mkdir -p ${{ github.workspace }}.cover/unit/cover && go test -cover -coverpkg=./... ./... -args -test.gocoverdir=${{ github.workspace }}.cover/unit/cover
 
       - name: Upload Coverage
         id: upload-coverage

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -271,7 +271,7 @@ To check code coverage:
 
 .. code-block:: console
 
-   go test --coverpkg=<./...|package> covermode=<set|count|atomic> -coverprofile=<OutputFile> <./...|package>
+   go test -coverpkg=<./...|package> -covermode=<set|count|atomic> -coverprofile=<OutputFile> <./...|package>
 
 
 For example, to measure coverage using all tests:

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -1598,6 +1599,14 @@ func (s *apiSuite) checkRestoreCalls(c *check.C, name string, sdks []string, fil
 		var f workshop.File
 		err := yaml.Unmarshal([]byte(files[i]), &f)
 		c.Assert(err, check.IsNil)
+
+		// Simulate passing through Task.Set and Task.Get.
+		// Converts plug and slot attributes from int to float64.
+		serialized, err := json.Marshal(&f)
+		c.Assert(err, check.IsNil)
+		err = json.Unmarshal(json.RawMessage(serialized), &f)
+		c.Assert(err, check.IsNil)
+
 		c.Assert(wpCalls[i].File, check.DeepEquals, &f)
 	}
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -2530,11 +2530,9 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		"system",
 		"test-sdk",
 		"test-sdk-2",
-		"test-sdk",
-		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_plugadded})
+	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks_plugadded})
 }
 
 func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
@@ -2603,11 +2601,9 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 		"system",
 		"test-sdk",
 		"test-sdk-2",
-		"system",
-		"test-sdk",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
+	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk"}, []string{manysdks_system_extended})
 }
 
 func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
@@ -2681,11 +2677,9 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		"system",
 		"test-sdk",
 		"test-sdk-2",
-		"test-sdk",
-		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks})
+	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks})
 }
 
 func (s *apiSuite) TestRefreshNoChanges(c *check.C) {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -512,22 +511,6 @@ func maybeRefresh(installed, candidate sdk.Setup) bool {
 	return installed.Channel != candidate.Channel || installed.Revision != candidate.Revision
 }
 
-func definitionChanged(old, new *workshop.File, sdkName string) bool {
-	byName := func(s workshop.SdkRecord) bool { return s.Name == sdkName }
-	oldidx := slices.IndexFunc(old.Sdks, byName)
-	newidx := slices.IndexFunc(new.Sdks, byName)
-
-	if oldidx == -1 || newidx == -1 {
-		// Check if the SDK definition was added or removed.
-		return oldidx != newidx
-	}
-
-	oldrec := old.Sdks[oldidx]
-	newrec := new.Sdks[newidx]
-
-	return !reflect.DeepEqual(oldrec.Plugs, newrec.Plugs) || !reflect.DeepEqual(oldrec.Slots, newrec.Slots)
-}
-
 type refreshPlan struct {
 	install []sdk.Setup
 	intact  []sdk.Setup
@@ -541,6 +524,10 @@ type refreshPlan struct {
 
 func (p refreshPlan) InstallOrRefresh() []sdk.Setup {
 	return ordered(p.installOrder, p.install, p.refresh)
+}
+
+func (p refreshPlan) Intact() []sdk.Setup {
+	return ordered(p.installOrder, p.intact)
 }
 
 func (p refreshPlan) IntactOrRefresh() []sdk.Setup {
@@ -558,12 +545,6 @@ func (p refreshPlan) InstallIntactOrRefresh() []sdk.Setup {
 	return ordered(p.installOrder, p.install, p.refresh, p.intact)
 }
 
-func (p refreshPlan) Remove() []sdk.Setup {
-	revOrder := slices.Clone(p.installedOrder)
-	slices.Reverse(revOrder)
-	return ordered(revOrder, p.remove)
-}
-
 func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []sdk.Setup) *refreshPlan {
 	plan := &refreshPlan{
 		install:        make([]sdk.Setup, 0),
@@ -577,34 +558,25 @@ func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []s
 	// Restore the order of SDKs installed in the running workshop.
 	installed := w.SdksByInstallOrder()
 
-	// Determine if a workshop can be partially updated.
-	lastIntactIdx := -1
-
 	if w.Base == newfile.Base {
 		for ci, s := range candidates {
 			// Do we have this SDK in the same order as in the running workshop?
-			if ci < len(installed) && installed[ci].Name == s.Name {
-				// Has this SDK had any updates?
-				if maybeRefresh(w.Sdks[s.Name], s) {
-					break
-				}
-				// Has this SDK had any changes in the workshop definition?
-				if definitionChanged(w.File, newfile, s.Name) {
-					break
-				}
-
-				plan.intact = append(plan.intact, s)
-				// No updates to the SDK - reuse its snapshot and keep looking.
-				// Otherwise, break the loop as the rest require to be reinstalled.
-				plan.sdkSnapshot = s.Name
-				lastIntactIdx = ci
-			} else {
+			if ci >= len(installed) || installed[ci].Name != s.Name {
 				break
 			}
+			// Has this SDK had any updates?
+			// If so, break the loop as the rest require to be reinstalled.
+			if maybeRefresh(w.Sdks[s.Name], s) {
+				break
+			}
+
+			plan.intact = append(plan.intact, s)
+			// No updates to the SDK - reuse its snapshot and keep looking.
+			plan.sdkSnapshot = s.Name
 		}
 	}
 
-	for _, s := range candidates[lastIntactIdx+1:] {
+	for _, s := range candidates[len(plan.intact):] {
 		if installed, exist := w.Sdks[s.Name]; exist {
 			plan.refresh = append(plan.refresh, s)
 			plan.remove = append(plan.remove, installed)
@@ -676,7 +648,7 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 
 	// Remove SDKs from interfaces repository. If refresh fails, the SDKs will be returned
 	// to the repository after restoring the stashed workshop (with the SDKs installed).
-	unregister := unregisterSdks(st, plan.Remove())
+	unregister, umap := unregisterSdks(st, plan.IntactOrRemove())
 	addTaskSet(unregister)
 
 	stash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
@@ -684,6 +656,10 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 
 	rebuild := rebuildWorkshop(st, file, plan.sdkSnapshot)
 	addTaskSet(rebuild)
+
+	// Re-register intact SDKs (the workshop definition can change plugs and slots).
+	register := registerSdks(st, plan.Intact(), umap)
+	addTaskSet(register)
 
 	// Install updated SDKs to the rebuilt workshop.
 	install := installSdks(st, w.Project.ProjectId, file.Name, plan.InstallOrRefresh(), rmap)
@@ -766,19 +742,36 @@ func autoconnectSdks(st *state.State, w string, sdks []sdk.Setup) *state.TaskSet
 	return autoconnectSet
 }
 
-func unregisterSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
+func registerSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
+	prev := (*state.Task)(nil)
+	registerSet := state.NewTaskSet()
+	for _, s := range sdks {
+		register := sdkstate.Register(st, s.Name, retrieveTasks[s.Name])
+		registerSet.AddTask(register)
+
+		if prev != nil {
+			register.WaitFor(prev)
+		}
+		prev = register
+	}
+	return registerSet
+}
+
+func unregisterSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string]string) {
 	prev := (*state.Task)(nil)
 	unregisterSet := state.NewTaskSet()
+	unregisterMap := map[string]string{}
 	for _, s := range sdks {
 		unregister := sdkstate.Unregister(st, s)
 		unregisterSet.AddTask(unregister)
+		unregisterMap[s.Name] = unregister.ID()
 
 		if prev != nil {
 			unregister.WaitFor(prev)
 		}
 		prev = unregister
 	}
-	return unregisterSet
+	return unregisterSet, unregisterMap
 }
 
 func disconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
@@ -997,7 +990,7 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", w.Name))
 	addTaskSet(state.NewTaskSet(discard))
 
-	unregister := unregisterSdks(st, slices.Collect(maps.Values(w.Sdks)))
+	unregister, _ := unregisterSdks(st, slices.Collect(maps.Values(w.Sdks)))
 	addTaskSet(unregister)
 
 	remove := st.NewTask("remove-workshop", fmt.Sprintf("Remove %q workshop", w.Name))

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -310,7 +310,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 	}
 }
 
-func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Context, name, action string, force bool) error {
+func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Context, name, action string, timeout int) error {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return fmt.Errorf("context key project-id not found")
@@ -329,8 +329,10 @@ func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Conte
 
 	req := api.InstanceStatePut{
 		Action:  action,
-		Timeout: 60,
-		Force:   force,
+		Timeout: timeout,
+		// Currently force is equivalent to zero timeout, but we might
+		// as well set it just in case.
+		Force: timeout == 0,
 	}
 
 	op, err := conn.UpdateInstanceState(inst.Name, req, etag)
@@ -371,7 +373,7 @@ func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, na
 		}
 	})
 
-	if err := s.updateInstanceState(conn, ctx, name, "start", false); err != nil {
+	if err := s.updateInstanceState(conn, ctx, name, "start", 60); err != nil {
 		return err
 	}
 
@@ -421,7 +423,19 @@ func (s *Backend) stopWorkshop(conn lxd.InstanceServer, ctx context.Context, nam
 		return err
 	}
 
-	return s.updateInstanceState(conn, ctx, name, "stop", force)
+	timeout := 60
+	if force {
+		timeout = 10
+	}
+	if err := s.updateInstanceState(conn, ctx, name, "stop", timeout); err != nil && force {
+		logger.Noticef("On stopWorkshop: failed to stop %q workshop: %v", name, err)
+	} else {
+		return err
+	}
+	if err := s.updateInstanceState(conn, ctx, name, "stop", 0); err != nil && err.Error() != "The instance is already stopped" {
+		return err
+	}
+	return nil
 }
 
 func (s *Backend) AddWorkshopConfig(ctx context.Context, name string, item *workshop.WorkshopConfigValue) error {


### PR DESCRIPTION
# Description

Restores SDK snapshots even if plugs and slots have changed. This means the interface repo has to be updated for some of the intact SDKs. This takes about 50ms per SDK, so we just update all of them for simplicity.

These changes uncovered a minor type issue when comparing workshop files in the tests.

While testing I noticed that stashing can be slow occasionally. After checking the LXD debug logs this seems to be caused by ZFS unmount being slow. I've only observed it for (the equivalent of) `lxc stop --force`, so I changed stash to only use force if it can't stop gracefully. I can't guarantee this fixes the unmount issue completely, but it should be easier to debug if I notice it again (because the journal cuts off abruptly when using force).

Also fixes the coverage reports sent to TIOBE. Previously code which was only covered by the API tests (or other tests from different packages) was not marked as covered.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
