### PR TITLE
Add pack to bare snapcraft and sdkcraft commands

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -8,7 +8,7 @@ environment:
   SDK_STORE_BUCKET_DIR: /data/sdkstore
   IMAGE_SERVER: $(HOST:echo -n $WORKSHOP_IMAGE_SERVER)
 repack: |
-  test -f tests/workshop*.snap || snapcraft -o tests/
+  test -f tests/workshop*.snap || snapcraft pack -o tests/
   cat <&3 >&4
 backends:
   lxd:

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -467,7 +467,7 @@ Under :file:`ollama/`, run:
 
 .. code-block:: console
 
-   $ sdkcraft
+   $ sdkcraft pack
 
 
 .. @artefact SDK part
@@ -489,7 +489,7 @@ Optionally, you can clean the build cache before a build attempt:
 
 .. code-block:: console
 
-   $ sdkcraft clean && sdkcraft
+   $ sdkcraft clean && sdkcraft pack
 
 
 .. @artefact SDK metadata

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -2,7 +2,11 @@
 
 # disable check for relative dir following
 # shellcheck disable=SC1091
-. "$SNAP/snap/lib/lxc-utils"
+if [ -n "${SNAP}" ]; then
+    . "$SNAP/snap/lib/lxc-utils"
+else
+    . "$(dirname -- "$0")/../lib/lxc-utils"
+fi
 
 # The workshop services are stopped by the moment the remove
 # hook is called. Therefore, for now, we walk the LXD projects created

--- a/snap/local/lib/lxc-utils
+++ b/snap/local/lib/lxc-utils
@@ -37,8 +37,10 @@ remove_images() {
 }
 
 remove_network() {
-    echo "Removing network: workshopbr0"
-    run_lxc network delete workshopbr0
+    if run_lxc network info workshopbr0 >/dev/null 2>&1; then
+        echo "Removing network: workshopbr0"
+        run_lxc network delete workshopbr0
+    fi
 }
 
 remove_project() {

--- a/tests/documentation/tutorial/task.yaml
+++ b/tests/documentation/tutorial/task.yaml
@@ -129,4 +129,4 @@ execute: |
   mkdir hooks
   mv ../{setup-base,save-state,restore-state,check-health} hooks/
   run_sdkcraft clean
-  run_sdkcraft
+  run_sdkcraft pack


### PR DESCRIPTION
# Description

Craft tools are deprecating default commands soon. We should switch to avoid unnecessary warnings. I also changed a few things in the snap remove hook, because I used to run it manually sometimes and that doesn't work at the moment.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
