### PR TITLE
Remove unused SDK volumes

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -73,4 +73,3 @@ jobs:
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           project: workshop
           installTics: true
-          branchname: ${{ github.ref_name }}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -483,6 +483,9 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	if err != nil {
+		if change != nil {
+			change.SetStatus(state.ErrorStatus)
+		}
 		return statusBadRequest("%w", err)
 	}
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
+	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
@@ -2083,6 +2084,20 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk"}, []string{manysdks_minusone})
+
+	// Ensure that the removed SDK volume is removed as unused.
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	for i := 0; i < 6; i = i + 1 {
+		s.d.overlord.StateEngine().Ensure()
+		s.d.overlord.StateEngine().Wait()
+	}
+
+	_, err := s.b.Volume(s.ctx, "test-sdk-1-1")
+	c.Check(err, testutil.ErrorIs, workshop.ErrVolumeNotFound)
+
+	_, err = s.b.Volume(s.ctx, "test-sdk-2-1")
+	c.Check(err, check.IsNil)
 }
 
 func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
@@ -4063,6 +4078,7 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
 	defer s.store.SetDownloadCallback(storeDownload)()
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
@@ -4083,10 +4099,5 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 			Summary: `Remove "workshopconns" workshop`,
 		},
 	}
-
 	s.runActionTest(c, requests, expected)
-
-	_, err := s.b.Workshop(s.ctx, "workshopconns")
-	c.Check(err, testutil.ErrorIs, workshop.ErrWorkshopNotLaunched)
-	c.Check(s.secBackend.RemoveCalls, check.HasLen, 3)
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1167,6 +1167,8 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 
 	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
 	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
+
+	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1"})
 }
 
 func (s *apiSuite) TestLaunchWorkshopNoTrySdk(c *check.C) {
@@ -1434,6 +1436,8 @@ func (s *apiSuite) TestLaunchWorkshopWithPlugOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(conns, check.HasLen, 1)
 	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplug/test-sdk:training-plug %s/workshopplug/system:mount`, s.project.ProjectId, s.project.ProjectId))
+
+	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1"})
 }
 
 func (s *apiSuite) TestLaunchWorkshopPlugAddedAndBound(c *check.C) {
@@ -1681,6 +1685,29 @@ func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
 	}
 }
 
+// ensureSdkVolumesAfterCooldown ensures that the SDK volumes are removed if unused by
+// setting the cooldown time to 0 and running the state engine multiple times to
+// trigger the garbage collection.
+func (s *apiSuite) ensureSdkVolumesAfterCooldown(c *check.C, want []string) {
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.d.overlord.StateEngine().Ensure(), check.IsNil)
+		s.d.overlord.StateEngine().Wait()
+	}
+
+	vols, err := s.b.Volumes(s.ctx, "sdk")
+	c.Assert(err, check.IsNil)
+	c.Assert(vols, check.HasLen, len(want))
+
+	for _, wv := range want {
+		v := slices.IndexFunc(vols, func(v workshop.VolumeInfo) bool {
+			return v.Name == wv
+		})
+		c.Assert(v, check.Not(check.Equals), -1)
+	}
+}
+
 func (s *apiSuite) checkSnapshotCalls(c *check.C, name string, sdks []string) {
 	wpCalls := []fakebackend.SnapshotCall{}
 	for _, sc := range s.b.SnapshotCalls {
@@ -1763,6 +1790,8 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		},
 	}
 	s.runActionTest(c, requests, expected)
+
+	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1", "mount-conflict-1"})
 
 	s.createWFile(c, "manysdks", manysdks_allremoved)
 	requests = []*bytes.Buffer{
@@ -1853,6 +1882,8 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic})
 	s.checkRestoreCalls(c, "somebound", []string{}, []string{})
 	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_allremoved})
+
+	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "mount-conflict-1"})
 }
 
 func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
@@ -2013,6 +2044,8 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_extended})
+
+	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1", "test-sdk-3-1"})
 }
 
 func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
@@ -2085,19 +2118,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 
 	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk"}, []string{manysdks_minusone})
 
-	// Ensure that the removed SDK volume is removed as unused.
-	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
-
-	for i := 0; i < 6; i = i + 1 {
-		s.d.overlord.StateEngine().Ensure()
-		s.d.overlord.StateEngine().Wait()
-	}
-
-	_, err := s.b.Volume(s.ctx, "test-sdk-1-1")
-	c.Check(err, testutil.ErrorIs, workshop.ErrVolumeNotFound)
-
-	_, err = s.b.Volume(s.ctx, "test-sdk-2-1")
-	c.Check(err, check.IsNil)
+	s.ensureSdkVolumesAfterCooldown(c, []string{"test-sdk-1", "system-1"})
 }
 
 func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
@@ -2265,6 +2286,12 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks})
+
+	s.ensureSdkVolumesAfterCooldown(c, []string{
+		"system-1",
+		"test-sdk-2",
+		"test-sdk-2-1",
+	})
 }
 
 func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
@@ -2991,6 +3018,8 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 	})
 
 	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks})
+
+	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1"})
 }
 
 func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
@@ -4078,7 +4107,6 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
 	defer s.store.SetDownloadCallback(storeDownload)()
-	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
@@ -4100,4 +4128,35 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 		},
 	}
 	s.runActionTest(c, requests, expected)
+	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1"})
+}
+
+func (s *apiSuite) TestRemoveWorkshopNotFound(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	// Setup
+	s.createWFile(c, "workshopconns", workshopconns)
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["workshopconns"],"action":"remove"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot remove "workshopconns": workshop not launched`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.d.state.Lock()
+	defer s.d.state.Unlock()
+	changes := s.d.state.Changes()
+	removeChange := changes[len(changes)-1]
+	c.Check(removeChange.Kind(), check.Equals, "remove")
+	c.Assert(removeChange.IsReady(), check.Equals, true)
 }

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -143,7 +143,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name: workshop.WorkshopStateVolumeName("ws", s.project.ProjectId),
 		Kind: "state-storage",
 	}
@@ -195,7 +195,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name: workshop.WorkshopStateVolumeName("ws", s.project.ProjectId),
 		Kind: "state-storage",
 	}
@@ -206,7 +206,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	}()
 	// Setup state storage (must be already set by the save-state in a real use
 	// case).
-	vfs := s.backend.WorkshopVolumeContents[volume.Name]
+	vfs := s.backend.SdkVolumeContents[volume.Name]
 	c.Check(err, check.IsNil)
 	err = os.MkdirAll(filepath.Join(vfs, "sdk", "one"), 0755)
 	c.Check(err, check.IsNil)
@@ -238,7 +238,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 
 	s.launchWorkshop(c, "one")
 
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name: workshop.WorkshopStateVolumeName("ws", s.project.ProjectId),
 		Kind: "state-storage",
 	}

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -94,7 +94,7 @@ func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sd
 	s.state.Lock()
 	be := s.o.WorkshopBackend()
 	s.state.Unlock()
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name:     sdk.VolumeName(name, rev),
 		Kind:     "sdk",
 		Sdk:      name,

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"gopkg.in/tomb.v2"
@@ -89,7 +90,7 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name:     sdk.VolumeName(rec.Name, rec.Revision),
 		Kind:     "sdk",
 		Sdk:      rec.Name,
@@ -267,26 +268,30 @@ func (m *SdkManager) doUnregisterSdk(task *state.Task, tomb *tomb.Tomb) error {
 
 type SdkVolumeCooldownTimeKey string
 
-func sameVolume(task *state.Task, other *state.Task) bool {
-	var sdkSetup sdk.Setup
-	if err := task.Get("sdk-setup", &sdkSetup); err != nil {
-		return false
-	}
-
-	var otherSdkSetup sdk.Setup
-	if err := other.Get("sdk-setup", &otherSdkSetup); err != nil {
-		return false
-	}
-
-	if !sdkSetup.IsVolume() || !otherSdkSetup.IsVolume() {
-		return false
-	}
-
-	return sdkSetup.Name == otherSdkSetup.Name && sdkSetup.Revision == otherSdkSetup.Revision
-}
-
+// doDeleteUnusedSdkVolumes is a cleanup handler that deletes unused SDK volumes.
+// It is called periodically to ensure that SDK volumes that are no longer
+// needed are removed from the system. The cleanup is done only if there are no
+// tasks in progress that use the same SDK volume. The cleanup is also
+// throttled to avoid deleting volumes too frequently. The cooldown time is
+// defined by the sdkVolumeCooldownTime constant.
+//
+// There are multiple scenarios when this cleanup is triggered:
+//   - A workshop was removed and an SDK volume was detached from it (unregister-sdk task)
+//   - An SDK volume was detached during a refresh change,
+//     and is no longer used by any other workshop (unregister-sdk or, if refresh failed, install-sdk task)
+//   - A workshop launch failed (install-sdk task)
 func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb) error {
 	st := task.State()
+
+	sdkSetup, err := SdkSetup(task)
+	if err != nil {
+		logger.Debugf("On SdkManager.Cleanup: the %q task is not associated with a SDK setup", task.ID())
+		return nil
+	}
+
+	if !sdkSetup.IsVolume() || sdkSetup.Source == sdk.SystemSource {
+		return nil
+	}
 
 	user, prj, _, err := UserProjectWorkshop(task)
 	if err != nil {
@@ -306,22 +311,14 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		return nil
 	}
 
-	var sdkSetup sdk.Setup
-	if err := task.Get("sdk-setup", &sdkSetup); err != nil {
-		logger.Debugf("On SdkManager.Cleanup: the %q task is not associated with a SDK setup", task.ID())
-		return nil
-	}
-
-	if !sdkSetup.IsVolume() || sdk.IsSystem(sdkSetup.Name) {
-		return nil
-	}
-
 	vk := SdkVolumeCooldownTimeKey(sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
 	cooldownStart, ok := st.Cached(vk).(time.Time)
 	if !ok {
 		// No cooldown start time cached means that clean up has just started or
 		// workshopd was restarted.
 		st.Cache(vk, task.ReadyTime())
+		// We need to return here to give other competing cleanup tasks a chance
+		// to find out who was the last one to initiate the cleanup.
 		return &state.Retry{}
 	} else {
 		// Imagine the situation when a change with multiple tasks that use this
@@ -330,52 +327,18 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		// can run concurrently. We need to ensure that only one of them will
 		// continue to track the volume cooldown time.
 		readyTime := task.ReadyTime()
-		if !readyTime.Equal(cooldownStart) {
-			if readyTime.Before(cooldownStart) {
-				// Another more recent task initiated cleanup for this SDK
-				// volume.
-				return nil
-			} else {
-				// Update the cooldown start time to the current task ready time.
-				st.Cache(vk, readyTime)
-				return &state.Retry{}
-			}
+		if readyTime.Before(cooldownStart) {
+			// Another more recent task initiated cleanup for this SDK
+			// volume, no need to continue.
+			return nil
 		}
-	}
-
-	// Check if there are any tasks in progress that use the same SDK volume.
-	// Remember, cleanup tasks are attempted on every Ensure call, which can be
-	// either periodic or triggered by a new API request. If it's the latter,
-	// there could be a chance that the volume will be used again.
-	changes := st.Changes()
-	for _, change := range changes {
-		// Other changes like "exec" do not affect SDK volumes, so we can skip them.
-		if !change.IsReady() {
-			if change.Kind() == "launch" {
-				for _, t := range change.Tasks() {
-					if t.Kind() == "install-sdk" {
-						if sameVolume(task, t) {
-							// Launch may end up using the same SDK volume if successful,
-							// so skip the cleanup for now.
-							return &state.Retry{}
-						}
-					}
-				}
-			}
-			if change.Kind() == "refresh" || change.Kind() == "remove" {
-				for _, t := range change.Tasks() {
-					if t.Kind() == "unregister-sdk" {
-						if sameVolume(task, t) {
-							// Another task in the same change is using the same SDK volume.
-							// We can skip the cleanup for now.
-							logger.Debugf("On SdkManager.Cleanup: another task %q in the %q change is using the %q SDK volume, skip clean up",
-								t.ID(), change.ID(), sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
-							st.Cache(vk, nil)
-							return nil
-						}
-					}
-				}
-			}
+		if readyTime.After(cooldownStart) {
+			// Update the cooldown start time to the current task ready time.
+			st.Cache(vk, readyTime)
+			// We need to return here to give other competing cleanup tasks
+			// a chance to find out who was the last one to initiate the
+			// cleanup.
+			return &state.Retry{}
 		}
 	}
 
@@ -383,11 +346,26 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		return &state.Retry{}
 	}
 
+	// Check if there are any tasks in progress that use the same SDK volume.
+	// Remember, cleanup tasks are attempted on every Ensure call, which can be
+	// either periodic or triggered by a new API request. If it's the latter,
+	// there could be a chance that the volume will be used again.
+	changes := st.Changes()
+	blocking := []string{"launch", "refresh", "remove"}
+	for _, change := range changes {
+		// Other changes like "exec" do not affect SDK volumes, so we can skip them.
+		if slices.Contains(blocking, change.Kind()) && !change.IsReady() {
+			return &state.Retry{}
+		}
+	}
+
 	// Delete volume ignores ErrVolumeNotFound.
 	err = m.backend.DeleteVolume(ctx, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
 	if err == nil || errors.Is(err, workshop.ErrVolumeInUse) {
 		if errors.Is(err, workshop.ErrVolumeInUse) {
 			logger.Debugf("On SdkManager.Cleanup: the %q volume is still in use, skip clean up", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+		} else {
+			logger.Debugf("On SdkManager.Cleanup: the %q volume was deleted", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
 		}
 		st.Cache(vk, nil)
 		return nil

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"gopkg.in/tomb.v2"
 
@@ -264,12 +265,34 @@ func (m *SdkManager) doUnregisterSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return m.repo.RemoveSdk(project.ProjectId, w, setup.Name)
 }
 
+type SdkVolumeCooldownTimeKey string
+
+func sameVolume(task *state.Task, other *state.Task) bool {
+	var sdkSetup sdk.Setup
+	if err := task.Get("sdk-setup", &sdkSetup); err != nil {
+		return false
+	}
+
+	var otherSdkSetup sdk.Setup
+	if err := other.Get("sdk-setup", &otherSdkSetup); err != nil {
+		return false
+	}
+
+	if !sdkSetup.IsVolume() || !otherSdkSetup.IsVolume() {
+		return false
+	}
+
+	return sdkSetup.Name == otherSdkSetup.Name && sdkSetup.Revision == otherSdkSetup.Revision
+}
+
 func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb) error {
 	st := task.State()
 
 	user, prj, _, err := UserProjectWorkshop(task)
 	if err != nil {
-		return err
+		// Log as an internal error, no need to retry again.
+		logger.Debugf("On SdkManager.Cleanup: internal error: %v", err)
+		return nil
 	}
 
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
@@ -288,20 +311,79 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		return nil
 	}
 
-	// No changes must be in progress, otherwise we cannot safely remove unused SDK volumes.
-	changes := st.Changes()
-	for _, change := range changes {
-		if change.Kind() != "launch" && change.Kind() != "refresh" {
-			continue
-		}
-		if !change.IsReady() {
-			return &state.Retry{}
+	vk := SdkVolumeCooldownTimeKey(sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+	cooldownStart, ok := st.Cached(vk).(time.Time)
+	if !ok {
+		// No cooldown start time cached means that clean up has just started or
+		// workshopd was restarted.
+		st.Cache(vk, task.ReadyTime())
+		return &state.Retry{}
+	} else {
+		// Imagine the situation when a change with multiple tasks that use this
+		// volume is in progress. Every unregister-sdk task will initiate a
+		// cleanup after the change is ready. All cleanups are unarranged and
+		// can run concurrently. We need to ensure that only one of them will
+		// continue to track the volume cooldown time.
+		readyTime := task.ReadyTime()
+		if !readyTime.Equal(cooldownStart) {
+			if readyTime.Before(cooldownStart) {
+				// Another more recent task initiated cleanup for this SDK
+				// volume.
+				return nil
+			} else {
+				// Update the cooldown start time to the current task ready time.
+				st.Cache(vk, readyTime)
+				return &state.Retry{}
+			}
 		}
 	}
 
+	// Check if there are any tasks in progress that use the same SDK volume.
+	// Remember, cleanup tasks are attempted on every Ensure call, which can be
+	// either periodic or triggered by a new API request. If it's the latter,
+	// there could be a chance that the volume will be used again.
+	changes := st.Changes()
+	for _, change := range changes {
+		// Other changes like "exec" do not affect SDK volumes, so we can skip them.
+		if !change.IsReady() {
+			if change.Kind() == "launch" {
+				for _, t := range change.Tasks() {
+					if t.Kind() == "install-sdk" {
+						if sameVolume(task, t) {
+							// Launch may end up using the same SDK volume if successful,
+							// so skip the cleanup for now.
+							return &state.Retry{}
+						}
+					}
+				}
+			}
+			if change.Kind() == "refresh" || change.Kind() == "remove" {
+				for _, t := range change.Tasks() {
+					if t.Kind() == "unregister-sdk" {
+						if sameVolume(task, t) {
+							// Another task in the same change is using the same SDK volume.
+							// We can skip the cleanup for now.
+							logger.Debugf("On SdkManager.Cleanup: another task %q in the %q change is using the %q SDK volume, skip clean up",
+								t.ID(), change.ID(), sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+							return nil
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if time.Since(cooldownStart) < sdkVolumeCooldownTime {
+		return &state.Retry{}
+	}
+
+	// Delete volume ignores ErrVolumeNotFound.
 	err = m.backend.DeleteVolume(ctx, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
-	if errors.Is(err, workshop.ErrVolumeInUse) {
-		logger.Debugf("On SdkManager.Cleanup: the %q volume is still in use", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+	if err == nil || errors.Is(err, workshop.ErrVolumeInUse) {
+		if errors.Is(err, workshop.ErrVolumeInUse) {
+			logger.Debugf("On SdkManager.Cleanup: the %q volume is still in use, skip clean up", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+		}
+		st.Cache(vk, nil)
 		return nil
 	}
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -263,3 +263,47 @@ func (m *SdkManager) doUnregisterSdk(task *state.Task, tomb *tomb.Tomb) error {
 
 	return m.repo.RemoveSdk(project.ProjectId, w, setup.Name)
 }
+
+func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+
+	user, prj, _, err := UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
+	defer cancel()
+
+	st.Lock()
+	defer st.Unlock()
+
+	var sdkSetup sdk.Setup
+	if err := task.Get("sdk-setup", &sdkSetup); err != nil {
+		logger.Debugf("On SdkManager.Cleanup: the %q task is not associated with a SDK setup", task.ID())
+		return nil
+	}
+
+	if !sdkSetup.IsVolume() || sdk.IsSystem(sdkSetup.Name) {
+		return nil
+	}
+
+	// No changes must be in progress, otherwise we cannot safely remove unused SDK volumes.
+	changes := st.Changes()
+	for _, change := range changes {
+		if change.Kind() != "launch" && change.Kind() != "refresh" {
+			continue
+		}
+		if !change.IsReady() {
+			return &state.Retry{}
+		}
+	}
+
+	err = m.backend.DeleteVolume(ctx, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+	if errors.Is(err, workshop.ErrVolumeInUse) {
+		logger.Debugf("On SdkManager.Cleanup: the %q volume is still in use", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+		return nil
+	}
+
+	return err
+}

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -301,6 +301,11 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 	st.Lock()
 	defer st.Unlock()
 
+	if task.Kind() == "install-sdk" && task.Status() == state.DoneStatus {
+		// If the launch or refresh was successful, no need to clean up the SDK volume.
+		return nil
+	}
+
 	var sdkSetup sdk.Setup
 	if err := task.Get("sdk-setup", &sdkSetup); err != nil {
 		logger.Debugf("On SdkManager.Cleanup: the %q task is not associated with a SDK setup", task.ID())
@@ -365,6 +370,7 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 							// We can skip the cleanup for now.
 							logger.Debugf("On SdkManager.Cleanup: another task %q in the %q change is using the %q SDK volume, skip clean up",
 								t.ID(), change.ID(), sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+							st.Cache(vk, nil)
 							return nil
 						}
 					}

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -216,7 +216,7 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	c.Check(chg.Status(), check.Equals, state.DoneStatus)
 
 	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 1)
-	c.Assert(s.backend.WorkshopVolumeMountPoints["test-2"], check.Equals, "/var/lib/workshop/sdk/test")
+	c.Assert(s.backend.WorkshopVolumeMountPoints[fakebackend.WorkshopVolumeMount{Workshop: "ws", VolumeName: "test-2"}], check.Equals, "/var/lib/workshop/sdk/test")
 
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
@@ -610,8 +610,12 @@ func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C
 	t2.Set("sdk-retrieve-task", t2.ID())
 	t2.Set("sdk-setup", newSdk)
 	t2.SetToWait(state.DoStatus)
-	setWorkshopProject("ws", s.project, t2)
+	// Make the launch unsuccessful, so the cleanup can stop as the SDK is "used".
+	t3 := s.state.NewTask("error-trigger", "t3")
+	t3.WaitFor(t2)
+	setWorkshopProject("ws", s.project, t2, t3)
 	other.AddTask(t2)
+	other.AddTask(t3)
 
 	s.state.Unlock()
 
@@ -626,7 +630,7 @@ func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C
 	c.Check(err, check.IsNil)
 	c.Check(t.IsClean(), check.Equals, false)
 
-	// Finish the launch change that would enable the t cleanup to finish.
+	// Finish the "launch" change that would enable the t cleanup to finish.
 	waited := t2.WaitedStatus()
 	t2.SetStatus(waited)
 	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
@@ -642,6 +646,42 @@ func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C
 	c.Check(t.IsClean(), check.Equals, true)
 	_, err = s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
 	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
+}
+
+func (s *sdkStateSuite) TestTaskExitCleanupOnSDKUsedAgain(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	t := s.state.NewTask("unregister-sdk", "...")
+	t.Set("sdk-retrieve-task", t.ID())
+	t.Set("sdk-setup", newSdk)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+
+	other := s.state.NewChange("launch", "...")
+	other.Set("user", "testuser")
+	t2 := s.state.NewTask("install-sdk", "t2")
+	t2.Set("sdk-retrieve-task", t2.ID())
+	t2.Set("sdk-setup", newSdk)
+	setWorkshopProject("ws", s.project, t2)
+	other.AddTask(t2)
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	s.state.Unlock()
+
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.IsNil)
+	c.Assert(t.IsClean(), check.Equals, true)
 }
 
 func (s *sdkStateSuite) TestSDKVolumeCleanupWithLaterUnregisterTask(c *check.C) {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -163,7 +163,7 @@ func (s *sdkStateSuite) mockSdk(c *check.C, name, sdkYaml string, rev sdk.Revisi
 	c.Assert(err, check.IsNil)
 	err = os.WriteFile(filepath.Join(meta, "sdk.yaml"), []byte(sdkYaml), 0644)
 	c.Assert(err, check.IsNil)
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name:     sdk.VolumeName(name, rev),
 		Kind:     "sdk",
 		Sdk:      name,
@@ -208,15 +208,15 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	chg.AddTask(t)
 
 	s.state.Unlock()
-	s.se.Ensure()
+	c.Check(s.se.Ensure(), check.IsNil)
 	s.se.Wait()
 	s.state.Lock()
 
 	c.Check(chg.Err(), check.IsNil)
 	c.Check(chg.Status(), check.Equals, state.DoneStatus)
 
-	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 1)
-	c.Assert(s.backend.WorkshopVolumeMountPoints[fakebackend.WorkshopVolumeMount{Workshop: "ws", VolumeName: "test-2"}], check.Equals, "/var/lib/workshop/sdk/test")
+	c.Assert(s.backend.SdkVolumeMountPoints, check.HasLen, 1)
+	c.Assert(s.backend.SdkVolumeMountPoints[fakebackend.WorkshopVolumeMount{ProjectId: "projectId", Workshop: "ws", VolumeName: "test-2"}], check.Equals, "/var/lib/workshop/sdk/test")
 
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
@@ -258,14 +258,14 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		_ = s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
 
 	c.Check(t1.Status(), check.Equals, state.UndoneStatus)
 
-	c.Assert(s.backend.WorkshopVolumeMountPoints, check.HasLen, 0)
+	c.Assert(s.backend.SdkVolumeMountPoints, check.HasLen, 0)
 }
 
 func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
@@ -284,7 +284,7 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 	chg.AddTask(t)
 
 	s.state.Unlock()
-	c.Assert(s.se.Ensure(), check.IsNil)
+	c.Check(s.se.Ensure(), check.IsNil)
 	s.se.Wait()
 	s.state.Lock()
 
@@ -346,7 +346,7 @@ func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		_ = s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -437,7 +437,7 @@ func (s *sdkStateSuite) TestDoUnregisterSdk(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -478,7 +478,7 @@ func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -507,7 +507,7 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
 
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 
@@ -516,6 +516,64 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
 	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
+	c.Assert(t.IsClean(), check.Equals, true)
+}
+
+func (s *sdkStateSuite) TestSDKVolumeRemovedAfterFailedLaunch(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	t := s.state.NewTask("install-sdk", "...")
+	t.Set("sdk-retrieve-task", t.ID())
+	t.Set("sdk-setup", newSdk)
+
+	t2 := s.state.NewTask("error-trigger", "...")
+	t2.WaitFor(t)
+
+	chg := s.state.NewChange("launch", "...")
+	chg.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t, t2)
+	chg.AddTask(t)
+	chg.AddTask(t2)
+	s.state.Unlock()
+
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
+	c.Assert(t.IsClean(), check.Equals, true)
+}
+
+func (s *sdkStateSuite) TestSDKVolumeExitCleanupAfterSuccessfulLaunch(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	t := s.state.NewTask("install-sdk", "...")
+	t.Set("sdk-retrieve-task", t.ID())
+	t.Set("sdk-setup", newSdk)
+
+	chg := s.state.NewChange("launch", "...")
+	chg.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+	s.state.Unlock()
+
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.IsNil)
 	c.Assert(t.IsClean(), check.Equals, true)
 }
 
@@ -537,7 +595,7 @@ func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 	defer sdkstate.FakeSdkVolumeCooldownTime(24 * time.Hour)()
 
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 
@@ -550,7 +608,7 @@ func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 	c.Assert(t.IsClean(), check.Equals, false)
 }
 
-func (s *sdkStateSuite) TestTaskQuitsCleanupIfOtherVolumeUsersExist(c *check.C) {
+func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
@@ -563,35 +621,31 @@ func (s *sdkStateSuite) TestTaskQuitsCleanupIfOtherVolumeUsersExist(c *check.C) 
 	setWorkshopProject("ws", s.project, t)
 	chg.AddTask(t)
 
-	other := s.state.NewChange("refresh", "...")
+	other := s.state.NewChange("launch", "...")
 	other.Set("user", "testuser")
-	t2 := s.state.NewTask("unregister-sdk", "t2")
+	t2 := s.state.NewTask("install-sdk", "t2")
 	t2.Set("sdk-retrieve-task", t2.ID())
 	t2.Set("sdk-setup", newSdk)
-	retry := s.state.NewTask("retry-task", "...")
-	retry.WaitFor(t2)
-	setWorkshopProject("ws", s.project, t2, retry)
+	setWorkshopProject("ws", s.project, t2)
 	other.AddTask(t2)
-	other.AddTask(retry)
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
 
 	s.state.Unlock()
 
-	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
-
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 
 	s.state.Lock()
-	defer s.state.Unlock()
+
 	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
 	c.Assert(err, check.IsNil)
 	c.Assert(t.IsClean(), check.Equals, true)
-	c.Assert(t2.IsClean(), check.Equals, false)
+	c.Assert(t2.IsClean(), check.Equals, true)
 }
 
-func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C) {
+func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePresent(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
@@ -610,7 +664,6 @@ func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C
 	t2.Set("sdk-retrieve-task", t2.ID())
 	t2.Set("sdk-setup", newSdk)
 	t2.SetToWait(state.DoStatus)
-	// Make the launch unsuccessful, so the cleanup can stop as the SDK is "used".
 	t3 := s.state.NewTask("error-trigger", "t3")
 	t3.WaitFor(t2)
 	setWorkshopProject("ws", s.project, t2, t3)
@@ -620,7 +673,7 @@ func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C
 	s.state.Unlock()
 
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 
@@ -638,7 +691,7 @@ func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C
 	s.state.Unlock()
 
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -646,45 +699,10 @@ func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C
 	c.Check(t.IsClean(), check.Equals, true)
 	_, err = s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
 	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
+	c.Check(t2.IsClean(), check.Equals, true)
 }
 
-func (s *sdkStateSuite) TestTaskExitCleanupOnSDKUsedAgain(c *check.C) {
-	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
-	t := s.state.NewTask("unregister-sdk", "...")
-	t.Set("sdk-retrieve-task", t.ID())
-	t.Set("sdk-setup", newSdk)
-
-	chg := s.state.NewChange("sample", "...")
-	chg.Set("user", "testuser")
-	setWorkshopProject("ws", s.project, t)
-	chg.AddTask(t)
-
-	other := s.state.NewChange("launch", "...")
-	other.Set("user", "testuser")
-	t2 := s.state.NewTask("install-sdk", "t2")
-	t2.Set("sdk-retrieve-task", t2.ID())
-	t2.Set("sdk-setup", newSdk)
-	setWorkshopProject("ws", s.project, t2)
-	other.AddTask(t2)
-	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
-
-	s.state.Unlock()
-
-	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
-		s.se.Wait()
-	}
-
-	s.state.Lock()
-
-	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
-	c.Assert(err, check.IsNil)
-	c.Assert(t.IsClean(), check.Equals, true)
-}
-
-func (s *sdkStateSuite) TestSDKVolumeCleanupWithLaterUnregisterTask(c *check.C) {
+func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
@@ -699,7 +717,7 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupWithLaterUnregisterTask(c *check.C) 
 	t2.WaitFor(t1)
 
 	// Add both tasks to their own changes
-	chg1 := s.state.NewChange("launch", "chg1")
+	chg1 := s.state.NewChange("refresh", "chg1")
 	chg1.Set("user", "testuser")
 	setWorkshopProject("ws", s.project, t1)
 	chg1.AddTask(t1)
@@ -713,7 +731,7 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupWithLaterUnregisterTask(c *check.C) 
 
 	// Use default cooldown (1h), so t2 will not be clean (cooldown not passed)
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 
@@ -728,86 +746,27 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupWithLaterUnregisterTask(c *check.C) 
 	c.Assert(err, check.IsNil)
 }
 
-func (s *sdkStateSuite) TestSDKVolumeCleanupWithDifferentRevisions(c *check.C) {
+func (s *sdkStateSuite) TestSDKVolumeExitCleanupOnNonvolume(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	s.mockSdk(c, "test", sdkYaml, sdk.R(2))
-	sdk1 := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
-	sdk2 := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 2}, Source: sdk.StoreSource}
-
-	t1 := s.state.NewTask("unregister-sdk", "t1")
-	t1.Set("sdk-retrieve-task", t1.ID())
-	t1.Set("sdk-setup", sdk1)
-	chg1 := s.state.NewChange("refresh", "chg1")
-	chg1.Set("user", "testuser")
-	setWorkshopProject("ws", s.project, t1)
-	chg1.AddTask(t1)
-
-	t2 := s.state.NewTask("unregister-sdk", "t2")
-	t2.Set("sdk-retrieve-task", t2.ID())
-	t2.Set("sdk-setup", sdk2)
-	t3 := s.state.NewTask("retry-task", "t3")
-	t3.WaitFor(t2)
-	chg2 := s.state.NewChange("refresh", "chg2")
-	chg2.Set("user", "testuser")
-	setWorkshopProject("ws", s.project, t2, t3)
-	chg2.AddTask(t2)
-	chg2.AddTask(t3)
-
-	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
-		s.se.Wait()
-	}
-	s.state.Lock()
-	defer s.state.Unlock()
-	c.Assert(t1.IsClean(), check.Equals, true)
-	c.Assert(t2.IsClean(), check.Equals, false)
-	// The volume should still exist
-	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(2)))
-	c.Assert(err, check.IsNil)
-}
-
-func (s *sdkStateSuite) TestSDKVolumeCleanupWithSameRevisionDifferentSource(c *check.C) {
-	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	sdkStore := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.TrySource}
 	sdkProject := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.ProjectSource}
 
 	t1 := s.state.NewTask("unregister-sdk", "t1")
 	t1.Set("sdk-retrieve-task", t1.ID())
-	t1.Set("sdk-setup", sdkStore)
+	t1.Set("sdk-setup", sdkProject)
 	chg1 := s.state.NewChange("launch", "chg1")
 	chg1.Set("user", "testuser")
 	setWorkshopProject("ws", s.project, t1)
 	chg1.AddTask(t1)
 
-	t2 := s.state.NewTask("unregister-sdk", "t2")
-	t2.Set("sdk-retrieve-task", t2.ID())
-	t2.Set("sdk-setup", sdkProject)
-	t2.WaitFor(t1)
-	t3 := s.state.NewTask("retry-task", "t3")
-	t3.WaitFor(t2)
-	chg2 := s.state.NewChange("refresh", "chg2")
-	chg2.Set("user", "testuser")
-	setWorkshopProject("ws", s.project, t2, t3)
-	chg2.AddTask(t2)
-	chg2.AddTask(t3)
-
 	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
 	defer s.state.Unlock()
 	c.Assert(t1.IsClean(), check.Equals, true)
-	// t2's change is not ready, so not clean.
-	c.Assert(t2.IsClean(), check.Equals, false)
-	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
-	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
 }

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -132,7 +132,12 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
 		return ErrTrigger
 	}
+	retryHandler := func(task *state.Task, _ *tomb.Tomb) error {
+		// to keep the change not ready
+		return &state.Retry{After: 1 * time.Hour}
+	}
 	s.runner.AddHandler("error-trigger", erroringHandler, nil)
+	s.runner.AddHandler("retry-task", retryHandler, nil)
 
 	s.se = overlord.NewStateEngine(s.state)
 	s.se.StartUp()
@@ -483,4 +488,286 @@ func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
 	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
+}
+
+func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	t := s.state.NewTask("unregister-sdk", "...")
+	t.Set("sdk-retrieve-task", t.ID())
+	t.Set("sdk-setup", newSdk)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+	s.state.Unlock()
+
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
+	c.Assert(t.IsClean(), check.Equals, true)
+}
+
+func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	t := s.state.NewTask("unregister-sdk", "...")
+	t.Set("sdk-retrieve-task", t.ID())
+	t.Set("sdk-setup", newSdk)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+	s.state.Unlock()
+
+	// Set cooldown to a large value so it never passes
+	defer sdkstate.FakeSdkVolumeCooldownTime(24 * time.Hour)()
+
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	// The volume should still exist
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.IsNil)
+	// The task should not be clean (cleanup not performed)
+	c.Assert(t.IsClean(), check.Equals, false)
+}
+
+func (s *sdkStateSuite) TestTaskQuitsCleanupIfOtherVolumeUsersExist(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	t := s.state.NewTask("unregister-sdk", "...")
+	t.Set("sdk-retrieve-task", t.ID())
+	t.Set("sdk-setup", newSdk)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+
+	other := s.state.NewChange("refresh", "...")
+	other.Set("user", "testuser")
+	t2 := s.state.NewTask("unregister-sdk", "t2")
+	t2.Set("sdk-retrieve-task", t2.ID())
+	t2.Set("sdk-setup", newSdk)
+	retry := s.state.NewTask("retry-task", "...")
+	retry.WaitFor(t2)
+	setWorkshopProject("ws", s.project, t2, retry)
+	other.AddTask(t2)
+	other.AddTask(retry)
+
+	s.state.Unlock()
+
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.IsNil)
+	c.Assert(t.IsClean(), check.Equals, true)
+	c.Assert(t2.IsClean(), check.Equals, false)
+}
+
+func (s *sdkStateSuite) TestTaskRetriesCleanupIfOtherVolumeUsersExist(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	t := s.state.NewTask("unregister-sdk", "...")
+	t.Set("sdk-retrieve-task", t.ID())
+	t.Set("sdk-setup", newSdk)
+
+	chg := s.state.NewChange("sample", "...")
+	chg.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+
+	other := s.state.NewChange("launch", "...")
+	other.Set("user", "testuser")
+	t2 := s.state.NewTask("install-sdk", "t2")
+	t2.Set("sdk-retrieve-task", t2.ID())
+	t2.Set("sdk-setup", newSdk)
+	t2.SetToWait(state.DoStatus)
+	setWorkshopProject("ws", s.project, t2)
+	other.AddTask(t2)
+
+	s.state.Unlock()
+
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Check(err, check.IsNil)
+	c.Check(t.IsClean(), check.Equals, false)
+
+	// Finish the launch change that would enable the t cleanup to finish.
+	waited := t2.WaitedStatus()
+	t2.SetStatus(waited)
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	s.state.Unlock()
+
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(t.IsClean(), check.Equals, true)
+	_, err = s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
+}
+
+func (s *sdkStateSuite) TestSDKVolumeCleanupWithLaterUnregisterTask(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+
+	t1 := s.state.NewTask("unregister-sdk", "t1")
+	t1.Set("sdk-retrieve-task", t1.ID())
+	t1.Set("sdk-setup", newSdk)
+
+	t2 := s.state.NewTask("unregister-sdk", "t2")
+	t2.Set("sdk-retrieve-task", t2.ID())
+	t2.Set("sdk-setup", newSdk)
+	t2.WaitFor(t1)
+
+	// Add both tasks to their own changes
+	chg1 := s.state.NewChange("launch", "chg1")
+	chg1.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t1)
+	chg1.AddTask(t1)
+
+	chg2 := s.state.NewChange("refresh", "chg2")
+	chg2.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t2)
+	chg2.AddTask(t2)
+
+	s.state.Unlock()
+
+	// Use default cooldown (1h), so t2 will not be clean (cooldown not passed)
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// The first task should be clean (cleanup skipped due to newer task)
+	c.Assert(t1.IsClean(), check.Equals, true)
+	// The second task should not be clean (cleanup not performed, cooldown not passed)
+	c.Assert(t2.IsClean(), check.Equals, false)
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.IsNil)
+}
+
+func (s *sdkStateSuite) TestSDKVolumeCleanupWithDifferentRevisions(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	s.mockSdk(c, "test", sdkYaml, sdk.R(2))
+	sdk1 := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	sdk2 := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 2}, Source: sdk.StoreSource}
+
+	t1 := s.state.NewTask("unregister-sdk", "t1")
+	t1.Set("sdk-retrieve-task", t1.ID())
+	t1.Set("sdk-setup", sdk1)
+	chg1 := s.state.NewChange("refresh", "chg1")
+	chg1.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t1)
+	chg1.AddTask(t1)
+
+	t2 := s.state.NewTask("unregister-sdk", "t2")
+	t2.Set("sdk-retrieve-task", t2.ID())
+	t2.Set("sdk-setup", sdk2)
+	t3 := s.state.NewTask("retry-task", "t3")
+	t3.WaitFor(t2)
+	chg2 := s.state.NewChange("refresh", "chg2")
+	chg2.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t2, t3)
+	chg2.AddTask(t2)
+	chg2.AddTask(t3)
+
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(t1.IsClean(), check.Equals, true)
+	c.Assert(t2.IsClean(), check.Equals, false)
+	// The volume should still exist
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(2)))
+	c.Assert(err, check.IsNil)
+}
+
+func (s *sdkStateSuite) TestSDKVolumeCleanupWithSameRevisionDifferentSource(c *check.C) {
+	s.state.Lock()
+	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	sdkStore := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.TrySource}
+	sdkProject := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.ProjectSource}
+
+	t1 := s.state.NewTask("unregister-sdk", "t1")
+	t1.Set("sdk-retrieve-task", t1.ID())
+	t1.Set("sdk-setup", sdkStore)
+	chg1 := s.state.NewChange("launch", "chg1")
+	chg1.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t1)
+	chg1.AddTask(t1)
+
+	t2 := s.state.NewTask("unregister-sdk", "t2")
+	t2.Set("sdk-retrieve-task", t2.ID())
+	t2.Set("sdk-setup", sdkProject)
+	t2.WaitFor(t1)
+	t3 := s.state.NewTask("retry-task", "t3")
+	t3.WaitFor(t2)
+	chg2 := s.state.NewChange("refresh", "chg2")
+	chg2.Set("user", "testuser")
+	setWorkshopProject("ws", s.project, t2, t3)
+	chg2.AddTask(t2)
+	chg2.AddTask(t3)
+
+	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Assert(t1.IsClean(), check.Equals, true)
+	// t2's change is not ready, so not clean.
+	c.Assert(t2.IsClean(), check.Equals, false)
+	_, err := s.backend.Volume(s.ctx, sdk.VolumeName("test", sdk.R(1)))
+	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -24,6 +24,8 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	runner.AddHandler("register-sdk", OnDo(manager.doRegisterSdk), OnUndo(manager.doUnregisterSdk))
 	runner.AddHandler("unregister-sdk", OnDo(manager.doUnregisterSdk), OnUndo(manager.doRegisterSdk))
 
+	runner.AddCleanup("unregister-sdk", manager.doDeleteUnusedSdkVolumes)
+
 	return manager
 }
 

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -1,6 +1,8 @@
 package sdkstate
 
 import (
+	"time"
+
 	"github.com/canonical/workshop/internal/interfaces"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -11,6 +13,10 @@ type SdkManager struct {
 	backend workshop.Backend
 	repo    *interfaces.Repository
 }
+
+var (
+	sdkVolumeCooldownTime = 1 * time.Hour
+)
 
 func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) *SdkManager {
 	manager := &SdkManager{repo: repo}
@@ -31,4 +37,12 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 
 func (w *SdkManager) Ensure() error {
 	return nil
+}
+
+func FakeSdkVolumeCooldownTime(t time.Duration) (restore func()) {
+	old := sdkVolumeCooldownTime
+	sdkVolumeCooldownTime = t
+	return func() {
+		sdkVolumeCooldownTime = old
+	}
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -15,7 +15,7 @@ type SdkManager struct {
 }
 
 var (
-	sdkVolumeCooldownTime = 1 * time.Hour
+	sdkVolumeCooldownTime = 1 * time.Hour // Time to wait before deleting unused SDK volumes.
 )
 
 func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) *SdkManager {

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -31,6 +31,7 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	runner.AddHandler("unregister-sdk", OnDo(manager.doUnregisterSdk), OnUndo(manager.doRegisterSdk))
 
 	runner.AddCleanup("unregister-sdk", manager.doDeleteUnusedSdkVolumes)
+	runner.AddCleanup("install-sdk", manager.doDeleteUnusedSdkVolumes)
 
 	return manager
 }

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -370,7 +370,7 @@ func (m *WorkshopManager) doCreateStateStorage(task *state.Task, tomb *tomb.Tomb
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
 
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name: workshop.WorkshopStateVolumeName(w, prj.ProjectId),
 		Kind: "state-storage",
 	}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -264,7 +264,7 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (sdk.R
 	}
 
 	revision := sdk.Revision{N: minRevision.N - 1}
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name:     sdk.VolumeName(sk, revision),
 		Kind:     "sdk",
 		Sha3_384: digest,
@@ -296,11 +296,11 @@ func (s *localSdkFinder) volumes(ctx context.Context) ([]workshop.VolumeInfo, er
 	return vols, nil
 }
 
-func (s *localSdkFinder) importVolume(ctx context.Context, info workshop.VolumeInfo, tarball *os.File) error {
-	if err := s.backend.ImportVolume(ctx, info, tarball); err != nil {
+func (s *localSdkFinder) importVolume(ctx context.Context, setup workshop.VolumeSetup, tarball *os.File) error {
+	if err := s.backend.ImportVolume(ctx, setup, tarball); err != nil {
 		return err
 	}
-	s.sdkVolumes = append(s.sdkVolumes, info)
+	s.sdkVolumes = append(s.sdkVolumes, workshop.VolumeInfo{VolumeSetup: setup, Workshops: make(map[string][]string)})
 	return nil
 }
 
@@ -1145,6 +1145,8 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 	remove.Set("forget", true)
 	addTaskSet(state.NewTaskSet(remove))
 
+	// The point of no return starts after the workshop is removed. If any of the tasks
+	// after this fails, we can only report the error, but cannot undo the removal.
 	removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
 	addTaskSet(state.NewTaskSet(removeStateStorage))
 
@@ -1159,6 +1161,8 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 	// If an error occurs when removing the directories, it will not affect the other tasks.
 	cleanupLane := st.NewLane()
 	removeDirs.JoinLane(cleanupLane)
+	removeStash.JoinLane(cleanupLane)
+	removeStateStorage.JoinLane(cleanupLane)
 
 	for _, task := range removeSet.Tasks() {
 		task.Set("workshop", w.Name)

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -109,8 +109,9 @@ type VolumeManager interface {
 	// Detach the volume from the workshop.
 	DetachVolume(ctx context.Context, wp, name string) error
 
-	// Delete a temporary storage volume for the workshop. It does not
-	// unmount the volume from the workshop if mounted.
+	// Delete a temporary storage volume for the workshop. It does not unmount
+	// the volume from the workshop if mounted. No error is returned if the
+	// volume does not exist.
 	DeleteVolume(ctx context.Context, name string) error
 
 	// List volumes of a given kind.

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -79,7 +79,7 @@ type Stash interface {
 	RemoveWorkshopStash(ctx context.Context, name string) error
 }
 
-type VolumeInfo struct {
+type VolumeSetup struct {
 	// Volume name.
 	Name string
 	// Kind of volume, e.g. "sdk" or "state-storage."
@@ -94,14 +94,20 @@ type VolumeInfo struct {
 	Metadata string
 }
 
+type VolumeInfo struct {
+	VolumeSetup
+	// Project ID / Workshop pairs that the volume is attached to.
+	Workshops map[string][]string
+}
+
 type VolumeManager interface {
 	// Create a temporary storage volume for the workshop. It does not
 	// mount the device to the workshop, it must be mounted to the required
 	// workshop as a separate operation.
-	CreateVolume(ctx context.Context, info VolumeInfo) error
+	CreateVolume(ctx context.Context, info VolumeSetup) error
 
 	// Import a tarball into the volume.
-	ImportVolume(ctx context.Context, info VolumeInfo, tarball *os.File) error
+	ImportVolume(ctx context.Context, info VolumeSetup, tarball *os.File) error
 
 	// Attach the volume to the workshop. The volume must be created before.
 	AttachVolume(ctx context.Context, wp, name, where string, ro bool) error

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -33,6 +33,7 @@ var (
 	ErrWorkshopNotLaunched = errors.New("workshop not launched")
 	ErrVolumeNotFound      = errors.New("volume not found")
 	ErrVolumeAlreadyExists = errors.New("volume already exists")
+	ErrVolumeInUse         = errors.New("volume is in use")
 	ErrSdkProfileNotFound  = errors.New("sdk profile not found")
 
 	User = user.User{

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -61,6 +61,7 @@ type RestoreCall struct {
 }
 
 type WorkshopVolumeMount struct {
+	ProjectId  string
 	Workshop   string
 	VolumeName string
 }
@@ -74,10 +75,10 @@ type FakeWorkshopBackend struct {
 	// workshops put to stash (e.g. during refresh)
 	StashedWorkshops map[string]map[string]*FakeWorkshop
 	// storage volumes, the key is a volume name
-	volumeLock                sync.Mutex
-	WorkshopVolumes           map[string]workshop.VolumeInfo
-	WorkshopVolumeContents    map[string]string
-	WorkshopVolumeMountPoints map[WorkshopVolumeMount]string
+	volumeLock           sync.Mutex
+	SdkVolumes           map[string]workshop.VolumeInfo
+	SdkVolumeContents    map[string]string
+	SdkVolumeMountPoints map[WorkshopVolumeMount]string
 	// the key is a username
 	projects map[string][]workshop.Project
 
@@ -107,9 +108,9 @@ func New(baseDir string) (*FakeWorkshopBackend, error) {
 	var be FakeWorkshopBackend
 	be.Workshops = make(map[string]map[string]*FakeWorkshop)
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
-	be.WorkshopVolumes = make(map[string]workshop.VolumeInfo)
-	be.WorkshopVolumeContents = make(map[string]string)
-	be.WorkshopVolumeMountPoints = make(map[WorkshopVolumeMount]string)
+	be.SdkVolumes = make(map[string]workshop.VolumeInfo)
+	be.SdkVolumeContents = make(map[string]string)
+	be.SdkVolumeMountPoints = make(map[WorkshopVolumeMount]string)
 	be.projects = make(map[string][]workshop.Project)
 
 	be.ExecCallback = DoExecDefault
@@ -216,13 +217,23 @@ func (f *FakeWorkshopBackend) RemoveWorkshop(ctx context.Context, name string, f
 	prj := f.project(user, projectId)
 
 	f.workshopLock.Lock()
-	defer f.workshopLock.Unlock()
-
-	if _, ok := f.Workshops[prj.ProjectId][name]; !ok {
+	wp, ok := f.Workshops[prj.ProjectId][name]
+	f.workshopLock.Unlock()
+	if !ok {
 		return workshop.ErrWorkshopNotLaunched
 	}
 
+	for _, sk := range wp.Sdks {
+		if sk.IsVolume() {
+			if err := f.DetachVolume(ctx, name, sdk.VolumeName(sk.Name, sk.Revision)); err != nil {
+				return err
+			}
+		}
+	}
+
+	f.workshopLock.Lock()
 	delete(f.Workshops[prj.ProjectId], name)
+	f.workshopLock.Unlock()
 	return nil
 }
 
@@ -516,11 +527,11 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	return nil
 }
 
-func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, info workshop.VolumeInfo) error {
+func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, info workshop.VolumeSetup) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	if _, ok := s.WorkshopVolumes[info.Name]; ok {
+	if _, ok := s.SdkVolumes[info.Name]; ok {
 		return workshop.ErrVolumeAlreadyExists
 	}
 
@@ -529,14 +540,19 @@ func (s *FakeWorkshopBackend) CreateVolume(ctx context.Context, info workshop.Vo
 		return err
 	}
 
-	s.WorkshopVolumeContents[info.Name] = vfs
-	s.WorkshopVolumes[info.Name] = info
+	s.SdkVolumeContents[info.Name] = vfs
+	s.SdkVolumes[info.Name] = workshop.VolumeInfo{VolumeSetup: info, Workshops: make(map[string][]string)}
 	return nil
 }
 
 func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, where string, ro bool) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
+
+	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
+	if !ok {
+		return fmt.Errorf("context key project-id not found")
+	}
 
 	s.AttachVolumeCalls = append(s.AttachVolumeCalls, AttachVolumeCall{Workshop: wp, Name: name})
 
@@ -551,7 +567,7 @@ func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, where 
 		return err
 	}
 
-	volumeFs := s.WorkshopVolumeContents[name]
+	volumeFs := s.SdkVolumeContents[name]
 	if volumeFs == "" {
 		return fmt.Errorf("volume %q not found", name)
 	}
@@ -564,7 +580,8 @@ func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, where 
 		return err
 	}
 
-	s.WorkshopVolumeMountPoints[WorkshopVolumeMount{Workshop: wp, VolumeName: name}] = where
+	s.SdkVolumes[name].Workshops[projectId] = append(s.SdkVolumes[name].Workshops[projectId], wp)
+	s.SdkVolumeMountPoints[WorkshopVolumeMount{ProjectId: projectId, Workshop: wp, VolumeName: name}] = where
 	return nil
 }
 
@@ -572,7 +589,12 @@ func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string)
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	target := s.WorkshopVolumeMountPoints[WorkshopVolumeMount{Workshop: wp, VolumeName: name}]
+	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
+	if !ok {
+		return fmt.Errorf("context key project-id not found")
+	}
+
+	target := s.SdkVolumeMountPoints[WorkshopVolumeMount{ProjectId: projectId, Workshop: wp, VolumeName: name}]
 
 	wfs, err := s.WorkshopFs(ctx, wp)
 	if err != nil {
@@ -581,18 +603,25 @@ func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string)
 	defer wfs.Close()
 
 	err = wfs.Remove(target)
-	delete(s.WorkshopVolumeMountPoints, WorkshopVolumeMount{Workshop: wp, VolumeName: name})
+	if err != nil {
+		return err
+	}
+	delete(s.SdkVolumeMountPoints, WorkshopVolumeMount{ProjectId: projectId, Workshop: wp, VolumeName: name})
+
+	s.SdkVolumes[name].Workshops[projectId] = slices.DeleteFunc(s.SdkVolumes[name].Workshops[projectId], func(w string) bool {
+		return w == wp
+	})
 	return err
 }
 
 // ImportVolume imports a tarball into the volume. The tarball must be a valid
 // directory (unpacked so that the tests could provide a temp directory instead
 // of a packed tarball).
-func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, tarball *os.File) error {
+func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, info workshop.VolumeSetup, tarball *os.File) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	if _, ok := s.WorkshopVolumes[info.Name]; ok {
+	if _, ok := s.SdkVolumes[info.Name]; ok {
 		return workshop.ErrVolumeAlreadyExists
 	}
 
@@ -604,8 +633,8 @@ func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, info workshop.Vo
 		}
 	}
 
-	s.WorkshopVolumeContents[info.Name] = tarball.Name()
-	s.WorkshopVolumes[info.Name] = info
+	s.SdkVolumeContents[info.Name] = tarball.Name()
+	s.SdkVolumes[info.Name] = workshop.VolumeInfo{VolumeSetup: info, Workshops: make(map[string][]string)}
 	return nil
 }
 
@@ -613,14 +642,14 @@ func (s *FakeWorkshopBackend) DeleteVolume(ctx context.Context, name string) err
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	for volume := range s.WorkshopVolumeMountPoints {
+	for volume := range s.SdkVolumeMountPoints {
 		if volume.VolumeName == name {
 			return workshop.ErrVolumeInUse
 		}
 	}
 
-	delete(s.WorkshopVolumes, name)
-	delete(s.WorkshopVolumeContents, name)
+	delete(s.SdkVolumes, name)
+	delete(s.SdkVolumeContents, name)
 	return nil
 }
 
@@ -629,11 +658,12 @@ func (s *FakeWorkshopBackend) Volumes(ctx context.Context, kind string) ([]works
 	defer s.volumeLock.Unlock()
 
 	var infos []workshop.VolumeInfo
-	for _, info := range s.WorkshopVolumes {
+	for _, info := range s.SdkVolumes {
 		if info.Kind == kind {
 			infos = append(infos, info)
 		}
 	}
+
 	return infos, nil
 }
 
@@ -641,11 +671,10 @@ func (s *FakeWorkshopBackend) Volume(ctx context.Context, name string) (workshop
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	info, ok := s.WorkshopVolumes[name]
+	info, ok := s.SdkVolumes[name]
 	if !ok {
 		return workshop.VolumeInfo{}, workshop.ErrVolumeNotFound
 	}
-
 	return info, nil
 }
 
@@ -710,10 +739,17 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, snapid string, 
 
 	// Remove SDKs from after the snapshot.
 	for _, sk := range unwantedSdks {
-		if err = fs.RemoveAll(sdk.SdkDir(sk.Name)); err != nil {
-			return err
-		}
 		delete(wp.Sdks, sk.Name)
+		// Restore would detach the volume attached after the snapshot.
+		if sk.IsVolume() {
+			if err = s.DetachVolume(ctx, name, sdk.VolumeName(sk.Name, sk.Revision)); err != nil {
+				return err
+			}
+		} else {
+			if err = fs.RemoveAll(sdk.SdkDir(sk.Name)); err != nil {
+				return err
+			}
+		}
 	}
 	value, err := json.Marshal(wp.Sdks)
 	if err != nil {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -60,6 +60,11 @@ type RestoreCall struct {
 	File     *workshop.File
 }
 
+type WorkshopVolumeMount struct {
+	Workshop   string
+	VolumeName string
+}
+
 type WorkshopFsCallback func(ctx context.Context, name string) (workshop.WorkshopFs, error)
 
 type FakeWorkshopBackend struct {
@@ -72,7 +77,7 @@ type FakeWorkshopBackend struct {
 	volumeLock                sync.Mutex
 	WorkshopVolumes           map[string]workshop.VolumeInfo
 	WorkshopVolumeContents    map[string]string
-	WorkshopVolumeMountPoints map[string]string
+	WorkshopVolumeMountPoints map[WorkshopVolumeMount]string
 	// the key is a username
 	projects map[string][]workshop.Project
 
@@ -104,7 +109,7 @@ func New(baseDir string) (*FakeWorkshopBackend, error) {
 	be.StashedWorkshops = make(map[string]map[string]*FakeWorkshop)
 	be.WorkshopVolumes = make(map[string]workshop.VolumeInfo)
 	be.WorkshopVolumeContents = make(map[string]string)
-	be.WorkshopVolumeMountPoints = make(map[string]string)
+	be.WorkshopVolumeMountPoints = make(map[WorkshopVolumeMount]string)
 	be.projects = make(map[string][]workshop.Project)
 
 	be.ExecCallback = DoExecDefault
@@ -559,7 +564,7 @@ func (s *FakeWorkshopBackend) AttachVolume(ctx context.Context, wp, name, where 
 		return err
 	}
 
-	s.WorkshopVolumeMountPoints[name] = where
+	s.WorkshopVolumeMountPoints[WorkshopVolumeMount{Workshop: wp, VolumeName: name}] = where
 	return nil
 }
 
@@ -567,7 +572,7 @@ func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string)
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	target := s.WorkshopVolumeMountPoints[name]
+	target := s.WorkshopVolumeMountPoints[WorkshopVolumeMount{Workshop: wp, VolumeName: name}]
 
 	wfs, err := s.WorkshopFs(ctx, wp)
 	if err != nil {
@@ -576,7 +581,7 @@ func (s *FakeWorkshopBackend) DetachVolume(ctx context.Context, wp, name string)
 	defer wfs.Close()
 
 	err = wfs.Remove(target)
-	delete(s.WorkshopVolumeMountPoints, name)
+	delete(s.WorkshopVolumeMountPoints, WorkshopVolumeMount{Workshop: wp, VolumeName: name})
 	return err
 }
 
@@ -607,6 +612,12 @@ func (s *FakeWorkshopBackend) ImportVolume(ctx context.Context, info workshop.Vo
 func (s *FakeWorkshopBackend) DeleteVolume(ctx context.Context, name string) error {
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
+
+	for volume := range s.WorkshopVolumeMountPoints {
+		if volume.VolumeName == name {
+			return workshop.ErrVolumeInUse
+		}
+	}
 
 	delete(s.WorkshopVolumes, name)
 	delete(s.WorkshopVolumeContents, name)

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -80,6 +81,24 @@ func InstanceName(name string, project_id string) string {
 
 func instanceStashName(name string, pid string) string {
 	return "stash-" + InstanceName(name, pid)
+}
+
+func workshopName(instance string) string {
+	idx := strings.LastIndex(instance, "-")
+	if idx == -1 {
+		return ""
+	}
+
+	// drop the project id from the name
+	return instance[:idx]
+}
+
+func workshopProjectId(instance string) (string, string) {
+	idx := strings.LastIndex(instance, "-")
+	if idx == -1 {
+		return "", ""
+	}
+	return instance[:idx], instance[idx+1:]
 }
 
 func ImageAlias(name string) string {

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -307,7 +307,7 @@ func (s *Backend) projectFsRoot(conn lxd.InstanceServer, ctx context.Context, pr
 		}
 
 		execCtx := context.WithValue(ctx, workshop.ContextProjectId, projectId)
-		meta, err := s.execCommand(conn, execCtx, workshop.WorkshopName(i.Name), &args)
+		meta, err := s.execCommand(conn, execCtx, workshopName(i.Name), &args)
 		if err != nil {
 			logger.Debugf("cannot check %q bind-mounts: %v", i.Name, err)
 			continue
@@ -376,7 +376,7 @@ func (s *Backend) updateProjectMounts(conn lxd.InstanceServer, ctx context.Conte
 			MakeWhere: true,
 			Type:      workshop.HostWorkshop,
 		}
-		err = s.AddWorkshopMount(projectCtx, workshop.WorkshopName(i.Name), mount)
+		err = s.AddWorkshopMount(projectCtx, workshopName(i.Name), mount)
 		if err != nil {
 			return fmt.Errorf("cannot update workshop %q project directory: %w", i.Name, err)
 		}

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/sdk"
@@ -95,7 +97,7 @@ func unlockVolume(volume string) {
 	}
 }
 
-func (s *Backend) CreateVolume(ctx context.Context, info workshop.VolumeInfo) error {
+func (s *Backend) CreateVolume(ctx context.Context, info workshop.VolumeSetup) error {
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
@@ -107,7 +109,7 @@ func (s *Backend) CreateVolume(ctx context.Context, info workshop.VolumeInfo) er
 	vol.Name = info.Name
 	vol.Type = "custom"
 	vol.ContentType = "filesystem"
-	vol.Config = volumeInfoToConfig(info)
+	vol.Config = volumeSetupToConfig(info)
 
 	err = conn.CreateStoragePoolVolume(storagePool, vol)
 	if api.StatusErrorCheck(err, http.StatusConflict) {
@@ -116,7 +118,7 @@ func (s *Backend) CreateVolume(ctx context.Context, info workshop.VolumeInfo) er
 	return err
 }
 
-func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, tarball *os.File) error {
+func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeSetup, tarball *os.File) error {
 	// There could be multiple launches that require the same volume. We don't
 	// want to unpack and import the volume multiple times.
 	if err := lockVolume(ctx, info.Name); err != nil {
@@ -239,7 +241,7 @@ func (s *Backend) ImportVolume(ctx context.Context, info workshop.VolumeInfo, ta
 		return err
 	}
 
-	volPut := api.StorageVolumePut{Config: volumeInfoToConfig(info)}
+	volPut := api.StorageVolumePut{Config: volumeSetupToConfig(info)}
 	return conn.UpdateStoragePoolVolume(storagePool, "custom", info.Name, volPut, "")
 }
 
@@ -289,7 +291,7 @@ func (s *Backend) Volumes(ctx context.Context, kind string) ([]workshop.VolumeIn
 
 	infos := make([]workshop.VolumeInfo, 0, len(vols))
 	for _, vol := range vols {
-		infos = append(infos, volumeConfigToInfo(vol.Name, vol.Config))
+		infos = append(infos, volumeToInfo(&vol))
 	}
 	return infos, nil
 }
@@ -309,10 +311,10 @@ func (s *Backend) Volume(ctx context.Context, name string) (workshop.VolumeInfo,
 		return workshop.VolumeInfo{}, err
 	}
 
-	return volumeConfigToInfo(vol.Name, vol.Config), nil
+	return volumeToInfo(vol), nil
 }
 
-func volumeInfoToConfig(info workshop.VolumeInfo) map[string]string {
+func volumeSetupToConfig(info workshop.VolumeSetup) map[string]string {
 	config := map[string]string{
 		"user.kind": info.Kind,
 	}
@@ -331,17 +333,41 @@ func volumeInfoToConfig(info workshop.VolumeInfo) map[string]string {
 	return config
 }
 
-func volumeConfigToInfo(name string, config map[string]string) workshop.VolumeInfo {
-	revision, err := sdk.ParseRevision(config["user.sdk.revision"])
+func volumeToInfo(volume *api.StorageVolume) workshop.VolumeInfo {
+	revision, err := sdk.ParseRevision(volume.Config["user.sdk.revision"])
 	if err != nil {
 		revision = sdk.Revision{}
 	}
+
+	workshops := make(map[string][]string)
+	for _, u := range volume.UsedBy {
+		parsedURL, err := url.Parse(u)
+		if err != nil {
+			logger.Debugf("Failed to parse URL %q: %v", u, err)
+			continue
+		}
+		entityType, _, _, pathArgs, err := entity.ParseURL(*parsedURL)
+		if err != nil {
+			logger.Debugf("Failed to parse entity from URL %q: %v", parsedURL.String(), err)
+			continue
+		}
+		if entityType != entity.TypeInstance || len(pathArgs) == 0 {
+			logger.Debugf("URL %q does not point to an instance, skipping", parsedURL.String())
+			continue
+		}
+		wp, pid := workshopProjectId(pathArgs[0])
+		workshops[pid] = append(workshops[pid], wp)
+	}
+
 	return workshop.VolumeInfo{
-		Name:     name,
-		Kind:     config["user.kind"],
-		Sha3_384: config["user.sha3-384"],
-		Sdk:      config["user.sdk.name"],
-		Revision: revision,
-		Metadata: config["user.sdk.meta"],
+		VolumeSetup: workshop.VolumeSetup{
+			Name:     volume.Name,
+			Kind:     volume.Config["user.kind"],
+			Sha3_384: volume.Config["user.sha3-384"],
+			Sdk:      volume.Config["user.sdk.name"],
+			Revision: revision,
+			Metadata: volume.Config["user.sdk.meta"],
+		},
+		Workshops: workshops,
 	}
 }

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -260,6 +261,9 @@ func (s *Backend) DeleteVolume(ctx context.Context, name string) error {
 	if err = conn.DeleteStoragePoolVolume(storagePool, "custom", name); err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return nil
+		}
+		if api.StatusErrorCheck(err, http.StatusBadRequest) && strings.Contains(err.Error(), "still in use") {
+			return workshop.ErrVolumeInUse
 		}
 		return err
 	}

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -130,8 +130,8 @@ func RemoveTestWorkshop(c *check.C, ctx context.Context, bd workshop.Backend) {
 	c.Assert(err, check.IsNil)
 }
 
-func MockSdkTarball(c *check.C, name, path, meta string) string {
-	sdkfs := filepath.Join(path, name)
+func MockSdkTarball(c *check.C, sdkname, path, meta string) string {
+	sdkfs := filepath.Join(path, sdkname)
 
 	metadir := filepath.Join(sdkfs, "meta")
 	err := os.MkdirAll(metadir, 0755)
@@ -144,7 +144,7 @@ func MockSdkTarball(c *check.C, name, path, meta string) string {
 	err = os.MkdirAll(hooksdir, 0755)
 	c.Assert(err, check.IsNil)
 
-	tarball := filepath.Join(path, fmt.Sprintf("%s_1.sdk", name))
+	tarball := filepath.Join(path, fmt.Sprintf("%s_1.sdk", sdkname))
 	pack := exec.CommandContext(context.Background(), "tar",
 		"--create",
 		"--format=posix",

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"os"
 	"os/user"
-	"path/filepath"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -19,7 +18,6 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
-	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -40,6 +38,8 @@ type wsOps struct {
 var _ = check.Suite(&wsOps{})
 
 func (f *wsOps) SetUpSuite(c *check.C) {
+	dirs.SetRootDir(c.MkDir())
+	dirs.SetCacheDir(c.MkDir())
 	c.Assert(dirs.CreateDirs(), check.IsNil)
 
 	var err error
@@ -162,7 +162,7 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 
 func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 	// Execute
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name:     "test",
 		Kind:     "testkind",
 		Sha3_384: "abc123",
@@ -175,7 +175,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(vols, check.HasLen, 1)
 
-	c.Check(vols[0], check.Equals, volume)
+	c.Check(vols[0], check.DeepEquals, workshop.VolumeInfo{VolumeSetup: volume, Workshops: map[string][]string{}})
 
 	// Execute
 	err = f.bd.DeleteVolume(f.ctx, "test")
@@ -199,14 +199,14 @@ sdkcraft-started-at: '2020-04-22T19:12:07.903032Z'
 func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	// Execute
 	sdkfs := c.MkDir()
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name:     "test-1",
 		Kind:     "sdk",
 		Sdk:      "test",
 		Revision: sdk.R(1),
 		Metadata: testsdk,
 	}
-	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
+	tarball := helper.MockSdkTarball(c, volume.Sdk, sdkfs, testsdk)
 
 	cmd := testutil.FakeCommand(c, "tar", `/usr/bin/tar "$@"`)
 
@@ -238,7 +238,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 
 	vinfo, err := f.bd.Volume(f.ctx, "test-1")
 	c.Check(err, check.IsNil)
-	c.Check(vinfo, check.Equals, volume)
+	c.Check(vinfo, check.DeepEquals, workshop.VolumeInfo{VolumeSetup: volume, Workshops: make(map[string][]string)})
 
 	err = f.bd.DeleteVolume(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
@@ -247,14 +247,14 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 	// Execute
 	sdkfs := c.MkDir()
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name:     "test-1",
 		Kind:     "sdk",
 		Sdk:      "test",
 		Revision: sdk.R(1),
 		Metadata: testsdk,
 	}
-	tarball := helper.MockSdkTarball(c, "test", sdkfs, testsdk)
+	tarball := helper.MockSdkTarball(c, volume.Sdk, sdkfs, testsdk)
 
 	cmd := testutil.FakeCommand(c, "tar", `/usr/bin/tar "$@"`)
 
@@ -297,7 +297,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 
 	vinfo, err := f.bd.Volume(f.ctx, "test-1")
 	c.Check(err, check.IsNil)
-	c.Check(vinfo, check.Equals, volume)
+	c.Check(vinfo, check.DeepEquals, workshop.VolumeInfo{VolumeSetup: volume, Workshops: make(map[string][]string)})
 
 	err = f.bd.DeleteVolume(f.ctx, "test-1")
 	c.Assert(err, check.IsNil)
@@ -473,43 +473,49 @@ func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
+func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) {
 	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
 	w, err := f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 
-	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
-	err = system.RetrieveSystemSdk(setup, nil)
+	sdkfs := c.MkDir()
+	setup := sdk.Setup{
+		Name:     "test-sdk",
+		Revision: sdk.R(5),
+		Source:   sdk.StoreSource,
+	}
+	err = w.AddSdk(f.ctx, setup)
 	c.Assert(err, check.IsNil)
-	meta, err := system.SystemSdkFs.ReadFile(filepath.Join("meta", "sdk.yaml"))
-	c.Assert(err, check.IsNil)
+	c.Check(w.Sdks, check.HasLen, 1)
 
-	volume := workshop.VolumeInfo{
+	volume := workshop.VolumeSetup{
 		Name:     sdk.VolumeName(setup.Name, setup.Revision),
 		Kind:     "sdk",
 		Sdk:      setup.Name,
 		Revision: setup.Revision,
-		Metadata: string(meta),
+		Metadata: testsdk,
 	}
-	file, err := os.Open(setup.Filepath())
+	tarball := helper.MockSdkTarball(c, setup.Name, sdkfs, testsdk)
+	file, err := os.Open(tarball)
 	c.Assert(err, check.IsNil)
+	defer file.Close()
+
 	err = f.bd.ImportVolume(f.ctx, volume, file)
-	file.Close()
 	c.Assert(err, check.IsNil)
 	defer func() { _ = f.bd.DeleteVolume(f.ctx, volume.Name) }()
 
-	info, err := f.bd.Volume(f.ctx, volume.Name)
-	c.Assert(err, check.IsNil)
-	c.Check(info, check.DeepEquals, volume)
-
 	err = f.bd.AttachVolume(f.ctx, "test", volume.Name, sdk.SdkDir(setup.Name), true)
 	c.Assert(err, check.IsNil)
+	defer func() { _ = f.bd.DetachVolume(f.ctx, "test", volume.Name) }()
 
-	err = w.AddSdk(f.ctx, setup)
+	info, err := f.bd.Volume(f.ctx, volume.Name)
 	c.Assert(err, check.IsNil)
-	c.Check(w.Sdks, check.HasLen, 1)
+	c.Check(info, check.DeepEquals, workshop.VolumeInfo{
+		VolumeSetup: volume,
+		Workshops:   map[string][]string{f.project.ProjectId: {"test"}},
+	})
 
 	err = f.bd.StopWorkshop(f.ctx, "test", true)
 	c.Assert(err, check.IsNil)
@@ -517,31 +523,98 @@ func (f *wsOps) TestLxdBackendWorkshopRestore(c *check.C) {
 	err = f.bd.Snapshot(f.ctx, "test", "snapshot-1")
 	c.Assert(err, check.IsNil)
 
-	err = f.bd.AttachVolume(f.ctx, "test", volume.Name, sdk.SdkDir("sdk"), true)
+	// Attach the SDK volume as "test-sdk-2" to the workshop after the snapshot
+	// to immitate further SDK configuration changes. These should be gone after
+	// Restore.
+	setup2 := sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(5)}
+	err = w.AddSdk(f.ctx, setup2)
+	c.Assert(err, check.IsNil)
+	err = f.bd.AttachVolume(f.ctx, "test", volume.Name, sdk.SdkDir(setup2.Name), true)
 	c.Assert(err, check.IsNil)
 
-	err = w.AddSdk(f.ctx, sdk.Setup{Name: "sdk", Revision: sdk.R(5)})
-	c.Assert(err, check.IsNil)
-	c.Check(w.Sdks, check.HasLen, 2)
-
-	wf := &workshop.File{
-		Name: "test",
-		Base: "ubuntu@24.04",
-	}
-	// The instance's configuration only has the system SDK after this.
+	// Restore the workshop from the snapshot.
+	wf := &workshop.File{Name: "test", Base: "ubuntu@24.04"}
 	err = f.bd.Restore(f.ctx, "test", "snapshot-1", wf)
 	c.Assert(err, check.IsNil)
 
 	w, err = f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 	c.Check(w.Running, check.Equals, false)
-	// Check that Restore uses the provided "user.workshop.file" and removes "sdk".
+
+	// Check that Restore uses the provided "user.workshop.file" and removes
+	// "test-sdk-2" setup from the workshop.
 	c.Check(w.File, check.DeepEquals, wf)
 	c.Check(w.Sdks, check.HasLen, 1)
+	c.Check(w.Sdks[setup2.Name], check.DeepEquals, sdk.Setup{})
 
+	// Check that "test-sdk-2" volume is not present in the workshop filesystem
+	// anymore.
 	fs, err := f.bd.WorkshopFs(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 	defer fs.Close()
-	_, err = fs.Stat(sdk.SdkDir("sdk"))
+	_, err = fs.Stat(sdk.SdkDir(setup2.Name))
 	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
+}
+
+func (f *wsOps) TestLxdBackendWorkshopUsedByInVolumeInfoOK(c *check.C) {
+	// First workshop
+	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
+
+	// Second workshop
+	other := workshop.Project{ProjectId: "24242424", Path: c.MkDir()}
+	otherCtx := helper.CreateTestContext(f.usr.Username, other.ProjectId)
+	helper.LaunchTestWorkshop(c, otherCtx, f.bd, other.Path)
+	defer helper.RemoveTestWorkshop(c, otherCtx, f.bd)
+
+	sdkfs := c.MkDir()
+	volume := workshop.VolumeSetup{
+		Name:     "test-sdk-1",
+		Kind:     "sdk",
+		Sdk:      "test-sdk",
+		Revision: sdk.R(1),
+		Metadata: testsdk,
+	}
+
+	tarball := helper.MockSdkTarball(c, volume.Sdk, sdkfs, testsdk)
+	file, err := os.Open(tarball)
+	c.Assert(err, check.IsNil)
+	defer file.Close()
+
+	err = f.bd.ImportVolume(f.ctx, volume, file)
+	c.Assert(err, check.IsNil)
+	defer func() { c.Check(f.bd.DeleteVolume(f.ctx, volume.Name), check.IsNil) }()
+
+	// Attach the volume to both workshops.
+	err = f.bd.AttachVolume(f.ctx, "test", volume.Name, sdk.SdkDir(volume.Sdk), true)
+	c.Assert(err, check.IsNil)
+	err = f.bd.AttachVolume(otherCtx, "test", volume.Name, sdk.SdkDir(volume.Sdk), true)
+	c.Assert(err, check.IsNil)
+
+	// Ensure the volume cannot be deleted while attached to workshops.
+	err = f.bd.DeleteVolume(f.ctx, volume.Name)
+	c.Assert(err, testutil.ErrorIs, workshop.ErrVolumeInUse)
+
+	// Validate UsedBy in VolumeInfo.
+	info, err := f.bd.Volume(f.ctx, volume.Name)
+	c.Assert(err, check.IsNil)
+	c.Check(info, check.DeepEquals, workshop.VolumeInfo{
+		VolumeSetup: volume,
+		Workshops:   map[string][]string{f.project.ProjectId: {"test"}, other.ProjectId: {"test"}},
+	})
+
+	// Detach the volume from the first workshop.
+	err = f.bd.DetachVolume(f.ctx, "test", volume.Name)
+	c.Assert(err, check.IsNil)
+
+	// Validate UsedBy in VolumeInfo.
+	info, err = f.bd.Volume(f.ctx, volume.Name)
+	c.Assert(err, check.IsNil)
+	c.Check(info, check.DeepEquals, workshop.VolumeInfo{
+		VolumeSetup: volume,
+		Workshops:   map[string][]string{other.ProjectId: {"test"}},
+	})
+
+	err = f.bd.DetachVolume(otherCtx, "test", volume.Name)
+	c.Assert(err, check.IsNil)
 }

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -79,16 +79,6 @@ func (w *Workshop) RemoveSdk(ctx context.Context, name string) error {
 	return w.Backend.AddWorkshopConfig(ctx, w.Name, item)
 }
 
-func WorkshopName(instance string) string {
-	idx := strings.LastIndex(instance, "-")
-	if idx == -1 {
-		return ""
-	}
-
-	// drop the project id from the name
-	return instance[:idx]
-}
-
 func WorkshopStateVolumeName(ws, pid string) string {
 	return fmt.Sprintf("%s-%s-state-volume", ws, pid)
 }


### PR DESCRIPTION
# Description

Implement tracking and removing unused SDK volumes. The implementation uses a clean up handler for the tasks of `install-sdk` or `unregister-sdk` type. Once a change with such a task is complete, it may indicate that an SDK volume became unused due to:
- workshop was removed
- SDK volume was detached from a workshop as a result of a refresh change and is no longer used by any other workshop
- workshop launch failed

If an SDK volume is found to be unused for longer than the `cool down time` (1 hr), it will be removed from the system. This is done to prevent `workshopd` to remove volumes that have a high chance to be immediately reused on a following refresh or launch.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
