### PR TITLE
Modernize codebase

### DIFF
--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -115,17 +115,14 @@ func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.
 	c.Assert(fl.Lock(), check.IsNil)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		result, err := s.DownloadSdk(context.Background(), setup, nil)
 		c.Assert(err, check.IsNil)
 		c.Check(result.Setup, check.Equals, setup)
 		c.Check(result.MD5, check.Equals, "md5sum")
 		c.Check(result.SdkYAML, check.Equals, "name: test-sdk-basic")
 		c.Check(m.String(), check.Matches, fmt.Sprintf(`(?s)*.DEBUG: SDK Store on Download: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_1.sdk.*`, dirs.SdkDownloads))
-	}()
+	})
 
 	// "download" is finished
 	c.Assert(os.WriteFile(target, nil, 0666), check.IsNil)

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -209,32 +209,26 @@ func (e *execution) do(ctx context.Context, task *state.Task, backend workshop.B
 	}()
 
 	if e.execArgs.Interactive {
-		wgOutputSent.Add(1)
-		go func() {
-			defer wgOutputSent.Done()
+		wgOutputSent.Go(func() {
 			logger.Debugf("Exec %s: started mirroring stdout websocket", task.ID())
 			defer logger.Debugf("Exec %s: finished mirroring stdout websocket", task.ID())
 			<-wsutil.WebsocketSendStream(ioConn, stdoutReader, -1)
-		}()
+		})
 	} else {
 		stdoutConn := e.getWebsocket(wsStdout)
-		wgOutputSent.Add(1)
-		go func() {
-			defer wgOutputSent.Done()
+		wgOutputSent.Go(func() {
 			logger.Debugf("Exec %s: started mirroring stdout websocket", task.ID())
 			defer logger.Debugf("Exec %s: finished mirroring stdout websocket", task.ID())
 			<-wsutil.WebsocketSendStream(stdoutConn, stdoutReader, -1)
-		}()
+		})
 
 		stderrConn := e.getWebsocket(wsStderr)
 		stderrReader, stderrWriter = io.Pipe()
-		wgOutputSent.Add(1)
-		go func() {
-			defer wgOutputSent.Done()
+		wgOutputSent.Go(func() {
 			logger.Debugf("Exec %s: started mirroring stderr websocket", task.ID())
 			defer logger.Debugf("Exec %s: finished mirroring stderr websocket", task.ID())
 			<-wsutil.WebsocketSendStream(stderrConn, stderrReader, -1)
-		}()
+		})
 		beforeClosers = append(beforeClosers, stderrWriter)
 		afterClosers = append(afterClosers, stderrReader)
 	}

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -37,8 +37,7 @@ func CleanupLxdProject(c *check.C, client lxd.InstanceServer, project string) {
 	c.Check(err, check.IsNil)
 	for _, i := range fingers {
 		op, err := cli.DeleteImage(i)
-		c.Check(err, check.IsNil)
-		if err == nil {
+		if c.Check(err, check.IsNil) {
 			c.Check(op.Wait(), check.IsNil)
 		}
 	}
@@ -54,15 +53,13 @@ func CleanupLxdProject(c *check.C, client lxd.InstanceServer, project string) {
 			}
 
 			op, err := cli.UpdateInstanceState(i.Name, req, "")
-			c.Check(err, check.IsNil)
-			if err == nil {
+			if c.Check(err, check.IsNil) {
 				c.Check(op.Wait(), check.IsNil)
 			}
 		}
 
 		op, err := cli.DeleteInstance(i.Name)
-		c.Check(err, check.IsNil)
-		if err == nil {
+		if c.Check(err, check.IsNil) {
 			c.Check(op.Wait(), check.IsNil)
 		}
 	}

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -350,10 +350,8 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 	var wg sync.WaitGroup
 
 	var successCnt, existCnt int32
-	wg.Add(5)
 	for i := 0; i < 5; i++ {
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			file, err := os.Open(tarball)
 			c.Assert(err, check.IsNil)
 			defer file.Close()
@@ -364,7 +362,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportOK(c *check.C) {
 			} else {
 				c.Assert(err, check.IsNil)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -399,7 +397,6 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 	var wg sync.WaitGroup
 
 	var successCnt, existCnt, canceled int32
-	wg.Add(5)
 	for i := 0; i < 5; i++ {
 		newctx, cancel := context.WithCancel(f.ctx)
 
@@ -409,8 +406,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 			defer cancel()
 		}
 
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			file, err := os.Open(tarball)
 			c.Assert(err, check.IsNil)
 			defer file.Close()
@@ -423,7 +419,7 @@ func (f *wsOps) TestLxdBackendStorageVolumeImportInterrupted(c *check.C) {
 			} else {
 				c.Assert(err, check.IsNil)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -514,13 +510,11 @@ func (f *wsOps) TestLxdBackendDownloadBase(c *check.C) {
 	c.Assert(fingerprint, check.Not(check.Equals), "")
 
 	var wg sync.WaitGroup
-	wg.Add(5)
 	for range 5 {
-		go func() {
+		wg.Go(func() {
 			err := f.bd.DownloadBase(f.ctx, "ubuntu@22.04", fingerprint, nil)
 			c.Check(err, check.IsNil)
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -575,13 +569,11 @@ func (f *wsOps) TestLxdBackendDownloadProtocolNotSupported(c *check.C) {
 
 func (f *wsOps) TestLxdBackendDownloadConcurrentErrors(c *check.C) {
 	var wg sync.WaitGroup
-	wg.Add(5)
 	for range 5 {
-		go func() {
+		wg.Go(func() {
 			err := f.bd.DownloadBase(f.ctx, "ubuntu@22.04", "##################", nil)
 			c.Check(err, check.ErrorMatches, `"ubuntu@22.04" download failed.*`)
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -599,9 +591,8 @@ func (f *wsOps) TestLxdBackendDownloadBaseResumeAfterCancellation(c *check.C) {
 
 	var wg sync.WaitGroup
 	var once sync.Once
-	wg.Add(3)
 	for range 3 {
-		go func() {
+		wg.Go(func() {
 			r := &progress.Reporter{
 				Name: "1",
 				Report: func(label string, done, total int) {
@@ -610,8 +601,7 @@ func (f *wsOps) TestLxdBackendDownloadBaseResumeAfterCancellation(c *check.C) {
 			}
 			err := f.bd.DownloadBase(wcancel, "ubuntu@22.04", fingerprint, r)
 			c.Check(err, testutil.ErrorIs, context.Canceled)
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -636,11 +626,8 @@ func (f *wsOps) TestLxdBackendDownloadMultipleBasesConcurrently(c *check.C) {
 	fingerprints := make([]string, len(workshop.SupportedBases))
 
 	var wg sync.WaitGroup
-	wg.Add(len(workshop.SupportedBases))
 	for i, b := range workshop.SupportedBases {
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			fingerprint, err := f.bd.GetBase(f.ctx, b)
 			c.Assert(err, check.IsNil)
 			c.Assert(fingerprint, check.Not(check.Equals), "")
@@ -648,7 +635,7 @@ func (f *wsOps) TestLxdBackendDownloadMultipleBasesConcurrently(c *check.C) {
 
 			err = f.bd.DownloadBase(f.ctx, b, fingerprint, nil)
 			c.Assert(err, check.IsNil)
-		}()
+		})
 	}
 	wg.Wait()
 


### PR DESCRIPTION
# Description

Go 1.25 introduced a `sync.WaitGroup.Go` function which makes wait groups more convenient to use.

I also didn't realise until recently that `check.C.Check` returns whether the check succeeded or failed, removing the need to check some conditions twice.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
