### PR TITLE
Test launch-workshop action with in-development snap

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -102,3 +102,48 @@ jobs:
           name: code-coverage-${{matrix.suite}}
           path: ${{ github.workspace }}.cover/lxd:ubuntu-24.04:tests/
           if-no-files-found: ignore
+  action-tests:
+    needs: build-snap
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+        base: ['20.04', '22.04', '24.04']
+    runs-on: ${{ matrix.os }}
+    steps:
+      # The Action can only download released versions of Workshop, but we can
+      # make it use a development snap by putting it in the tool cache. This
+      # hack can be removed once we start publishing snaps for the main branch.
+      - name: Create tool cache
+        run: |
+          arch="$(node -e 'console.log(process.arch)')"
+          path="${RUNNER_TOOL_CACHE}/workshop/0.1.0/${arch}"
+          printf 'path=%s\n' "$path" >> "$GITHUB_OUTPUT"
+
+          mkdir -p "$path"
+          touch "${path}.complete"
+        id: tool_cache
+      - name: Download Workshop Snap
+        uses: actions/download-artifact@master
+        with:
+          name: snap_workshop
+          path: ${{ steps.tool_cache.outputs.path }}
+      - name: Create workshop definition
+        run: |
+          cat >workshop.yaml <<EOF
+          name: test
+          base: ubuntu@$BASE
+          EOF
+        env:
+          BASE: ${{ matrix.base }}
+      - name: Launch workshop
+        uses: canonical/launch-workshop@v0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: '0.1.0'
+      - name: Check base image
+        run: |
+          release="$(workshop exec -- lsb_release --release --short)"
+          [ "${BASE}" = "$release" ]
+        env:
+          BASE: ${{ matrix.base }}


### PR DESCRIPTION
# Description

The latest Workshop release is more strict about LXD versions, which required changes in the launch-workshop GitHub Action. This job will help us detect similar issues earlier on. Once the action supports installing snaps, and we publish `edge` snaps for Workshop regularly, we can move this job into the launch-workshop repository.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
