### PR TITLE
Support and document multi-base builds

### DIFF
--- a/docs/.coverage.yaml
+++ b/docs/.coverage.yaml
@@ -92,6 +92,11 @@
   specs:
     - SK000
 
+"SDK platforms":
+  category: SDK
+  type: concept
+  specs: []
+
 "SDK publisher":
   category: SDK
   type: concept

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -17,6 +17,7 @@ config
 ConnectionError
 cooldown
 coverprofile
+CPUs
 cuda
 customisable
 cwd

--- a/docs/explanation/sdks/concepts.rst
+++ b/docs/explanation/sdks/concepts.rst
@@ -51,6 +51,9 @@ the definition may look like this:
      Go is an open source programming language that enables the production
      of simple, efficient and reliable software at scale.
 
+   platforms:
+     amd64:
+
    plugs:
      mod-cache:
        interface: mount
@@ -107,6 +110,32 @@ the states of the SDKs are saved
 by invoking their :samp:`save-state` hooks.
 On success,
 they are restored using the :samp:`restore-state` hooks.
+
+
+SDK platforms
+-------------
+
+.. @artefact SDK platforms
+
+Platforms describe where SDKs can be built and installed.
+Some SDKs include compiled code,
+which only certain families of CPUs will understand.
+Others depend on particular versions of software provided by the workshop's base image.
+
+The :samp:`platforms` section of the :ref:`definition <exp_sdk_definition>`
+lists the platforms that the SDK supports.
+Each build corresponds to one of these platforms.
+By default, |sdk_markup| builds SDKs for every possible platform.
+This typically means all platforms
+with the same CPU architecture as the build machine.
+
+When installing an SDK,
+|ws_markup| will check its platform metadata for compatibility.
+
+|ws_markup| and |sdk_markup| follow `Debian's naming scheme <https://www.debian.org/ports/>`_
+for CPU architectures.
+SDKs that don't ship compiled binaries
+can use the :samp:`all` architecture instead.
 
 
 .. _exp_system_sdk:

--- a/docs/reference/definition-files/sdk-definition.rst
+++ b/docs/reference/definition-files/sdk-definition.rst
@@ -28,16 +28,16 @@ Structure
 The definition in the file must be written in
 `YAML <https://yaml.org/>`__
 and include these top-level fields:
-:samp:`name`, :samp:`base`, :samp:`version`, :samp:`summary`,
-:samp:`description`, :samp:`license`, :samp:`platforms` and :samp:`parts`.
-The :samp:`plugs` field is optional.
+:samp:`name`, :samp:`version`, and :samp:`platforms`.
+Other fields are optional.
 
 .. @artefact SDK base image
+.. @artefact SDK platforms
 
 .. list-table::
    :header-rows: 1
    :width: 95
-   :widths: 1 1 7
+   :widths: 3 2 15
 
    * - Key
      - Value
@@ -53,8 +53,17 @@ The :samp:`plugs` field is optional.
      - SDK's base image
        that provides the underlying OS capabilities.
 
-       It can be :samp:`ubuntu@20.04`, :samp:`ubuntu@22.04`
+       It can be :samp:`ubuntu@20.04`, :samp:`ubuntu@22.04`,
        or :samp:`ubuntu@24.04`.
+
+       SDKs with a :samp:`base` can only be added to a workshop with the same :samp:`base`.
+       SDKs without a :samp:`base` can be added to any workshop.
+
+   * - :samp:`build-base`
+     - string
+     - Base OS used to build the SDK.
+
+       Required by |sdk_markup| if a :samp:`base` is not defined.
 
    * - :samp:`version`
      - string
@@ -89,7 +98,10 @@ The :samp:`plugs` field is optional.
 
    * - :samp:`platforms`
      - object
-     - Lists individual architectures that the SDK supports.
+     - A collection of named platforms,
+       describing where the SDK can be built and installed.
+
+       See :ref:`ref_sdk_platform` for a detailed discussion.
 
 
    * - :samp:`parts`
@@ -111,26 +123,26 @@ For example:
 .. code-block:: yaml
    :caption: sdk.yaml
 
-    name: go
-    title: Go SDK
-    base: ubuntu@22.04
-    summary: The Go programming language
-    description: |
-      Go is an open source programming language that enables the production
-      of simple, efficient and reliable software at scale.
-    version: '0.1'
-    license: LGPL-2.1
-    platforms:
-        amd64:
+   name: go
+   title: Go SDK
+   base: ubuntu@22.04
+   summary: The Go programming language
+   description: |
+     Go is an open source programming language that enables the production
+     of simple, efficient and reliable software at scale.
+   version: '0.1'
+   license: LGPL-2.1
+   platforms:
+     amd64:
 
-    parts:
-      go-part:
-        plugin: nil
+   parts:
+     go-part:
+       plugin: nil
 
-    plugs:
-      mod-cache:
-        interface: mount
-        workshop-target: /home/workshop/go/pkg/mod
+   plugs:
+     mod-cache:
+       interface: mount
+       workshop-target: /home/workshop/go/pkg/mod
 
    slots:
       tools:
@@ -155,28 +167,29 @@ formalizes the description above:
 Examples
 --------
 
-This YAML file defines a simple :samp:`go` SDK:
+This YAML file defines a simple :samp:`go` SDK
+that supports multiple bases:
 
 .. code-block:: yaml
    :caption: sdk.yaml
 
    name: go
-   base: ubuntu@24.04
    version: '0.1'
    summary: Go SDK
    description: |
      This is my Go SDK description.
    license: GPL-3.0
    platforms:
-     amd64:
-
-   parts:
-     my-part:
-       plugin: nil
+     noble:
+       build-on: ['ubuntu@24.04:amd64', 'ubuntu@24.04:arm64']
+       build-for: 'ubuntu@24.04:all'
+     jammy:
+       build-on: ['ubuntu@22.04:amd64', 'ubuntu@22.04:arm64']
+       build-for: 'ubuntu@22.04:all'
 
 
 This is a more elaborate example of an SDK
-that uses several :ref:`plugs <ref_sdk_plugs_slots>` and multiple platforms:
+that uses several :ref:`plugs <ref_sdk_plugs_slots>`:
 
 .. code-block:: yaml
    :caption: sdk.yaml
@@ -199,10 +212,6 @@ that uses several :ref:`plugs <ref_sdk_plugs_slots>` and multiple platforms:
    platforms:
      amd64:
      arm64:
-   
-   parts:
-     ros2-part:
-       plugin: nil
    
    plugs:
      ros-cache:

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -64,7 +64,7 @@ and includes a number of mandatory and optional keys:
        or :samp:`ubuntu@24.04`.
 
    * - :samp:`sdks`
-     - object
+     - array
      - List of individual SDKs
        from the SDK Store to include in the workshop.
 

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -19,6 +19,95 @@ where you'll run |sdk_markup|
 to initialize, define, pack and publish the SDK.
 
 
+.. _ref_sdk_platform:
+
+SDK platform
+------------
+
+.. @artefact SDK platforms
+
+A platform describes where an SDK can be built and installed.
+
+The components describing a platform are:
+
+- The base image: used to build SDKs and initialize workshops.
+- The CPU architecture: :samp:`amd64`, :samp:`arm64`, :samp:`armhf`, :samp:`i386`,
+  :samp:`ppc64el`, :samp:`riscv64`, or :samp:`s390x`.
+
+The easiest way to define a platform
+is to name it after the CPU architecture:
+
+.. code-block:: yaml
+   :caption: sdk.yaml
+
+   # ...
+   base: ubuntu@24.04
+   platforms:
+     amd64:
+     arm64:
+
+
+The above SDK can be built on :samp:`amd64` or :samp:`arm64` machines
+and installed in :samp:`ubuntu@24.04` workshops with the same architecture.
+
+The :samp:`base` can also be moved into the platform names:
+
+.. code-block:: yaml
+   :caption: sdk.yaml
+
+   # ...
+   platforms:
+     ubuntu@24.04:amd64:
+     ubuntu@24.04:arm64:
+
+
+More complex scenarios can be described using the following attributes:
+
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 3 2 15
+
+   * - Key
+     - Value
+     - Description
+
+   * - :samp:`build-on`
+     - array
+     - List of supported CPU architectures
+       that can build the SDK for the platform.
+
+       If the SDK has no :samp:`base` or :samp:`build-base`,
+       each entry must be prefixed by a valid base and a colon,
+       e.g. :samp:`ubuntu@22.04:amd64`.
+       This has no effect on the supported build machines,
+       because |sdk_markup| performs builds in containers.
+       The prefix must match :samp:`build-for`.
+
+   * - :samp:`build-for`
+     - string
+     - CPU architecture the SDK is expected to run on,
+       or :samp:`all` if the SDK can run on all supported architectures.
+       SDK authors are responsible for ensuring compatibility.
+
+       If the SDK has no :samp:`base` or :samp:`build-base`,
+       each entry must be prefixed by a valid base and a colon,
+       e.g. :samp:`ubuntu@24.04:riscv64`.
+       The prefix must match every entry in :samp:`build-on`.
+
+
+Architecture-independent SDKs require the complex format:
+
+.. code-block:: yaml
+   :caption: sdk.yaml
+
+   # ...
+   platforms:
+     all:
+       build-on: [amd64, arm64, riscv64]
+       build-for: all
+
+
 .. _ref_sdk_parts:
 
 SDK parts

--- a/docs/tutorial/craft-sdks.rst
+++ b/docs/tutorial/craft-sdks.rst
@@ -435,7 +435,7 @@ Optionally, you can clean the build cache before a build attempt:
 .. @artefact SDK metadata
 
 Ran without arguments,
-:command:`sdkcraft` builds and packs the SDK into the :file:`go.sdk` file,
+:command:`sdkcraft` builds and packs the SDK into the :file:`go_amd64_ubuntu@24.04.sdk` file,
 which contains the build artifacts from the previous step
 along with SDK metadata, hooks and other components.
 
@@ -453,7 +453,7 @@ for use with |ws_markup|:
 
 .. code-block:: console
 
-   $ sdkcraft.publish ./go.sdk latest/beta
+   $ sdkcraft.publish ./go_amd64_ubuntu@24.04.sdk latest/beta
 
 
 This publishes the newly created SDK

--- a/internal/arch/arch.go
+++ b/internal/arch/arch.go
@@ -1,0 +1,133 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package arch
+
+import (
+	"log"
+	"runtime"
+
+	"github.com/canonical/workshop/internal/osutil"
+)
+
+// ArchitectureType is the type for a supported snappy architecture
+type ArchitectureType string
+
+// arch is global to allow tools like ubuntu-device-flash to
+// change the architecture. This is important to e.g. install
+// armhf snaps onto a armhf image that is generated on an amd64
+// machine
+var arch = ArchitectureType(dpkgArchFromGoArch(runtime.GOARCH))
+
+// SetArchitecture allows overriding the auto detected Architecture
+func SetArchitecture(newArch ArchitectureType) {
+	arch = newArch
+}
+
+// DpkgArchitecture returns the debian equivalent architecture for the
+// currently running architecture.
+//
+// If the architecture does not map any debian architecture, the
+// GOARCH is returned.
+func DpkgArchitecture() string {
+	return string(arch)
+}
+
+// dpkgArchFromGoArch maps a go architecture string to the coresponding
+// Debian equivalent architecture string.
+//
+// E.g. the go "386" architecture string maps to the ubuntu "i386"
+// architecture.
+func dpkgArchFromGoArch(goarch string) string {
+	goArchMapping := map[string]string{
+		// go      dpkg
+		"386":     "i386",
+		"amd64":   "amd64",
+		"arm":     "armhf",
+		"arm64":   "arm64",
+		"ppc":     "powerpc",
+		"ppc64":   "ppc64", // available in debian and other distros
+		"ppc64le": "ppc64el",
+		"riscv64": "riscv64",
+		"s390x":   "s390x",
+	}
+
+	// If we are running on an ARM platform we need to have a
+	// closer look if we are on armhf or armel. If we're not
+	// on a armv6 platform we can continue to use the Go
+	// arch mapping. The Go arch sadly doesn't map this out
+	// for us so we have to fallback to uname here.
+	if goarch == "arm" {
+		if osutil.MachineName() == "armv6l" {
+			return "armel"
+		}
+	}
+
+	dpkgArch := goArchMapping[goarch]
+	if dpkgArch == "" {
+		log.Panicf("unknown goarch %q", goarch)
+	}
+
+	return dpkgArch
+}
+
+// DpkgKernelArchitecture returns the debian equivalent architecture
+// for the current running kernel. This is usually the same as the
+// DpkgArchitecture - however there maybe cases that you run e.g.
+// a snapd:i386 on an amd64 kernel.
+func DpkgKernelArchitecture() string {
+	return dpkgArchFromKernelArch(osutil.MachineName())
+}
+
+// dpkgArchFromkernelArch maps the kernel architecture as reported
+// via uname() to the dpkg architecture
+func dpkgArchFromKernelArch(utsMachine string) string {
+	kernelArchMapping := map[string]string{
+		// kernel  dpkg
+		"aarch64": "arm64",
+		"armv7l":  "armhf",
+		"armv8l":  "arm64",
+		"i686":    "i386",
+		"ppc":     "powerpc",
+		"ppc64":   "ppc64", // available in debian and other distros
+		"ppc64le": "ppc64el",
+		"riscv64": "riscv64",
+		"s390x":   "s390x",
+		"x86_64":  "amd64",
+	}
+
+	dpkgArch := kernelArchMapping[utsMachine]
+	if dpkgArch == "" {
+		log.Panicf("unknown kernel arch %q", utsMachine)
+	}
+
+	return dpkgArch
+}
+
+// IsSupportedArchitecture returns true if the system architecture is in the
+// list of architectures.
+func IsSupportedArchitecture(architectures []string) bool {
+	for _, a := range architectures {
+		if a == "all" || a == string(arch) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/arch/arch.go
+++ b/internal/arch/arch.go
@@ -131,3 +131,15 @@ func IsSupportedArchitecture(architectures []string) bool {
 
 	return false
 }
+
+var AllowedArchitectures = []string{
+	"amd64",
+	"arm64",
+	"armhf",
+	"i386",
+	"powerpc",
+	"ppc64",
+	"ppc64el",
+	"riscv64",
+	"s390x",
+}

--- a/internal/arch/arch_test.go
+++ b/internal/arch/arch_test.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package arch
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+var _ = Suite(&ArchTestSuite{})
+
+type ArchTestSuite struct {
+}
+
+func (ts *ArchTestSuite) TestArchDpkgArchitecture(c *C) {
+	c.Check(dpkgArchFromGoArch("386"), Equals, "i386")
+	c.Check(dpkgArchFromGoArch("amd64"), Equals, "amd64")
+	c.Check(dpkgArchFromGoArch("arm"), Equals, "armhf")
+	c.Check(dpkgArchFromGoArch("arm64"), Equals, "arm64")
+	c.Check(dpkgArchFromGoArch("ppc"), Equals, "powerpc")
+	c.Check(dpkgArchFromGoArch("ppc64"), Equals, "ppc64")
+	c.Check(dpkgArchFromGoArch("ppc64le"), Equals, "ppc64el")
+	c.Check(dpkgArchFromGoArch("riscv64"), Equals, "riscv64")
+	c.Check(dpkgArchFromGoArch("s390x"), Equals, "s390x")
+}
+
+func (ts *ArchTestSuite) TestArchSetArchitecture(c *C) {
+	SetArchitecture("armhf")
+	c.Assert(DpkgArchitecture(), Equals, "armhf")
+}
+
+func (ts *ArchTestSuite) TestArchSupportedArchitectures(c *C) {
+	arch = "armhf"
+	c.Check(IsSupportedArchitecture([]string{"all"}), Equals, true)
+	c.Check(IsSupportedArchitecture([]string{"amd64", "armhf", "powerpc"}), Equals, true)
+	c.Check(IsSupportedArchitecture([]string{"armhf"}), Equals, true)
+	c.Check(IsSupportedArchitecture([]string{"amd64", "powerpc"}), Equals, false)
+
+	arch = "amd64"
+	c.Check(IsSupportedArchitecture([]string{"all"}), Equals, true)
+	c.Check(IsSupportedArchitecture([]string{"amd64", "armhf", "powerpc"}), Equals, true)
+	c.Check(IsSupportedArchitecture([]string{"powerpc"}), Equals, false)
+}

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -93,7 +94,7 @@ func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sd
 			if info.Name != act.Name {
 				return nil, fmt.Errorf("SDK must be named %q (now: %q)", act.Name, info.Name)
 			}
-			if act.Base != info.Base {
+			if !slices.Contains([]string{"", act.Base}, info.Base) {
 				return nil, fmt.Errorf("%q SDK from %q has %q base; required: %q", act.Name, act.Channel, info.Base, act.Base)
 			}
 

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
 
+	"github.com/canonical/workshop/internal/arch"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/progress"
@@ -96,6 +97,9 @@ func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sd
 			}
 			if !slices.Contains([]string{"", act.Base}, info.Base) {
 				return nil, fmt.Errorf("%q SDK from %q has %q base; required: %q", act.Name, act.Channel, info.Base, act.Base)
+			}
+			if !slices.Contains([]string{"", "all", arch.DpkgArchitecture()}, info.Arch) {
+				return nil, fmt.Errorf(`%q SDK from %q has %q architecture; required: %q or "all"`, act.Name, act.Channel, info.Arch, arch.DpkgArchitecture())
 			}
 
 			info.Revision = s.Revision

--- a/internal/fakestore/store_test.go
+++ b/internal/fakestore/store_test.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/arch"
 	store "github.com/canonical/workshop/internal/fakestore"
 	"github.com/canonical/workshop/internal/sdk"
 )
@@ -129,4 +130,34 @@ func (s *storeSuite) TestSdkActionInstallIncompatibleBase(c *check.C) {
 	}
 	_, err := store.SdkAction(context.Background(), acts)
 	c.Assert(err, check.ErrorMatches, `"test-sdk" SDK from "latest/stable" has "ubuntu@20.04" base; required: "ubuntu@22.04"`)
+}
+
+func (s *storeSuite) TestSdkActionInstallIncompatibleArch(c *check.C) {
+	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
+		var s = store.StoreSdk{
+			Name:     "test-sdk",
+			Channel:  channel,
+			Revision: sdk.Revision{N: 123},
+			SdkYAML:  testSdk + "architecture: amd64\n",
+		}
+		return s, nil
+	})
+	defer r()
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+	oldarch := arch.ArchitectureType(arch.DpkgArchitecture())
+	arch.SetArchitecture("ppc64el")
+	defer arch.SetArchitecture(oldarch)
+
+	store := store.New()
+	acts := []sdk.SdkAction{{
+		ProjectId: "24242424",
+		Workshop:  "test-workshop",
+		Action:    sdk.Install,
+		Name:      "test-sdk",
+		Base:      "ubuntu@20.04",
+		Channel:   "latest/stable",
+	},
+	}
+	_, err := store.SdkAction(context.Background(), acts)
+	c.Assert(err, check.ErrorMatches, `"test-sdk" SDK from "latest/stable" has "amd64" architecture; required: "ppc64el" or "all"`)
 }

--- a/internal/osutil/export_test.go
+++ b/internal/osutil/export_test.go
@@ -142,6 +142,15 @@ func MockMaxCp(new int64) (restore func()) {
 	}
 }
 
+// MockUname mocks syscall.Uname as used by MachineName and KernelVersion
+func MockUname(f func(*syscall.Utsname) error) (restore func()) {
+	old := syscallUname
+	syscallUname = f
+	return func() {
+		syscallUname = old
+	}
+}
+
 func FakeRandomString(f func(int) string) (restore func()) {
 	old := randomString
 	randomString = f

--- a/internal/osutil/uname.go
+++ b/internal/osutil/uname.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+var KernelVersion = kernelVersion
+
+// We have to implement separate functions for the kernel version and the
+// machine name at the moment as the utsname struct is either using int8
+// or uint8 depending on the architecture the code is built for. As there
+// is no easy way to generalise this implements the same code twice (other
+// than going via unsafe.Pointer, or interfaces, which are overkill). The
+// way to get this solved is by using []byte inside the utsname struct
+// instead of []int8/[]uint8. See https://github.com/golang/go/issues/20753
+// for details.
+
+func kernelVersion() string {
+	u, err := uname()
+	if err != nil {
+		return "unknown"
+	}
+
+	// Release is more informative than Version.
+	buf := make([]byte, len(u.Release))
+	for i, c := range u.Release {
+		if c == 0 {
+			buf = buf[:i]
+			break
+		}
+		// c can be uint8 or int8 depending on arch (see comment above)
+		buf[i] = byte(c)
+	}
+
+	return string(buf)
+}
+
+func MachineName() string {
+	u, err := uname()
+	if err != nil {
+		return "unknown"
+	}
+
+	buf := make([]byte, len(u.Machine))
+	for i, c := range u.Machine {
+		if c == 0 {
+			buf = buf[:i]
+			break
+		}
+		// c can be uint8 or int8 depending on arch (see comment above)
+		buf[i] = byte(c)
+	}
+
+	return string(buf)
+}
+
+// MockKernelVersion replaces the function that returns the kernel version string.
+func MockKernelVersion(version string) (restore func()) {
+	old := KernelVersion
+	KernelVersion = func() string { return version }
+	return func() {
+		KernelVersion = old
+	}
+}

--- a/internal/osutil/uname_darwin.go
+++ b/internal/osutil/uname_darwin.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func uname() (*unix.Utsname, error) {
+	var u unix.Utsname
+	err := unix.Uname(&u)
+	return &u, err
+}

--- a/internal/osutil/uname_linux.go
+++ b/internal/osutil/uname_linux.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+)
+
+var syscallUname = syscall.Uname
+
+func uname() (*syscall.Utsname, error) {
+	var u syscall.Utsname
+	err := syscallUname(&u)
+	return &u, err
+}

--- a/internal/osutil/uname_linux_test.go
+++ b/internal/osutil/uname_linux_test.go
@@ -1,0 +1,96 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"syscall"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil"
+)
+
+type unameSuite struct{}
+
+var _ = check.Suite(unameSuite{})
+
+func ucmd1(c *check.C, arg string) string {
+	out, err := exec.Command("uname", arg).CombinedOutput()
+	c.Assert(err, check.IsNil)
+	return string(bytes.TrimSpace(out))
+}
+
+func (unameSuite) TestUname(c *check.C) {
+	c.Check(osutil.KernelVersion(), check.Equals, ucmd1(c, "-r"))
+	c.Check(osutil.MachineName(), check.Equals, ucmd1(c, "-m"))
+}
+
+func (unameSuite) TestUnameErrorMeansUnknown(c *check.C) {
+	restore := osutil.MockUname(func(buf *syscall.Utsname) error {
+		return errors.New("bzzzt")
+	})
+	defer restore()
+
+	c.Check(osutil.KernelVersion(), check.Equals, "unknown")
+	c.Check(osutil.MachineName(), check.Equals, "unknown")
+}
+
+func (unameSuite) TestKernelVersionStopsAtZeroes(c *check.C) {
+	restore := osutil.MockUname(func(buf *syscall.Utsname) error {
+		buf.Release[0] = 'f'
+		buf.Release[1] = 'o'
+		buf.Release[2] = 'o'
+		buf.Release[3] = 0
+		buf.Release[4] = 'u'
+		buf.Release[5] = 'n'
+		buf.Release[6] = 'u'
+		buf.Release[7] = 's'
+		buf.Release[8] = 'e'
+		buf.Release[9] = 'd'
+		return nil
+	})
+	defer restore()
+
+	c.Check(osutil.KernelVersion(), check.Equals, "foo")
+}
+
+func (unameSuite) TestMachineNameStopsAtZeroes(c *check.C) {
+	restore := osutil.MockUname(func(buf *syscall.Utsname) error {
+		buf.Machine[0] = 'a'
+		buf.Machine[1] = 'r'
+		buf.Machine[2] = 'm'
+		buf.Machine[3] = 'v'
+		buf.Machine[4] = '7'
+		buf.Machine[5] = 'a'
+		buf.Machine[6] = 0
+		buf.Machine[7] = 'u'
+		buf.Machine[8] = 'n'
+		buf.Machine[9] = 'u'
+		buf.Machine[10] = 's'
+		buf.Machine[11] = 'e'
+		buf.Machine[12] = 'd'
+		return nil
+	})
+	defer restore()
+	c.Check(osutil.MachineName(), check.Equals, "armv7a")
+}

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -38,6 +38,7 @@ func VolumeName(name string, revision Revision) string {
 type sdkYaml struct {
 	Name      string                 `yaml:"name"`
 	Base      string                 `yaml:"base"`
+	Arch      string                 `yaml:"architecture"`
 	Version   string                 `yaml:"version,omitempty"`
 	Type      string                 `yaml:"type"`
 	BuildTime *time.Time             `yaml:"sdkcraft-started-at,omitempty"`
@@ -71,6 +72,7 @@ type Info struct {
 	Workshop  string
 	Name      string
 	Base      string
+	Arch      string
 	Version   string
 	Type      Type
 	Revision  Revision
@@ -190,6 +192,7 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 		Workshop:      workshop,
 		Name:          sdkYaml.Name,
 		Base:          sdkYaml.Base,
+		Arch:          sdkYaml.Arch,
 		Version:       sdkYaml.Version,
 		Type:          Type(sdkYaml.Type),
 		BuildTime:     sdkYaml.BuildTime,

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"golang.org/x/exp/slices"
+
+	"github.com/canonical/workshop/internal/arch"
 )
 
 var (
@@ -23,6 +25,10 @@ func Validate(sdk *Info) error {
 
 	if sdk.Base != "" && !slices.Contains(AllowedBases, sdk.Base) {
 		return fmt.Errorf("invalid SDK base %q; supported bases: %s", sdk.Base, strings.Join(AllowedBases, ", "))
+	}
+	if !slices.Contains([]string{"", "all"}, sdk.Arch) && !slices.Contains(arch.AllowedArchitectures, sdk.Arch) {
+		arches := strings.Join(arch.AllowedArchitectures, ", ")
+		return fmt.Errorf("invalid SDK architecture %q; supported architectures: %s", sdk.Arch, arches)
 	}
 
 	if sdk.BuildTime != nil && sdk.BuildTime.Location() != time.UTC {

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -21,7 +21,7 @@ func Validate(sdk *Info) error {
 		return fmt.Errorf("invalid SDK name %q", sdk.Name)
 	}
 
-	if !slices.Contains(AllowedBases, sdk.Base) {
+	if sdk.Base != "" && !slices.Contains(AllowedBases, sdk.Base) {
 		return fmt.Errorf("invalid SDK base %q; supported bases: %s", sdk.Base, strings.Join(AllowedBases, ", "))
 	}
 

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -83,6 +83,16 @@ base: ubuntu@21.04
 	c.Check(err, check.ErrorMatches, `invalid SDK base "ubuntu@21.04"; supported bases: ubuntu@20.04, ubuntu@22.04, ubuntu@24.04`)
 }
 
+func (s *ValidateSuite) TestIllegalSdkArch(c *check.C) {
+	info, err := sdk.ReadSdkInfo([]byte(`name: foo
+architecture: '8086'
+`), s.projectId, "ws")
+	c.Assert(err, check.IsNil)
+
+	err = sdk.Validate(info)
+	c.Check(err, check.ErrorMatches, `invalid SDK architecture "8086"; supported architectures: amd64, arm64, armhf, i386, powerpc, ppc64, ppc64el, riscv64, s390x`)
+}
+
 func (s *ValidateSuite) TestSdkBuildTimeNotUTC(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo
 base: ubuntu@24.04

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -158,10 +158,6 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 		info.Name = "project-" + info.Name
 	}
 
-	// Local and system SDKs match the workshop's base by default.
-	if info.Base == "" && (setup.Revision.Local() || info.Type == sdk.System) {
-		info.Base = w.Base
-	}
 	info.Revision = setup.Revision
 	info.Channel = setup.Channel
 	info.Source = setup.Source

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -21,7 +21,7 @@ var (
 	sdkBlocklist   = []string{"agent"}
 
 	workshopName = regexp.MustCompile(`^[a-z](?:-?[a-z0-9])*$`)
-	channel      = regexp.MustCompile(`^(?:[a-zA-Z0-9\.-]+/(?:stable|candidate|beta|edge)|)$`)
+	channel      = regexp.MustCompile(`^(?:[a-z0-9](?:[.-]?[a-z0-9])*/(?:stable|candidate|beta|edge)|)$`)
 	scriptName   = workshopName
 
 	Directory = ".workshop"


### PR DESCRIPTION
# Description

Relaxes `base` requirements for store SDKs. Like local SDKs, they can now omit `base`. But SDKcraft requires a `build-base` in that case.

Adds architecture requirements for store SDKs. SDKs without an architecture in the metadata (which is all local SDKs and all existing built SDKs) are treated as `all`, i.e. compatible with any architecture.

In future I imagine the store will handle these checks for us.

Expands the SDK definition docs to mention `build-base` and describe `platforms`.

Restricts channel tracks to lowercase alphanumeric characters, dots and dashes.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
