### PR TITLE
Prevent concurrent TICS server jobs

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -8,11 +8,12 @@ on:
     - cron: "0 0 */2 * *"
   workflow_dispatch:
 
-# Cancel currently-running builds when pushing new commits to a PR or branch
-# https://stackoverflow.com/a/72408109
+# Cancel currently-running builds when pushing new commits to a PR.
+# Prevent TICS qserver from running concurrently.
+# https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Call spread and unit tests as reusable workflows. This is the most


### PR DESCRIPTION
# Description

Previously, pushing to main would cancel the previous run. If the cancel happens in the middle of the TICS step, the next run may fail because TICS has yet to be cancelled properly. Now we'll only cancel jobs for pull requests, which run TICS in client mode.

I also removed the fallback to `github.run_id`. All the [events we support](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) define GITHUB_REF [1]. The linked stackoverflow post is based on the [official docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency), which only use a fallback for more obscure settings like `github.head_ref`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
