### PR TITLE
Extend refresh with new options

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -434,12 +434,21 @@ func (e *Error) Error() string {
 }
 
 const (
-	ErrorKindLoginRequired     = "login-required"
-	ErrorKindSystemRestart     = "system-restart"
-	ErrorKindDaemonRestart     = "daemon-restart"
-	ErrorKindNoDefaultServices = "no-default-services"
-	ErrorKindUnsuccessful      = "unsuccessful"
+	ErrorKindLoginRequired      = "login-required"
+	ErrorKindSystemRestart      = "system-restart"
+	ErrorKindDaemonRestart      = "daemon-restart"
+	ErrorKindNoDefaultServices  = "no-default-services"
+	ErrorKindUnsuccessful       = "unsuccessful"
+	ErrorKindNoUpdatesAvailable = "no-updates-available"
 )
+
+func IsNoUpdatesAvailable(err error) bool {
+	e, ok := err.(*Error)
+	if !ok || e == nil {
+		return false
+	}
+	return e.Kind == ErrorKindNoUpdatesAvailable
+}
 
 func (rsp *response) err(cli *Client) error {
 	if cli != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -443,11 +443,11 @@ const (
 )
 
 func IsNoUpdatesAvailable(err error) bool {
-	e, ok := err.(*Error)
-	if !ok || e == nil {
-		return false
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Kind == ErrorKindNoUpdatesAvailable
 	}
-	return e.Kind == ErrorKindNoUpdatesAvailable
+	return false
 }
 
 func (rsp *response) err(cli *Client) error {

--- a/client/projects.go
+++ b/client/projects.go
@@ -13,6 +13,8 @@ type Project struct {
 
 type WorkshopActionOptions struct {
 	Mode string `json:"mode,omitempty"`
+	// Supported refresh options: "update", "restore".
+	RefreshOption string `json:"refresh-option,omitempty"`
 }
 
 type WorkshopActionSetup struct {
@@ -80,12 +82,13 @@ func (client *Client) Launch(projectId string, names []string, mode string) (cha
 	})
 }
 
-func (client *Client) Refresh(projectId string, names []string, mode string) (changeId string, err error) {
+func (client *Client) Refresh(projectId string, names []string, mode string, option string) (changeId string, err error) {
 	return client.doWorkshopAction(projectId, &WorkshopActionSetup{
 		Action: "refresh",
 		Names:  names,
 		Options: &WorkshopActionOptions{
-			Mode: mode,
+			Mode:          mode,
+			RefreshOption: option,
 		},
 	})
 }

--- a/client/projects_test.go
+++ b/client/projects_test.go
@@ -52,7 +52,7 @@ func (cs *clientSuite) TestClientLaunch(c *check.C) {
 func (cs *clientSuite) TestClientRefresh(c *check.C) {
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
-	id, err := cs.cli.Refresh("42ws42ws", []string{"ws"}, "transactional")
+	id, err := cs.cli.Refresh("42ws42ws", []string{"ws"}, "transactional", "update")
 
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Assert(id, check.Equals, "24")
@@ -61,7 +61,7 @@ func (cs *clientSuite) TestClientRefresh(c *check.C) {
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(string(body), check.Matches, `{"names":\["ws"\],"action":"refresh","options":{"mode":"transactional"}}\n`)
+	c.Assert(string(body), check.Matches, `{"names":\["ws"\],"action":"refresh","options":{"mode":"transactional","refresh-option":"update"}}\n`)
 }
 
 func (cs *clientSuite) TestClientStart(c *check.C) {

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -16,26 +16,17 @@ type CmdRefresh struct {
 	WaitOnError bool
 	Continue    bool
 	Abort       bool
+	Restore     bool
 }
 
 func (c *CmdRefresh) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "refresh [--abort|--continue|--wait-on-error] <WORKSHOP>...",
+		Use:   "refresh [--abort|--continue|--restore|--wait-on-error] <WORKSHOP>...",
 		Short: "Update workshops according to their definitions",
 		Long: `
-This command updates the workshops listed as arguments by going over their
-definitions once again. For each workshop, it:
-
-- Saves the working state of the workshop
-
-- Checks the workshop definition and identifies any updates required
-
-- Retrieves the updated components
-
-- Applies and verifies the changes to the workshop
-
-- Restores the working state of the workshop
-
+This command updates the workshops listed as arguments. For each workshop, 
+it checks the workshop definition and applies any required updates 
+to the base image, SDKs and interface connections.
 
 The '--wait-on-error' option pauses the refresh if an error occurs.
 Thus, you can fix the error and resume the operation or abort and revert it.
@@ -43,26 +34,20 @@ This option can only be used with a single workshop.
 If multiple workshops are listed and an error occurs,
 the operation is aborted and reverted for all of them.
 
+The '--restore' option restores the workshop from the snapshot that was 
+created after the last successful launch or refresh. Any changes made 
+to the workshop will be discarded.
 
 Notes:
 
-- The workshop must be 'Ready' to be refreshed.
-
-- To construct a newly defined workshop, use 'workshop launch' instead.
-
-- Throughout the refresh, all affected workshops remain 'Pending'.
-
-- If the refresh removes an SDK from the workshop, the SDK state isn't saved.
+- The workshop must be 'Ready' to be refreshed. Throughout 
+  the refresh, all affected workshops remain unavailable for other changes.
 
 - Updated and newly added SDKs are installed in the order
   they are listed in the workshop definition.
+ 
+- To construct a newly defined workshop, use 'workshop launch' instead.
 
-- For mount interface plugs, mounts the last source
-  set by 'workshop remount', if any.
-
-- If the optional <SDK> is supplied,
-  the operation is limited to this SDK;
-  currently, it can only be 'sketch'.
 `,
 		Example: `
 Refresh the 'nimble' and 'jazzy' workshops in the current project directory:
@@ -99,8 +84,12 @@ $ workshop refresh --continue`,
 	cmd.PersistentFlags().BoolVar(&c.verbose, "verbose",
 		false,
 		"Combine stdout and stderr output from hooks.")
+	cmd.PersistentFlags().BoolVar(&c.Restore, "restore",
+		false,
+		"Restore the workshop to the state after the most recent launch or refresh.")
 
 	cmd.MarkFlagsMutuallyExclusive("abort", "continue", "wait-on-error")
+	cmd.MarkFlagsMutuallyExclusive("restore", "continue", "abort")
 
 	return cmd
 }
@@ -126,7 +115,15 @@ func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av 
 		mode = "abort"
 	}
 
-	changeId, err := cli.Refresh(project.Id, av, mode)
+	option := ""
+	if mode == "transactional" || mode == "wait-on-error" {
+		option = "update"
+		if c.Restore {
+			option = "restore"
+		}
+	}
+
+	changeId, err := cli.Refresh(project.Id, av, mode, option)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -169,7 +169,12 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		av = []string{name}
 	}
 
-	if err := c.RunRefresh(cli, project, av); err != nil {
+	err = c.RunRefresh(cli, project, av)
+	if client.IsNoUpdatesAvailable(err) {
+		fmt.Fprintf(Stdout, "no updates available for %s\n", strutil.Quoted(av))
+		return nil
+	}
+	if err != nil {
 		return err
 	}
 

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -140,6 +140,7 @@ func (m *workshopRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
 func (m *workshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 	cmd := &CmdRefresh{root: &CmdRoot{}}
 	cmd.WaitOnError = true
+	cmd.Restore = true
 
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -158,7 +159,7 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "wait-on-error"}})
+				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "wait-on-error", "refresh-option": "restore"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 4:

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -499,6 +499,10 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	cmdrefresh.verbose = c.verbose
 
 	if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
+		// Nor other SDKs / definition, nor the sketch itself was changed.
+		if client.IsNoUpdatesAvailable(err) {
+			return nil
+		}
 		return err
 	}
 	fmt.Fprintf(Stdout, "%q sketch refreshed\n", wp.Name)

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -90,22 +90,22 @@ type SketchFile struct {
 }
 
 var sketchTemplate = `# Sketch SDK for %s
-# Sketch SDK provides local customisation of this specific workshop.
+# Sketch SDK provides local customization of this specific workshop.
 
-# To read more about the sketch SDK, its and syntax, see:
+# To read more about the sketch SDK and its syntax, see:
 # https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/sdks/#sketch-sdk
 name: sketch
 hooks:
-  # EXAMPLE: setup-base runs once at workshop launch, use it to install some packages.
+  # EXAMPLE: setup-base runs once at workshop launch; use it to install some packages.
   # setup-base: |
     # apt-get update
     # apt-get install PACKAGE...
     # snap install SNAP...
-  # EXAMPLE: setup-project runs after connecting plugs and slots, use it to install the project environment.
+  # EXAMPLE: setup-project runs after connecting plugs and slots; use it to install the project environment.
   # setup-project: |
     # go mod download
     # uv sync
-  # EXAMPLE: check-health runs after all SDK setup completes, call 'workshopctl set-health okay' for OK.
+  # EXAMPLE: check-health runs after entire SDK setup completes; run 'workshopctl set-health okay' if OK.
   # check-health: |
     # if CHECK_HEALTH_COMMAND ; then
     #   workshopctl set-health okay
@@ -113,7 +113,7 @@ hooks:
     #   workshopctl set-health --code=installation-failed error "Installation failed"
     # fi
 plugs:
-  # EXAMPLE: forward your SSH agent into the workshop enabling 'git push' inside the workshop.
+  # EXAMPLE: forward your SSH agent into the workshop, enabling 'git push' inside the workshop.
   # ssh-agent:
   #   interface: ssh-agent
   # EXAMPLE: expose well-known config file locations to the workshop
@@ -243,7 +243,7 @@ func ejectSketch(project, sketchdir string, name string) (*revert.Reverter, erro
 		return nil, err
 	}
 
-	// This won't be cleaned up on failure. In most cases the user
+	// This won't be cleaned up on failure. In most cases, the user
 	// is likely to retry the eject after fixing the underlying issue.
 	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 		return nil, err
@@ -439,7 +439,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		// Run refresh with the stashed sketch SDK. We do not revert dirs exchange
 		// on a failed refresh here as it is run with the content from "stored"
 		// and with --wait-on-error. Hence, there is always a possibility to
-		// workshop refresh --abort and workshop sketch-sdk --stash to restore the
+		// run 'workshop refresh --abort' and 'workshop sketch-sdk --stash' to restore the
 		// original stash content.
 		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
 			return err
@@ -499,7 +499,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	cmdrefresh.verbose = c.verbose
 
 	if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
-		// Nor other SDKs / definition, nor the sketch itself was changed.
+		// Neither other SDKs and definitions nor the sketch itself were changed.
 		if client.IsNoUpdatesAvailable(err) {
 			return nil
 		}

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -163,7 +163,7 @@ func (m *workshopSketch) mockSketchHappyRefreshPath(c *check.C, refreshname stri
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{refreshname}, "options": map[string]interface{}{"mode": mode}})
+				"names": []interface{}{refreshname}, "options": map[string]interface{}{"mode": mode, "refresh-option": "update"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 4:
@@ -413,8 +413,14 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode}})
+
+			if mode == "wait-on-error" {
+				c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
+					"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode, "refresh-option": "update"}})
+			} else {
+				c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
+					"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode}})
+			}
 			w.WriteHeader(202)
 			fmt.Fprintln(w, response)
 		case 4, 8, 10:
@@ -540,7 +546,7 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "transactional"}})
+				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "transactional", "refresh-option": "update"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 4:
@@ -793,7 +799,7 @@ func (m *workshopSketch) TestSketchSdkRemoveRevertOnFail(c *check.C) {
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "transactional"}})
+				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "transactional", "refresh-option": "update"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 4:

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -118,6 +118,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 func (s *apiSuite) TearDownTest(c *check.C) {
 	s.d = nil
 	s.workshopDir = ""
+	s.vars = nil
 	s.restoreMuxVars()
 	s.restoreRetrieve()
 	s.restoreProjectId()

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -25,7 +25,11 @@ import (
 )
 
 type actionOpts struct {
+	// Supported action modes: "transactional", "wait-on-error", "continue",
+	// "abort".
 	Mode string `json:"mode"`
+	// Supported refresh options: "update", "restore".
+	RefreshOption string `json:"refresh-option"`
 }
 
 type workshopReq struct {
@@ -405,11 +409,32 @@ func actionMode(reqData *workshopReq) (conflict.Mode, error) {
 	return mode, nil
 }
 
+func refreshOption(reqData *workshopReq) (conflict.RefreshOption, error) {
+	if reqData.Options.RefreshOption == "" {
+		reqData.Options.RefreshOption = "update"
+	}
+
+	return conflict.ParseRefreshSetting(reqData.Options.RefreshOption)
+}
+
 func refresh(ctx context.Context, st *state.State, mgr *workshopstate.WorkshopManager, reqData *workshopReq, user, pid string) (*state.Change, []*state.TaskSet, error) {
+	refreshOption, err := refreshOption(reqData)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	change := newWorkshopChange(st, "refresh", user, pid, reqData.Action, reqData.Names)
-	taskset, err := mgr.RefreshMany(ctx, pid, reqData.Names)
+	taskset, err := mgr.RefreshMany(ctx, pid, reqData.Names, refreshOption)
 
 	return change, taskset, err
+}
+
+var validActions = []string{
+	"launch",
+	"refresh",
+	"start",
+	"stop",
+	"remove",
 }
 
 func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
@@ -427,14 +452,6 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 
 	reqData.Names = strutil.Deduplicate(reqData.Names)
 
-	validActions := []string{
-		"launch",
-		"refresh",
-		"start",
-		"stop",
-		"remove",
-	}
-
 	if !slices.Contains(validActions, reqData.Action) {
 		return statusBadRequest(fmt.Sprintf("unknown action %q", reqData.Action))
 	}
@@ -442,6 +459,14 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	mode, err := actionMode(&reqData)
 	if err != nil {
 		return statusBadRequest("%w", err)
+	}
+
+	if reqData.Options.RefreshOption != "" && reqData.Action != "refresh" {
+		return statusBadRequest(`cannot %s: "refresh-option" is only valid for refresh actions`, reqData.Action)
+	}
+
+	if reqData.Options.RefreshOption != "" && (mode != conflict.ChangeTransactional && mode != conflict.ChangeWaitOnError) {
+		return statusBadRequest(`cannot %s: "refresh-option" is only applicable to "transactional" and "wait-on-error" modes; given: %q`, reqData.Action, mode)
 	}
 
 	user, ok := r.Context().Value(workshop.ContextUser).(string)
@@ -452,7 +477,6 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	st := c.d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	wsmgr := c.d.overlord.WorkshopManager()
 
 	var change *state.Change
 	var taskset []*state.TaskSet
@@ -460,6 +484,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	if mode.Resume() {
 		change, err = conflict.ResumeAfterWait(st, reqData.Names[0], projectId, mode, reqData.Action)
 	} else {
+		wsmgr := c.d.overlord.WorkshopManager()
 		switch reqData.Action {
 		case "launch":
 			change = newWorkshopChange(st, "launch", user, projectId, reqData.Action, reqData.Names)
@@ -494,7 +519,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 	if len(change.Tasks()) == 0 {
 		change.SetStatus(state.DoneStatus)
-		return WorkshopUnchanged()
+		return workshopUnchanged()
 	}
 
 	ensureStateSoon(st, 0)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -494,6 +494,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 	if len(change.Tasks()) == 0 {
 		change.SetStatus(state.DoneStatus)
+		return WorkshopUnchanged()
 	}
 
 	ensureStateSoon(st, 0)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -459,6 +459,7 @@ func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string) {
 	st.Lock()
 	change := st.Change(rsp.Change)
 	st.Unlock()
+	c.Assert(change, check.NotNil)
 	<-change.Ready()
 
 	st.Lock()
@@ -1622,7 +1623,7 @@ type expectedWorkshop struct {
 	slots       []string
 }
 
-func (s *apiSuite) ensureWorskhops(c *check.C, want []expectedWorkshop) {
+func (s *apiSuite) ensureWorkshops(c *check.C, want []expectedWorkshop) {
 	got, err := s.b.ProjectWorkshops(s.ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(got, check.HasLen, len(want), check.Commentf("expected %d workshops, got %d", len(want), len(got)))
@@ -1861,7 +1862,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "basic", []string{
 		"system",
@@ -1879,8 +1880,8 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		"mount-conflict",
 	})
 
-	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic})
-	s.checkRestoreCalls(c, "somebound", []string{}, []string{})
+	s.checkRestoreCalls(c, "basic", nil, nil)
+	s.checkRestoreCalls(c, "somebound", nil, nil)
 	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_allremoved})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "mount-conflict-1"})
@@ -1955,7 +1956,7 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "basic", []string{
 		"system",
@@ -2032,7 +2033,7 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2108,7 +2109,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2185,7 +2186,7 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 			"system:ssh-agent",
 		},
 	}}
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2275,7 +2276,7 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 			"system:ssh-agent",
 		},
 	}}
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2318,9 +2319,9 @@ func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
 
 	s.checkHookCalls(c, "manysdks", nil, nil)
 
-	// Refresh saves and restores state for intact SDKs
+	// Refresh saves and restores state for intact SDKs.
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options":{"mode":"transactional","refresh-option":"restore"}}`),
 	}
 	expected = []*expectedResp{
 		{
@@ -2346,11 +2347,11 @@ func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
 	})
 	s.b.ExecCalls = nil
 
-	// Refresh saves and restores state for updated SDKs
+	// Refresh saves and restores state for updated SDKs.
 	defer updateSdkStoreRev("test-sdk", 2, testsdk_r2)()
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options":{"mode":"transactional","refresh-option":"update"}}`),
 	}
 	expected = []*expectedResp{
 		{
@@ -2376,11 +2377,11 @@ func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
 	})
 	s.b.ExecCalls = nil
 
-	// Refresh doesn't save or restore state for removed SDKs
+	// Refresh doesn't save or restore state for removed SDKs.
 	s.createWFile(c, "manysdks", manysdks_minusone)
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options":{"mode":"transactional","refresh-option":"update"}}`),
 	}
 	expected = []*expectedResp{
 		{
@@ -2401,11 +2402,11 @@ func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
 	})
 	s.b.ExecCalls = nil
 
-	// Refresh doesn't save or restore state for installed SDKs
+	// Refresh doesn't save or restore state for newly installed SDKs.
 	s.createWFile(c, "manysdks", manysdks)
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options":{"mode":"transactional","refresh-option":"update"}}`),
 	}
 	expected = []*expectedResp{
 		{
@@ -2416,6 +2417,11 @@ func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
 		},
 	}
 	s.runActionTest(c, requests, expected)
+
+	wp, err := s.b.Workshop(s.ctx, "manysdks")
+	c.Assert(err, check.IsNil)
+	_, err = wp.SdkInfo(s.ctx, "test-sdk-2")
+	c.Assert(err, check.IsNil)
 
 	s.checkHookCalls(c, "manysdks", []string{
 		"test-sdk",
@@ -2476,7 +2482,7 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 			"system:ssh-agent",
 		},
 	}}
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
 	c.Assert(os.RemoveAll(workshop.TrySdkDir(userDataDir, "test-sdk")), check.IsNil)
@@ -2523,7 +2529,7 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 			"system:ssh-agent",
 		},
 	}}
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2586,7 +2592,7 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 			"system:ssh-agent",
 		},
 	}}
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	c.Assert(os.RemoveAll(workshop.ProjectSdkPath(s.project.Path, "test-sdk")), check.IsNil)
 	s.mockProjectSdk(c, "test-sdk", testsdk_r2)
@@ -2632,7 +2638,7 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 			"system:ssh-agent",
 		},
 	}}
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2710,7 +2716,7 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2788,7 +2794,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2859,7 +2865,7 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2935,7 +2941,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -2969,6 +2975,82 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 
 	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: "no updates available",
+			Kind:    string(errorKindNoUpdatesAvailable),
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+		},
+		plugs: []string{
+			"test-sdk:data",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
+		},
+		slots: []string{
+			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+
+	s.ensureWorkshops(c, want)
+
+	s.checkSnapshotCalls(c, "manysdks", []string{
+		"system",
+		"test-sdk",
+		"test-sdk-2",
+	})
+
+	s.checkRestoreCalls(c, "manysdks", nil, nil)
+
+	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1"})
+}
+
+func (s *apiSuite) TestRefreshRestore(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer func() { _ = s.d.Overlord().Stop() }()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options":{"mode":"transactional","refresh-option":"restore"}}`),
 	}
 	expected = []*expectedResp{
 		{
@@ -3009,7 +3091,7 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -3087,7 +3169,7 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -3160,7 +3242,7 @@ func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -3225,7 +3307,7 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "basic", []string{
 		"system",
@@ -3302,7 +3384,7 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	s.checkSnapshotCalls(c, "manysdks", []string{
 		"system",
@@ -3477,7 +3559,7 @@ func (s *apiSuite) TestRefreshAbort(c *check.C) {
 
 // Tests the input validation logic of v1PostProjectWorkshop. Excludes any
 // dispatch validation, these are covered by their own tests.
-func (s *apiSuite) TestValidateActionModeInputs(c *check.C) {
+func (s *apiSuite) TestValidateIncorrectActionModeInputs(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
@@ -3486,6 +3568,8 @@ func (s *apiSuite) TestValidateActionModeInputs(c *check.C) {
 		cmd    string
 		result map[string]string
 	}
+
+	s.vars = map[string]string{"id": s.project.ProjectId}
 
 	// Note we are explicitly testing the validation up until dispatch here. All
 	// error messages are desired. 'mode' errors represent an invalid
@@ -3546,16 +3630,17 @@ func (s *apiSuite) TestValidateActionModeInputs(c *check.C) {
 	}
 
 	for _, cmd := range cmds {
-		for mode, error := range cmd.result {
+		for mode, experr := range cmd.result {
 			// Construct request
-			req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workshops", strings.NewReader(fmt.Sprintf(`{"names":["basic"],"action":"%s", "options": {"mode":"%s"}}`, cmd.cmd, mode)))
+			body := strings.NewReader(fmt.Sprintf(`{"names":["basic"],"action":"%s", "options": {"mode":"%s"}}`, cmd.cmd, mode))
+			req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workshops", body)
 			c.Assert(err, check.IsNil)
 
 			// Construct response
 			exp := expectedResp{
 				Type:    ResponseTypeError,
 				Status:  http.StatusBadRequest,
-				Message: error,
+				Message: experr,
 			}
 
 			// Execute
@@ -3566,6 +3651,65 @@ func (s *apiSuite) TestValidateActionModeInputs(c *check.C) {
 			c.Check(rsp.Status, check.Equals, exp.Status)
 			c.Check(rsp.Result.(*errorResult).Message, check.Matches, exp.Message)
 		}
+	}
+}
+
+func (s *apiSuite) TestValidateIncorrectRefreshOption(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.vars = map[string]string{"id": s.project.ProjectId}
+
+	type table struct {
+		action string
+		mode   string
+		option string
+		result string
+	}
+
+	cmds := []table{
+		{
+			action: "refresh",
+			mode:   "continue",
+			option: "update",
+			result: `cannot refresh: "refresh-option" is only applicable to "transactional" and "wait-on-error" modes; given: "continue"`,
+		},
+		{
+			action: "refresh",
+			mode:   "abort",
+			option: "update",
+			result: `cannot refresh: "refresh-option" is only applicable to "transactional" and "wait-on-error" modes; given: "abort"`,
+		},
+		{
+			action: "launch",
+			mode:   "abort",
+			option: "update",
+			result: `cannot launch: "refresh-option" is only valid for refresh actions`,
+		},
+	}
+
+	for _, cmd := range cmds {
+		// Construct request
+		reqBody := strings.NewReader(fmt.Sprintf(`{"names":["basic"],"action":"%s", "options": {"mode":"%s","refresh-option":"%s"}}`, cmd.action, cmd.mode, cmd.option))
+		req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workshops", reqBody)
+		c.Assert(err, check.IsNil)
+
+		// Construct response
+		exp := expectedResp{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: cmd.result,
+		}
+
+		// Execute
+		rsp := v1PostProjectWorkshop(apiCmd("/v1/projects/{id}/workshops"), req, nil).(*resp)
+
+		// Validate
+		c.Check(rsp.Type, check.Equals, exp.Type)
+		c.Check(rsp.Status, check.Equals, exp.Status)
+		c.Check(rsp.Result.(*errorResult).Message, check.Matches, exp.Message)
+
 	}
 }
 
@@ -3847,7 +3991,7 @@ base: ubuntu@22.04
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 
 	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
 	sketchdir := workshop.SketchSdkCurrent(userDataDir, s.project.ProjectId, "manysdks")
@@ -3899,10 +4043,10 @@ plugs:
 		},
 	}}
 
-	s.ensureWorskhops(c, want)
+	s.ensureWorkshops(c, want)
 }
 
-func (s *apiSuite) TestRefreshPartialConflictChange(c *check.C) {
+func (s *apiSuite) TestRefreshConflictChange(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
@@ -3930,6 +4074,7 @@ base: ubuntu@22.04
 	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh", "options": {"mode":"transactional", "refresh-option":"restore"}}`),
 	}
 	expected = []*expectedResp{
 		{
@@ -3938,6 +4083,12 @@ base: ubuntu@22.04
 			Kind:      "refresh",
 			Summary:   `Refresh "manysdks" workshop`,
 			ChangeErr: `(?s).*\(SDK must be named "sketch" \(now: "illegal-sketch-name"\)\)`,
+		},
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot refresh "manysdks": waiting on error`,
+			Summary: `Refresh "manysdks" workshop`,
 		},
 		{
 			Type:    ResponseTypeError,

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -118,13 +118,14 @@ func (r *resp) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 type errorKind string
 
 const (
-	errorKindLoginRequired     = errorKind("login-required")
-	errorKindDaemonRestart     = errorKind("daemon-restart")
-	errorKindSystemRestart     = errorKind("system-restart")
-	errorKindNoDefaultServices = errorKind("no-default-services")
-	errorKindNotFound          = errorKind("not-found")
-	errorKindPermissionDenied  = errorKind("permission-denied")
-	errorKindGenericFileError  = errorKind("generic-file-error")
+	errorKindLoginRequired      = errorKind("login-required")
+	errorKindDaemonRestart      = errorKind("daemon-restart")
+	errorKindSystemRestart      = errorKind("system-restart")
+	errorKindNoDefaultServices  = errorKind("no-default-services")
+	errorKindNotFound           = errorKind("not-found")
+	errorKindPermissionDenied   = errorKind("permission-denied")
+	errorKindGenericFileError   = errorKind("generic-file-error")
+	errorKindNoUpdatesAvailable = errorKind("no-updates-available")
 )
 
 type errorValue interface{}
@@ -210,3 +211,12 @@ var (
 	statusNotImplemented   = makeErrorResponder(501)
 	statusGatewayTimeout   = makeErrorResponder(504)
 )
+
+func WorkshopUnchanged() Response {
+	res := &errorResult{Message: "no updates available", Kind: errorKindNoUpdatesAvailable}
+	return &resp{
+		Type:   ResponseTypeError,
+		Result: res,
+		Status: 400,
+	}
+}

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -212,7 +212,7 @@ var (
 	statusGatewayTimeout   = makeErrorResponder(504)
 )
 
-func WorkshopUnchanged() Response {
+func workshopUnchanged() Response {
 	res := &errorResult{Message: "no updates available", Kind: errorKindNoUpdatesAvailable}
 	return &resp{
 		Type:   ResponseTypeError,

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -43,6 +43,28 @@ func ParseMode(s string) (Mode, error) {
 	return -1, errors.New(`change mode must be any of: "transactional", "wait-on-error", "continue", "abort"`)
 }
 
+type RefreshOption int
+
+const (
+	RefreshUpdate RefreshOption = iota
+	RefreshRestore
+)
+
+func (s RefreshOption) String() string {
+	return [...]string{"update", "restore"}[s]
+}
+
+func ParseRefreshSetting(s string) (RefreshOption, error) {
+	refreshMap := map[string]RefreshOption{
+		RefreshUpdate.String():  RefreshUpdate,
+		RefreshRestore.String(): RefreshRestore,
+	}
+	if val, ok := refreshMap[s]; ok {
+		return val, nil
+	}
+	return -1, errors.New(`refresh behaviour must be any of: "update", "restore"`)
+}
+
 // ChangeConflictError represents an error because of snap conflicts between changes.
 type ChangeConflictError struct {
 	ProjectId  string

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -325,7 +325,7 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		st.Cache(vk, task.ReadyTime())
 		// We need to return here to give other competing cleanup tasks a chance
 		// to find out who was the last one to initiate the cleanup.
-		return &state.Retry{}
+		return fmt.Errorf("New cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), task.ReadyTime())
 	} else {
 		// Imagine the situation when a change with multiple tasks that use this
 		// volume is in progress. Every unregister-sdk task will initiate a
@@ -344,12 +344,14 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 			// We need to return here to give other competing cleanup tasks
 			// a chance to find out who was the last one to initiate the
 			// cleanup.
-			return &state.Retry{}
+			return fmt.Errorf("New cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), readyTime)
 		}
 	}
 
 	if time.Since(cooldownStart) < sdkVolumeCooldownTime {
-		return &state.Retry{}
+		remaining := sdkVolumeCooldownTime - time.Since(cooldownStart)
+		return fmt.Errorf("Cooldown period for %q SDK volume has not elapsed yet, time remaining: %s",
+			sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), remaining.Round(time.Second))
 	}
 
 	// Check if there are any tasks in progress that use the same SDK volume.
@@ -369,9 +371,9 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 	err = m.backend.DeleteVolume(ctx, sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
 	if err == nil || errors.Is(err, workshop.ErrVolumeInUse) {
 		if errors.Is(err, workshop.ErrVolumeInUse) {
-			logger.Debugf("On SdkManager.Cleanup: the %q volume is still in use, skip clean up", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+			logger.Debugf("On SdkManager.Cleanup: the %q SDK volume is still in use, skip clean up", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
 		} else {
-			logger.Debugf("On SdkManager.Cleanup: the %q volume was deleted", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
+			logger.Debugf("On SdkManager.Cleanup: the %q SDK volume was deleted", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
 		}
 		st.Cache(vk, nil)
 		return nil

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -325,7 +325,7 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		st.Cache(vk, task.ReadyTime())
 		// We need to return here to give other competing cleanup tasks a chance
 		// to find out who was the last one to initiate the cleanup.
-		return fmt.Errorf("New cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), task.ReadyTime())
+		return fmt.Errorf("new cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), task.ReadyTime())
 	} else {
 		// Imagine the situation when a change with multiple tasks that use this
 		// volume is in progress. Every unregister-sdk task will initiate a
@@ -344,13 +344,13 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 			// We need to return here to give other competing cleanup tasks
 			// a chance to find out who was the last one to initiate the
 			// cleanup.
-			return fmt.Errorf("New cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), readyTime)
+			return fmt.Errorf("new cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), readyTime)
 		}
 	}
 
 	if time.Since(cooldownStart) < sdkVolumeCooldownTime {
 		remaining := sdkVolumeCooldownTime - time.Since(cooldownStart)
-		return fmt.Errorf("Cooldown period for %q SDK volume has not elapsed yet, time remaining: %s",
+		return fmt.Errorf("cooldown period for %q SDK volume has not elapsed yet, time remaining: %s",
 			sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), remaining.Round(time.Second))
 	}
 

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
@@ -106,7 +107,7 @@ func (s *managerSuite) TestRefreshManyOK(c *check.C) {
 	s.launchWorkshopWithSDKs(c, "test-1", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 	s.launchWorkshopWithSDKs(c, "test-2", []workshop.SdkRecord{{Name: "test", Channel: "latest/stable"}})
 
-	_, err := s.manager.RefreshMany(s.ctx, s.project.ProjectId, []string{"test-1", "test-2"})
+	_, err := s.manager.RefreshMany(s.ctx, s.project.ProjectId, []string{"test-1", "test-2"}, conflict.RefreshUpdate)
 	c.Assert(err, check.IsNil)
 }
 
@@ -118,7 +119,7 @@ func (s *managerSuite) TestRefreshRequireStatusReady(c *check.C) {
 	err := s.backend.StopWorkshop(s.ctx, workshop2.Name, true)
 	c.Assert(err, check.IsNil)
 
-	_, err = s.manager.RefreshMany(s.ctx, s.project.ProjectId, []string{"test-1", "test-2"})
+	_, err = s.manager.RefreshMany(s.ctx, s.project.ProjectId, []string{"test-1", "test-2"}, conflict.RefreshUpdate)
 	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop not running`)
 }
 
@@ -130,6 +131,6 @@ func (s *managerSuite) TestRefreshRequireWorkshopExistence(c *check.C) {
 	err := s.backend.RemoveWorkshop(s.ctx, workshop2.Name, true)
 	c.Assert(err, check.IsNil)
 
-	_, err = s.manager.RefreshMany(s.ctx, s.project.ProjectId, []string{"test-1", "test-2"})
+	_, err = s.manager.RefreshMany(s.ctx, s.project.ProjectId, []string{"test-1", "test-2"}, conflict.RefreshUpdate)
 	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop not launched`)
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -586,7 +586,7 @@ func launch(st *state.State, file *workshop.File, fileText string, sdks []sdk.Se
 	return all
 }
 
-func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, names []string) ([]*state.TaskSet, error) {
+func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, names []string, option conflict.RefreshOption) ([]*state.TaskSet, error) {
 	username, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
 		return nil, fmt.Errorf("context key user not found")
@@ -602,45 +602,68 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 	if err != nil {
 		return nil, err
 	}
-	finder := localSdkFinder{
-		backend:     w.backend,
-		user:        usr,
-		userDataDir: userDataDir,
-		project:     project,
-	}
 
-	reqs, err := w.findAllStoreSdks(ctx, project, names, "refresh")
-	if err != nil {
-		return nil, err
-	}
-
-	taskset := make([]*state.TaskSet, 0, len(reqs))
+	taskset := make([]*state.TaskSet, 0, len(names))
 	allowed := []healthstate.Status{healthstate.ReadyStatus}
-	for _, req := range reqs {
-		name := req.file.Name
-		wp, err := w.Workshop(ctx, name, projectId)
+
+	switch option {
+	case conflict.RefreshUpdate:
+		reqs, err := w.findAllStoreSdks(ctx, project, names, "refresh")
 		if err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+			return nil, err
 		}
 
-		// Check for conflicting changes.
-		// Has to happen after calling findAllStoreSdks (because it unlocks the state).
-		if err := healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+		finder := localSdkFinder{
+			backend:     w.backend,
+			user:        usr,
+			userDataDir: userDataDir,
+			project:     project,
 		}
 
-		localSdks, err := finder.findLocalSdks(ctx, wp, req.file)
-		if err != nil {
-			return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
-		}
-		sdks := ordered(req.installOrder, req.storeSdks, localSdks)
-
-		plan := resolveRefresh(wp, req.file, sdks)
-		if plan.HasUpdates() {
-			tasks := refresh(w.state, plan, wp, req.file, req.fileText)
-			if len(tasks.Tasks()) == 0 {
-				continue
+		for _, req := range reqs {
+			name := req.file.Name
+			wp, err := w.Workshop(ctx, name, projectId)
+			if err != nil {
+				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 			}
+
+			// Check for conflicting changes. Has to happen after calling
+			// findAllStoreSdks (because it unlocks the state).
+			if err := healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+			}
+
+			localSdks, err := finder.findLocalSdks(ctx, wp, req.file)
+			if err != nil {
+				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+			}
+			sdks := ordered(req.installOrder, req.storeSdks, localSdks)
+
+			plan := resolveRefresh(wp, req.file, sdks)
+			if plan.HasUpdates() {
+				tasks := refresh(w.state, plan, wp, req.file, req.fileText)
+				taskset = append(taskset, tasks)
+			}
+		}
+	case conflict.RefreshRestore:
+		for _, name := range names {
+			wp, err := w.Workshop(ctx, name, projectId)
+			if err != nil {
+				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+			}
+
+			if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+			}
+
+			fileBlob, err := yaml.Marshal(wp.File)
+			if err != nil {
+				return nil, fmt.Errorf("cannot refresh %q: invalid workshop file: %w", name, err)
+			}
+
+			sdks := wp.SdksByInstallOrder()
+			plan := resolveRefresh(wp, wp.File, sdks)
+			tasks := refresh(w.state, plan, wp, wp.File, string(fileBlob))
 			taskset = append(taskset, tasks)
 		}
 	}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -635,11 +636,13 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 		sdks := ordered(req.installOrder, req.storeSdks, localSdks)
 
 		plan := resolveRefresh(wp, req.file, sdks)
-		tasks := refresh(w.state, plan, wp, req.file, req.fileText)
-		if len(tasks.Tasks()) == 0 {
-			continue
+		if plan.HasUpdates() {
+			tasks := refresh(w.state, plan, wp, req.file, req.fileText)
+			if len(tasks.Tasks()) == 0 {
+				continue
+			}
+			taskset = append(taskset, tasks)
 		}
-		taskset = append(taskset, tasks)
 	}
 
 	for _, ts := range taskset {
@@ -683,6 +686,10 @@ type refreshPlan struct {
 	sdkSnapshot    string
 	installOrder   []string
 	installedOrder []string
+
+	// Indicates if the Workshop definition was updated, i.e. if any new plugs,
+	// slots or connections were added.
+	workshopDefinitionUpdated bool
 }
 
 func (p refreshPlan) InstallOrRefresh() []sdk.Setup {
@@ -706,6 +713,10 @@ func (p refreshPlan) IntactOrRemove() []sdk.Setup {
 
 func (p refreshPlan) InstallIntactOrRefresh() []sdk.Setup {
 	return ordered(p.installOrder, p.install, p.refresh, p.intact)
+}
+
+func (p refreshPlan) HasUpdates() bool {
+	return len(p.InstallOrRefresh()) > 0 || len(p.remove) > 0 || p.workshopDefinitionUpdated
 }
 
 func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []sdk.Setup) *refreshPlan {
@@ -766,6 +777,9 @@ func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, candidates []s
 	for _, s := range candidates {
 		plan.installOrder = append(plan.installOrder, s.Name)
 	}
+
+	plan.workshopDefinitionUpdated = !reflect.DeepEqual(w.File.Sdks, newfile.Sdks) ||
+		!reflect.DeepEqual(w.File.Connections, newfile.Connections)
 
 	return plan
 }

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -27,7 +27,7 @@ execute: |
   echo "Check workshop refresh --no-wait"
   echo -e "sdks:\n  - name: test-sdk-health-waiting\n    channel: latest/stable" >> workshop.yaml
   workshop_exec refresh --no-wait
-  
+
   # The refresh process here takes about 10s. 
   # The hook check-health should fail four times before final success.
   # Check tests/lib/sdk/test-sdk-health-waiting/latest/stable/sdk/hooks/check-health for details
@@ -50,6 +50,9 @@ execute: |
 
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-sdk[[:space:]]+Ready[[:space:]]+-$"
+
+  echo "Check workshop refresh when no updates are available"
+  workshop_exec refresh ws-refresh-sdk | MATCH "no updates available for \"ws-refresh-sdk\""
 
   validate_snapshots() {
     local expected_output="$1"

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -9,11 +9,9 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Install empty sketch SDK"
-  output="$(sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
   q
   EOF
-  )"
-  [ -z "$output" ]
 
   workshop_exec info | grep -v notes | yq '.sdks["sketch"].tracking' | MATCH '^~/.local/share/workshop/id/.*/ws-sketch/sdk/sketch'
   workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
@@ -64,11 +62,9 @@ execute: |
   workshop_exec sketch-sdk --remove
 
   echo "Install empty sketch SDK"
-  output="$(sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
   q
   EOF
-  )"
-  [ -z "$output" ]
 
   echo "Add a breaking change to sketch"
   ! sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -9,9 +9,11 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Install empty sketch SDK"
-  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  output="$(sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
   q
   EOF
+  )"
+  [ -z "$output" ]
 
   workshop_exec info | grep -v notes | yq '.sdks["sketch"].tracking' | MATCH '^~/.local/share/workshop/id/.*/ws-sketch/sdk/sketch'
   workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
@@ -35,6 +37,15 @@ execute: |
 
   workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x2\)$'
 
+  echo "Check refresh is not run if no updates to the sketch"
+  output="$(sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  q
+  EOF
+  )"
+  [ -z "$output" ]
+  workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x2\)$'
+
+
   echo "Add a new mount"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
   1/^plugs:$/a
@@ -53,9 +64,11 @@ execute: |
   workshop_exec sketch-sdk --remove
 
   echo "Install empty sketch SDK"
-  sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
+  output="$(sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
   q
   EOF
+  )"
+  [ -z "$output" ]
 
   echo "Add a breaking change to sketch"
   ! sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF


### PR DESCRIPTION
# Description

* `workshop refresh` will skip the change if no updates to the SDKs, interface connections or the base were found by the resolver.

* `workshop refresh --restore` will restore the workshop from the latest snapshot made after the last successful setup-base run.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
