### PR TITLE
Adjust revision timestamps in TestCommitKeepsInstalled

### DIFF
--- a/internal/sdk/local_test.go
+++ b/internal/sdk/local_test.go
@@ -167,9 +167,9 @@ func (s *localSdk) TestCommitKeepsInstalled(c *check.C) {
 	t3 := time.Now()
 	t2 := t3.Add(-time.Minute)
 	t1 := t2.Add(-time.Minute)
-	c.Assert(os.Chtimes(filepath.Join(s.target, "x42"), time.Time{}, t2), check.IsNil)
-	c.Assert(os.Chtimes(filepath.Join(s.target, "x43"), time.Time{}, t1), check.IsNil)
-	c.Assert(os.Chtimes(filepath.Join(s.target, "x44"), time.Time{}, t3), check.IsNil)
+	c.Assert(sys.Lchtimes(filepath.Join(s.target, "x42"), time.Time{}, t2), check.IsNil)
+	c.Assert(sys.Lchtimes(filepath.Join(s.target, "x43"), time.Time{}, t1), check.IsNil)
+	c.Assert(sys.Lchtimes(filepath.Join(s.target, "x44"), time.Time{}, t3), check.IsNil)
 
 	source := s.createSource(c, "45")
 	revision, digest45, err := sdk.CommitRevision(s.user, source, s.target, sdk.R(-43))


### PR DESCRIPTION
# Description

In bb0d2c8 I introduced hashes for local SDKs. To track the oldest SDK, timestamps are stored in revision symlinks which point to the hash (a directory containing the SDK). For some reason I neglected to migrate from `os.Chtimes` to `sys.Lchtimes` in this test. This results in an extremely rare error when revision 44 is deleted instead of 42, if they end up with the same timestamp.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
