### PR TITLE
Improve test coverage for base-agnostic SDKs

### DIFF
--- a/internal/fakestore/store_test.go
+++ b/internal/fakestore/store_test.go
@@ -35,6 +35,9 @@ plugs:
     interface: gpu
 `
 
+var testSdkNoBase = `name: test-sdk
+`
+
 func (s *storeSuite) TestSdkActionInstallOK(c *check.C) {
 	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
 		var s = store.StoreSdk{
@@ -103,6 +106,34 @@ func (s *storeSuite) TestSdkActionInstallCannotParseSdkInfo(c *check.C) {
 	res, err := store.SdkAction(context.Background(), acts)
 	c.Assert(res, check.HasLen, 1)
 	c.Assert(err, check.ErrorMatches, "(?s).*test-sdk-broken: yaml: block sequence entries are not allowed in this context")
+}
+
+func (s *storeSuite) TestSdkActionInstallNoBase(c *check.C) {
+	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
+		var s = store.StoreSdk{
+			Name:     "test-sdk",
+			Channel:  channel,
+			Revision: sdk.Revision{N: 123},
+			SdkYAML:  testSdkNoBase,
+		}
+		return s, nil
+	})
+	defer r()
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	store := store.New()
+	acts := []sdk.SdkAction{{
+		ProjectId: "24242424",
+		Workshop:  "test-workshop",
+		Action:    sdk.Install,
+		Name:      "test-sdk",
+		Base:      "ubuntu@20.04",
+		Channel:   "latest/stable",
+	},
+	}
+	res, err := store.SdkAction(context.Background(), acts)
+	c.Assert(res, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *storeSuite) TestSdkActionInstallIncompatibleBase(c *check.C) {

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -73,6 +73,15 @@ func (s *ValidateSuite) TestIllegalSdkName(c *check.C) {
 	c.Check(err, check.ErrorMatches, `invalid SDK name "foo.something"`)
 }
 
+func (s *ValidateSuite) TestNoSdkBase(c *check.C) {
+	info, err := sdk.ReadSdkInfo([]byte(`name: foo
+`), s.projectId, "ws")
+	c.Assert(err, check.IsNil)
+
+	err = sdk.Validate(info)
+	c.Check(err, check.IsNil)
+}
+
 func (s *ValidateSuite) TestIllegalSdkBase(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo
 base: ubuntu@21.04


### PR DESCRIPTION
# Description

I think this is working as intended but I only added tests for the architecture changes, not the base changes. Not sure why.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
