### PR TITLE
Cache base image metadata to speed up GetBase

### DIFF
--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -47,6 +47,8 @@ var (
 	CacheDir string
 	// Work directory
 	ExecDir string
+	// The directory to store downloaded base images and associated metadata
+	BaseDownloads string
 	// The directory to store downloaded SDKs
 	SdkDownloads string
 	// Path to the daemon's unix socket
@@ -112,6 +114,7 @@ func SetCacheDir(cachedir string) {
 	}
 	CacheDir = cachedir
 
+	BaseDownloads = filepath.Join(CacheDir, "base")
 	SdkDownloads = filepath.Join(CacheDir, "sdk")
 }
 
@@ -120,6 +123,9 @@ func CreateDirs() error {
 		return err
 	}
 	if err := os.MkdirAll(CacheDir, 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(BaseDownloads, 0755); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(SdkDownloads, 0755); err != nil {

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -80,6 +80,10 @@ func defaultTestDevices(pid, w string) ([]workshop.Mount, []workshop.ProxyEntry)
 }
 
 func (f *backendDeviceSuite) SetUpTest(c *check.C) {
+	dirs.SetRootDir(c.MkDir())
+	dirs.SetCacheDir(c.MkDir())
+	c.Assert(dirs.CreateDirs(), check.IsNil)
+
 	var err error
 	f.pid = "42424242"
 	f.usr = &user.User{

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -38,7 +38,7 @@ func (b *Backend) GetBase(ctx context.Context, base string) (string, error) {
 	}
 	defer imageServer.Disconnect()
 
-	alias, _, err := imageServer.GetImageAliasType(string(api.InstanceTypeContainer), source.Alias)
+	alias, _, err := imageServer.GetImageAliasType(source.ImageType, source.Alias)
 	if err != nil {
 		return "", fmt.Errorf("base %q not found: %w", base, err)
 	}
@@ -266,7 +266,7 @@ func lxdConnectionArgs() (*lxd.ConnectionArgs, error) {
 func connectImageServer(source api.ImageSource) (lxd.ImageServer, error) {
 	switch source.Protocol {
 	case "simplestreams":
-		conn, err := ConnectSimpleStreams(source.Server, nil)
+		conn, err := ConnectSimpleStreams(source.Server, &lxd.ConnectionArgs{CachePath: dirs.BaseDownloads})
 		if err != nil {
 			return nil, fmt.Errorf("image server is not available: %w", err)
 		}

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/daemon"
+	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
@@ -54,6 +55,10 @@ func execTestDevices(projectDir string) func(pid, w string) ([]workshop.Mount, [
 }
 
 func (f *wsExec) SetUpSuite(c *check.C) {
+	dirs.SetRootDir(c.MkDir())
+	dirs.SetCacheDir(c.MkDir())
+	c.Assert(dirs.CreateDirs(), check.IsNil)
+
 	f.restoreImageServer = lxdbackend.FakeImageServer(helper.MinimalImageServer)
 
 	socketPath := c.MkDir() + ".workshop.socket"


### PR DESCRIPTION
# Description

The slow part of `GetBase` is downloading a big JSON file with all the images inside. LXD has a builtin mechanism to cache this download for 1 hour. We just need to give it a place to store the data.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
