### PR TITLE
Wait for systemd to be ready before waiting for systemd-networkd

### DIFF
--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"gopkg.in/check.v1"
 
@@ -81,18 +82,31 @@ func (f *wsOps) TearDownSuite(c *check.C) {
 }
 
 func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
-	// Wait a bit longer than the default start command, to ensure both
-	// IPv4 and IPv6 addresses are ready.
-	defer lxdbackend.FakeStartCommand(
-		"/usr/lib/systemd/systemd-networkd-wait-online --ipv4 --ipv6 --operational-state=routable",
-	)()
-
 	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
+
+	// Wait a bit longer than the default start command, to ensure both
+	// IPv4 and IPv6 addresses are ready.
+	args := workshop.Execution{
+		ExecArgs: workshop.ExecArgs{
+			Command: []string{
+				"/usr/lib/systemd/systemd-networkd-wait-online",
+				"--ipv4",
+				"--ipv6",
+				"--operational-state=routable",
+			},
+			WorkDir: "/",
+			Timeout: time.Minute,
+		},
+	}
+	exectx, err := f.bd.Exec(f.ctx, "test", &args)
+	c.Assert(err, check.IsNil)
+	c.Assert(exectx.WaitExecution(f.ctx), check.IsNil)
+
 	addresses := f.ipAddresses(c, "test")
 
 	// Execute
-	err := f.bd.StashWorkshop(f.ctx, "test")
+	err = f.bd.StashWorkshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 
 	// Validate


### PR DESCRIPTION
# Description

This test is flaky on my "update base image" branch, which is odd because I've never noticed it being flaky before, and I don't think I made any major changes to the code this exercises. In any case, it should be more reliable now.

The error manifests as "command exit code 1" when LaunchTestWorkshop runs the start command. The stderr of the start command is "Could not create manager: No such file or directory." After installing strace in a custom base image, and looking at the code a bit, I was able to confirm that the file in question is /run/systemd/. So this particular error is definitely fixed by waiting for systemd to be ready.

I probably should have done this from the beginning, the extra Exec call is much simpler than I was imagining.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
