### PR TITLE
Complete script names if no workshop names match partial argument

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -357,15 +357,31 @@ func (c *CmdRun) complete(cmd *cobra.Command, args []string, toComplete string) 
 	}
 
 	if scriptIdx > len(args) {
-		// Just complete workshop names, even though script names are valid
-		// if there's a single workshop.
-		return c.root.doCompleteWorkshopNames(args, []string{"Ready", "Waiting"})
+		names, directive := c.root.doCompleteWorkshopNames(args, []string{"Ready", "Waiting"})
+
+		// Try script names if no workshop names match partial argument.
+		partialMatch := func(name string) bool {
+			return strings.HasPrefix(name, toComplete)
+		}
+		if directive != cobra.ShellCompDirectiveError && !slices.ContainsFunc(names, partialMatch) {
+			names, directive := completeScripts(c.root, args)
+			if directive != cobra.ShellCompDirectiveError {
+				return names, directive
+			}
+
+		}
+
+		return names, directive
 	}
 	if scriptIdx < len(args) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	scriptsCmd := CmdScripts{root: c.root}
+	return completeScripts(c.root, args)
+}
+
+func completeScripts(root *CmdRoot, args []string) ([]string, cobra.ShellCompDirective) {
+	scriptsCmd := CmdScripts{root: root}
 	scripts, err := scriptsCmd.scripts(args)
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -98,17 +98,17 @@ func (m *workshopExec) TestWorkshopRunCompletion(c *check.C) {
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 3, 5, 7, 10:
+		case 1, 3, 5, 7, 10, 12, 14:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
 			fmt.Fprintln(w, r)
-		case 2, 8:
+		case 2, 8, 13, 15:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
 			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
-		case 4, 9, 11:
+		case 4, 9, 11, 16:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws/scripts", m.prjId))
 			w.WriteHeader(200)
@@ -119,7 +119,7 @@ func (m *workshopExec) TestWorkshopRunCompletion(c *check.C) {
 			w.WriteHeader(404)
 			fmt.Fprintln(w, mockWorkshopScriptsError)
 		default:
-			c.Errorf("expected 11 calls, now on %d", n)
+			c.Errorf("expected 16 calls, now on %d", n)
 		}
 	})
 
@@ -171,5 +171,10 @@ func (m *workshopExec) TestWorkshopRunCompletion(c *check.C) {
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(result, check.HasLen, 0)
 
-	c.Check(n, check.Equals, 11)
+	os.Args = []string{"workshop", "__complete", "run", "f"}
+	result, compDirective = run.ValidArgsFunction(run, nil, "f")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+
+	c.Check(n, check.Equals, 16)
 }


### PR DESCRIPTION
# Description

I always type `workshop run te<TAB>` and get no suggestions. This makes it complete to `workshop run test` (if there's a `test` script) but preserves the behaviour of `workshop run <TAB>` only completing workshop names.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
