### PR TITLE
Doc: Add v0.1.20 info

### DIFF
--- a/docs/how-to/fix-workshops/troubleshoot.rst
+++ b/docs/how-to/fix-workshops/troubleshoot.rst
@@ -29,7 +29,7 @@ If it's outdated, download and install the update:
 
 .. code-block:: console
 
-   $ sudo snap install --dangerous --classic ./workshop_0.1.19_amd64.snap
+   $ sudo snap install --dangerous --classic ./workshop_0.1.20_amd64.snap
 
 
 Install and start LXD

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -62,7 +62,7 @@ for example:
 
 .. code-block:: console
 
-   sudo snap install --dangerous --classic ./workshop_0.1.19_amd64.snap
+   sudo snap install --dangerous --classic ./workshop_0.1.20_amd64.snap
 
 
 Launching workshops

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -36,10 +36,11 @@ but you can confidently use the pre-release versions.
 
 Latest version:
 
-- `Workshop v0.1.19 <https://github.com/canonical/workshop/releases/tag/v0.1.19>`_
+- `Workshop v0.1.20 <https://github.com/canonical/workshop/releases/tag/v0.1.20>`_
 
 Older versions:
 
+- `Workshop v0.1.19 <https://github.com/canonical/workshop/releases/tag/v0.1.19>`_
 - `Workshop v0.1.18 <https://github.com/canonical/workshop/releases/tag/v0.1.18>`_
 - `Workshop v0.1.17 <https://github.com/canonical/workshop/releases/tag/v0.1.17>`_
 - Workshop v0.1.16 didn't go public
@@ -107,7 +108,7 @@ to download and install the latest snap:
 
 .. code-block:: console
 
-   $ sudo snap install --dangerous --classic ./workshop_0.1.19_amd64.snap
+   $ sudo snap install --dangerous --classic ./workshop_0.1.20_amd64.snap
 
 Snaps are available for the :samp:`amd64` and :samp:`arm64` architectures.
 


### PR DESCRIPTION
Release notes draft:

----

## 18 July 2025

These release notes cover new features and changes in Workshop v0.1.20.

## Requirements and compatibility

Workshop relies on Snap and LXD:
- See the [Tutorial](https://canonical-workshop.readthedocs-hosted.com/stable/tutorial/) for setup instructions.
- Refer to the [Contribution Guide](https://canonical-workshop.readthedocs-hosted.com/stable/contributing/) for development prerequisites.

## What’s new in Workshop v0.1.20

This release focuses on Workshop itself: the tooling, the SDKs, and the user experience.
Now we have faster refreshes when interface definitions change, a few behind-the-scenes optimizations,
and a substantial overhaul of the documentation system that includes a brand-new starter pack SDK.

### Faster refreshes when only plugs or slots change

Workshop now restores existing SDK snapshots even when only the plugs or slots sections of the project definition have changed.
Because intact SDKs must have their interface repositories refreshed, Workshop simply updates them all (about 50 ms per SDK) to keep the logic straightforward.

### More graceful stashing on ZFS

Stopping a container with `lxc stop --force` could trigger slow ZFS unmounts, leading to occasional delays when stashing. Workshop now attempts a graceful stop first and falls back to `--force` only if necessary, making stash operations faster and easier to debug.

### Docs and coverage

- The [Tutorial](https://canonical-workshop.readthedocs-hosted.com/stable/tutorial/) has been reorganised into four clear parts that guide the user through Workshop end-to-end.
- Detailed guidance on documentation processes in the [Contribution Guide](https://canonical-workshop.readthedocs-hosted.com/stable/contributing/).
- A new starter pack SDK is now available, giving new collaborators an immediate, ready-to-use environment.
- A new `SECURITY.md` file outlines the responsible-disclosure process.
- Coverage reports sent to TIOBE now also include code covered only by API or cross-package tests.

## Changelog