### PR TITLE
Project name fallback

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -96,3 +96,18 @@ jobs:
           name: code-coverage-${{ steps.sanitize.outputs.sanitized_name }}
           path: ${{ github.workspace }}.cover/lxd:ubuntu-24.04:tests/
           if-no-files-found: ignore
+  publish:
+    needs: [build-snap, snap-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap
+      - uses: canonical/action-publish@v1
+        if: github.event_name == 'push'
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_CREDENTIALS }}
+        with:
+          snap: ${{ needs.build-snap.outputs.snap }}
+          release: edge

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -28,7 +28,7 @@ func lxdProjectConfig(username string) map[string]string {
 }
 
 // Checks if a user name can be used in a LXD project name.
-var isValidProjectSuffix = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z0-9._]*$`).MatchString
+var isValidProjectSuffix = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z0-9.]{0,31}$`).MatchString
 
 func projectName(prefix, username string) (string, error) {
 	if isValidProjectSuffix(username) {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,8 @@ parts:
     plugin: go
     source: .
     source-type: local
+    build-packages:
+      - git
     build-snaps:
       - go/1.25/stable
     build-environment:
@@ -61,9 +63,10 @@ parts:
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshopctl" ./cmd/workshopctl
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/sdk" ./cmd/sdk
 
-      # Set snap version
+      # Set snap version including git commit hash
       VERSION="$("${CRAFT_PART_INSTALL}/bin/workshop" --version)"
-      craftctl set version="$VERSION"
+      COMMIT_HASH="$(git rev-parse --short HEAD)"
+      craftctl set version="${VERSION}-${COMMIT_HASH}"
     stage-packages:
       - zstd
     prime:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,8 +35,6 @@ apps:
       unix:
         listen-stream: $SNAP_COMMON/workshop/workshop.socket
         socket-mode: 0666
-    plugs:
-      - network-bind
   workshopctl:
     command: bin/workshopctl
   sdk:


### PR DESCRIPTION
- Update project name regex to reflect LXD project name limitations
- Publish to `latest/edge` on a merge to master