### PR TITLE
Use UID instead of username for systemctl machine

### DIFF
--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -204,7 +204,7 @@ func currentUserAndEnv() (*user.User, map[string]string, error) {
 // Returns the environment for the user as set by systemd.
 // This is the equivalent of running 'systemctl --user show-environment'
 func userEnvironment(user *user.User) (map[string]string, error) {
-	cmd := exec.Command("systemctl", "--user", "show-environment", "--machine", fmt.Sprintf("%s@.host", user.Username))
+	cmd := exec.Command("systemctl", "--user", "show-environment", "--machine", fmt.Sprintf("%s@.host", user.Uid))
 	// XDG_RUNTIME_DIR may not be set if a command is invoked by sudo or
 	// systemd-run; set it here to the default location. It is required for
 	// systemctl to work with --user. See:


### PR DESCRIPTION
# Description

The previous command fails for nonstandard usernames like email addresses.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
