### PR TITLE
Make verbose mode off for sketch-sdk by default

### DIFF
--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -2,9 +2,8 @@ name: dev
 base: ubuntu@24.04
 sdks:
   - name: go
-    channel: noble/stable
+    channel: all/edge
   - name: project-tools
-  - name: project-starter-pack
   - name: system
     plugs:
       fake-store:
@@ -29,7 +28,7 @@ scripts:
     git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck
     "$HOME"/snapd-testing-tools/utils/spread-shellcheck tests/integration
   cover: |
-    go test ./... -coverprofile=coverage.out
+    go test -covermode=count -coverpkg=./... -coverprofile=coverage.out ./...
   fake-store: |
     STORE_DIR=/tmp/sdkstore
     source tests/lib/utils.sh

--- a/.workshop/tools/hooks/setup-project
+++ b/.workshop/tools/hooks/setup-project
@@ -1,3 +1,7 @@
+cat <<EOF >"$HOME"/.profile
+export PATH="$HOME/go/bin:\$PATH"
+EOF
+
 [ -f "$HOME"/go/bin/fake-gcs-server ] || go install github.com/fsouza/fake-gcs-server@latest
 [ -f "$HOME"/go/bin/golangci-lint ] || go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -27,6 +27,7 @@ type CmdSketch struct {
 	eject   bool
 	name    string
 	remove  bool
+	verbose bool
 }
 
 func (c *CmdSketch) Command() *cobra.Command {
@@ -74,6 +75,7 @@ $ workshop sketch-sdk nimble --stash`,
 	cmd.Flags().BoolVar(&c.eject, "eject", false, "Promote the sketch SDK to an in-project SDK.")
 	cmd.Flags().StringVar(&c.name, "name", "", "Name for the ejected SDK.")
 	cmd.Flags().BoolVar(&c.remove, "remove", false, "Remove the sketch SDK from the workshop.")
+	cmd.Flags().BoolVar(&c.verbose, "verbose", false, "Combine stdout and stderr output from hooks.")
 
 	cmd.MarkFlagsMutuallyExclusive("stash", "restore", "eject", "remove")
 
@@ -412,6 +414,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		defer reverter.Fail()
 
 		cmdrefresh := &CmdRefresh{root: c.root}
+		cmdrefresh.verbose = c.verbose
 		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 			// Refresh failed, revert the stash operation so a possible subsequent
 			// refresh won't fail due to the lack of a sketch SDK definition.
@@ -425,6 +428,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	if c.restore {
 		cmdrefresh := &CmdRefresh{root: c.root}
 		cmdrefresh.WaitOnError = true
+		cmdrefresh.verbose = c.verbose
 
 		stashdir := workshop.SketchSdkStash(userDataDir, p.Id, wp.Name)
 
@@ -465,6 +469,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		defer reverter.Fail()
 
 		cmdrefresh := &CmdRefresh{root: c.root}
+		cmdrefresh.verbose = c.verbose
 		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 			return err
 		}
@@ -491,7 +496,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 	cmdrefresh := &CmdRefresh{root: c.root}
 	cmdrefresh.WaitOnError = true
-	cmdrefresh.verbose = true
+	cmdrefresh.verbose = c.verbose
 
 	if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 		return err


### PR DESCRIPTION
# Description

1. Verbose mode does not seem to be a good choice to have on by default for `sketch-sdk`, especially if it's used for many consequential iterations. Add `--verbose` flag to control this behaviour similarly to `refresh`.
2. @akcano I turned the `project-starter-pack` temporarily from the project as it prevents the workshop from launching. It should come back with your fix. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
