### PR TITLE
Remove stashed layers if stashing fails

### DIFF
--- a/internal/workshop/lxd/lxd_backend_layers.go
+++ b/internal/workshop/lxd/lxd_backend_layers.go
@@ -128,7 +128,7 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 
 	rev.Add(func() {
 		if rerr := s.startWorkshop(conn, ctx, name); rerr != nil {
-			logger.Debugf("On StashWorkshop: Cannot restart %q workshop after failed stash operation: %v", name, rerr)
+			logger.Noticef("On StashWorkshop: Cannot restart %q workshop after failed stash operation: %v", name, rerr)
 		}
 	})
 
@@ -145,6 +145,11 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		if err := s.copyInstance(layerConn, layerConn, layer, newname, false, config, nil); err != nil {
 			return err
 		}
+		rev.Add(func() {
+			if rerr := s.deleteLayer(layerConn, newname); rerr != nil {
+				logger.Noticef("On StashWorkshop: Cannot remove layer %q after failed stash operation: %v", newname, rerr)
+			}
+		})
 	}
 
 	// Backup the workshop itself.


### PR DESCRIPTION
# Description

Fixes an issue where layers remain in the stash when stashing fails. I'm still not entirely happy with the logic here, especially during `UnstashWorkshop` - which is already an error recovery operation so it's very difficult to recover from errors inside it. The global cache will help with this, but in the meantime it's easy enough to clean up after a failed stash.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
