### PR TITLE
Add workflow to prevent accidentally merging fixup commits

### DIFF
--- a/.github/workflows/fixup.yaml
+++ b/.github/workflows/fixup.yaml
@@ -1,0 +1,45 @@
+name: Check for fixup and squash commits
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  check:
+    name: Check commits
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: 'tree:0'
+
+      - name: Check history
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != 'pull_request' ]; then
+            printf '::error::This workflow only supports pull request events.\n'
+            exit 1
+          fi
+
+          git fetch --filter=tree:0 --no-recurse-submodules origin "+${GITHUB_BASE_REF}:${GITHUB_BASE_REF}"
+
+          log() {
+            git log --pretty='format:%s (%h)' "${GITHUB_BASE_REF}..HEAD"
+          }
+          filter() {
+            grep -E '^(fixup|squash)!' || [ $? -eq 1 ]
+          }
+
+          log | filter >log
+          fixups=$(wc -l <log)
+
+          if [ "$fixups" -ne 0 ]; then
+            printf '::error::Found %d fixup! or squash! commit(s).\n' "$fixups"
+            printf 'Found %d fixup! or squash! commit(s):\n```\n' "$fixups" >>"${GITHUB_STEP_SUMMARY}"
+            tee -a "${GITHUB_STEP_SUMMARY}" <log >&2
+            printf '```\n' >>"${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+        shell: bash


### PR DESCRIPTION
# Description

I messed this up recently (https://github.com/canonical/sdkcraft/pull/167) and don't think I can rely on remembering to do it every time.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
