### PR TITLE
Workaround issue starting 22.04 containers on recent kernels

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -8,7 +8,7 @@ environment:
   SDK_STORE_BUCKET_DIR: /data/sdkstore
   IMAGE_SERVER: $(HOST:echo -n $WORKSHOP_IMAGE_SERVER)
 repack: |
-  test -f tests/workshop*.snap || snapcraft pack -o tests/
+  test -f tests/workshop_*.snap || snapcraft pack -o tests/
   cat <&3 >&4
 backends:
   lxd:
@@ -38,12 +38,13 @@ suites:
   tests/documentation/:
     summary: Documentation tests
     repack: |
-      test -f tests/sdkcraft*.snap
+      test -f tests/sdkcraft_*.snap
       cat <&3 >&4
     prepare: |
       . "$TESTSLIB"/utils.sh
       prepare_environment
       setup_workshop
+      install_sdkcraft
     restore: |
       . "$TESTSLIB"/utils.sh
       cleanup_workshop

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1,6 +1,7 @@
 package lxdbackend
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	_ "embed"
@@ -326,8 +327,11 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		if err != nil {
 			return err
 		}
+		if err := op.Wait(); err != nil {
+			return err
+		}
 
-		return op.Wait()
+		return s.patchInstance(ctx, file.Name, file.Base)
 	default:
 		// Rebuild the existing workshop.
 		snapshots, err := s.layerNames(layerConn, projectId, file.Name, "sdk")
@@ -375,11 +379,55 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		if err != nil {
 			return err
 		}
-		if err = op.Wait(); err != nil {
+		if err := op.Wait(); err != nil {
 			return err
 		}
+
+		return s.patchInstance(ctx, file.Name, file.Base)
+	}
+}
+
+//go:embed snap-confine.old
+var snapConfineOld []byte
+
+//go:embed snap-confine.new
+var snapConfineNew []byte
+
+// Workaround https://bugs.launchpad.net/snapd/+bug/2127244. As of 20251017,
+// ubuntu:22.04 images contain snapd 2.71, which use a new AppArmor version
+// (at least 4.0). When the host has a recent kernel (e.g. 6.14.0-33-generic),
+// AppArmor denies access to /run/systemd/journal/stdout. This prevents some
+// systemd services which log to stdout from starting, since the snapd apt
+// package uses an old Go runtime (versions 1.21 and later redirect standard
+// file descriptors to /dev/null if they are closed). This affects the seeded
+// LXD snap, and snapd refuses to operate until the LXD snap can be installed.
+// For us this manifests as `systemctl is-system-running` remaining in
+// "starting" forever, and the workshop will never start. This workaround
+// applies the patch from https://github.com/canonical/snapd/pull/16131.
+func (s *Backend) patchInstance(ctx context.Context, name, base string) error {
+	if base != "ubuntu@22.04" {
 		return nil
 	}
+
+	fs, err := s.WorkshopFs(ctx, name)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+
+	content, err := fs.ReadFile("/etc/apparmor.d/usr.lib.snapd.snap-confine.real")
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if !slices.Equal(content, snapConfineOld) {
+		return nil
+	}
+
+	return fs.AtomicWriteTo(bytes.NewReader(snapConfineNew), "/etc/apparmor.d/usr.lib.snapd.snap-confine.real", 0644)
 }
 
 func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Context, name, action string, timeout int) error {

--- a/internal/workshop/lxd/snap-confine.new
+++ b/internal/workshop/lxd/snap-confine.new
@@ -1,0 +1,653 @@
+# Author: Jamie Strandboge <jamie@canonical.com>
+#include <tunables/global>
+
+@{SNAP_MOUNT_DIR_LIST}="{,/var/lib/snapd}/snap"
+
+/usr/lib/snapd/snap-confine (attach_disconnected) {
+    # Include any additional files that snapd chose to generate.
+    # - for $HOME on remote file system.
+    # - for $HOME on encrypted media
+    #
+    # Those are discussed on https://forum.snapcraft.io/t/snapd-vs-upstream-kernel-vs-apparmor
+    # and https://forum.snapcraft.io/t/snaps-and-nfs-home/
+    #include "/var/lib/snapd/apparmor/snap-confine"
+
+    # We run privileged, so be fanatical about what we include and don't use
+    # any abstractions
+    /etc/ld.so.cache r,
+    /etc/ld.so.preload r,
+
+    # Do not assume that the interpreter is always named like
+    # ld-linux-x86_64.so, as on some architectures there can be a version after
+    # the .so suffix, eg. ld-linux-aarch64.so.1
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so* mrix,
+    # libc, you are funny
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,glibc-hwcaps/*/,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libreadline{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}librt{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libgcc_s.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libncursesw{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libresolv{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre{,2}{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
+    # normal libs in order
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libdl{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnih.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnih-dbus.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libdbus-1.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libudev.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libseccomp.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcap.so* mr,
+
+    /usr/lib/snapd/snap-confine mr,
+
+    # This rule is needed when executing from a "base: core" devmode snap on 
+    # UC18 and newer where the /usr/lib/snapd/snap-confine inside the 
+    # "base: core" mount namespace always comes from the snapd snap, and thus
+    # we will execute snap-confine via this path, and thus need to be able to
+    # read this path when executing. It's also necessary on classic where both
+    # the snapd and the core snap are installed at the same time.
+    # TODO: remove this rule when we stop supporting executing other snaps from
+    # inside devmode snaps, ideally even in the short term we would only include
+    # this rule on core only, and specifically uc18 and newer where we need it
+    #@VERBATIM_LIBEXECDIR_SNAP_CONFINE@ mr,
+
+    /dev/null rw,
+    /dev/full rw,
+    /dev/zero rw,
+    /dev/random r,
+    /dev/urandom r,
+    /dev/pts/[0-9]* rw,
+    /dev/tty rw,
+
+    # Stdout may be inherited from systemd. This is normally provided by <abstractions/base>
+    /{,var/}run/systemd/journal/stdout rw,
+
+    # SNAP_MOUNT_DIR probe logic
+    /proc/1/root/snap r,
+
+    # cgroup: devices
+    capability sys_admin,
+    capability dac_read_search,
+    capability dac_override,
+    /sys/fs/cgroup/ r,
+    /sys/fs/cgroup/devices/ r,
+    /sys/fs/cgroup/devices/snap.*/ rw,
+    /sys/fs/cgroup/devices/snap.*/cgroup.procs w,
+    /sys/fs/cgroup/devices/snap.*/devices.{allow,deny} w,
+
+    # cgroup: freezer
+    # Allow creating per-snap cgroup freezers and adding snap command (task)
+    # invocations to the freezer. This allows for reliably enumerating all
+    # running processes for the snap. In addition, allow enumerating processes
+    # in the cgroup to determine if it is occupied.
+    /sys/fs/cgroup/freezer/ r,
+    /sys/fs/cgroup/freezer/snap.*/ w,
+    /sys/fs/cgroup/freezer/snap.*/cgroup.procs rw,
+    /sys/fs/cgroup/ r,
+    /sys/fs/cgroup/** r,
+
+    # cgroup: reading own cgroup
+    @{PROC}/@{pid}/cgroup r,
+
+    # cgroup: manage bpf map for device cgroup
+    /sys/fs/bpf/ r,
+    /sys/fs/bpf/snap/ rw,
+    /sys/fs/bpf/snap/* rw,
+    # s-c may need to raise the memlock limit
+    capability sys_resource,
+
+    # querying udev
+    /etc/udev/udev.conf r,
+    /sys/**/uevent r,
+    /run/udev/** rw,
+    /{,usr/}bin/tr ixr,
+    /usr/lib/locale/** r,
+    /usr/lib/@{multiarch}/gconv/gconv-modules r,
+    /usr/lib/@{multiarch}/gconv/gconv-modules.cache r,
+
+    # priv dropping
+    capability setuid,
+    capability setgid,
+
+    # changing profile
+    @{PROC}/[0-9]*/attr/{,apparmor/}exec w,
+    # Reading current profile
+    @{PROC}/[0-9]*/attr/{,apparmor/}current r,
+    # Reading available filesystems
+    @{PROC}/filesystems r,
+
+    # To find where apparmor is mounted
+    @{PROC}/[0-9]*/mounts r,
+    # To find if apparmor is enabled
+    /sys/module/apparmor/parameters/enabled r,
+
+    # For detecting if we're in a container
+    /run/systemd/container r,
+
+    # Don't allow changing profile to unconfined or profiles that start with
+    # '/'. Use 'unsafe' to support snap-exec on armhf and its reliance on
+    # the environment for determining the capabilities of the architecture.
+    # 'unsafe' is ok here because the kernel will have already cleared the
+    # environment as part of launching snap-confine with CAP_SYS_ADMIN. This
+    # does leave directories as configured by ld.so.preload as well as
+    # LD_PRELOAD to be set to a library which is in a directory configured by
+    # ld.so.conf, but access to those locations is mediated by this profile
+    # (which requires rules for specific locations).
+    # TODO: use GenerateAAREExclusionPatterns for this, though the first
+    # rule and the fact that the generative aspect is not an absolute filepath
+    # complicate using that function directly
+    change_profile unsafe /** -> [^u/]**,
+    change_profile unsafe /** -> u[^n]**,
+    change_profile unsafe /** -> un[^c]**,
+    change_profile unsafe /** -> unc[^o]**,
+    change_profile unsafe /** -> unco[^n]**,
+    change_profile unsafe /** -> uncon[^f]**,
+    change_profile unsafe /** -> unconf[^i]**,
+    change_profile unsafe /** -> unconfi[^n]**,
+    change_profile unsafe /** -> unconfin[^e]**,
+    change_profile unsafe /** -> unconfine[^d]**,
+    change_profile unsafe /** -> unconfined?**,
+
+    # allow changing to a few not caught above
+    change_profile unsafe /** -> {u,un,unc,unco,uncon,unconf,unconfi,unconfin,unconfine},
+
+    # LP: #1446794 - when this bug is fixed, change the above to:
+    # deny change_profile unsafe /** -> {unconfined,/**},
+    # change_profile unsafe /** -> **,
+
+    # reading seccomp filters.
+    # Note 1: We still need to consider .bin extension because of global.bin file.
+    # Note 2: This rule is not needed because of rule '/var/lib/** rw', however we keep it because at
+    # some point we want to investigate if we can narrow the scope of the aforementioned rule.
+    /{tmp/snap.rootfs_*/,}var/lib/snapd/seccomp/bpf/*.bin{,2} r,
+
+    # adding a missing bpf mount
+    mount fstype=bpf options=(rw) bpf -> /sys/fs/bpf/,
+
+    # For mounting base dir by dir (write dirs and mount on them)
+    /tmp/snap.rootfs_** rw,
+    mount options=(remount ro) -> /tmp/snap.rootfs_*/,
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/*/*/**/ -> /tmp/snap.rootfs_**/,
+    # For mounting individual files
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/** -> /tmp/snap.rootfs_*/**,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_**/,
+    # Allow mounting dirs from /
+    mount options=(rw rbind) /*/ -> /tmp/snap.rootfs_**/,
+
+    # LP: #1668659 and parallel instances of classic snaps
+    mount options=(rw rbind) /snap/ -> /snap/,
+    mount options=(rw rshared) -> /snap/,
+    mount options=(rw rbind) /var/lib/snapd/snap/ -> /var/lib/snapd/snap/,
+    mount options=(rw rshared) -> /var/lib/snapd/snap/,
+
+    # boostrapping the mount namespace
+    /tmp/snap.rootfs_*/ rw,
+    mount fstype=tmpfs none -> /tmp/snap.rootfs_*/,
+    mount options=(rw rshared) -> /,
+    mount options=(rw bind) /tmp/snap.rootfs_*/ -> /tmp/snap.rootfs_*/,
+    mount options=(rw unbindable) -> /tmp/snap.rootfs_*/,
+    # the next line is for classic system
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/*/*/ -> /tmp/snap.rootfs_*/,
+    # the next line is for core system
+    mount options=(rw rbind) / -> /tmp/snap.rootfs_*/,
+    # all of the constructed rootfs is a rslave
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/,
+    # bidirectional mounts (for both classic and core)
+    # NOTE: this doesn't capture the MERGED_USR configuration option so that
+    # when a distro with merged /usr and / that uses apparmor shows up it
+    # should be handled here.
+    /{,run/}media/ w,
+    mount options=(rw rbind) /{,run/}media/ -> /tmp/snap.rootfs_*/{,run/}media/,
+    /run/netns/ w,
+    mount options=(rw rbind) /run/netns/ -> /tmp/snap.rootfs_*/run/netns/,
+    # unidirectional mounts (only for classic system)
+    mount options=(rw rbind) /dev/ -> /tmp/snap.rootfs_*/dev/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/dev/,
+
+    mount options=(rw rbind) /etc/ -> /tmp/snap.rootfs_*/etc/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/etc/,
+
+    mount options=(rw rbind) /home/ -> /tmp/snap.rootfs_*/home/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/home/,
+
+    mount options=(rw rbind) /root/ -> /tmp/snap.rootfs_*/root/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/root/,
+
+    mount options=(rw rbind) /proc/ -> /tmp/snap.rootfs_*/proc/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/proc/,
+
+    mount options=(rw rbind) /sys/ -> /tmp/snap.rootfs_*/sys/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/sys/,
+
+    mount options=(rw rbind) /tmp/ -> /tmp/snap.rootfs_*/tmp/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/tmp/,
+
+    mount options=(rw rbind) /var/lib/dhcp/ -> /tmp/snap.rootfs_*/var/lib/dhcp/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/dhcp/,
+
+    mount options=(rw rbind) /var/lib/snapd/ -> /tmp/snap.rootfs_*/var/lib/snapd/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/snapd/,
+
+    mount options=(rw rbind) /var/snap/ -> /tmp/snap.rootfs_*/var/snap/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/snap/,
+
+    mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
+    # /var/volatile is the default volatile location on Yocto/Poky, typically used with read-only rootfs setups
+    mount options=(rw rbind) /var/volatile/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/tmp/,
+
+    mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/run/,
+
+    mount options=(rw rbind) /var/lib/extrausers/ -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+
+    mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/modules/ -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
+
+    mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/firmware/ -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
+
+    mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
+    # /var/volatile is the default volatile location on Yocto/Poky, typically used with read-only rootfs setups
+    mount options=(rw rbind) /var/volatile/log/ -> /tmp/snap.rootfs_*/var/log/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/log/,
+
+    mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/usr/src/,
+
+    mount options=(rw rbind) /mnt/ -> /tmp/snap.rootfs_*/mnt/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/mnt/,
+
+    # allow making host snap-exec available inside base snaps
+    mount options=(rw bind) /usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+
+    # allow making re-execed host snap-exec available inside base snaps
+    mount options=(ro bind) @{SNAP_MOUNT_DIR_LIST}/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    # allow making snapd snap tools available inside base snaps
+    mount options=(ro bind) @{SNAP_MOUNT_DIR_LIST}/snapd/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+
+    mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,
+
+    # /etc/alternatives (classic and normal mode)
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/ssl/ -> /tmp/snap.rootfs_*/etc/ssl/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/nsswitch.conf -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/apparmor/ -> /tmp/snap.rootfs_*/etc/apparmor/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/apparmor.d/ -> /tmp/snap.rootfs_*/etc/apparmor.d/,
+
+    # /etc/alternatives (core/legacy mode)
+    mount options=(rw bind) /etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+
+    # making all those directories slave shared.
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/ssl/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/apparmor/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/apparmor.d/,
+
+    # the /snap directory
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/ -> /tmp/snap.rootfs_*/snap/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/snap/,
+    # pivot_root preparation and execution
+    mount options=(rw bind) /tmp/snap.rootfs_*/var/lib/snapd/hostfs/ -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
+    mount options=(rw private) -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
+
+    # pivot_root mediation in AppArmor is not complete. See LP: #1791711.
+    # However, we can mediate the new_root and put_old to be what we expect,
+    # and then deny directory creation within old_root to prevent trivial
+    # pivoting into an allowlisted path.
+    pivot_root oldroot=/tmp/snap.rootfs_*/var/lib/snapd/hostfs/ /tmp/snap.rootfs_*/,
+    # Explicitly deny creating the old_root directory in case it is
+    # inadvertently added somewhere else. While this doesn't resolve
+    # LP: #1791711, it provides some hardening.
+    # For dir on dir mounts, we do need write permissions in /var though
+    audit deny /tmp/snap.rootfs_*/{var/lib/,var/lib/snapd/,var/lib/snapd/hostfs/} w,
+
+    # cleanup
+    umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,
+    umount /var/lib/snapd/hostfs/sys/,
+    umount /var/lib/snapd/hostfs/dev/,
+    umount /var/lib/snapd/hostfs/proc/,
+    mount options=(rw rslave) -> /var/lib/snapd/hostfs/,
+
+    # Hide /writable from view of snaps.
+    mount options=(rprivate) -> /{,var/lib/snapd/hostfs/}writable/,
+    umount /{,var/lib/snapd/hostfs/}writable/,
+
+    # set up user mount namespace
+    mount options=(rslave) -> /,
+
+    # set up mount namespace for parallel instances of classic snaps
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/{,*/} -> @{SNAP_MOUNT_DIR_LIST}/{,*/},
+    mount options=(rslave) -> @{SNAP_MOUNT_DIR_LIST}/,
+    mount options=(rslave) -> /var/snap/,
+    mount options=(rw rbind) /var/snap/{,*/} -> /var/snap/{,*/},
+    mount options=(rw rshared) -> /var/snap/,
+
+    # Allow reading the os-release file (possibly a symlink to /usr/lib).
+    /{etc/,usr/lib/}os-release r,
+
+    # Allow creating /var/lib/snapd/hostfs, if missing
+    /var/lib/snapd/hostfs/ rw,
+
+    # set up snap-specific private /tmp dir
+    capability chown,
+    /tmp/ rw,
+    /tmp/snap-private-tmp/ rw,
+    /tmp/snap-private-tmp/snap.*/ rw,
+    /tmp/snap-private-tmp/snap.*/tmp/ rw,
+    mount options=(rw private) ->  /tmp/,
+    mount options=(rw bind) /tmp/snap-private-tmp/snap.*/tmp/ -> /tmp/,
+    mount fstype=devpts options=(rw) devpts -> /dev/pts/,
+    mount options=(rw bind) /dev/pts/ptmx -> /dev/ptmx,     # for bind mounting
+    mount options=(rw bind) /dev/pts/ptmx -> /dev/pts/ptmx, # for bind mounting under LXD
+    # Workaround for LP: #1584456 on older kernels that mistakenly think
+    # /dev/pts/ptmx needs a trailing '/'
+    mount options=(rw bind) /dev/pts/ptmx/ -> /dev/ptmx/,
+    mount options=(rw bind) /dev/pts/ptmx/ -> /dev/pts/ptmx/,
+
+    # for running snaps on classic
+    /snap/ r,
+    /snap/** r,
+    @{SNAP_MOUNT_DIR_LIST}/ r,
+    @{SNAP_MOUNT_DIR_LIST}/** r,
+
+    # NOTE: at this stage the /snap directory is stable as we have called
+    # pivot_root already.
+
+    # nvidia handling, glob needs /usr/** and the launcher must be
+    # able to bind mount the nvidia dir
+    /sys/module/nvidia/version r,
+    /sys/**/drivers/nvidia{,_*}/* r,
+    /sys/**/nvidia*/uevent r,
+    /sys/module/nvidia{,_*}/* r,
+    /dev/nvidia[0-9]* r,
+    /dev/nvidiactl r,
+    /dev/nvidia-uvm r,
+    /usr/** r,
+    mount options=(rw bind) /usr/lib{,32}/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl{,32}/,
+    mount options=(rw bind) /usr/lib{,32}/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl{,32}/,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/{,*} w,
+    mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
+
+    # Vulkan support
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/{,*} w,
+    mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
+
+    # GLVND EGL vendor
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/{,*} w,
+    mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
+
+    # create gl dirs as needed
+    /tmp/snap.rootfs_*/ r,
+    /tmp/snap.rootfs_*/var/ r,
+    /tmp/snap.rootfs_*/var/lib/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/** rw,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/** rw,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/** rw,
+
+    # for chroot on steroids, we use pivot_root as a better chroot that makes
+    # apparmor rules behave the same on classic and outside of classic.
+
+    # for creating the user data directories: ~/snap, ~/snap/<name> and
+    # ~/snap/<name>/<version>
+    / r,
+    @{HOMEDIRS}/ r,
+    # These should both have 'owner' match but due to LP: #1466234, we can't
+    # yet
+    @{HOME}/ r,
+    @{HOME}/snap/{,*/,*/*/} rw,
+
+    # experimental
+    @{HOME}/.snap/                rw,
+    @{HOME}/.snap/data/{,*/,*/*/} rw,
+    @{HOME}/Snap/{,*/,*/*/}       rw,
+
+    # Special case for *classic* snaps that are used by users with existing dirs
+    # in /var/lib/. Like jenkins, postgresql, mysql, puppet, ...
+    # (see https://forum.snapcraft.io/t/9717)
+    # TODO: this can be removed once we support home-dirs outside of /home
+    #       better
+    /var/ r,
+    /var/lib/ r,
+    # These should both have 'owner' match but due to LP: #1466234, we can't
+    # yet
+    /var/lib/*/ r,
+    /var/lib/*/snap/{,*/,*/*/} rw,
+
+    # for creating the user shared memory directories
+    /{dev,run}/{,shm/} r,
+    # This should both have 'owner' match but due to LP: #1466234, we can't yet
+    /{dev,run}/shm/{,*/,*/*/} rw,
+
+    # for creating the user XDG_RUNTIME_DIR: /run/user, /run/user/UID and
+    # /run/user/UID/<name>
+    /run/user/{,[0-9]*/,[0-9]*/*/} rw,
+
+    # Workaround https://launchpad.net/bugs/359338 until upstream handles
+    # stacked filesystems generally.
+    # encrypted ~/.Private and old-style encrypted $HOME
+    @{HOME}/.Private/ r,
+    @{HOME}/.Private/** mrwlk,
+    # new-style encrypted $HOME
+    @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
+    @{HOMEDIRS}/.ecryptfs/*/.Private/** mrwlk,
+
+    # Allow snap-confine to move to the void, creating it if necessary.
+    /var/lib/snapd/void/ rw,
+
+    # Allow snap-confine to read snap contexts
+    /var/lib/snapd/context/snap.* r,
+
+    # Allow snap-confine to unmount stale mount namespaces.
+    umount /run/snapd/ns/*.mnt,
+    /run/snapd/ns/snap.*.fstab w,
+    # Allow snap-confine to read and write mount namespace information files.
+    /run/snapd/ns/snap.*.info rw,
+    # Required to correctly unmount bound mount namespace.
+    # See LP: #1735459 for details.
+    umount /,
+
+    # support for locking
+    /run/snapd/lock/ rw,
+    /run/snapd/lock/*.lock rwk,
+
+    # support for the mount namespace sharing
+    capability fowner,
+    capability sys_ptrace,
+    # allow snap-confine to read /proc/1/ns/mnt
+    ptrace read peer=unconfined,
+    # https://forum.snapcraft.io/t/custom-kernel-error-on-readlinkat-in-mount-namespace/6097/21
+    ptrace trace peer=unconfined,
+
+    mount options=(rw rbind) /run/snapd/ns/ -> /run/snapd/ns/,
+    mount options=(private) -> /run/snapd/ns/,
+    / rw,
+    /run/ rw,
+    /run/snapd/ rw,
+    /run/snapd/ns/ rw,
+    /run/snapd/ns/*.lock rwk,
+    /run/snapd/ns/*.mnt rw,
+    ptrace (read, readby, tracedby) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+    @{PROC}/*/mountinfo r,
+    capability sys_chroot,
+    capability sys_admin,
+    signal (send, receive) set=(abrt) peer=/usr/lib/snapd/snap-confine,
+    signal (send) set=(int) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+    signal (send, receive) set=(int, alrm, exists) peer=/usr/lib/snapd/snap-confine,
+    signal (receive) set=(exists) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+
+    # workaround for linux 4.13/upstream, see
+    # https://forum.snapcraft.io/t/snapd-2-27-6-2-in-debian-sid-blocked-on-apparmor-in-kernel-4-13-0-1/2813/3
+    ptrace (trace, tracedby) peer=/usr/lib/snapd/snap-confine,
+
+    # Allow reading snap cookies.
+    /var/lib/snapd/cookie/snap.* r,
+
+    # For aa_change_hat() to go into ^mount-namespace-capture-helper
+    @{PROC}/[0-9]*/attr/{,apparmor/}current w,
+
+    # As a special exception allow snap-confine to write to anything in /var/lib.
+    # This code should be changed to allow delegation so that snap-confine can
+    # inherit any file descriptor and pass it to the invoked application but
+    # this is not possible in apparmor yet.
+    # See https://bugs.launchpad.net/snapd/+bug/1815869
+    /var/lib/** rw,
+
+    ^mount-namespace-capture-helper (attach_disconnected) {
+        # We run privileged, so be fanatical about what we include and don't use
+        # any abstractions
+        /etc/ld.so.cache r,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so* mrix,
+        # libc, you are funny
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,glibc-hwcaps/*/,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libreadline{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}librt{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libgcc_s.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libncursesw{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libresolv{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
+        # normal libs in order
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libdl{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnih.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnih-dbus.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libdbus-1.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libudev.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libseccomp.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcap.so* mr,
+
+        /usr/lib/snapd/snap-confine mr,
+
+        /dev/null rw,
+        /dev/full rw,
+        /dev/zero rw,
+        /dev/random r,
+        /dev/urandom r,
+
+        # Stdout may be inherited from systemd. This is normally provided by <abstractions/base>
+        /{,var/}run/systemd/journal/stdout rw,
+
+        capability dac_override,
+        capability sys_ptrace,
+        capability sys_admin,
+        # This allows us to read and bind mount the namespace file
+        / r,
+        @{PROC}/ r,
+        @{PROC}/*/ r,
+        @{PROC}/*/ns/ r,
+        @{PROC}/*/ns/mnt r,
+        /run/ r,
+        /run/snapd/ r,
+        /run/snapd/ns/ r,
+        /run/snapd/ns/*.mnt rw,
+        # NOTE: the source name is / even though we map /proc/123/ns/mnt
+        mount options=(rw bind) / -> /run/snapd/ns/*.mnt,
+        # This is the SIGALRM that we send and receive if a timeout expires
+        signal (send, receive) set=(alrm) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+        # Those two rules are exactly the same but we don't know if the parent process is still alive
+        # and hence has the appropriate label or is already dead and hence has no label.
+        signal (send) set=(exists) peer=/usr/lib/snapd/snap-confine,
+        signal (send) set=(exists) peer=unconfined,
+        # This is so that we can abort
+        signal (send, receive) set=(abrt) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+        #  This is the signal we get if snap-confine dies (we subscribe to it with prctl)
+        signal (receive) set=(int) peer=/usr/lib/snapd/snap-confine,
+        # This allows snap-confine to be killed from the outside.
+        signal (receive) peer=unconfined,
+        # This allows snap-confine to wait for us
+        ptrace (read, trace, tracedby) peer=/usr/lib/snapd/snap-confine,
+    }
+
+    # Allow snap-confine to be killed
+    signal (receive) peer=unconfined,
+
+    # Allow switching to snap-update-ns with a per-snap profile.
+    change_profile -> snap-update-ns.*,
+
+    # Allow executing snap-update-ns when...
+
+    # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
+    # from the distribution package. This is also the location used when using
+    # the core/base snap on all-snap systems. The variants here represent
+    # various locations of libexecdir across distributions.
+    /usr/lib{,exec,64}/snapd/snap-update-ns r,
+
+    # ...snap-confine is not, conceptually, re-executing and uses
+    # snap-update-ns from the distribution package but we are already inside
+    # the constructed mount namespace so we must traverse "hostfs". The
+    # variants here represent various locations of libexecdir across
+    # distributions.
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns r,
+
+    # ..snap-confine is, conceptually, re-executing and uses snap-update-ns
+    # from the core or snapd snaps. Note that the location of the actual snap
+    # varies from distribution to distribution. The variants here represent
+    # different locations of snap mount directory across distributions.
+    /{,var/lib/snapd/}snap/{core,snapd}/*/usr/lib/snapd/snap-update-ns r,
+
+    # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
+    # from the core snap or snapd snap, but we are already inside the
+    # constructed mount namespace. Here the apparmor kernel module
+    # re-constructs the path to snap-update-ns using the "hostfs" mount entry
+    # rather than the more "natural" /snap mount entry but we have no control
+    # over that.  This is reported as (LP: #1716339). The variants here
+    # represent different locations of snap mount directory across
+    # distributions.
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/{core,snapd}/*/usr/lib/snapd/snap-update-ns r,
+
+    # Allow executing snap-discard-ns, just like the set for snap-update-ns
+    # above but with the key difference that snap-discard-ns does not
+    # have a dedicated profile so we need to inherit snap-confine's profile.
+
+    /usr/lib{,exec,64}/snapd/snap-discard-ns rix,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-discard-ns rix,
+    /{,var/lib/snapd/}snap/{core,snapd}/*/usr/lib/snapd/snap-discard-ns rix,
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/{core,snapd}/*/usr/lib/snapd/snap-discard-ns rix,
+
+    # Allow mounting /var/lib/jenkins from the host into the snap.
+    mount options=(rw rbind) /var/lib/jenkins/ -> /tmp/snap.rootfs_*/var/lib/jenkins/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/jenkins/,
+
+    # Suppress noisy file_inherit denials (LP: #1850552) until LP: #1849753 is
+    # fixed.
+    deny /dev/shm/.org.chromium.Chromium.* rw,
+
+    # While snap-confine itself doesn't require unix rules and therefore all
+    # unix rules are implicitly denied, adding an explicit deny for unix to
+    # silence noisy denials breaks nested lxd. Until the cause is determined,
+    # do not use an explicit deny for unix. (LP: #1855355)
+    #deny unix,
+
+    # Explicitly deny these accesses which show up on Arch to silence the
+    # denials for this unneeded access.
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_files-[0-9]*.so* mr,
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_mymachines.[0-9]*.so* mr,
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_systemd.[0-9]*.so* mr,
+    deny /etc/nsswitch.conf r,
+    deny /etc/passwd r,
+}

--- a/internal/workshop/lxd/snap-confine.old
+++ b/internal/workshop/lxd/snap-confine.old
@@ -1,0 +1,647 @@
+# Author: Jamie Strandboge <jamie@canonical.com>
+#include <tunables/global>
+
+@{SNAP_MOUNT_DIR_LIST}="{,/var/lib/snapd}/snap"
+
+/usr/lib/snapd/snap-confine (attach_disconnected) {
+    # Include any additional files that snapd chose to generate.
+    # - for $HOME on remote file system.
+    # - for $HOME on encrypted media
+    #
+    # Those are discussed on https://forum.snapcraft.io/t/snapd-vs-upstream-kernel-vs-apparmor
+    # and https://forum.snapcraft.io/t/snaps-and-nfs-home/
+    #include "/var/lib/snapd/apparmor/snap-confine"
+
+    # We run privileged, so be fanatical about what we include and don't use
+    # any abstractions
+    /etc/ld.so.cache r,
+    /etc/ld.so.preload r,
+
+    # Do not assume that the interpreter is always named like
+    # ld-linux-x86_64.so, as on some architectures there can be a version after
+    # the .so suffix, eg. ld-linux-aarch64.so.1
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so* mrix,
+    # libc, you are funny
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,glibc-hwcaps/*/,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libreadline{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}librt{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libgcc_s.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libncursesw{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libresolv{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre{,2}{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
+    # normal libs in order
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libdl{,-[0-9]*}.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnih.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnih-dbus.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libdbus-1.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libudev.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libseccomp.so* mr,
+    /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcap.so* mr,
+
+    /usr/lib/snapd/snap-confine mr,
+
+    # This rule is needed when executing from a "base: core" devmode snap on 
+    # UC18 and newer where the /usr/lib/snapd/snap-confine inside the 
+    # "base: core" mount namespace always comes from the snapd snap, and thus
+    # we will execute snap-confine via this path, and thus need to be able to
+    # read this path when executing. It's also necessary on classic where both
+    # the snapd and the core snap are installed at the same time.
+    # TODO: remove this rule when we stop supporting executing other snaps from
+    # inside devmode snaps, ideally even in the short term we would only include
+    # this rule on core only, and specifically uc18 and newer where we need it
+    #@VERBATIM_LIBEXECDIR_SNAP_CONFINE@ mr,
+
+    /dev/null rw,
+    /dev/full rw,
+    /dev/zero rw,
+    /dev/random r,
+    /dev/urandom r,
+    /dev/pts/[0-9]* rw,
+    /dev/tty rw,
+
+    # SNAP_MOUNT_DIR probe logic
+    /proc/1/root/snap r,
+
+    # cgroup: devices
+    capability sys_admin,
+    capability dac_read_search,
+    capability dac_override,
+    /sys/fs/cgroup/ r,
+    /sys/fs/cgroup/devices/ r,
+    /sys/fs/cgroup/devices/snap.*/ rw,
+    /sys/fs/cgroup/devices/snap.*/cgroup.procs w,
+    /sys/fs/cgroup/devices/snap.*/devices.{allow,deny} w,
+
+    # cgroup: freezer
+    # Allow creating per-snap cgroup freezers and adding snap command (task)
+    # invocations to the freezer. This allows for reliably enumerating all
+    # running processes for the snap. In addition, allow enumerating processes
+    # in the cgroup to determine if it is occupied.
+    /sys/fs/cgroup/freezer/ r,
+    /sys/fs/cgroup/freezer/snap.*/ w,
+    /sys/fs/cgroup/freezer/snap.*/cgroup.procs rw,
+    /sys/fs/cgroup/ r,
+    /sys/fs/cgroup/** r,
+
+    # cgroup: reading own cgroup
+    @{PROC}/@{pid}/cgroup r,
+
+    # cgroup: manage bpf map for device cgroup
+    /sys/fs/bpf/ r,
+    /sys/fs/bpf/snap/ rw,
+    /sys/fs/bpf/snap/* rw,
+    # s-c may need to raise the memlock limit
+    capability sys_resource,
+
+    # querying udev
+    /etc/udev/udev.conf r,
+    /sys/**/uevent r,
+    /run/udev/** rw,
+    /{,usr/}bin/tr ixr,
+    /usr/lib/locale/** r,
+    /usr/lib/@{multiarch}/gconv/gconv-modules r,
+    /usr/lib/@{multiarch}/gconv/gconv-modules.cache r,
+
+    # priv dropping
+    capability setuid,
+    capability setgid,
+
+    # changing profile
+    @{PROC}/[0-9]*/attr/{,apparmor/}exec w,
+    # Reading current profile
+    @{PROC}/[0-9]*/attr/{,apparmor/}current r,
+    # Reading available filesystems
+    @{PROC}/filesystems r,
+
+    # To find where apparmor is mounted
+    @{PROC}/[0-9]*/mounts r,
+    # To find if apparmor is enabled
+    /sys/module/apparmor/parameters/enabled r,
+
+    # For detecting if we're in a container
+    /run/systemd/container r,
+
+    # Don't allow changing profile to unconfined or profiles that start with
+    # '/'. Use 'unsafe' to support snap-exec on armhf and its reliance on
+    # the environment for determining the capabilities of the architecture.
+    # 'unsafe' is ok here because the kernel will have already cleared the
+    # environment as part of launching snap-confine with CAP_SYS_ADMIN. This
+    # does leave directories as configured by ld.so.preload as well as
+    # LD_PRELOAD to be set to a library which is in a directory configured by
+    # ld.so.conf, but access to those locations is mediated by this profile
+    # (which requires rules for specific locations).
+    # TODO: use GenerateAAREExclusionPatterns for this, though the first
+    # rule and the fact that the generative aspect is not an absolute filepath
+    # complicate using that function directly
+    change_profile unsafe /** -> [^u/]**,
+    change_profile unsafe /** -> u[^n]**,
+    change_profile unsafe /** -> un[^c]**,
+    change_profile unsafe /** -> unc[^o]**,
+    change_profile unsafe /** -> unco[^n]**,
+    change_profile unsafe /** -> uncon[^f]**,
+    change_profile unsafe /** -> unconf[^i]**,
+    change_profile unsafe /** -> unconfi[^n]**,
+    change_profile unsafe /** -> unconfin[^e]**,
+    change_profile unsafe /** -> unconfine[^d]**,
+    change_profile unsafe /** -> unconfined?**,
+
+    # allow changing to a few not caught above
+    change_profile unsafe /** -> {u,un,unc,unco,uncon,unconf,unconfi,unconfin,unconfine},
+
+    # LP: #1446794 - when this bug is fixed, change the above to:
+    # deny change_profile unsafe /** -> {unconfined,/**},
+    # change_profile unsafe /** -> **,
+
+    # reading seccomp filters.
+    # Note 1: We still need to consider .bin extension because of global.bin file.
+    # Note 2: This rule is not needed because of rule '/var/lib/** rw', however we keep it because at
+    # some point we want to investigate if we can narrow the scope of the aforementioned rule.
+    /{tmp/snap.rootfs_*/,}var/lib/snapd/seccomp/bpf/*.bin{,2} r,
+
+    # adding a missing bpf mount
+    mount fstype=bpf options=(rw) bpf -> /sys/fs/bpf/,
+
+    # For mounting base dir by dir (write dirs and mount on them)
+    /tmp/snap.rootfs_** rw,
+    mount options=(remount ro) -> /tmp/snap.rootfs_*/,
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/*/*/**/ -> /tmp/snap.rootfs_**/,
+    # For mounting individual files
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/** -> /tmp/snap.rootfs_*/**,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_**/,
+    # Allow mounting dirs from /
+    mount options=(rw rbind) /*/ -> /tmp/snap.rootfs_**/,
+
+    # LP: #1668659 and parallel instances of classic snaps
+    mount options=(rw rbind) /snap/ -> /snap/,
+    mount options=(rw rshared) -> /snap/,
+    mount options=(rw rbind) /var/lib/snapd/snap/ -> /var/lib/snapd/snap/,
+    mount options=(rw rshared) -> /var/lib/snapd/snap/,
+
+    # boostrapping the mount namespace
+    /tmp/snap.rootfs_*/ rw,
+    mount fstype=tmpfs none -> /tmp/snap.rootfs_*/,
+    mount options=(rw rshared) -> /,
+    mount options=(rw bind) /tmp/snap.rootfs_*/ -> /tmp/snap.rootfs_*/,
+    mount options=(rw unbindable) -> /tmp/snap.rootfs_*/,
+    # the next line is for classic system
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/*/*/ -> /tmp/snap.rootfs_*/,
+    # the next line is for core system
+    mount options=(rw rbind) / -> /tmp/snap.rootfs_*/,
+    # all of the constructed rootfs is a rslave
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/,
+    # bidirectional mounts (for both classic and core)
+    # NOTE: this doesn't capture the MERGED_USR configuration option so that
+    # when a distro with merged /usr and / that uses apparmor shows up it
+    # should be handled here.
+    /{,run/}media/ w,
+    mount options=(rw rbind) /{,run/}media/ -> /tmp/snap.rootfs_*/{,run/}media/,
+    /run/netns/ w,
+    mount options=(rw rbind) /run/netns/ -> /tmp/snap.rootfs_*/run/netns/,
+    # unidirectional mounts (only for classic system)
+    mount options=(rw rbind) /dev/ -> /tmp/snap.rootfs_*/dev/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/dev/,
+
+    mount options=(rw rbind) /etc/ -> /tmp/snap.rootfs_*/etc/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/etc/,
+
+    mount options=(rw rbind) /home/ -> /tmp/snap.rootfs_*/home/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/home/,
+
+    mount options=(rw rbind) /root/ -> /tmp/snap.rootfs_*/root/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/root/,
+
+    mount options=(rw rbind) /proc/ -> /tmp/snap.rootfs_*/proc/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/proc/,
+
+    mount options=(rw rbind) /sys/ -> /tmp/snap.rootfs_*/sys/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/sys/,
+
+    mount options=(rw rbind) /tmp/ -> /tmp/snap.rootfs_*/tmp/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/tmp/,
+
+    mount options=(rw rbind) /var/lib/dhcp/ -> /tmp/snap.rootfs_*/var/lib/dhcp/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/dhcp/,
+
+    mount options=(rw rbind) /var/lib/snapd/ -> /tmp/snap.rootfs_*/var/lib/snapd/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/snapd/,
+
+    mount options=(rw rbind) /var/snap/ -> /tmp/snap.rootfs_*/var/snap/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/snap/,
+
+    mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
+    # /var/volatile is the default volatile location on Yocto/Poky, typically used with read-only rootfs setups
+    mount options=(rw rbind) /var/volatile/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/tmp/,
+
+    mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/run/,
+
+    mount options=(rw rbind) /var/lib/extrausers/ -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/extrausers/,
+
+    mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/modules/ -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/modules/,
+
+    mount options=(rw rbind) {,/usr}/lib{,32,64,x32}/firmware/ -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*{,/usr}/lib/firmware/,
+
+    mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
+    # /var/volatile is the default volatile location on Yocto/Poky, typically used with read-only rootfs setups
+    mount options=(rw rbind) /var/volatile/log/ -> /tmp/snap.rootfs_*/var/log/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/log/,
+
+    mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/usr/src/,
+
+    mount options=(rw rbind) /mnt/ -> /tmp/snap.rootfs_*/mnt/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/mnt/,
+
+    # allow making host snap-exec available inside base snaps
+    mount options=(rw bind) /usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+
+    # allow making re-execed host snap-exec available inside base snaps
+    mount options=(ro bind) @{SNAP_MOUNT_DIR_LIST}/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    # allow making snapd snap tools available inside base snaps
+    mount options=(ro bind) @{SNAP_MOUNT_DIR_LIST}/snapd/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+
+    mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,
+
+    # /etc/alternatives (classic and normal mode)
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/ssl/ -> /tmp/snap.rootfs_*/etc/ssl/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/nsswitch.conf -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/apparmor/ -> /tmp/snap.rootfs_*/etc/apparmor/,
+    mount options=(rw bind) @{SNAP_MOUNT_DIR_LIST}/*/*/etc/apparmor.d/ -> /tmp/snap.rootfs_*/etc/apparmor.d/,
+
+    # /etc/alternatives (core/legacy mode)
+    mount options=(rw bind) /etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+
+    # making all those directories slave shared.
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/ssl/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/apparmor/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/apparmor.d/,
+
+    # the /snap directory
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/ -> /tmp/snap.rootfs_*/snap/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/snap/,
+    # pivot_root preparation and execution
+    mount options=(rw bind) /tmp/snap.rootfs_*/var/lib/snapd/hostfs/ -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
+    mount options=(rw private) -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
+
+    # pivot_root mediation in AppArmor is not complete. See LP: #1791711.
+    # However, we can mediate the new_root and put_old to be what we expect,
+    # and then deny directory creation within old_root to prevent trivial
+    # pivoting into an allowlisted path.
+    pivot_root oldroot=/tmp/snap.rootfs_*/var/lib/snapd/hostfs/ /tmp/snap.rootfs_*/,
+    # Explicitly deny creating the old_root directory in case it is
+    # inadvertently added somewhere else. While this doesn't resolve
+    # LP: #1791711, it provides some hardening.
+    # For dir on dir mounts, we do need write permissions in /var though
+    audit deny /tmp/snap.rootfs_*/{var/lib/,var/lib/snapd/,var/lib/snapd/hostfs/} w,
+
+    # cleanup
+    umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,
+    umount /var/lib/snapd/hostfs/sys/,
+    umount /var/lib/snapd/hostfs/dev/,
+    umount /var/lib/snapd/hostfs/proc/,
+    mount options=(rw rslave) -> /var/lib/snapd/hostfs/,
+
+    # Hide /writable from view of snaps.
+    mount options=(rprivate) -> /{,var/lib/snapd/hostfs/}writable/,
+    umount /{,var/lib/snapd/hostfs/}writable/,
+
+    # set up user mount namespace
+    mount options=(rslave) -> /,
+
+    # set up mount namespace for parallel instances of classic snaps
+    mount options=(rw rbind) @{SNAP_MOUNT_DIR_LIST}/{,*/} -> @{SNAP_MOUNT_DIR_LIST}/{,*/},
+    mount options=(rslave) -> @{SNAP_MOUNT_DIR_LIST}/,
+    mount options=(rslave) -> /var/snap/,
+    mount options=(rw rbind) /var/snap/{,*/} -> /var/snap/{,*/},
+    mount options=(rw rshared) -> /var/snap/,
+
+    # Allow reading the os-release file (possibly a symlink to /usr/lib).
+    /{etc/,usr/lib/}os-release r,
+
+    # Allow creating /var/lib/snapd/hostfs, if missing
+    /var/lib/snapd/hostfs/ rw,
+
+    # set up snap-specific private /tmp dir
+    capability chown,
+    /tmp/ rw,
+    /tmp/snap-private-tmp/ rw,
+    /tmp/snap-private-tmp/snap.*/ rw,
+    /tmp/snap-private-tmp/snap.*/tmp/ rw,
+    mount options=(rw private) ->  /tmp/,
+    mount options=(rw bind) /tmp/snap-private-tmp/snap.*/tmp/ -> /tmp/,
+    mount fstype=devpts options=(rw) devpts -> /dev/pts/,
+    mount options=(rw bind) /dev/pts/ptmx -> /dev/ptmx,     # for bind mounting
+    mount options=(rw bind) /dev/pts/ptmx -> /dev/pts/ptmx, # for bind mounting under LXD
+    # Workaround for LP: #1584456 on older kernels that mistakenly think
+    # /dev/pts/ptmx needs a trailing '/'
+    mount options=(rw bind) /dev/pts/ptmx/ -> /dev/ptmx/,
+    mount options=(rw bind) /dev/pts/ptmx/ -> /dev/pts/ptmx/,
+
+    # for running snaps on classic
+    /snap/ r,
+    /snap/** r,
+    @{SNAP_MOUNT_DIR_LIST}/ r,
+    @{SNAP_MOUNT_DIR_LIST}/** r,
+
+    # NOTE: at this stage the /snap directory is stable as we have called
+    # pivot_root already.
+
+    # nvidia handling, glob needs /usr/** and the launcher must be
+    # able to bind mount the nvidia dir
+    /sys/module/nvidia/version r,
+    /sys/**/drivers/nvidia{,_*}/* r,
+    /sys/**/nvidia*/uevent r,
+    /sys/module/nvidia{,_*}/* r,
+    /dev/nvidia[0-9]* r,
+    /dev/nvidiactl r,
+    /dev/nvidia-uvm r,
+    /usr/** r,
+    mount options=(rw bind) /usr/lib{,32}/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl{,32}/,
+    mount options=(rw bind) /usr/lib{,32}/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl{,32}/,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/{,*} w,
+    mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
+
+    # Vulkan support
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/{,*} w,
+    mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
+
+    # GLVND EGL vendor
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/{,*} w,
+    mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
+    mount options=(remount ro bind) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
+
+    # create gl dirs as needed
+    /tmp/snap.rootfs_*/ r,
+    /tmp/snap.rootfs_*/var/ r,
+    /tmp/snap.rootfs_*/var/lib/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/** rw,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/** rw,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/** rw,
+
+    # for chroot on steroids, we use pivot_root as a better chroot that makes
+    # apparmor rules behave the same on classic and outside of classic.
+
+    # for creating the user data directories: ~/snap, ~/snap/<name> and
+    # ~/snap/<name>/<version>
+    / r,
+    @{HOMEDIRS}/ r,
+    # These should both have 'owner' match but due to LP: #1466234, we can't
+    # yet
+    @{HOME}/ r,
+    @{HOME}/snap/{,*/,*/*/} rw,
+
+    # experimental
+    @{HOME}/.snap/                rw,
+    @{HOME}/.snap/data/{,*/,*/*/} rw,
+    @{HOME}/Snap/{,*/,*/*/}       rw,
+
+    # Special case for *classic* snaps that are used by users with existing dirs
+    # in /var/lib/. Like jenkins, postgresql, mysql, puppet, ...
+    # (see https://forum.snapcraft.io/t/9717)
+    # TODO: this can be removed once we support home-dirs outside of /home
+    #       better
+    /var/ r,
+    /var/lib/ r,
+    # These should both have 'owner' match but due to LP: #1466234, we can't
+    # yet
+    /var/lib/*/ r,
+    /var/lib/*/snap/{,*/,*/*/} rw,
+
+    # for creating the user shared memory directories
+    /{dev,run}/{,shm/} r,
+    # This should both have 'owner' match but due to LP: #1466234, we can't yet
+    /{dev,run}/shm/{,*/,*/*/} rw,
+
+    # for creating the user XDG_RUNTIME_DIR: /run/user, /run/user/UID and
+    # /run/user/UID/<name>
+    /run/user/{,[0-9]*/,[0-9]*/*/} rw,
+
+    # Workaround https://launchpad.net/bugs/359338 until upstream handles
+    # stacked filesystems generally.
+    # encrypted ~/.Private and old-style encrypted $HOME
+    @{HOME}/.Private/ r,
+    @{HOME}/.Private/** mrwlk,
+    # new-style encrypted $HOME
+    @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
+    @{HOMEDIRS}/.ecryptfs/*/.Private/** mrwlk,
+
+    # Allow snap-confine to move to the void, creating it if necessary.
+    /var/lib/snapd/void/ rw,
+
+    # Allow snap-confine to read snap contexts
+    /var/lib/snapd/context/snap.* r,
+
+    # Allow snap-confine to unmount stale mount namespaces.
+    umount /run/snapd/ns/*.mnt,
+    /run/snapd/ns/snap.*.fstab w,
+    # Allow snap-confine to read and write mount namespace information files.
+    /run/snapd/ns/snap.*.info rw,
+    # Required to correctly unmount bound mount namespace.
+    # See LP: #1735459 for details.
+    umount /,
+
+    # support for locking
+    /run/snapd/lock/ rw,
+    /run/snapd/lock/*.lock rwk,
+
+    # support for the mount namespace sharing
+    capability fowner,
+    capability sys_ptrace,
+    # allow snap-confine to read /proc/1/ns/mnt
+    ptrace read peer=unconfined,
+    # https://forum.snapcraft.io/t/custom-kernel-error-on-readlinkat-in-mount-namespace/6097/21
+    ptrace trace peer=unconfined,
+
+    mount options=(rw rbind) /run/snapd/ns/ -> /run/snapd/ns/,
+    mount options=(private) -> /run/snapd/ns/,
+    / rw,
+    /run/ rw,
+    /run/snapd/ rw,
+    /run/snapd/ns/ rw,
+    /run/snapd/ns/*.lock rwk,
+    /run/snapd/ns/*.mnt rw,
+    ptrace (read, readby, tracedby) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+    @{PROC}/*/mountinfo r,
+    capability sys_chroot,
+    capability sys_admin,
+    signal (send, receive) set=(abrt) peer=/usr/lib/snapd/snap-confine,
+    signal (send) set=(int) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+    signal (send, receive) set=(int, alrm, exists) peer=/usr/lib/snapd/snap-confine,
+    signal (receive) set=(exists) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+
+    # workaround for linux 4.13/upstream, see
+    # https://forum.snapcraft.io/t/snapd-2-27-6-2-in-debian-sid-blocked-on-apparmor-in-kernel-4-13-0-1/2813/3
+    ptrace (trace, tracedby) peer=/usr/lib/snapd/snap-confine,
+
+    # Allow reading snap cookies.
+    /var/lib/snapd/cookie/snap.* r,
+
+    # For aa_change_hat() to go into ^mount-namespace-capture-helper
+    @{PROC}/[0-9]*/attr/{,apparmor/}current w,
+
+    # As a special exception allow snap-confine to write to anything in /var/lib.
+    # This code should be changed to allow delegation so that snap-confine can
+    # inherit any file descriptor and pass it to the invoked application but
+    # this is not possible in apparmor yet.
+    # See https://bugs.launchpad.net/snapd/+bug/1815869
+    /var/lib/** rw,
+
+    ^mount-namespace-capture-helper (attach_disconnected) {
+        # We run privileged, so be fanatical about what we include and don't use
+        # any abstractions
+        /etc/ld.so.cache r,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}ld{-*,64}.so* mrix,
+        # libc, you are funny
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,glibc-hwcaps/*/,@{multiarch}/{,atomics/}}libc{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libpthread{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libreadline{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}librt{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libgcc_s.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libncursesw{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libresolv{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libselinux.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpcre.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libmount.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libblkid.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libuuid.so* mr,
+        # normal libs in order
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libapparmor.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcgmanager.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/{,atomics/}}libdl{,-[0-9]*}.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnih.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnih-dbus.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libdbus-1.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libudev.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libseccomp.so* mr,
+        /{,{,var/lib/snapd/}snap/{snapd,core}/*/}{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcap.so* mr,
+
+        /usr/lib/snapd/snap-confine mr,
+
+        /dev/null rw,
+        /dev/full rw,
+        /dev/zero rw,
+        /dev/random r,
+        /dev/urandom r,
+
+        capability dac_override,
+        capability sys_ptrace,
+        capability sys_admin,
+        # This allows us to read and bind mount the namespace file
+        / r,
+        @{PROC}/ r,
+        @{PROC}/*/ r,
+        @{PROC}/*/ns/ r,
+        @{PROC}/*/ns/mnt r,
+        /run/ r,
+        /run/snapd/ r,
+        /run/snapd/ns/ r,
+        /run/snapd/ns/*.mnt rw,
+        # NOTE: the source name is / even though we map /proc/123/ns/mnt
+        mount options=(rw bind) / -> /run/snapd/ns/*.mnt,
+        # This is the SIGALRM that we send and receive if a timeout expires
+        signal (send, receive) set=(alrm) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+        # Those two rules are exactly the same but we don't know if the parent process is still alive
+        # and hence has the appropriate label or is already dead and hence has no label.
+        signal (send) set=(exists) peer=/usr/lib/snapd/snap-confine,
+        signal (send) set=(exists) peer=unconfined,
+        # This is so that we can abort
+        signal (send, receive) set=(abrt) peer=/usr/lib/snapd/snap-confine//mount-namespace-capture-helper,
+        #  This is the signal we get if snap-confine dies (we subscribe to it with prctl)
+        signal (receive) set=(int) peer=/usr/lib/snapd/snap-confine,
+        # This allows snap-confine to be killed from the outside.
+        signal (receive) peer=unconfined,
+        # This allows snap-confine to wait for us
+        ptrace (read, trace, tracedby) peer=/usr/lib/snapd/snap-confine,
+    }
+
+    # Allow snap-confine to be killed
+    signal (receive) peer=unconfined,
+
+    # Allow switching to snap-update-ns with a per-snap profile.
+    change_profile -> snap-update-ns.*,
+
+    # Allow executing snap-update-ns when...
+
+    # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
+    # from the distribution package. This is also the location used when using
+    # the core/base snap on all-snap systems. The variants here represent
+    # various locations of libexecdir across distributions.
+    /usr/lib{,exec,64}/snapd/snap-update-ns r,
+
+    # ...snap-confine is not, conceptually, re-executing and uses
+    # snap-update-ns from the distribution package but we are already inside
+    # the constructed mount namespace so we must traverse "hostfs". The
+    # variants here represent various locations of libexecdir across
+    # distributions.
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns r,
+
+    # ..snap-confine is, conceptually, re-executing and uses snap-update-ns
+    # from the core or snapd snaps. Note that the location of the actual snap
+    # varies from distribution to distribution. The variants here represent
+    # different locations of snap mount directory across distributions.
+    /{,var/lib/snapd/}snap/{core,snapd}/*/usr/lib/snapd/snap-update-ns r,
+
+    # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
+    # from the core snap or snapd snap, but we are already inside the
+    # constructed mount namespace. Here the apparmor kernel module
+    # re-constructs the path to snap-update-ns using the "hostfs" mount entry
+    # rather than the more "natural" /snap mount entry but we have no control
+    # over that.  This is reported as (LP: #1716339). The variants here
+    # represent different locations of snap mount directory across
+    # distributions.
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/{core,snapd}/*/usr/lib/snapd/snap-update-ns r,
+
+    # Allow executing snap-discard-ns, just like the set for snap-update-ns
+    # above but with the key difference that snap-discard-ns does not
+    # have a dedicated profile so we need to inherit snap-confine's profile.
+
+    /usr/lib{,exec,64}/snapd/snap-discard-ns rix,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-discard-ns rix,
+    /{,var/lib/snapd/}snap/{core,snapd}/*/usr/lib/snapd/snap-discard-ns rix,
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/{core,snapd}/*/usr/lib/snapd/snap-discard-ns rix,
+
+    # Allow mounting /var/lib/jenkins from the host into the snap.
+    mount options=(rw rbind) /var/lib/jenkins/ -> /tmp/snap.rootfs_*/var/lib/jenkins/,
+    mount options=(rw rslave) -> /tmp/snap.rootfs_*/var/lib/jenkins/,
+
+    # Suppress noisy file_inherit denials (LP: #1850552) until LP: #1849753 is
+    # fixed.
+    deny /dev/shm/.org.chromium.Chromium.* rw,
+
+    # While snap-confine itself doesn't require unix rules and therefore all
+    # unix rules are implicitly denied, adding an explicit deny for unix to
+    # silence noisy denials breaks nested lxd. Until the cause is determined,
+    # do not use an explicit deny for unix. (LP: #1855355)
+    #deny unix,
+
+    # Explicitly deny these accesses which show up on Arch to silence the
+    # denials for this unneeded access.
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_files-[0-9]*.so* mr,
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_mymachines.[0-9]*.so* mr,
+    deny /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnss_systemd.[0-9]*.so* mr,
+    deny /etc/nsswitch.conf r,
+    deny /etc/passwd r,
+}

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -64,7 +64,7 @@ EOF
 }
 
 function setup_workshop() {
-    snap install --dangerous --classic /workshop/tests/*.snap
+    snap install --dangerous --classic /workshop/tests/workshop_*.snap
     snap set workshop store.url=http://localhost:8080/storage/v1/
     snap set workshop workshop.image.server.url="$IMAGE_SERVER"
     snap alias workshop.sdk sdk
@@ -157,10 +157,5 @@ function run_sdkcraft() {
 
 # Install sdkcraft from a local snap file
 function install_sdkcraft() {
-    if stat /sdkcraft/tests/*.snap 2>/dev/null; then
-        snap install --classic --dangerous /sdkcraft/tests/*.snap
-    else
-        echo "Expected a snap to exist in /sdkcraft/tests/"
-        exit 1
-    fi
+    snap install --dangerous --classic /workshop/tests/sdkcraft_*.snap
 }


### PR DESCRIPTION
# Description

Workaround https://bugs.launchpad.net/snapd/+bug/2127244. See comments for details.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
