### PR TITLE
Fix sdk info

### DIFF
--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -62,7 +62,8 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 
 	if info.Description != "" {
 		fmt.Fprintln(Stdout, "description: |")
-		lines := strings.Split(info.Description, "\n")
+		description := strings.TrimSuffix(info.Description, "\n")
+		lines := strings.Split(description, "\n")
 		for _, line := range lines {
 			fmt.Fprintf(Stdout, "  %s\n", line)
 		}

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -70,7 +70,9 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		fmt.Fprintln(Stdout, "description: -")
 	}
 
-	fmt.Fprintln(Stdout, "installed:")
+	if len(info.Installed) > 0 {
+		fmt.Fprintln(Stdout, "installed:")
+	}
 	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', 0)
 	for _, it := range info.Installed {
 		project := cmdutil.ContractHome(it.ProjectPath)

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -284,6 +284,11 @@ func (s *Backend) Volumes(ctx context.Context, kind string) ([]workshop.VolumeIn
 	}
 	defer conn.Disconnect()
 
+	info, err := conn.GetConnectionInfo()
+	if err != nil {
+		return nil, err
+	}
+
 	filters := []string{
 		"type=custom",
 		fmt.Sprintf("config.user.kind=%s", kind),
@@ -296,7 +301,7 @@ func (s *Backend) Volumes(ctx context.Context, kind string) ([]workshop.VolumeIn
 	infos := make([]workshop.VolumeInfo, 0, len(vols))
 	for _, vol := range vols {
 		size := volumeSize(conn, vol.Name)
-		infos = append(infos, volumeToInfo(&vol, size))
+		infos = append(infos, volumeToInfo(&vol, info.Project, size))
 	}
 	return infos, nil
 }
@@ -308,6 +313,11 @@ func (s *Backend) Volume(ctx context.Context, name string) (workshop.VolumeInfo,
 	}
 	defer conn.Disconnect()
 
+	info, err := conn.GetConnectionInfo()
+	if err != nil {
+		return workshop.VolumeInfo{}, err
+	}
+
 	vol, _, err := conn.GetStoragePoolVolume(storagePool, "custom", name)
 	if api.StatusErrorCheck(err, http.StatusNotFound) {
 		return workshop.VolumeInfo{}, workshop.ErrVolumeNotFound
@@ -317,7 +327,7 @@ func (s *Backend) Volume(ctx context.Context, name string) (workshop.VolumeInfo,
 	}
 
 	size := volumeSize(conn, vol.Name)
-	return volumeToInfo(vol, size), nil
+	return volumeToInfo(vol, info.Project, size), nil
 }
 
 func volumeSetupToConfig(info workshop.VolumeSetup) map[string]string {
@@ -339,7 +349,7 @@ func volumeSetupToConfig(info workshop.VolumeSetup) map[string]string {
 	return config
 }
 
-func volumeToInfo(volume *api.StorageVolume, size uint64) workshop.VolumeInfo {
+func volumeToInfo(volume *api.StorageVolume, lxdProject string, size uint64) workshop.VolumeInfo {
 	revision, err := sdk.ParseRevision(volume.Config["user.sdk.revision"])
 	if err != nil {
 		revision = sdk.Revision{}
@@ -352,13 +362,17 @@ func volumeToInfo(volume *api.StorageVolume, size uint64) workshop.VolumeInfo {
 			logger.Debugf("Failed to parse URL %q: %v", u, err)
 			continue
 		}
-		entityType, _, _, pathArgs, err := entity.ParseURL(*parsedURL)
+		entityType, projectName, _, pathArgs, err := entity.ParseURL(*parsedURL)
 		if err != nil {
 			logger.Debugf("Failed to parse entity from URL %q: %v", parsedURL.String(), err)
 			continue
 		}
 		if entityType != entity.TypeInstance || len(pathArgs) == 0 {
 			logger.Debugf("URL %q does not point to an instance, skipping", parsedURL.String())
+			continue
+		}
+		if projectName != lxdProject {
+			// Ignore SDK layers, and workshops owned by other users.
 			continue
 		}
 		wp, pid := workshopProjectId(pathArgs[0])

--- a/tests/lib/sdk/test-sdk-info/latest/edge/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-info/latest/edge/meta/sdk.yaml
@@ -1,0 +1,10 @@
+name: test-sdk-info
+title: SDK info
+base: ubuntu@22.04
+version: "2.0"
+
+summary: test-sdk-info summary
+description: |
+  test-sdk-info description
+
+sdkcraft-started-at: "2025-07-03T02:01:00.123456Z"

--- a/tests/lib/sdk/test-sdk-info/latest/edge/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-info/latest/edge/sdk/hooks/setup-base
@@ -1,0 +1,1 @@
+echo "setup-base ran successfully!"

--- a/tests/lib/sdk/test-sdk-info/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-info/latest/stable/meta/sdk.yaml
@@ -1,0 +1,10 @@
+name: test-sdk-info
+title: SDK info
+base: ubuntu@22.04
+version: "1.0"
+
+summary: test-sdk-info summary
+description: |
+  test-sdk-info description
+
+sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"

--- a/tests/lib/sdk/test-sdk-info/latest/stable/sdk/hooks/setup-base
+++ b/tests/lib/sdk/test-sdk-info/latest/stable/sdk/hooks/setup-base
@@ -1,0 +1,1 @@
+echo "setup-base ran successfully!"

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -67,6 +67,7 @@ function setup_workshop() {
     snap install --dangerous --classic /workshop/tests/*.snap
     snap set workshop store.url=http://localhost:8080/storage/v1/
     snap set workshop workshop.image.server.url="$IMAGE_SERVER"
+    snap alias workshop.sdk sdk
     snap restart workshop
 
     # required to keep /lib/systemd/systemd --user running for a regular user
@@ -144,6 +145,10 @@ function publish_test_sdks() {
 # Workshop sub-command wrappers
 function workshop_exec() {
     sudo -u ubuntu -- workshop "$@" 2>&1
+}
+
+function sdk_exec() {
+    sudo -u ubuntu -- sdk "$@" 2>&1
 }
 
 function run_sdkcraft() {

--- a/tests/main/sdk-info/.workshop/edge.yaml
+++ b/tests/main/sdk-info/.workshop/edge.yaml
@@ -1,0 +1,5 @@
+name: edge
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-info
+    channel: latest/edge

--- a/tests/main/sdk-info/.workshop/stable.yaml
+++ b/tests/main/sdk-info/.workshop/stable.yaml
@@ -1,0 +1,5 @@
+name: stable
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-info
+    channel: latest/stable

--- a/tests/main/sdk-info/header.txt
+++ b/tests/main/sdk-info/header.txt
@@ -1,0 +1,5 @@
+name: test-sdk-info
+summary: test-sdk-info summary
+description: |
+  test-sdk-info description
+installed:

--- a/tests/main/sdk-info/task.yaml
+++ b/tests/main/sdk-info/task.yaml
@@ -1,0 +1,46 @@
+summary: Test sdk info output
+prepare: |
+  sdk_info_volumes() {
+    lxc storage volume list --columns n --format csv workshop config.user.sdk.name=test-sdk-info
+  }
+  sdk_info_volumes | xargs -n1 -r lxc storage volume delete workshop
+restore: |
+  . "$TESTSLIB"/utils.sh
+
+  workshop_exec remove edge || true
+  workshop_exec remove stable || true
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Test SDK info without any volumes"
+  ! sdk_exec info test-sdk-info
+
+  echo "Test SDK info with one volume"
+  workshop_exec launch edge
+  sdk_exec list | MATCH '^test-sdk-info[[:space:]]+2\.0[[:space:]]+[[:digit:]]+[[:space:]]+.*kB$'
+
+  sdk_exec info test-sdk-info > info.log
+  head --lines=-1 info.log > header.log
+  diff -u header.log header.txt
+  tail --lines=1 info.log | MATCH "$PWD:[[:space:]]+edge[[:space:]]+latest/edge[[:space:]]+2025-07-03[[:space:]]+\\([[:digit:]]+\\)[[:space:]]+.*kB$"
+
+  echo "Test SDK info with two volumes"
+  workshop_exec launch stable
+  sdk_exec list | MATCH '^test-sdk-info[[:space:]]+1\.0[[:space:]]+[[:digit:]]+[[:space:]]+.*kB$'
+  sdk_exec list | MATCH '^test-sdk-info[[:space:]]+2\.0[[:space:]]+[[:digit:]]+[[:space:]]+.*kB$'
+
+  sdk_exec info test-sdk-info > info.log
+  head --lines=-2 info.log > header.log
+  diff -u header.log header.txt
+  tail --lines=2 info.log | MATCH "$PWD:[[:space:]]+edge[[:space:]]+latest/edge[[:space:]]+2025-07-03[[:space:]]+\\([[:digit:]]+\\)[[:space:]]+.*kB$"
+  tail --lines=2 info.log | MATCH "$PWD:[[:space:]]+stable[[:space:]]+latest/stable[[:space:]]+2025-04-03[[:space:]]+\\([[:digit:]]+\\)[[:space:]]+.*kB$"
+
+  echo "Test SDK info with two volumes but one workshop"
+  workshop_exec remove edge
+  sdk_exec list | MATCH '^test-sdk-info[[:space:]]+1\.0[[:space:]]+[[:digit:]]+[[:space:]]+.*kB$'
+  sdk_exec list | MATCH '^test-sdk-info[[:space:]]+2\.0[[:space:]]+[[:digit:]]+[[:space:]]+.*kB$'
+
+  sdk_exec info test-sdk-info > info.log
+  head --lines=-1 info.log > header.log
+  diff -u header.log header.txt
+  tail --lines=1 info.log | MATCH "$PWD:[[:space:]]+stable[[:space:]]+latest/stable[[:space:]]+2025-04-03[[:space:]]+\\([[:digit:]]+\\)[[:space:]]+.*kB$"


### PR DESCRIPTION
# Description

I broke the `sdk info` command when introducing SDK layers, which can depend on SDK volumes but don't follow the usual workshop naming convention. For now at least, these are excluded from the list of workshops using the SDK volume, as are workshops and layers owned by other users.

Also fixes a couple of formatting nitpicks I had with `sdk info`, and adds spread tests for `sdk info` and `sdk list`.

For the tests I'm using `snap alias workshop.sdk sdk`, but we'll want to add this at the Store level. I'm not sure if doing that will remove the need to do it manually for locally-built snaps.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
