### PR TITLE
Unify error reporting for launch, refresh and sketch changes

### DIFF
--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -118,28 +119,23 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	if _, err := c.wait(cli, changeId); err != nil {
-		if err == errNoWait {
-			return nil
-		}
-		if err == errWaitOnError {
-			w := workshopName(av[0])
-			return fmt.Errorf(`cannot complete launch for %q, execution is paused
+	_, err = c.wait(cli, changeId)
+
+	switch {
+	case err == nil:
+		fmt.Fprintf(Stdout, "%s launched\n", strutil.Quoted(av))
+	case errors.Is(err, errNoWait):
+	case errors.Is(err, errUndone):
+		fmt.Fprintf(Stdout, "%s launch aborted\n", strutil.Quoted(av))
+	case errors.Is(err, errWaitOnError):
+		w := workshopName(av[0])
+		return fmt.Errorf(`cannot complete launch for %q, execution is paused
 
 To proceed, resolve the issue and run 'workshop launch --continue %s'
 To cancel and undo: 'workshop launch --abort %s'
 To view more information: 'workshop tasks %s'`, w, w, w, changeId)
-		}
+	default:
 		return fmt.Errorf("%v\n%s launch aborted", err, strutil.Quoted(av))
-	}
-
-	if c.Abort {
-		fmt.Fprintf(Stdout, "%q launch aborted\n", av[0])
-		return nil
-	}
-
-	for _, i := range av {
-		fmt.Fprintf(Stdout, "%q launched\n", i)
 	}
 
 	return nil

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -53,7 +53,7 @@ func (m *workshopLaunch) TestLaunchSuccess(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1", "ws"})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, `"ws" launched\n"ws-1" launched\n`)
+	c.Assert(m.stdout.String(), check.Matches, `"ws", "ws-1" launched\n`)
 }
 
 func (m *workshopLaunch) TestLaunchWaitOnErrorFailed(c *check.C) {

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -103,7 +104,7 @@ func workshopName(name string) string {
 	return name
 }
 
-func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av []string) error {
+func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av []string) (*client.Change, error) {
 	mode := "transactional"
 	if c.WaitOnError {
 		mode = "wait-on-error"
@@ -125,25 +126,10 @@ func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av 
 
 	changeId, err := cli.Refresh(project.Id, av, mode, option)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err := c.wait(cli, changeId); err != nil {
-		if err == errNoWait {
-			return nil
-		}
-		if err == errWaitOnError {
-			w := workshopName(av[0])
-			return fmt.Errorf(`cannot complete refresh for %q, execution is paused
-
-To proceed, resolve the issue and run 'workshop refresh --continue %s'
-To cancel and undo: 'workshop refresh --abort %s'
-To view more information: 'workshop tasks %s'`, w, w, w, changeId)
-		}
-
-		return fmt.Errorf("%v\n%s refresh aborted", err, strutil.Quoted(av))
-	}
-	return nil
+	return c.wait(cli, changeId)
 }
 
 func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
@@ -166,22 +152,26 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		av = []string{name}
 	}
 
-	err = c.RunRefresh(cli, project, av)
-	if client.IsNoUpdatesAvailable(err) {
+	chg, err := c.RunRefresh(cli, project, av)
+
+	switch {
+	case err == nil:
+		fmt.Fprintf(Stdout, "%s refreshed\n", strutil.Quoted(av))
+	case errors.Is(err, errNoWait):
+	case client.IsNoUpdatesAvailable(err):
 		fmt.Fprintf(Stdout, "no updates available for %s\n", strutil.Quoted(av))
-		return nil
-	}
-	if err != nil {
-		return err
+	case errors.Is(err, errUndone):
+		fmt.Fprintf(Stdout, "%s refresh aborted\n", strutil.Quoted(av))
+	case errors.Is(err, errWaitOnError):
+		w := workshopName(av[0])
+		return fmt.Errorf(`cannot complete refresh for %q, execution is paused
+
+To proceed, resolve the issue and run 'workshop refresh --continue %s'
+To cancel and undo: 'workshop refresh --abort %s'
+To view more information: 'workshop tasks %s'`, w, w, w, chg.ID)
+	default:
+		return fmt.Errorf("%v\n%s refresh aborted", err, strutil.Quoted(av))
 	}
 
-	if c.Abort {
-		fmt.Fprintf(Stdout, "%q refresh aborted\n", av[0])
-		return nil
-	}
-
-	for _, i := range av {
-		fmt.Fprintf(Stdout, "%q refreshed\n", i)
-	}
 	return nil
 }

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -25,7 +25,7 @@ var mockSingleWorkshopJSON = `{"type":"sync","status-code":200,"status":"OK","re
 }}`
 
 var mockReadyChangeJSON = `{"type": "sync", "result":{
-    "id":   "four",
+    "id":   "42",
     "kind": "refresh",
     "summary": "...",
     "status": "Done",
@@ -36,7 +36,18 @@ var mockReadyChangeJSON = `{"type": "sync", "result":{
 }}`
 
 var mockWaitChangeJSON = `{"type": "sync", "result":{
-    "id":   "four",
+    "id":   "42",
+    "kind": "refresh",
+    "summary": "...",
+    "status": "Wait",
+    "ready": false,
+    "spawn-time": "2015-02-21T01:02:03Z",
+    "ready-time": "2015-02-21T01:02:04Z",
+    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Wait", "progress": {"done": 1, "total": 1}, "spawn-time": "2015-02-21T01:02:03Z", "ready-time": "2015-02-21T01:02:04Z"}]
+}}`
+
+var mockSketchWaitChangeJSON = `{"type": "sync", "result":{
+    "id":   "43",
     "kind": "refresh",
     "summary": "...",
     "status": "Wait",
@@ -47,7 +58,18 @@ var mockWaitChangeJSON = `{"type": "sync", "result":{
 }}`
 
 var mockAbortedChangeJSON = `{"type": "sync", "result":{
-    "id":   "four",
+    "id":   "42",
+    "kind": "refresh",
+    "summary": "...",
+    "status": "Undone",
+    "ready": true,
+    "spawn-time": "2015-02-21T01:02:03Z",
+    "ready-time": "2015-02-21T01:02:04Z",
+    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Undone", "progress": {"done": 1, "total": 1}, "spawn-time": "2015-02-21T01:02:03Z", "ready-time": "2015-02-21T01:02:04Z"},{"kind": "foo", "summary": "some summary", "status": "Hold", "progress": {"done": 1, "total": 1}, "spawn-time": "2015-02-21T01:02:03Z", "ready-time": "2015-02-21T01:02:04Z" , "log":["2015-02-21T01:02:03Z INFO Aborting for workshop \"ws\"..."], "data":{"workshop":"ws"}}]
+}}`
+
+var mockSketchAbortedChangeJSON = `{"type": "sync", "result":{
+    "id":   "43",
     "kind": "refresh",
     "summary": "...",
     "status": "Undone",
@@ -58,7 +80,7 @@ var mockAbortedChangeJSON = `{"type": "sync", "result":{
 }}`
 
 var mockChangeWithError = `{"type": "sync", "result":{
-    "id":   "four",
+    "id":   "42",
     "kind": "refresh",
     "summary": "...",
     "status": "Error",

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -358,6 +358,23 @@ func hideSketch(sketchdir string) (string, *revert.Reverter, error) {
 	return temp, clone, nil
 }
 
+func handleSketchRefreshErrors(wp string, chg *client.Change, err error) error {
+	switch {
+	case client.IsNoUpdatesAvailable(err):
+	case errors.Is(err, errUndone):
+		fmt.Fprintf(Stdout, "%q sketch refresh aborted\n", wp)
+	case errors.Is(err, errWaitOnError):
+		return fmt.Errorf(`cannot complete sketch refresh for %q, execution is paused
+
+To proceed, resolve the issue and run 'workshop refresh --continue %s'
+To cancel and undo: 'workshop refresh --abort %s'
+To view more information: 'workshop tasks %s'`, wp, wp, wp, chg.ID)
+	default:
+		return fmt.Errorf("%v\n%s sketch refresh aborted", err, wp)
+	}
+	return nil
+}
+
 func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	if c.name != "" && !c.eject {
 		return errors.New("flag --name requires --eject")
@@ -389,8 +406,11 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	if wp.Status == "Waiting" {
 		fmt.Fprintf(Stdout, "Reverting incomplete change for %q...\n", wp.Name)
 		cmdabort := &CmdRefresh{root: c.root, Abort: true}
-		if err = cmdabort.RunRefresh(cli, p, []string{wp.Name}); err != nil {
-			return err
+		// Skip the Undone status as this is desired; we will continue with the
+		// regular sketch SDK flow afterwards.
+		chg, err := cmdabort.RunRefresh(cli, p, []string{wp.Name})
+		if err != nil && !errors.Is(err, errUndone) {
+			return handleSketchRefreshErrors(wp.Name, chg, err)
 		}
 	} else if wp.Status != "Ready" {
 		return fmt.Errorf(`cannot sketch: workshop %q currently %q, must be "Ready"`, wp.Name, wp.Status)
@@ -415,10 +435,11 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 		cmdrefresh := &CmdRefresh{root: c.root}
 		cmdrefresh.verbose = c.verbose
-		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
+		chg, err := cmdrefresh.RunRefresh(cli, p, []string{wp.Name})
+		if err != nil {
 			// Refresh failed, revert the stash operation so a possible subsequent
 			// refresh won't fail due to the lack of a sketch SDK definition.
-			return err
+			return handleSketchRefreshErrors(wp.Name, chg, err)
 		}
 		fmt.Fprintf(Stdout, "%q sketch stashed\n", wp.Name)
 		reverter.Success()
@@ -441,8 +462,9 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		// and with --wait-on-error. Hence, there is always a possibility to
 		// run 'workshop refresh --abort' and 'workshop sketch-sdk --stash' to restore the
 		// original stash content.
-		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
-			return err
+		chg, err := cmdrefresh.RunRefresh(cli, p, []string{wp.Name})
+		if err != nil {
+			return handleSketchRefreshErrors(wp.Name, chg, err)
 		}
 		fmt.Fprintf(Stdout, "%q sketch restored\n", wp.Name)
 		return nil
@@ -470,8 +492,9 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 
 		cmdrefresh := &CmdRefresh{root: c.root}
 		cmdrefresh.verbose = c.verbose
-		if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
-			return err
+		chg, err := cmdrefresh.RunRefresh(cli, p, []string{wp.Name})
+		if err != nil {
+			return handleSketchRefreshErrors(wp.Name, chg, err)
 		}
 
 		reverter.Success()
@@ -498,12 +521,9 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	cmdrefresh.WaitOnError = true
 	cmdrefresh.verbose = c.verbose
 
-	if err = cmdrefresh.RunRefresh(cli, p, []string{wp.Name}); err != nil {
-		// Neither other SDKs and definitions nor the sketch itself were changed.
-		if client.IsNoUpdatesAvailable(err) {
-			return nil
-		}
-		return err
+	chg, err := cmdrefresh.RunRefresh(cli, p, []string{wp.Name})
+	if err != nil {
+		return handleSketchRefreshErrors(wp.Name, chg, err)
 	}
 	fmt.Fprintf(Stdout, "%q sketch refreshed\n", wp.Name)
 	return nil

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -428,9 +428,9 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/changes/%d", change))
 			switch n {
 			case 4:
-				fmt.Fprintln(w, mockWaitChangeJSON)
+				fmt.Fprintln(w, mockSketchWaitChangeJSON)
 			case 8:
-				fmt.Fprintln(w, mockAbortedChangeJSON)
+				fmt.Fprintln(w, mockSketchAbortedChangeJSON)
 			case 10:
 				fmt.Fprintln(w, mockReadyChangeJSON)
 			}
@@ -466,7 +466,7 @@ hooks:
 	defer restore()
 
 	err := cmd.Run(cmd.Command(), []string{"ws"})
-	c.Assert(err, check.ErrorMatches, "cannot complete refresh for \"ws\", execution is paused\n\n"+
+	c.Assert(err, check.ErrorMatches, "cannot complete sketch refresh for \"ws\", execution is paused\n\n"+
 		"To proceed, resolve the issue and run 'workshop refresh --continue ws'\n"+
 		"To cancel and undo: 'workshop refresh --abort ws'\n"+
 		"To view more information: 'workshop tasks 43'")

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -27,8 +27,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/canonical/x-go/i18n"
-
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/progress"
 )
@@ -48,6 +46,7 @@ type waitMixin struct {
 
 var errNoWait = errors.New("no wait for op")
 var errWaitOnError = errors.New("wait-on-error")
+var errUndone = errors.New("change undone")
 
 //nolint:unparam // Copied from snapd.
 func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error) {
@@ -71,6 +70,7 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		if sig == nil || wmx.skipAbort {
 			return
 		}
+
 		_, err := cli.Abort(id)
 		if err != nil {
 			fmt.Fprintf(Stderr, "%v\n", err)
@@ -114,7 +114,7 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 			if now.After(tMax) {
 				return nil, err
 			}
-			pb.Spin(i18n.G("Waiting for server to restart"))
+			pb.Spin("Waiting for server to restart")
 			time.Sleep(pollTime)
 			continue
 		}
@@ -135,7 +135,7 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		// the messages: "Task set to wait until a manual system restart allows to continue"
 		for _, t := range chg.Tasks {
 			if t.Status == "Wait" {
-				return nil, errWaitOnError
+				return chg, errWaitOnError
 			}
 		}
 
@@ -160,11 +160,14 @@ func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error)
 		}
 
 		if chg.Ready {
-			if chg.Status == "Error" {
-				if chg.Err != "" {
-					return chg, errors.New(chg.Err)
-				}
-				return chg, errors.New(i18n.G(`change finished in status "Error" with no error message`))
+			if chg.Err != "" {
+				return chg, errors.New(chg.Err)
+			}
+			if chg.Status == "Undone" {
+				return chg, errUndone
+			}
+			if chg.Status != "Done" && chg.Err == "" {
+				return chg, fmt.Errorf(`change finished in status %q with no error message`, chg.Status)
 			}
 			return chg, nil
 		}


### PR DESCRIPTION
# Description

- Make error reporting for `refresh`, `launch` and `sketch-sdk` consistent in cases when the progress is aborted. Earlier, if the change became 'Undone' after Ctrl+C it either reported the results as an aborted change or just finished silently.
- Fix reporting for the `sketch-sdk` command if sketch refresh was interrupted.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
