### PR TITLE
Remove all created SDK profiles if the change is undone

### DIFF
--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -858,7 +858,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 
 			rev.Add(func() {
 				if err1 := backend.Remove(ctx, ref); err1 != nil {
-					logger.Noticef(`On doSetupProfiles: Failed to clean up %q SDK backend setup`, ref.ShortRef())
+					logger.Noticef(`On doSetupProfiles: Failed to clean up %q SDK backend setup (%v)`, ref.ShortRef(), err1)
 				}
 			})
 		}
@@ -869,19 +869,12 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 
 func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) error {
 	st := task.State()
-	user, p, w, err := handlersetup.UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
 	st.Lock()
-	s, err := handlersetup.Sdk(task)
+	user, err := handlersetup.User(task.Change())
 	st.Unlock()
 	if err != nil {
 		return err
 	}
-
-	sdkRef := sdk.Ref{ProjectId: p.ProjectId, Workshop: w, Sdk: s}
 
 	var sdks []sdk.Ref
 	st.Lock()
@@ -895,14 +888,8 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
 		defer cancel()
 		for _, backend := range m.repo.Backends() {
-			if ref != sdkRef {
-				if err := backend.Setup(ctx, ref, m.repo); err != nil {
-					return err
-				}
-			} else {
-				if err := backend.Remove(ctx, sdkRef); err != nil {
-					return err
-				}
+			if err := backend.Remove(ctx, ref); err != nil {
+				logger.Noticef(`On undoSetupProfiles: Failed to remove %q SDK profile (%v)`, ref.ShortRef(), err)
 			}
 		}
 	}

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -545,6 +545,47 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
+func (s *interfaceHandlersSuite) TestUndoAutoConnect(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a candidate SDK/slot
+	repo := s.mgr.Repository()
+	_, err := s.launchWorkshop(c, "ws-producer", []testSdkSetup{{psetup, producer}})
+	c.Check(err, check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	// Launch another workshop with a candidate plug
+	_, err = s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumer}})
+	c.Check(err, check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange()
+	terr := s.state.NewTask("error-trigger", "...")
+	terr.WaitAll(state.NewTaskSet(chg.Tasks()...))
+	chg.AddTask(terr)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*error-trigger task.*")
+
+	// Validate
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 0)
+	c.Assert(err, check.IsNil)
+
+	ref, err = repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Assert(ref, check.HasLen, 0)
+	c.Assert(err, check.IsNil)
+
+	// ensure that backend profiles were set for both SDKs
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 2)
+}
+
 func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Change {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1098,7 +1139,7 @@ func (s *interfaceHandlersSuite) newUndoDisconnectInterfacesChange(sdkName strin
 	return chg
 }
 
-func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesSuccess(c *check.C) {
+func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
 	s.launchWorkshop(c, "ws-consumer", []testSdkSetup{
@@ -1149,7 +1190,7 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesSuccess(c *check.C)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
-func (s *interfaceHandlersSuite) TestUndoDisconnectInterfacesManualRestored(c *check.C) {
+func (s *interfaceHandlersSuite) TestUndoAutoDisconnectManualRestored(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
 	s.launchWorkshop(c, "ws-consumer", []testSdkSetup{
@@ -1359,7 +1400,7 @@ func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestundoDisconnectSuccess(c *check.C) {
+func (s *interfaceHandlersSuite) TestUndoDisconnect(c *check.C) {
 	// Setup
 	s.launchWorkshop(c, "ws", []testSdkSetup{
 		{csetup, consumer},
@@ -1382,7 +1423,7 @@ func (s *interfaceHandlersSuite) TestundoDisconnectSuccess(c *check.C) {
 	chg := s.disconnectChange(c, "ws", false)
 	s.state.Lock()
 	terr := s.state.NewTask("error-trigger", "...")
-	terr.WaitFor(chg.Tasks()[0])
+	terr.WaitAll(state.NewTaskSet(chg.Tasks()...))
 	chg.AddTask(terr)
 	s.state.Unlock()
 
@@ -1411,7 +1452,7 @@ func (s *interfaceHandlersSuite) TestundoDisconnectSuccess(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestundoDisconnectUndesiredSuccess(c *check.C) {
+func (s *interfaceHandlersSuite) TestUndoDisconnectUndesiredSuccess(c *check.C) {
 	// Setup
 	s.launchWorkshop(c, "ws", []testSdkSetup{
 		{csetup, consumer},


### PR DESCRIPTION
# Description

If `undoSetupProfiles` does not remove all the previously created SDK profiles by `doSetupProfiles`, it results in remaining LXD profiles that were created for the new SDKs in a failed refresh change. I.e. the workshop will have an SDK profile created and assigned from an SDK that is not installed. The easiest reproducer would be a failing `setup-project` hook in a refresh change that installs new SDKs.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
