### PR TITLE
Hash Store, in-project and sketch SDKs

### DIFF
--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/testutil"
@@ -80,7 +81,10 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	}
 
 	s.store = &sdk.FakeStore{}
-	s.restoreRetrieve = system.FakeRetrieveSystemSdk(s.store.RetrieveSystemSdk)
+	retrieveSystemSdk := func(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error) {
+		return s.store.DownloadSdk(context.TODO(), setup, report)
+	}
+	s.restoreRetrieve = system.FakeRetrieveSystemSdk(retrieveSystemSdk)
 
 	s.b, err = fakebackend.New(c.MkDir())
 	c.Check(err, check.IsNil)

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -183,6 +183,13 @@ sdks:
         endpoint: 8080
 `
 
+	wrongbase = `name: wrongbase
+base: ubuntu@24.04
+sdks:
+  - name: test-sdk-3
+    channel: latest/stable
+`
+
 	workshoptunnels = `name: tunnels
 base: ubuntu@22.04
 sdks:
@@ -351,7 +358,6 @@ connections:
 	testsdk = `
 name: test-sdk
 title: title
-base: ubuntu@20.04
 version: '0.1.2'
 summary: summary
 description: SDK
@@ -367,7 +373,6 @@ plugs:
 	testsdk_r2 = `
 name: test-sdk
 title: title
-base: ubuntu@20.04
 version: '0.1.3'
 summary: summary
 description: SDK
@@ -382,7 +387,6 @@ plugs:
 	testsdk2 = `
 name: test-sdk-2
 title: title
-base: ubuntu@20.04
 version: '20200401.3f3a63f'
 summary: summary
 description: SDK
@@ -399,10 +403,13 @@ slots:
     interface: mount
 `
 
+	testsdk2_invalid = `name: sdk-2
+`
+
 	mount_conflict = `
 name: mount-conflict
 title: title
-base: ubuntu@20.04
+base: ubuntu@22.04
 version: '20200401.3f3a63f'
 summary: summary
 description: SDK
@@ -422,7 +429,7 @@ slots:
 	testsdk3 = `
 name: test-sdk-3
 title: title
-base: ubuntu@20.04
+base: ubuntu@22.04
 version: '20200401.3f3a63f'
 summary: summary
 description: SDK
@@ -973,15 +980,11 @@ func storeDownload(ctx context.Context, setup sdk.Setup, report *progress.Report
 }
 
 func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
-	var result = []sdk.SdkResult{}
+	result := make([]sdk.SdkResult, 0, len(actions))
 	for _, act := range actions {
-		info, err := sdk.ReadSdkInfo([]byte(apiSuiteSdks[act.Name].meta), act.ProjectId, act.Workshop)
-		if err != nil {
-			return nil, err
-		}
-		info.Channel = act.Channel
-		info.Revision = apiSuiteSdks[act.Name].s.Revision
-		result = append(result, sdk.SdkResult{Info: info})
+		setup := apiSuiteSdks[act.Name].s
+		setup.Channel = act.Channel
+		result = append(result, sdk.SdkResult{Setup: setup, SdkYAML: apiSuiteSdks[act.Name].meta})
 	}
 	return result, nil
 }
@@ -3851,6 +3854,82 @@ func (s *apiSuite) TestValidateActionInputs(c *check.C) {
 	}
 }
 
+// ValidateSdkInfo is already covered by unit tests. This test ensures it's
+// applied to every type of SDK on both launch and refresh.
+func (s *apiSuite) TestValidateSdkInfo(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.mockProjectSdk(c, "test-sdk-2", testsdk2_invalid)
+	s.createWFile(c, "basic", basic_refreshed)
+	s.mockTrySdk(c, "test-sdk", "test-sdk_all.sdk", testsdk)
+	s.mockTrySdk(c, "test-sdk-2", "test-sdk-2_all.sdk", testsdk2_invalid)
+	s.createWFile(c, "manysdks", manysdks_try)
+	s.createWFile(c, "wrongbase", wrongbase)
+	defer s.store.SetDownloadCallback(storeDownload)()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["wrongbase"],"action":"launch"}`),
+	}
+
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot launch "basic": SDK must be named "test-sdk-2" (now: "sdk-2")`,
+		},
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot launch "manysdks": SDK must be named "test-sdk-2" (now: "sdk-2")`,
+		},
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot launch "wrongbase": "test-sdk-3" SDK has "ubuntu@22.04" base; required: "ubuntu@24.04"`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	s.createWFile(c, "basic", basic)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+	}
+
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	s.mockSketchSdk(c, "basic", `name: illegal-sketch-name
+`)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh"}`),
+	}
+
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeError,
+			Status:  http.StatusBadRequest,
+			Message: `cannot refresh "basic": SDK must be named "sketch" (now: "illegal-sketch-name")`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+}
+
 func (s *apiSuite) TestLaunchWorkshopRefreshLaunchInProgress(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
@@ -4146,54 +4225,63 @@ func (s *apiSuite) TestRefreshConflictChange(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 	// Setup
-	s.createWFile(c, "manysdks", manysdks)
+	s.createWFile(c, "basic", basic)
 	defer s.store.SetDownloadCallback(storeDownload)()
 
+	var errOnce sync.Once
+	s.secBackend.RemoveCallback = func(sdkName string) error {
+		var err error
+		errOnce.Do(func() { err = errors.New("cannot remove profile") })
+		return err
+	}
+
 	requests := []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
 	}
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeAsync,
 			Status:  http.StatusAccepted,
 			Kind:    "launch",
-			Summary: `Launch "manysdks" workshop`,
+			Summary: `Launch "basic" workshop`,
 		},
 	}
 	s.runActionTest(c, requests, expected)
 
-	s.mockSketchSdk(c, "manysdks", `name: illegal-sketch-name
-base: ubuntu@22.04
-`)
+	s.mockProjectSdk(c, "test-sdk-2", testsdk2)
+	s.createWFile(c, "basic", basic_refreshed)
 
 	requests = []*bytes.Buffer{
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
-		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh", "options": {"mode":"transactional", "refresh-option":"restore"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh","options": {"mode":"wait-on-error"}}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh", "options": {"mode":"transactional", "refresh-option":"restore"}}`),
 	}
 	expected = []*expectedResp{
 		{
 			Type:      ResponseTypeAsync,
 			Status:    http.StatusAccepted,
 			Kind:      "refresh",
-			Summary:   `Refresh "manysdks" workshop`,
-			ChangeErr: `(?s).*\(SDK must be named "sketch" \(now: "illegal-sketch-name"\)\)`,
+			Summary:   `Refresh "basic" workshop`,
+			ChangeErr: `(?s).*\(cannot remove profile\)`,
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot refresh "manysdks": waiting on error`,
-			Summary: `Refresh "manysdks" workshop`,
+			Message: `cannot refresh "basic": waiting on error`,
+			Summary: `Refresh "basic" workshop`,
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot refresh "manysdks": waiting on error`,
-			Summary: `Refresh "manysdks" workshop`,
+			Message: `cannot refresh "basic": waiting on error`,
+			Summary: `Refresh "basic" workshop`,
 		},
 	}
 
 	s.runActionTest(c, requests, expected)
+
+	// This will be called by the first refresh, the others fail earlier.
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
 func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"crypto/md5"
 	"crypto/sha3"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -984,7 +986,9 @@ func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult,
 	for _, act := range actions {
 		setup := apiSuiteSdks[act.Name].s
 		setup.Channel = act.Channel
-		result = append(result, sdk.SdkResult{Setup: setup, SdkYAML: apiSuiteSdks[act.Name].meta})
+		sdkYaml := apiSuiteSdks[act.Name].meta
+		digest := md5.Sum([]byte(sdkYaml))
+		result = append(result, sdk.SdkResult{Setup: setup, MD5: hex.EncodeToString(digest[:]), SdkYAML: sdkYaml})
 	}
 	return result, nil
 }
@@ -1717,6 +1721,13 @@ func (s *apiSuite) ensureSdkVolumesAfterCooldown(c *check.C, want []string) {
 			return v.Name == wv
 		})
 		c.Assert(v, check.Not(check.Equals), -1)
+		vol := vols[v]
+		c.Check(vol.Kind, check.Equals, "sdk")
+		if vol.Sha3_384 == "" {
+			c.Check(vol.MD5, check.Not(check.Equals), "")
+		}
+		c.Check(sdk.VolumeName(vol.Sdk, vol.Revision), check.Equals, vol.Name)
+		c.Check(vol.Metadata, check.Not(check.Equals), "")
 	}
 }
 

--- a/internal/fakestore/export_test.go
+++ b/internal/fakestore/export_test.go
@@ -2,16 +2,16 @@ package store
 
 import (
 	"context"
-	"io"
 
 	"github.com/canonical/workshop/internal/sdk"
 )
 
 type (
-	StoreSdk = storeSdk
+	StoreSdk  = storeSdk
+	SdkReader = sdkReader
 )
 
-func FakeSdkStoreInfo(f func(ctx context.Context, name, channel string) (storeSdk, error)) (restore func()) {
+func FakeSdkStoreInfo(f func(ctx context.Context, name, channel string) (StoreSdk, error)) (restore func()) {
 	old := storeSdkInfo
 	storeSdkInfo = f
 	return func() {
@@ -19,7 +19,7 @@ func FakeSdkStoreInfo(f func(ctx context.Context, name, channel string) (storeSd
 	}
 }
 
-func FakeSdkStoreSdkReader(f func(ctx context.Context, setup sdk.Setup) (io.ReadCloser, int64, error)) (restore func()) {
+func FakeSdkStoreSdkReader(f func(ctx context.Context, setup sdk.Setup) (*SdkReader, error)) (restore func()) {
 	old := storeSdkReader
 	storeSdkReader = f
 	return func() {

--- a/internal/fakestore/export_test.go
+++ b/internal/fakestore/export_test.go
@@ -19,14 +19,6 @@ func FakeSdkStoreInfo(f func(ctx context.Context, name, channel string) (storeSd
 	}
 }
 
-func FakeSdkStoreConnect(f func(ctx context.Context) (*ClientWrapper, error)) (restore func()) {
-	old := storeConnect
-	storeConnect = f
-	return func() {
-		storeConnect = old
-	}
-}
-
 func FakeSdkStoreSdkReader(f func(ctx context.Context, setup sdk.Setup) (io.ReadCloser, error)) (restore func()) {
 	old := storeSdkReader
 	storeSdkReader = f

--- a/internal/fakestore/export_test.go
+++ b/internal/fakestore/export_test.go
@@ -19,7 +19,7 @@ func FakeSdkStoreInfo(f func(ctx context.Context, name, channel string) (storeSd
 	}
 }
 
-func FakeSdkStoreSdkReader(f func(ctx context.Context, setup sdk.Setup) (io.ReadCloser, error)) (restore func()) {
+func FakeSdkStoreSdkReader(f func(ctx context.Context, setup sdk.Setup) (io.ReadCloser, int64, error)) (restore func()) {
 	old := storeSdkReader
 	storeSdkReader = f
 	return func() {

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"gopkg.in/check.v1"
@@ -28,7 +27,7 @@ type storeIntegration struct {
 
 var _ = check.Suite(&storeIntegration{})
 
-func (f *storeIntegration) SetUpSuite(c *check.C) {
+func (f *storeIntegration) SetUpTest(c *check.C) {
 	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8080/storage/v1/"), check.IsNil)
 	f.oldRoot = dirs.BaseDir
 	f.oldCache = dirs.CacheDir
@@ -37,7 +36,7 @@ func (f *storeIntegration) SetUpSuite(c *check.C) {
 	c.Assert(dirs.CreateDirs(), check.IsNil)
 }
 
-func (f *storeIntegration) TearDownSuite(c *check.C) {
+func (f *storeIntegration) TearDownTest(c *check.C) {
 	c.Assert(os.Unsetenv("SDK_STORE_URL"), check.IsNil)
 	dirs.SetCacheDir(f.oldCache)
 	dirs.SetRootDir(f.oldRoot)
@@ -45,49 +44,50 @@ func (f *storeIntegration) TearDownSuite(c *check.C) {
 
 func (f *storeIntegration) TestStoreDownloadOK(c *check.C) {
 	s := store.New()
-	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable"}
-	err := s.DownloadSdk(context.Background(), setup, nil)
+	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.R(1)}
+	result, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
+	c.Check(result.Setup, check.Equals, setup)
+	c.Check(result.MD5, check.Not(check.Equals), "")
+	c.Check(result.SdkYAML, check.Not(check.Equals), "")
 	c.Assert(setup.Filepath(), testutil.FilePresent)
-	c.Assert(os.Remove(setup.Filepath()), check.IsNil)
 }
 
 func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
 	s := store.New()
-	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable"}
+	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.R(1)}
 	done, total := 0, 0
 	r := &progress.Reporter{Name: "1", Report: func(label string, d, t int) {
 		done = d
 		total = t
 	}}
-	err := s.DownloadSdk(context.Background(), setup, r)
+	_, err := s.DownloadSdk(context.Background(), setup, r)
 	c.Assert(err, check.IsNil)
 	c.Assert(setup.Filepath(), testutil.FilePresent)
 	c.Check(done, testutil.IntGreaterThan, 0)
 	c.Check(total, testutil.IntGreaterThan, 0)
 	c.Check(done, check.Equals, total)
-	c.Assert(os.Remove(setup.Filepath()), check.IsNil)
 }
 
 func (f *storeIntegration) TestStoreDownloadCleanupPrevious(c *check.C) {
 	s := store.New()
-	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
-	prev := filepath.Join(dirs.SdkDownloads, setup.Name) + "_5.sdk"
-	_, err := os.Create(prev)
-	c.Assert(err, check.IsNil)
-	err = s.DownloadSdk(context.Background(), setup, nil)
+	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.R(1)}
+	prev := setup
+	prev.Revision = sdk.R(5)
+	c.Assert(os.WriteFile(prev.Filepath(), nil, 0644), check.IsNil)
+
+	_, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(setup.Filepath(), testutil.FilePresent)
-	c.Assert(prev, testutil.FileAbsent)
-	c.Assert(os.Remove(setup.Filepath()), check.IsNil)
+	c.Check(prev.Filepath(), testutil.FileAbsent)
 }
 
 func (f *storeIntegration) TestStoreDownloadNotfound(c *check.C) {
 	s := store.New()
-	setup := sdk.Setup{Name: "test-sdk-unknown", Channel: "latest/stable"}
-	err := s.DownloadSdk(context.Background(), setup, nil)
+	setup := sdk.Setup{Name: "test-sdk-unknown", Channel: "latest/stable", Revision: sdk.R(1)}
+	_, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.ErrorMatches, `SDK not found in "latest/stable"`)
-	c.Assert(setup.Filepath(), testutil.FileAbsent)
+	c.Check(setup.Filepath(), testutil.FileAbsent)
 }
 
 func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.C) {
@@ -109,15 +109,20 @@ func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		err := s.DownloadSdk(context.Background(), setup, nil)
-		c.Check(err, check.IsNil)
+		defer wg.Done()
+
+		result, err := s.DownloadSdk(context.Background(), setup, nil)
+		c.Assert(err, check.IsNil)
+		c.Check(result.Setup, check.Equals, setup)
+		c.Check(result.MD5, check.Equals, "md5sum")
+		c.Check(result.SdkYAML, check.Equals, "name: test-sdk-basic")
 		c.Check(m.String(), check.Matches, fmt.Sprintf(`(?s)*.DEBUG: SDK Store on Download: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_1.sdk.*`, dirs.SdkDownloads))
-		wg.Done()
 	}()
 
 	// "download" is finished
-	_, err = os.Create(target)
-	c.Assert(err, check.IsNil)
+	c.Assert(os.WriteFile(target, nil, 0666), check.IsNil)
+	c.Assert(os.WriteFile(target+".md5", []byte("md5sum"), 0666), check.IsNil)
+	c.Assert(os.WriteFile(target+".yaml", []byte("name: test-sdk-basic"), 0666), check.IsNil)
 	fl.Close()
 	wg.Wait()
 }
@@ -137,7 +142,7 @@ func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
 
 	s := store.New()
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 55}}
-	err := s.DownloadSdk(context.Background(), setup, nil)
+	_, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.NotNil)
 	c.Assert(setup.Filepath(), testutil.FileAbsent)
 }

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -6,7 +6,6 @@ package store_test
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"sync"
 
@@ -47,10 +46,12 @@ func (f *storeIntegration) TestStoreDownloadOK(c *check.C) {
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.R(1)}
 	result, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
+	setup.Revision = result.Revision
 	c.Check(result.Setup, check.Equals, setup)
+	c.Check(result.Revision, check.Not(check.Equals), sdk.R(0))
 	c.Check(result.MD5, check.Not(check.Equals), "")
 	c.Check(result.SdkYAML, check.Not(check.Equals), "")
-	c.Assert(setup.Filepath(), testutil.FilePresent)
+	c.Assert(result.Filepath(), testutil.FilePresent)
 }
 
 func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
@@ -61,9 +62,9 @@ func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
 		done = d
 		total = t
 	}}
-	_, err := s.DownloadSdk(context.Background(), setup, r)
+	result, err := s.DownloadSdk(context.Background(), setup, r)
 	c.Assert(err, check.IsNil)
-	c.Assert(setup.Filepath(), testutil.FilePresent)
+	c.Assert(result.Filepath(), testutil.FilePresent)
 	c.Check(done, testutil.IntGreaterThan, 0)
 	c.Check(total, testutil.IntGreaterThan, 0)
 	c.Check(done, check.Equals, total)
@@ -75,11 +76,19 @@ func (f *storeIntegration) TestStoreDownloadCleanupPrevious(c *check.C) {
 	prev := setup
 	prev.Revision = sdk.R(5)
 	c.Assert(os.WriteFile(prev.Filepath(), nil, 0644), check.IsNil)
+	other := setup
+	other.Revision = sdk.R(2)
+	c.Assert(os.WriteFile(other.Filepath(), nil, 0644), check.IsNil)
 
-	_, err := s.DownloadSdk(context.Background(), setup, nil)
+	result, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(setup.Filepath(), testutil.FilePresent)
-	c.Check(prev.Filepath(), testutil.FileAbsent)
+	c.Check(result.Filepath(), testutil.FilePresent)
+	if prev.Revision != result.Revision {
+		c.Check(prev.Filepath(), testutil.FileAbsent)
+	}
+	if other.Revision != result.Revision {
+		c.Check(other.Filepath(), testutil.FileAbsent)
+	}
 }
 
 func (f *storeIntegration) TestStoreDownloadNotfound(c *check.C) {
@@ -87,7 +96,7 @@ func (f *storeIntegration) TestStoreDownloadNotfound(c *check.C) {
 	setup := sdk.Setup{Name: "test-sdk-unknown", Channel: "latest/stable", Revision: sdk.R(1)}
 	_, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.ErrorMatches, `SDK not found in "latest/stable"`)
-	c.Check(setup.Filepath(), testutil.FileAbsent)
+	c.Check(dirs.SdkDownloads, testutil.DirEquals, []string{})
 }
 
 func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.C) {
@@ -135,8 +144,8 @@ func (*failingReader) Read(p []byte) (n int, err error) {
 func (*failingReader) Close() error { return nil }
 
 func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
-	r := store.FakeSdkStoreSdkReader(func(ctx context.Context, setup sdk.Setup) (io.ReadCloser, int64, error) {
-		return &failingReader{}, 0, nil
+	r := store.FakeSdkStoreSdkReader(func(ctx context.Context, setup sdk.Setup) (*store.SdkReader, error) {
+		return &store.SdkReader{ReadCloser: &failingReader{}, Revision: setup.Revision}, nil
 	})
 	defer r()
 
@@ -144,7 +153,7 @@ func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 55}}
 	_, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(setup.Filepath(), testutil.FileAbsent)
+	c.Assert(dirs.SdkDownloads, testutil.DirEquals, []string{})
 }
 
 func (s *storeIntegration) TestSdkActionInstallStoreError(c *check.C) {

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -130,8 +130,8 @@ func (*failingReader) Read(p []byte) (n int, err error) {
 func (*failingReader) Close() error { return nil }
 
 func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
-	r := store.FakeSdkStoreSdkReader(func(ctx context.Context, setup sdk.Setup) (io.ReadCloser, error) {
-		return &failingReader{}, nil
+	r := store.FakeSdkStoreSdkReader(func(ctx context.Context, setup sdk.Setup) (io.ReadCloser, int64, error) {
+		return &failingReader{}, 0, nil
 	})
 	defer r()
 

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
 
-	"github.com/canonical/workshop/internal/arch"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/progress"
@@ -85,25 +83,8 @@ func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sd
 				continue
 			}
 
-			info, err := sdk.ReadSdkInfo([]byte(s.SdkYAML), act.ProjectId, act.Workshop)
-			if err != nil {
-				actError.errors[act.Name] = err
-				continue
-			}
-			if info.Name != act.Name {
-				return nil, fmt.Errorf("SDK must be named %q (now: %q)", act.Name, info.Name)
-			}
-			if !slices.Contains([]string{"", act.Base}, info.Base) {
-				return nil, fmt.Errorf("%q SDK from %q has %q base; required: %q", act.Name, act.Channel, info.Base, act.Base)
-			}
-			if !slices.Contains([]string{"", "all", arch.DpkgArchitecture()}, info.Arch) {
-				return nil, fmt.Errorf(`%q SDK from %q has %q architecture; required: %q or "all"`, act.Name, act.Channel, info.Arch, arch.DpkgArchitecture())
-			}
-
-			info.Revision = s.Revision
-			info.Channel = s.Channel
-
-			results = append(results, sdk.SdkResult{Info: info})
+			setup := sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision}
+			results = append(results, sdk.SdkResult{Setup: setup, SdkYAML: s.SdkYAML})
 		default:
 			return nil, fmt.Errorf("unknown SDK store action")
 		}

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -4,12 +4,15 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -48,6 +51,7 @@ type storeSdk struct {
 	Channel  string       `json:"channel"`
 	Revision sdk.Revision `json:"revision"`
 	SdkYAML  string       `json:"sdk-yaml"`
+	MD5      string       `json:"md5"`
 }
 
 type SdkActionError struct {
@@ -84,7 +88,7 @@ func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sd
 			}
 
 			setup := sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision}
-			results = append(results, sdk.SdkResult{Setup: setup, SdkYAML: s.SdkYAML})
+			results = append(results, sdk.SdkResult{Setup: setup, MD5: s.MD5, SdkYAML: s.SdkYAML})
 		default:
 			return nil, fmt.Errorf("unknown SDK store action")
 		}
@@ -110,34 +114,50 @@ func (r *reporterWriter) Write(p []byte) (n int, err error) {
 	return plen, nil
 }
 
-func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *progress.Reporter) error {
+func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error) {
 	fl, err := sdk.OpenLock(setup.Name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err = fl.Lock(); err != nil {
-		return err
+		return nil, err
 	}
 	defer fl.Close()
 
 	target := setup.Filepath()
 	if osutil.FileExists(target) {
 		logger.Debugf("SDK Store on Download: SDK %q found locally: %s", setup.Name, target)
-		return nil
+
+		// TODO: after a transition period, it should be safe to assume
+		// that the hash and metadata are stored next to the SDK file.
+		// Probably not worth changing the code since they will likely
+		// be pulled from the Store instead of computed client side.
+		digest, err := hashSdk(setup)
+		if err != nil {
+			return nil, err
+		}
+		sdkYaml, err := extractSdkYAML(ctx, setup)
+		if err != nil {
+			return nil, err
+		}
+
+		return &sdk.SdkResult{Setup: setup, MD5: digest, SdkYAML: sdkYaml}, nil
 	}
 
 	r, size, err := storeSdkReader(ctx, setup)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer r.Close()
 
 	reverter := revert.New()
 	defer reverter.Fail()
 
+	// TODO: Use a temporary file to prevent corruption if the process is
+	// killed abruptly.
 	file, err := os.Create(target)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer file.Close()
 	reverter.Add(func() {
@@ -147,16 +167,27 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		}
 	})
 
-	var writer io.Writer
+	hash := md5.New()
+	writers := []io.Writer{file, hash}
 	if report != nil {
-		writer = io.MultiWriter(file, &reporterWriter{r: report, total: int(size)})
-	} else {
-		writer = file
+		writers = append(writers, &reporterWriter{r: report, total: int(size)})
 	}
 
-	if _, err = io.Copy(writer, r); err != nil {
-		return err
+	if _, err = io.Copy(io.MultiWriter(writers...), r); err != nil {
+		return nil, err
 	}
+
+	digest := hex.EncodeToString(hash.Sum(nil))
+	if err := os.WriteFile(target+".md5", []byte(digest+"\n"), 0666); err != nil {
+		return nil, err
+	}
+	reverter.Add(func() { _ = os.Remove(target + ".md5") })
+
+	sdkYaml, err := extractSdkYAML(ctx, setup)
+	if err != nil {
+		return nil, err
+	}
+	reverter.Add(func() { _ = os.Remove(target + ".yaml") })
 
 	reverter.Success()
 	// If the SDK was downloaded successfully, remove its previous rev if any.
@@ -171,8 +202,69 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		if err := os.Remove(m); err != nil {
 			logger.Noticef("SDK Store on Download: Cannot cleanup previous download (%s): %v", m, err)
 		}
+		if err := os.Remove(m + ".md5"); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logger.Noticef("SDK Store on Download: Cannot cleanup previous download (%s): %v", m, err)
+		}
+		if err := os.Remove(m + ".yaml"); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logger.Noticef("SDK Store on Download: Cannot cleanup previous download (%s): %v", m, err)
+		}
 	}
-	return nil
+
+	return &sdk.SdkResult{Setup: setup, MD5: digest, SdkYAML: sdkYaml}, nil
+}
+
+func hashSdk(setup sdk.Setup) (string, error) {
+	target := setup.Filepath()
+	cache := target + ".md5"
+
+	content, err := os.ReadFile(cache)
+	if err == nil {
+		return strings.TrimSpace(string(content)), nil
+	}
+
+	file, err := os.Open(target)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := md5.New()
+	if _, err := file.WriteTo(hash); err != nil {
+		return "", err
+	}
+
+	digest := hex.EncodeToString(hash.Sum(nil))
+	if err := os.WriteFile(cache, []byte(digest+"\n"), 0666); err != nil {
+		return "", err
+	}
+	return digest, nil
+}
+
+func extractSdkYAML(ctx context.Context, setup sdk.Setup) (string, error) {
+	target := setup.Filepath()
+	cache := target + ".yaml"
+
+	content, err := os.ReadFile(cache)
+	if err == nil {
+		return string(content), nil
+	}
+
+	cmd := exec.CommandContext(ctx, "tar",
+		"--extract",
+		"--to-stdout",
+		"--force-local",
+		"--file="+target,
+		"meta/sdk.yaml",
+	)
+	content, err = cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(cache, content, 0666); err != nil {
+		return "", err
+	}
+	return string(content), nil
 }
 
 func storeConnect(ctx context.Context) (*ClientWrapper, error) {
@@ -231,6 +323,7 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 	sSdk.Channel = channel
 	// A simple modulo to keep revision numbers in a readable form for testing
 	sSdk.Revision = sdk.Revision{N: int(atr.Generation%1000) + 1}
+	sSdk.MD5 = hex.EncodeToString(atr.MD5)
 	// The test server for the SDK store cannot store metadata.
 	if !client.isTesting {
 		if _, ok := atr.Metadata["sdk-yaml"]; !ok {

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -54,6 +54,12 @@ type storeSdk struct {
 	MD5      string       `json:"md5"`
 }
 
+type sdkReader struct {
+	io.ReadCloser
+	Revision sdk.Revision
+	Size     int64
+}
+
 type SdkActionError struct {
 	// maps an SDK name to an error
 	errors map[string]error
@@ -124,9 +130,8 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 	}
 	defer fl.Close()
 
-	target := setup.Filepath()
-	if osutil.FileExists(target) {
-		logger.Debugf("SDK Store on Download: SDK %q found locally: %s", setup.Name, target)
+	if osutil.FileExists(setup.Filepath()) {
+		logger.Debugf("SDK Store on Download: SDK %q found locally: %s", setup.Name, setup.Filepath())
 
 		// TODO: after a transition period, it should be safe to assume
 		// that the hash and metadata are stored next to the SDK file.
@@ -144,11 +149,14 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		return &sdk.SdkResult{Setup: setup, MD5: digest, SdkYAML: sdkYaml}, nil
 	}
 
-	r, size, err := storeSdkReader(ctx, setup)
+	r, err := storeSdkReader(ctx, setup)
 	if err != nil {
 		return nil, err
 	}
 	defer r.Close()
+
+	setup.Revision = r.Revision
+	target := setup.Filepath()
 
 	reverter := revert.New()
 	defer reverter.Fail()
@@ -170,7 +178,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 	hash := md5.New()
 	writers := []io.Writer{file, hash}
 	if report != nil {
-		writers = append(writers, &reporterWriter{r: report, total: int(size)})
+		writers = append(writers, &reporterWriter{r: report, total: int(r.Size)})
 	}
 
 	if _, err = io.Copy(io.MultiWriter(writers...), r); err != nil {
@@ -360,16 +368,16 @@ func readTestMetadata(ctx context.Context, client *ClientWrapper, name, track, r
 	return b.String(), nil
 }
 
-func storeSdkReaderImpl(ctx context.Context, setup sdk.Setup) (io.ReadCloser, int64, error) {
+func storeSdkReaderImpl(ctx context.Context, setup sdk.Setup) (*sdkReader, error) {
 	client, err := storeConnect(ctx)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	defer client.Close()
 
 	var sa = strings.Split(setup.Channel, "/")
 	if len(sa) != 2 {
-		return nil, 0, fmt.Errorf("%s has an invalid channel %s, must take the form <track>/<risk>", setup.Name, setup.Channel)
+		return nil, fmt.Errorf("%s has an invalid channel %s, must take the form <track>/<risk>", setup.Name, setup.Channel)
 	}
 	track, risk := sa[0], sa[1]
 	bkt := client.Bucket(SDK_STORE_BUCKET_NAME)
@@ -381,9 +389,12 @@ func storeSdkReaderImpl(ctx context.Context, setup sdk.Setup) (io.ReadCloser, in
 	r, err := obj.NewReader(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrObjectNotExist) {
-			return nil, 0, fmt.Errorf("SDK not found in %q", setup.Channel)
+			return nil, fmt.Errorf("SDK not found in %q", setup.Channel)
 		}
-		return nil, 0, err
+		return nil, err
 	}
-	return r, r.Attrs.Size, nil
+
+	// A simple modulo to keep revision numbers in a readable form for testing
+	revision := sdk.Revision{N: int(r.Attrs.Generation%1000) + 1}
+	return &sdkReader{ReadCloser: r, Revision: revision, Size: r.Attrs.Size}, nil
 }

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -50,7 +50,6 @@ type storeSdk struct {
 	Channel  string       `json:"channel"`
 	Revision sdk.Revision `json:"revision"`
 	SdkYAML  string       `json:"sdk-yaml"`
-	Size     int64        `json:"size"`
 }
 
 type SdkActionError struct {
@@ -146,12 +145,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		return nil
 	}
 
-	info, err := storeSdkInfo(ctx, setup.Name, setup.Channel)
-	if err != nil {
-		return err
-	}
-
-	r, err := storeSdkReader(ctx, setup)
+	r, size, err := storeSdkReader(ctx, setup)
 	if err != nil {
 		return err
 	}
@@ -174,7 +168,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 
 	var writer io.Writer
 	if report != nil {
-		writer = io.MultiWriter(file, &reporterWriter{r: report, total: int(info.Size)})
+		writer = io.MultiWriter(file, &reporterWriter{r: report, total: int(size)})
 	} else {
 		writer = file
 	}
@@ -256,7 +250,6 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 	sSdk.Channel = channel
 	// A simple modulo to keep revision numbers in a readable form for testing
 	sSdk.Revision = sdk.Revision{N: int(atr.Generation%1000) + 1}
-	sSdk.Size = atr.Size
 	// The test server for the SDK store cannot store metadata.
 	if !client.isTesting {
 		if _, ok := atr.Metadata["sdk-yaml"]; !ok {
@@ -293,16 +286,16 @@ func readTestMetadata(ctx context.Context, client *ClientWrapper, name, track, r
 	return b.String(), nil
 }
 
-func storeSdkReaderImpl(ctx context.Context, setup sdk.Setup) (io.ReadCloser, error) {
+func storeSdkReaderImpl(ctx context.Context, setup sdk.Setup) (io.ReadCloser, int64, error) {
 	client, err := storeConnect(ctx)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer client.Close()
 
 	var sa = strings.Split(setup.Channel, "/")
 	if len(sa) != 2 {
-		return nil, fmt.Errorf("%s has an invalid channel %s, must take the form <track>/<risk>", setup.Name, setup.Channel)
+		return nil, 0, fmt.Errorf("%s has an invalid channel %s, must take the form <track>/<risk>", setup.Name, setup.Channel)
 	}
 	track, risk := sa[0], sa[1]
 	bkt := client.Bucket(SDK_STORE_BUCKET_NAME)
@@ -314,9 +307,9 @@ func storeSdkReaderImpl(ctx context.Context, setup sdk.Setup) (io.ReadCloser, er
 	r, err := obj.NewReader(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrObjectNotExist) {
-			return nil, errors.New("SDK not found")
+			return nil, 0, fmt.Errorf("SDK not found in %q", setup.Channel)
 		}
-		return nil, err
+		return nil, 0, err
 	}
-	return r, nil
+	return r, r.Attrs.Size, nil
 }

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -35,7 +35,6 @@ var (
 	SDK_STORE_BUCKET_NAME = "sdkstore"
 
 	storeSdkInfo   = storeSdkInfoImpl
-	storeConnect   = storeConnectImpl
 	storeSdkReader = storeSdkReaderImpl
 )
 
@@ -201,7 +200,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 	return nil
 }
 
-func storeConnectImpl(ctx context.Context) (*ClientWrapper, error) {
+func storeConnect(ctx context.Context) (*ClientWrapper, error) {
 	opt := option.WithoutAuthentication()
 	testing := false
 	if url := os.Getenv("SDK_STORE_URL"); url != "" { // Set STORAGE_EMULATOR_HOST environment variable for GSC.

--- a/internal/fakestore/store_test.go
+++ b/internal/fakestore/store_test.go
@@ -6,7 +6,6 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/canonical/workshop/internal/arch"
 	store "github.com/canonical/workshop/internal/fakestore"
 	"github.com/canonical/workshop/internal/sdk"
 )
@@ -66,48 +65,6 @@ func (s *storeSuite) TestSdkActionInstallOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *storeSuite) TestSdkActionInstallCannotParseSdkInfo(c *check.C) {
-	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
-		var s = map[string]store.StoreSdk{
-			"test-sdk-broken": {
-				Name:     "test-sdk-broken",
-				Channel:  channel,
-				Revision: sdk.Revision{N: 123},
-				SdkYAML:  `incorrect yaml: -`,
-			},
-			"test-sdk": {
-				Name:     "test-sdk",
-				Channel:  channel,
-				Revision: sdk.Revision{N: 123},
-				SdkYAML:  testSdk,
-			},
-		}
-		return s[name], nil
-	})
-	defer r()
-	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-
-	store := store.New()
-	acts := []sdk.SdkAction{{
-		ProjectId: "24242424",
-		Workshop:  "test-workshop",
-		Action:    sdk.Install,
-		Name:      "test-sdk-broken",
-		Base:      "ubuntu@20.04",
-		Channel:   "latest/stable",
-	}, {
-		ProjectId: "24242424",
-		Workshop:  "test-workshop",
-		Action:    sdk.Install,
-		Name:      "test-sdk",
-		Base:      "ubuntu@20.04",
-		Channel:   "latest/stable",
-	}}
-	res, err := store.SdkAction(context.Background(), acts)
-	c.Assert(res, check.HasLen, 1)
-	c.Assert(err, check.ErrorMatches, "(?s).*test-sdk-broken: yaml: block sequence entries are not allowed in this context")
-}
-
 func (s *storeSuite) TestSdkActionInstallNoBase(c *check.C) {
 	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
 		var s = store.StoreSdk{
@@ -134,61 +91,4 @@ func (s *storeSuite) TestSdkActionInstallNoBase(c *check.C) {
 	res, err := store.SdkAction(context.Background(), acts)
 	c.Assert(res, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
-}
-
-func (s *storeSuite) TestSdkActionInstallIncompatibleBase(c *check.C) {
-	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
-		var s = store.StoreSdk{
-			Name:     "test-sdk",
-			Channel:  channel,
-			Revision: sdk.Revision{N: 123},
-			SdkYAML:  testSdk,
-		}
-		return s, nil
-	})
-	defer r()
-	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-
-	store := store.New()
-	acts := []sdk.SdkAction{{
-		ProjectId: "24242424",
-		Workshop:  "test-workshop",
-		Action:    sdk.Install,
-		Name:      "test-sdk",
-		Base:      "ubuntu@22.04",
-		Channel:   "latest/stable",
-	},
-	}
-	_, err := store.SdkAction(context.Background(), acts)
-	c.Assert(err, check.ErrorMatches, `"test-sdk" SDK from "latest/stable" has "ubuntu@20.04" base; required: "ubuntu@22.04"`)
-}
-
-func (s *storeSuite) TestSdkActionInstallIncompatibleArch(c *check.C) {
-	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
-		var s = store.StoreSdk{
-			Name:     "test-sdk",
-			Channel:  channel,
-			Revision: sdk.Revision{N: 123},
-			SdkYAML:  testSdk + "architecture: amd64\n",
-		}
-		return s, nil
-	})
-	defer r()
-	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-	oldarch := arch.ArchitectureType(arch.DpkgArchitecture())
-	arch.SetArchitecture("ppc64el")
-	defer arch.SetArchitecture(oldarch)
-
-	store := store.New()
-	acts := []sdk.SdkAction{{
-		ProjectId: "24242424",
-		Workshop:  "test-workshop",
-		Action:    sdk.Install,
-		Name:      "test-sdk",
-		Base:      "ubuntu@20.04",
-		Channel:   "latest/stable",
-	},
-	}
-	_, err := store.SdkAction(context.Background(), acts)
-	c.Assert(err, check.ErrorMatches, `"test-sdk" SDK from "latest/stable" has "amd64" architecture; required: "ppc64el" or "all"`)
 }

--- a/internal/osutil/cp.go
+++ b/internal/osutil/cp.go
@@ -21,6 +21,7 @@ package osutil
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -218,6 +219,10 @@ func copyDirChown(info os.FileInfo, src, dst string, uid sys.UserID, gid sys.Gro
 	}
 
 	infos, err := regularFilesDirsAndLinks(src)
+	if errors.Is(err, os.ErrNotExist) {
+		// If src no longer exists, no longer any need to copy it.
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -259,6 +264,10 @@ func copyChown(info os.FileInfo, src, dst string, uid sys.UserID, gid sys.GroupI
 
 func copyLinkChown(src, dst string, uid sys.UserID, gid sys.GroupID) error {
 	path, err := os.Readlink(src)
+	if errors.Is(err, os.ErrNotExist) {
+		// If src no longer exists, no longer any need to copy it.
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -270,6 +279,10 @@ func copyLinkChown(src, dst string, uid sys.UserID, gid sys.GroupID) error {
 
 func copyFileChown(src, dst string, uid sys.UserID, gid sys.GroupID, info os.FileInfo) error {
 	r, err := os.Open(src)
+	if errors.Is(err, os.ErrNotExist) {
+		// If src no longer exists, no longer any need to copy it.
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/osutil/hash.go
+++ b/internal/osutil/hash.go
@@ -1,0 +1,150 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"fmt"
+	"hash"
+	"os"
+	"path/filepath"
+)
+
+// Updates hash with entry metadata for the given directory, and returns the
+// resulting digest. Based on git, but allows any hashing algorithm and takes
+// all permission bits into account.
+func HashDirEntries(hash hash.Cloner, path string) ([]byte, error) {
+	buf := make([]byte, 0, hash.Size())
+	if err := hashDir(hash, buf, path); err != nil {
+		return nil, err
+	}
+	return hash.Sum(buf), nil
+}
+
+// Updates hash with entry metadata for the given directory. Based on git, but
+// allows any hashing algorithm and takes all permission bits into account.
+func WriteDirEntries(hash hash.Cloner, path string) error {
+	buf := make([]byte, 0, hash.Size())
+	return hashDir(hash, buf, path)
+}
+
+// Updates hash with entry metadata for the given directory. The given buffer
+// is used as temporary storage. It should have capacity >= hash.Size().
+func hashDir(hash hash.Cloner, buf []byte, path string) error {
+	infos, err := regularFilesDirsAndLinks(path)
+	if err != nil {
+		return err
+	}
+
+	clone, err := hash.Clone()
+	if err != nil {
+		return err
+	}
+
+	hashSize := hash.Size()
+	var size int64
+	for _, info := range infos {
+		size += int64(len(gitMode(info)))
+		size += 1 // Space delimiter.
+		size += int64(len(info.Name()))
+		size += 1 // NUL delimiter.
+		size += int64(hashSize)
+	}
+
+	if _, err := fmt.Fprintf(hash, "tree %d\x00", size); err != nil {
+		return err
+	}
+
+	for _, info := range infos {
+		name := info.Name()
+		entry := filepath.Join(path, name)
+
+		clone.Reset()
+		if err := hashDirEntry(clone, buf, entry, info); err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintf(hash, "%s %s\x00", gitMode(info), name); err != nil {
+			return err
+		}
+
+		if _, err := hash.Write(clone.Sum(buf[:0])); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func hashDirEntry(hash hash.Cloner, buf []byte, path string, info os.FileInfo) error {
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		return hashLink(hash, path)
+	case info.Mode().IsRegular():
+		return hashFile(hash, path, info.Size())
+	case info.IsDir():
+		return hashDir(hash, buf, path)
+	default:
+		return fmt.Errorf("unexpected file %q", path)
+	}
+}
+
+func hashLink(hash hash.Hash, path string) error {
+	target, err := os.Readlink(path)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(hash, "blob %d\x00%s", len(target), target)
+	return err
+}
+
+func hashFile(hash hash.Hash, path string, size int64) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if _, err := fmt.Fprintf(hash, "blob %d\x00", size); err != nil {
+		return err
+	}
+
+	_, err = file.WriteTo(hash)
+	return err
+}
+
+// We hard code the file type bits to match Linux and git, but allow arbitrary
+// permissions for regular files and directories.
+func gitMode(info os.FileInfo) string {
+	var prefix string
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		return "120000"
+	case info.Mode().IsRegular():
+		prefix = "100"
+	case info.Mode().IsDir():
+		prefix = "40"
+	default:
+		// Error handled in hashDirEntry.
+		return ""
+	}
+
+	return fmt.Sprintf("%s%03o", prefix, info.Mode().Perm())
+}

--- a/internal/osutil/hash_test.go
+++ b/internal/osutil/hash_test.go
@@ -1,0 +1,198 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"crypto/sha1"
+	"crypto/sha3"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+// Embed some files from the initial Workshop commit, so we can check our
+// directory hash works the same as git. Only works because we use 644
+// permissions. Subdirectories won't work because git lists them as 000.
+//
+// $ git rev-list --max-parents=0 HEAD
+// c1e044fdaf453800f8eca00abe10ae8941ba5c1b
+// $ git rev-parse c1e044fdaf453800f8eca00abe10ae8941ba5c1b:cmd
+// 54b847f650bbb2485acf1101facf009abd4de2b4
+// $ git cat-file -p 54b847f650bbb2485acf1101facf009abd4de2b4
+// 100644 blob 490aed778fb6c9d8d63ae30060dda337f815534d	launch.go
+// 100644 blob bd3b483ffe002e94a3339c2ac980e4f6994b996d	main.go
+const (
+	launchGo = `package main
+
+import (
+	workspace "github.com/canonical/workspace/internal"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+type CmdLaunch struct {
+}
+
+func (c *CmdLaunch) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "launch [workspace-name]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Launch a workspace",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
+	fs := afero.NewOsFs()
+	_, err := workspace.NewWorkspace(fs, ".workspace.project.yaml")
+	return err
+}
+`
+
+	mainGo = `package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	app := &cobra.Command{
+		Use:           "workspace",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	app.AddCommand((&CmdLaunch{}).Command())
+
+	if err := app.Execute(); err != nil {
+		return
+	}
+}
+`
+)
+
+type hashSuite struct {
+	testutil.BaseTest
+}
+
+var _ = check.Suite(&hashSuite{})
+
+func (s *hashSuite) TestHashDirEntriesMatchesGit(c *check.C) {
+	root := c.MkDir()
+
+	c.Assert(os.WriteFile(filepath.Join(root, "launch.go"), []byte(launchGo), 0644), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "main.go"), []byte(mainGo), 0644), check.IsNil)
+
+	digest, err := osutil.HashDirEntries(sha1.New().(hash.Cloner), root)
+	c.Assert(err, check.IsNil)
+	c.Check(hex.EncodeToString(digest), check.Equals, "54b847f650bbb2485acf1101facf009abd4de2b4")
+}
+
+func (s *hashSuite) TestHashDirEntriesRespectsPerms(c *check.C) {
+	root := c.MkDir()
+
+	c.Assert(os.Mkdir(filepath.Join(root, "dir"), 0755), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "file"), []byte("foo"), 0644), check.IsNil)
+
+	digest, err := osutil.HashDirEntries(sha3.New384(), root)
+	c.Assert(err, check.IsNil)
+	first := hex.EncodeToString(digest)
+
+	c.Assert(os.Chmod(filepath.Join(root, "dir"), 0775), check.IsNil)
+
+	digest, err = osutil.HashDirEntries(sha3.New384(), root)
+	c.Assert(err, check.IsNil)
+	second := hex.EncodeToString(digest)
+	c.Check(second, check.Not(check.Equals), first)
+
+	c.Assert(os.Chmod(filepath.Join(root, "file"), 0664), check.IsNil)
+
+	digest, err = osutil.HashDirEntries(sha3.New384(), root)
+	c.Assert(err, check.IsNil)
+	third := hex.EncodeToString(digest)
+	c.Check(third, check.Not(check.Equals), second)
+}
+
+func (s *hashSuite) TestHashDirEntriesHandlesLinks(c *check.C) {
+	root := c.MkDir()
+
+	c.Assert(os.WriteFile(filepath.Join(root, "file"), []byte("foo"), os.ModePerm), check.IsNil)
+
+	digest, err := osutil.HashDirEntries(sha3.New384(), root)
+	c.Assert(err, check.IsNil)
+	fileDigest := hex.EncodeToString(digest)
+
+	c.Assert(os.Remove(filepath.Join(root, "file")), check.IsNil)
+	c.Assert(os.Symlink("foo", filepath.Join(root, "file")), check.IsNil)
+
+	digest, err = osutil.HashDirEntries(sha3.New384(), root)
+	c.Assert(err, check.IsNil)
+	linkDigest := hex.EncodeToString(digest)
+	c.Check(linkDigest, check.Not(check.Equals), fileDigest)
+}
+
+// Check that lengths of non-ASCII strings and directory file modes are
+// calculated correctly.
+func (s *hashSuite) TestHashDirEntriesMeasuresLengths(c *check.C) {
+	root := c.MkDir()
+
+	c.Assert(os.Mkdir(filepath.Join(root, "dir"), 0755), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "file"), []byte("üńîċōđę"), 0644), check.IsNil)
+	c.Assert(os.Symlink("ŨŃĪĈŐĐĘ", filepath.Join(root, "link↦")), check.IsNil)
+
+	var metadata []byte
+
+	hash := sha3.New384()
+	_, _ = hash.Write([]byte("tree 0\x00"))
+	// Mode length is only 5 bytes for directories.
+	metadata = append(metadata, []byte("40755 dir\x00")...)
+	metadata = hash.Sum(metadata)
+
+	hash.Reset()
+	// Blob length is 7 codepoints but 14 bytes.
+	fmt.Fprintf(hash, "blob 14\x00%s", "üńîċōđę")
+	metadata = append(metadata, []byte("100644 file\x00")...)
+	metadata = hash.Sum(metadata)
+
+	hash.Reset()
+	// Blob length is 7 codepoints but 14 bytes.
+	fmt.Fprintf(hash, "blob 14\x00%s", "ŨŃĪĈŐĐĘ")
+	metadata = append(metadata, []byte("120000 link↦\x00")...)
+	metadata = hash.Sum(metadata)
+
+	hash.Reset()
+	fmt.Fprintf(hash, "tree %d\x00", len(metadata))
+	_, _ = hash.Write(metadata)
+	expected := hex.EncodeToString(hash.Sum(nil))
+
+	hash.Reset()
+	digest, err := osutil.HashDirEntries(hash, root)
+	c.Assert(err, check.IsNil)
+	c.Check(hex.EncodeToString(digest), check.Equals, expected)
+}

--- a/internal/osutil/sys/syscall.go
+++ b/internal/osutil/sys/syscall.go
@@ -20,9 +20,13 @@
 package sys
 
 import (
+	"cmp"
 	"errors"
 	"os"
 	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // FlagID can be passed to chown-ish functions to mean "no change",
@@ -89,4 +93,32 @@ func FileOwner(info os.FileInfo) (UserID, GroupID, error) {
 		return 0, 0, errors.New("user and group unavailable")
 	}
 	return UserID(stat.Uid), GroupID(stat.Gid), nil
+}
+
+// AccessTime returns the file access time if available.
+func AccessTime(info os.FileInfo) (time.Time, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}, errors.New("file access time unavailable")
+	}
+	return time.Unix(stat.Atim.Unix()), nil
+}
+
+// Lchtimes is like os.Chtimes but doesn't follow symlinks.
+func Lchtimes(path string, atime time.Time, mtime time.Time) error {
+	time1, err1 := timeToTimespec(atime)
+	time2, err2 := timeToTimespec(mtime)
+	if err := cmp.Or(err1, err2); err != nil {
+		return err
+	}
+	times := []unix.Timespec{time1, time2}
+
+	return unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW)
+}
+
+func timeToTimespec(t time.Time) (unix.Timespec, error) {
+	if t.IsZero() {
+		return unix.Timespec{Sec: unix.UTIME_OMIT, Nsec: unix.UTIME_OMIT}, nil
+	}
+	return unix.TimeToTimespec(t)
 }

--- a/internal/osutil/sys/syscall_test.go
+++ b/internal/osutil/sys/syscall_test.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sys_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil/sys"
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type sysSuite struct {
+	testutil.BaseTest
+}
+
+var _ = check.Suite(&sysSuite{})
+
+func (s *sysSuite) TestLchtimes(c *check.C) {
+	root := c.MkDir()
+
+	c.Assert(os.Symlink("target", filepath.Join(root, "link")), check.IsNil)
+
+	// Update atime to +1h and mtime to +1d.
+	soon := time.Now().Add(time.Hour)
+	tomorrow := soon.Add(24 * time.Hour)
+	c.Assert(sys.Lchtimes(filepath.Join(root, "link"), soon, tomorrow), check.IsNil)
+
+	info, err := os.Lstat(filepath.Join(root, "link"))
+	c.Assert(err, check.IsNil)
+	atime, err := sys.AccessTime(info)
+	c.Assert(err, check.IsNil)
+	c.Check(atime.Equal(soon), check.Equals, true, check.Commentf("%v != %v", atime, soon))
+	mtime := info.ModTime()
+	c.Check(mtime.Equal(tomorrow), check.Equals, true, check.Commentf("%v != %v", mtime, tomorrow))
+
+	// Update atime to +2h and leave mtime unchanged.
+	soon = soon.Add(time.Hour)
+	c.Assert(sys.Lchtimes(filepath.Join(root, "link"), soon, time.Time{}), check.IsNil)
+
+	info, err = os.Lstat(filepath.Join(root, "link"))
+	c.Assert(err, check.IsNil)
+	atime, err = sys.AccessTime(info)
+	c.Assert(err, check.IsNil)
+	c.Check(atime.Equal(soon), check.Equals, true, check.Commentf("%v != %v", atime, soon))
+	mtime = info.ModTime()
+	c.Check(mtime.Equal(tomorrow), check.Equals, true, check.Commentf("%v != %v", mtime, tomorrow))
+}

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -46,6 +46,29 @@ func SdkSetup(task *state.Task) (sdk.Setup, error) {
 	return sdkSetup, nil
 }
 
+func maybeSdkYaml(task *state.Task) (string, error) {
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var retrieveId string
+	var sdkYaml string
+
+	if err := task.Get("sdk-retrieve-task", &retrieveId); err != nil {
+		return "", err
+	}
+
+	retrieve := st.Task(retrieveId)
+	if retrieve == nil {
+		return "", fmt.Errorf("internal error: no corresponding retrieve-sdk task found")
+	}
+
+	if err := retrieve.Get("sdk-yaml", &sdkYaml); err != nil {
+		return "", nil
+	}
+	return sdkYaml, nil
+}
+
 func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	user, project, _, err := UserProjectWorkshop(task)
 	if err != nil {
@@ -86,6 +109,20 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	}
 	if err != nil {
 		return err
+	}
+
+	// TODO: We should be downloading a specific revision. Remove this when
+	// the Store supports that (it will probably have to be removed anyway
+	// since DownloadSdk won't return a result after that).
+	if result.Revision != rec.Revision {
+		st.Lock()
+		task.Set("sdk-setup", result.Setup)
+		// Ideally we would validate the YAML here, but we can't check
+		// the base without knowing about the workshop. And this task
+		// should remain workshop-agnostic if possible. Instead we
+		// pass it to doInstallSdk and validate there.
+		task.Set("sdk-yaml", result.SdkYAML)
+		st.Unlock()
 	}
 
 	volume := workshop.VolumeSetup{
@@ -137,6 +174,18 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	wp, err := m.backend.Workshop(ctx, w)
 	if err != nil {
 		return err
+	}
+
+	// TODO: Remove this section when we can download a specific SDK
+	// revision from the Store (this revision was validated earlier).
+	sdkYaml, err := maybeSdkYaml(task)
+	if err != nil {
+		return err
+	}
+	if sdkYaml != "" {
+		if err := workshop.ValidateSdkInfo(project.ProjectId, wp.File, sdkSetup.Name, sdkYaml); err != nil {
+			return err
+		}
 	}
 
 	rev := revert.New()

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -74,34 +74,36 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		},
 	}
 
+	var result *sdk.SdkResult
 	if rec.Source == sdk.SystemSource {
-		if err := system.RetrieveSystemSdk(rec, reporter); err != nil {
-			return err
-		}
+		result, err = system.RetrieveSystemSdk(rec, reporter)
 	} else {
 		st.Lock()
 		store := sdk.StoreService(st)
 		st.Unlock()
 
-		if err = store.DownloadSdk(ctx, rec, reporter); err != nil {
-			return err
-		}
+		result, err = store.DownloadSdk(ctx, rec, reporter)
+	}
+	if err != nil {
+		return err
 	}
 
 	volume := workshop.VolumeSetup{
-		Name:     sdk.VolumeName(rec.Name, rec.Revision),
+		Name:     sdk.VolumeName(result.Name, result.Revision),
 		Kind:     "sdk",
-		Sdk:      rec.Name,
-		Revision: rec.Revision,
+		Sha3_384: result.Sha3_384,
+		MD5:      result.MD5,
+		Sdk:      result.Name,
+		Revision: result.Revision,
 	}
-	file, err := os.Open(rec.Filepath())
+	file, err := os.Open(result.Filepath())
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 	err = m.backend.ImportVolume(ctx, volume, file)
 	if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
-		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", sdk.VolumeName(rec.Name, rec.Revision))
+		logger.Debugf("SDK Manager on maybeCreateVolume: reuse existing SDK volume %q", volume.Name)
 		return nil
 	}
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"gopkg.in/tomb.v2"
@@ -225,7 +227,18 @@ func (m *SdkManager) mountSdk(ctx context.Context, user string, project *worksho
 		return err
 	}
 	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
-	what := workshop.LocalSdkRevision(userDataDir, project.ProjectId, w, sdkSetup.Name, sdkSetup.Revision)
+
+	sdkDir := workshop.LocalSdkDir(userDataDir, project.ProjectId, w, sdkSetup.Name)
+	revision := filepath.Join(sdkDir, sdkSetup.Revision.String())
+	digest, err := os.Readlink(revision)
+	if err != nil {
+		return err
+	}
+	// Ensure we only mount actual SDKs and avoid malicious symlinks.
+	if strings.ContainsRune(digest, os.PathSeparator) {
+		return &os.PathError{Op: "mount", Path: revision, Err: fmt.Errorf("invalid hash %q", digest)}
+	}
+	what := filepath.Join(sdkDir, digest)
 
 	mnt := workshop.Mount{
 		Name:     name,

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -416,18 +416,18 @@ func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk string, sou
 	}
 
 	target := workshop.LocalSdkDir(s.userDataDir, s.project.ProjectId, w, sk)
-	revision, err := sdk.CommitRevision(s.user, path, target, installed)
+	revision, digest, err := sdk.CommitRevision(s.user, path, target, installed)
 	if err != nil {
 		return nil, err
 	}
 
-	sdkYaml, err := os.ReadFile(filepath.Join(target, revision.String(), "meta", "sdk.yaml"))
+	sdkYaml, err := os.ReadFile(filepath.Join(target, digest, "meta", "sdk.yaml"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid %q SDK: %w", sk, err)
 	}
 
 	setup := sdk.Setup{Name: sk, Source: source, Revision: revision}
-	return &sdk.SdkResult{Setup: setup, SdkYAML: string(sdkYaml)}, nil
+	return &sdk.SdkResult{Setup: setup, Sha3_384: digest, SdkYAML: string(sdkYaml)}, nil
 }
 
 func validateSdkResults(projectId string, file *workshop.File, sdks []sdk.SdkResult) ([]sdk.Setup, error) {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -291,7 +291,7 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.
 
 		if volume.Sha3_384 == digest {
 			setup := sdk.Setup{Name: volume.Sdk, Source: sdk.TrySource, Revision: volume.Revision}
-			return &sdk.SdkResult{Setup: setup, SdkYAML: volume.Metadata}, nil
+			return &sdk.SdkResult{Setup: setup, Sha3_384: volume.Sha3_384, SdkYAML: volume.Metadata}, nil
 		}
 	}
 
@@ -308,7 +308,7 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.
 		return nil, err
 	}
 	setup := sdk.Setup{Name: volume.Sdk, Source: sdk.TrySource, Revision: volume.Revision}
-	return &sdk.SdkResult{Setup: setup, SdkYAML: volume.Metadata}, nil
+	return &sdk.SdkResult{Setup: setup, Sha3_384: volume.Sha3_384, SdkYAML: volume.Metadata}, nil
 }
 
 func (s *localSdkFinder) volumes(ctx context.Context) ([]workshop.VolumeInfo, error) {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -107,7 +107,11 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		if err != nil {
 			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
-		sdks := ordered(req.installOrder, req.storeSdks, localSdks)
+		setups, err := validateSdkResults(projectId, req.file, localSdks)
+		if err != nil {
+			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
+		}
+		sdks := ordered(req.installOrder, req.storeSdks, setups)
 
 		tasks := launch(w.state, req.file, req.fileText, req.baseFingerprint, sdks, project)
 		taskset = append(taskset, tasks)
@@ -164,7 +168,11 @@ func (w *WorkshopManager) findRemoteArtifacts(ctx context.Context, project works
 		}
 		installOrder = append(installOrder, sdk.Sketch)
 
-		storeSdks, err := findStoreSdks(sto, ctx, project.ProjectId, file)
+		sdks, err := findStoreSdks(sto, ctx, project.ProjectId, file)
+		if err != nil {
+			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
+		}
+		setups, err := validateSdkResults(project.ProjectId, file, sdks)
 		if err != nil {
 			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
 		}
@@ -173,7 +181,7 @@ func (w *WorkshopManager) findRemoteArtifacts(ctx context.Context, project works
 			fileText:        string(fileBlob),
 			baseFingerprint: fingerprint,
 			installOrder:    installOrder,
-			storeSdks:       storeSdks,
+			storeSdks:       setups,
 		}
 		reqs = append(reqs, req)
 	}
@@ -181,7 +189,12 @@ func (w *WorkshopManager) findRemoteArtifacts(ctx context.Context, project works
 	return reqs, nil
 }
 
-func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.Setup, error) {
+func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.SdkResult, error) {
+	result, err := system.SystemSdkResult()
+	if err != nil {
+		return nil, err
+	}
+
 	acts := []sdk.SdkAction{}
 	for _, sd := range file.Sdks {
 		if sd.Source != sdk.StoreSource {
@@ -191,18 +204,13 @@ func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *w
 		acts = append(acts, act)
 	}
 
-	infos, err := sto.SdkAction(ctx, acts)
+	results, err := sto.SdkAction(ctx, acts)
 	if err != nil {
 		return nil, err
 	}
 
-	setups := make([]sdk.Setup, 1, len(infos)+1)
-	setups[0] = sdk.Setup{Name: "system", Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
-	for _, s := range infos {
-		setups = append(setups, sdk.Setup{Name: s.Name, Channel: s.Channel, Source: sdk.StoreSource, Revision: s.Revision})
-	}
-
-	return setups, nil
+	results = slices.Insert(results, 0, *result)
+	return results, nil
 }
 
 type localSdkFinder struct {
@@ -213,64 +221,63 @@ type localSdkFinder struct {
 	sdkVolumes  []workshop.VolumeInfo
 }
 
-func (s *localSdkFinder) findLocalSdks(ctx context.Context, wp *workshop.Workshop, file *workshop.File) ([]sdk.Setup, error) {
-	localSdks := []sdk.Setup{}
+func (s *localSdkFinder) findLocalSdks(ctx context.Context, wp *workshop.Workshop, file *workshop.File) ([]sdk.SdkResult, error) {
+	localSdks := []sdk.SdkResult{}
 
 	for _, sd := range file.Sdks {
-		revision, err := s.maybeFindLocalSdk(ctx, wp, file, sd)
+		result, err := s.maybeFindLocalSdk(ctx, wp, file, sd)
 		if err != nil {
 			return nil, err
 		}
-		if revision.Unset() {
-			continue
+		if result != nil {
+			localSdks = append(localSdks, *result)
 		}
-		localSdks = append(localSdks, sdk.Setup{Name: sd.Name, Source: sd.Source, Revision: revision})
 	}
 
-	revision, err := s.maybeFindSketchSdk(wp, file.Name)
+	result, err := s.maybeFindSketchSdk(wp, file.Name)
 	if err != nil {
 		return nil, err
 	}
-	if !revision.Unset() {
-		localSdks = append(localSdks, sdk.Setup{Name: sdk.Sketch, Source: sdk.SketchSource, Revision: revision})
+	if result != nil {
+		localSdks = append(localSdks, *result)
 	}
 
 	return localSdks, nil
 }
 
-func (s *localSdkFinder) maybeFindLocalSdk(ctx context.Context, wp *workshop.Workshop, file *workshop.File, sd workshop.SdkRecord) (sdk.Revision, error) {
+func (s *localSdkFinder) maybeFindLocalSdk(ctx context.Context, wp *workshop.Workshop, file *workshop.File, sd workshop.SdkRecord) (*sdk.SdkResult, error) {
 	switch sd.Source {
 	case sdk.TrySource:
 		return s.findTrySdk(ctx, file.Base, sd.Name)
 	case sdk.ProjectSource:
 		return s.findInProjectSdk(wp, file.Name, sd.Name)
 	default:
-		return sdk.Revision{}, nil
+		return nil, nil
 	}
 }
 
-func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (sdk.Revision, error) {
+func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.SdkResult, error) {
 	trydir := workshop.TrySdkDir(s.userDataDir, sk)
 	root, err := os.OpenRoot(trydir)
 	if err != nil {
-		return sdk.Revision{}, fmt.Errorf("SDK %q not found: %w", "try-"+sk, err)
+		return nil, fmt.Errorf("SDK %q not found: %w", "try-"+sk, err)
 	}
 	defer root.Close()
 
 	file, filename, err := findTrySdkFile(root, sk, arch.DpkgArchitecture(), base)
 	if err != nil {
-		return sdk.Revision{}, fmt.Errorf("SDK %q not found: %w", "try-"+sk, err)
+		return nil, fmt.Errorf("SDK %q not found: %w", "try-"+sk, err)
 	}
 	defer file.Close()
 
 	digest, meta, err := readTrySdkMetadata(root, filename)
 	if err != nil {
-		return sdk.Revision{}, fmt.Errorf("invalid SDK %q: %w", "try-"+sk, err)
+		return nil, fmt.Errorf("invalid SDK %q: %w", "try-"+sk, err)
 	}
 
 	volumes, err := s.volumes(ctx)
 	if err != nil {
-		return sdk.Revision{}, err
+		return nil, err
 	}
 
 	minRevision := sdk.Revision{}
@@ -283,7 +290,8 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (sdk.R
 		}
 
 		if volume.Sha3_384 == digest {
-			return volume.Revision, nil
+			setup := sdk.Setup{Name: volume.Sdk, Source: sdk.TrySource, Revision: volume.Revision}
+			return &sdk.SdkResult{Setup: setup, SdkYAML: volume.Metadata}, nil
 		}
 	}
 
@@ -297,9 +305,10 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (sdk.R
 		Metadata: meta,
 	}
 	if err := s.importVolume(ctx, volume, file); err != nil {
-		return sdk.Revision{}, err
+		return nil, err
 	}
-	return revision, nil
+	setup := sdk.Setup{Name: volume.Sdk, Source: sdk.TrySource, Revision: volume.Revision}
+	return &sdk.SdkResult{Setup: setup, SdkYAML: volume.Metadata}, nil
 }
 
 func (s *localSdkFinder) volumes(ctx context.Context) ([]workshop.VolumeInfo, error) {
@@ -370,21 +379,21 @@ func prependRootPath(root *os.Root, err error) error {
 	return err
 }
 
-func (s *localSdkFinder) findInProjectSdk(wp *workshop.Workshop, w, sk string) (sdk.Revision, error) {
+func (s *localSdkFinder) findInProjectSdk(wp *workshop.Workshop, w, sk string) (*sdk.SdkResult, error) {
 	sdkdir := workshop.ProjectSdkPath(s.project.Path, sk)
-	return s.commitRevision(wp, w, sk, sdkdir)
+	return s.commitRevision(wp, w, sk, sdk.ProjectSource, sdkdir)
 }
 
-func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (sdk.Revision, error) {
+func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (*sdk.SdkResult, error) {
 	sketchdir := workshop.SketchSdkCurrent(s.userDataDir, s.project.ProjectId, w)
 
 	recs, err := os.ReadDir(sketchdir)
 	// no Sketch SDK exists for the workshop and it is not an error.
 	if (err == nil && len(recs) == 0) || osutil.IsDirNotExist(err) {
-		return sdk.Revision{}, nil
+		return nil, nil
 	}
 	if err != nil {
-		return sdk.Revision{}, err
+		return nil, err
 	}
 
 	if wp == nil {
@@ -392,31 +401,44 @@ func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (sd
 		// No workshop exists currently; including the sketch SDK would be unexpected.
 		// We remove it (but keep the stash) to prevent future refreshes from including it.
 		if err = os.RemoveAll(sketchdir); err != nil {
-			return sdk.Revision{}, err
+			return nil, err
 		}
-		return sdk.Revision{}, nil
+		return nil, nil
 	}
 
-	return s.commitRevision(wp, w, sdk.Sketch, sketchdir)
+	return s.commitRevision(wp, w, sdk.Sketch, sdk.SketchSource, sketchdir)
 }
 
-func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk, source string) (sdk.Revision, error) {
+func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk string, source sdk.Source, path string) (*sdk.SdkResult, error) {
 	var installed sdk.Revision
 	if wp != nil {
 		installed = wp.Sdks[sk].Revision
 	}
 
 	target := workshop.LocalSdkDir(s.userDataDir, s.project.ProjectId, w, sk)
-	revision, err := sdk.CommitRevision(s.user, source, target, installed)
+	revision, err := sdk.CommitRevision(s.user, path, target, installed)
 	if err != nil {
-		return sdk.Revision{}, err
+		return nil, err
 	}
 
-	if !osutil.FileExists(filepath.Join(target, revision.String(), "meta", "sdk.yaml")) {
-		return sdk.Revision{}, fmt.Errorf("sdk.yaml file not found for SDK %q", sk)
+	sdkYaml, err := os.ReadFile(filepath.Join(target, revision.String(), "meta", "sdk.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid %q SDK: %w", sk, err)
 	}
 
-	return revision, nil
+	setup := sdk.Setup{Name: sk, Source: source, Revision: revision}
+	return &sdk.SdkResult{Setup: setup, SdkYAML: string(sdkYaml)}, nil
+}
+
+func validateSdkResults(projectId string, file *workshop.File, sdks []sdk.SdkResult) ([]sdk.Setup, error) {
+	setups := make([]sdk.Setup, 0, len(sdks))
+	for _, s := range sdks {
+		if err := workshop.ValidateSdkInfo(projectId, file, s.Name, s.SdkYAML); err != nil {
+			return nil, err
+		}
+		setups = append(setups, s.Setup)
+	}
+	return setups, nil
 }
 
 func ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {
@@ -655,7 +677,11 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 			if err != nil {
 				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 			}
-			sdks := ordered(req.installOrder, req.storeSdks, localSdks)
+			setups, err := validateSdkResults(projectId, req.file, localSdks)
+			if err != nil {
+				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
+			}
+			sdks := ordered(req.installOrder, req.storeSdks, setups)
 
 			plan := resolveRefresh(wp, req.file, req.baseFingerprint, sdks)
 			if plan.HasUpdates() {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -433,6 +433,9 @@ func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk string, sou
 func validateSdkResults(projectId string, file *workshop.File, sdks []sdk.SdkResult) ([]sdk.Setup, error) {
 	setups := make([]sdk.Setup, 0, len(sdks))
 	for _, s := range sdks {
+		if s.MD5 == "" && s.Sha3_384 == "" {
+			return nil, fmt.Errorf("internal error: hash not found for %q SDK", s.Name)
+		}
 		if err := workshop.ValidateSdkInfo(projectId, file, s.Name, s.SdkYAML); err != nil {
 			return nil, err
 		}

--- a/internal/sdk/local.go
+++ b/internal/sdk/local.go
@@ -2,12 +2,15 @@ package sdk
 
 import (
 	"cmp"
+	"crypto/sha3"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/canonical/workshop/internal/logger"
@@ -22,86 +25,72 @@ import (
 // revision, e.g. -124. After creating a new revision, all but the three most recently installed
 // revisions will be removed. The currently installed revision can be passed as an argument,
 // to avoid relying too heavily on directory timestamps.
-func CommitRevision(u *user.User, source, target string, installed Revision) (Revision, error) {
-	revisions, err := listRevisions(target)
+func CommitRevision(u *user.User, source, target string, installed Revision) (Revision, string, error) {
+	digest, err := copySdkDir(u, source, target)
 	if err != nil {
-		return Revision{}, err
+		return Revision{}, "", err
 	}
 
-	temp, rev, err := copyRevision(u, source, target)
+	revision, err := linkRevision(target, digest, installed)
 	if err != nil {
-		return Revision{}, err
-	}
-	defer rev.Fail()
-
-	revision, exists := nextRevision(temp, target, revisions)
-	if exists {
-		return revision, nil
+		return Revision{}, "", err
 	}
 
-	if err := moveRevision(temp, target, revision); err != nil {
-		return Revision{}, err
-	}
-	rev.Success()
-	if err := commitRevision(target); err != nil {
-		return Revision{}, err
-	}
-
-	remove := len(revisions) - 2
-	revisions = slices.DeleteFunc(revisions, func(rev Revision) bool { return rev == installed })
-	removeOldRevisions(target, revisions, remove)
-
-	return revision, nil
+	return revision, digest, nil
 }
 
-func listRevisions(path string) ([]Revision, error) {
-	recs, err := os.ReadDir(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	revisions := make([]Revision, 0, len(recs))
-	for _, rec := range recs {
-		name := rec.Name()
-		revision, err := ParseRevision(name)
-		if err == nil && revision.Local() && revision.String() == name {
-			revisions = append(revisions, revision)
-		}
-	}
-	return revisions, nil
-}
-
-func copyRevision(u *user.User, source, target string) (string, *revert.Reverter, error) {
+func copySdkDir(u *user.User, source, target string) (string, error) {
 	uid, gid, err := osutil.UidGid(u)
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 	if err := osutil.MkdirAllChown(target, os.ModePerm, uid, gid); err != nil {
-		return "", nil, err
+		return "", err
 	}
 
 	rev := revert.New()
 	defer rev.Fail()
 
+	dirfd, err := os.Open(target)
+	if err != nil {
+		return "", err
+	}
+	defer dirfd.Close()
+
 	temp, err := os.MkdirTemp(target, "copy-*")
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 	rev.Add(func() { _ = os.RemoveAll(temp) })
 
 	if err := osutil.CopyAllChown(source, temp, uid, gid); err != nil {
-		return "", nil, err
+		return "", err
 	}
 
 	if err := fixLayout(source, temp, uid, gid); err != nil {
-		return "", nil, err
+		return "", err
 	}
 
-	clone := rev.Clone()
+	// FIXME: should drop privileges for this. There's a (small) chance that
+	// unauthorised users can brute force the source directory contents.
+	sum, err := osutil.HashDirEntries(sha3.New384(), temp)
+	if err != nil {
+		return "", err
+	}
+	digest := hex.EncodeToString(sum)
+
+	if err := os.Rename(temp, filepath.Join(target, digest)); errors.Is(err, os.ErrExist) {
+		return digest, nil
+	} else if err != nil {
+		return "", err
+	}
 	rev.Success()
-	return temp, clone, nil
+
+	if err := dirfd.Sync(); err != nil {
+		return "", err
+	}
+
+	return digest, nil
 }
 
 // fixLayout moves sdk.yaml to meta/sdk.yaml and hooks/ to sdk/hooks/.
@@ -206,50 +195,91 @@ func mkdirChmodChown(path string, perm os.FileMode, uid sys.UserID, gid sys.Grou
 	return nil
 }
 
-func nextRevision(source, target string, revisions []Revision) (Revision, bool) {
-	if len(revisions) == 0 {
-		return R(-1), false
+func linkRevision(target, digest string, installed Revision) (Revision, error) {
+	dirfd, err := os.Open(target)
+	if err != nil {
+		return Revision{}, err
+	}
+	defer dirfd.Close()
+
+	revisions, latest, err := listRevisions(dirfd)
+	if err != nil {
+		return Revision{}, err
 	}
 
 	for _, revision := range revisions {
-		dir := filepath.Join(target, revision.String())
-		// FIXME: should drop privileges for this. There's a (small) chance that
-		// unauthorised users can brute force the source directory contents.
-		if osutil.DirsAreEqual(source, dir) {
+		path := filepath.Join(target, revision.String())
+
+		link, err := os.Readlink(path)
+		if err != nil {
+			return Revision{}, err
+		}
+
+		if link == digest {
 			// Extend revision lifetime.
-			if err := os.Chtimes(dir, time.Time{}, time.Now()); err != nil {
+			if err := sys.Lchtimes(path, time.Time{}, time.Now()); err != nil {
 				logger.Noticef("Cannot update revision timestamp: %v", err)
 			}
-			return revision, true
+			return revision, nil
 		}
 	}
 
-	revision := slices.MinFunc(revisions, func(a, b Revision) int { return cmp.Compare(a.N, b.N) })
-	return Revision{N: revision.N - 1}, false
-}
-
-func moveRevision(source, target string, revision Revision) error {
-	return os.Rename(source, filepath.Join(target, revision.String()))
-}
-
-func commitRevision(target string) error {
-	d, err := os.Open(target)
-	if err != nil {
-		return err
+	revision := Revision{N: latest.N - 1}
+	if err := os.Symlink(digest, filepath.Join(target, revision.String())); err != nil {
+		return Revision{}, err
 	}
-	defer d.Close()
-	return d.Sync()
+
+	if err := dirfd.Sync(); err != nil {
+		return Revision{}, err
+	}
+
+	removeOldRevisions(target, revisions, installed)
+
+	return revision, nil
 }
 
-func removeOldRevisions(path string, revisions []Revision, remove int) {
+// List all symlinks in the given directory which look like local revisions
+// (x1, x2, ...). Also return the latest existing revision (among all files,
+// not just symlinks), or the zero revision if there aren't any.
+func listRevisions(dirfd *os.File) ([]Revision, Revision, error) {
+	recs, err := dirfd.ReadDir(-1)
+	if err != nil {
+		return nil, Revision{}, err
+	}
+
+	revisions := make([]Revision, 0, len(recs))
+	latest := Revision{}
+
+	for _, rec := range recs {
+		name := rec.Name()
+		revision, err := ParseRevision(name)
+		if err != nil || !revision.Local() || revision.String() != name {
+			continue
+		}
+
+		if revision.N < latest.N {
+			latest.N = revision.N
+		}
+
+		if rec.Type()&os.ModeSymlink != 0 {
+			revisions = append(revisions, revision)
+		}
+	}
+
+	return revisions, latest, nil
+}
+
+func removeOldRevisions(target string, revisions []Revision, installed Revision) {
+	remove := len(revisions) - 2
 	if remove <= 0 {
 		return
 	}
+	revisions = slices.DeleteFunc(revisions, func(rev Revision) bool { return rev == installed })
 
 	times := make([]revTime, 0, len(revisions))
 	for _, revision := range revisions {
 		var modTime time.Time
-		info, err := os.Stat(filepath.Join(path, revision.String()))
+		info, err := os.Lstat(filepath.Join(target, revision.String()))
 		if err != nil {
 			// Broken revision, use zero modTime so it is removed first.
 			logger.Noticef("Cannot read revision timestamp: %v", err)
@@ -262,10 +292,46 @@ func removeOldRevisions(path string, revisions []Revision, remove int) {
 	slices.SortFunc(times, func(a, b revTime) int { return a.modTime.Compare(b.modTime) })
 	times = times[:remove]
 	for _, time := range times {
-		if err := os.RemoveAll(filepath.Join(path, time.revision.String())); err != nil {
+		if err := removeRevision(target, time.revision.String()); err != nil {
 			logger.Noticef("Cannot remove old revision: %v", err)
 		}
 	}
+}
+
+func removeRevision(target string, revision string) (err error) {
+	path := filepath.Join(target, revision)
+
+	digest, err := os.Readlink(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	// Ensure we only delete actual SDKs and ignore malicious symlinks.
+	if strings.ContainsRune(digest, os.PathSeparator) {
+		return &os.PathError{Op: "remove", Path: path, Err: fmt.Errorf("invalid hash %q", digest)}
+	}
+
+	temp, err := os.MkdirTemp(target, "remove-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err1 := os.RemoveAll(temp); err1 != nil {
+			err = cmp.Or(err, err1)
+		}
+	}()
+
+	if err := os.Rename(filepath.Join(target, digest), filepath.Join(temp, digest)); !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 type revTime struct {

--- a/internal/sdk/local_test.go
+++ b/internal/sdk/local_test.go
@@ -1,9 +1,12 @@
 package sdk_test
 
 import (
+	"crypto/sha3"
+	"encoding/hex"
 	"os"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"gopkg.in/check.v1"
@@ -41,45 +44,77 @@ func (s *localSdk) createSource(c *check.C, contents string) string {
 	return source
 }
 
-func (s *localSdk) createRevision(c *check.C, revision, contents string) {
+func (s *localSdk) createRevision(c *check.C, revision, contents string) string {
 	c.Assert(os.Mkdir(filepath.Join(s.target, revision), 0755), check.IsNil)
 	c.Assert(os.WriteFile(filepath.Join(s.target, revision, "contents"), []byte(contents), 0644), check.IsNil)
+
+	digest, err := osutil.HashDirEntries(sha3.New384(), filepath.Join(s.target, revision))
+	c.Assert(err, check.IsNil)
+	name := hex.EncodeToString(digest)
+
+	c.Assert(os.Rename(filepath.Join(s.target, revision), filepath.Join(s.target, name)), check.IsNil)
+	c.Assert(os.Symlink(name, filepath.Join(s.target, revision)), check.IsNil)
+
+	return name
+}
+
+func dirEntries(names ...string) []string {
+	slices.Sort(names)
+	for i, name := range names {
+		r, err := sdk.ParseRevision(name)
+		if err == nil && r.Local() && r.String() == name {
+			names[i] = "Lrwxrwxrwx " + name
+		} else {
+			names[i] = "drwxr-xr-x " + name
+		}
+	}
+	return names
 }
 
 func (s *localSdk) TestCommitSuccess(c *check.C) {
 	one := s.createSource(c, "1")
-	revision, err := sdk.CommitRevision(s.user, one, s.target, sdk.Revision{})
+	revision, digest1, err := sdk.CommitRevision(s.user, one, s.target, sdk.Revision{})
 	c.Assert(err, check.IsNil)
 	c.Check(revision, check.Equals, sdk.R(-1))
 
 	checkRev1 := func() {
-		c.Check(filepath.Join(s.target, "x1"), testutil.DirEquals, []string{"-rw-r--r-- contents"})
-		c.Check(filepath.Join(s.target, "x1", "contents"), testutil.FileEquals, "1")
+		c.Check(filepath.Join(s.target, "x1"), testutil.SymlinkTargetEquals, digest1)
+		c.Check(filepath.Join(s.target, digest1), testutil.DirEquals, []string{"-rw-r--r-- contents"})
+		c.Check(filepath.Join(s.target, digest1, "contents"), testutil.FileEquals, "1")
 	}
-	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x1"})
+	c.Check(s.target, testutil.DirEquals, dirEntries(digest1, "x1"))
 	checkRev1()
 
 	two := s.createSource(c, "2")
-	revision, err = sdk.CommitRevision(s.user, two, s.target, revision)
+	revision, digest2, err := sdk.CommitRevision(s.user, two, s.target, revision)
 	c.Assert(err, check.IsNil)
 	c.Check(revision, check.Equals, sdk.R(-2))
 
 	checkRev2 := func() {
-		c.Check(filepath.Join(s.target, "x2"), testutil.DirEquals, []string{"-rw-r--r-- contents"})
-		c.Check(filepath.Join(s.target, "x2", "contents"), testutil.FileEquals, "2")
+		c.Check(filepath.Join(s.target, "x2"), testutil.SymlinkTargetEquals, digest2)
+		c.Check(filepath.Join(s.target, digest2), testutil.DirEquals, []string{"-rw-r--r-- contents"})
+		c.Check(filepath.Join(s.target, digest2, "contents"), testutil.FileEquals, "2")
 	}
-	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x1", "drwxr-xr-x x2"})
+	c.Check(s.target, testutil.DirEquals, dirEntries(digest1, digest2, "x1", "x2"))
 	checkRev1()
 	checkRev2()
 
 	oneAgain := s.createSource(c, "1")
-	revision, err = sdk.CommitRevision(s.user, oneAgain, s.target, revision)
+	revision, digest1Again, err := sdk.CommitRevision(s.user, oneAgain, s.target, revision)
 	c.Assert(err, check.IsNil)
 	c.Check(revision, check.Equals, sdk.R(-1))
+	c.Check(digest1Again, check.Equals, digest1)
 
-	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x1", "drwxr-xr-x x2"})
+	c.Check(s.target, testutil.DirEquals, dirEntries(digest1, digest2, "x1", "x2"))
 	checkRev1()
 	checkRev2()
+
+	hash1, err := osutil.HashDirEntries(sha3.New384(), filepath.Join(s.target, digest1))
+	c.Assert(err, check.IsNil)
+	c.Check(hex.EncodeToString(hash1), check.Equals, digest1)
+	hash2, err := osutil.HashDirEntries(sha3.New384(), filepath.Join(s.target, digest2))
+	c.Assert(err, check.IsNil)
+	c.Check(hex.EncodeToString(hash2), check.Equals, digest2)
 }
 
 func (s *localSdk) TestCommitIncreasesRevision(c *check.C) {
@@ -88,7 +123,7 @@ func (s *localSdk) TestCommitIncreasesRevision(c *check.C) {
 	s.createRevision(c, "x1111", "1111")
 
 	source := s.createSource(c, "1112")
-	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-111))
+	revision, _, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-111))
 	c.Assert(err, check.IsNil)
 	c.Check(revision, check.Equals, sdk.R(-1112))
 }
@@ -100,34 +135,34 @@ func (s *localSdk) TestCommitIgnoresUnusualRevisions(c *check.C) {
 	s.createRevision(c, "x013", "13")
 
 	source := s.createSource(c, "1")
-	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.Revision{})
+	revision, _, err := sdk.CommitRevision(s.user, source, s.target, sdk.Revision{})
 	c.Assert(err, check.IsNil)
 	c.Check(revision, check.Equals, sdk.R(-1))
 }
 
 func (s *localSdk) TestCommitRemovesOldRevisions(c *check.C) {
-	s.createRevision(c, "x42", "42")
+	digest42 := s.createRevision(c, "x42", "42")
 	s.createRevision(c, "x43", "43")
-	s.createRevision(c, "x44", "44")
+	digest44 := s.createRevision(c, "x44", "44")
 
 	t3 := time.Now()
 	t2 := t3.Add(-time.Minute)
 	t1 := t2.Add(-time.Minute)
-	c.Assert(os.Chtimes(filepath.Join(s.target, "x42"), time.Time{}, t2), check.IsNil)
-	c.Assert(os.Chtimes(filepath.Join(s.target, "x43"), time.Time{}, t1), check.IsNil)
-	c.Assert(os.Chtimes(filepath.Join(s.target, "x44"), time.Time{}, t3), check.IsNil)
+	c.Assert(sys.Lchtimes(filepath.Join(s.target, "x42"), time.Time{}, t2), check.IsNil)
+	c.Assert(sys.Lchtimes(filepath.Join(s.target, "x43"), time.Time{}, t1), check.IsNil)
+	c.Assert(sys.Lchtimes(filepath.Join(s.target, "x44"), time.Time{}, t3), check.IsNil)
 
 	source := s.createSource(c, "45")
-	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-44))
+	revision, digest45, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-44))
 	c.Assert(err, check.IsNil)
 	c.Check(revision, check.Equals, sdk.R(-45))
-	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x42", "drwxr-xr-x x44", "drwxr-xr-x x45"})
+	c.Check(s.target, testutil.DirEquals, dirEntries(digest42, digest44, digest45, "x42", "x44", "x45"))
 }
 
 func (s *localSdk) TestCommitKeepsInstalled(c *check.C) {
 	s.createRevision(c, "x42", "42")
-	s.createRevision(c, "x43", "43")
-	s.createRevision(c, "x44", "44")
+	digest43 := s.createRevision(c, "x43", "43")
+	digest44 := s.createRevision(c, "x44", "44")
 
 	t3 := time.Now()
 	t2 := t3.Add(-time.Minute)
@@ -137,31 +172,32 @@ func (s *localSdk) TestCommitKeepsInstalled(c *check.C) {
 	c.Assert(os.Chtimes(filepath.Join(s.target, "x44"), time.Time{}, t3), check.IsNil)
 
 	source := s.createSource(c, "45")
-	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-43))
+	revision, digest45, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-43))
 	c.Assert(err, check.IsNil)
 	c.Check(revision, check.Equals, sdk.R(-45))
-	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x43", "drwxr-xr-x x44", "drwxr-xr-x x45"})
+	c.Check(s.target, testutil.DirEquals, dirEntries(digest43, digest44, digest45, "x43", "x44", "x45"))
 }
 
 func (s *localSdk) TestCommitExistingUpdatesTimestamp(c *check.C) {
-	s.createRevision(c, "x41", "41")
-	s.createRevision(c, "x42", "42")
-	s.createRevision(c, "x43", "43")
-	s.createRevision(c, "x44", "44")
+	digest41 := s.createRevision(c, "x41", "41")
+	digest42 := s.createRevision(c, "x42", "42")
+	digest43 := s.createRevision(c, "x43", "43")
+	digest44 := s.createRevision(c, "x44", "44")
 
 	old := time.Now().Add(-time.Minute)
-	c.Assert(os.Chtimes(filepath.Join(s.target, "x43"), time.Time{}, old), check.IsNil)
-	info, err := os.Stat(filepath.Join(s.target, "x43"))
+	c.Assert(sys.Lchtimes(filepath.Join(s.target, "x43"), time.Time{}, old), check.IsNil)
+	info, err := os.Lstat(filepath.Join(s.target, "x43"))
 	c.Assert(err, check.IsNil)
 	c.Check(info.ModTime().Compare(old), check.Equals, 0)
 
 	source := s.createSource(c, "43")
-	revision, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-44))
+	revision, digest43Again, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-44))
 	c.Assert(err, check.IsNil)
 	c.Check(revision, check.Equals, sdk.R(-43))
-	c.Check(s.target, testutil.DirEquals, []string{"drwxr-xr-x x41", "drwxr-xr-x x42", "drwxr-xr-x x43", "drwxr-xr-x x44"})
+	c.Check(digest43Again, check.Equals, digest43)
+	c.Check(s.target, testutil.DirEquals, dirEntries(digest41, digest42, digest43, digest44, "x41", "x42", "x43", "x44"))
 
-	info, err = os.Stat(filepath.Join(s.target, "x43"))
+	info, err = os.Lstat(filepath.Join(s.target, "x43"))
 	c.Assert(err, check.IsNil)
 	c.Check(info.ModTime().Compare(old), check.Equals, 1)
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -243,7 +243,7 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 		sdkYaml.Type = Regular.String()
 	}
 	if sdkYaml.Type == System.String() && !IsSystem(sdkYaml.Name) {
-		return nil, fmt.Errorf("SDK %q has type %q but is not the system SDK", sdkYaml.Name, sdkYaml.Type)
+		return nil, fmt.Errorf("type %q is reserved for the system SDK", sdkYaml.Type)
 	}
 
 	sdkInfo := &Info{

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -20,7 +20,8 @@ func (s StoreAction) String() string {
 }
 
 type SdkResult struct {
-	*Info
+	Setup
+	SdkYAML string
 }
 
 type SdkAction struct {

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -2,6 +2,11 @@ package sdk
 
 import (
 	"context"
+	"crypto/md5"
+	"crypto/sha3"
+	"encoding/hex"
+	"fmt"
+	"hash"
 	"sync"
 
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -21,7 +26,9 @@ func (s StoreAction) String() string {
 
 type SdkResult struct {
 	Setup
-	SdkYAML string
+	Sha3_384 string
+	MD5      string
+	SdkYAML  string
 }
 
 type SdkAction struct {
@@ -62,7 +69,7 @@ func StoreService(st *state.State) Store {
 
 type Store interface {
 	SdkAction(ctx context.Context, actions []SdkAction) ([]SdkResult, error)
-	DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) error
+	DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*SdkResult, error)
 }
 
 func NewFakeStore() Store {
@@ -115,26 +122,37 @@ func (f *FakeStore) SdkAction(ctx context.Context, actions []SdkAction) ([]SdkRe
 	return nil, nil
 }
 
-func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) error {
+func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*SdkResult, error) {
 	f.downloadLock.Lock()
 	defer f.downloadLock.Unlock()
 	f.DownloadCalls = append(f.DownloadCalls, TestDownloadCall{
 		Setup: setup,
 	})
 	if f.DownloadCallback != nil {
-		return f.DownloadCallback(ctx, setup, report)
+		if err := f.DownloadCallback(ctx, setup, report); err != nil {
+			return nil, err
+		}
 	}
-	return nil
-}
 
-func (f *FakeStore) RetrieveSystemSdk(setup Setup, report *progress.Reporter) error {
-	f.downloadLock.Lock()
-	defer f.downloadLock.Unlock()
-	f.DownloadCalls = append(f.DownloadCalls, TestDownloadCall{
-		Setup: setup,
-	})
-	if f.DownloadCallback != nil {
-		return f.DownloadCallback(nil, setup, report)
+	source, err := setup.Source.MarshalText()
+	if err != nil {
+		return nil, err
 	}
-	return nil
+
+	var hash hash.Hash
+	if IsSystem(setup.Name) {
+		hash = sha3.New384()
+	} else {
+		hash = md5.New()
+	}
+	fmt.Fprintf(hash, "%s:%s:%s:%s", setup.Name, source, setup.Channel, setup.Revision)
+	digest := hex.EncodeToString(hash.Sum(nil))
+
+	result := &SdkResult{Setup: setup, SdkYAML: "name: " + setup.Name}
+	if IsSystem(setup.Name) {
+		result.Sha3_384 = digest
+	} else {
+		result.MD5 = digest
+	}
+	return result, nil
 }

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -25,6 +25,15 @@ var (
 	RetrieveSystemSdk = retrieveSystemSdk
 )
 
+func SystemSdkResult() (*sdk.SdkResult, error) {
+	setup := sdk.Setup{Name: "system", Source: sdk.SystemSource, Revision: SystemSdkRevision}
+	sdkYaml, err := SystemSdkFs.ReadFile("meta/sdk.yaml")
+	if err != nil {
+		return nil, err
+	}
+	return &sdk.SdkResult{Setup: setup, SdkYAML: string(sdkYaml)}, nil
+}
+
 func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) error {
 	fl, err := sdk.OpenLock(setup.Name)
 	if err != nil {

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -25,33 +25,36 @@ var (
 	RetrieveSystemSdk = retrieveSystemSdk
 )
 
+// Update the system SDK revision number when this hash changes.
+const SystemSdkDigest = "5891a3a98ed62339c5c24ded56de52a18873bd73ba8e1e03725376e7fc89c7560944b5fb7260c288b17e115e538d7da6"
+
 func SystemSdkResult() (*sdk.SdkResult, error) {
 	setup := sdk.Setup{Name: "system", Source: sdk.SystemSource, Revision: SystemSdkRevision}
 	sdkYaml, err := SystemSdkFs.ReadFile("meta/sdk.yaml")
 	if err != nil {
 		return nil, err
 	}
-	return &sdk.SdkResult{Setup: setup, SdkYAML: string(sdkYaml)}, nil
+	return &sdk.SdkResult{Setup: setup, Sha3_384: SystemSdkDigest, SdkYAML: string(sdkYaml)}, nil
 }
 
-func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) error {
+func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error) {
 	fl, err := sdk.OpenLock(setup.Name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err = fl.Lock(); err != nil {
-		return err
+		return nil, err
 	}
 	defer fl.Close()
 
 	target := setup.Filepath()
 	if osutil.FileExists(target) {
 		logger.Debugf("System SDK on Retrieve: SDK found locally: %s", target)
-		return nil
+		return SystemSdkResult()
 	}
 
 	if setup.Revision != SystemSdkRevision {
-		return fmt.Errorf("system SDK (%s) not available", setup.Revision)
+		return nil, fmt.Errorf("system SDK (%s) not available", setup.Revision)
 	}
 
 	r := revert.New()
@@ -60,7 +63,7 @@ func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) error {
 	// TODO: remove old system SDKs when no longer in use.
 	file, err := os.Create(target)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer file.Close()
 	r.Add(func() {
@@ -71,10 +74,10 @@ func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) error {
 
 	writer := tar.NewWriter(file)
 	if err := addWritableFS(writer, SystemSdkFs); err != nil {
-		return err
+		return nil, err
 	}
 	if err := writer.Close(); err != nil {
-		return err
+		return nil, err
 	}
 
 	if report != nil {
@@ -89,7 +92,7 @@ func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) error {
 	}
 
 	r.Success()
-	return nil
+	return SystemSdkResult()
 }
 
 // Like w.AddFs(fsys) but ensures the user always has write permissions.
@@ -147,7 +150,7 @@ func addWritableFS(w *tar.Writer, fsys fs.FS) error {
 	})
 }
 
-func FakeRetrieveSystemSdk(f func(setup sdk.Setup, report *progress.Reporter) error) func() {
+func FakeRetrieveSystemSdk(f func(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error)) func() {
 	oldRetrieveSystemSdk := RetrieveSystemSdk
 	RetrieveSystemSdk = f
 	return func() { RetrieveSystemSdk = oldRetrieveSystemSdk }

--- a/internal/sdk/system/system_test.go
+++ b/internal/sdk/system/system_test.go
@@ -1,10 +1,9 @@
 package system_test
 
 import (
-	"crypto/sha256"
+	"crypto/sha3"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"testing"
 
@@ -39,9 +38,6 @@ func (f *systemSdk) TearDownSuite(c *check.C) {
 	dirs.SetRootDir(f.oldRoot)
 }
 
-// Update this hash with new SDK revision numbers.
-const systemSdkHash = "9ccfd0116a39ce9ab210697f2e451a7aecd0c07146288ce6bb7ff0c4a847890b"
-
 func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 	done, total := 0, 0
 	report := &progress.Reporter{Name: "1", Report: func(label string, d, t int) {
@@ -49,7 +45,11 @@ func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 		total = t
 	}}
 	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
-	c.Assert(system.RetrieveSystemSdk(setup, report), check.IsNil)
+	result, err := system.RetrieveSystemSdk(setup, report)
+	c.Assert(err, check.IsNil)
+	c.Check(result.Setup, check.Equals, setup)
+	c.Check(result.Sha3_384, check.Equals, system.SystemSdkDigest)
+	c.Check(result.SdkYAML, check.Not(check.Equals), "")
 	c.Check(done, testutil.IntGreaterThan, 0)
 	c.Check(total, testutil.IntGreaterThan, 0)
 	c.Check(done, check.Equals, total)
@@ -58,21 +58,21 @@ func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer r.Close()
 
-	w := sha256.New()
-	_, err = io.Copy(w, r)
+	hash := sha3.New384()
+	_, err = r.WriteTo(hash)
 	c.Assert(err, check.IsNil)
 
-	hash := hex.EncodeToString(w.Sum(nil))
-	c.Check(hash, check.Equals, systemSdkHash, check.Commentf("system SDK revision needs updating"))
+	digest := hex.EncodeToString(hash.Sum(nil))
+	c.Check(digest, check.Equals, system.SystemSdkDigest, check.Commentf("system SDK revision needs updating"))
 	c.Check(system.SystemSdkRevision, check.Equals, sdk.R(1))
 }
 
 func (s *systemSdk) TestRetrieveSystemSdkWrongRevision(c *check.C) {
 	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: sdk.R(system.SystemSdkRevision.N - 1)}
-	err := system.RetrieveSystemSdk(setup, nil)
+	_, err := system.RetrieveSystemSdk(setup, nil)
 	c.Check(err, check.ErrorMatches, fmt.Sprintf(`system SDK \(%s\) not available`, setup.Revision))
 
 	setup.Revision.N += 2
-	err = system.RetrieveSystemSdk(setup, nil)
+	_, err = system.RetrieveSystemSdk(setup, nil)
 	c.Check(err, check.ErrorMatches, fmt.Sprintf(`system SDK \(%s\) not available`, setup.Revision))
 }

--- a/internal/testutil/symlinktargetchecker.go
+++ b/internal/testutil/symlinktargetchecker.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/check.v1"
+)
+
+type symlinkTargetChecker struct {
+	*check.CheckerInfo
+	exact bool
+}
+
+// SymlinkTargetEquals verifies that the given file is a symbolic link with the given target.
+var SymlinkTargetEquals check.Checker = &symlinkTargetChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "SymlinkTargetEquals", Params: []string{"filename", "target"}},
+	exact:       true,
+}
+
+// SymlinkTargetContains verifies that the given file is a symbolic link whose target contains the provided text.
+var SymlinkTargetContains check.Checker = &symlinkTargetChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "SymlinkTargetContains", Params: []string{"filename", "target"}},
+}
+
+// SymlinkTargetMatches verifies that the given file is a symbolic link whose target matches the provided regular expression.
+var SymlinkTargetMatches check.Checker = &symlinkTargetChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "SymlinkTargetMatches", Params: []string{"filename", "regex"}},
+}
+
+func (c *symlinkTargetChecker) Check(params []any, names []string) (result bool, error string) {
+	filename, ok := params[0].(string)
+	if !ok {
+		return false, "Filename must be a string"
+	}
+	if names[1] == "regex" {
+		regexpr, ok := params[1].(string)
+		if !ok {
+			return false, "Regex must be a string"
+		}
+		rx, err := regexp.Compile(regexpr)
+		if err != nil {
+			return false, fmt.Sprintf("Cannot compile regexp %q: %v", regexpr, err)
+		}
+		params[1] = rx
+	}
+	return symlinkTargetCheck(filename, params[1], c.exact)
+}
+
+func symlinkTargetCheck(filename string, expectedTarget any, exact bool) (result bool, error string) {
+	target, err := os.Readlink(filename)
+	if err != nil {
+		return false, fmt.Sprintf("Cannot read symbolic link: %v", err)
+	}
+	if exact {
+		switch expectedTarget := expectedTarget.(type) {
+		case string:
+			result = target == expectedTarget
+		default:
+			error = fmt.Sprintf("Cannot compare symbolic link target with something of type %T", expectedTarget)
+		}
+	} else {
+		switch expectedTarget := expectedTarget.(type) {
+		case string:
+			result = strings.Contains(target, expectedTarget)
+		case *regexp.Regexp:
+			result = expectedTarget.MatchString(target)
+		default:
+			error = fmt.Sprintf("Cannot compare symbolic link target with something of type %T", expectedTarget)
+		}
+	}
+	if !result {
+		if error == "" {
+			error = fmt.Sprintf("Failed to match with symbolic link target:\n%v", target)
+		}
+		return result, error
+	}
+	return result, ""
+}

--- a/internal/testutil/symlinktargetchecker_test.go
+++ b/internal/testutil/symlinktargetchecker_test.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"gopkg.in/check.v1"
+
+	. "github.com/canonical/workshop/internal/testutil"
+)
+
+type symlinkTargetCheckerSuite struct {
+	d       string
+	symlink string
+	target  string
+}
+
+var _ = check.Suite(&symlinkTargetCheckerSuite{})
+
+func (s *symlinkTargetCheckerSuite) SetUpTest(c *check.C) {
+	s.d = c.MkDir()
+	s.symlink = filepath.Join(s.d, "symlink")
+	s.target = "target"
+	c.Assert(os.Symlink(s.target, s.symlink), check.IsNil)
+}
+
+func (s *symlinkTargetCheckerSuite) TestSymlinkTargetEquals(c *check.C) {
+	testInfo(c, SymlinkTargetEquals, "SymlinkTargetEquals", []string{"filename", "target"})
+	testCheck(c, SymlinkTargetEquals, true, "", s.symlink, s.target)
+
+	testCheck(c, SymlinkTargetEquals, false, "Failed to match with symbolic link target:\ntarget", s.symlink, "not-target")
+	testCheck(c, SymlinkTargetEquals, false, `Cannot read symbolic link: readlink missing: no such file or directory`, "missing", "")
+	testCheck(c, SymlinkTargetEquals, false, "Filename must be a string", 42, "")
+	testCheck(c, SymlinkTargetEquals, false, "Cannot compare symbolic link target with something of type int", s.symlink, 1)
+}
+
+func (s *symlinkTargetCheckerSuite) TestSymlinkTargetContains(c *check.C) {
+	testInfo(c, SymlinkTargetContains, "SymlinkTargetContains", []string{"filename", "target"})
+	testCheck(c, SymlinkTargetContains, true, "", s.symlink, s.target[1:])
+	testCheck(c, SymlinkTargetContains, true, "", s.symlink, regexp.MustCompile(".*"))
+
+	testCheck(c, SymlinkTargetContains, false, "Failed to match with symbolic link target:\ntarget", s.symlink, "not-target")
+	testCheck(c, SymlinkTargetContains, false, "Failed to match with symbolic link target:\ntarget", s.symlink, regexp.MustCompile("^$"))
+	testCheck(c, SymlinkTargetContains, false, `Cannot read symbolic link: readlink missing: no such file or directory`, "missing", "")
+	testCheck(c, SymlinkTargetContains, false, "Filename must be a string", 42, "")
+	testCheck(c, SymlinkTargetContains, false, "Cannot compare symbolic link target with something of type int", s.symlink, 1)
+}
+
+func (s *symlinkTargetCheckerSuite) TestSymlinkTargetMatches(c *check.C) {
+	testInfo(c, SymlinkTargetMatches, "SymlinkTargetMatches", []string{"filename", "regex"})
+	testCheck(c, SymlinkTargetMatches, true, "", s.symlink, ".*")
+	testCheck(c, SymlinkTargetMatches, true, "", s.symlink, "^"+regexp.QuoteMeta(s.target)+"$")
+
+	testCheck(c, SymlinkTargetMatches, false, "Failed to match with symbolic link target:\ntarget", s.symlink, "^$")
+	testCheck(c, SymlinkTargetMatches, false, "Failed to match with symbolic link target:\ntarget", s.symlink, "123"+regexp.QuoteMeta(s.target))
+	testCheck(c, SymlinkTargetMatches, false, `Cannot read symbolic link: readlink missing: no such file or directory`, "missing", "")
+	testCheck(c, SymlinkTargetMatches, false, "Filename must be a string", 42, ".*")
+	testCheck(c, SymlinkTargetMatches, false, "Regex must be a string", s.symlink, 1)
+}

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -91,6 +91,8 @@ type VolumeSetup struct {
 	Kind string
 	// Hash of tarball used to create volume.
 	Sha3_384 string
+	// MD5 hash of tarball used to create volume (TODO: remove during Store migration).
+	MD5 string
 	// Name of SDK associated with volume, if any.
 	Sdk string
 	// Revision of SDK associated with volume, if any.

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -327,6 +327,9 @@ func volumeSetupToConfig(info workshop.VolumeSetup) map[string]string {
 	if info.Sha3_384 != "" {
 		config["user.sha3-384"] = info.Sha3_384
 	}
+	if info.MD5 != "" {
+		config["user.md5"] = info.MD5
+	}
 	if info.Sdk != "" {
 		config["user.sdk.name"] = info.Sdk
 	}
@@ -370,6 +373,7 @@ func volumeToInfo(volume *api.StorageVolume, size uint64) workshop.VolumeInfo {
 			Name:     volume.Name,
 			Kind:     volume.Config["user.kind"],
 			Sha3_384: volume.Config["user.sha3-384"],
+			MD5:      volume.Config["user.md5"],
 			Sdk:      volume.Config["user.sdk.name"],
 			Revision: revision,
 			Metadata: volume.Config["user.sdk.meta"],

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -302,6 +302,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 		Name:     "test",
 		Kind:     "testkind",
 		Sha3_384: "abc123",
+		MD5:      "ab12",
 	}
 	err := f.bd.CreateVolume(f.ctx, volume)
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -108,8 +108,8 @@ func (w *Workshop) metaFromFile(ctx context.Context, setup sdk.Setup) (string, e
 	}
 	userDataDir := UserDataRootDir(usr.HomeDir, env)
 
-	rev := LocalSdkRevision(userDataDir, w.Project.ProjectId, w.Name, setup.Name, setup.Revision)
-	metapath := filepath.Join(rev, "meta", "sdk.yaml")
+	sdkDir := LocalSdkDir(userDataDir, w.Project.ProjectId, w.Name, setup.Name)
+	metapath := filepath.Join(sdkDir, setup.Revision.String(), "meta", "sdk.yaml")
 
 	meta, err := os.ReadFile(metapath)
 	return string(meta), err

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/canonical/workshop/internal/arch"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
 )
@@ -112,6 +113,25 @@ func (w *Workshop) metaFromFile(ctx context.Context, setup sdk.Setup) (string, e
 
 	meta, err := os.ReadFile(metapath)
 	return string(meta), err
+}
+
+func ValidateSdkInfo(projectId string, file *File, name, sdkYaml string) error {
+	info, err := sdk.ReadSdkInfo([]byte(sdkYaml), projectId, file.Name)
+	if err != nil {
+		return fmt.Errorf("invalid %q SDK definition: %w", name, err)
+	}
+
+	if info.Name != name {
+		return fmt.Errorf("SDK must be named %q (now: %q)", name, info.Name)
+	}
+	if !slices.Contains([]string{"", file.Base}, info.Base) {
+		return fmt.Errorf("%q SDK has %q base; required: %q", name, info.Base, file.Base)
+	}
+	if !slices.Contains([]string{"", "all", arch.DpkgArchitecture()}, info.Arch) {
+		return fmt.Errorf(`%q SDK has %q architecture; required: %q or "all"`, name, info.Arch, arch.DpkgArchitecture())
+	}
+
+	return nil
 }
 
 // Reads information about the installed SDK from its meta file.

--- a/internal/workshop/workshop_dirs.go
+++ b/internal/workshop/workshop_dirs.go
@@ -43,10 +43,6 @@ func LocalSdkDir(userDataDir, pid, w, name string) string {
 	return filepath.Join(UserData(userDataDir, pid, w), "sdk", name)
 }
 
-func LocalSdkRevision(userDataDir, pid, w, name string, revision sdk.Revision) string {
-	return filepath.Join(LocalSdkDir(userDataDir, pid, w, name), revision.String())
-}
-
 func SketchSdkDir(userDataDir, pid, w string) string {
 	return LocalSdkDir(userDataDir, pid, w, sdk.Sketch)
 }

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/arch"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -36,6 +37,67 @@ func (f *workshopSuite) SetUpTest(c *check.C) {
 func writeFile(c *check.C, path string, content string) {
 	c.Assert(os.MkdirAll(filepath.Dir(path), 0755), check.IsNil)
 	c.Assert(os.WriteFile(path, []byte(content), 0644), check.IsNil)
+}
+
+func (f *workshopSuite) TestValidateSdkSyntax(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	wpath := filepath.Join(f.project.Path, "workshop.yaml")
+	writeFile(c, wpath, string(workshopyaml))
+	file, err := workshop.ReadWorkshop(wpath)
+	c.Assert(err, check.IsNil)
+
+	sdkYaml := `incorrect yaml: -
+`
+	err = workshop.ValidateSdkInfo(f.project.ProjectId, file, "test-sdk-1", sdkYaml)
+	c.Check(err, check.ErrorMatches, `invalid "test-sdk-1" SDK definition: yaml: block sequence entries are not allowed in this context`)
+}
+
+func (f *workshopSuite) TestValidateSdkName(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	wpath := filepath.Join(f.project.Path, "workshop.yaml")
+	writeFile(c, wpath, string(workshopyaml))
+	file, err := workshop.ReadWorkshop(wpath)
+	c.Assert(err, check.IsNil)
+
+	sdkYaml := `name: sdk-1
+`
+	err = workshop.ValidateSdkInfo(f.project.ProjectId, file, "test-sdk-1", sdkYaml)
+	c.Check(err, check.ErrorMatches, `SDK must be named "test-sdk-1" \(now: "sdk-1"\)`)
+}
+
+func (f *workshopSuite) TestValidateSdkBase(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	wpath := filepath.Join(f.project.Path, "workshop.yaml")
+	writeFile(c, wpath, string(workshopyaml))
+	file, err := workshop.ReadWorkshop(wpath)
+	c.Assert(err, check.IsNil)
+
+	sdkYaml := `name: test-sdk-1
+base: ubuntu@24.04
+`
+	err = workshop.ValidateSdkInfo(f.project.ProjectId, file, "test-sdk-1", sdkYaml)
+	c.Check(err, check.ErrorMatches, `"test-sdk-1" SDK has "ubuntu@24.04" base; required: "ubuntu@22.04"`)
+}
+
+func (f *workshopSuite) TestValidateSdkArchitecture(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+	architecture := arch.ArchitectureType(arch.DpkgArchitecture())
+	arch.SetArchitecture("mock32")
+	defer arch.SetArchitecture(architecture)
+
+	wpath := filepath.Join(f.project.Path, "workshop.yaml")
+	writeFile(c, wpath, string(workshopyaml))
+	file, err := workshop.ReadWorkshop(wpath)
+	c.Assert(err, check.IsNil)
+
+	sdkYaml := `name: test-sdk-1
+architecture: mock64
+`
+	err = workshop.ValidateSdkInfo(f.project.ProjectId, file, "test-sdk-1", sdkYaml)
+	c.Check(err, check.ErrorMatches, `"test-sdk-1" SDK has "mock64" architecture; required: "mock32" or "all"`)
 }
 
 func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {


### PR DESCRIPTION
# Description

We already hash SDKs published using `sdkcraft try`. This brings the other types of SDKs in line with that, with a view towards caching SDK snapshots across multiple workshops.

For Store SDKs, the GCS server only supports MD5 hashes and there's no easy way to download a specific SDK revision. Until we switch to the actual Store, SDKs will have either an MD5 or SHA3 hash. The hash is recomputed when downloading the SDK, since it might have changed since the initial query. Both the hash and SDK YAML are cached alongside the download, similar to try SDKs.

I added a validation step for all SDKs, which happens just before planning a launch or refresh. It checks that every SDK in the workshop has a hash and a valid `sdk.yaml`. Previously `sdk.yaml` was only parsed this early for Store SDKs. If the downloaded SDK differs from the plan, we validate the new version before installing it in the workshop.

For local SDKs, on launch/refresh the SDK files are copied to a temporary directory, to make them immutable. Instead of comparing this directory with others, we now compute a hash of the contents. The temporary directory is renamed to the hex digest (unless it already exists). If needed, a revision number is allocated, as a symlink (e.g. `x42 -> abcdef1234567890`). Otherwise the timestamp of the revision is bumped, using a new function `Lchtimes` to avoid following the link.

I fixed a minor bug in the previous local SDK logic: if a user deletes a file within an SDK just before it's copied to the temporary directory, Workshop now ignores the file instead of raising an error.

The hash of a directory is recursive. It accounts for filenames, contents, permissions and doesn't follow symlinks. The exact format is based on `git`:
- For regular files, the data we hash is `blob <file size>\0<file contents>`.
- For symlinks, the data is `blob <target length in bytes>\0<link target>`.
- For directories, the data is `tree <entries length>\0<entries>`, where `entries` is a sequence of items like `<file mode> <file name>\0<hash>`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
