### PR TITLE
Stop creating ~/bin in workshops

### DIFF
--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -159,6 +159,7 @@ func (c *CmdRoot) Command() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&c.prj, "project", "p", c.cwd, "Specify the project's directory path.")
 	cmd.PersistentFlags().BoolP("help", "h", false, "Print the help message for the command.")
+	cmd.PersistentFlags().BoolP("version", "v", false, "Print Workshop version.")
 
 	cmd.DisableAutoGenTag = true
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -453,7 +453,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	reqData.Names = strutil.Deduplicate(reqData.Names)
 
 	if !slices.Contains(validActions, reqData.Action) {
-		return statusBadRequest(fmt.Sprintf("unknown action %q", reqData.Action))
+		return statusBadRequest("unknown action %q", reqData.Action)
 	}
 
 	mode, err := actionMode(&reqData)

--- a/internal/metautil/type_conversions.go
+++ b/internal/metautil/type_conversions.go
@@ -70,15 +70,15 @@ func convertValue(value reflect.Value, outputType reflect.Type) (reflect.Value, 
 	case reflect.Float64:
 		// Special case: encoding/json can mangle int64 -> float64.
 		v, ok := maybeFloatToInt(value.Float())
-		// Recall that -0.0 == 0.0 in Go (and IEEE 754).
 		if ok && outputType.Kind() == reflect.Int64 {
-			return reflect.ValueOf(int64(v)), nil
+			return reflect.ValueOf(v), nil
 		}
 	}
 	return nullValue, fmt.Errorf(`cannot convert value "%v" into a %v`, value, outputType)
 }
 
 func maybeFloatToInt(v float64) (int64, bool) {
+	// Recall that -0.0 == 0.0 in Go (and IEEE 754).
 	if _, frac := math.Modf(v); frac != 0 {
 		return 0, false
 	}
@@ -94,7 +94,7 @@ func maybeFloatToInt(v float64) (int64, bool) {
 // the val parameter, which therefore must be a pointer.
 func SetValueFromAttribute(attrVal any, val any) error {
 	rt := reflect.TypeOf(val)
-	if rt.Kind() != reflect.Ptr || val == nil {
+	if rt.Kind() != reflect.Pointer || val == nil {
 		return errors.New("internal error: value must be a pointer")
 	}
 

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -66,7 +66,7 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 				}
 
 				if mode == conflict.ChangeWaitOnError {
-					task.Errorf(err.Error())
+					task.Errorf("%v", err)
 					return &state.Wait{
 						WaitedStatus: state.DoingStatus,
 						Reason:       fmt.Sprintf("wait on error: %v", err),

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -258,7 +258,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, hook *H
 
 	if len(taskLog) > 0 {
 		st.Lock()
-		task.Logf(string(taskLog))
+		task.Logf("%s", string(taskLog))
 		st.Unlock()
 	}
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1164,8 +1164,8 @@ runcmd:
   - install --directory --mode=755 /project
   # Create XDG base directories so SDKs don't need an extra mode=700 step.
   - install --directory --mode=700 --owner=workshop --group=workshop /home/workshop/.cache /home/workshop/.config /home/workshop/.local
-  # Create PATH entries so SDKs don't need to source ~/.profile again.
-  - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/bin /home/workshop/.local/bin
+  # Create ~/.local/bin so SDKs don't need to source ~/.profile to add it to the PATH.
+  - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/.local/bin
   - systemctl daemon-reload
   - systemctl enable --now xauth-copy.service
   - systemctl enable --now xauth-watch.path


### PR DESCRIPTION
# Description

Although this is in `~/.profile` by default, SDKs are unlikely to use it over `~/.local/bin`. We can always add it back if a use case arises.

Carries over some minor fixes from https://github.com/canonical/workshop/pull/433:
- use literal format strings
- make help message for `-v, --version` consistent with other flags

Also fixes some style issues I noticed recently in my recent changes to `metautil`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
