### PR TITLE
Reduce dpkg fsync calls

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1123,6 +1123,12 @@ apt:
     # Bypass confirmation prompts
     APT::Get::Assume-Yes "1";
 write_files:
+# Sacrifice some durability for performance:
+# https://wiki.debian.org/Teams/Dpkg/FAQ#Q:_Why_is_dpkg_so_slow_when_using_new_filesystems_such_as_btrfs_or_ext4.3F
+- content: |
+    # Managed by workshop, do not remove
+    force-unsafe-io
+  path: /etc/dpkg/dpkg.cfg.d/unsafe-io
 - content: |
     # Managed by workshop, do not remove
     [Unit]


### PR DESCRIPTION
# Description

Taken [from LXD](https://github.com/canonical/lxd/blob/5a2f6640c0c20e16792360cf2a223ce04d597abf/doc/lxd-test.yaml#L23). This option can improve unpacking performance, but if the system crashes there's a chance some files are truncated. This seems to be a reasonable trade-off for ephemeral environments like workshops.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
