### PR TITLE
Fix abortion for injected tasks

### DIFF
--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -168,4 +168,19 @@ func InjectTasks(mainTask *state.Task, extraTasks *state.TaskSet) {
 
 	// make the extra tasks wait for main task
 	extraTasks.WaitFor(mainTask)
+
+	// Update status of the injected tasks in case the main task was aborted
+	// already. Lets consider what status the main task can have at the time
+	// of the call:
+	// - Do (request processing stage, change is not in a Doing state)
+	// - Doing (Do handler is executed for the main task)
+	// - Abort (the task was aborted *before* the InjectTasks was called AND the
+	// state was locked but *after* the Do handler for the task was started)
+	// - Undoing (Undo handler is executed for the task)
+	status := mainTask.Status()
+	if status == state.AbortStatus {
+		for _, t := range extraTasks.Tasks() {
+			t.SetStatus(state.HoldStatus)
+		}
+	}
 }

--- a/internal/overlord/handlersetup/handler_setup_test.go
+++ b/internal/overlord/handlersetup/handler_setup_test.go
@@ -145,3 +145,30 @@ func (s *CommonStateFuncs) TestInjectTasksWithNullChange(c *check.C) {
 	c.Assert(t1.HaltTasks(), check.HasLen, 1)
 	c.Assert(t1.HaltTasks()[0].Kind(), check.Equals, "task1-1")
 }
+
+func (s *CommonStateFuncs) TestInjectTasksMainAborted(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	lane := s.state.NewLane()
+
+	chg := s.state.NewChange("change", "")
+	t0 := s.state.NewTask("task1", "")
+	// Emulate scenario when the task handler is being executed.
+	t0.SetStatus(state.DoingStatus)
+	chg.AddTask(t0)
+	t0.JoinLane(lane)
+	t01 := s.state.NewTask("task1-1", "")
+	t01.WaitFor(t0)
+	t02 := s.state.NewTask("task1-2", "")
+	t02.WaitFor(t0)
+
+	ts := state.NewTaskSet(t01, t02)
+	// This will abort the main task.
+	chg.Abort()
+	handlersetup.InjectTasks(t0, ts)
+
+	// verify that extra tasks are on hold
+	c.Assert(t01.Status(), check.Equals, state.HoldStatus)
+	c.Assert(t02.Status(), check.Equals, state.HoldStatus)
+}


### PR DESCRIPTION
# Description

If tasks were injected after the change was aborted, it results in a deadlock between the
tasks that would wait for the parent to finish and the parent that would wait for the children to
undo.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
