### PR TITLE
Fix parsing mount plug attributes from the state

### DIFF
--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -242,40 +243,56 @@ func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 	return nil
 }
 
-func (iface *mountInterface) setPlugAttrs(mount *workshop.Mount, plug *interfaces.ConnectedPlug) {
-	_ = plug.Attr("workshop-target", &mount.Where)
+func (iface *mountInterface) setPlugAttrs(mount *workshop.Mount, plug *interfaces.ConnectedPlug) error {
+	if err := plug.Attr("workshop-target", &mount.Where); err != nil {
+		return err
+	}
 	mount.MakeWhere = true
 
 	var value int64
-	_ = plug.Attr("mode", &value)
+	if err := plug.Attr("mode", &value); err != nil {
+		return err
+	}
 	mount.Mode = os.FileMode(value)
 
-	_ = plug.Attr("uid", &value)
+	if err := plug.Attr("uid", &value); err != nil {
+		return err
+	}
 	mount.Owner = sys.UserID(value)
 
-	_ = plug.Attr("gid", &value)
+	if err := plug.Attr("gid", &value); err != nil {
+		return err
+	}
 	mount.Group = sys.GroupID(value)
 
-	_ = plug.Attr("read-only", &mount.ReadOnly)
+	if err := plug.Attr("read-only", &mount.ReadOnly); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (iface *mountInterface) setRegularSlotAttrs(mount *workshop.Mount, slot *interfaces.ConnectedSlot) {
+func (iface *mountInterface) setRegularSlotAttrs(mount *workshop.Mount, slot *interfaces.ConnectedSlot) error {
 	mount.Type = workshop.WorkshopWorkshop
 
-	_ = slot.Attr("workshop-source", &mount.What)
+	return slot.Attr("workshop-source", &mount.What)
 }
 
-func (iface *mountInterface) setSystemSlotAttrs(mount *workshop.Mount, spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) {
+func (iface *mountInterface) setSystemSlotAttrs(mount *workshop.Mount, spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	mount.Type = workshop.HostWorkshop
 
+	var attrErr *sdk.AttributeNotFoundError
 	if err := slot.Attr("host-source", &mount.What); err == nil {
-		return
+		return nil
+	} else if !errors.As(err, &attrErr) {
+		return err
 	}
 
 	// default dir: <sdk>/<plug>
 	userDataDir := workshop.UserDataRootDir(spec.User.HomeDir, spec.Environment)
 	mount.What = workshop.SdkMountHostSource(userDataDir, slot.Sdk().ProjectId, slot.Sdk().Workshop, plug.Sdk().Name, plug.Name())
 	mount.MakeWhat = true
+	return nil
 }
 
 func (iface *mountInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
@@ -286,11 +303,19 @@ func (iface *mountInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo)
 // Interactions with the mount backend.
 func (iface *mountInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	mount := workshop.Mount{Name: plug.Name()}
-	iface.setPlugAttrs(&mount, plug)
+
+	if err := iface.setPlugAttrs(&mount, plug); err != nil {
+		return err
+	}
+
 	if slot.Sdk().Type == sdk.System {
-		iface.setSystemSlotAttrs(&mount, spec, plug, slot)
+		if err := iface.setSystemSlotAttrs(&mount, spec, plug, slot); err != nil {
+			return err
+		}
 	} else {
-		iface.setRegularSlotAttrs(&mount, slot)
+		if err := iface.setRegularSlotAttrs(&mount, slot); err != nil {
+			return err
+		}
 	}
 
 	return spec.AddMountEntry(mount)

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -501,6 +501,10 @@ plugs:
  mount:
   interface: mount
   workshop-target: /project/training
+  mode: 0
+  uid: 0
+  gid: 0
+  read-only: false
 `, s.projectId, "ws", "consumer", "mount")
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 
@@ -540,8 +544,10 @@ plugs:
   interface: mount
   workshop-target: /project/training
   mode: 0o755
-  uid: 123
+  # Use float to simulate passing through the state
+  uid: 123.0
   gid: 321
+  read-only: false
 `, s.projectId, "ws", "consumer", "mount")
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 
@@ -583,6 +589,10 @@ plugs:
  mount:
   interface: mount
   workshop-target: /project/training
+  mode: 0
+  uid: 0
+  gid: 0
+  read-only: false
 `, s.projectId, "ws", "consumer", "mount")
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -182,8 +182,10 @@ func prepareMount(fs fsutil.Fs, user *user.User, mnt workshop.Mount) error {
 }
 
 func prepareHostWorkshopMount(fs fsutil.Fs, user *user.User, mnt workshop.Mount) error {
-	whatIsDir := true
-	if mnt.MakeWhat {
+	info, err := os.Stat(mnt.What)
+	isDir := err == nil && info.IsDir()
+
+	if mnt.MakeWhat && !isDir {
 		uid, gid, err := osutil.UidGid(user)
 		if err != nil {
 			return err
@@ -196,19 +198,16 @@ func prepareHostWorkshopMount(fs fsutil.Fs, user *user.User, mnt workshop.Mount)
 		if err := os.Chmod(mnt.What, mnt.Mode); err != nil {
 			return err
 		}
-	} else {
-		info, err := os.Stat(mnt.What)
-		if err != nil {
-			return err
-		}
-		whatIsDir = info.IsDir()
+		isDir = true
+	} else if err != nil {
+		return err
 	}
 
-	return prepareMountWhere(fs, mnt, whatIsDir)
+	return prepareMountWhere(fs, mnt, isDir)
 }
 
 func prepareWorkshopWorkshopMount(fs fsutil.Fs, mnt workshop.Mount) error {
-	whatIsDir := true
+	isDir := true
 	if mnt.MakeWhat {
 		if err := fs.MkdirAllChmodChown(mnt.What, mnt.Mode, int(mnt.Owner), int(mnt.Group)); err != nil {
 			return err
@@ -218,18 +217,18 @@ func prepareWorkshopWorkshopMount(fs fsutil.Fs, mnt workshop.Mount) error {
 		if err != nil {
 			return err
 		}
-		whatIsDir = info.IsDir()
+		isDir = info.IsDir()
 	}
 
-	return prepareMountWhere(fs, mnt, whatIsDir)
+	return prepareMountWhere(fs, mnt, isDir)
 }
 
-func prepareMountWhere(fs fsutil.Fs, mnt workshop.Mount, whatIsDir bool) error {
+func prepareMountWhere(fs fsutil.Fs, mnt workshop.Mount, isDir bool) error {
 	if !mnt.MakeWhere {
-		return checkMountWhere(fs, mnt, whatIsDir)
+		return checkMountWhere(fs, mnt, isDir)
 	}
 
-	if whatIsDir {
+	if isDir {
 		return fs.MkdirAllChmodChown(mnt.Where, mnt.Mode, int(mnt.Owner), int(mnt.Group))
 	}
 
@@ -240,7 +239,7 @@ func prepareMountWhere(fs fsutil.Fs, mnt workshop.Mount, whatIsDir bool) error {
 
 	file, err := fs.OpenFile(mnt.Where, os.O_RDWR|os.O_CREATE|os.O_EXCL, mnt.Mode)
 	if errors.Is(err, os.ErrExist) {
-		return checkMountWhere(fs, mnt, whatIsDir)
+		return checkMountWhere(fs, mnt, isDir)
 	}
 	if err != nil {
 		return err
@@ -253,9 +252,9 @@ func prepareMountWhere(fs fsutil.Fs, mnt workshop.Mount, whatIsDir bool) error {
 	return file.Chown(int(mnt.Owner), int(mnt.Group))
 }
 
-func checkMountWhere(fs fsutil.Fs, mnt workshop.Mount, whatIsDir bool) error {
+func checkMountWhere(fs fsutil.Fs, mnt workshop.Mount, isDir bool) error {
 	info, err := fs.Stat(mnt.Where)
-	if err != nil || info.IsDir() == whatIsDir {
+	if err != nil || info.IsDir() == isDir {
 		return err
 	}
 	err = syscall.ENOTDIR

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -131,12 +131,17 @@ plugs:
     one:
         interface: mount
         workshop-target: /opt
+        mode: 0
+        uid: 0
+        gid: 0
+        read-only: false
     two:
         interface: mount
         workshop-target: /mnt/a/b
         mode: 0o777
         uid: 0
         gid: 100
+        read-only: false
     ssh-agent:
         interface: ssh-agent
     desktop:

--- a/internal/metautil/type_conversions.go
+++ b/internal/metautil/type_conversions.go
@@ -22,6 +22,7 @@ package metautil
 import (
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 )
 
@@ -38,7 +39,7 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 			break
 		}
 		outputValue := reflect.MakeSlice(outputType, 0, value.Len())
-		for i := 0; i < value.Len(); i++ {
+		for i := range value.Len() {
 			convertedElem, err := convertValue(value.Index(i), outputType.Elem())
 			if err != nil {
 				return nullValue, err
@@ -66,15 +67,32 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 			outputValue.SetMapIndex(convertedKey, convertedValue)
 		}
 		return outputValue, nil
+	case reflect.Float64:
+		// Special case: encoding/json can mangle int64 -> float64.
+		v, ok := maybeFloatToInt(value.Float())
+		// Recall that -0.0 == 0.0 in Go (and IEEE 754).
+		if ok && outputType.Kind() == reflect.Int64 {
+			return reflect.ValueOf(int64(v)), nil
+		}
 	}
 	return nullValue, fmt.Errorf(`cannot convert value "%v" into a %v`, value, outputType)
+}
+
+func maybeFloatToInt(v float64) (int64, bool) {
+	if _, frac := math.Modf(v); frac != 0 {
+		return 0, false
+	}
+	if v < float64(math.MinInt64) || v > float64(math.MaxInt64) {
+		return 0, false
+	}
+	return int64(v), true
 }
 
 // SetValueFromAttribute attempts to convert the attribute value read from the
 // given sdk/interface into the desired type. This function only
 // operates converting the attrVal parameter into a value which can fit into
 // the val parameter, which therefore must be a pointer.
-func SetValueFromAttribute(attrVal interface{}, val interface{}) error {
+func SetValueFromAttribute(attrVal any, val any) error {
 	rt := reflect.TypeOf(val)
 	if rt.Kind() != reflect.Ptr || val == nil {
 		return errors.New("internal error: value must be a pointer")

--- a/internal/metautil/type_conversions_test.go
+++ b/internal/metautil/type_conversions_test.go
@@ -20,6 +20,7 @@
 package metautil_test
 
 import (
+	"math"
 	"reflect"
 
 	. "gopkg.in/check.v1"
@@ -40,6 +41,10 @@ func (s *conversionssSuite) TestConvertHappy(c *C) {
 		{"a string", "a string"},
 		{42, 42},
 		{true, true},
+
+		// Special case of float64 -> int64.
+		{float64(42.0), int64(42)},
+		{float64(-42.0), int64(-42)},
 
 		// Complex types with no conversion
 		{[]string{"one", "two"}, []string{"one", "two"}},
@@ -74,6 +79,11 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 		// Basic types
 		{"a string", t(42), `cannot convert value "a string" into a int`},
 		{true, t(""), `cannot convert value "true" into a string`},
+
+		// Special case of float64 -> int64.
+		{float64(4.2), t(int64(0)), `cannot convert value "4.2" into a int64`},
+		{math.Nextafter(math.MinInt64, math.Inf(-1)), t(int64(0)), `cannot convert value "-[0-9.]*e\+18" into a int64`},
+		{math.Nextafter(math.MaxInt64, math.Inf(1)), t(int64(0)), `cannot convert value "[0-9.]*e\+18" into a int64`},
 
 		// Complex types
 		{[]interface{}{"one", "two", 3}, t([]string{}), `cannot convert value "3" into a string`},


### PR DESCRIPTION
# Description

Some tasks use plug and slot attributes from the state rather than the interface repository. These attributes can be mangled because JSON doesn't have a notion of integers (and they are deserialised into a `map[string]any`).

When undoing a failed refresh for a workshop with an auto-connected mount plug, the original connection is restored incorrectly. The mount interface ignored errors relating to float to int conversions, resulting in the `mode`, `uid` and `gid` attributes being zero, when they should have been more reasonable defaults. Ultimately this can cause permission issues when trying to read or write files in the mounted directory.

For now, this fix allows `float64 -> int64` conversions if they are safe. The mount interface will also report these errors, since we clearly can't rely on them being impossible (but I still think they are, currently).

Also, I don't think the mount interface should have been modifying the directory anyway, since it already existed. Although maybe you could argue that an updated mode should be reflected on refresh (this is automatic for the actual target because it goes away when restoring the snapshot).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
