### PR TITLE
Remove image aliases from spread tests

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -52,20 +52,6 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - name: Pre-download LXD images
-        run: |
-          image_dir="$HOME/images"
-          mkdir -p "$image_dir"
-
-          for version in 22.04 24.04; do
-            if [ ! -f "$image_dir/ubuntu-$version.tar.gz" ]; then
-              lxc image copy "ubuntu:$version/amd64" local: --alias "$version/amd64"
-              lxc image export "$version/amd64" "$image_dir/ubuntu-$version.tar.gz"
-            fi
-          done
-
-          lxc project switch default
-          lxc profile device add default mnt-image disk source=$image_dir path=/mnt
       - name: Checkout Workshop
         uses: actions/checkout@v4
         with:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -255,17 +255,6 @@ of ``Spread``:
 
    spread tests/<TestPathName>
 
-When running locally, you can accelerate the test runs by reusing instances 
-and local LXD base images. For more examples, see the ``spread`` GitHub workflow.
-
-.. code-block:: console
-
-   image_dir=$HOME/images
-   lxc image export <fingerprint> "$image_dir/ubuntu-22.04.tar.gz"   
-   lxc profile device add default mnt-image disk source=$image_dir path=/mnt
-   
-   spread -reuse -resend tests/<TestPathName>
-
 
 To check code coverage:
 

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -13,21 +13,6 @@ function setup_lxd() {
     if [ "$(lxc storage list -f compact | grep -c default)" -eq 0 ]; then
         lxd init --auto --storage-backend=zfs
     fi
-
-    # Import LXD base images instead of downloading in every spread instance.
-    # This assumes images are mounted into the spread instance at /mnt.
-    image_dir="/mnt"
-    versions=("20.04" "22.04" "24.04")
-
-    for version in "${versions[@]}"; do
-        image_file="$image_dir/ubuntu-$version.tar.gz"
-        image_root="$image_dir/ubuntu-$version.tar.gz.root"
-        image_alias="workshop-ubuntu@$version-amd64"
-
-        if [ -f "$image_file" ] && ! lxc image info "$image_alias" &>/dev/null; then
-            lxc image import "$image_file" "$image_root" --alias "$image_alias"
-        fi
-    done
 }
 
 function prepare_environment() {

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -83,9 +83,8 @@ execute: |
   cat .workshop/ws-refresh-snapshots.yaml | yq '(.base) |= sub("ubuntu@22.04"; "ubuntu@24.04")' | sponge .workshop/ws-refresh-snapshots.yaml
 
   # Ensure there is no cached image so that refresh will take care of downloading it.
-  if ! lxc image delete workshop-ubuntu@24.04-amd64 --project workshop.ubuntu &> image.log; then
-    MATCH 'Failed fetching fingerprint' < image.log
-  fi
+  lxc image list --columns F --format csv os=ubuntu version=24.04 | xargs -r lxc image delete
+
   workshop_exec refresh ws-refresh-snapshots
   workshop_exec info ws-refresh-snapshots | MATCH ubuntu@24.04
   workshop_exec exec ws-refresh-snapshots -- lsb_release -a | MATCH 24.04


### PR DESCRIPTION
# Description

Fixes a couple of things I overlooked in https://github.com/canonical/workshop/pull/491 and https://github.com/canonical/workshop/pull/493.

Since images update more frequently now, caching them requires more work. And apparently there wasn't much of a speedup in the first place. So I removed support for that.

Also, the refresh tests was trying to delete an image using an alias that we don't use anymore. It now deletes all Ubuntu 24.04 images.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
