### PR TITLE
Support trying out packed SDKs

### DIFF
--- a/docs/.coverage.yaml
+++ b/docs/.coverage.yaml
@@ -269,6 +269,11 @@
     - SK028
     - SK039
 
+"try SDK":
+  category: SDK
+  type: action
+  specs: []
+
 "tunnel interface":
   category: interface
   type: concept

--- a/docs/explanation/sdks/concepts.rst
+++ b/docs/explanation/sdks/concepts.rst
@@ -192,6 +192,27 @@ Note that :samp:`sketch` is a reserved name,
 and the sketch SDK is always installed last.
 
 
+.. _exp_try_sdk:
+
+Trying out SDKs
+---------------
+
+.. @artefact sdkcraft (CLI)
+.. @artefact try SDK
+
+The :command:`sdkcraft try` command allows publishers to test SDKs
+before uploading them to the Store.
+Once installed in a workshop, these SDKs behave identically to SDKs from the Store.
+
+|sdk_markup| does not install SDKs in a workshop by itself;
+it simply copies packed SDKs to a directory called the *try area*.
+|ws_markup| looks in this directory when installing an SDK with the :samp:`try-` prefix.
+
+The try area has no channels;
+only one version of an SDK can be tested at a time.
+However, this version can be tested in multiple workshops with different :ref:`bases <exp_base>`.
+
+
 .. _exp_in_project_sdk:
 
 In-project SDKs

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -114,9 +114,11 @@ Each SDK is described with the following keys:
      - Name of an existing SDK,
        typically from the SDK Store.
 
-       The :ref:`system SDK <ref_system_sdk>` is named :samp:`system`.
+       - The :ref:`system SDK <ref_system_sdk>` is named :samp:`system`.
 
-       :ref:`In-project SDKs <ref_in_project_sdk>` should be prefixed by :samp:`project-`.
+       - When :ref:`trying out SDKs <ref_try_sdk>`, the name should be prefixed by :samp:`try-`.
+
+       - :ref:`In-project SDKs <ref_in_project_sdk>` should be prefixed by :samp:`project-`.
 
    * - :samp:`channel`
      - string
@@ -184,6 +186,22 @@ largely due to security considerations,
 because the system SDK exposes sensitive host system resources.
 To the contrary, plugs added under the system SDK can be auto-connected
 because they expose workshop internals.
+
+
+.. _ref_try_sdk:
+
+Trying out SDKs
+~~~~~~~~~~~~~~~
+
+.. @artefact sdkcraft (CLI)
+.. @artefact try SDK
+
+The :command:`sdkcraft try` command makes SDKs available locally
+without having to publish them in the Store.
+
+Workshops consume these SDKs
+using names like :samp:`try-<NAME>`;
+a :samp:`channel` is not required in this case.
 
 
 .. _ref_in_project_sdk:

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -113,7 +114,7 @@ func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo 
 
 // Returns essential workshop properties and its SDKs health statuses (if
 // available).
-func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) *WorkshopInfo {
+func workshopToInfo(username string, w *workshop.Workshop, health healthstate.HealthState) (*WorkshopInfo, error) {
 	var info WorkshopInfo
 	info.Name = w.Name
 	info.ProjectId = w.Project.ProjectId
@@ -121,7 +122,15 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) *Works
 
 	sdkSetups := w.SdksByInstallOrder()
 
+	usr, env, err := osutil.UserAndEnv(username)
+	if err != nil {
+		return nil, err
+	}
+	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
+
 	for _, sk := range sdkSetups {
+		source := workshop.SdkSourcePath(userDataDir, w.Project, w.Name, sk.Name, sk.Source)
+
 		var healthInfo *HealthCheckInfo
 		if sdkHealth, ok := health.SdkHealth[sk.Name]; ok {
 			healthInfo = &HealthCheckInfo{
@@ -134,7 +143,7 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) *Works
 		info.Sdks = append(info.Sdks, &SdkInfo{
 			Name:        sk.Name,
 			Channel:     sk.Channel,
-			Source:      workshop.ExpandSdkSource(sk.Source, w.Project.Path),
+			Source:      source,
 			Revision:    sk.Revision.String(),
 			InstallTime: sk.InstallTime,
 			Health:      healthInfo,
@@ -145,14 +154,14 @@ func workshopToInfo(w *workshop.Workshop, health healthstate.HealthState) *Works
 		info.Notes = append(info.Notes, health.Code)
 	}
 	info.Status = health.Status.String()
-	return &info
+	return &info, nil
 }
 
 // Returns essential workshop properties, SDK health statuses (if available) and
 // information about the installed SDKs. This function reads from the workshop's
 // filesystem to obtain certain fields, it has to be used with possible latency
 // changes in mind.
-func workshopToInfoFull(ctx context.Context, w *workshop.Workshop, health healthstate.HealthState) (*WorkshopInfo, error) {
+func workshopToInfoFull(ctx context.Context, username string, w *workshop.Workshop, health healthstate.HealthState) (*WorkshopInfo, error) {
 	var info WorkshopInfo
 	info.Name = w.Name
 	info.ProjectId = w.Project.ProjectId
@@ -166,7 +175,15 @@ func workshopToInfoFull(ctx context.Context, w *workshop.Workshop, health health
 	mnts := w.Mounts(sdks)
 	tunnels := w.Tunnels(sdks)
 
+	usr, env, err := osutil.UserAndEnv(username)
+	if err != nil {
+		return nil, err
+	}
+	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
+
 	for _, sk := range sdks {
+		source := workshop.SdkSourcePath(userDataDir, w.Project, w.Name, sk.Name, sk.Source)
+
 		var healthInfo *HealthCheckInfo
 		if sdkHealth, ok := health.SdkHealth[sk.Name]; ok {
 			healthInfo = &HealthCheckInfo{
@@ -187,7 +204,7 @@ func workshopToInfoFull(ctx context.Context, w *workshop.Workshop, health health
 			Name:        sk.Name,
 			Version:     sk.Version,
 			Channel:     sk.Channel,
-			Source:      workshop.ExpandSdkSource(sk.Source, w.Project.Path),
+			Source:      source,
 			Revision:    sk.Revision.String(),
 			BuildTime:   sk.BuildTime,
 			InstallTime: w.Sdks[sk.Name].InstallTime,
@@ -319,12 +336,20 @@ func v1GetProjectWorkshops(c *Command, r *http.Request, _ *userState) Response {
 		return statusInternalError("%w", err)
 	}
 
+	username, ok := r.Context().Value(workshop.ContextUser).(string)
+	if !ok {
+		return statusBadRequest("internal error: user is not known")
+	}
+
 	info := Workshops{}
 	info.Workshops = make([]*WorkshopInfo, 0, len(workshops))
 	for _, w := range workshops {
 		health := healthstate.WorkshopHealth(state, w)
 		if ignoreStatus || health.Status == status {
-			wi := workshopToInfo(w, health)
+			wi, err := workshopToInfo(username, w, health)
+			if err != nil {
+				return statusBadRequest("%w", err)
+			}
 			info.Workshops = append(info.Workshops, wi)
 		}
 	}
@@ -498,7 +523,12 @@ func v1GetProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 
 	ctx := context.WithValue(r.Context(), workshop.ContextProjectId, projectId)
 
-	info, err := workshopToInfoFull(ctx, w, health)
+	username, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return statusBadRequest("internal error: user is not known")
+	}
+
+	info, err := workshopToInfoFull(ctx, username, w, health)
 	if err != nil {
 		return statusBadRequest("%w", err)
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"crypto/sha3"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
 
+	"github.com/canonical/workshop/internal/arch"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
@@ -121,6 +123,13 @@ sdks:
         workshop-target: /opt
   - name: test-sdk-2
     channel: latest/stable
+`
+
+	manysdks_try = `name: manysdks
+base: ubuntu@22.04
+sdks:
+  - name: try-test-sdk
+  - name: try-test-sdk-2
 `
 
 	manysdks_project = `name: manysdks
@@ -984,15 +993,32 @@ func mockSdk(metadir, hooksdir string, meta string) error {
 	return os.MkdirAll(hooksdir, 0755)
 }
 
+func (s *apiSuite) mockTrySdk(c *check.C, name, filename string, meta string) {
+	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
+	sdkdir := filepath.Join(workshop.TrySdkDir(userDataDir, name), filename)
+	metadir := filepath.Join(sdkdir, "meta")
+	hooksdir := filepath.Join(sdkdir, "sdk", "hooks")
+	c.Assert(mockSdk(metadir, hooksdir, meta), check.IsNil)
+
+	c.Assert(os.WriteFile(sdkdir+".yaml", []byte(meta), 0666), check.IsNil)
+
+	hash := sha3.New384()
+	_, _ = hash.Write([]byte(meta))
+	digest := fmt.Appendf(nil, "%x", hash.Sum(nil))
+	c.Assert(os.WriteFile(sdkdir+".sha3-384", digest, 0666), check.IsNil)
+}
+
 func (s *apiSuite) mockProjectSdk(c *check.C, name string, meta string) {
 	sdkdir := workshop.ProjectSdkPath(s.project.Path, name)
-	c.Assert(mockSdk(sdkdir, filepath.Join(sdkdir, "hooks"), meta), check.IsNil)
+	hooksdir := filepath.Join(sdkdir, "hooks")
+	c.Assert(mockSdk(sdkdir, hooksdir, meta), check.IsNil)
 }
 
 func (s *apiSuite) mockSketchSdk(c *check.C, ws string, meta string) {
 	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
 	sdkdir := workshop.SketchSdkCurrent(userDataDir, s.project.ProjectId, ws)
-	c.Assert(mockSdk(sdkdir, filepath.Join(sdkdir, "hooks"), meta), check.IsNil)
+	hooksdir := filepath.Join(sdkdir, "hooks")
+	c.Assert(mockSdk(sdkdir, hooksdir, meta), check.IsNil)
 }
 
 func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
@@ -1126,6 +1152,92 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 		},
 	}
 
+	s.runActionTest(c, requests, expected)
+
+	_, err := s.b.Workshop(s.ctx, "manysdks")
+	c.Assert(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
+
+	repo := s.d.overlord.InterfaceManager().Repository()
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", sdk.System.String()), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", sdk.System.String()), check.HasLen, 0)
+
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk"), check.HasLen, 0)
+
+	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
+}
+
+func (s *apiSuite) TestLaunchWorkshopNoTrySdk(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks_try)
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
+	trydir := workshop.TrySdkDir(userDataDir, "test-sdk")
+	message := fmt.Sprintf(`cannot launch "manysdks": SDK "try-test-sdk" not found: open %s: no such file or directory`, trydir)
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: message,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	c.Assert(os.MkdirAll(trydir, os.ModePerm), check.IsNil)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	filename := fmt.Sprintf("test-sdk_%s_ubuntu@22.04.sdk", arch.DpkgArchitecture())
+	tryfile := filepath.Join(trydir, filename)
+	message = fmt.Sprintf(`cannot launch "manysdks": SDK "try-test-sdk" not found: openat %s: no such file or directory`, tryfile)
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: message,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	c.Assert(os.WriteFile(tryfile, nil, 0666), check.IsNil)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	trydigest := tryfile + ".sha3-384"
+	message = fmt.Sprintf(`cannot launch "manysdks": invalid SDK "try-test-sdk": openat %s: no such file or directory`, trydigest)
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: message,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	c.Assert(os.WriteFile(trydigest, nil, 0666), check.IsNil)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	trymeta := tryfile + ".yaml"
+	message = fmt.Sprintf(`cannot launch "manysdks": invalid SDK "try-test-sdk": openat %s: no such file or directory`, trymeta)
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: message,
+		},
+	}
 	s.runActionTest(c, requests, expected)
 
 	_, err := s.b.Workshop(s.ctx, "manysdks")
@@ -2270,6 +2382,116 @@ func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
 		hookstate.SaveState,
 		hookstate.RestoreState,
 	})
+}
+
+func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+	// Setup
+	s.mockTrySdk(c, "test-sdk", "test-sdk_all.sdk", testsdk)
+	s.mockTrySdk(c, "test-sdk-2", "test-sdk-2_all_ubuntu@22.04.sdk", testsdk2)
+	s.createWFile(c, "manysdks", manysdks_try)
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: "test-sdk", Source: sdk.TrySource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Source: sdk.TrySource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+		},
+		plugs: []string{
+			"test-sdk:data",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
+		},
+		slots: []string{
+			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+	s.ensureWorskhops(c, want)
+
+	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
+	c.Assert(os.RemoveAll(workshop.TrySdkDir(userDataDir, "test-sdk")), check.IsNil)
+	s.mockTrySdk(c, "test-sdk", "test-sdk_all.sdk", testsdk_r2)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	want = []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: "test-sdk", Source: sdk.TrySource, Revision: sdk.R(-2), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Source: sdk.TrySource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+		},
+		plugs: []string{
+			"test-sdk:ssh-agent",
+			"test-sdk:desktop",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
+		},
+		slots: []string{
+			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+	s.ensureWorskhops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_try})
 }
 
 func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -923,7 +923,7 @@ func (s *apiSuite) createWFile(c *check.C, name, yaml string) {
 }
 
 func storeDownloadWithSaveRestore(ctx context.Context, setup sdk.Setup, report *progress.Reporter) error {
-	if err := storeDownload(ctx, setup, report); err != nil || sdk.IsSystem(setup.Name) {
+	if err := storeDownload(ctx, setup, report); err != nil || setup.Source == sdk.SystemSource {
 		return err
 	}
 	hooksdir := filepath.Join(setup.Filepath(), "sdk", "hooks")
@@ -945,7 +945,7 @@ func storeDownload(ctx context.Context, setup sdk.Setup, report *progress.Report
 		return err
 	}
 
-	if sdk.IsSystem(setup.Name) {
+	if setup.Source == sdk.SystemSource {
 		return os.CopyFS(sdkdir, system.SystemSdkFs)
 	}
 	metadir := filepath.Join(sdkdir, "meta")
@@ -1670,7 +1670,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "somebound",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "mount-conflict", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		}, connections: []string{
@@ -1695,7 +1695,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 		},
 		slots: []string{
 			"system:camera",
@@ -1708,7 +1708,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 		},
 		slots: []string{
 			"system:camera",
@@ -1787,9 +1787,9 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/basic/test-sdk:data b8639dea/basic/system:mount",
@@ -1863,7 +1863,7 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-3", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
@@ -1944,7 +1944,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
 		connections: []string{
@@ -2014,7 +2014,7 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/edge", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2104,7 +2104,7 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(2), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2299,9 +2299,9 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Source: "$PROJECT/.workshop/test-sdk", Revision: sdk.R(-1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: "test-sdk", Source: sdk.ProjectSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -2345,9 +2345,9 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Source: "$PROJECT/.workshop/test-sdk", Revision: sdk.R(-2), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Source: "$PROJECT/.workshop/test-sdk-2", Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: "test-sdk", Source: sdk.ProjectSource, Revision: sdk.R(-2), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
@@ -2422,7 +2422,7 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2498,7 +2498,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2576,7 +2576,7 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
 		connections: []string{
@@ -2647,7 +2647,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2721,7 +2721,7 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2797,7 +2797,7 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@24.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -2876,7 +2876,7 @@ func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
 		connections: []string{
@@ -2948,7 +2948,7 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 		},
 		slots: []string{
 			"system:camera",
@@ -3012,7 +3012,7 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
 		},
@@ -3558,16 +3558,13 @@ base: ubuntu@22.04
 
 	s.runActionTest(c, requests, expected)
 
-	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
-	sketchdir := workshop.SketchSdkCurrent(userDataDir, s.project.ProjectId, "manysdks")
-
 	want := []expectedWorkshop{{
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "sketch", Source: sketchdir, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -3586,6 +3583,8 @@ base: ubuntu@22.04
 
 	s.ensureWorskhops(c, want)
 
+	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
+	sketchdir := workshop.SketchSdkCurrent(userDataDir, s.project.ProjectId, "manysdks")
 	c.Assert(os.RemoveAll(sketchdir), check.IsNil)
 	s.mockSketchSdk(c, "manysdks", `name: sketch
 base: ubuntu@22.04
@@ -3613,9 +3612,9 @@ plugs:
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
 			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "sketch", Source: sketchdir, Revision: sdk.R(-2), InstallTime: &s.installTime},
+			{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-2), InstallTime: &s.installTime},
 		},
 		connections: []string{
 			"b8639dea/manysdks/sketch:sketch-plug b8639dea/manysdks/system:mount",

--- a/internal/osutil/env.go
+++ b/internal/osutil/env.go
@@ -107,6 +107,52 @@ func parseRawEnvironment(raw []string) (Environment, error) {
 	return env, nil
 }
 
+func parseSystemctlEnvironment(raw []string) (Environment, error) {
+	env, err := parseRawEnvironment(raw)
+	if err != nil {
+		return env, err
+	}
+
+	for key, value := range env {
+		unescaped, err := unescapeSystemctlValue(value)
+		if err != nil {
+			entry := fmt.Sprintf("%s=%s", key, value)
+			return nil, fmt.Errorf("cannot parse environment entry: %q", entry)
+		}
+		env[key] = unescaped
+	}
+
+	return env, nil
+}
+
+func unescapeSystemctlValue(value string) (string, error) {
+	s, found := strings.CutPrefix(value, "$'")
+	if !found {
+		return value, nil
+	}
+	s, found = strings.CutSuffix(s, "'")
+	if !found {
+		return "", strconv.ErrSyntax
+	}
+
+	var builder strings.Builder
+	for {
+		idx := strings.IndexByte(s, '\\')
+		if idx < 0 {
+			builder.WriteString(s)
+			return builder.String(), nil
+		}
+
+		builder.WriteString(s[:idx])
+		rune, _, tail, err := strconv.UnquoteChar(s[idx:], '\'')
+		if err != nil {
+			return "", err
+		}
+		builder.WriteRune(rune)
+		s = tail
+	}
+}
+
 func ParseEnvironment(raw []string) (Environment, error) {
 	return parseRawEnvironment(raw)
 }

--- a/internal/osutil/env_test.go
+++ b/internal/osutil/env_test.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"os"
 	"strings"
+	"unicode"
 
 	. "gopkg.in/check.v1"
 
@@ -147,6 +148,100 @@ func (s *envSuite) TestParseRawEnvironmentDuplicateKey(c *C) {
 	env, err := osutil.ParseRawEnvironment([]string{"K=1", "K=2"})
 	c.Assert(err, ErrorMatches, `cannot overwrite earlier value of "K"`)
 	c.Assert(env, IsNil)
+}
+
+func (s *envSuite) TestParseSystemctlEnvironmentHappy(c *C) {
+	for _, t := range []struct {
+		lines []string
+		env   map[string]string
+	}{
+		{
+			[]string{"K=V"},
+			map[string]string{"K": "V"},
+		},
+		{
+			[]string{"K=V=V=V"},
+			map[string]string{"K": "V=V=V"},
+		},
+		{
+			[]string{"K1=V1", "K2=V2"},
+			map[string]string{"K1": "V1", "K2": "V2"},
+		},
+	} {
+		env, err := osutil.ParseSystemctlEnvironment(t.lines)
+		c.Assert(err, IsNil)
+		c.Check(env, DeepEquals, osutil.Environment(t.env))
+	}
+}
+
+func (s *envSuite) TestParseSystemctlEnvironmentEscaped(c *C) {
+	var raw, escaped strings.Builder
+	for rune := range unicode.MaxASCII + 1 {
+		raw.WriteRune(rune)
+		switch rune {
+		case '\a':
+			escaped.WriteString(`\a`)
+		case '\b':
+			escaped.WriteString(`\b`)
+		case '\f':
+			escaped.WriteString(`\f`)
+		case '\n':
+			escaped.WriteString(`\n`)
+		case '\r':
+			escaped.WriteString(`\r`)
+		case '\t':
+			escaped.WriteString(`\t`)
+		case '\v':
+			escaped.WriteString(`\v`)
+		case '\\':
+			escaped.WriteString(`\\`)
+		case '\'':
+			escaped.WriteString(`\'`)
+		default:
+			if unicode.IsControl(rune) {
+				fmt.Fprintf(&escaped, `\%03o`, rune)
+			} else {
+				escaped.WriteRune(rune)
+			}
+		}
+	}
+
+	entry := fmt.Sprintf("K=$'%s'", escaped.String())
+	expected := map[string]string{"K": raw.String()}
+
+	env, err := osutil.ParseSystemctlEnvironment([]string{entry})
+	c.Assert(err, IsNil)
+	c.Check(env, DeepEquals, osutil.Environment(expected))
+}
+
+func (s *envSuite) TestParseSystemctlEnvironmentNotKeyValue(c *C) {
+	env, err := osutil.ParseSystemctlEnvironment([]string{"KEY"})
+	c.Assert(err, ErrorMatches, `cannot parse environment entry: "KEY"`)
+	c.Check(env, IsNil)
+}
+
+func (s *envSuite) TestParseSystemctlEnvironmentEmptyKey(c *C) {
+	env, err := osutil.ParseSystemctlEnvironment([]string{"=VALUE"})
+	c.Assert(err, ErrorMatches, `environment variable name cannot be empty: "=VALUE"`)
+	c.Check(env, IsNil)
+}
+
+func (s *envSuite) TestParseSystemctlEnvironmentDuplicateKey(c *C) {
+	env, err := osutil.ParseSystemctlEnvironment([]string{"K=1", "K=2"})
+	c.Assert(err, ErrorMatches, `cannot overwrite earlier value of "K"`)
+	c.Check(env, IsNil)
+}
+
+func (s *envSuite) TestParseSystemctlEnvironmentUnterminated(c *C) {
+	env, err := osutil.ParseSystemctlEnvironment([]string{"K=$'1"})
+	c.Assert(err, ErrorMatches, `cannot parse environment entry: "K=\$'1"`)
+	c.Check(env, IsNil)
+}
+
+func (s *envSuite) TestParseSystemctlEnvironmentInvalidEscape(c *C) {
+	env, err := osutil.ParseSystemctlEnvironment([]string{"K=$'1\\"})
+	c.Assert(err, ErrorMatches, `cannot parse environment entry: "K=\$'1\\\\"`)
+	c.Check(env, IsNil)
 }
 
 func (s *envSuite) TestOSEnvironment(c *C) {

--- a/internal/osutil/export_test.go
+++ b/internal/osutil/export_test.go
@@ -28,10 +28,11 @@ import (
 )
 
 var (
-	FilesAreEqualChunked = filesAreEqualChunked
-	StreamsEqualChunked  = streamsEqualChunked
-	ParseRawEnvironment  = parseRawEnvironment
-	DoCopyFile           = doCopyFile
+	FilesAreEqualChunked      = filesAreEqualChunked
+	StreamsEqualChunked       = streamsEqualChunked
+	ParseRawEnvironment       = parseRawEnvironment
+	ParseSystemctlEnvironment = parseSystemctlEnvironment
+	DoCopyFile                = doCopyFile
 )
 
 // ParseRawExpandableEnv returns a new expandable environment parsed from key=value strings.

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -216,8 +216,9 @@ func userEnvironment(user *user.User) (map[string]string, error) {
 		return nil, fmt.Errorf("%s", string(errOut))
 	}
 
+	// TODO: use --output=json once systemd >= 250.
 	rawEnv := strings.FieldsFunc(string(out), func(r rune) bool { return r == '\n' })
-	return ParseEnvironment(rawEnv)
+	return parseSystemctlEnvironment(rawEnv)
 }
 
 func FakeUserEnvironment(f func(user *user.User) (map[string]string, error)) func() {

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -144,7 +144,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	s.launchWorkshop(c, "one")
 
 	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
-	err := s.backend.CreateVolume(s.ctx, volume)
+	err := s.backend.CreateVolume(s.ctx, volume, "state-storage")
 	c.Assert(err, check.IsNil)
 	defer func() {
 		_ = s.backend.DeleteVolume(s.ctx, volume)
@@ -193,7 +193,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	s.launchWorkshop(c, "one")
 
 	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
-	err := s.backend.CreateVolume(s.ctx, volume)
+	err := s.backend.CreateVolume(s.ctx, volume, "state-storage")
 	c.Assert(err, check.IsNil)
 	defer func() {
 		_ = s.backend.DeleteVolume(s.ctx, volume)
@@ -233,7 +233,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 	s.launchWorkshop(c, "one")
 
 	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
-	err := s.backend.CreateVolume(s.ctx, volume)
+	err := s.backend.CreateVolume(s.ctx, volume, "state-storage")
 	c.Assert(err, check.IsNil)
 	defer func() {
 		_ = s.backend.DeleteVolume(s.ctx, volume)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -143,11 +143,14 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
-	err := s.backend.CreateVolume(s.ctx, volume, "state-storage")
+	volume := workshop.VolumeInfo{
+		Name: workshop.WorkshopStateVolumeName("ws", s.project.ProjectId),
+		Kind: "state-storage",
+	}
+	err := s.backend.CreateVolume(s.ctx, volume)
 	c.Assert(err, check.IsNil)
 	defer func() {
-		_ = s.backend.DeleteVolume(s.ctx, volume)
+		_ = s.backend.DeleteVolume(s.ctx, volume.Name)
 	}()
 
 	s.state.Unlock()
@@ -164,7 +167,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
 	defer ws.Close()
-	err = s.backend.AttachVolume(s.ctx, "ws", volume, dirs.WorkshopStateDir, false)
+	err = s.backend.AttachVolume(s.ctx, "ws", volume.Name, dirs.WorkshopStateDir, false)
 	c.Check(err, check.IsNil)
 	info, err := ws.Stat("/var/lib/workshop/state/sdk/one")
 	c.Check(err, check.IsNil)
@@ -192,15 +195,18 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
-	err := s.backend.CreateVolume(s.ctx, volume, "state-storage")
+	volume := workshop.VolumeInfo{
+		Name: workshop.WorkshopStateVolumeName("ws", s.project.ProjectId),
+		Kind: "state-storage",
+	}
+	err := s.backend.CreateVolume(s.ctx, volume)
 	c.Assert(err, check.IsNil)
 	defer func() {
-		_ = s.backend.DeleteVolume(s.ctx, volume)
+		_ = s.backend.DeleteVolume(s.ctx, volume.Name)
 	}()
 	// Setup state storage (must be already set by the save-state in a real use
 	// case).
-	vfs := s.backend.WorkshopVolumeContents[volume]
+	vfs := s.backend.WorkshopVolumeContents[volume.Name]
 	c.Check(err, check.IsNil)
 	err = os.MkdirAll(filepath.Join(vfs, "sdk", "one"), 0755)
 	c.Check(err, check.IsNil)
@@ -232,11 +238,14 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	volume := workshop.WorkshopStateVolumeName("ws", s.project.ProjectId)
-	err := s.backend.CreateVolume(s.ctx, volume, "state-storage")
+	volume := workshop.VolumeInfo{
+		Name: workshop.WorkshopStateVolumeName("ws", s.project.ProjectId),
+		Kind: "state-storage",
+	}
+	err := s.backend.CreateVolume(s.ctx, volume)
 	c.Assert(err, check.IsNil)
 	defer func() {
-		_ = s.backend.DeleteVolume(s.ctx, volume)
+		_ = s.backend.DeleteVolume(s.ctx, volume.Name)
 	}()
 
 	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -98,6 +98,7 @@ func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sd
 		Name:     sdk.VolumeName(name, rev),
 		Kind:     "sdk",
 		Sdk:      name,
+		Revision: rev,
 		Metadata: sdkYaml,
 	}
 	if err := be.ImportVolume(s.ctx, volume, vfs); err != nil {

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -94,7 +94,12 @@ func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sd
 	s.state.Lock()
 	be := s.o.WorkshopBackend()
 	s.state.Unlock()
-	if err := be.ImportVolume(s.ctx, sdk.VolumeName(name, rev), "sdk", vfs); err != nil {
+	volume := workshop.VolumeInfo{
+		Name:     sdk.VolumeName(name, rev),
+		Kind:     "sdk",
+		Metadata: sdkYaml,
+	}
+	if err := be.ImportVolume(s.ctx, volume, vfs); err != nil {
 		c.Assert(err, testutil.ErrorIs, workshop.ErrVolumeAlreadyExists)
 	}
 }

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -101,7 +101,10 @@ func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sd
 		Revision: rev,
 		Metadata: sdkYaml,
 	}
-	if err := be.ImportVolume(s.ctx, volume, vfs); err != nil {
+	file, err := os.Open(vfs)
+	c.Assert(err, check.IsNil)
+	defer file.Close()
+	if err := be.ImportVolume(s.ctx, volume, file); err != nil {
 		c.Assert(err, testutil.ErrorIs, workshop.ErrVolumeAlreadyExists)
 	}
 }

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -94,7 +94,7 @@ func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sd
 	s.state.Lock()
 	be := s.o.WorkshopBackend()
 	s.state.Unlock()
-	if err := be.ImportVolume(s.ctx, sdk.VolumeName(name, rev), vfs); err != nil {
+	if err := be.ImportVolume(s.ctx, sdk.VolumeName(name, rev), "sdk", vfs); err != nil {
 		c.Assert(err, testutil.ErrorIs, workshop.ErrVolumeAlreadyExists)
 	}
 }

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -97,6 +97,7 @@ func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sd
 	volume := workshop.VolumeInfo{
 		Name:     sdk.VolumeName(name, rev),
 		Kind:     "sdk",
+		Sdk:      name,
 		Metadata: sdkYaml,
 	}
 	if err := be.ImportVolume(s.ctx, volume, vfs); err != nil {

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -119,7 +119,7 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	c.Assert(err, check.IsNil)
 	defer wsfs.Close()
 
-	allsdks := []testSdkSetup{{Setup: sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(1)}, yaml: systemYaml}}
+	allsdks := []testSdkSetup{{Setup: sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: sdk.R(1)}, yaml: systemYaml}}
 	allsdks = append(allsdks, sdks...)
 
 	for _, setup := range allsdks {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -90,6 +90,7 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	volume := workshop.VolumeInfo{
 		Name: sdk.VolumeName(rec.Name, rec.Revision),
 		Kind: "sdk",
+		Sdk:  rec.Name,
 	}
 	err = m.backend.ImportVolume(ctx, volume, rec.Filepath())
 	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"gopkg.in/tomb.v2"
 
@@ -93,7 +94,12 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		Sdk:      rec.Name,
 		Revision: rec.Revision,
 	}
-	err = m.backend.ImportVolume(ctx, volume, rec.Filepath())
+	file, err := os.Open(rec.Filepath())
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	err = m.backend.ImportVolume(ctx, volume, file)
 	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
 		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", sdk.VolumeName(rec.Name, rec.Revision))
 		return nil

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -87,7 +87,7 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
-	err = m.backend.ImportVolume(ctx, sdk.VolumeName(rec.Name, rec.Revision), rec.Filepath())
+	err = m.backend.ImportVolume(ctx, sdk.VolumeName(rec.Name, rec.Revision), "sdk", rec.Filepath())
 	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
 		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", sdk.VolumeName(rec.Name, rec.Revision))
 		return nil

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -73,7 +73,7 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		},
 	}
 
-	if sdk.IsSystem(rec.Name) {
+	if rec.Source == sdk.SystemSource {
 		if err := system.RetrieveSystemSdk(rec, reporter); err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func (m *SdkManager) mountSdk(ctx context.Context, user string, project *worksho
 	name := sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision)
 	sdkPath := sdk.SdkDir(sdkSetup.Name)
 
-	if sdkSetup.Revision.Store() {
+	if sdkSetup.IsVolume() {
 		return m.backend.AttachVolume(ctx, w, name, sdkPath, true)
 	}
 
@@ -196,7 +196,7 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 
 func (m *SdkManager) unmountSdk(ctx context.Context, w string, sdkSetup sdk.Setup) error {
 	name := sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision)
-	if sdkSetup.Revision.Store() {
+	if sdkSetup.IsVolume() {
 		return m.backend.DetachVolume(ctx, w, name)
 	}
 	return m.backend.RemoveWorkshopMount(ctx, w, name)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -88,9 +88,10 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	volume := workshop.VolumeInfo{
-		Name: sdk.VolumeName(rec.Name, rec.Revision),
-		Kind: "sdk",
-		Sdk:  rec.Name,
+		Name:     sdk.VolumeName(rec.Name, rec.Revision),
+		Kind:     "sdk",
+		Sdk:      rec.Name,
+		Revision: rec.Revision,
 	}
 	err = m.backend.ImportVolume(ctx, volume, rec.Filepath())
 	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -87,7 +87,11 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
-	err = m.backend.ImportVolume(ctx, sdk.VolumeName(rec.Name, rec.Revision), "sdk", rec.Filepath())
+	volume := workshop.VolumeInfo{
+		Name: sdk.VolumeName(rec.Name, rec.Revision),
+		Kind: "sdk",
+	}
+	err = m.backend.ImportVolume(ctx, volume, rec.Filepath())
 	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
 		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", sdk.VolumeName(rec.Name, rec.Revision))
 		return nil

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -162,6 +162,7 @@ func (s *sdkStateSuite) mockSdk(c *check.C, name, sdkYaml string, rev sdk.Revisi
 		Name:     sdk.VolumeName(name, rev),
 		Kind:     "sdk",
 		Sdk:      name,
+		Revision: rev,
 		Metadata: sdkYaml,
 	}
 	err = s.backend.ImportVolume(s.ctx, volume, vfs)

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -158,7 +158,7 @@ func (s *sdkStateSuite) mockSdk(c *check.C, name, sdkYaml string, rev sdk.Revisi
 	c.Assert(err, check.IsNil)
 	err = os.WriteFile(filepath.Join(meta, "sdk.yaml"), []byte(sdkYaml), 0644)
 	c.Assert(err, check.IsNil)
-	err = s.backend.ImportVolume(s.ctx, sdk.VolumeName(name, rev), vfs)
+	err = s.backend.ImportVolume(s.ctx, sdk.VolumeName(name, rev), "sdk", vfs)
 	c.Assert(err, check.IsNil)
 }
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -259,7 +259,7 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Setup{Name: sdk.System.String(), Revision: system.SystemSdkRevision}
+	newSdk := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
 	t := s.state.NewTask("retrieve-sdk", "retrieve")
 	t.Set("sdk-setup", newSdk)
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -158,7 +158,12 @@ func (s *sdkStateSuite) mockSdk(c *check.C, name, sdkYaml string, rev sdk.Revisi
 	c.Assert(err, check.IsNil)
 	err = os.WriteFile(filepath.Join(meta, "sdk.yaml"), []byte(sdkYaml), 0644)
 	c.Assert(err, check.IsNil)
-	err = s.backend.ImportVolume(s.ctx, sdk.VolumeName(name, rev), "sdk", vfs)
+	volume := workshop.VolumeInfo{
+		Name:     sdk.VolumeName(name, rev),
+		Kind:     "sdk",
+		Metadata: sdkYaml,
+	}
+	err = s.backend.ImportVolume(s.ctx, volume, vfs)
 	c.Assert(err, check.IsNil)
 }
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -161,6 +161,7 @@ func (s *sdkStateSuite) mockSdk(c *check.C, name, sdkYaml string, rev sdk.Revisi
 	volume := workshop.VolumeInfo{
 		Name:     sdk.VolumeName(name, rev),
 		Kind:     "sdk",
+		Sdk:      name,
 		Metadata: sdkYaml,
 	}
 	err = s.backend.ImportVolume(s.ctx, volume, vfs)

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -165,7 +165,10 @@ func (s *sdkStateSuite) mockSdk(c *check.C, name, sdkYaml string, rev sdk.Revisi
 		Revision: rev,
 		Metadata: sdkYaml,
 	}
-	err = s.backend.ImportVolume(s.ctx, volume, vfs)
+	file, err := os.Open(vfs)
+	c.Assert(err, check.IsNil)
+	defer file.Close()
+	err = s.backend.ImportVolume(s.ctx, volume, file)
 	c.Assert(err, check.IsNil)
 }
 

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -9,7 +9,7 @@ import (
 
 func Retrieve(st *state.State, s sdk.Setup) *state.Task {
 	summary := fmt.Sprintf("Retrieve %q SDK from channel %q", s.Name, s.Channel)
-	if sdk.IsSystem(s.Name) {
+	if s.Source != sdk.StoreSource {
 		summary = fmt.Sprintf("Retrieve %q SDK", s.Name)
 	}
 

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -370,7 +370,7 @@ func (m *WorkshopManager) doCreateStateStorage(task *state.Task, tomb *tomb.Tomb
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
 
-	return m.backend.CreateVolume(ctx, workshop.WorkshopStateVolumeName(w, prj.ProjectId))
+	return m.backend.CreateVolume(ctx, workshop.WorkshopStateVolumeName(w, prj.ProjectId), "state-storage")
 }
 
 func (m *WorkshopManager) doRemoveStateStorage(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -370,7 +370,11 @@ func (m *WorkshopManager) doCreateStateStorage(task *state.Task, tomb *tomb.Tomb
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
 
-	return m.backend.CreateVolume(ctx, workshop.WorkshopStateVolumeName(w, prj.ProjectId), "state-storage")
+	volume := workshop.VolumeInfo{
+		Name: workshop.WorkshopStateVolumeName(w, prj.ProjectId),
+		Kind: "state-storage",
+	}
+	return m.backend.CreateVolume(ctx, volume)
 }
 
 func (m *WorkshopManager) doRemoveStateStorage(task *state.Task, tomb *tomb.Tomb) error {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -9,7 +9,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/canonical/workshop/internal/osutil"
@@ -153,7 +152,7 @@ func (w *WorkshopManager) findAllStoreSdks(ctx context.Context, project workshop
 func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.Setup, error) {
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
-		if workshop.IsImplicitSdk(sd.Name) || sd.Source != "" {
+		if sd.Source != sdk.StoreSource {
 			continue
 		}
 		act := sdk.SdkAction{ProjectId: projectid, Workshop: file.Name, Name: sd.Name, Base: file.Base, Channel: sd.Channel, Action: sdk.Install}
@@ -166,9 +165,9 @@ func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *w
 	}
 
 	setups := make([]sdk.Setup, 1, len(infos)+1)
-	setups[0] = sdk.Setup{Name: "system", Revision: system.SystemSdkRevision}
+	setups[0] = sdk.Setup{Name: "system", Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
 	for _, s := range infos {
-		setups = append(setups, sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision})
+		setups = append(setups, sdk.Setup{Name: s.Name, Channel: s.Channel, Source: sdk.StoreSource, Revision: s.Revision})
 	}
 
 	return setups, nil
@@ -184,44 +183,42 @@ func (s *localSdkFinder) findLocalSdks(wp *workshop.Workshop, file *workshop.Fil
 	localSdks := []sdk.Setup{}
 
 	for _, sd := range file.Sdks {
-		if sd.Source != "project" {
+		if sd.Source != sdk.ProjectSource {
 			continue
 		}
-		setup, err := s.findInProjectSdk(wp, file.Name, sd.Name)
+		revision, err := s.findInProjectSdk(wp, file.Name, sd.Name)
 		if err != nil {
 			return nil, err
 		}
-		localSdks = append(localSdks, *setup)
+		localSdks = append(localSdks, sdk.Setup{Name: sd.Name, Source: sdk.ProjectSource, Revision: revision})
 	}
 
-	sketch, err := s.maybeFindSketchSdk(wp, file.Name)
+	revision, err := s.maybeFindSketchSdk(wp, file.Name)
 	if err != nil {
 		return nil, err
 	}
-	if sketch != nil {
-		localSdks = append(localSdks, *sketch)
+	if !revision.Unset() {
+		localSdks = append(localSdks, sdk.Setup{Name: sdk.Sketch, Source: sdk.SketchSource, Revision: revision})
 	}
 
 	return localSdks, nil
 }
 
-func (s *localSdkFinder) findInProjectSdk(wp *workshop.Workshop, w, sk string) (*sdk.Setup, error) {
-	relative := workshop.ProjectSdkPath("", sk)
-	escaped := strings.ReplaceAll(relative, "$", "$$")
-	source := filepath.Join("$PROJECT", escaped)
-	return s.commitRevision(wp, w, sk, source)
+func (s *localSdkFinder) findInProjectSdk(wp *workshop.Workshop, w, sk string) (sdk.Revision, error) {
+	sdkdir := workshop.ProjectSdkPath(s.project.Path, sk)
+	return s.commitRevision(wp, w, sk, sdkdir)
 }
 
-func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (*sdk.Setup, error) {
+func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (sdk.Revision, error) {
 	sketchdir := workshop.SketchSdkCurrent(s.userDataDir, s.project.ProjectId, w)
 
 	recs, err := os.ReadDir(sketchdir)
 	// no Sketch SDK exists for the workshop and it is not an error.
 	if (err == nil && len(recs) == 0) || osutil.IsDirNotExist(err) {
-		return nil, nil
+		return sdk.Revision{}, nil
 	}
 	if err != nil {
-		return nil, err
+		return sdk.Revision{}, err
 	}
 
 	if wp == nil {
@@ -229,30 +226,22 @@ func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (*s
 		// No workshop exists currently; including the sketch SDK would be unexpected.
 		// We remove it (but keep the stash) to prevent future refreshes from including it.
 		if err = os.RemoveAll(sketchdir); err != nil {
-			return nil, err
+			return sdk.Revision{}, err
 		}
-		return nil, nil
+		return sdk.Revision{}, nil
 	}
 
-	source := strings.ReplaceAll(sketchdir, "$", "$$")
-	return s.commitRevision(wp, w, sdk.Sketch, source)
+	return s.commitRevision(wp, w, sdk.Sketch, sketchdir)
 }
 
-func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk, source string) (*sdk.Setup, error) {
+func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk, source string) (sdk.Revision, error) {
 	var installed sdk.Revision
 	if wp != nil {
 		installed = wp.Sdks[sk].Revision
 	}
 
-	sourcePath := workshop.ExpandSdkSource(source, s.project.Path)
 	target := workshop.LocalSdkDir(s.userDataDir, s.project.ProjectId, w, sk)
-
-	revision, err := sdk.CommitRevision(s.user, sourcePath, target, installed)
-	if err != nil {
-		return nil, err
-	}
-
-	return &sdk.Setup{Name: sk, Source: source, Revision: revision}, nil
+	return sdk.CommitRevision(s.user, source, target, installed)
 }
 
 func ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {
@@ -282,7 +271,7 @@ func retrieveSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string
 	retrieve := state.NewTaskSet()
 	retrieveMap := map[string]string{}
 	for _, s := range sdks {
-		if s.Revision.Store() {
+		if s.Source.NeedsRetrieve() {
 			r := sdkstate.Retrieve(st, s)
 			retrieve.AddTask(r)
 			retrieveMap[s.Name] = r.ID()
@@ -311,12 +300,12 @@ func installSdks(st *state.State, pid, w string, sdks []sdk.Setup, retrieveTasks
 		// guarantee safety of concurrent installations.
 		var install *state.Task
 		var retrieveTask string
-		if setup.Revision.Local() {
-			install = sdkstate.InstallLocalSdk(st, setup)
-			retrieveTask = install.ID()
-		} else {
+		if setup.Source.NeedsRetrieve() {
 			retrieveTask = retrieveTasks[setup.Name]
 			install = sdkstate.Install(st, setup.Name, retrieveTask)
+		} else {
+			install = sdkstate.InstallLocalSdk(st, setup)
+			retrieveTask = install.ID()
 		}
 		addTask(install)
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -71,9 +71,9 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	if err != nil {
 		return nil, err
 	}
-	local := localStore{usr, userDataDir, project}
+	finder := localSdkFinder{usr, userDataDir, project}
 
-	reqs, err := w.resolveWorkshops(ctx, project, names, "launch")
+	reqs, err := w.findAllStoreSdks(ctx, project, names, "launch")
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	for _, req := range reqs {
 		name := req.file.Name
 		// Make sure the workshop doesn't exist.
-		// Has to happen after calling resolveWorkshops (because it unlocks the state).
+		// Has to happen after calling findAllStoreSdks (because it unlocks the state).
 		_, err := w.Workshop(ctx, name, projectId)
 		if err == nil {
 			return nil, fmt.Errorf("cannot launch %q: workshop exists", name)
@@ -93,7 +93,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, fmt.Errorf("cannot launch %q, other changes in progress: %w", name, err)
 		}
 
-		localSdks, err := local.resolveSdks(name, req.file, nil)
+		localSdks, err := finder.findLocalSdks(nil, req.file)
 		if err != nil {
 			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
@@ -114,7 +114,7 @@ type workshopReq struct {
 	storeSdks []sdk.Setup
 }
 
-func (w *WorkshopManager) resolveWorkshops(ctx context.Context, project workshop.Project, names []string, action string) ([]workshopReq, error) {
+func (w *WorkshopManager) findAllStoreSdks(ctx context.Context, project workshop.Project, names []string, action string) ([]workshopReq, error) {
 	sto := sdk.StoreService(w.state)
 	reqs := make([]workshopReq, 0, len(names))
 
@@ -140,7 +140,7 @@ func (w *WorkshopManager) resolveWorkshops(ctx context.Context, project workshop
 		}
 		installOrder = append(installOrder, sdk.Sketch)
 
-		storeSdks, err := resolveStoreSdks(sto, ctx, project.ProjectId, file)
+		storeSdks, err := findStoreSdks(sto, ctx, project.ProjectId, file)
 		if err != nil {
 			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
 		}
@@ -150,7 +150,7 @@ func (w *WorkshopManager) resolveWorkshops(ctx context.Context, project workshop
 	return reqs, nil
 }
 
-func resolveStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.Setup, error) {
+func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.Setup, error) {
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
 		if workshop.IsImplicitSdk(sd.Name) || sd.Source != "" {
@@ -174,26 +174,27 @@ func resolveStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file
 	return setups, nil
 }
 
-type localStore struct {
+type localSdkFinder struct {
 	user        *user.User
 	userDataDir string
 	project     workshop.Project
 }
 
-func (s *localStore) resolveSdks(name string, file *workshop.File, wp *workshop.Workshop) ([]sdk.Setup, error) {
+func (s *localSdkFinder) findLocalSdks(wp *workshop.Workshop, file *workshop.File) ([]sdk.Setup, error) {
 	localSdks := []sdk.Setup{}
 
 	for _, sd := range file.Sdks {
 		if sd.Source != "project" {
 			continue
 		}
-		relative := workshop.ProjectSdkPath("", sd.Name)
-		escaped := strings.ReplaceAll(relative, "$", "$$")
-		source := filepath.Join("$PROJECT", escaped)
-		localSdks = append(localSdks, sdk.Setup{Name: sd.Name, Source: source})
+		setup, err := s.findInProjectSdk(wp, file.Name, sd.Name)
+		if err != nil {
+			return nil, err
+		}
+		localSdks = append(localSdks, *setup)
 	}
 
-	sketch, err := maybeSketch(s.userDataDir, s.project.ProjectId, name, wp == nil)
+	sketch, err := s.maybeFindSketchSdk(wp, file.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -201,26 +202,18 @@ func (s *localStore) resolveSdks(name string, file *workshop.File, wp *workshop.
 		localSdks = append(localSdks, *sketch)
 	}
 
-	for i, sk := range localSdks {
-		var installed sdk.Revision
-		if wp != nil {
-			installed = wp.Sdks[sk.Name].Revision
-		}
-
-		source := workshop.ExpandSdkSource(sk.Source, s.project.Path)
-		target := workshop.LocalSdkDir(s.userDataDir, s.project.ProjectId, name, sk.Name)
-
-		localSdks[i].Revision, err = sdk.CommitRevision(s.user, source, target, installed)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return localSdks, nil
 }
 
-func maybeSketch(userDataDir, pid, name string, launch bool) (*sdk.Setup, error) {
-	sketchdir := workshop.SketchSdkCurrent(userDataDir, pid, name)
+func (s *localSdkFinder) findInProjectSdk(wp *workshop.Workshop, w, sk string) (*sdk.Setup, error) {
+	relative := workshop.ProjectSdkPath("", sk)
+	escaped := strings.ReplaceAll(relative, "$", "$$")
+	source := filepath.Join("$PROJECT", escaped)
+	return s.commitRevision(wp, w, sk, source)
+}
+
+func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (*sdk.Setup, error) {
+	sketchdir := workshop.SketchSdkCurrent(s.userDataDir, s.project.ProjectId, w)
 
 	recs, err := os.ReadDir(sketchdir)
 	// no Sketch SDK exists for the workshop and it is not an error.
@@ -231,7 +224,7 @@ func maybeSketch(userDataDir, pid, name string, launch bool) (*sdk.Setup, error)
 		return nil, err
 	}
 
-	if launch {
+	if wp == nil {
 		// Old sketches might exist because the snap remove hook doesn't remove them.
 		// No workshop exists currently; including the sketch SDK would be unexpected.
 		// We remove it (but keep the stash) to prevent future refreshes from including it.
@@ -241,8 +234,25 @@ func maybeSketch(userDataDir, pid, name string, launch bool) (*sdk.Setup, error)
 		return nil, nil
 	}
 
-	escaped := strings.ReplaceAll(sketchdir, "$", "$$")
-	return &sdk.Setup{Name: sdk.Sketch, Source: escaped}, nil
+	source := strings.ReplaceAll(sketchdir, "$", "$$")
+	return s.commitRevision(wp, w, sdk.Sketch, source)
+}
+
+func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk, source string) (*sdk.Setup, error) {
+	var installed sdk.Revision
+	if wp != nil {
+		installed = wp.Sdks[sk].Revision
+	}
+
+	sourcePath := workshop.ExpandSdkSource(source, s.project.Path)
+	target := workshop.LocalSdkDir(s.userDataDir, s.project.ProjectId, w, sk)
+
+	revision, err := sdk.CommitRevision(s.user, sourcePath, target, installed)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sdk.Setup{Name: sk, Source: source, Revision: revision}, nil
 }
 
 func ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {
@@ -443,9 +453,9 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 	if err != nil {
 		return nil, err
 	}
-	local := localStore{usr, userDataDir, project}
+	finder := localSdkFinder{usr, userDataDir, project}
 
-	reqs, err := w.resolveWorkshops(ctx, project, names, "refresh")
+	reqs, err := w.findAllStoreSdks(ctx, project, names, "refresh")
 	if err != nil {
 		return nil, err
 	}
@@ -460,12 +470,12 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 		}
 
 		// Check for conflicting changes.
-		// Has to happen after calling resolveWorkshops (because it unlocks the state).
+		// Has to happen after calling findAllStoreSdks (because it unlocks the state).
 		if err := healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
 			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}
 
-		localSdks, err := local.resolveSdks(name, req.file, wp)
+		localSdks, err := finder.findLocalSdks(wp, req.file)
 		if err != nil {
 			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -1,16 +1,20 @@
 package workshopstate
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"maps"
 	"os"
 	"os/user"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
+	"github.com/canonical/workshop/internal/arch"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/cmdstate"
 	"github.com/canonical/workshop/internal/overlord/conflict"
@@ -70,7 +74,12 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 	if err != nil {
 		return nil, err
 	}
-	finder := localSdkFinder{usr, userDataDir, project}
+	finder := localSdkFinder{
+		backend:     w.backend,
+		user:        usr,
+		userDataDir: userDataDir,
+		project:     project,
+	}
 
 	reqs, err := w.findAllStoreSdks(ctx, project, names, "launch")
 	if err != nil {
@@ -92,7 +101,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 			return nil, fmt.Errorf("cannot launch %q, other changes in progress: %w", name, err)
 		}
 
-		localSdks, err := finder.findLocalSdks(nil, req.file)
+		localSdks, err := finder.findLocalSdks(ctx, nil, req.file)
 		if err != nil {
 			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
@@ -174,23 +183,25 @@ func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *w
 }
 
 type localSdkFinder struct {
+	backend     workshop.Backend
 	user        *user.User
 	userDataDir string
 	project     workshop.Project
+	sdkVolumes  []workshop.VolumeInfo
 }
 
-func (s *localSdkFinder) findLocalSdks(wp *workshop.Workshop, file *workshop.File) ([]sdk.Setup, error) {
+func (s *localSdkFinder) findLocalSdks(ctx context.Context, wp *workshop.Workshop, file *workshop.File) ([]sdk.Setup, error) {
 	localSdks := []sdk.Setup{}
 
 	for _, sd := range file.Sdks {
-		if sd.Source != sdk.ProjectSource {
-			continue
-		}
-		revision, err := s.findInProjectSdk(wp, file.Name, sd.Name)
+		revision, err := s.maybeFindLocalSdk(ctx, wp, file, sd)
 		if err != nil {
 			return nil, err
 		}
-		localSdks = append(localSdks, sdk.Setup{Name: sd.Name, Source: sdk.ProjectSource, Revision: revision})
+		if revision.Unset() {
+			continue
+		}
+		localSdks = append(localSdks, sdk.Setup{Name: sd.Name, Source: sd.Source, Revision: revision})
 	}
 
 	revision, err := s.maybeFindSketchSdk(wp, file.Name)
@@ -202,6 +213,139 @@ func (s *localSdkFinder) findLocalSdks(wp *workshop.Workshop, file *workshop.Fil
 	}
 
 	return localSdks, nil
+}
+
+func (s *localSdkFinder) maybeFindLocalSdk(ctx context.Context, wp *workshop.Workshop, file *workshop.File, sd workshop.SdkRecord) (sdk.Revision, error) {
+	switch sd.Source {
+	case sdk.TrySource:
+		return s.findTrySdk(ctx, file.Base, sd.Name)
+	case sdk.ProjectSource:
+		return s.findInProjectSdk(wp, file.Name, sd.Name)
+	default:
+		return sdk.Revision{}, nil
+	}
+}
+
+func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (sdk.Revision, error) {
+	trydir := workshop.TrySdkDir(s.userDataDir, sk)
+	root, err := os.OpenRoot(trydir)
+	if err != nil {
+		return sdk.Revision{}, fmt.Errorf("SDK %q not found: %w", "try-"+sk, err)
+	}
+
+	file, filename, err := findTrySdkFile(root, sk, arch.DpkgArchitecture(), base)
+	if err != nil {
+		return sdk.Revision{}, fmt.Errorf("SDK %q not found: %w", "try-"+sk, err)
+	}
+	defer file.Close()
+
+	digest, meta, err := readTrySdkMetadata(root, filename)
+	if err != nil {
+		return sdk.Revision{}, fmt.Errorf("invalid SDK %q: %w", "try-"+sk, err)
+	}
+
+	volumes, err := s.volumes(ctx)
+	if err != nil {
+		return sdk.Revision{}, err
+	}
+
+	minRevision := sdk.Revision{}
+	for _, volume := range volumes {
+		if volume.Sdk != sk || !volume.Revision.Local() {
+			continue
+		}
+		if volume.Revision.N < minRevision.N {
+			minRevision = volume.Revision
+		}
+
+		if volume.Sha3_384 == digest {
+			return volume.Revision, nil
+		}
+	}
+
+	revision := sdk.Revision{N: minRevision.N - 1}
+	volume := workshop.VolumeInfo{
+		Name:     sdk.VolumeName(sk, revision),
+		Kind:     "sdk",
+		Sha3_384: digest,
+		Sdk:      sk,
+		Revision: revision,
+		Metadata: meta,
+	}
+	if err := s.importVolume(ctx, volume, file); err != nil {
+		return sdk.Revision{}, err
+	}
+	return revision, nil
+}
+
+func (s *localSdkFinder) volumes(ctx context.Context) ([]workshop.VolumeInfo, error) {
+	if s.sdkVolumes != nil {
+		// The state is locked, preventing other launches and refreshes
+		// from calling ImportVolume, so it's safe to reuse sdkVolumes.
+		return s.sdkVolumes, nil
+	}
+
+	vols, err := s.backend.Volumes(ctx, "sdk")
+	if err != nil {
+		return nil, err
+	}
+	if vols == nil {
+		vols = []workshop.VolumeInfo{}
+	}
+	s.sdkVolumes = vols
+	return vols, nil
+}
+
+func (s *localSdkFinder) importVolume(ctx context.Context, info workshop.VolumeInfo, tarball *os.File) error {
+	if err := s.backend.ImportVolume(ctx, info, tarball); err != nil {
+		return err
+	}
+	s.sdkVolumes = append(s.sdkVolumes, info)
+	return nil
+}
+
+func findTrySdkFile(root *os.Root, sk, arch, base string) (*os.File, string, error) {
+	filenames := []string{
+		fmt.Sprintf("%s_%s_%s.sdk", sk, arch, base),
+		fmt.Sprintf("%s_%s.sdk", sk, arch),
+		fmt.Sprintf("%s_all_%s.sdk", sk, base),
+		fmt.Sprintf("%s_all.sdk", sk),
+	}
+	var firstErr error
+	for _, filename := range filenames {
+		file, err := root.Open(filename)
+		if err == nil {
+			return file, filename, nil
+		}
+		firstErr = cmp.Or(firstErr, err)
+	}
+	return nil, "", prependRootPath(root, firstErr)
+}
+
+func readTrySdkMetadata(root *os.Root, filename string) (string, string, error) {
+	fs := root.FS().(fs.ReadFileFS)
+
+	content, err := fs.ReadFile(filename + ".sha3-384")
+	if err != nil {
+		return "", "", prependRootPath(root, err)
+	}
+	digest := strings.TrimSpace(string(content))
+
+	content, err = fs.ReadFile(filename + ".yaml")
+	if err != nil {
+		return "", "", prependRootPath(root, err)
+	}
+	meta := string(content)
+
+	return digest, meta, nil
+}
+
+func prependRootPath(root *os.Root, err error) error {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		pathErr.Path = filepath.Join(root.Name(), pathErr.Path)
+	}
+	return err
 }
 
 func (s *localSdkFinder) findInProjectSdk(wp *workshop.Workshop, w, sk string) (sdk.Revision, error) {
@@ -442,7 +586,12 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 	if err != nil {
 		return nil, err
 	}
-	finder := localSdkFinder{usr, userDataDir, project}
+	finder := localSdkFinder{
+		backend:     w.backend,
+		user:        usr,
+		userDataDir: userDataDir,
+		project:     project,
+	}
 
 	reqs, err := w.findAllStoreSdks(ctx, project, names, "refresh")
 	if err != nil {
@@ -464,7 +613,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}
 
-		localSdks, err := finder.findLocalSdks(wp, req.file)
+		localSdks, err := finder.findLocalSdks(ctx, wp, req.file)
 		if err != nil {
 			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 		}
@@ -507,7 +656,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 }
 
 func maybeRefresh(installed, candidate sdk.Setup) bool {
-	return installed.Channel != candidate.Channel || installed.Revision != candidate.Revision
+	return installed.Source != candidate.Source || installed.Channel != candidate.Channel || installed.Revision != candidate.Revision
 }
 
 type refreshPlan struct {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -93,7 +93,7 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 
 	for _, sd := range sdks {
 		s.writeSDKMetaFile(c, wfs, sd.Name, fmt.Sprintf(sdkTemplate, sd.Name))
-		c.Assert(w.AddSdk(s.ctx, sdk.Setup{Name: sd.Name, Channel: sd.Channel}), check.IsNil)
+		c.Assert(w.AddSdk(s.ctx, sdk.Setup{Name: sd.Name, Source: sdk.StoreSource, Channel: sd.Channel}), check.IsNil)
 	}
 
 	return w

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -32,7 +32,7 @@ func (s *Setup) filename() string {
 }
 
 func (s *Setup) IsVolume() bool {
-	return s.Source == StoreSource || s.Source == SystemSource
+	return s.Source == StoreSource || s.Source == SystemSource || s.Source == TrySource
 }
 
 func VolumeName(name string, revision Revision) string {
@@ -44,6 +44,7 @@ type Source int
 const (
 	StoreSource Source = iota
 	SystemSource
+	TrySource
 	ProjectSource
 	SketchSource
 )
@@ -55,6 +56,8 @@ func (s Source) MarshalText() ([]byte, error) {
 		text = "store"
 	case SystemSource:
 		text = "system"
+	case TrySource:
+		text = "try"
 	case ProjectSource:
 		text = "project"
 	case SketchSource:
@@ -71,6 +74,8 @@ func (s *Source) UnmarshalText(text []byte) error {
 		*s = StoreSource
 	case "system":
 		*s = SystemSource
+	case "try":
+		*s = TrySource
 	case "project":
 		*s = ProjectSource
 	case "sketch":

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -18,7 +18,7 @@ import (
 type Setup struct {
 	Name        string     `json:"name"`
 	Channel     string     `json:"channel,omitempty"`
-	Source      string     `json:"source,omitempty"`
+	Source      Source     `json:"source,omitempty"`
 	Revision    Revision   `json:"revision"`
 	InstallTime *time.Time `json:"install-time"`
 }
@@ -31,8 +31,58 @@ func (s *Setup) filename() string {
 	return fmt.Sprintf("%s_%s.sdk", s.Name, s.Revision.String())
 }
 
+func (s *Setup) IsVolume() bool {
+	return s.Source == StoreSource || s.Source == SystemSource
+}
+
 func VolumeName(name string, revision Revision) string {
 	return fmt.Sprintf("%s-%s", name, revision)
+}
+
+type Source int
+
+const (
+	StoreSource Source = iota
+	SystemSource
+	ProjectSource
+	SketchSource
+)
+
+func (s Source) MarshalText() ([]byte, error) {
+	var text string
+	switch s {
+	case StoreSource:
+		text = "store"
+	case SystemSource:
+		text = "system"
+	case ProjectSource:
+		text = "project"
+	case SketchSource:
+		text = "sketch"
+	default:
+		return nil, fmt.Errorf("invalid SDK source: %v", int(s))
+	}
+	return []byte(text), nil
+}
+
+func (s *Source) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "store":
+		*s = StoreSource
+	case "system":
+		*s = SystemSource
+	case "project":
+		*s = ProjectSource
+	case "sketch":
+		*s = SketchSource
+	default:
+		return fmt.Errorf("invalid SDK source: %q", string(text))
+	}
+	return nil
+}
+
+func (s Source) NeedsRetrieve() bool {
+	return s == StoreSource || s == SystemSource
 }
 
 type sdkYaml struct {
@@ -77,7 +127,7 @@ type Info struct {
 	Type      Type
 	Revision  Revision
 	Channel   string
-	Source    string
+	Source    Source
 	BuildTime *time.Time
 
 	Plugs     map[string]*PlugInfo

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -1,6 +1,7 @@
 package sdk_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -27,6 +28,18 @@ func (s *SdkSuite) SetUpTest(c *check.C) {
 
 func (s *SdkSuite) TearDownTest(c *check.C) {
 	s.BaseTest.TearDownTest(c)
+}
+
+func (s *SdkSuite) TestSourceMarshalUnmarshal(c *check.C) {
+	for i := range sdk.SketchSource + 1 {
+		setup := sdk.Setup{Name: "sdk", Source: i}
+		data, err := json.Marshal(setup)
+		c.Assert(err, check.IsNil)
+
+		var result sdk.Setup
+		c.Assert(json.Unmarshal(data, &result), check.IsNil)
+		c.Check(result, check.Equals, setup)
+	}
 }
 
 func (s *SdkSuite) TestSimple(c *check.C) {

--- a/internal/sdk/system/system_test.go
+++ b/internal/sdk/system/system_test.go
@@ -48,7 +48,7 @@ func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 		done = d
 		total = t
 	}}
-	setup := sdk.Setup{Name: sdk.System.String(), Revision: system.SystemSdkRevision}
+	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
 	c.Assert(system.RetrieveSystemSdk(setup, report), check.IsNil)
 	c.Check(done, testutil.IntGreaterThan, 0)
 	c.Check(total, testutil.IntGreaterThan, 0)
@@ -68,7 +68,7 @@ func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 }
 
 func (s *systemSdk) TestRetrieveSystemSdkWrongRevision(c *check.C) {
-	setup := sdk.Setup{Name: sdk.System.String(), Revision: sdk.R(system.SystemSdkRevision.N - 1)}
+	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: sdk.R(system.SystemSdkRevision.N - 1)}
 	err := system.RetrieveSystemSdk(setup, nil)
 	c.Check(err, check.ErrorMatches, fmt.Sprintf(`system SDK \(%s\) not available`, setup.Revision))
 

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -56,7 +56,7 @@ func Validate(sdk *Info) error {
 
 // ValidateName checks if a string can be used as an SDK name.
 func ValidateName(name string) error {
-	if name == "agent" || strings.HasPrefix(name, "project-") {
+	if name == "agent" || strings.HasPrefix(name, "try-") || strings.HasPrefix(name, "project-") {
 		return fmt.Errorf("%q is a reserved SDK name", name)
 	}
 	if !sdkName.MatchString(name) {

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/user"
 	"time"
 
@@ -96,8 +97,8 @@ type VolumeManager interface {
 	// workshop as a separate operation.
 	CreateVolume(ctx context.Context, info VolumeInfo) error
 
-	// Import a tarball into the volume. The tarball must be a valid tarball filepath.
-	ImportVolume(ctx context.Context, info VolumeInfo, tarball string) error
+	// Import a tarball into the volume.
+	ImportVolume(ctx context.Context, info VolumeInfo, tarball *os.File) error
 
 	// Attach the volume to the workshop. The volume must be created before.
 	AttachVolume(ctx context.Context, wp, name, where string, ro bool) error

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -85,10 +85,10 @@ type VolumeManager interface {
 	// Create a temporary storage volume for the workshop. It does not
 	// mount the device to the workshop, it must be mounted to the required
 	// workshop as a separate operation.
-	CreateVolume(ctx context.Context, name string) error
+	CreateVolume(ctx context.Context, name, kind string) error
 
 	// Import a tarball into the volume. The tarball must be a valid tarball filepath.
-	ImportVolume(ctx context.Context, name string, tarball string) error
+	ImportVolume(ctx context.Context, name, kind string, tarball string) error
 
 	// Attach the volume to the workshop. The volume must be created before.
 	AttachVolume(ctx context.Context, wp, name, where string, ro bool) error

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -83,6 +83,8 @@ type VolumeInfo struct {
 	Name string
 	// Kind of volume, e.g. "sdk" or "state-storage."
 	Kind string
+	// Hash of tarball used to create volume.
+	Sha3_384 string
 	// Name of SDK associated with volume, if any.
 	Sdk string
 	// Revision of SDK associated with volume, if any.

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -100,6 +100,9 @@ type VolumeManager interface {
 	// unmount the volume from the workshop if mounted.
 	DeleteVolume(ctx context.Context, name string) error
 
+	// List volumes of a given kind.
+	Volumes(ctx context.Context, kind string) ([]VolumeInfo, error)
+
 	// Get the volume information.
 	Volume(ctx context.Context, name string) (VolumeInfo, error)
 }

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -77,18 +77,22 @@ type Stash interface {
 }
 
 type VolumeInfo struct {
-	Name   string
-	Config map[string]string
+	// Volume name.
+	Name string
+	// Kind of volume, e.g. "sdk" or "state-storage."
+	Kind string
+	// For SDK volumes, a copy of meta/sdk.yaml.
+	Metadata string
 }
 
 type VolumeManager interface {
 	// Create a temporary storage volume for the workshop. It does not
 	// mount the device to the workshop, it must be mounted to the required
 	// workshop as a separate operation.
-	CreateVolume(ctx context.Context, name, kind string) error
+	CreateVolume(ctx context.Context, info VolumeInfo) error
 
 	// Import a tarball into the volume. The tarball must be a valid tarball filepath.
-	ImportVolume(ctx context.Context, name, kind string, tarball string) error
+	ImportVolume(ctx context.Context, info VolumeInfo, tarball string) error
 
 	// Attach the volume to the workshop. The volume must be created before.
 	AttachVolume(ctx context.Context, wp, name, where string, ro bool) error

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -81,6 +81,8 @@ type VolumeInfo struct {
 	Name string
 	// Kind of volume, e.g. "sdk" or "state-storage."
 	Kind string
+	// Name of SDK associated with volume, if any.
+	Sdk string
 	// For SDK volumes, a copy of meta/sdk.yaml.
 	Metadata string
 }

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 type ContextKeyProjectId string
@@ -83,6 +84,8 @@ type VolumeInfo struct {
 	Kind string
 	// Name of SDK associated with volume, if any.
 	Sdk string
+	// Revision of SDK associated with volume, if any.
+	Revision sdk.Revision
 	// For SDK volumes, a copy of meta/sdk.yaml.
 	Metadata string
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -70,7 +70,7 @@ type FakeWorkshopBackend struct {
 	StashedWorkshops map[string]map[string]*FakeWorkshop
 	// storage volumes, the key is a volume name
 	volumeLock                sync.Mutex
-	WorkshopVolumes           map[string]map[string]string
+	WorkshopVolumes           map[string]workshop.VolumeInfo
 	WorkshopVolumeContents    map[string]string
 	WorkshopVolumeMountPoints map[string]string
 	// the key is a username
@@ -102,7 +102,7 @@ func New(baseDir string) (*FakeWorkshopBackend, error) {
 	var be FakeWorkshopBackend
 	be.Workshops = make(map[string]map[string]*FakeWorkshop)
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
-	be.WorkshopVolumes = make(map[string]map[string]string)
+	be.WorkshopVolumes = make(map[string]workshop.VolumeInfo)
 	be.WorkshopVolumeContents = make(map[string]string)
 	be.WorkshopVolumeMountPoints = make(map[string]string)
 	be.projects = make(map[string][]workshop.Project)
@@ -511,21 +511,21 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	return nil
 }
 
-func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, name, kind string) error {
+func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, info workshop.VolumeInfo) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	if _, ok := s.WorkshopVolumes[name]; ok {
+	if _, ok := s.WorkshopVolumes[info.Name]; ok {
 		return workshop.ErrVolumeAlreadyExists
 	}
 
-	vfs := filepath.Join(s.BaseDir, "volumes", name)
+	vfs := filepath.Join(s.BaseDir, "volumes", info.Name)
 	if err := os.MkdirAll(vfs, 0755); err != nil {
 		return err
 	}
 
-	s.WorkshopVolumeContents[name] = vfs
-	s.WorkshopVolumes[name] = map[string]string{workshop.ConfigVolumeKind: kind}
+	s.WorkshopVolumeContents[info.Name] = vfs
+	s.WorkshopVolumes[info.Name] = info
 	return nil
 }
 
@@ -583,24 +583,24 @@ func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string)
 // ImportVolume imports a tarball into the volume. The tarball must be a valid
 // directory (unpacked so that the tests could provide a temp directory instead
 // of a packed tarball).
-func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, name, kind string, tarball string) error {
+func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, tarball string) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	if _, ok := s.WorkshopVolumes[name]; ok {
+	if _, ok := s.WorkshopVolumes[info.Name]; ok {
 		return workshop.ErrVolumeAlreadyExists
 	}
 
-	config := map[string]string{workshop.ConfigVolumeKind: kind}
-	if kind == "sdk" {
+	// TODO: Remove when we can reliably fetch metadata from the store.
+	if info.Kind == "sdk" && info.Metadata == "" {
 		meta, err := os.ReadFile(filepath.Join(tarball, "meta", "sdk.yaml"))
 		if err == nil {
-			config[workshop.ConfigVolumeMeta] = string(meta)
+			info.Metadata = string(meta)
 		}
 	}
 
-	s.WorkshopVolumeContents[name] = tarball
-	s.WorkshopVolumes[name] = config
+	s.WorkshopVolumeContents[info.Name] = tarball
+	s.WorkshopVolumes[info.Name] = info
 	return nil
 }
 
@@ -618,9 +618,9 @@ func (s *FakeWorkshopBackend) Volumes(ctx context.Context, kind string) ([]works
 	defer s.volumeLock.Unlock()
 
 	var infos []workshop.VolumeInfo
-	for name, config := range s.WorkshopVolumes {
-		if config[workshop.ConfigVolumeKind] == kind {
-			infos = append(infos, workshop.VolumeInfo{Name: name, Config: config})
+	for _, info := range s.WorkshopVolumes {
+		if info.Kind == kind {
+			infos = append(infos, info)
 		}
 	}
 	return infos, nil
@@ -630,12 +630,12 @@ func (s *FakeWorkshopBackend) Volume(ctx context.Context, name string) (workshop
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	config, ok := s.WorkshopVolumes[name]
+	info, ok := s.WorkshopVolumes[name]
 	if !ok {
 		return workshop.VolumeInfo{}, workshop.ErrVolumeNotFound
 	}
 
-	return workshop.VolumeInfo{Name: name, Config: config}, nil
+	return info, nil
 }
 
 func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, error) {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -70,7 +70,7 @@ type FakeWorkshopBackend struct {
 	StashedWorkshops map[string]map[string]*FakeWorkshop
 	// storage volumes, the key is a volume name
 	volumeLock                sync.Mutex
-	WorkshopVolumes           map[string]bool
+	WorkshopVolumes           map[string]map[string]string
 	WorkshopVolumeContents    map[string]string
 	WorkshopVolumeMountPoints map[string]string
 	// the key is a username
@@ -102,7 +102,7 @@ func New(baseDir string) (*FakeWorkshopBackend, error) {
 	var be FakeWorkshopBackend
 	be.Workshops = make(map[string]map[string]*FakeWorkshop)
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
-	be.WorkshopVolumes = make(map[string]bool)
+	be.WorkshopVolumes = make(map[string]map[string]string)
 	be.WorkshopVolumeContents = make(map[string]string)
 	be.WorkshopVolumeMountPoints = make(map[string]string)
 	be.projects = make(map[string][]workshop.Project)
@@ -511,11 +511,11 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	return nil
 }
 
-func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, name string) error {
+func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, name, kind string) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	if s.WorkshopVolumes[name] {
+	if _, ok := s.WorkshopVolumes[name]; ok {
 		return workshop.ErrVolumeAlreadyExists
 	}
 
@@ -525,7 +525,7 @@ func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, name string) err
 	}
 
 	s.WorkshopVolumeContents[name] = vfs
-	s.WorkshopVolumes[name] = true
+	s.WorkshopVolumes[name] = map[string]string{workshop.ConfigVolumeKind: kind}
 	return nil
 }
 
@@ -583,15 +583,24 @@ func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string)
 // ImportVolume imports a tarball into the volume. The tarball must be a valid
 // directory (unpacked so that the tests could provide a temp directory instead
 // of a packed tarball).
-func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, name string, tarball string) error {
+func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, name, kind string, tarball string) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	if s.WorkshopVolumes[name] {
+	if _, ok := s.WorkshopVolumes[name]; ok {
 		return workshop.ErrVolumeAlreadyExists
 	}
+
+	config := map[string]string{workshop.ConfigVolumeKind: kind}
+	if kind == "sdk" {
+		meta, err := os.ReadFile(filepath.Join(tarball, "meta", "sdk.yaml"))
+		if err == nil {
+			config[workshop.ConfigVolumeMeta] = string(meta)
+		}
+	}
+
 	s.WorkshopVolumeContents[name] = tarball
-	s.WorkshopVolumes[name] = true
+	s.WorkshopVolumes[name] = config
 	return nil
 }
 
@@ -608,16 +617,12 @@ func (s *FakeWorkshopBackend) Volume(ctx context.Context, name string) (workshop
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	if !s.WorkshopVolumes[name] {
+	config, ok := s.WorkshopVolumes[name]
+	if !ok {
 		return workshop.VolumeInfo{}, workshop.ErrVolumeNotFound
 	}
 
-	meta, err := os.ReadFile(filepath.Join(s.WorkshopVolumeContents[name], "meta", "sdk.yaml"))
-	if err != nil {
-		return workshop.VolumeInfo{}, err
-	}
-
-	return workshop.VolumeInfo{Name: name, Config: map[string]string{workshop.ConfigVolumeMeta: string(meta)}}, nil
+	return workshop.VolumeInfo{Name: name, Config: config}, nil
 }
 
 func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, error) {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -583,7 +583,7 @@ func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string)
 // ImportVolume imports a tarball into the volume. The tarball must be a valid
 // directory (unpacked so that the tests could provide a temp directory instead
 // of a packed tarball).
-func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, tarball string) error {
+func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, tarball *os.File) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
@@ -593,13 +593,13 @@ func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, info workshop.Vo
 
 	// TODO: Remove when we can reliably fetch metadata from the store.
 	if info.Kind == "sdk" && info.Metadata == "" {
-		meta, err := os.ReadFile(filepath.Join(tarball, "meta", "sdk.yaml"))
+		meta, err := os.ReadFile(filepath.Join(tarball.Name(), "meta", "sdk.yaml"))
 		if err == nil {
 			info.Metadata = string(meta)
 		}
 	}
 
-	s.WorkshopVolumeContents[info.Name] = tarball
+	s.WorkshopVolumeContents[info.Name] = tarball.Name()
 	s.WorkshopVolumes[info.Name] = info
 	return nil
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -613,6 +613,19 @@ func (s *FakeWorkshopBackend) DeleteVolume(ctx context.Context, name string) err
 	return nil
 }
 
+func (s *FakeWorkshopBackend) Volumes(ctx context.Context, kind string) ([]workshop.VolumeInfo, error) {
+	s.volumeLock.Lock()
+	defer s.volumeLock.Unlock()
+
+	var infos []workshop.VolumeInfo
+	for name, config := range s.WorkshopVolumes {
+		if config[workshop.ConfigVolumeKind] == kind {
+			infos = append(infos, workshop.VolumeInfo{Name: name, Config: config})
+		}
+	}
+	return infos, nil
+}
+
 func (s *FakeWorkshopBackend) Volume(ctx context.Context, name string) (workshop.VolumeInfo, error) {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 
 	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -315,6 +316,9 @@ func volumeInfoToConfig(info workshop.VolumeInfo) map[string]string {
 	if info.Sdk != "" {
 		config["user.sdk.name"] = info.Sdk
 	}
+	if !info.Revision.Unset() {
+		config["user.sdk.revision"] = info.Revision.String()
+	}
 	if info.Metadata != "" {
 		config["user.sdk.meta"] = info.Metadata
 	}
@@ -322,10 +326,15 @@ func volumeInfoToConfig(info workshop.VolumeInfo) map[string]string {
 }
 
 func volumeConfigToInfo(name string, config map[string]string) workshop.VolumeInfo {
+	revision, err := sdk.ParseRevision(config["user.sdk.revision"])
+	if err != nil {
+		revision = sdk.Revision{}
+	}
 	return workshop.VolumeInfo{
 		Name:     name,
 		Kind:     config["user.kind"],
 		Sdk:      config["user.sdk.name"],
+		Revision: revision,
 		Metadata: config["user.sdk.meta"],
 	}
 }

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -266,6 +266,29 @@ func (s *Backend) DeleteVolume(ctx context.Context, name string) error {
 	return nil
 }
 
+func (s *Backend) Volumes(ctx context.Context, kind string) ([]workshop.VolumeInfo, error) {
+	conn, err := s.LxdClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Disconnect()
+
+	filters := []string{
+		"type=custom",
+		fmt.Sprintf("config.%s=%s", workshop.ConfigVolumeKind, kind),
+	}
+	vols, err := conn.GetStoragePoolVolumesWithFilter(storagePool, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	infos := make([]workshop.VolumeInfo, 0, len(vols))
+	for _, vol := range vols {
+		infos = append(infos, workshop.VolumeInfo{Name: vol.Name, Config: vol.Config})
+	}
+	return infos, nil
+}
+
 func (s *Backend) Volume(ctx context.Context, name string) (workshop.VolumeInfo, error) {
 	var info workshop.VolumeInfo
 	conn, err := s.LxdClient(ctx)

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -93,7 +93,7 @@ func unlockVolume(volume string) {
 	}
 }
 
-func (s *Backend) CreateVolume(ctx context.Context, name string) error {
+func (s *Backend) CreateVolume(ctx context.Context, name, kind string) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func (s *Backend) CreateVolume(ctx context.Context, name string) error {
 	vol.Name = name
 	vol.Type = "custom"
 	vol.ContentType = "filesystem"
-	vol.Config = map[string]string{}
+	vol.Config = map[string]string{workshop.ConfigVolumeKind: kind}
 
 	err = conn.CreateStoragePoolVolume(storagePool, vol)
 	if api.StatusErrorCheck(err, http.StatusConflict) {
@@ -114,7 +114,7 @@ func (s *Backend) CreateVolume(ctx context.Context, name string) error {
 	return err
 }
 
-func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string) error {
+func (s *Backend) ImportVolume(ctx context.Context, name, kind string, tarball string) error {
 	// There could be multiple launches that require the same volume. We don't
 	// want to unpack and import the volume multiple times.
 	if err := lockVolume(ctx, name); err != nil {
@@ -141,7 +141,7 @@ func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string)
 	// following format:
 	//
 	// backup/
-	//	volume/
+	//  volume/
 	//  index.yaml
 
 	dir, err := os.MkdirTemp("", name)
@@ -184,14 +184,18 @@ func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string)
 
 	newtar := filepath.Join(dir, filepath.Base(tarball))
 
-	// Read the metadata to store it as a volume's property. This is not ideal
-	// when the backend knows the name of the file with metadata as the volume
-	// manager should be able to import any tarball as a volume. But given that
-	// it is only applicable to SDKs in the nearest future, it should be acceptable
-	// as the alternative would be to change the interface to accept the metadata.
-	meta, err := os.ReadFile(filepath.Join(dir, "volume", "meta", "sdk.yaml"))
-	if err != nil {
-		return err
+	config := map[string]string{workshop.ConfigVolumeKind: kind}
+	if kind == "sdk" {
+		// Read the metadata to store it as a volume's property. This is not ideal
+		// when the backend knows the name of the file with metadata as the volume
+		// manager should be able to import any tarball as a volume. But given that
+		// it is only applicable to SDKs in the nearest future, it should be acceptable
+		// as the alternative would be to change the interface to accept the metadata.
+		meta, err := os.ReadFile(filepath.Join(dir, "volume", "meta", "sdk.yaml"))
+		if err != nil {
+			return err
+		}
+		config[workshop.ConfigVolumeMeta] = string(meta)
 	}
 
 	repack := exec.CommandContext(ctx, "tar",
@@ -234,10 +238,7 @@ func (s *Backend) ImportVolume(ctx context.Context, name string, tarball string)
 		return err
 	}
 
-	return conn.UpdateStoragePoolVolume(storagePool, "custom", name, api.StorageVolumePut{
-		Config: map[string]string{
-			workshop.ConfigVolumeMeta: string(meta),
-		}}, "")
+	return conn.UpdateStoragePoolVolume(storagePool, "custom", name, api.StorageVolumePut{Config: config}, "")
 }
 
 func (s *Backend) AttachVolume(ctx context.Context, wp, name, where string, ro bool) error {

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -312,6 +312,9 @@ func volumeInfoToConfig(info workshop.VolumeInfo) map[string]string {
 	config := map[string]string{
 		"user.kind": info.Kind,
 	}
+	if info.Sdk != "" {
+		config["user.sdk.name"] = info.Sdk
+	}
 	if info.Metadata != "" {
 		config["user.sdk.meta"] = info.Metadata
 	}
@@ -322,6 +325,7 @@ func volumeConfigToInfo(name string, config map[string]string) workshop.VolumeIn
 	return workshop.VolumeInfo{
 		Name:     name,
 		Kind:     config["user.kind"],
+		Sdk:      config["user.sdk.name"],
 		Metadata: config["user.sdk.meta"],
 	}
 }

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -312,6 +312,9 @@ func volumeInfoToConfig(info workshop.VolumeInfo) map[string]string {
 	config := map[string]string{
 		"user.kind": info.Kind,
 	}
+	if info.Sha3_384 != "" {
+		config["user.sha3-384"] = info.Sha3_384
+	}
 	if info.Sdk != "" {
 		config["user.sdk.name"] = info.Sdk
 	}
@@ -332,6 +335,7 @@ func volumeConfigToInfo(name string, config map[string]string) workshop.VolumeIn
 	return workshop.VolumeInfo{
 		Name:     name,
 		Kind:     config["user.kind"],
+		Sha3_384: config["user.sha3-384"],
 		Sdk:      config["user.sdk.name"],
 		Revision: revision,
 		Metadata: config["user.sdk.meta"],

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -93,7 +93,7 @@ func unlockVolume(volume string) {
 	}
 }
 
-func (s *Backend) CreateVolume(ctx context.Context, name, kind string) error {
+func (s *Backend) CreateVolume(ctx context.Context, info workshop.VolumeInfo) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -102,10 +102,10 @@ func (s *Backend) CreateVolume(ctx context.Context, name, kind string) error {
 
 	// Create the storage volume entry
 	vol := api.StorageVolumesPost{}
-	vol.Name = name
+	vol.Name = info.Name
 	vol.Type = "custom"
 	vol.ContentType = "filesystem"
-	vol.Config = map[string]string{workshop.ConfigVolumeKind: kind}
+	vol.Config = volumeInfoToConfig(info)
 
 	err = conn.CreateStoragePoolVolume(storagePool, vol)
 	if api.StatusErrorCheck(err, http.StatusConflict) {
@@ -114,13 +114,13 @@ func (s *Backend) CreateVolume(ctx context.Context, name, kind string) error {
 	return err
 }
 
-func (s *Backend) ImportVolume(ctx context.Context, name, kind string, tarball string) error {
+func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, tarball string) error {
 	// There could be multiple launches that require the same volume. We don't
 	// want to unpack and import the volume multiple times.
-	if err := lockVolume(ctx, name); err != nil {
+	if err := lockVolume(ctx, info.Name); err != nil {
 		return err
 	}
-	defer unlockVolume(name)
+	defer unlockVolume(info.Name)
 
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
@@ -128,7 +128,7 @@ func (s *Backend) ImportVolume(ctx context.Context, name, kind string, tarball s
 	}
 	defer conn.Disconnect()
 
-	_, _, err = conn.GetStoragePoolVolume(storagePool, "custom", name)
+	_, _, err = conn.GetStoragePoolVolume(storagePool, "custom", info.Name)
 	if err == nil {
 		return workshop.ErrVolumeAlreadyExists
 	}
@@ -144,7 +144,7 @@ func (s *Backend) ImportVolume(ctx context.Context, name, kind string, tarball s
 	//  volume/
 	//  index.yaml
 
-	dir, err := os.MkdirTemp("", name)
+	dir, err := os.MkdirTemp("", info.Name)
 	if err != nil {
 		return err
 	}
@@ -178,14 +178,14 @@ func (s *Backend) ImportVolume(ctx context.Context, name, kind string, tarball s
 	}
 
 	// Generate index.yaml for the volume.
-	if err = os.WriteFile(filepath.Join(dir, "index.yaml"), []byte(volumeIndexContent(name)), 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(dir, "index.yaml"), []byte(volumeIndexContent(info.Name)), 0644); err != nil {
 		return err
 	}
 
 	newtar := filepath.Join(dir, filepath.Base(tarball))
 
-	config := map[string]string{workshop.ConfigVolumeKind: kind}
-	if kind == "sdk" {
+	// TODO: Remove when we can reliably fetch metadata from the store.
+	if info.Kind == "sdk" && info.Metadata == "" {
 		// Read the metadata to store it as a volume's property. This is not ideal
 		// when the backend knows the name of the file with metadata as the volume
 		// manager should be able to import any tarball as a volume. But given that
@@ -195,7 +195,7 @@ func (s *Backend) ImportVolume(ctx context.Context, name, kind string, tarball s
 		if err != nil {
 			return err
 		}
-		config[workshop.ConfigVolumeMeta] = string(meta)
+		info.Metadata = string(meta)
 	}
 
 	repack := exec.CommandContext(ctx, "tar",
@@ -226,7 +226,7 @@ func (s *Backend) ImportVolume(ctx context.Context, name, kind string, tarball s
 
 	vol := lxd.StoragePoolVolumeBackupArgs{
 		BackupFile: f,
-		Name:       name,
+		Name:       info.Name,
 	}
 
 	op, err := conn.CreateStoragePoolVolumeFromBackup(storagePool, vol)
@@ -238,7 +238,8 @@ func (s *Backend) ImportVolume(ctx context.Context, name, kind string, tarball s
 		return err
 	}
 
-	return conn.UpdateStoragePoolVolume(storagePool, "custom", name, api.StorageVolumePut{Config: config}, "")
+	volPut := api.StorageVolumePut{Config: volumeInfoToConfig(info)}
+	return conn.UpdateStoragePoolVolume(storagePool, "custom", info.Name, volPut, "")
 }
 
 func (s *Backend) AttachVolume(ctx context.Context, wp, name, where string, ro bool) error {
@@ -275,7 +276,7 @@ func (s *Backend) Volumes(ctx context.Context, kind string) ([]workshop.VolumeIn
 
 	filters := []string{
 		"type=custom",
-		fmt.Sprintf("config.%s=%s", workshop.ConfigVolumeKind, kind),
+		fmt.Sprintf("config.user.kind=%s", kind),
 	}
 	vols, err := conn.GetStoragePoolVolumesWithFilter(storagePool, filters)
 	if err != nil {
@@ -284,29 +285,43 @@ func (s *Backend) Volumes(ctx context.Context, kind string) ([]workshop.VolumeIn
 
 	infos := make([]workshop.VolumeInfo, 0, len(vols))
 	for _, vol := range vols {
-		infos = append(infos, workshop.VolumeInfo{Name: vol.Name, Config: vol.Config})
+		infos = append(infos, volumeConfigToInfo(vol.Name, vol.Config))
 	}
 	return infos, nil
 }
 
 func (s *Backend) Volume(ctx context.Context, name string) (workshop.VolumeInfo, error) {
-	var info workshop.VolumeInfo
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
-		return info, err
+		return workshop.VolumeInfo{}, err
 	}
 	defer conn.Disconnect()
 
 	vol, _, err := conn.GetStoragePoolVolume(storagePool, "custom", name)
 	if api.StatusErrorCheck(err, http.StatusNotFound) {
-		return info, workshop.ErrVolumeNotFound
+		return workshop.VolumeInfo{}, workshop.ErrVolumeNotFound
 	}
-
 	if err != nil {
-		return info, err
+		return workshop.VolumeInfo{}, err
 	}
 
-	info.Name = vol.Name
-	info.Config = vol.Config
-	return info, nil
+	return volumeConfigToInfo(vol.Name, vol.Config), nil
+}
+
+func volumeInfoToConfig(info workshop.VolumeInfo) map[string]string {
+	config := map[string]string{
+		"user.kind": info.Kind,
+	}
+	if info.Metadata != "" {
+		config["user.sdk.meta"] = info.Metadata
+	}
+	return config
+}
+
+func volumeConfigToInfo(name string, config map[string]string) workshop.VolumeInfo {
+	return workshop.VolumeInfo{
+		Name:     name,
+		Kind:     config["user.kind"],
+		Metadata: config["user.sdk.meta"],
+	}
 }

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -115,7 +115,7 @@ func (s *Backend) CreateVolume(ctx context.Context, info workshop.VolumeInfo) er
 	return err
 }
 
-func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, tarball string) error {
+func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, tarball *os.File) error {
 	// There could be multiple launches that require the same volume. We don't
 	// want to unpack and import the volume multiple times.
 	if err := lockVolume(ctx, info.Name); err != nil {
@@ -163,12 +163,12 @@ func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, ta
 		"--no-same-owner",
 		"--no-same-permissions",
 		"--keep-old-files",
-		"--force-local",
-		"--file="+tarball,
+		"--file=/dev/stdin",
 		"--transform",
 		"s,^,volume/,",
 		"--directory="+dir,
 	)
+	unpack.Stdin = tarball
 
 	if _, err := unpack.Output(); err != nil {
 		var exitErr *exec.ExitError
@@ -182,8 +182,6 @@ func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, ta
 	if err = os.WriteFile(filepath.Join(dir, "index.yaml"), []byte(volumeIndexContent(info.Name)), 0644); err != nil {
 		return err
 	}
-
-	newtar := filepath.Join(dir, filepath.Base(tarball))
 
 	// TODO: Remove when we can reliably fetch metadata from the store.
 	if info.Kind == "sdk" && info.Metadata == "" {
@@ -199,6 +197,7 @@ func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, ta
 		info.Metadata = string(meta)
 	}
 
+	newtar := filepath.Join(dir, filepath.Base(tarball.Name()))
 	repack := exec.CommandContext(ctx, "tar",
 		"--create",
 		"--format=posix",

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -453,7 +453,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	w, err := f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 
-	setup := sdk.Setup{Name: sdk.System.String(), Revision: system.SystemSdkRevision}
+	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
 	err = system.RetrieveSystemSdk(setup, nil)
 	c.Assert(err, check.IsNil)
 

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -201,6 +201,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	volume := workshop.VolumeInfo{
 		Name:     "test-1",
 		Kind:     "sdk",
+		Sdk:      "test",
 		Metadata: testsdk,
 	}
 	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
@@ -245,6 +246,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 	volume := workshop.VolumeInfo{
 		Name:     "test-1",
 		Kind:     "sdk",
+		Sdk:      "test",
 		Metadata: testsdk,
 	}
 	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
@@ -480,6 +482,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	volume := workshop.VolumeInfo{
 		Name:     sdk.VolumeName(setup.Name, setup.Revision),
 		Kind:     "sdk",
+		Sdk:      setup.Name,
 		Metadata: string(meta),
 	}
 	err = f.bd.ImportVolume(f.ctx, volume, setup.Filepath())

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"os/user"
+	"path/filepath"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -161,7 +162,11 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 
 func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 	// Execute
-	err := f.bd.CreateVolume(f.ctx, "test", "testkind")
+	volume := workshop.VolumeInfo{
+		Name: "test",
+		Kind: "testkind",
+	}
+	err := f.bd.CreateVolume(f.ctx, volume)
 	c.Assert(err, check.IsNil)
 
 	// Validate
@@ -169,11 +174,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(vols, check.HasLen, 1)
 
-	expected := workshop.VolumeInfo{
-		Name:   "test",
-		Config: map[string]string{workshop.ConfigVolumeKind: "testkind"},
-	}
-	c.Check(vols[0], check.DeepEquals, expected)
+	c.Check(vols[0], check.Equals, volume)
 
 	// Execute
 	err = f.bd.DeleteVolume(f.ctx, "test")
@@ -197,6 +198,11 @@ sdkcraft-started-at: '2020-04-22T19:12:07.903032Z'
 func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	// Execute
 	sdkfs := c.MkDir()
+	volume := workshop.VolumeInfo{
+		Name:     "test-1",
+		Kind:     "sdk",
+		Metadata: testsdk,
+	}
 	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
 
 	cmd := testutil.FakeCommand(c, "tar", `/usr/bin/tar "$@"`)
@@ -207,7 +213,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	wg.Add(5)
 	for i := 0; i < 5; i++ {
 		go func() {
-			err := f.bd.ImportVolume(f.ctx, "test-1", "sdk", tarball)
+			err := f.bd.ImportVolume(f.ctx, volume, tarball)
 			if err == nil {
 				atomic.AddInt32(&successCnt, 1)
 			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
@@ -227,12 +233,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 
 	vinfo, err := f.bd.Volume(f.ctx, "test-1")
 	c.Check(err, check.IsNil)
-	c.Check(vinfo.Name, check.Equals, "test-1")
-	expected := map[string]string{
-		"user.kind":     "sdk",
-		"user.sdk.meta": testsdk,
-	}
-	c.Check(vinfo.Config, check.DeepEquals, expected)
+	c.Check(vinfo, check.Equals, volume)
 
 	err = f.bd.DeleteVolume(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
@@ -241,6 +242,11 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 	// Execute
 	sdkfs := c.MkDir()
+	volume := workshop.VolumeInfo{
+		Name:     "test-1",
+		Kind:     "sdk",
+		Metadata: testsdk,
+	}
 	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
 
 	cmd := testutil.FakeCommand(c, "tar", `/usr/bin/tar "$@"`)
@@ -259,7 +265,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 		}
 
 		go func() {
-			err := f.bd.ImportVolume(newctx, "test-1", "sdk", tarball)
+			err := f.bd.ImportVolume(newctx, volume, tarball)
 			if err == nil {
 				atomic.AddInt32(&successCnt, 1)
 			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
@@ -282,12 +288,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 
 	vinfo, err := f.bd.Volume(f.ctx, "test-1")
 	c.Check(err, check.IsNil)
-	c.Check(vinfo.Name, check.Equals, "test-1")
-	expected := map[string]string{
-		"user.kind":     "sdk",
-		"user.sdk.meta": testsdk,
-	}
-	c.Check(vinfo.Config, check.DeepEquals, expected)
+	c.Check(vinfo, check.Equals, volume)
 
 	err = f.bd.DeleteVolume(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
@@ -473,13 +474,19 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
 	err = system.RetrieveSystemSdk(setup, nil)
 	c.Assert(err, check.IsNil)
-
-	volume := sdk.VolumeName(setup.Name, setup.Revision)
-	err = f.bd.ImportVolume(f.ctx, volume, "sdk", setup.Filepath())
+	meta, err := system.SystemSdkFs.ReadFile(filepath.Join("meta", "sdk.yaml"))
 	c.Assert(err, check.IsNil)
-	defer func() { _ = f.bd.DeleteVolume(f.ctx, volume) }()
 
-	err = f.bd.AttachVolume(f.ctx, "test", volume, sdk.SdkDir(setup.Name), true)
+	volume := workshop.VolumeInfo{
+		Name:     sdk.VolumeName(setup.Name, setup.Revision),
+		Kind:     "sdk",
+		Metadata: string(meta),
+	}
+	err = f.bd.ImportVolume(f.ctx, volume, setup.Filepath())
+	c.Assert(err, check.IsNil)
+	defer func() { _ = f.bd.DeleteVolume(f.ctx, volume.Name) }()
+
+	err = f.bd.AttachVolume(f.ctx, "test", volume.Name, sdk.SdkDir(setup.Name), true)
 	c.Assert(err, check.IsNil)
 
 	err = w.AddSdk(f.ctx, setup)
@@ -492,7 +499,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	err = f.bd.Snapshot(f.ctx, "test", "snapshot-1")
 	c.Assert(err, check.IsNil)
 
-	err = f.bd.AttachVolume(f.ctx, "test", volume, sdk.SdkDir("sdk"), true)
+	err = f.bd.AttachVolume(f.ctx, "test", volume.Name, sdk.SdkDir("sdk"), true)
 	c.Assert(err, check.IsNil)
 
 	err = w.AddSdk(f.ctx, sdk.Setup{Name: "sdk", Revision: sdk.R(5)})

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -163,8 +163,9 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 	// Execute
 	volume := workshop.VolumeInfo{
-		Name: "test",
-		Kind: "testkind",
+		Name:     "test",
+		Kind:     "testkind",
+		Sha3_384: "abc123",
 	}
 	err := f.bd.CreateVolume(f.ctx, volume)
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -215,15 +215,17 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	wg.Add(5)
 	for i := 0; i < 5; i++ {
 		go func() {
-			err := f.bd.ImportVolume(f.ctx, volume, tarball)
-			if err == nil {
+			defer wg.Done()
+			file, err := os.Open(tarball)
+			c.Assert(err, check.IsNil)
+			defer file.Close()
+			if err := f.bd.ImportVolume(f.ctx, volume, file); err == nil {
 				atomic.AddInt32(&successCnt, 1)
 			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
 				atomic.AddInt32(&existCnt, 1)
 			} else {
-				c.Logf("unexpected error: %v", err)
+				c.Assert(err, check.IsNil)
 			}
-			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -269,17 +271,19 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 		}
 
 		go func() {
-			err := f.bd.ImportVolume(newctx, volume, tarball)
-			if err == nil {
+			defer wg.Done()
+			file, err := os.Open(tarball)
+			c.Assert(err, check.IsNil)
+			defer file.Close()
+			if err := f.bd.ImportVolume(newctx, volume, file); err == nil {
 				atomic.AddInt32(&successCnt, 1)
 			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
 				atomic.AddInt32(&existCnt, 1)
 			} else if errors.Is(err, context.Canceled) {
 				atomic.AddInt32(&canceled, 1)
 			} else {
-				c.Logf("unexpected error: %v", err)
+				c.Assert(err, check.IsNil)
 			}
-			wg.Done()
 		}()
 	}
 	wg.Wait()
@@ -488,9 +492,16 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 		Revision: setup.Revision,
 		Metadata: string(meta),
 	}
-	err = f.bd.ImportVolume(f.ctx, volume, setup.Filepath())
+	file, err := os.Open(setup.Filepath())
+	c.Assert(err, check.IsNil)
+	err = f.bd.ImportVolume(f.ctx, volume, file)
+	file.Close()
 	c.Assert(err, check.IsNil)
 	defer func() { _ = f.bd.DeleteVolume(f.ctx, volume.Name) }()
+
+	info, err := f.bd.Volume(f.ctx, volume.Name)
+	c.Assert(err, check.IsNil)
+	c.Check(info, check.DeepEquals, volume)
 
 	err = f.bd.AttachVolume(f.ctx, "test", volume.Name, sdk.SdkDir(setup.Name), true)
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -164,7 +164,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
 	// Execute
-	err := f.bd.CreateVolume(f.ctx, "test")
+	err := f.bd.CreateVolume(f.ctx, "test", "testkind")
 
 	// Validate
 	c.Assert(err, check.IsNil)
@@ -198,7 +198,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	wg.Add(5)
 	for i := 0; i < 5; i++ {
 		go func() {
-			err := f.bd.ImportVolume(f.ctx, "test-1", tarball)
+			err := f.bd.ImportVolume(f.ctx, "test-1", "sdk", tarball)
 			if err == nil {
 				atomic.AddInt32(&successCnt, 1)
 			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
@@ -219,7 +219,11 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	vinfo, err := f.bd.Volume(f.ctx, "test-1")
 	c.Check(err, check.IsNil)
 	c.Check(vinfo.Name, check.Equals, "test-1")
-	c.Check(vinfo.Config, check.DeepEquals, map[string]string{"user.sdk.meta": testsdk})
+	expected := map[string]string{
+		"user.kind":     "sdk",
+		"user.sdk.meta": testsdk,
+	}
+	c.Check(vinfo.Config, check.DeepEquals, expected)
 
 	err = f.bd.DeleteVolume(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
@@ -246,7 +250,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 		}
 
 		go func() {
-			err := f.bd.ImportVolume(newctx, "test-1", tarball)
+			err := f.bd.ImportVolume(newctx, "test-1", "sdk", tarball)
 			if err == nil {
 				atomic.AddInt32(&successCnt, 1)
 			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
@@ -270,7 +274,11 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 	vinfo, err := f.bd.Volume(f.ctx, "test-1")
 	c.Check(err, check.IsNil)
 	c.Check(vinfo.Name, check.Equals, "test-1")
-	c.Check(vinfo.Config, check.DeepEquals, map[string]string{"user.sdk.meta": testsdk})
+	expected := map[string]string{
+		"user.kind":     "sdk",
+		"user.sdk.meta": testsdk,
+	}
+	c.Check(vinfo.Config, check.DeepEquals, expected)
 
 	err = f.bd.DeleteVolume(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
@@ -458,7 +466,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	volume := sdk.VolumeName(setup.Name, setup.Revision)
-	err = f.bd.ImportVolume(f.ctx, volume, setup.Filepath())
+	err = f.bd.ImportVolume(f.ctx, volume, "sdk", setup.Filepath())
 	c.Assert(err, check.IsNil)
 	defer func() { _ = f.bd.DeleteVolume(f.ctx, volume) }()
 

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -160,20 +160,29 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 }
 
 func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
-	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
-	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
-
 	// Execute
 	err := f.bd.CreateVolume(f.ctx, "test", "testkind")
+	c.Assert(err, check.IsNil)
 
 	// Validate
+	vols, err := f.bd.Volumes(f.ctx, "testkind")
 	c.Assert(err, check.IsNil)
+	c.Check(vols, check.HasLen, 1)
+
+	expected := workshop.VolumeInfo{
+		Name:   "test",
+		Config: map[string]string{workshop.ConfigVolumeKind: "testkind"},
+	}
+	c.Check(vols[0], check.DeepEquals, expected)
 
 	// Execute
 	err = f.bd.DeleteVolume(f.ctx, "test")
+	c.Assert(err, check.IsNil)
 
 	// Validate
+	vols, err = f.bd.Volumes(f.ctx, "testkind")
 	c.Assert(err, check.IsNil)
+	c.Check(vols, check.HasLen, 0)
 }
 
 var testsdk = `name: test-sdk

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -202,6 +202,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 		Name:     "test-1",
 		Kind:     "sdk",
 		Sdk:      "test",
+		Revision: sdk.R(1),
 		Metadata: testsdk,
 	}
 	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
@@ -247,6 +248,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 		Name:     "test-1",
 		Kind:     "sdk",
 		Sdk:      "test",
+		Revision: sdk.R(1),
 		Metadata: testsdk,
 	}
 	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
@@ -483,6 +485,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 		Name:     sdk.VolumeName(setup.Name, setup.Revision),
 		Kind:     "sdk",
 		Sdk:      setup.Name,
+		Revision: setup.Revision,
 		Metadata: string(meta),
 	}
 	err = f.bd.ImportVolume(f.ctx, volume, setup.Filepath())

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -20,8 +20,6 @@ var (
 	ConfigProjectId         = "user.workshop.project-id"
 	ConfigWorkshopFile      = "user.workshop.file"
 	ConfigWorkshopSdks      = "user.workshop.sdks"
-	ConfigVolumeKind        = "user.kind"
-	ConfigVolumeMeta        = "user.sdk.meta"
 	ConfigProjectPathDevice = "workshop.project"
 )
 
@@ -101,11 +99,10 @@ func (w *Workshop) metaFromVolume(ctx context.Context, setup sdk.Setup) (string,
 		return "", err
 	}
 
-	meta, ok := vinfo.Config[ConfigVolumeMeta]
-	if !ok {
+	if vinfo.Metadata == "" {
 		return "", fmt.Errorf("cannot find %q SDK metadata", setup.Name)
 	}
-	return meta, nil
+	return vinfo.Metadata, nil
 }
 
 func (w *Workshop) metaFromFile(ctx context.Context, setup sdk.Setup) (string, error) {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -20,6 +20,7 @@ var (
 	ConfigProjectId         = "user.workshop.project-id"
 	ConfigWorkshopFile      = "user.workshop.file"
 	ConfigWorkshopSdks      = "user.workshop.sdks"
+	ConfigVolumeKind        = "user.kind"
 	ConfigVolumeMeta        = "user.sdk.meta"
 	ConfigProjectPathDevice = "workshop.project"
 )

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -135,10 +135,10 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 
 	var err error
 	var meta string
-	if setup.Revision.Local() {
-		meta, err = w.metaFromFile(ctx, setup)
-	} else {
+	if setup.IsVolume() {
 		meta, err = w.metaFromVolume(ctx, setup)
+	} else {
+		meta, err = w.metaFromFile(ctx, setup)
 	}
 
 	if err != nil {

--- a/internal/workshop/workshop_dirs.go
+++ b/internal/workshop/workshop_dirs.go
@@ -59,6 +59,10 @@ func SketchSdkStash(userDataDir, pid, w string) string {
 	return filepath.Join(SketchSdkDir(userDataDir, pid, w), "stash")
 }
 
+func TrySdkDir(userDataDir, sdk string) string {
+	return filepath.Join(userDataDir, "try", sdk)
+}
+
 func ProjectCacheDir(pid string) string {
 	return filepath.Join(dirs.CacheDir, "id", pid)
 }
@@ -73,6 +77,8 @@ func AptCacheDir(pid, w string) string {
 
 func SdkSourcePath(userDataDir string, project Project, w, sk string, source sdk.Source) string {
 	switch source {
+	case sdk.TrySource:
+		return TrySdkDir(userDataDir, sk)
 	case sdk.ProjectSource:
 		return ProjectSdkPath(project.Path, sk)
 	case sdk.SketchSource:

--- a/internal/workshop/workshop_dirs.go
+++ b/internal/workshop/workshop_dirs.go
@@ -70,3 +70,14 @@ func CacheDir(pid, w string) string {
 func AptCacheDir(pid, w string) string {
 	return filepath.Join(CacheDir(pid, w), "apt")
 }
+
+func SdkSourcePath(userDataDir string, project Project, w, sk string, source sdk.Source) string {
+	switch source {
+	case sdk.ProjectSource:
+		return ProjectSdkPath(project.Path, sk)
+	case sdk.SketchSource:
+		return SketchSdkCurrent(userDataDir, project.ProjectId, w)
+	default:
+		return ""
+	}
+}

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -132,7 +132,10 @@ type SdkRecord struct {
 }
 
 func (s SdkRecord) MarshalYAML() (interface{}, error) {
-	if s.Source == sdk.ProjectSource {
+	switch s.Source {
+	case sdk.TrySource:
+		s.Name = fmt.Sprintf("try-%s", s.Name)
+	case sdk.ProjectSource:
 		s.Name = fmt.Sprintf("project-%s", s.Name)
 	}
 	s.Source = 0
@@ -144,20 +147,30 @@ func (s SdkRecord) MarshalYAML() (interface{}, error) {
 func (s *SdkRecord) UnmarshalYAML(value *yaml.Node) error {
 	type record SdkRecord
 	err := value.Decode((*record)(s))
+	s.Name, s.Source = parseSdkName(s.Name)
+	return err
+}
 
-	name, found := strings.CutPrefix(s.Name, "project-")
-	if found {
-		s.Name = name
-		s.Source = sdk.ProjectSource
-	} else if sdk.IsSystem(s.Name) {
-		s.Source = sdk.SystemSource
-	} else if sdk.IsSketch(s.Name) {
-		s.Source = sdk.SketchSource
-	} else {
-		s.Source = sdk.StoreSource
+func parseSdkName(name string) (string, sdk.Source) {
+	if sdk.IsSystem(name) {
+		return name, sdk.SystemSource
 	}
 
-	return err
+	if sdk.IsSketch(name) {
+		return name, sdk.SketchSource
+	}
+
+	suffix, found := strings.CutPrefix(name, "try-")
+	if found {
+		return suffix, sdk.TrySource
+	}
+
+	suffix, found = strings.CutPrefix(name, "project-")
+	if found {
+		return suffix, sdk.ProjectSource
+	}
+
+	return name, sdk.StoreSource
 }
 
 type Connection struct {

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -39,21 +39,6 @@ func ProjectSdkPath(project, name string) string {
 	return filepath.Join(project, Directory, name)
 }
 
-func ExpandSdkSource(source, project string) string {
-	return os.Expand(source, func(s string) string {
-		switch s {
-		case "PROJECT":
-			return project
-		case "$":
-			// Unescape $$ -> $.
-			return "$"
-		default:
-			// Should never be reached because Workshop controls the source.
-			return ""
-		}
-	})
-}
-
 type PlugOrBind struct {
 	Bind *PlugRef
 	Plug interface{}
@@ -141,16 +126,16 @@ func (b PlugRef) MarshalYAML() (interface{}, error) {
 type SdkRecord struct {
 	Name    string                 `yaml:"name"`
 	Channel string                 `yaml:"channel,omitempty"`
-	Source  string                 `yaml:"source,omitempty"`
+	Source  sdk.Source             `yaml:"source,omitempty"`
 	Plugs   map[string]PlugOrBind  `yaml:"plugs,omitempty"`
 	Slots   map[string]interface{} `yaml:"slots,omitempty"`
 }
 
 func (s SdkRecord) MarshalYAML() (interface{}, error) {
-	if s.Source != "" {
-		s.Name = fmt.Sprintf("%s-%s", s.Source, s.Name)
-		s.Source = ""
+	if s.Source == sdk.ProjectSource {
+		s.Name = fmt.Sprintf("project-%s", s.Name)
 	}
+	s.Source = 0
 
 	type record SdkRecord
 	return (*record)(&s), nil
@@ -163,9 +148,13 @@ func (s *SdkRecord) UnmarshalYAML(value *yaml.Node) error {
 	name, found := strings.CutPrefix(s.Name, "project-")
 	if found {
 		s.Name = name
-		s.Source = "project"
+		s.Source = sdk.ProjectSource
+	} else if sdk.IsSystem(s.Name) {
+		s.Source = sdk.SystemSource
+	} else if sdk.IsSketch(s.Name) {
+		s.Source = sdk.SketchSource
 	} else {
-		s.Source = ""
+		s.Source = sdk.StoreSource
 	}
 
 	return err

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -87,7 +87,7 @@ scripts:
 	c.Assert(file.Sdks[1], check.DeepEquals, workshop.SdkRecord{Name: "cuda", Channel: "latest/edge"})
 	c.Assert(file.Sdks[2], check.DeepEquals, workshop.SdkRecord{Name: "zookeeper", Channel: "latest/candidate"})
 	c.Assert(file.Sdks[3], check.DeepEquals, workshop.SdkRecord{Name: "automotive", Channel: "latest/beta"})
-	c.Assert(file.Sdks[4], check.DeepEquals, workshop.SdkRecord{Name: "linter", Source: "project"})
+	c.Assert(file.Sdks[4], check.DeepEquals, workshop.SdkRecord{Name: "linter", Source: sdk.ProjectSource})
 	lines := len(strings.Split(yaml, "\n"))
 	skip := strings.Repeat("\n", lines-5)
 	c.Assert(string(file.Scripts["oneline"]), check.Equals, skip+"echo one line\n")
@@ -101,7 +101,7 @@ func (f *workshopFile) TestWorkshopFileSave(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: []workshop.SdkRecord{
 			{Name: "one", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"plug": {Bind: &workshop.PlugRef{Sdk: "two", Name: "plug"}}}},
-			{Name: "two", Source: "project", Plugs: map[string]workshop.PlugOrBind{"plug": {Bind: &workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
+			{Name: "two", Source: sdk.ProjectSource, Plugs: map[string]workshop.PlugOrBind{"plug": {Bind: &workshop.PlugRef{Sdk: "one", Name: "plug"}}}},
 		},
 		Scripts: map[string]workshop.Script{
 			"oneline":   "\n\n\necho one line\n",
@@ -549,7 +549,7 @@ sdks:
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, check.DeepEquals, []workshop.SdkRecord{
-		{Name: sdk.System.String(), Slots: map[string]interface{}{"training-data": map[string]interface{}{"workshop-source": "relative/path"}}}})
+		{Name: sdk.System.String(), Source: sdk.SystemSource, Slots: map[string]interface{}{"training-data": map[string]interface{}{"workshop-source": "relative/path"}}}})
 }
 
 func (f *workshopFile) TestWorkshopConnectionsOK(c *check.C) {

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -63,6 +63,7 @@ func (f *workshopFile) TestWorkshopFileParse(c *check.C) {
 	yaml := `name: xbert-gpu
 base: ubuntu@20.04
 sdks:
+  - name: system
   - name: huggingface
     channel: latest/stable
   - name: cuda
@@ -71,7 +72,9 @@ sdks:
     channel: latest/candidate
   - name: automotive
     channel: latest/beta
+  - name: try-rocm
   - name: project-linter
+  - name: sketch
 scripts:
   oneline: echo one line
   multiline: |
@@ -83,11 +86,14 @@ scripts:
 	c.Assert(err, check.Equals, nil)
 	c.Assert(file.Name, check.Equals, "xbert-gpu")
 	c.Assert(file.Base, check.Equals, "ubuntu@20.04")
-	c.Assert(file.Sdks[0], check.DeepEquals, workshop.SdkRecord{Name: "huggingface", Channel: "latest/stable"})
-	c.Assert(file.Sdks[1], check.DeepEquals, workshop.SdkRecord{Name: "cuda", Channel: "latest/edge"})
-	c.Assert(file.Sdks[2], check.DeepEquals, workshop.SdkRecord{Name: "zookeeper", Channel: "latest/candidate"})
-	c.Assert(file.Sdks[3], check.DeepEquals, workshop.SdkRecord{Name: "automotive", Channel: "latest/beta"})
-	c.Assert(file.Sdks[4], check.DeepEquals, workshop.SdkRecord{Name: "linter", Source: sdk.ProjectSource})
+	c.Assert(file.Sdks[0], check.DeepEquals, workshop.SdkRecord{Name: "system", Source: sdk.SystemSource})
+	c.Assert(file.Sdks[1], check.DeepEquals, workshop.SdkRecord{Name: "huggingface", Channel: "latest/stable"})
+	c.Assert(file.Sdks[2], check.DeepEquals, workshop.SdkRecord{Name: "cuda", Channel: "latest/edge"})
+	c.Assert(file.Sdks[3], check.DeepEquals, workshop.SdkRecord{Name: "zookeeper", Channel: "latest/candidate"})
+	c.Assert(file.Sdks[4], check.DeepEquals, workshop.SdkRecord{Name: "automotive", Channel: "latest/beta"})
+	c.Assert(file.Sdks[5], check.DeepEquals, workshop.SdkRecord{Name: "rocm", Source: sdk.TrySource})
+	c.Assert(file.Sdks[6], check.DeepEquals, workshop.SdkRecord{Name: "linter", Source: sdk.ProjectSource})
+	c.Assert(file.Sdks[7], check.DeepEquals, workshop.SdkRecord{Name: "sketch", Source: sdk.SketchSource})
 	lines := len(strings.Split(yaml, "\n"))
 	skip := strings.Repeat("\n", lines-5)
 	c.Assert(string(file.Scripts["oneline"]), check.Equals, skip+"echo one line\n")
@@ -272,6 +278,16 @@ sdks:
 	f.createWFile(c, "xbert-gpu", yaml)
 	file, err = f.project.Workshop("xbert-gpu")
 	c.Assert(err, check.ErrorMatches, `"project-foo" is a reserved SDK name`)
+	c.Assert(file, check.IsNil)
+
+	yaml = `name: xbert-gpu
+base: ubuntu@20.04
+sdks:
+  - name: project-try-foo
+`
+	f.createWFile(c, "xbert-gpu", yaml)
+	file, err = f.project.Workshop("xbert-gpu")
+	c.Assert(err, check.ErrorMatches, `"try-foo" is a reserved SDK name`)
 	c.Assert(file, check.IsNil)
 }
 

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -48,15 +48,15 @@ func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
 	w.Sdks = map[string]sdk.Setup{
 		"test-sdk-1": {Name: "test-sdk-1", Revision: sdk.R(1), Channel: "latest/stable"},
 		"test-sdk-2": {Name: "test-sdk-2", Revision: sdk.R(1), Channel: "latest/edge"},
-		"system":     {Name: "system", Revision: sdk.R(1)},
-		"sketch":     {Name: "sketch", Revision: sdk.R(-3)},
+		"system":     {Name: "system", Source: sdk.SystemSource, Revision: sdk.R(1)},
+		"sketch":     {Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-3)},
 	}
 
 	sdks := w.SdksByInstallOrder()
 	c.Assert(sdks, check.DeepEquals, []sdk.Setup{
-		{Name: "system", Revision: sdk.R(1)},
+		{Name: "system", Source: sdk.SystemSource, Revision: sdk.R(1)},
 		{Name: "test-sdk-1", Revision: sdk.R(1), Channel: "latest/stable"},
 		{Name: "test-sdk-2", Revision: sdk.R(1), Channel: "latest/edge"},
-		{Name: "sketch", Revision: sdk.R(-3)},
+		{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-3)},
 	})
 }

--- a/tests/lib/sdk/test-sdk-basic/latest/edge/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-basic/latest/edge/meta/sdk.yaml
@@ -1,0 +1,10 @@
+name: test-sdk-basic
+title: test-sdk-basic
+base: ubuntu@22.04
+version: "2.0"
+
+summary: test-sdk-basic SDK
+description: |
+  test-sdk-basic SDK
+
+sdkcraft-started-at: "2025-07-03T02:01:00.123456Z"

--- a/tests/lib/sdk/test-sdk-basic/latest/edge/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-basic/latest/edge/sdk/hooks/setup-base
@@ -1,0 +1,1 @@
+echo "setup-base v2 ran successfully!"

--- a/tests/main/project-sdks/task.yaml
+++ b/tests/main/project-sdks/task.yaml
@@ -1,4 +1,4 @@
-summary: Check workshop sketch-sdk
+summary: Check in-project SDKs
 restore: |
   . "$TESTSLIB"/utils.sh
   workshop_exec remove || true

--- a/tests/main/try-sdks/.workshop/dev.yaml
+++ b/tests/main/try-sdks/.workshop/dev.yaml
@@ -1,0 +1,4 @@
+name: dev
+base: ubuntu@22.04
+sdks:
+  - name: try-test-sdk-basic

--- a/tests/main/try-sdks/.workshop/test-sdk-basic/hooks/setup-base
+++ b/tests/main/try-sdks/.workshop/test-sdk-basic/hooks/setup-base
@@ -1,0 +1,1 @@
+touch /in-project-marker

--- a/tests/main/try-sdks/.workshop/test-sdk-basic/sdk.yaml
+++ b/tests/main/try-sdks/.workshop/test-sdk-basic/sdk.yaml
@@ -1,0 +1,1 @@
+name: test-sdk-basic

--- a/tests/main/try-sdks/task.yaml
+++ b/tests/main/try-sdks/task.yaml
@@ -1,0 +1,44 @@
+summary: Check support for trying out packed SDKs
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove || true
+  lxc storage volume delete workshop custom/test-sdk-basic-x1 || true
+  lxc storage volume delete workshop custom/test-sdk-basic-x2 || true
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Launch workshop with SDKs from try area"
+  store_area="$SDK_STORE_BUCKET_DIR/test-sdk-basic"
+  try_area='/home/ubuntu/.local/share/workshop/try/test-sdk-basic'
+  sudo -u ubuntu mkdir -p "$try_area"
+  sudo -u ubuntu cp "$store_area/latest/stable/test-sdk-basic.sdk" "$try_area/test-sdk-basic_all.sdk"
+  echo fakehash | sudo -u ubuntu tee "$try_area/test-sdk-basic_all.sdk.sha3-384"
+  sudo -u ubuntu cp "$store_area/latest/stable/sdk.yaml" "$try_area/test-sdk-basic_all.sdk.yaml"
+
+  workshop_exec launch
+  workshop_exec exec -- findmnt /var/lib/workshop/sdk/test-sdk-basic | MATCH 'workshop/custom/default_test-sdk-basic-x1'
+  try_area_contracted="~${try_area#*ubuntu}"
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].tracking' | MATCH "^${try_area_contracted}\$"
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
+
+  echo "Check try and in-project SDKs can share revision numbers"
+  sed 's/try-test-sdk-basic/project-test-sdk-basic/' -i .workshop/dev.yaml
+  workshop_exec exec -- test ! -f /in-project-marker
+  workshop_exec refresh
+  workshop_exec exec -- test -f /in-project-marker
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
+
+  echo "Check existing try revisions are reused"
+  sed 's/project-test-sdk-basic/try-test-sdk-basic/' -i .workshop/dev.yaml
+  workshop_exec refresh
+  workshop_exec exec -- test ! -f /in-project-marker
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
+
+  echo "Check SDKs in try area can be updated"
+  sudo -u ubuntu cp "$store_area/latest/edge/test-sdk-basic.sdk" "$try_area/test-sdk-basic_all.sdk"
+  echo fakehash2 | sudo -u ubuntu tee "$try_area/test-sdk-basic_all.sdk.sha3-384"
+  sudo -u ubuntu cp "$store_area/latest/edge/sdk.yaml" "$try_area/test-sdk-basic_all.sdk.yaml"
+
+  workshop_exec refresh
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x2\)$'
+  workshop_exec exec -- cat /var/lib/workshop/sdk/test-sdk-basic/sdk/hooks/setup-base | MATCH 'setup-base v2'


### PR DESCRIPTION
# Description

Support `sdkcraft try`. After running `sdkcraft try` in an SDKcraft project, the local user can use the SDK(s) it built by adding `- name: try-<SDK>` to a workshop definition.

Currently the SDK volume is imported synchronously (i.e. not part of the `launch` or `refresh` change). This is something we'll look to rework once we know more about the Store API (and maybe have nicer output for dynamic `workshop tasks`).

Another outstanding issue is cleaning up SDK volumes (and SDKs copied to the try area) when no longer in use.

Breaking changes:
- The list of installed SDKs in the workshop's metadata now tracks where the SDK came from. Existing workshops may need to be removed before switching to this branch.
- SDK volumes now include additional metadata. I don't think any of this is currently used outside of `try`, but it might be worth removing old volumes.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
