### PR TITLE
Cut in-project SDK name prefix as early as possible

### DIFF
--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -80,6 +80,13 @@ $ workshop sketch-sdk nimble --stash`,
 	return cmd
 }
 
+type SketchFile struct {
+	Name  string                 `yaml:"name"`
+	Plugs map[string]interface{} `yaml:"plugs,omitempty"`
+	Slots map[string]interface{} `yaml:"slots,omitempty"`
+	Hooks map[string]string      `yaml:"hooks,omitempty"`
+}
+
 var sketchTemplate = `# Sketch SDK for %s
 # Sketch SDK provides local customisation of this specific workshop.
 
@@ -197,12 +204,8 @@ func (c *CmdSketch) inferSdkName(project string) error {
 		inferred = true
 	}
 
-	if sdk.SdkName.MatchString(c.name) {
-		return nil
-	}
-
-	err := fmt.Errorf("invalid SDK name %q", c.name)
-	if inferred {
+	err := sdk.ValidateName(c.name)
+	if err != nil && inferred {
 		err = fmt.Errorf("flag --name required: %w", err)
 	}
 	return err
@@ -225,16 +228,16 @@ func ejectSketch(project, sketchdir string, name string) (*revert.Reverter, erro
 		return nil, err
 	}
 
-	var rec workshop.SdkRecord
-	if err := document.Decode(&rec); err != nil {
+	var file SketchFile
+	if err := document.Decode(&file); err != nil {
 		return nil, err
 	}
-	rec.Name = name
+	file.Name = name
 
 	if err := sketchToProjectSdk(&document, name); err != nil {
 		return nil, err
 	}
-	if err := validateProjectSdk(&document, &rec); err != nil {
+	if err := validateProjectSdk(&document, &file); err != nil {
 		return nil, err
 	}
 
@@ -263,7 +266,7 @@ func ejectSketch(project, sketchdir string, name string) (*revert.Reverter, erro
 	if err := encoder.Encode(&document); err != nil {
 		return nil, err
 	}
-	if err := writeHooks(temp, rec); err != nil {
+	if err := writeHooks(temp, file); err != nil {
 		return nil, err
 	}
 
@@ -299,8 +302,8 @@ func sketchToProjectSdk(document *yaml.Node, name string) error {
 	return nil
 }
 
-func validateProjectSdk(document *yaml.Node, expected *workshop.SdkRecord) error {
-	var actual workshop.SdkRecord
+func validateProjectSdk(document *yaml.Node, expected *SketchFile) error {
+	var actual SketchFile
 	if err := document.Decode(&actual); err != nil {
 		return err
 	}
@@ -545,21 +548,21 @@ func writeSketchSdk(path string, content []byte) error {
 }
 
 func writeSketchHooks(sketchdir string, content []byte) error {
-	var rec workshop.SdkRecord
-	if err := yaml.Unmarshal(content, &rec); err != nil {
+	var file SketchFile
+	if err := yaml.Unmarshal(content, &file); err != nil {
 		return err
 	}
 
-	if !sdk.IsSketch(rec.Name) {
-		return fmt.Errorf("SDK must be named %q (now: %q)", sdk.Sketch, rec.Name)
+	if !sdk.IsSketch(file.Name) {
+		return fmt.Errorf("SDK must be named %q (now: %q)", sdk.Sketch, file.Name)
 	}
 
-	return writeHooks(sketchdir, rec)
+	return writeHooks(sketchdir, file)
 }
 
-func writeHooks(sdkdir string, rec workshop.SdkRecord) error {
+func writeHooks(sdkdir string, file SketchFile) error {
 	hooksdir := filepath.Join(sdkdir, "hooks")
-	if len(rec.Hooks) > 0 {
+	if len(file.Hooks) > 0 {
 		if err := os.MkdirAll(hooksdir, 0755); err != nil {
 			return err
 		}
@@ -567,7 +570,7 @@ func writeHooks(sdkdir string, rec workshop.SdkRecord) error {
 
 	for _, hook := range []string{"setup-base", "setup-project", "save-state", "restore-state", "check-health"} {
 		hookpath := filepath.Join(hooksdir, hook)
-		if script := rec.Hooks[hook]; len(script) > 0 {
+		if script := file.Hooks[hook]; len(script) > 0 {
 			if !strings.HasSuffix(script, "\n") {
 				script += "\n"
 			}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1173,11 +1173,11 @@ func (s *apiSuite) TestLaunchWorkshopNoProjectSdk(c *check.C) {
 	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", sdk.System.String()), check.HasLen, 0)
 	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", sdk.System.String()), check.HasLen, 0)
 
-	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "project-test-sdk"), check.HasLen, 0)
-	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "project-test-sdk"), check.HasLen, 0)
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk"), check.HasLen, 0)
 
-	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "project-test-sdk-2"), check.HasLen, 0)
-	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "project-test-sdk-2"), check.HasLen, 0)
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
 }
 
 func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {
@@ -1789,20 +1789,20 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		sdks: []sdk.Setup{
 			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "project-test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/basic/test-sdk:data b8639dea/basic/system:mount",
-			"b8639dea/basic/project-test-sdk-2:photos b8639dea/basic/system:mount",
-			"b8639dea/basic/project-test-sdk-2:gpu b8639dea/basic/system:gpu",
+			"b8639dea/basic/test-sdk-2:photos b8639dea/basic/system:mount",
+			"b8639dea/basic/test-sdk-2:gpu b8639dea/basic/system:gpu",
 		},
 		plugs: []string{
 			"test-sdk:data",
-			"project-test-sdk-2:photos",
-			"project-test-sdk-2:gpu",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
 		},
 		slots: []string{
-			"project-test-sdk-2:data-slot",
+			"test-sdk-2:data-slot",
 			"system:camera",
 			"system:desktop",
 			"system:gpu",
@@ -1816,7 +1816,7 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 	s.checkSnapshotCalls(c, "basic", []string{
 		"system",
 		"test-sdk",
-		"project-test-sdk-2",
+		"test-sdk-2",
 	})
 
 	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic_refreshed})
@@ -2300,21 +2300,21 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
 			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "project-test-sdk", Source: "$PROJECT/.workshop/test-sdk", Revision: sdk.R(-1), InstallTime: &s.installTime},
-			{Name: "project-test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk", Source: "$PROJECT/.workshop/test-sdk", Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
 		},
 		connections: []string{
-			"b8639dea/manysdks/project-test-sdk:data b8639dea/manysdks/system:mount",
-			"b8639dea/manysdks/project-test-sdk-2:photos b8639dea/manysdks/system:mount",
-			"b8639dea/manysdks/project-test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
 		},
 		plugs: []string{
-			"project-test-sdk:data",
-			"project-test-sdk-2:photos",
-			"project-test-sdk-2:gpu",
+			"test-sdk:data",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
 		},
 		slots: []string{
-			"project-test-sdk-2:data-slot",
+			"test-sdk-2:data-slot",
 			"system:camera",
 			"system:desktop",
 			"system:gpu",
@@ -2346,21 +2346,21 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
 			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "project-test-sdk", Source: "$PROJECT/.workshop/test-sdk", Revision: sdk.R(-2), InstallTime: &s.installTime},
-			{Name: "project-test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk", Source: "$PROJECT/.workshop/test-sdk", Revision: sdk.R(-2), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
 		},
 		connections: []string{
-			"b8639dea/manysdks/project-test-sdk-2:photos b8639dea/manysdks/system:mount",
-			"b8639dea/manysdks/project-test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
 		},
 		plugs: []string{
-			"project-test-sdk:ssh-agent",
-			"project-test-sdk:desktop",
-			"project-test-sdk-2:photos",
-			"project-test-sdk-2:gpu",
+			"test-sdk:ssh-agent",
+			"test-sdk:desktop",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
 		},
 		slots: []string{
-			"project-test-sdk-2:data-slot",
+			"test-sdk-2:data-slot",
 			"system:camera",
 			"system:desktop",
 			"system:gpu",
@@ -2372,10 +2372,10 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
-		"project-test-sdk",
-		"project-test-sdk-2",
-		"project-test-sdk",
-		"project-test-sdk-2",
+		"test-sdk",
+		"test-sdk-2",
+		"test-sdk",
+		"test-sdk-2",
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_project})
@@ -2964,7 +2964,7 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 	s.checkSnapshotCalls(c, "basic", []string{
 		"system",
 		"test-sdk",
-		"project-test-sdk-2",
+		"test-sdk-2",
 	})
 
 	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic})

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -107,14 +107,12 @@ func ensureTaskHealthIsSet(t *state.Task, expected *healthstate.HealthCheck, c *
 var (
 	oneSdk = []workshop.SdkRecord{{Name: "one", Channel: "latest/stable"}}
 
-	oneSdkWithHealthCheck = []workshop.SdkRecord{{
-		Name:    "one",
-		Channel: "latest/stable",
-		Hooks:   map[string]string{hookstate.CheckHealth.String(): ""},
-	}}
+	oneSdkHealthCheck = map[string]map[string]string{
+		"one": map[string]string{hookstate.CheckHealth.String(): ""},
+	}
 )
 
-func (s *healthSuite) launchWorkshopWithSDKs(c *check.C, sdks []workshop.SdkRecord) *workshop.Workshop {
+func (s *healthSuite) launchWorkshopWithSDKs(c *check.C, sdks []workshop.SdkRecord, hooks map[string]map[string]string) *workshop.Workshop {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: sdks}
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf)
 	c.Check(err, check.IsNil)
@@ -125,7 +123,7 @@ func (s *healthSuite) launchWorkshopWithSDKs(c *check.C, sdks []workshop.SdkReco
 		err = ws.MkdirAll(sdk.SdkHooksDir(sk.Name), 0744)
 		c.Check(err, check.IsNil)
 
-		for name, hook := range sk.Hooks {
+		for name, hook := range hooks[sk.Name] {
 			c.Assert(afero.WriteFile(ws, sdk.SdkHookPath(sk.Name, name), []byte(hook), 0644), check.IsNil)
 		}
 	}
@@ -155,7 +153,7 @@ func (s *healthSuite) TestWorkshopHealthReady(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 	health := healthstate.WorkshopHealth(s.state, workshop)
 
 	c.Assert(health.Status, check.Equals, healthstate.ReadyStatus)
@@ -168,7 +166,7 @@ func (s *healthSuite) TestWorkshopHealthStopped(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 	c.Assert(s.backend.StopWorkshop(s.ctx, "ws", true), check.IsNil)
 	health := healthstate.WorkshopHealth(s.state, workshop)
 
@@ -182,7 +180,7 @@ func (s *healthSuite) TestWorkshopHealthMissingProject(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 	c.Assert(os.RemoveAll(s.project.Path), check.IsNil)
 	health := healthstate.WorkshopHealth(s.state, workshop)
 
@@ -208,7 +206,7 @@ func (s *healthSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 	health := healthstate.WorkshopHealth(s.state, workshop)
 
 	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
@@ -229,7 +227,7 @@ func (s *healthSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 	health := healthstate.WorkshopHealth(s.state, workshop)
 
 	c.Assert(health.Status, check.Equals, healthstate.WaitingStatus)
@@ -255,7 +253,7 @@ func (s *healthSuite) TestWorkshopHealthSdkHealth(c *check.C) {
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
-	workshop := s.launchWorkshopWithSDKs(c, oneSdk)
+	workshop := s.launchWorkshopWithSDKs(c, oneSdk, nil)
 	health := healthstate.WorkshopHealth(s.state, workshop)
 
 	c.Assert(health.Status, check.Equals, healthstate.PendingStatus)
@@ -268,7 +266,7 @@ func (s *healthSuite) TestWorkshopHealthSdkHealth(c *check.C) {
 func (s *healthSuite) TestCheckStatusReady(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 
 	// Ready status should not return an error
 	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ReadyStatus})
@@ -291,7 +289,7 @@ func (s *healthSuite) TestCheckStatusPending(c *check.C) {
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 
 	// Pending status should not return an error
 	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.PendingStatus})
@@ -314,7 +312,7 @@ func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 
 	// Waiting status should not return an error
 	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.WaitingStatus})
@@ -328,7 +326,7 @@ func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
 func (s *healthSuite) TestCheckStatusError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 	c.Assert(os.RemoveAll(s.project.Path), check.IsNil)
 
 	// Error status should not return an error
@@ -343,7 +341,7 @@ func (s *healthSuite) TestCheckStatusError(c *check.C) {
 func (s *healthSuite) TestCheckStatusStopped(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	workshop := s.launchWorkshopWithSDKs(c, nil)
+	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
 	c.Assert(s.backend.StopWorkshop(s.ctx, "ws", true), check.IsNil)
 
 	// Stopped status should not return an error
@@ -365,7 +363,7 @@ func (s *healthSuite) TestExecCheckHealthNotProvided(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.launchWorkshopWithSDKs(c, oneSdk)
+	s.launchWorkshopWithSDKs(c, oneSdk, nil)
 
 	s.state.Unlock()
 	s.se.Ensure()
@@ -386,7 +384,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthNotCalled(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
+	s.launchWorkshopWithSDKs(c, oneSdk, oneSdkHealthCheck)
 	restore := healthstate.FakeRetryTimeout(0 * time.Second)
 	defer restore()
 
@@ -438,7 +436,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthError(c *check.C) {
 		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
-	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
+	s.launchWorkshopWithSDKs(c, oneSdk, oneSdkHealthCheck)
 	s.state.Unlock()
 	s.se.Ensure()
 	s.se.Wait()
@@ -511,7 +509,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthWaiting(c *check.C) {
 		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
-	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
+	s.launchWorkshopWithSDKs(c, oneSdk, oneSdkHealthCheck)
 	s.state.Unlock()
 	for i := 0; i < 2; i = i + 1 {
 		s.se.Ensure()
@@ -568,7 +566,7 @@ func (s *healthSuite) TestExecCheckHealthSetHealthExceededAttempts(c *check.C) {
 		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
-	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
+	s.launchWorkshopWithSDKs(c, oneSdk, oneSdkHealthCheck)
 	s.state.Unlock()
 	for i := 0; i < 3; i = i + 1 {
 		s.se.Ensure()
@@ -611,7 +609,7 @@ func (s *healthSuite) TestExecCheckHealthTimeout(c *check.C) {
 		s.backend.ExecCallback = fakebackend.DoExecDefault
 	}()
 
-	s.launchWorkshopWithSDKs(c, oneSdkWithHealthCheck)
+	s.launchWorkshopWithSDKs(c, oneSdk, oneSdkHealthCheck)
 	s.state.Unlock()
 	s.se.Ensure()
 	s.se.Wait()

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -153,7 +153,7 @@ func (w *WorkshopManager) resolveWorkshops(ctx context.Context, project workshop
 func resolveStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.Setup, error) {
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
-		if workshop.IsImplicitSdk(sd.Name) || workshop.IsProjectSdk(sd.Name) {
+		if workshop.IsImplicitSdk(sd.Name) || sd.Source != "" {
 			continue
 		}
 		act := sdk.SdkAction{ProjectId: projectid, Workshop: file.Name, Name: sd.Name, Base: file.Base, Channel: sd.Channel, Action: sdk.Install}
@@ -184,10 +184,10 @@ func (s *localStore) resolveSdks(name string, file *workshop.File, wp *workshop.
 	localSdks := []sdk.Setup{}
 
 	for _, sd := range file.Sdks {
-		if !workshop.IsProjectSdk(sd.Name) {
+		if sd.Source != "project" {
 			continue
 		}
-		relative := workshop.ProjectSdkPath("", strings.TrimPrefix(sd.Name, "project-"))
+		relative := workshop.ProjectSdkPath("", sd.Name)
 		escaped := strings.ReplaceAll(relative, "$", "$$")
 		source := filepath.Join("$PROJECT", escaped)
 		localSdks = append(localSdks, sdk.Setup{Name: sd.Name, Source: source})

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -11,14 +11,14 @@ import (
 
 var (
 	AllowedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
-	SdkName      = regexp.MustCompile(`^(?:[a-z0-9]-?)*[a-z](?:-?[a-z0-9])*$`)
+	sdkName      = regexp.MustCompile(`^(?:[a-z0-9]-?)*[a-z](?:-?[a-z0-9])*$`)
 	// Regular expression describing correct plug, slot and interface names.
 	validPlugSlotIface = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 )
 
 func Validate(sdk *Info) error {
-	if !SdkName.MatchString(sdk.Name) {
-		return fmt.Errorf("invalid SDK name %q", sdk.Name)
+	if err := ValidateName(sdk.Name); err != nil {
+		return err
 	}
 
 	if !slices.Contains(AllowedBases, sdk.Base) {
@@ -44,6 +44,17 @@ func Validate(sdk *Info) error {
 		if err := ValidateInterfaceName(slot.Interface); err != nil {
 			return fmt.Errorf("invalid interface name %q for slot %q", slot.Interface, slotName)
 		}
+	}
+	return nil
+}
+
+// ValidateName checks if a string can be used as an SDK name.
+func ValidateName(name string) error {
+	if name == "agent" || strings.HasPrefix(name, "project-") {
+		return fmt.Errorf("%q is a reserved SDK name", name)
+	}
+	if !sdkName.MatchString(name) {
+		return fmt.Errorf("invalid SDK name %q", name)
 	}
 	return nil
 }

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -149,13 +149,8 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	if err != nil {
 		return nil, err
 	}
-
-	trimmed := strings.TrimPrefix(sdkName, "project-")
-	if info.Name != trimmed {
-		return nil, fmt.Errorf("SDK must be named %q (now: %q)", trimmed, info.Name)
-	}
-	if IsProjectSdk(sdkName) {
-		info.Name = "project-" + info.Name
+	if info.Name != sdkName {
+		return nil, fmt.Errorf("SDK must be named %q (now: %q)", sdkName, info.Name)
 	}
 
 	// Local and system SDKs match the workshop's base by default.

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -18,7 +18,6 @@ import (
 
 var (
 	SupportedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
-	sdkBlocklist   = []string{"agent"}
 
 	workshopName = regexp.MustCompile(`^[a-z](?:-?[a-z0-9])*$`)
 	channel      = regexp.MustCompile(`^(?:[a-zA-Z0-9\.-]+/(?:stable|candidate|beta|edge)|)$`)
@@ -126,8 +125,8 @@ func (b *PlugRef) UnmarshalYAML(value *yaml.Node) error {
 	if len(parts[0]) == 0 {
 		parts[0] = sdk.System.String()
 	}
-	if !sdk.SdkName.MatchString(parts[0]) {
-		return fmt.Errorf("%q is not a valid plug or slot reference: invalid SDK name %q", refStr, parts[0])
+	if err := sdk.ValidateName(parts[0]); err != nil {
+		return fmt.Errorf("%q is not a valid plug or slot reference: %w", refStr, err)
 	}
 
 	b.Sdk = parts[0]
@@ -141,10 +140,35 @@ func (b PlugRef) MarshalYAML() (interface{}, error) {
 
 type SdkRecord struct {
 	Name    string                 `yaml:"name"`
-	Channel string                 `yaml:"channel"`
+	Channel string                 `yaml:"channel,omitempty"`
+	Source  string                 `yaml:"source,omitempty"`
 	Plugs   map[string]PlugOrBind  `yaml:"plugs,omitempty"`
 	Slots   map[string]interface{} `yaml:"slots,omitempty"`
-	Hooks   map[string]string      `yaml:"hooks,omitempty"`
+}
+
+func (s SdkRecord) MarshalYAML() (interface{}, error) {
+	if s.Source != "" {
+		s.Name = fmt.Sprintf("%s-%s", s.Source, s.Name)
+		s.Source = ""
+	}
+
+	type record SdkRecord
+	return (*record)(&s), nil
+}
+
+func (s *SdkRecord) UnmarshalYAML(value *yaml.Node) error {
+	type record SdkRecord
+	err := value.Decode((*record)(s))
+
+	name, found := strings.CutPrefix(s.Name, "project-")
+	if found {
+		s.Name = name
+		s.Source = "project"
+	} else {
+		s.Source = ""
+	}
+
+	return err
 }
 
 type Connection struct {
@@ -255,8 +279,8 @@ func readWorkshop(path string) (*File, error) {
 func validateSdks(sdks []SdkRecord) error {
 	seen := map[string]bool{}
 	for _, s := range sdks {
-		if slices.Contains(sdkBlocklist, s.Name) {
-			return fmt.Errorf("%q is a reserved SDK name", s.Name)
+		if err := sdk.ValidateName(s.Name); err != nil {
+			return err
 		}
 
 		if _, ok := seen[s.Name]; ok {
@@ -264,8 +288,6 @@ func validateSdks(sdks []SdkRecord) error {
 		}
 		seen[s.Name] = true
 
-		// An SDK installed from a local source (e.g. system SDK) does not have a
-		// channel.
 		if !channel.MatchString(s.Channel) {
 			return fmt.Errorf("unsupported channel %q for %q SDK", s.Channel, s.Name)
 		}

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -71,6 +71,7 @@ sdks:
     channel: latest/candidate
   - name: automotive
     channel: latest/beta
+  - name: project-linter
 scripts:
   oneline: echo one line
   multiline: |
@@ -82,14 +83,11 @@ scripts:
 	c.Assert(err, check.Equals, nil)
 	c.Assert(file.Name, check.Equals, "xbert-gpu")
 	c.Assert(file.Base, check.Equals, "ubuntu@20.04")
-	c.Assert(file.Sdks[0].Name, check.Equals, "huggingface")
-	c.Assert(file.Sdks[0].Channel, check.Equals, "latest/stable")
-	c.Assert(file.Sdks[1].Name, check.Equals, "cuda")
-	c.Assert(file.Sdks[1].Channel, check.Equals, "latest/edge")
-	c.Assert(file.Sdks[2].Name, check.Equals, "zookeeper")
-	c.Assert(file.Sdks[2].Channel, check.Equals, "latest/candidate")
-	c.Assert(file.Sdks[3].Name, check.Equals, "automotive")
-	c.Assert(file.Sdks[3].Channel, check.Equals, "latest/beta")
+	c.Assert(file.Sdks[0], check.DeepEquals, workshop.SdkRecord{Name: "huggingface", Channel: "latest/stable"})
+	c.Assert(file.Sdks[1], check.DeepEquals, workshop.SdkRecord{Name: "cuda", Channel: "latest/edge"})
+	c.Assert(file.Sdks[2], check.DeepEquals, workshop.SdkRecord{Name: "zookeeper", Channel: "latest/candidate"})
+	c.Assert(file.Sdks[3], check.DeepEquals, workshop.SdkRecord{Name: "automotive", Channel: "latest/beta"})
+	c.Assert(file.Sdks[4], check.DeepEquals, workshop.SdkRecord{Name: "linter", Source: "project"})
 	lines := len(strings.Split(yaml, "\n"))
 	skip := strings.Repeat("\n", lines-5)
 	c.Assert(string(file.Scripts["oneline"]), check.Equals, skip+"echo one line\n")
@@ -103,7 +101,7 @@ func (f *workshopFile) TestWorkshopFileSave(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: []workshop.SdkRecord{
 			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"plug": {Bind: &workshop.PlugRef{Sdk: "two", Name: "plug"}}}},
-			{Name: "two", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"plug": {Bind: &workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
+			{Name: "two", Source: "project", Plugs: map[string]workshop.PlugOrBind{"plug": {Bind: &workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
 		},
 		Scripts: map[string]workshop.Script{
 			"oneline":   "\n\n\necho one line\n",
@@ -120,8 +118,7 @@ sdks:
       plugs:
         plug:
             bind: two:plug
-    - name: two
-      channel: latest/stable
+    - name: project-two
       plugs:
         plug:
             bind: one:plug
@@ -231,6 +228,18 @@ sdks:
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(file, check.IsNil)
 	c.Assert(err, check.ErrorMatches, `"cuda" SDK must only be included once`)
+
+	yaml = `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  - name: cuda
+    channel: latest/stable
+  - name: project-cuda
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	file, err = f.project.Workshop("xbert-gpu")
+	c.Assert(file, check.IsNil)
+	c.Assert(err, check.ErrorMatches, `"cuda" SDK must only be included once`)
 }
 
 func (f *workshopFile) TestWorkshopFileReservedNames(c *check.C) {
@@ -243,6 +252,26 @@ sdks:
 	f.createWFile(c, "xbert-gpu", yaml)
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
+	c.Assert(file, check.IsNil)
+
+	yaml = `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  - name: project-agent
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	file, err = f.project.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
+	c.Assert(file, check.IsNil)
+
+	yaml = `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  - name: project-project-foo
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	file, err = f.project.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `"project-foo" is a reserved SDK name`)
 	c.Assert(file, check.IsNil)
 }
 

--- a/tests/main/project-sdks/project/.workshop/one/hooks/setup-project
+++ b/tests/main/project-sdks/project/.workshop/one/hooks/setup-project
@@ -6,5 +6,5 @@ set -x
 [ "$HOME" = '/home/workshop' ]
 [ "$USER" = 'workshop' ]
 [ "$LANG" = 'C.UTF-8' ]
-[ "$SDK" = '/var/lib/workshop/sdk/project-one' ]
+[ "$SDK" = '/var/lib/workshop/sdk/one' ]
 sudo touch /setup-project.log

--- a/tests/main/project-sdks/project/.workshop/three/hooks/restore-state
+++ b/tests/main/project-sdks/project/.workshop/three/hooks/restore-state
@@ -1,2 +1,2 @@
-[ "$SDK_STATE_DIR" = '/var/lib/workshop/state/sdk/project-three' ]
+[ "$SDK_STATE_DIR" = '/var/lib/workshop/state/sdk/three' ]
 cp "${SDK_STATE_DIR}/saved" /restored-state

--- a/tests/main/project-sdks/project/.workshop/three/hooks/save-state
+++ b/tests/main/project-sdks/project/.workshop/three/hooks/save-state
@@ -1,2 +1,2 @@
-[ "$SDK_STATE_DIR" = '/var/lib/workshop/state/sdk/project-three' ]
+[ "$SDK_STATE_DIR" = '/var/lib/workshop/state/sdk/three' ]
 touch "${SDK_STATE_DIR}/saved"

--- a/tests/main/project-sdks/task.yaml
+++ b/tests/main/project-sdks/task.yaml
@@ -5,17 +5,17 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  echo "Launch workshop with project-defined SDKs"
+  echo "Launch workshop with in-project SDKs"
   cd project
   workshop_exec launch
   workshop_exec exec -- test -d /one/two/three
   workshop_exec exec -- test -f /setup-project.log
 
-  workshop_exec connections dev | MATCH "^ssh-agent.+dev/project-one:ssh-agent.+\-.+\-$"
-  workshop_exec connections dev | MATCH "^tunnel.+\-.+dev/project-two:http.+\-$"
-  workshop_exec connections dev | MATCH "^desktop.+dev/project-three:desktop.+\-.+\-$"
+  workshop_exec connections dev | MATCH "^ssh-agent.+dev/one:ssh-agent.+\-.+\-$"
+  workshop_exec connections dev | MATCH "^tunnel.+\-.+dev/two:http.+\-$"
+  workshop_exec connections dev | MATCH "^desktop.+dev/three:desktop.+\-.+\-$"
 
-  echo "Move project-defined SDKs"
+  echo "Move in-project SDKs"
   mv .workshop/{one,two,three} ./
   workshop_exec exec -- test -d /one/two/three
   workshop_exec stop
@@ -28,12 +28,12 @@ execute: |
   cd moved
   workshop_exec exec -- test -d /one/two/three
 
-  workshop_exec info | grep -v notes | yq '.sdks["project-one"].tracking' | MATCH "^$PWD/\\.workshop/one\$"
-  workshop_exec info | grep -v notes | yq '.sdks["project-one"].installed' | MATCH '\(x1\)$'
-  workshop_exec info | grep -v notes | yq '.sdks["project-two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
-  workshop_exec info | grep -v notes | yq '.sdks["project-two"].installed' | MATCH '\(x1\)$'
-  workshop_exec info | grep -v notes | yq '.sdks["project-three"].tracking' | MATCH "^$PWD/\\.workshop/three\$"
-  workshop_exec info | grep -v notes | yq '.sdks["project-three"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | grep -v notes | yq '.sdks["one"].tracking' | MATCH "^$PWD/\\.workshop/one\$"
+  workshop_exec info | grep -v notes | yq '.sdks["one"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | grep -v notes | yq '.sdks["two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
+  workshop_exec info | grep -v notes | yq '.sdks["two"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | grep -v notes | yq '.sdks["three"].tracking' | MATCH "^$PWD/\\.workshop/three\$"
+  workshop_exec info | grep -v notes | yq '.sdks["three"].installed' | MATCH '\(x1\)$'
 
   echo "Break second SDK"
   echo false >> .workshop/two/sdk/hooks/setup-base
@@ -41,8 +41,8 @@ execute: |
   workshop_exec exec -- test -d /one/two/three
   workshop_exec exec -- test ! -f /restored-state
 
-  workshop_exec info | grep -v notes | yq '.sdks["project-two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
-  workshop_exec info | grep -v notes | yq '.sdks["project-two"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | grep -v notes | yq '.sdks["two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
+  workshop_exec info | grep -v notes | yq '.sdks["two"].installed' | MATCH '\(x1\)$'
 
   echo "Fix second SDK"
   sed 's@false@mkdir /two@' -i .workshop/two/sdk/hooks/setup-base
@@ -51,14 +51,14 @@ execute: |
   workshop_exec exec -- test -d /two
   workshop_exec exec -- test -f /restored-state
 
-  workshop_exec info | grep -v notes | yq '.sdks["project-one"].installed' | MATCH '\(x1\)$'
-  workshop_exec info | grep -v notes | yq '.sdks["project-two"].installed' | MATCH '\(x3\)$'
-  workshop_exec info | grep -v notes | yq '.sdks["project-three"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | grep -v notes | yq '.sdks["one"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | grep -v notes | yq '.sdks["two"].installed' | MATCH '\(x3\)$'
+  workshop_exec info | grep -v notes | yq '.sdks["three"].installed' | MATCH '\(x1\)$'
 
   echo "Add a new plug"
   sed 's@ssh-agent@camera@' -i .workshop/one/sdk.yaml
-  workshop_exec connections dev | MATCH "^ssh-agent.+dev/project-one:ssh-agent.+\-.+\-$"
-  workshop_exec connections dev | NOMATCH "^camera.+dev/project-one:camera.+\-.+\-$"
+  workshop_exec connections dev | MATCH "^ssh-agent.+dev/one:ssh-agent.+\-.+\-$"
+  workshop_exec connections dev | NOMATCH "^camera.+dev/one:camera.+\-.+\-$"
   workshop_exec refresh
-  workshop_exec connections dev | NOMATCH "^ssh-agent.+dev/project-one:ssh-agent.+\-.+\-$"
-  workshop_exec connections dev | MATCH "^camera.+dev/project-one:camera.+\-.+\-$"
+  workshop_exec connections dev | NOMATCH "^ssh-agent.+dev/one:ssh-agent.+\-.+\-$"
+  workshop_exec connections dev | MATCH "^camera.+dev/one:camera.+\-.+\-$"


### PR DESCRIPTION
# Description

This makes it easier to extract a packed SDK as an in-project SDK without messing around with naming. Some differences remain, mainly file ownership, but also the permissions of the SDK directory.

This will break running workshops, and can also break "Off" workshops which define plug bindings or connections. Fix for the latter is to remove the `project-` prefix from the SDKs involved.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
