### PR TITLE
Remove support for scripts

### DIFF
--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -188,25 +188,6 @@ type File struct {
 	Actions     map[string]Action `yaml:"actions,omitempty"`
 }
 
-func (f *File) UnmarshalYAML(value *yaml.Node) error {
-	type file File
-	if err := value.Decode((*file)(f)); err != nil {
-		return err
-	}
-	var scripts struct {
-		Scripts map[string]Action `yaml:"scripts,omitempty"`
-	}
-	if err := value.Decode(&scripts); err != nil {
-		return err
-	}
-	if f.Actions == nil {
-		f.Actions = scripts.Scripts
-	} else {
-		maps.Copy(f.Actions, scripts.Scripts)
-	}
-	return nil
-}
-
 func (a Action) String() string {
 	// Trim newlines, then append a newline for multi-line scripts.
 	script := strings.Trim(string(a), "\n")


### PR DESCRIPTION
# Description

Now we can require `actions:` instead.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
