### PR TITLE
Fix a few issues in LXD backend

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -445,6 +445,7 @@ func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, na
 		return err
 	}
 
+	var stderr strings.Builder
 	args := workshop.Execution{
 		ExecArgs: workshop.ExecArgs{
 			UserId:  0,
@@ -455,6 +456,9 @@ func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, na
 			WorkDir: "/",
 			Timeout: startCommandTimeout,
 		},
+		ExecControls: workshop.ExecControls{
+			Stderr: &stderr,
+		},
 	}
 
 	exectx, err := s.execCommand(conn, ctx, name, &args)
@@ -462,7 +466,14 @@ func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, na
 		return err
 	}
 
-	if err = exectx.WaitExecution(ctx); err != nil {
+	var errExec *workshop.ErrExec
+	if err := exectx.WaitExecution(ctx); errors.As(err, &errExec) {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			return err
+		}
+		return errors.New(message)
+	} else if err != nil {
 		return err
 	}
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -676,8 +676,6 @@ func (s *Backend) execCommand(conn lxd.InstanceServer, ctx context.Context, name
 	return workshop.ExecContext{
 		Environment: env,
 		WaitExecution: func(ctx context.Context) error {
-			defer conn.Disconnect()
-
 			if err := op.WaitContext(ctx); err != nil {
 				switch err.Error() {
 				case "Command not executable", "Command not found":
@@ -702,12 +700,28 @@ func (s *Backend) execCommand(conn lxd.InstanceServer, ctx context.Context, name
 }
 
 func (s *Backend) Exec(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	rev := revert.New()
+	defer rev.Fail()
+
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return workshop.ExecContext{}, err
 	}
+	rev.Add(conn.Disconnect)
 
-	return s.execCommand(conn, ctx, name, args)
+	exectx, err := s.execCommand(conn, ctx, name, args)
+	if err != nil {
+		return exectx, err
+	}
+
+	// Extend the connection until WaitExecution is done.
+	waitExecution := exectx.WaitExecution
+	exectx.WaitExecution = func(ctx context.Context) error {
+		defer conn.Disconnect()
+		return waitExecution(ctx)
+	}
+	rev.Success()
+	return exectx, err
 }
 
 func (s *Backend) Workshop(ctx context.Context, name string) (*workshop.Workshop, error) {

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -159,6 +159,7 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, 
 	if err != nil {
 		return nil, ErrorLxdBackend(err)
 	}
+	defer client.Disconnect()
 	// list all projects for all users if the user is not provided
 	lxdProjects, err := client.GetProjects()
 	if err != nil {

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -64,7 +64,7 @@ func (b *Backend) Download(ctx context.Context, base string, report *progress.Re
 
 func (b *Backend) download(ctx context.Context, op *downloadOp, base string) (err error) {
 	defer func() {
-		op.waitCh <- err
+		op.err = err
 		close(op.waitCh)
 
 		imageLock.Lock()
@@ -231,8 +231,8 @@ func waitDownloadOp(ctx context.Context, op *downloadOp) error {
 		// image download properly. Instead, we'll wait for it to finish if
 		// the task will be restarted.
 		return ctx.Err()
-	case err := <-op.waitCh:
-		return err
+	case <-op.waitCh:
+		return op.err
 	}
 }
 
@@ -311,14 +311,15 @@ type downloadUpdate struct {
 }
 
 type downloadOp struct {
-	waitCh chan error
+	waitCh chan struct{}
+	err    error
 
 	reportersLock sync.Mutex
 	reporters     map[string]*progress.Reporter
 }
 
 func newImageDownloadOp() *downloadOp {
-	return &downloadOp{waitCh: make(chan error), reporters: make(map[string]*progress.Reporter, 0)}
+	return &downloadOp{waitCh: make(chan struct{}), reporters: make(map[string]*progress.Reporter, 0)}
 }
 
 func (r *downloadOp) AddReporter(rep *progress.Reporter) {

--- a/internal/workshop/lxd/tests/integration/project_test.go
+++ b/internal/workshop/lxd/tests/integration/project_test.go
@@ -47,6 +47,7 @@ func (f *wsProject) SetUpTest(c *check.C) {
 func (f *wsProject) TearDownTest(c *check.C) {
 	helper.CleanupLxdProject(c, f.client, "workshop."+f.username)
 	helper.CleanupLxdProject(c, f.client, "workshop-stash."+f.username)
+	f.client.Disconnect()
 }
 
 func TestWorkshopBackendIntegration(t *testing.T) { check.TestingT(t) }
@@ -391,6 +392,7 @@ func (f *wsProject) TestPosixUsernameAsProjectSuffix(c *check.C) {
 	be := lxdbackend.Backend{}
 	p, err := be.LxdClient(ctx)
 	c.Assert(err, check.IsNil)
+	defer p.Disconnect()
 
 	props, err := p.GetConnectionInfo()
 	c.Assert(err, check.IsNil)
@@ -418,6 +420,7 @@ func (f *wsProject) TestNonPosixUsernameAsProjectSuffix(c *check.C) {
 	be := lxdbackend.Backend{}
 	p, err := be.LxdClient(ctx)
 	c.Assert(err, check.IsNil)
+	defer p.Disconnect()
 
 	props, err := p.GetConnectionInfo()
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -121,6 +121,7 @@ func (f *wsExec) TearDownSuite(c *check.C) {
 	f.restoreDevices()
 	helper.CleanupLxdProject(c, f.lxdClient, "workshop."+f.usr.Username)
 	helper.CleanupLxdProject(c, f.lxdClient, "workshop-stash."+f.usr.Username)
+	f.lxdClient.Disconnect()
 }
 
 func (f *wsExec) exec(stdin string, workshop, projectId string, opts *client.ExecOptions) (stdout, stderr string, waitErr error) {

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -68,6 +68,7 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 func (f *wsOps) TearDownSuite(c *check.C) {
 	lxdclient, err := f.bd.LxdClient(f.ctx)
 	c.Check(err, check.IsNil)
+	defer lxdclient.Disconnect()
 
 	helper.CleanupLxdProject(c, lxdclient, "workshop."+f.usr.Username)
 	helper.CleanupLxdProject(c, lxdclient, "workshop-stash."+f.usr.Username)
@@ -134,6 +135,7 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 func (f *wsOps) ipAddresses(c *check.C, name string) []string {
 	conn, err := f.bd.LxdClient(f.ctx)
 	c.Assert(err, check.IsNil)
+	defer conn.Disconnect()
 
 	inst, _, err := conn.GetInstanceFull(lxdbackend.InstanceName(name, f.project.ProjectId))
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -385,6 +385,19 @@ func (f *wsOps) TestLxdBackendDownloadProtocolNotSupported(c *check.C) {
 	c.Check(err, check.ErrorMatches, `unknown image server URL prefix \(supported: simplestreams, lxd\)`)
 }
 
+func (f *wsOps) TestLxdBackendDownloadConcurrentErrors(c *check.C) {
+	var wg sync.WaitGroup
+	wg.Add(5)
+	for range 5 {
+		go func() {
+			err := f.bd.Download(f.ctx, "ubuntu@1.01", nil)
+			c.Check(err, check.ErrorMatches, `"ubuntu@1.01" download failed.*`)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
 func (f *wsOps) TestLxdBackendDownloadWorkshopBaseResumeAfterCancellation(c *check.C) {
 	// ensure there is no image in LXD storage
 	fp, err := f.image(c, "ubuntu@22.04")


### PR DESCRIPTION
# Description

Fixes some issues I noticed while working on https://github.com/canonical/workshop/pull/491:
- If a base image download fails, concurrent downloads don't report the error.
- Sometimes LXD clients aren't closed, or might be closed too early.
- If a container's start command fails, the error message is limited to the exit code and doesn't show anything printed on `stderr`.

The last one is something I'm unsure about. It would have been helpful when working on https://github.com/canonical/workshop/pull/488, but it gives us very little control over the error message.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
