### PR TITLE
Fail early if local SDK has no sdk.yaml

### DIFF
--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -409,7 +409,16 @@ func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk, source str
 	}
 
 	target := workshop.LocalSdkDir(s.userDataDir, s.project.ProjectId, w, sk)
-	return sdk.CommitRevision(s.user, source, target, installed)
+	revision, err := sdk.CommitRevision(s.user, source, target, installed)
+	if err != nil {
+		return sdk.Revision{}, err
+	}
+
+	if !osutil.FileExists(filepath.Join(target, revision.String(), "meta", "sdk.yaml")) {
+		return sdk.Revision{}, fmt.Errorf("sdk.yaml file not found for SDK %q", sk)
+	}
+
+	return revision, nil
 }
 
 func ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {


### PR DESCRIPTION
# Description

Before:
```console
$ workshop launch
error: cannot perform the following tasks:
- Register "nav2-sdk" SDK plugs and slots (open /home/ubuntu/.local/share/workshop/id/967fc9ea/nav2/sdk/nav2-sdk/x1/meta/sdk.yaml: no such file or directory)
"nav2" launch aborted
```

After:
```console
$ workshop launch
error: cannot launch "nav2": sdk.yaml file not found for SDK "nav2-sdk"
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
