### PR TITLE
Check for ZFS support before creating storage pool

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -148,6 +148,21 @@ func checkVersion(version string) error {
 	return nil
 }
 
+func checkStorage(drivers []api.ServerStorageDriverInfo) error {
+	isZfs := func(driver api.ServerStorageDriverInfo) bool {
+		return driver.Name == "zfs"
+	}
+	if slices.ContainsFunc(drivers, isZfs) {
+		return nil
+	}
+
+	// The LXD error message when creating a pool is:
+	//  Error: Error loading "zfs" module: Failed to run: modprobe -b zfs:
+	//  exit status 1 (modprobe: FATAL: Module zfs not found ...)
+	// We keep the first part for consistency, the rest doesn't add much.
+	return errors.New(`suitable storage backend not found: error loading "zfs" module`)
+}
+
 func checkServerCapabilities() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -163,7 +178,11 @@ func checkServerCapabilities() error {
 		return err
 	}
 
-	return checkVersion(info.Environment.ServerVersion)
+	if err := checkVersion(info.Environment.ServerVersion); err != nil {
+		return err
+	}
+
+	return checkStorage(info.Environment.StorageSupportedDrivers)
 }
 
 func New() (*Backend, error) {


### PR DESCRIPTION
# Description

Previously the daemon would refuse to start if the host didn't support ZFS. Now it will enter degraded mode, showing a more useful error message to clients.

Tested in a Debian VM. After installing LXD, ZFS was absent from the supported drivers. Installing ZFS and restarting LXD made it appear. Uninstalling ZFS made it disappear again. However, on Ubuntu I wasn't able to remove ZFS from the list by blacklisting the kernel module or redirecting it to /bin/true. Should still work for Ubuntu users with unusual kernels, though.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
