### PR TITLE
Add write permissions to the system SDK files and directories

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Generate CLI reference docs
         run: go run ./cmd/workshop generate-docs ./docs/reference/cli

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: false
       - name: Download Workshop Snap
         uses: actions/download-artifact@master

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Build
         run: go build -v ./...
@@ -32,7 +32,7 @@ jobs:
       - name: Setup
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Check for races
         run: go test -race ./...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.2.1
+    rev: v2.5.0
     hooks:
       - id: golangci-lint
       - id: golangci-lint

--- a/docs/examples/go-sdk.yaml
+++ b/docs/examples/go-sdk.yaml
@@ -4,7 +4,7 @@ title: Go SDK
 summary: The Go programming language
 description: |
   Go is an open source programming language that enables the production of simple, efficient and reliable software at scale.
-version: "1.24.6"
+version: "1.25.1"
 license: LGPL-2.1
 platforms:
   amd64:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/workshop
 
-go 1.24.4
+go 1.25.2
 
 require (
 	cloud.google.com/go/storage v1.37.0

--- a/internal/fsutil/fs.go
+++ b/internal/fsutil/fs.go
@@ -111,11 +111,10 @@ func (f Fs) MkdirAllChmodChown(path string, perm os.FileMode, uid, gid int) erro
 }
 
 func parentDir(path string) string {
-	idx := strings.LastIndexFunc(path, func(r rune) bool { return r != os.PathSeparator })
-	idx = max(idx, 0)
-	idx = strings.LastIndexByte(path[:idx], os.PathSeparator)
-	idx = max(idx, 0)
-	return path[:idx]
+	path = strings.TrimRight(path, string(os.PathSeparator))
+	path = strings.TrimRightFunc(path, func(r rune) bool { return r != os.PathSeparator })
+	path = strings.TrimRight(path, string(os.PathSeparator))
+	return path
 }
 
 // MkdirTemp is like os.MkdirTemp, but it treats an empty dir as the current directory.

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -301,12 +301,12 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 		c.Assert(err, check.IsNil)
 
 		info := hdr.FileInfo()
+		entry := fmt.Sprintf("%s %s", info.Mode(), hdr.Name)
+		entries = append(entries, entry)
+
 		if info.IsDir() {
 			continue
 		}
-
-		entry := fmt.Sprintf("%s %s", info.Mode().Perm(), hdr.Name)
-		entries = append(entries, entry)
 
 		r, err := system.SystemSdkFs.Open(hdr.Name)
 		c.Assert(err, check.IsNil)
@@ -314,7 +314,7 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 		r.Close()
 	}
 
-	c.Check(entries, check.DeepEquals, []string{"-r--r--r-- meta/sdk.yaml"})
+	c.Check(entries, check.DeepEquals, []string{"drwxr-xr-x meta/", "-rw-r--r-- meta/sdk.yaml"})
 }
 
 func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"maps"
 	"os"
 	"os/user"
@@ -256,6 +255,7 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (sdk.R
 	if err != nil {
 		return sdk.Revision{}, fmt.Errorf("SDK %q not found: %w", "try-"+sk, err)
 	}
+	defer root.Close()
 
 	file, filename, err := findTrySdkFile(root, sk, arch.DpkgArchitecture(), base)
 	if err != nil {
@@ -347,15 +347,13 @@ func findTrySdkFile(root *os.Root, sk, arch, base string) (*os.File, string, err
 }
 
 func readTrySdkMetadata(root *os.Root, filename string) (string, string, error) {
-	fs := root.FS().(fs.ReadFileFS)
-
-	content, err := fs.ReadFile(filename + ".sha3-384")
+	content, err := root.ReadFile(filename + ".sha3-384")
 	if err != nil {
 		return "", "", prependRootPath(root, err)
 	}
 	digest := strings.TrimSpace(string(content))
 
-	content, err = fs.ReadFile(filename + ".yaml")
+	content, err = root.ReadFile(filename + ".yaml")
 	if err != nil {
 		return "", "", prependRootPath(root, err)
 	}

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -3,7 +3,10 @@ package system
 import (
 	"archive/tar"
 	"embed"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 
 	"github.com/canonical/workshop/internal/logger"
@@ -58,7 +61,7 @@ func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) error {
 	})
 
 	writer := tar.NewWriter(file)
-	if err := writer.AddFS(SystemSdkFs); err != nil {
+	if err := addWritableFS(writer, SystemSdkFs); err != nil {
 		return err
 	}
 	if err := writer.Close(); err != nil {
@@ -78,6 +81,61 @@ func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) error {
 
 	r.Success()
 	return nil
+}
+
+// Like w.AddFs(fsys) but ensures the user always has write permissions.
+func addWritableFS(w *tar.Writer, fsys fs.FS) error {
+	return fs.WalkDir(fsys, ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if name == "." {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		typ := d.Type()
+		linkTarget := ""
+		if typ == fs.ModeSymlink {
+			var err error
+			linkTarget, err = fs.ReadLink(fsys, name)
+			if err != nil {
+				return err
+			}
+		} else if !typ.IsRegular() && typ != fs.ModeDir {
+			return errors.New("tar: cannot add non-regular file")
+		}
+
+		h, err := tar.FileInfoHeader(info, linkTarget)
+		if err != nil {
+			return err
+		}
+		h.Name = name
+		if typ.IsDir() {
+			h.Name += "/"
+		}
+		// Adjust permissions so user can always write.
+		h.Mode |= 0200
+
+		if err := w.WriteHeader(h); err != nil {
+			return err
+		}
+		if !typ.IsRegular() {
+			return nil
+		}
+
+		f, err := fsys.Open(name)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(w, f)
+		return err
+	})
 }
 
 func FakeRetrieveSystemSdk(f func(setup sdk.Setup, report *progress.Reporter) error) func() {

--- a/internal/sdk/system/system_test.go
+++ b/internal/sdk/system/system_test.go
@@ -40,7 +40,7 @@ func (f *systemSdk) TearDownSuite(c *check.C) {
 }
 
 // Update this hash with new SDK revision numbers.
-const systemSdkHash = "0d45fbec8ff7cfdfafaa3e6279537f3d28a25b61c06bab99f9f5f13c362453f7"
+const systemSdkHash = "9ccfd0116a39ce9ab210697f2e451a7aecd0c07146288ce6bb7ff0c4a847890b"
 
 func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 	done, total := 0, 0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,7 +50,7 @@ parts:
     source: .
     source-type: local
     build-snaps:
-      - go/1.24/stable
+      - go/1.25/stable
     build-environment:
       - CGO_LDFLAGS_ALLOW: ".*"
     override-build: |

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -50,7 +50,7 @@ EOF
 
     setup_lxd
 
-    snap install --classic --channel=1.24/stable go
+    snap install --classic --channel=1.25/stable go
     snap install yq
 }
 


### PR DESCRIPTION
# Description

Without this, if workshopd is running as a non-superuser, importing the system SDK fails when tar tries to remove the temporarily extracted filed.

Since this only affects Workshop devs, it seems unnecessary to update the revision number for this change.

I took the simple path of archiving the system SDK files one by one, changing the mode as we go. I think the `FS` interface is still too unstable to attempt writing a comprehensive wrapper.

Note that `tar.Writer.AddFS` recently added symlink support, so I upgraded the Go version we use to follow suit. Even if this sees further changes, I think the logic I reimplemented will be robust enough for a while.

The Go upgrade simplifies a bit of the `os.Root` code, and I noticed I somehow forgot to close it, which is now fixed.

I had some trouble with `pre-commit`, since `golangci-lint` is still on `1.24`. In order to make it use `1.25` I had to refresh my `go` snap to `latest/edge`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
