### PR TITLE
Refactor SDK metadata

### DIFF
--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -21,6 +21,8 @@ package daemon
 
 import (
 	"bytes"
+	"crypto/sha3"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -110,7 +112,16 @@ func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop
 	defer wfs.Close()
 	s.writeSDKMetaFile(c, wfs, info.Name, yaml)
 
-	err = wp.AddSdk(s.ctx, sdk.Setup{Name: info.Name, Channel: info.Channel, Source: info.Source, Revision: info.Revision})
+	digest := sha3.Sum384([]byte(yaml))
+
+	setup := sdk.Setup{
+		Name:     info.Name,
+		Channel:  info.Channel,
+		Source:   info.Source,
+		Revision: info.Revision,
+		Sha3_384: hex.EncodeToString(digest[:]),
+	}
+	err = wp.AddSdk(s.ctx, setup)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -99,7 +99,8 @@ func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop
 
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
 	wf := s.workshopFile(w, []*sdk.Info{info})
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123"), check.IsNil)
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
 
 	wp, err := s.b.Workshop(s.ctx, w)
 	c.Check(err, check.IsNil)
@@ -126,7 +127,8 @@ func (s *apiSuite) mockInstalledSDKBoundPlug(c *check.C, yaml string, w string, 
 		Name:      to}
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
 	wf := s.workshopFile(w, []*sdk.Info{info})
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123"), check.IsNil)
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
 	wp, err := s.b.Workshop(s.ctx, w)
 	c.Check(err, check.IsNil)
 	return wp

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -26,8 +26,9 @@ func (s *apiSuite) setupExec(c *check.C) *Command {
 	s.createWFile(c, "ws", wsYaml)
 
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Actions: map[string]workshop.Action{"lint": "\n\n\ngolangci-lint run\n"}}
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
 
-	err := s.b.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123")
+	err := s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image)
 	c.Assert(err, check.IsNil)
 
 	wp, err := s.b.Workshop(s.ctx, "ws")

--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -151,16 +151,31 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 	// Add SDK setups with channels so the endpoint can report channels.
 	w1, err := s.b.Workshop(s.ctx, "nav2")
 	c.Assert(err, check.IsNil)
-	c.Assert(w1.AddSdk(s.ctx, sdk.Setup{Name: "openvino", Channel: "latest/stable", Source: sdk.StoreSource, Revision: sdk.R(85)}), check.IsNil)
+	setup := sdk.Setup{
+		Name:     "openvino",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(85),
+		Sha3_384: "e7439cbefe3266aa299e09c99a6ce7b0163aceea20a67e178445f588d3433fd7a3cd55036be3f92ceb0cfae54934da73",
+	}
+	c.Assert(w1.AddSdk(s.ctx, setup), check.IsNil)
 
 	w2, err := s.b.Workshop(s.ctx, "lerobot")
 	c.Assert(err, check.IsNil)
-	c.Assert(w2.AddSdk(s.ctx, sdk.Setup{Name: "openvino", Channel: "latest/edge", Source: sdk.StoreSource, Revision: sdk.R(82)}), check.IsNil)
+	setup = sdk.Setup{
+		Name:     "openvino",
+		Channel:  "latest/edge",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(82),
+		Sha3_384: "6ca811792aa9c9a4859726425bc6f3059bf90aefd1e3371b81bca7317b6429fceb9546fa47457eacbf84b373a8215059",
+	}
+	c.Assert(w2.AddSdk(s.ctx, setup), check.IsNil)
 
 	// Create volumes and attach to workshops.
 	s.createVolume(c, workshop.VolumeSetup{
 		Name:     "openvino-85",
 		Kind:     "sdk",
+		Sha3_384: "e7439cbefe3266aa299e09c99a6ce7b0163aceea20a67e178445f588d3433fd7a3cd55036be3f92ceb0cfae54934da73",
 		Sdk:      "openvino",
 		Revision: sdk.R(85),
 		Metadata: "name: openvino\nversion: 2.1-084c8c8\nsummary: Intel OpenVINO toolkit\ndescription: Accelerated toolkit\nsdkcraft-started-at: 2024-11-20T00:00:00Z\n",
@@ -169,6 +184,7 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 	s.createVolume(c, workshop.VolumeSetup{
 		Name:     "openvino-82",
 		Kind:     "sdk",
+		Sha3_384: "6ca811792aa9c9a4859726425bc6f3059bf90aefd1e3371b81bca7317b6429fceb9546fa47457eacbf84b373a8215059",
 		Sdk:      "openvino",
 		Revision: sdk.R(82),
 		Metadata: "name: openvino\nversion: 2.0\nsummary: Intel OpenVINO toolkit (legacy)\ndescription: Legacy release\nsdkcraft-started-at: 2024-11-25T00:00:00Z\n",
@@ -232,7 +248,14 @@ func (s *apiSuite) TestSdkInfoGetInvalidMetadata(c *check.C) {
 	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
 	w, err := s.b.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	c.Assert(w.AddSdk(s.ctx, sdk.Setup{Name: "bad", Channel: "latest/stable", Source: sdk.StoreSource, Revision: sdk.R(1)}), check.IsNil)
+	setup := sdk.Setup{
+		Name:     "bad",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(1),
+		Sha3_384: "71baf962e8a7abd38480289e173d6a48364c8f6f5f8a391fdb83465b4ad676aa7504d100906a0efa8749c97fd61d367e",
+	}
+	c.Assert(w.AddSdk(s.ctx, setup), check.IsNil)
 
 	s.createVolume(c, workshop.VolumeSetup{
 		Name:     "bad-1",

--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -140,8 +140,13 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 	s.createWFile(c, "nav2", "name: nav2\nbase: ubuntu@20.04\n")
 	s.createWFile(c, "lerobot", "name: lerobot\nbase: ubuntu@20.04\n")
 
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, &workshop.File{Name: "nav2", Base: "ubuntu@20.04"}, "fakeimage123"), check.IsNil)
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, &workshop.File{Name: "lerobot", Base: "ubuntu@20.04"}, "fakeimage123"), check.IsNil)
+	wf := &workshop.File{Name: "nav2", Base: "ubuntu@20.04"}
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
+
+	wf = &workshop.File{Name: "lerobot", Base: "ubuntu@20.04"}
+	image = workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
 
 	// Add SDK setups with channels so the endpoint can report channels.
 	w1, err := s.b.Workshop(s.ctx, "nav2")
@@ -222,7 +227,9 @@ func (s *apiSuite) TestSdkInfoGetInvalidMetadata(c *check.C) {
 	s.daemon(c)
 
 	s.createWFile(c, "ws", "name: ws\nbase: ubuntu@20.04\n")
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, &workshop.File{Name: "ws", Base: "ubuntu@20.04"}, "fakeimage123"), check.IsNil)
+	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
 	w, err := s.b.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
 	c.Assert(w.AddSdk(s.ctx, sdk.Setup{Name: "bad", Channel: "latest/stable", Source: sdk.StoreSource, Revision: sdk.R(1)}), check.IsNil)

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -81,7 +81,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	}
 
 	s.store = &sdk.FakeStore{}
-	retrieveSystemSdk := func(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error) {
+	retrieveSystemSdk := func(setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error) {
 		return s.store.DownloadSdk(context.TODO(), setup, report)
 	}
 	s.restoreRetrieve = system.FakeRetrieveSystemSdk(retrieveSystemSdk)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -51,7 +51,7 @@ type SdkInfo struct {
 	Source      string           `json:"source,omitempty"`
 	Revision    string           `json:"revision"`
 	BuildTime   *time.Time       `json:"build-time,omitempty"`
-	InstallTime *time.Time       `json:"install-time,omitempty"`
+	InstallTime time.Time        `json:"install-time,omitempty"`
 	Health      *HealthCheckInfo `json:"health-check,omitempty"`
 	Mounts      []*Mount         `json:"mounts,omitempty"`
 	Tunnels     []*Tunnel        `json:"tunnels,omitempty"`

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -527,7 +527,6 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 	_, err = rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
 
-	install1 := time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
 	info := rsp.Result.(Workshops)
 
 	c.Check(info.Workshops, testutil.DeepUnsortedMatches, []*WorkshopInfo{{
@@ -539,13 +538,13 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 			{
 				Name:        "system",
 				Revision:    system.SystemSdkRevision.String(),
-				InstallTime: &install1,
+				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 			},
 			{
 				Name:        "test-sdk",
 				Channel:     "latest/stable",
 				Revision:    "1",
-				InstallTime: &install1,
+				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 			},
 		},
 	}, {
@@ -556,7 +555,7 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 		Sdks: []*SdkInfo{{
 			Name:        "system",
 			Revision:    system.SystemSdkRevision.String(),
-			InstallTime: &install1,
+			InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 		}},
 	}})
 
@@ -645,7 +644,6 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 	build1 := time.Date(2020, 4, 22, 19, 12, 7, 903032000, time.UTC)
 	build2 := time.Date(2020, 5, 3, 22, 5, 35, 811829000, time.UTC)
 	// for DeepEqual to work correctly
-	install1, install2 := s.installTime, s.installTime
 	result := rsp.Result.(Workshop)
 	for _, c := range result.Sdks {
 		slices.SortFunc(c.Mounts, func(a, b *Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
@@ -662,7 +660,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 				{
 					Name:        "system",
 					Revision:    system.SystemSdkRevision.String(),
-					InstallTime: &install1,
+					InstallTime: s.installTime,
 					Tunnels: []*Tunnel{
 						{
 							Plug: sdk.PlugRef{
@@ -689,7 +687,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 					Channel:     "latest/stable",
 					Revision:    "1",
 					BuildTime:   &build1,
-					InstallTime: &install1,
+					InstallTime: s.installTime,
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource,
@@ -729,7 +727,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 					Channel:     "latest/stable",
 					Revision:    "1",
 					BuildTime:   &build2,
-					InstallTime: &install2,
+					InstallTime: s.installTime,
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource2,
@@ -798,7 +796,6 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 	build1 := time.Date(2020, 4, 22, 19, 12, 7, 903032000, time.UTC)
 	build2 := time.Date(2020, 5, 3, 22, 5, 35, 811829000, time.UTC)
 	// for DeepEqual to work correctly
-	install1, install2 := s.installTime, s.installTime
 	result := rsp.Result.(Workshop)
 	slices.SortFunc(result.Sdks, func(a, b *SdkInfo) int { return cmp.Compare(a.Name, b.Name) })
 	for _, c := range result.Sdks {
@@ -818,7 +815,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 					Channel:     "latest/stable",
 					Revision:    "1",
 					BuildTime:   &build2,
-					InstallTime: &install2,
+					InstallTime: s.installTime,
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource,
@@ -835,7 +832,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 				{
 					Name:        "system",
 					Revision:    system.SystemSdkRevision.String(),
-					InstallTime: &install1,
+					InstallTime: s.installTime,
 				},
 				{
 					Name:        "test-sdk",
@@ -843,7 +840,7 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 					Channel:     "latest/stable",
 					Revision:    "1",
 					BuildTime:   &build1,
-					InstallTime: &install1,
+					InstallTime: s.installTime,
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource,
@@ -1673,7 +1670,8 @@ func (s *apiSuite) ensureWorkshops(c *check.C, want []expectedWorkshop) {
 		for _, sk := range wantws.sdks {
 			sk.Sha3_384 = w.Sdks[sk.Name].Sha3_384
 			c.Check(sk.Sha3_384, check.Not(check.Equals), "")
-			c.Assert(w.Sdks[sk.Name], check.DeepEquals, sk)
+			c.Assert(w.Sdks[sk.Name].Setup, check.DeepEquals, sk)
+			c.Check(w.Sdks[sk.Name].InstallTime, check.Equals, s.installTime)
 		}
 
 		repo := s.d.overlord.InterfaceManager().Repository()
@@ -1853,9 +1851,9 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "somebound",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "mount-conflict", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "mount-conflict", Channel: "latest/stable", Revision: sdk.R(1)},
 		}, connections: []string{
 			"b8639dea/somebound/test-sdk:data b8639dea/somebound/system:mount",
 			"b8639dea/somebound/mount-conflict:photos b8639dea/somebound/system:mount",
@@ -1878,7 +1876,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
 		},
 		slots: []string{
 			"system:camera",
@@ -1891,7 +1889,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
 		},
 		slots: []string{
 			"system:camera",
@@ -1972,9 +1970,9 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1)},
 		},
 		connections: []string{
 			"b8639dea/basic/test-sdk:data b8639dea/basic/system:mount",
@@ -2048,10 +2046,10 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-3", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-3", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -2131,8 +2129,8 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -2203,9 +2201,9 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/edge", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/edge", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -2293,9 +2291,9 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(2), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(2)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
@@ -2499,9 +2497,9 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Source: sdk.TrySource, Revision: sdk.R(-1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Source: sdk.TrySource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Source: sdk.TrySource, Revision: sdk.R(-1)},
+			{Name: "test-sdk-2", Source: sdk.TrySource, Revision: sdk.R(-1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -2546,9 +2544,9 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Source: sdk.TrySource, Revision: sdk.R(-2), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Source: sdk.TrySource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Source: sdk.TrySource, Revision: sdk.R(-2)},
+			{Name: "test-sdk-2", Source: sdk.TrySource, Revision: sdk.R(-1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
@@ -2609,9 +2607,9 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Source: sdk.ProjectSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Source: sdk.ProjectSource, Revision: sdk.R(-1)},
+			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -2655,9 +2653,9 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Source: sdk.ProjectSource, Revision: sdk.R(-2), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Source: sdk.ProjectSource, Revision: sdk.R(-2)},
+			{Name: "test-sdk-2", Source: sdk.ProjectSource, Revision: sdk.R(-1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
@@ -2732,9 +2730,9 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/test-sdk-2:data-slot",
@@ -2808,9 +2806,9 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -2886,8 +2884,8 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -2957,9 +2955,9 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -3031,9 +3029,9 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -3107,9 +3105,9 @@ func (s *apiSuite) TestRefreshRestore(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -3185,9 +3183,9 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@24.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -3280,9 +3278,9 @@ func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -3359,8 +3357,8 @@ func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -3431,7 +3429,7 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 		name: "basic",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
 		},
 		slots: []string{
 			"system:camera",
@@ -3495,9 +3493,9 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "test-sdk-2", Channel: "latest/stable", Revision: sdk.R(1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -4183,9 +4181,9 @@ base: ubuntu@22.04
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-1), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-1)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/test-sdk:data b8639dea/manysdks/system:mount",
@@ -4233,9 +4231,9 @@ plugs:
 		name: "manysdks",
 		base: "ubuntu@22.04",
 		sdks: []sdk.Setup{
-			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision, InstallTime: &s.installTime},
-			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1), InstallTime: &s.installTime},
-			{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-2), InstallTime: &s.installTime},
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", Channel: "latest/stable", Revision: sdk.R(1)},
+			{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-2)},
 		},
 		connections: []string{
 			"b8639dea/manysdks/sketch:sketch-plug b8639dea/manysdks/system:mount",

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"crypto/md5"
 	"crypto/sha3"
 	"encoding/hex"
 	"errors"
@@ -987,8 +986,8 @@ func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult,
 		setup := apiSuiteSdks[act.Name].s
 		setup.Channel = act.Channel
 		sdkYaml := apiSuiteSdks[act.Name].meta
-		digest := md5.Sum([]byte(sdkYaml))
-		result = append(result, sdk.SdkResult{Setup: setup, MD5: hex.EncodeToString(digest[:]), SdkYAML: sdkYaml})
+		digest := sha3.Sum384([]byte(sdkYaml))
+		result = append(result, sdk.SdkResult{Setup: setup, Sha3_384: hex.EncodeToString(digest[:]), SdkYAML: sdkYaml})
 	}
 	return result, nil
 }
@@ -1723,9 +1722,7 @@ func (s *apiSuite) ensureSdkVolumesAfterCooldown(c *check.C, want []string) {
 		c.Assert(v, check.Not(check.Equals), -1)
 		vol := vols[v]
 		c.Check(vol.Kind, check.Equals, "sdk")
-		if vol.Sha3_384 == "" {
-			c.Check(vol.MD5, check.Not(check.Equals), "")
-		}
+		c.Check(vol.Sha3_384, check.Not(check.Equals), "")
 		c.Check(sdk.VolumeName(vol.Sdk, vol.Revision), check.Equals, vol.Name)
 		c.Check(vol.Metadata, check.Not(check.Equals), "")
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -437,44 +437,38 @@ sdkcraft-started-at: '2020-05-03T22:05:35.811829Z'
 `
 )
 
-// TODO: Consider replacing with SdkResult once SDK structs are finalised.
-type testSdk struct {
-	s    sdk.Setup
-	meta string
-}
-
-var apiSuiteSdks = map[string]testSdk{
+var apiSuiteSdks = map[string]sdk.Meta{
 	"test-sdk": {
-		s: sdk.Setup{
+		Setup: sdk.Setup{
 			Name:     "test-sdk",
 			Revision: sdk.R(1),
 			Sha3_384: "d024fbe91c6b99d0064306d52006c17a5d0406822ff253fbbe6a934ca9be50d3ff9a6ec3bac3be8396006029a1ff453a",
 		},
-		meta: testsdk,
+		SdkYAML: testsdk,
 	},
 	"test-sdk-2": {
-		s: sdk.Setup{
+		Setup: sdk.Setup{
 			Name:     "test-sdk-2",
 			Revision: sdk.R(1),
 			Sha3_384: "d4089378c26310627268153caa216240311f2a3193c778e96ed6dd895dc10c82db50f4f39676b29d23d9813b21e14b9b",
 		},
-		meta: testsdk2,
+		SdkYAML: testsdk2,
 	},
 	"mount-conflict": {
-		s: sdk.Setup{
+		Setup: sdk.Setup{
 			Name:     "mount-conflict",
 			Revision: sdk.R(1),
 			Sha3_384: "b2bd882ceec6746f00ea2b6cbb6c2073d46d5844b2a3a92a573dd6ea02847a98085b7a7b192d7e24c3f87ba01bbf554e",
 		},
-		meta: mount_conflict,
+		SdkYAML: mount_conflict,
 	},
 	"test-sdk-3": {
-		s: sdk.Setup{
+		Setup: sdk.Setup{
 			Name:     "test-sdk-3",
 			Revision: sdk.R(1),
 			Sha3_384: "0b4b94c4685db0970a15d294ce8e0683b5c6957b08a94ab8a3b14d3aac90f06a4d2cc1240dad04e5be0fe358276e64fc",
 		},
-		meta: testsdk3,
+		SdkYAML: testsdk3,
 	},
 }
 
@@ -1002,18 +996,18 @@ func storeDownload(ctx context.Context, setup sdk.Setup, report *progress.Report
 	}
 	metadir := filepath.Join(sdkdir, "meta")
 	hooksdir := filepath.Join(sdkdir, "sdk", "hooks")
-	return mockSdk(metadir, hooksdir, apiSuiteSdks[setup.Name].meta)
+	return mockSdk(metadir, hooksdir, apiSuiteSdks[setup.Name].SdkYAML)
 }
 
-func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
-	result := make([]sdk.SdkResult, 0, len(actions))
+func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.Meta, error) {
+	sdks := make([]sdk.Meta, 0, len(actions))
 	for _, act := range actions {
-		setup := apiSuiteSdks[act.Name].s
+		setup := apiSuiteSdks[act.Name].Setup
 		setup.Channel = act.Channel
-		sdkYaml := apiSuiteSdks[act.Name].meta
-		result = append(result, sdk.SdkResult{Setup: setup, SdkYAML: sdkYaml})
+		sdkYaml := apiSuiteSdks[act.Name].SdkYAML
+		sdks = append(sdks, sdk.Meta{Setup: setup, SdkYAML: sdkYaml})
 	}
-	return result, nil
+	return sdks, nil
 }
 
 func mockSdk(metadir, hooksdir string, meta string) error {
@@ -2238,15 +2232,15 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 }
 
 func updateSdkStoreRev(name string, rev int, meta string) func() {
-	oldrev := apiSuiteSdks[name].s
-	oldmeta := apiSuiteSdks[name].meta
+	oldrev := apiSuiteSdks[name]
 
 	newrev := oldrev
 	newrev.Revision = sdk.R(rev)
-	apiSuiteSdks[name] = testSdk{s: newrev, meta: meta}
+	newrev.SdkYAML = meta
+	apiSuiteSdks[name] = newrev
 
 	return func() {
-		apiSuiteSdks[name] = testSdk{s: oldrev, meta: oldmeta}
+		apiSuiteSdks[name] = oldrev
 	}
 }
 
@@ -4347,8 +4341,8 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	}
 	s.runActionTest(c, requests, expected)
 
-	s1 := apiSuiteSdks["test-sdk"].s
-	s2 := apiSuiteSdks["test-sdk-2"].s
+	s1 := apiSuiteSdks["test-sdk"].Setup
+	s2 := apiSuiteSdks["test-sdk-2"].Setup
 
 	c.Assert(s.b.AttachVolumeCalls, check.DeepEquals, []fakebackend.AttachVolumeCall{
 		{Workshop: "manysdks", Name: sdk.VolumeName(sdk.System.String(), system.SystemSdkRevision)},

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -5,7 +5,6 @@ import (
 	"cmp"
 	"context"
 	"crypto/sha3"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -438,16 +437,45 @@ sdkcraft-started-at: '2020-05-03T22:05:35.811829Z'
 `
 )
 
+// TODO: Consider replacing with SdkResult once SDK structs are finalised.
 type testSdk struct {
 	s    sdk.Setup
 	meta string
 }
 
 var apiSuiteSdks = map[string]testSdk{
-	"test-sdk":       {s: sdk.Setup{Name: "test-sdk", Revision: sdk.R(1)}, meta: testsdk},
-	"test-sdk-2":     {s: sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(1)}, meta: testsdk2},
-	"mount-conflict": {s: sdk.Setup{Name: "mount-conflict", Revision: sdk.R(1)}, meta: mount_conflict},
-	"test-sdk-3":     {s: sdk.Setup{Name: "test-sdk-3", Revision: sdk.R(1)}, meta: testsdk3},
+	"test-sdk": {
+		s: sdk.Setup{
+			Name:     "test-sdk",
+			Revision: sdk.R(1),
+			Sha3_384: "d024fbe91c6b99d0064306d52006c17a5d0406822ff253fbbe6a934ca9be50d3ff9a6ec3bac3be8396006029a1ff453a",
+		},
+		meta: testsdk,
+	},
+	"test-sdk-2": {
+		s: sdk.Setup{
+			Name:     "test-sdk-2",
+			Revision: sdk.R(1),
+			Sha3_384: "d4089378c26310627268153caa216240311f2a3193c778e96ed6dd895dc10c82db50f4f39676b29d23d9813b21e14b9b",
+		},
+		meta: testsdk2,
+	},
+	"mount-conflict": {
+		s: sdk.Setup{
+			Name:     "mount-conflict",
+			Revision: sdk.R(1),
+			Sha3_384: "b2bd882ceec6746f00ea2b6cbb6c2073d46d5844b2a3a92a573dd6ea02847a98085b7a7b192d7e24c3f87ba01bbf554e",
+		},
+		meta: mount_conflict,
+	},
+	"test-sdk-3": {
+		s: sdk.Setup{
+			Name:     "test-sdk-3",
+			Revision: sdk.R(1),
+			Sha3_384: "0b4b94c4685db0970a15d294ce8e0683b5c6957b08a94ab8a3b14d3aac90f06a4d2cc1240dad04e5be0fe358276e64fc",
+		},
+		meta: testsdk3,
+	},
 }
 
 func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string) {
@@ -986,8 +1014,7 @@ func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult,
 		setup := apiSuiteSdks[act.Name].s
 		setup.Channel = act.Channel
 		sdkYaml := apiSuiteSdks[act.Name].meta
-		digest := sha3.Sum384([]byte(sdkYaml))
-		result = append(result, sdk.SdkResult{Setup: setup, Sha3_384: hex.EncodeToString(digest[:]), SdkYAML: sdkYaml})
+		result = append(result, sdk.SdkResult{Setup: setup, SdkYAML: sdkYaml})
 	}
 	return result, nil
 }
@@ -1644,6 +1671,8 @@ func (s *apiSuite) ensureWorkshops(c *check.C, want []expectedWorkshop) {
 
 		c.Assert(w.Sdks, check.HasLen, len(wantws.sdks))
 		for _, sk := range wantws.sdks {
+			sk.Sha3_384 = w.Sdks[sk.Name].Sha3_384
+			c.Check(sk.Sha3_384, check.Not(check.Equals), "")
 			c.Assert(w.Sdks[sk.Name], check.DeepEquals, sk)
 		}
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -3206,8 +3206,8 @@ func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
 	defer s.store.SetDownloadCallback(storeDownload)()
 
 	oldGetBase := s.b.GetBaseCallback
-	s.b.GetBaseCallback = func(ctx context.Context, base string) (string, error) {
-		return "oldimage123", nil
+	s.b.GetBaseCallback = func(ctx context.Context, base string) (workshop.BaseImage, error) {
+		return workshop.BaseImage{Name: base, Fingerprint: "oldimage123"}, nil
 	}
 	defer func() { s.b.GetBaseCallback = oldGetBase }()
 
@@ -3226,7 +3226,7 @@ func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
 
 	wp, err := s.b.Workshop(s.ctx, "manysdks")
 	c.Assert(err, check.IsNil)
-	c.Check(wp.BaseFingerprint, check.Equals, "oldimage123")
+	c.Check(wp.Image, check.Equals, workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "oldimage123"})
 
 	requests = []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
@@ -3240,15 +3240,15 @@ func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
 		},
 	}
 
-	s.b.GetBaseCallback = func(ctx context.Context, base string) (string, error) {
-		return "newimage321", nil
+	s.b.GetBaseCallback = func(ctx context.Context, base string) (workshop.BaseImage, error) {
+		return workshop.BaseImage{Name: base, Fingerprint: "newimage321"}, nil
 	}
 
 	s.runActionTest(c, requests, expected)
 
 	wp, err = s.b.Workshop(s.ctx, "manysdks")
 	c.Assert(err, check.IsNil)
-	c.Check(wp.BaseFingerprint, check.Equals, "newimage321")
+	c.Check(wp.Image, check.Equals, workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "newimage321"})
 
 	want := []expectedWorkshop{{
 		name: "manysdks",

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -46,6 +46,7 @@ func (f *storeIntegration) TestStoreDownloadOK(c *check.C) {
 	result, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
 	setup.Revision = result.Revision
+	setup.Sha3_384 = result.Sha3_384
 	c.Check(result.Setup, check.Equals, setup)
 	c.Check(result.Revision, check.Not(check.Equals), sdk.R(0))
 	c.Check(result.Sha3_384, check.Not(check.Equals), "")
@@ -106,7 +107,12 @@ func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.
 	defer r()
 
 	s := store.New()
-	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
+	setup := sdk.Setup{
+		Name:     "test-sdk-basic",
+		Channel:  "latest/stable",
+		Revision: sdk.Revision{N: 1},
+		Sha3_384: "19133c4b2d9157b9edf9128e583245a621f172725abb5965282c8b2d9dfa60eae592d08cb0a0a5d48205ce8f25d2be91",
+	}
 
 	// Lock the file to emulate a concurrent download is going on
 	target := setup.Filepath()
@@ -119,14 +125,13 @@ func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.
 		result, err := s.DownloadSdk(context.Background(), setup, nil)
 		c.Assert(err, check.IsNil)
 		c.Check(result.Setup, check.Equals, setup)
-		c.Check(result.Sha3_384, check.Equals, "19133c4b2d9157b9edf9128e583245a621f172725abb5965282c8b2d9dfa60eae592d08cb0a0a5d48205ce8f25d2be91")
 		c.Check(result.SdkYAML, check.Equals, "name: test-sdk-basic")
 		c.Check(m.String(), check.Matches, fmt.Sprintf(`(?s)*.DEBUG: SDK Store on Download: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_1.sdk.*`, dirs.SdkDownloads))
 	})
 
 	// "download" is finished
 	c.Assert(os.WriteFile(target, nil, 0666), check.IsNil)
-	c.Assert(os.WriteFile(target+".sha3-384", []byte("19133c4b2d9157b9edf9128e583245a621f172725abb5965282c8b2d9dfa60eae592d08cb0a0a5d48205ce8f25d2be91"), 0666), check.IsNil)
+	c.Assert(os.WriteFile(target+".sha3-384", []byte(setup.Sha3_384), 0666), check.IsNil)
 	c.Assert(os.WriteFile(target+".yaml", []byte("name: test-sdk-basic"), 0666), check.IsNil)
 	fl.Close()
 	wg.Wait()

--- a/internal/fakestore/integration_test.go
+++ b/internal/fakestore/integration_test.go
@@ -48,7 +48,7 @@ func (f *storeIntegration) TestStoreDownloadOK(c *check.C) {
 	setup.Revision = result.Revision
 	c.Check(result.Setup, check.Equals, setup)
 	c.Check(result.Revision, check.Not(check.Equals), sdk.R(0))
-	c.Check(result.MD5, check.Not(check.Equals), "")
+	c.Check(result.Sha3_384, check.Not(check.Equals), "")
 	c.Check(result.SdkYAML, check.Not(check.Equals), "")
 	c.Assert(result.Filepath(), testutil.FilePresent)
 }
@@ -119,14 +119,14 @@ func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.
 		result, err := s.DownloadSdk(context.Background(), setup, nil)
 		c.Assert(err, check.IsNil)
 		c.Check(result.Setup, check.Equals, setup)
-		c.Check(result.MD5, check.Equals, "md5sum")
+		c.Check(result.Sha3_384, check.Equals, "19133c4b2d9157b9edf9128e583245a621f172725abb5965282c8b2d9dfa60eae592d08cb0a0a5d48205ce8f25d2be91")
 		c.Check(result.SdkYAML, check.Equals, "name: test-sdk-basic")
 		c.Check(m.String(), check.Matches, fmt.Sprintf(`(?s)*.DEBUG: SDK Store on Download: SDK "test-sdk-basic" found locally: %s/test-sdk-basic_1.sdk.*`, dirs.SdkDownloads))
 	})
 
 	// "download" is finished
 	c.Assert(os.WriteFile(target, nil, 0666), check.IsNil)
-	c.Assert(os.WriteFile(target+".md5", []byte("md5sum"), 0666), check.IsNil)
+	c.Assert(os.WriteFile(target+".sha3-384", []byte("19133c4b2d9157b9edf9128e583245a621f172725abb5965282c8b2d9dfa60eae592d08cb0a0a5d48205ce8f25d2be91"), 0666), check.IsNil)
 	c.Assert(os.WriteFile(target+".yaml", []byte("name: test-sdk-basic"), 0666), check.IsNil)
 	fl.Close()
 	wg.Wait()

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"crypto/sha3"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -51,7 +52,7 @@ type storeSdk struct {
 	Channel  string       `json:"channel"`
 	Revision sdk.Revision `json:"revision"`
 	SdkYAML  string       `json:"sdk-yaml"`
-	MD5      string       `json:"md5"`
+	Sha3_384 string       `json:"sha3-384"`
 }
 
 type sdkReader struct {
@@ -94,7 +95,7 @@ func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sd
 			}
 
 			setup := sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision}
-			results = append(results, sdk.SdkResult{Setup: setup, MD5: s.MD5, SdkYAML: s.SdkYAML})
+			results = append(results, sdk.SdkResult{Setup: setup, Sha3_384: s.Sha3_384, SdkYAML: s.SdkYAML})
 		default:
 			return nil, fmt.Errorf("unknown SDK store action")
 		}
@@ -146,7 +147,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 			return nil, err
 		}
 
-		return &sdk.SdkResult{Setup: setup, MD5: digest, SdkYAML: sdkYaml}, nil
+		return &sdk.SdkResult{Setup: setup, Sha3_384: digest, SdkYAML: sdkYaml}, nil
 	}
 
 	r, err := storeSdkReader(ctx, setup)
@@ -185,11 +186,11 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		return nil, err
 	}
 
-	digest := hex.EncodeToString(hash.Sum(nil))
-	if err := os.WriteFile(target+".md5", []byte(digest+"\n"), 0666); err != nil {
+	digest := md5ToSha3(hash.Sum(nil))
+	if err := os.WriteFile(target+".sha3-384", []byte(digest+"\n"), 0666); err != nil {
 		return nil, err
 	}
-	reverter.Add(func() { _ = os.Remove(target + ".md5") })
+	reverter.Add(func() { _ = os.Remove(target + ".sha3-384") })
 
 	sdkYaml, err := extractSdkYAML(ctx, setup)
 	if err != nil {
@@ -210,7 +211,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		if err := os.Remove(m); err != nil {
 			logger.Noticef("SDK Store on Download: Cannot cleanup previous download (%s): %v", m, err)
 		}
-		if err := os.Remove(m + ".md5"); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := os.Remove(m + ".sha3-384"); err != nil && !errors.Is(err, os.ErrNotExist) {
 			logger.Noticef("SDK Store on Download: Cannot cleanup previous download (%s): %v", m, err)
 		}
 		if err := os.Remove(m + ".yaml"); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -218,12 +219,12 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		}
 	}
 
-	return &sdk.SdkResult{Setup: setup, MD5: digest, SdkYAML: sdkYaml}, nil
+	return &sdk.SdkResult{Setup: setup, Sha3_384: digest, SdkYAML: sdkYaml}, nil
 }
 
 func hashSdk(setup sdk.Setup) (string, error) {
 	target := setup.Filepath()
-	cache := target + ".md5"
+	cache := target + ".sha3-384"
 
 	content, err := os.ReadFile(cache)
 	if err == nil {
@@ -241,11 +242,18 @@ func hashSdk(setup sdk.Setup) (string, error) {
 		return "", err
 	}
 
-	digest := hex.EncodeToString(hash.Sum(nil))
+	digest := md5ToSha3(hash.Sum(nil))
 	if err := os.WriteFile(cache, []byte(digest+"\n"), 0666); err != nil {
 		return "", err
 	}
 	return digest, nil
+}
+
+// Since the current Store only supports MD5, but we expect the actual store to
+// use SHA3, for now we just hash the md5sum to convert it.
+func md5ToSha3(md5sum []byte) string {
+	sum := sha3.Sum384(append([]byte("md5\x00"), md5sum...))
+	return hex.EncodeToString(sum[:])
 }
 
 func extractSdkYAML(ctx context.Context, setup sdk.Setup) (string, error) {
@@ -331,7 +339,7 @@ func storeSdkInfoImpl(ctx context.Context, name, channel string) (storeSdk, erro
 	sSdk.Channel = channel
 	// A simple modulo to keep revision numbers in a readable form for testing
 	sSdk.Revision = sdk.Revision{N: int(atr.Generation%1000) + 1}
-	sSdk.MD5 = hex.EncodeToString(atr.MD5)
+	sSdk.Sha3_384 = md5ToSha3(atr.MD5)
 	// The test server for the SDK store cannot store metadata.
 	if !client.isTesting {
 		if _, ok := atr.Metadata["sdk-yaml"]; !ok {

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -80,8 +80,8 @@ type ClientWrapper struct {
 	isTesting bool
 }
 
-func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.SdkResult, error) {
-	results := []sdk.SdkResult{}
+func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.Meta, error) {
+	sdks := make([]sdk.Meta, 0, len(actions))
 	actError := &SdkActionError{
 		errors: make(map[string]error),
 	}
@@ -95,17 +95,17 @@ func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sd
 			}
 
 			setup := sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision, Sha3_384: s.Sha3_384}
-			results = append(results, sdk.SdkResult{Setup: setup, SdkYAML: s.SdkYAML})
+			sdks = append(sdks, sdk.Meta{Setup: setup, SdkYAML: s.SdkYAML})
 		default:
 			return nil, fmt.Errorf("unknown SDK store action")
 		}
 	}
 
 	if len(actError.errors) > 0 {
-		return results, actError
+		return sdks, actError
 	}
 
-	return results, nil
+	return sdks, nil
 }
 
 type reporterWriter struct {
@@ -121,7 +121,7 @@ func (r *reporterWriter) Write(p []byte) (n int, err error) {
 	return plen, nil
 }
 
-func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error) {
+func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error) {
 	fl, err := sdk.OpenLock(setup.Name)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 			return nil, err
 		}
 
-		return &sdk.SdkResult{Setup: setup, SdkYAML: sdkYaml}, nil
+		return &sdk.Meta{Setup: setup, SdkYAML: sdkYaml}, nil
 	}
 
 	r, err := storeSdkReader(ctx, setup)
@@ -219,7 +219,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		}
 	}
 
-	return &sdk.SdkResult{Setup: setup, SdkYAML: sdkYaml}, nil
+	return &sdk.Meta{Setup: setup, SdkYAML: sdkYaml}, nil
 }
 
 func hashSdk(setup sdk.Setup) (string, error) {

--- a/internal/fakestore/store.go
+++ b/internal/fakestore/store.go
@@ -94,8 +94,8 @@ func (c *GcsStore) SdkAction(ctx context.Context, actions []sdk.SdkAction) ([]sd
 				continue
 			}
 
-			setup := sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision}
-			results = append(results, sdk.SdkResult{Setup: setup, Sha3_384: s.Sha3_384, SdkYAML: s.SdkYAML})
+			setup := sdk.Setup{Name: s.Name, Channel: s.Channel, Revision: s.Revision, Sha3_384: s.Sha3_384}
+			results = append(results, sdk.SdkResult{Setup: setup, SdkYAML: s.SdkYAML})
 		default:
 			return nil, fmt.Errorf("unknown SDK store action")
 		}
@@ -138,7 +138,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		// that the hash and metadata are stored next to the SDK file.
 		// Probably not worth changing the code since they will likely
 		// be pulled from the Store instead of computed client side.
-		digest, err := hashSdk(setup)
+		setup.Sha3_384, err = hashSdk(setup)
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +147,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 			return nil, err
 		}
 
-		return &sdk.SdkResult{Setup: setup, Sha3_384: digest, SdkYAML: sdkYaml}, nil
+		return &sdk.SdkResult{Setup: setup, SdkYAML: sdkYaml}, nil
 	}
 
 	r, err := storeSdkReader(ctx, setup)
@@ -186,8 +186,8 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		return nil, err
 	}
 
-	digest := md5ToSha3(hash.Sum(nil))
-	if err := os.WriteFile(target+".sha3-384", []byte(digest+"\n"), 0666); err != nil {
+	setup.Sha3_384 = md5ToSha3(hash.Sum(nil))
+	if err := os.WriteFile(target+".sha3-384", []byte(setup.Sha3_384+"\n"), 0666); err != nil {
 		return nil, err
 	}
 	reverter.Add(func() { _ = os.Remove(target + ".sha3-384") })
@@ -219,7 +219,7 @@ func (c *GcsStore) DownloadSdk(ctx context.Context, setup sdk.Setup, report *pro
 		}
 	}
 
-	return &sdk.SdkResult{Setup: setup, Sha3_384: digest, SdkYAML: sdkYaml}, nil
+	return &sdk.SdkResult{Setup: setup, SdkYAML: sdkYaml}, nil
 }
 
 func hashSdk(setup sdk.Setup) (string, error) {

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -113,7 +113,8 @@ var (
 
 func (s *healthSuite) launchWorkshopWithSDKs(c *check.C, sdks []workshop.SdkRecord, hooks map[string]map[string]string) *workshop.Workshop {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: sdks}
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123")
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
@@ -203,7 +204,7 @@ func (s *healthSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop", "ws")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
-	task.Set("workshop-base-fingerprint", "fakeimage123")
+	task.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
@@ -225,7 +226,7 @@ func (s *healthSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop", "ws")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
-	task.Set("workshop-base-fingerprint", "fakeimage123")
+	task.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
@@ -288,7 +289,7 @@ func (s *healthSuite) TestCheckStatusPending(c *check.C) {
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop", "ws")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
-	task.Set("workshop-base-fingerprint", "fakeimage123")
+	task.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 
@@ -312,7 +313,7 @@ func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop", "ws")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
-	task.Set("workshop-base-fingerprint", "fakeimage123")
+	task.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("project-id", s.project.ProjectId)
 	chg.AddTask(task)
 

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -96,7 +96,9 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 	chg.AddTask(t1)
 
 	// Launch a workshop provinding no hooks
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, &workshop.File{Name: "ws", Base: "ubuntu@20.04"}, "fakeimage123")
+	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
 	c.Check(err, check.IsNil)
 
 	s.state.Unlock()
@@ -532,7 +534,8 @@ func (s *hookSuite) TestHookWithMultipleHandlersIsError(c *check.C) {
 
 func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{{Name: "one", Channel: "latest/stable"}}}
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123")
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -46,7 +46,13 @@ base: ubuntu@22.04
 slots:
   slot:
     interface: mock-network`
-var psetup = sdk.Setup{Name: "producer", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
+
+var psetup = sdk.Setup{
+	Name:     "producer",
+	Channel:  "latest/stable",
+	Revision: sdk.Revision{N: 1},
+	Sha3_384: "ad5e649bf9faebda8ede856fc0ba67c333146698648f36b5b4ee89ace57f17deb4488675687a3bc096e91cc9a1b5a6e4",
+}
 
 var consumer = `name: consumer
 base: ubuntu@22.04
@@ -55,6 +61,13 @@ plugs:
     interface: mock-network
     attribute: one
 `
+
+var csetup = sdk.Setup{
+	Name:     "consumer",
+	Channel:  "latest/stable",
+	Revision: sdk.Revision{N: 1},
+	Sha3_384: "5cb2865793d51841462193fccc18c77d74c6571f5ed45556d94d1b247d4f2090185f9edbaa705faace62f5df11f349af",
+}
 
 var consumerManyPlugs = `name: consumer
 base: ubuntu@22.04
@@ -84,6 +97,13 @@ plugs:
     attribute: one
 `
 
+var csetup2 = sdk.Setup{
+	Name:     "consumer2",
+	Channel:  "latest/stable",
+	Revision: sdk.Revision{N: 1},
+	Sha3_384: "aa5b6a08c6be283b51d5430b21aa3cdc523f63dab50cff2ee13c83a7680bedd44475521af9aeec175105efa97c83a12b",
+}
+
 var conflictingTarget1 = `name: conflict-1
 base: ubuntu@22.04
 plugs:
@@ -91,6 +111,13 @@ plugs:
     interface: mount
     workshop-target: /opt
 `
+
+var ctsetup1 = sdk.Setup{
+	Name:     "conflict-1",
+	Channel:  "latest/stable",
+	Revision: sdk.Revision{N: 1},
+	Sha3_384: "e31b080cd302fdbbe9a5c207dcba039c2ae8e47c208ca5bd51588b5f89dc6679132b31d94d279faebb1fb2823df0068e",
+}
 
 var conflictingTarget2 = `name: conflict-2
 base: ubuntu@22.04
@@ -100,8 +127,12 @@ plugs:
     workshop-target: /opt
 `
 
-var csetup = sdk.Setup{Name: "consumer", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
-var csetup2 = sdk.Setup{Name: "consumer2", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}
+var ctsetup2 = sdk.Setup{
+	Name:     "conflict-2",
+	Channel:  "latest/stable",
+	Revision: sdk.Revision{N: 1},
+	Sha3_384: "7fcc3b8c47bb26bbf8502df69804342be1eace51606c3e2283c720cb41ad165a9fa130947e0066a479b6cc40e213168d",
+}
 
 func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 	s.interfaceManagerSuite.SetUpTest(c)
@@ -387,8 +418,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c *check.C) {
 	// Setup
 	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{sdk.Setup{Name: "conflict-1", Channel: "latest/stable", Revision: sdk.R(1)}, conflictingTarget1},
-		{sdk.Setup{Name: "conflict-2", Channel: "latest/stable", Revision: sdk.R(1)}, conflictingTarget2},
+		{ctsetup1, conflictingTarget1},
+		{ctsetup2, conflictingTarget2},
 	})
 	repo := s.mgr.Repository()
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget1, s.prj.ProjectId, "ws")), check.IsNil)
@@ -423,8 +454,8 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c
 func (s *interfaceHandlersSuite) TestAutoconnectBindResolvesMountConflicts(c *check.C) {
 	// Setup
 	wp, err := s.launchWorkshop(c, "ws", []testSdkSetup{
-		{sdk.Setup{Name: "conflict-1", Channel: "latest/stable", Revision: sdk.R(1)}, conflictingTarget1},
-		{sdk.Setup{Name: "conflict-2", Channel: "latest/stable", Revision: sdk.R(1)}, conflictingTarget2},
+		{ctsetup1, conflictingTarget1},
+		{ctsetup2, conflictingTarget2},
 	})
 	c.Assert(err, check.IsNil)
 	wp.File.Sdks[1].Plugs = map[string]workshop.PlugOrBind{}

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"gopkg.in/check.v1"
@@ -41,35 +40,50 @@ func fakeHandler(task *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-var producer = `name: producer
+var producer = sdk.Meta{
+	Setup: sdk.Setup{
+		Name:     "producer",
+		Channel:  "latest/stable",
+		Revision: sdk.Revision{N: 1},
+		Sha3_384: "ad5e649bf9faebda8ede856fc0ba67c333146698648f36b5b4ee89ace57f17deb4488675687a3bc096e91cc9a1b5a6e4",
+	},
+	SdkYAML: `name: producer
 base: ubuntu@22.04
 slots:
   slot:
-    interface: mock-network`
-
-var psetup = sdk.Setup{
-	Name:     "producer",
-	Channel:  "latest/stable",
-	Revision: sdk.Revision{N: 1},
-	Sha3_384: "ad5e649bf9faebda8ede856fc0ba67c333146698648f36b5b4ee89ace57f17deb4488675687a3bc096e91cc9a1b5a6e4",
+    interface: mock-network
+`,
 }
 
-var consumer = `name: consumer
+var producerSSH = sdk.Meta{
+	Setup: producer.Setup,
+	SdkYAML: `name: producer
+base: ubuntu@22.04
+slots:
+  slot:
+    interface: mock-ssh-agent
+`,
+}
+
+var consumer = sdk.Meta{
+	Setup: sdk.Setup{
+		Name:     "consumer",
+		Channel:  "latest/stable",
+		Revision: sdk.Revision{N: 1},
+		Sha3_384: "5cb2865793d51841462193fccc18c77d74c6571f5ed45556d94d1b247d4f2090185f9edbaa705faace62f5df11f349af",
+	},
+	SdkYAML: `name: consumer
 base: ubuntu@22.04
 plugs:
   plug:
     interface: mock-network
     attribute: one
-`
-
-var csetup = sdk.Setup{
-	Name:     "consumer",
-	Channel:  "latest/stable",
-	Revision: sdk.Revision{N: 1},
-	Sha3_384: "5cb2865793d51841462193fccc18c77d74c6571f5ed45556d94d1b247d4f2090185f9edbaa705faace62f5df11f349af",
+`,
 }
 
-var consumerManyPlugs = `name: consumer
+var consumerManyPlugs = sdk.Meta{
+	Setup: consumer.Setup,
+	SdkYAML: `name: consumer
 base: ubuntu@22.04
 plugs:
   plug:
@@ -87,51 +101,55 @@ plugs:
   bound:
     interface: mock-network
     attribute: one
-`
+`,
+}
 
-var consumer2 = `name: consumer2
+var consumer2 = sdk.Meta{
+	Setup: sdk.Setup{
+		Name:     "consumer2",
+		Channel:  "latest/stable",
+		Revision: sdk.Revision{N: 1},
+		Sha3_384: "aa5b6a08c6be283b51d5430b21aa3cdc523f63dab50cff2ee13c83a7680bedd44475521af9aeec175105efa97c83a12b",
+	},
+	SdkYAML: `name: consumer2
 base: ubuntu@22.04
 plugs:
   plug2:
     interface: mock-network
     attribute: one
-`
-
-var csetup2 = sdk.Setup{
-	Name:     "consumer2",
-	Channel:  "latest/stable",
-	Revision: sdk.Revision{N: 1},
-	Sha3_384: "aa5b6a08c6be283b51d5430b21aa3cdc523f63dab50cff2ee13c83a7680bedd44475521af9aeec175105efa97c83a12b",
+`,
 }
 
-var conflictingTarget1 = `name: conflict-1
+var conflictingTarget1 = sdk.Meta{
+	Setup: sdk.Setup{
+		Name:     "conflict-1",
+		Channel:  "latest/stable",
+		Revision: sdk.Revision{N: 1},
+		Sha3_384: "e31b080cd302fdbbe9a5c207dcba039c2ae8e47c208ca5bd51588b5f89dc6679132b31d94d279faebb1fb2823df0068e",
+	},
+	SdkYAML: `name: conflict-1
 base: ubuntu@22.04
 plugs:
   plug:
     interface: mount
     workshop-target: /opt
-`
-
-var ctsetup1 = sdk.Setup{
-	Name:     "conflict-1",
-	Channel:  "latest/stable",
-	Revision: sdk.Revision{N: 1},
-	Sha3_384: "e31b080cd302fdbbe9a5c207dcba039c2ae8e47c208ca5bd51588b5f89dc6679132b31d94d279faebb1fb2823df0068e",
+`,
 }
 
-var conflictingTarget2 = `name: conflict-2
+var conflictingTarget2 = sdk.Meta{
+	Setup: sdk.Setup{
+		Name:     "conflict-2",
+		Channel:  "latest/stable",
+		Revision: sdk.Revision{N: 1},
+		Sha3_384: "7fcc3b8c47bb26bbf8502df69804342be1eace51606c3e2283c720cb41ad165a9fa130947e0066a479b6cc40e213168d",
+	},
+	SdkYAML: `name: conflict-2
 base: ubuntu@22.04
 plugs:
   plug:
     interface: mount
     workshop-target: /opt
-`
-
-var ctsetup2 = sdk.Setup{
-	Name:     "conflict-2",
-	Channel:  "latest/stable",
-	Revision: sdk.Revision{N: 1},
-	Sha3_384: "7fcc3b8c47bb26bbf8502df69804342be1eace51606c3e2283c720cb41ad165a9fa130947e0066a479b6cc40e213168d",
+`,
 }
 
 func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
@@ -226,12 +244,12 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-producer", []testSdkSetup{{psetup, producer}})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
-	s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumer}})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -272,14 +290,13 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-producer", []testSdkSetup{{psetup, producer}})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
-	wp, err := s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumerManyPlugs}})
-	c.Check(err, check.IsNil)
+	wp := s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs})
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.PlugOrBind)
 	wp.File.Sdks[0].Plugs["bound"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}}
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -336,14 +353,13 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindMasterPlugNotFound(c *check.
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-producer", []testSdkSetup{{psetup, producer}})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
-	wp, err := s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumerManyPlugs}})
-	c.Check(err, check.IsNil)
+	wp := s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs})
 	wp.File.Sdks[0].Plugs = make(map[string]workshop.PlugOrBind)
 	wp.File.Sdks[0].Plugs["plug"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "consumer", Name: "no-such-plug2"}}
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -370,12 +386,12 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 	// Setup
 	// Create an already launched workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-producer", []testSdkSetup{{psetup, producer}})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
-	s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumerManyPlugs}, {csetup2, consumer2}})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer2, s.prj.ProjectId, "ws")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs, consumer2})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer2.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	n := 0
 	// One of the SDKs setup fails, we need to make sure that any partial
@@ -417,13 +433,10 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{ctsetup1, conflictingTarget1},
-		{ctsetup2, conflictingTarget2},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{conflictingTarget1, conflictingTarget2})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget1, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget2, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget1.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget2.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
@@ -453,16 +466,12 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c
 
 func (s *interfaceHandlersSuite) TestAutoconnectBindResolvesMountConflicts(c *check.C) {
 	// Setup
-	wp, err := s.launchWorkshop(c, "ws", []testSdkSetup{
-		{ctsetup1, conflictingTarget1},
-		{ctsetup2, conflictingTarget2},
-	})
-	c.Assert(err, check.IsNil)
+	wp := s.launchWorkshop(c, "ws", []sdk.Meta{conflictingTarget1, conflictingTarget2})
 	wp.File.Sdks[1].Plugs = map[string]workshop.PlugOrBind{}
 	wp.File.Sdks[1].Plugs["plug"] = workshop.PlugOrBind{Bind: &workshop.PlugRef{Sdk: "conflict-1", Name: "plug"}}
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget1, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget2, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget1.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, conflictingTarget2.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")
@@ -491,7 +500,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindResolvesMountConflicts(c *ch
 func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumer}})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer})
 
 	// Execute
 	s.state.Lock()
@@ -528,12 +537,12 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-producer", []testSdkSetup{{psetup, producer}})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
-	s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumer}})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -580,14 +589,12 @@ func (s *interfaceHandlersSuite) TestUndoAutoConnect(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
-	_, err := s.launchWorkshop(c, "ws-producer", []testSdkSetup{{psetup, producer}})
-	c.Check(err, check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-producer")), check.IsNil)
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
 
 	// Launch another workshop with a candidate plug
-	_, err = s.launchWorkshop(c, "ws", []testSdkSetup{{csetup, consumer}})
-	c.Check(err, check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -652,8 +659,7 @@ slots:
     mount:
         interface: mount
 `
-	wm, err := s.launchWorkshop(c, "ws-consumer", []testSdkSetup{{csetup, sdkYaml}})
-	c.Assert(err, check.IsNil)
+	wm := s.launchWorkshop(c, "ws-consumer", []sdk.Meta{{Setup: consumer.Setup, SdkYAML: sdkYaml}})
 	wm.Running = true
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, systemYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
@@ -671,7 +677,7 @@ slots:
 			"slot-dynamic": dynamic,
 		},
 	})
-	_, err = ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws-consumer", "consumer")
+	_, err := ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws-consumer", "consumer")
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 }
@@ -998,10 +1004,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a connected plug
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-consumer", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws-consumer", []sdk.Meta{consumer, producer})
 
 	connRef := &interfaces.ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
@@ -1105,12 +1108,9 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectIgnoresAutoConnections(c *che
 func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	s.state.Lock()
@@ -1134,12 +1134,9 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 func (s *interfaceHandlersSuite) TestAutoDisconnectNoSdkProfile(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.secBackend.RemoveCallback = func(sdkName string) error { return workshop.ErrSdkProfileNotFound }
 
@@ -1173,12 +1170,9 @@ func (s *interfaceHandlersSuite) newUndoDisconnectInterfacesChange(sdkName strin
 func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-consumer", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	s.launchWorkshop(c, "ws-consumer", []sdk.Meta{consumer, producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
 	connRef := &interfaces.ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
@@ -1224,12 +1218,9 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 func (s *interfaceHandlersSuite) TestUndoAutoDisconnectManualRestored(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-consumer", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	s.launchWorkshop(c, "ws-consumer", []sdk.Meta{consumer, producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
 	connRef := &interfaces.ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
@@ -1293,13 +1284,10 @@ func (s *interfaceHandlersSuite) disconnectChange(c *check.C, workshop string, f
 
 func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
 		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
@@ -1336,13 +1324,10 @@ func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	connRefKey := "42424242/ws/consumer:plug 42424242/ws/producer:slot"
 	s.state.Set("conns", map[string]interface{}{
@@ -1385,13 +1370,10 @@ func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	connRefKey := "42424242/ws/consumer:plug 42424242/ws/producer:slot"
 	s.state.Set("conns", map[string]interface{}{
@@ -1433,13 +1415,10 @@ func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoDisconnect(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
 		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
@@ -1485,13 +1464,10 @@ func (s *interfaceHandlersSuite) TestUndoDisconnect(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoDisconnectUndesiredSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	conn := map[string]interface{}{
 		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
@@ -1560,13 +1536,10 @@ func (s *interfaceHandlersSuite) connectChange(workshop string, auto bool, delay
 
 func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	chg := s.connectChange("ws", false, true)
@@ -1591,13 +1564,10 @@ func (s *interfaceHandlersSuite) TestConnectSuccess(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestConnectSuccessSetupBackend(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	chg := s.connectChange("ws", false, false)
@@ -1622,13 +1592,10 @@ func (s *interfaceHandlersSuite) TestConnectSuccessSetupBackend(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestConnectDisconnectsIfBackedSetupFailed(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		return errors.New("cannot finish backend setup")
@@ -1653,13 +1620,10 @@ func (s *interfaceHandlersSuite) TestConnectDisconnectsIfBackedSetupFailed(c *ch
 
 func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	chg := s.connectChange("ws", false, true)
 	s.state.Lock()
@@ -1702,13 +1666,10 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	chg := s.connectChange("ws", true, true)
@@ -1743,13 +1704,10 @@ func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoConnectUndesired(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
@@ -1796,13 +1754,10 @@ func (s *interfaceHandlersSuite) TestUndoConnectUndesired(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoConnectBackendSetup(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Execute
 	chg := s.connectChange("ws", false, false)
@@ -1830,13 +1785,10 @@ func (s *interfaceHandlersSuite) TestUndoConnectBackendSetup(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestDiscardConnsSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
 		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
@@ -1903,13 +1855,10 @@ func (s *interfaceHandlersSuite) TestDiscardConnsSuccess(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoDiscardConnsSuccess(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumer},
-		{psetup, producer},
-	})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
@@ -1965,12 +1914,9 @@ func (s *interfaceHandlersSuite) TestUndoDiscardConnsSuccess(c *check.C) {
 func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
 	// Launch
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumerManyPlugs},
-		{psetup, strings.Replace(producer, "mock-network", "mock-ssh-agent", 1)},
-	})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, strings.Replace(producer, "mock-network", "mock-ssh-agent", 1), s.prj.ProjectId, "ws")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs, producerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producerSSH.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Connect
 	s.state.Lock()
@@ -2039,12 +1985,9 @@ func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailure(c *check.C) {
 func (s *interfaceHandlersSuite) TestDoDisconnectSetupFailureAuto(c *check.C) {
 	// Launch
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumerManyPlugs},
-		{psetup, strings.Replace(producer, "mock-network", "mock-ssh-agent", 1)},
-	})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs, s.prj.ProjectId, "ws")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, strings.Replace(producer, "mock-network", "mock-ssh-agent", 1), s.prj.ProjectId, "ws")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs, producerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producerSSH.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	// Connect
 	s.state.Lock()

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -122,7 +122,8 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	err = yaml.Unmarshal(workshopFile.Bytes(), &wf)
 	c.Assert(err, check.IsNil)
 
-	err = s.wsbackend.LaunchOrRebuildWorkshop(ctx, &wf, "fakeimage123")
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	err = s.wsbackend.LaunchOrRebuildWorkshop(ctx, &wf, image)
 	c.Assert(err, check.IsNil)
 
 	wsfs, err := s.wsbackend.WorkshopFs(ctx, ws)

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
@@ -69,6 +70,7 @@ func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
 	s.BaseTest.TearDownTest(c)
 }
 
+// TODO: Consider replacing with SdkResult once SDK structs are finalised.
 type testSdkSetup struct {
 	sdk.Setup
 	yaml string
@@ -130,8 +132,13 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 	c.Assert(err, check.IsNil)
 	defer wsfs.Close()
 
-	allsdks := []testSdkSetup{{Setup: sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: sdk.R(1)}, yaml: systemYaml}}
-	allsdks = append(allsdks, sdks...)
+	systemSetup := sdk.Setup{
+		Name:     sdk.System.String(),
+		Source:   sdk.SystemSource,
+		Revision: sdk.R(1),
+		Sha3_384: "6b499970ebf370d4dbc4e9a005c042dee003c19a9420a78944bcbf32653d257f80f7c56bad55b4c967dca68a1ea92be7",
+	}
+	allsdks := slices.Insert(sdks, 0, testSdkSetup{Setup: systemSetup, yaml: systemYaml})
 
 	for _, setup := range allsdks {
 		s.mockSdk(c, setup.Name, setup.yaml, setup.Revision)
@@ -165,7 +172,7 @@ plugs:
 `
 
 	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{sdk.Setup{Name: "consumer", Channel: "latest/stable", Revision: sdk.Revision{N: 1}}, consumerYaml},
+		{csetup, consumerYaml},
 	})
 
 	s.state.Lock()
@@ -233,8 +240,8 @@ slots:
   attr2: value2
 `
 	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{sdk.Setup{Name: "consumer", Channel: "latest/stable", Revision: sdk.R(1)}, consumerYaml},
-		{sdk.Setup{Name: "producer", Channel: "latest/stable", Revision: sdk.R(1)}, producerYaml},
+		{csetup, consumerYaml},
+		{psetup, producerYaml},
 	})
 
 	s.state.Lock()
@@ -276,8 +283,8 @@ slots:
   attr2: value2
 `
 	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{sdk.Setup{Name: "consumer", Channel: "latest/stable", Revision: sdk.R(1)}, consumerYaml},
-		{sdk.Setup{Name: "producer", Channel: "latest/stable", Revision: sdk.R(1)}, producerYaml},
+		{csetup, consumerYaml},
+		{psetup, producerYaml},
 	})
 
 	s.state.Lock()

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -70,12 +70,6 @@ func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-// TODO: Consider replacing with SdkResult once SDK structs are finalised.
-type testSdkSetup struct {
-	sdk.Setup
-	yaml string
-}
-
 var systemYaml = `name: system
 base: ubuntu@22.04
 type: system
@@ -84,24 +78,24 @@ slots:
     interface: mount
 `
 
-func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sdk.Revision) {
+func (s *interfaceManagerSuite) mockSdk(c *check.C, meta sdk.Meta) {
 	vfs := c.MkDir()
 
-	meta := filepath.Join(vfs, "meta")
-	err := os.MkdirAll(meta, 0755)
+	path := filepath.Join(vfs, "meta", "sdk.yaml")
+	err := os.MkdirAll(filepath.Dir(path), 0755)
 	c.Assert(err, check.IsNil)
-	err = os.WriteFile(filepath.Join(meta, "sdk.yaml"), []byte(sdkYaml), 0644)
+	err = os.WriteFile(path, []byte(meta.SdkYAML), 0644)
 	c.Assert(err, check.IsNil)
 
 	s.state.Lock()
 	be := s.o.WorkshopBackend()
 	s.state.Unlock()
 	volume := workshop.VolumeSetup{
-		Name:     sdk.VolumeName(name, rev),
+		Name:     sdk.VolumeName(meta.Name, meta.Revision),
 		Kind:     "sdk",
-		Sdk:      name,
-		Revision: rev,
-		Metadata: sdkYaml,
+		Sdk:      meta.Name,
+		Revision: meta.Revision,
+		Metadata: meta.SdkYAML,
 	}
 	file, err := os.Open(vfs)
 	c.Assert(err, check.IsNil)
@@ -111,7 +105,7 @@ func (s *interfaceManagerSuite) mockSdk(c *check.C, name, sdkYaml string, rev sd
 	}
 }
 
-func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []testSdkSetup) (*workshop.Workshop, error) {
+func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []sdk.Meta) *workshop.Workshop {
 	ctx := context.WithValue(s.ctx, workshop.ContextProjectId, s.prj.ProjectId)
 
 	t, err := template.New("workshop").Parse(fmt.Sprintf(workshopTemplate, ws))
@@ -138,10 +132,10 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 		Revision: sdk.R(1),
 		Sha3_384: "6b499970ebf370d4dbc4e9a005c042dee003c19a9420a78944bcbf32653d257f80f7c56bad55b4c967dca68a1ea92be7",
 	}
-	allsdks := slices.Insert(sdks, 0, testSdkSetup{Setup: systemSetup, yaml: systemYaml})
+	allsdks := slices.Insert(sdks, 0, sdk.Meta{Setup: systemSetup, SdkYAML: systemYaml})
 
-	for _, setup := range allsdks {
-		s.mockSdk(c, setup.Name, setup.yaml, setup.Revision)
+	for _, meta := range allsdks {
+		s.mockSdk(c, meta)
 	}
 
 	w, err := s.wsbackend.Workshop(ctx, ws)
@@ -158,7 +152,7 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []tes
 		c.Assert(err, check.IsNil)
 	}
 
-	return w, nil
+	return w
 }
 
 func (s *interfaceManagerSuite) TestManagerReloadsConnections(c *check.C) {
@@ -171,8 +165,8 @@ plugs:
   attr: plug-value
 `
 
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumerYaml},
+	s.launchWorkshop(c, "ws", []sdk.Meta{
+		{Setup: consumer.Setup, SdkYAML: consumerYaml},
 	})
 
 	s.state.Lock()
@@ -239,9 +233,9 @@ slots:
   interface: mount
   attr2: value2
 `
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumerYaml},
-		{psetup, producerYaml},
+	s.launchWorkshop(c, "ws", []sdk.Meta{
+		{Setup: consumer.Setup, SdkYAML: consumerYaml},
+		{Setup: producer.Setup, SdkYAML: producerYaml},
 	})
 
 	s.state.Lock()
@@ -282,9 +276,9 @@ slots:
   interface: mount
   attr2: value2
 `
-	s.launchWorkshop(c, "ws", []testSdkSetup{
-		{csetup, consumerYaml},
-		{psetup, producerYaml},
+	s.launchWorkshop(c, "ws", []sdk.Meta{
+		{Setup: consumer.Setup, SdkYAML: consumerYaml},
+		{Setup: producer.Setup, SdkYAML: producerYaml},
 	})
 
 	s.state.Lock()

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -131,7 +131,6 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		Name:     sdk.VolumeName(result.Name, result.Revision),
 		Kind:     "sdk",
 		Sha3_384: result.Sha3_384,
-		MD5:      result.MD5,
 		Sdk:      result.Name,
 		Revision: result.Revision,
 	}

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"time"
 
 	"gopkg.in/tomb.v2"
@@ -228,16 +227,7 @@ func (m *SdkManager) mountSdk(ctx context.Context, user string, project *worksho
 	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
 
 	sdkDir := workshop.LocalSdkDir(userDataDir, project.ProjectId, w, sdkSetup.Name)
-	revision := filepath.Join(sdkDir, sdkSetup.Revision.String())
-	digest, err := os.Readlink(revision)
-	if err != nil {
-		return err
-	}
-	// Ensure we only mount actual SDKs and avoid malicious symlinks.
-	if strings.ContainsRune(digest, os.PathSeparator) {
-		return &os.PathError{Op: "mount", Path: revision, Err: fmt.Errorf("invalid hash %q", digest)}
-	}
-	what := filepath.Join(sdkDir, digest)
+	what := filepath.Join(sdkDir, sdkSetup.Sha3_384)
 
 	mnt := workshop.Mount{
 		Name:     name,

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -98,15 +98,15 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		},
 	}
 
-	var result *sdk.SdkResult
+	var meta *sdk.Meta
 	if rec.Source == sdk.SystemSource {
-		result, err = system.RetrieveSystemSdk(rec, reporter)
+		meta, err = system.RetrieveSystemSdk(rec, reporter)
 	} else {
 		st.Lock()
 		store := sdk.StoreService(st)
 		st.Unlock()
 
-		result, err = store.DownloadSdk(ctx, rec, reporter)
+		meta, err = store.DownloadSdk(ctx, rec, reporter)
 	}
 	if err != nil {
 		return err
@@ -114,26 +114,26 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 
 	// TODO: We should be downloading a specific revision. Remove this when
 	// the Store supports that (it will probably have to be removed anyway
-	// since DownloadSdk won't return a result after that).
-	if result.Revision != rec.Revision {
+	// since DownloadSdk won't return metadata after that).
+	if meta.Revision != rec.Revision {
 		st.Lock()
-		task.Set("sdk-setup", result.Setup)
+		task.Set("sdk-setup", meta.Setup)
 		// Ideally we would validate the YAML here, but we can't check
 		// the base without knowing about the workshop. And this task
 		// should remain workshop-agnostic if possible. Instead we
 		// pass it to doInstallSdk and validate there.
-		task.Set("sdk-yaml", result.SdkYAML)
+		task.Set("sdk-yaml", meta.SdkYAML)
 		st.Unlock()
 	}
 
 	volume := workshop.VolumeSetup{
-		Name:     sdk.VolumeName(result.Name, result.Revision),
+		Name:     sdk.VolumeName(meta.Name, meta.Revision),
 		Kind:     "sdk",
-		Sha3_384: result.Sha3_384,
-		Sdk:      result.Name,
-		Revision: result.Revision,
+		Sha3_384: meta.Sha3_384,
+		Sdk:      meta.Name,
+		Revision: meta.Revision,
 	}
-	file, err := os.Open(result.Filepath())
+	file, err := os.Open(meta.Filepath())
 	if err != nil {
 		return err
 	}

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -148,7 +148,8 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 		{Name: "test", Channel: "latest/stable"},
 		{Name: "test-broken", Channel: "latest/stable"},
 	}}
-	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123")
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
 	c.Assert(err, check.IsNil)
 }
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -153,20 +153,20 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *sdkStateSuite) mockSdk(c *check.C, name, sdkYaml string, rev sdk.Revision) {
+func (s *sdkStateSuite) mockSdk(c *check.C, meta sdk.Meta) {
 	vfs := c.MkDir()
 
-	meta := filepath.Join(vfs, "meta")
-	err := os.MkdirAll(meta, 0755)
+	path := filepath.Join(vfs, "meta", "sdk.yaml")
+	err := os.MkdirAll(filepath.Dir(path), 0755)
 	c.Assert(err, check.IsNil)
-	err = os.WriteFile(filepath.Join(meta, "sdk.yaml"), []byte(sdkYaml), 0644)
+	err = os.WriteFile(path, []byte(meta.SdkYAML), 0644)
 	c.Assert(err, check.IsNil)
 	volume := workshop.VolumeSetup{
-		Name:     sdk.VolumeName(name, rev),
+		Name:     sdk.VolumeName(meta.Name, meta.Revision),
 		Kind:     "sdk",
-		Sdk:      name,
-		Revision: rev,
-		Metadata: sdkYaml,
+		Sdk:      meta.Name,
+		Revision: meta.Revision,
+		Metadata: meta.SdkYAML,
 	}
 	file, err := os.Open(vfs)
 	c.Assert(err, check.IsNil)
@@ -191,16 +191,19 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Revision: sdk.R(2),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Revision: sdk.R(2),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
-	s.mockSdk(c, "test", sdkYaml, sdk.R(2))
+	s.mockSdk(c, newSdk)
 
 	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 	t1 := s.state.NewTask("install-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
 
@@ -223,7 +226,7 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	c.Check(props.Sdks["test"].Setup, check.DeepEquals, newSdk)
+	c.Check(props.Sdks["test"].Setup, check.DeepEquals, newSdk.Setup)
 	c.Check(props.Sdks["test"].InstallTime, check.Equals, s.installTime)
 
 	sdkInfo, err := props.SdkInfo(s.ctx, "test")
@@ -236,16 +239,19 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Setup{
-		Name:     "test-2",
-		Channel:  "latest/stable",
-		Revision: sdk.R(2),
-		Sha3_384: "335783e65660ee5cfeb96b1323585f0c2ad006582c3c3dde89dd62a9f081c24b81e4972c8ce87787531c85e0683479a5",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test-2",
+			Channel:  "latest/stable",
+			Revision: sdk.R(2),
+			Sha3_384: "335783e65660ee5cfeb96b1323585f0c2ad006582c3c3dde89dd62a9f081c24b81e4972c8ce87787531c85e0683479a5",
+		},
+		SdkYAML: sdkYaml,
 	}
-	s.mockSdk(c, "test-2", sdkYaml, sdk.R(2))
+	s.mockSdk(c, newSdk)
 
 	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 
 	t1 := s.state.NewTask("install-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
@@ -340,16 +346,19 @@ func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {
 
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
-	testSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	testSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
+	s.mockSdk(c, testSdk)
 
 	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", testSdk)
+	t.Set("sdk-setup", testSdk.Setup)
 	t1 := s.state.NewTask("install-sdk", "test")
 	t1.Set("sdk-retrieve-task", t.ID())
 	t2 := s.state.NewTask("register-sdk", "test")
@@ -382,17 +391,20 @@ func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
 	defer s.state.Unlock()
 
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-	s.mockSdk(c, "test-broken", sdkYamlViolatesPolicy, sdk.R(2))
 
-	testSdk := sdk.Setup{
-		Name:     "test-broken",
-		Channel:  "latest/stable",
-		Revision: sdk.R(2),
-		Sha3_384: "eee11792d075bd015406afe6450ac4f5080d78867da10cc5aa9380c383f31b71c8c71d831edd53c67eafc4b745a6bc80",
+	testSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test-broken",
+			Channel:  "latest/stable",
+			Revision: sdk.R(2),
+			Sha3_384: "eee11792d075bd015406afe6450ac4f5080d78867da10cc5aa9380c383f31b71c8c71d831edd53c67eafc4b745a6bc80",
+		},
+		SdkYAML: sdkYamlViolatesPolicy,
 	}
+	s.mockSdk(c, testSdk)
 
 	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", testSdk)
+	t.Set("sdk-setup", testSdk.Setup)
 	t1 := s.state.NewTask("install-sdk", "...")
 	t1.Set("sdk-retrieve-task", t.ID())
 	t2 := s.state.NewTask("register-sdk", "test-broken")
@@ -437,16 +449,19 @@ func (s *sdkStateSuite) TestDoUnregisterSdk(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 	t1 := s.state.NewTask("install-sdk", "...")
 	t1.Set("sdk-retrieve-task", t.ID())
 	register := s.state.NewTask("register-sdk", "test")
@@ -487,16 +502,19 @@ func (s *sdkStateSuite) TestDoUnregisterSdk(c *check.C) {
 func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 	t := s.state.NewTask("fake-task", "retrieve")
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 	t1 := s.state.NewTask("install-sdk", "...")
 	t1.Set("sdk-retrieve-task", t.ID())
 	register := s.state.NewTask("register-sdk", "test")
@@ -527,17 +545,20 @@ func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
 
 func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Source:   sdk.StoreSource,
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 	t := s.state.NewTask("unregister-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
@@ -562,17 +583,20 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 
 func (s *sdkStateSuite) TestSDKVolumeRemovedAfterFailedLaunch(c *check.C) {
 	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Source:   sdk.StoreSource,
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 	t := s.state.NewTask("install-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 
 	t2 := s.state.NewTask("error-trigger", "...")
 	t2.WaitFor(t)
@@ -600,17 +624,20 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterFailedLaunch(c *check.C) {
 
 func (s *sdkStateSuite) TestSDKVolumeExitCleanupAfterSuccessfulLaunch(c *check.C) {
 	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Source:   sdk.StoreSource,
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 	t := s.state.NewTask("install-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 
 	chg := s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
@@ -632,17 +659,20 @@ func (s *sdkStateSuite) TestSDKVolumeExitCleanupAfterSuccessfulLaunch(c *check.C
 
 func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Source:   sdk.StoreSource,
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 	t := s.state.NewTask("unregister-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
@@ -669,17 +699,20 @@ func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 
 func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Source:   sdk.StoreSource,
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 	t := s.state.NewTask("unregister-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
@@ -690,7 +723,7 @@ func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 	other.Set("user", "testuser")
 	t2 := s.state.NewTask("install-sdk", "t2")
 	t2.Set("sdk-retrieve-task", t2.ID())
-	t2.Set("sdk-setup", newSdk)
+	t2.Set("sdk-setup", newSdk.Setup)
 	setWorkshopProject("ws", s.project, t2)
 	other.AddTask(t2)
 	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
@@ -712,17 +745,20 @@ func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 
 func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePresent(c *check.C) {
 	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Source:   sdk.StoreSource,
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 	t := s.state.NewTask("unregister-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
-	t.Set("sdk-setup", newSdk)
+	t.Set("sdk-setup", newSdk.Setup)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
@@ -733,7 +769,7 @@ func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePrese
 	other.Set("user", "testuser")
 	t2 := s.state.NewTask("install-sdk", "t2")
 	t2.Set("sdk-retrieve-task", t2.ID())
-	t2.Set("sdk-setup", newSdk)
+	t2.Set("sdk-setup", newSdk.Setup)
 	t2.SetToWait(state.DoStatus)
 	t3 := s.state.NewTask("error-trigger", "t3")
 	t3.WaitFor(t2)
@@ -775,22 +811,25 @@ func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePrese
 
 func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Source:   sdk.StoreSource,
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, newSdk)
 
 	t1 := s.state.NewTask("unregister-sdk", "t1")
 	t1.Set("sdk-retrieve-task", t1.ID())
-	t1.Set("sdk-setup", newSdk)
+	t1.Set("sdk-setup", newSdk.Setup)
 
 	t2 := s.state.NewTask("unregister-sdk", "t2")
 	t2.Set("sdk-retrieve-task", t2.ID())
-	t2.Set("sdk-setup", newSdk)
+	t2.Set("sdk-setup", newSdk.Setup)
 	t2.WaitFor(t1)
 
 	// Add both tasks to their own changes
@@ -825,18 +864,21 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 
 func (s *sdkStateSuite) TestSDKVolumeExitCleanupOnNonvolume(c *check.C) {
 	s.state.Lock()
-	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	sdkProject := sdk.Setup{
-		Name:     "test",
-		Channel:  "latest/stable",
-		Source:   sdk.ProjectSource,
-		Revision: sdk.R(1),
-		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	sdkProject := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Source:   sdk.ProjectSource,
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
 	}
+	s.mockSdk(c, sdkProject)
 
 	t1 := s.state.NewTask("unregister-sdk", "t1")
 	t1.Set("sdk-retrieve-task", t1.ID())
-	t1.Set("sdk-setup", sdkProject)
+	t1.Set("sdk-setup", sdkProject.Setup)
 	chg1 := s.state.NewChange("launch", "chg1")
 	chg1.Set("user", "testuser")
 	setWorkshopProject("ws", s.project, t1)

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -192,11 +192,10 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
 	newSdk := sdk.Setup{
-		Name:        "test",
-		Channel:     "latest/stable",
-		Revision:    sdk.R(2),
-		Sha3_384:    "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
-		InstallTime: &s.installTime,
+		Name:     "test",
+		Channel:  "latest/stable",
+		Revision: sdk.R(2),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
 	}
 	s.mockSdk(c, "test", sdkYaml, sdk.R(2))
 
@@ -224,8 +223,8 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	info := props.Sdks
-	c.Check(info["test"], check.DeepEquals, newSdk)
+	c.Check(props.Sdks["test"].Setup, check.DeepEquals, newSdk)
+	c.Check(props.Sdks["test"].InstallTime, check.Equals, s.installTime)
 
 	sdkInfo, err := props.SdkInfo(s.ctx, "test")
 	c.Assert(err, check.IsNil)
@@ -238,11 +237,10 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	defer s.state.Unlock()
 
 	newSdk := sdk.Setup{
-		Name:        "test-2",
-		Channel:     "latest/stable",
-		Revision:    sdk.R(2),
-		Sha3_384:    "335783e65660ee5cfeb96b1323585f0c2ad006582c3c3dde89dd62a9f081c24b81e4972c8ce87787531c85e0683479a5",
-		InstallTime: &s.installTime,
+		Name:     "test-2",
+		Channel:  "latest/stable",
+		Revision: sdk.R(2),
+		Sha3_384: "335783e65660ee5cfeb96b1323585f0c2ad006582c3c3dde89dd62a9f081c24b81e4972c8ce87787531c85e0683479a5",
 	}
 	s.mockSdk(c, "test-2", sdkYaml, sdk.R(2))
 
@@ -343,11 +341,10 @@ func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
 	testSdk := sdk.Setup{
-		Name:        "test",
-		Channel:     "latest/stable",
-		Revision:    sdk.R(1),
-		Sha3_384:    "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
-		InstallTime: &s.installTime,
+		Name:     "test",
+		Channel:  "latest/stable",
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
 	}
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 
@@ -388,11 +385,10 @@ func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
 	s.mockSdk(c, "test-broken", sdkYamlViolatesPolicy, sdk.R(2))
 
 	testSdk := sdk.Setup{
-		Name:        "test-broken",
-		Channel:     "latest/stable",
-		Revision:    sdk.R(2),
-		Sha3_384:    "eee11792d075bd015406afe6450ac4f5080d78867da10cc5aa9380c383f31b71c8c71d831edd53c67eafc4b745a6bc80",
-		InstallTime: &s.installTime,
+		Name:     "test-broken",
+		Channel:  "latest/stable",
+		Revision: sdk.R(2),
+		Sha3_384: "eee11792d075bd015406afe6450ac4f5080d78867da10cc5aa9380c383f31b71c8c71d831edd53c67eafc4b745a6bc80",
 	}
 
 	t := s.state.NewTask("fake-task", "retrieve")

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -191,7 +191,13 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
-	newSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
+	newSdk := sdk.Setup{
+		Name:        "test",
+		Channel:     "latest/stable",
+		Revision:    sdk.R(2),
+		Sha3_384:    "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		InstallTime: &s.installTime,
+	}
 	s.mockSdk(c, "test", sdkYaml, sdk.R(2))
 
 	t := s.state.NewTask("fake-task", "retrieve")
@@ -231,7 +237,13 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Setup{Name: "test-2", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
+	newSdk := sdk.Setup{
+		Name:        "test-2",
+		Channel:     "latest/stable",
+		Revision:    sdk.R(2),
+		Sha3_384:    "335783e65660ee5cfeb96b1323585f0c2ad006582c3c3dde89dd62a9f081c24b81e4972c8ce87787531c85e0683479a5",
+		InstallTime: &s.installTime,
+	}
 	s.mockSdk(c, "test-2", sdkYaml, sdk.R(2))
 
 	t := s.state.NewTask("fake-task", "retrieve")
@@ -272,7 +284,12 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	newSdk := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
+	newSdk := sdk.Setup{
+		Name:     sdk.System.String(),
+		Source:   sdk.SystemSource,
+		Revision: system.SystemSdkRevision,
+		Sha3_384: system.SystemSdkDigest,
+	}
 	t := s.state.NewTask("retrieve-sdk", "retrieve")
 	t.Set("sdk-setup", newSdk)
 
@@ -325,7 +342,13 @@ func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {
 
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
-	testSdk := sdk.Setup{Name: "test", Channel: "latest/stable", Revision: sdk.Revision{N: 1}, InstallTime: &s.installTime}
+	testSdk := sdk.Setup{
+		Name:        "test",
+		Channel:     "latest/stable",
+		Revision:    sdk.R(1),
+		Sha3_384:    "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		InstallTime: &s.installTime,
+	}
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 
 	t := s.state.NewTask("fake-task", "retrieve")
@@ -364,7 +387,13 @@ func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 	s.mockSdk(c, "test-broken", sdkYamlViolatesPolicy, sdk.R(2))
 
-	testSdk := sdk.Setup{Name: "test-broken", Channel: "latest/stable", Revision: sdk.Revision{N: 2}, InstallTime: &s.installTime}
+	testSdk := sdk.Setup{
+		Name:        "test-broken",
+		Channel:     "latest/stable",
+		Revision:    sdk.R(2),
+		Sha3_384:    "eee11792d075bd015406afe6450ac4f5080d78867da10cc5aa9380c383f31b71c8c71d831edd53c67eafc4b745a6bc80",
+		InstallTime: &s.installTime,
+	}
 
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", testSdk)
@@ -414,7 +443,12 @@ func (s *sdkStateSuite) TestDoUnregisterSdk(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "...")
@@ -459,7 +493,12 @@ func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
 	defer s.state.Unlock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
 
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 	t := s.state.NewTask("fake-task", "retrieve")
 	t.Set("sdk-setup", newSdk)
 	t1 := s.state.NewTask("install-sdk", "...")
@@ -493,7 +532,13 @@ func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
 func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 	t := s.state.NewTask("unregister-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
 	t.Set("sdk-setup", newSdk)
@@ -522,7 +567,13 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 func (s *sdkStateSuite) TestSDKVolumeRemovedAfterFailedLaunch(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 	t := s.state.NewTask("install-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
 	t.Set("sdk-setup", newSdk)
@@ -554,7 +605,13 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterFailedLaunch(c *check.C) {
 func (s *sdkStateSuite) TestSDKVolumeExitCleanupAfterSuccessfulLaunch(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 	t := s.state.NewTask("install-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
 	t.Set("sdk-setup", newSdk)
@@ -580,7 +637,13 @@ func (s *sdkStateSuite) TestSDKVolumeExitCleanupAfterSuccessfulLaunch(c *check.C
 func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 	t := s.state.NewTask("unregister-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
 	t.Set("sdk-setup", newSdk)
@@ -611,7 +674,13 @@ func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 	t := s.state.NewTask("unregister-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
 	t.Set("sdk-setup", newSdk)
@@ -648,7 +717,13 @@ func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePresent(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 	t := s.state.NewTask("unregister-sdk", "...")
 	t.Set("sdk-retrieve-task", t.ID())
 	t.Set("sdk-setup", newSdk)
@@ -705,7 +780,13 @@ func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePrese
 func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	newSdk := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.StoreSource}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Source:   sdk.StoreSource,
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 
 	t1 := s.state.NewTask("unregister-sdk", "t1")
 	t1.Set("sdk-retrieve-task", t1.ID())
@@ -749,7 +830,13 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 func (s *sdkStateSuite) TestSDKVolumeExitCleanupOnNonvolume(c *check.C) {
 	s.state.Lock()
 	s.mockSdk(c, "test", sdkYaml, sdk.R(1))
-	sdkProject := sdk.Setup{Name: "test", Revision: sdk.Revision{N: 1}, Source: sdk.ProjectSource}
+	sdkProject := sdk.Setup{
+		Name:     "test",
+		Channel:  "latest/stable",
+		Source:   sdk.ProjectSource,
+		Revision: sdk.R(1),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}
 
 	t1 := s.state.NewTask("unregister-sdk", "t1")
 	t1.Set("sdk-retrieve-task", t1.ID())

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -129,8 +129,9 @@ func (w *SdkManager) Sdk(ctx context.Context, name string) (*SdkFullInfo, error)
 				}
 
 				channel := ""
-				if setup, ok := winfo.Sdks[name]; ok {
-					channel = setup.Channel
+				sk, ok := winfo.Sdks[name]
+				if ok {
+					channel = sk.Channel
 				}
 
 				full.Installed = append(full.Installed, SdkInstalled{

--- a/internal/overlord/sdkstate/request_test.go
+++ b/internal/overlord/sdkstate/request_test.go
@@ -38,7 +38,13 @@ func (i *SdkStateTasks) TestRetrieve(c *check.C) {
 	i.state.Lock()
 	defer i.state.Unlock()
 
-	rec := sdk.Setup{Name: "sdk", Channel: "latest/stable"}
+	rec := sdk.Setup{
+		Name:     "sdk",
+		Channel:  "latest/stable",
+		Source:   sdk.TrySource,
+		Revision: sdk.R(42),
+		Sha3_384: "e1cfa86c92b87afc44a68c2f8f7c3b62b8dc926aa99234ab8ac2e94e242736c05c80a431041a686f3f2bcb5c648676ea",
+	}
 
 	task := sdkstate.Retrieve(i.state, rec)
 
@@ -46,5 +52,9 @@ func (i *SdkStateTasks) TestRetrieve(c *check.C) {
 	c.Assert(task.Get("sdk-setup", &s), check.IsNil)
 	c.Check(s, check.DeepEquals, rec)
 	c.Check(task.Kind(), check.Equals, "retrieve-sdk")
-	c.Check(task.Summary(), check.Equals, "Retrieve \"sdk\" SDK from channel \"latest/stable\"")
+	c.Check(task.Summary(), check.Equals, `Retrieve "sdk" SDK`)
+
+	rec.Source = sdk.StoreSource
+	task = sdkstate.Retrieve(i.state, rec)
+	c.Check(task.Summary(), check.Equals, `Retrieve "sdk" SDK from channel "latest/stable"`)
 }

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -38,7 +38,7 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 	err = task.Get("workshop-base", &image)
 	st.Unlock()
 	if err != nil {
-		return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
+		return fmt.Errorf("internal error: %q workshop base image not found (task ID: %s)", w, task.ID())
 	}
 
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
@@ -72,7 +72,7 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 	err = task.Get("workshop-file", &fileText)
 	st.Unlock()
 	if err != nil {
-		return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
+		return fmt.Errorf("internal error: %q workshop definition not found (task ID: %s)", w, task.ID())
 	}
 
 	var wf workshop.File
@@ -85,7 +85,7 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 	err = task.Get("sdk-snapshot", &sdkSnapshot)
 	st.Unlock()
 	if err != nil && !errors.Is(err, state.ErrNoState) {
-		return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
+		return fmt.Errorf("internal error: %q workshop snapshot not found (task ID: %s)", w, task.ID())
 	}
 
 	rev := revert.New()
@@ -111,7 +111,7 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 		err = task.Get("workshop-base", &image)
 		st.Unlock()
 		if err != nil {
-			return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
+			return fmt.Errorf("internal error: %q workshop base image not found (task ID: %s)", w, task.ID())
 		}
 
 		if err := m.backend.LaunchOrRebuildWorkshop(ctx, &wf, image); err != nil {

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -1,7 +1,6 @@
 package workshopstate
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -34,12 +33,11 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 	}
 
 	st := task.State()
-	var base, fingerprint string
+	var image workshop.BaseImage
 	st.Lock()
-	err1 := task.Get("workshop-base", &base)
-	err2 := task.Get("workshop-base-fingerprint", &fingerprint)
+	err = task.Get("workshop-base", &image)
 	st.Unlock()
-	if cmp.Or(err1, err2) != nil {
+	if err != nil {
 		return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
 	}
 
@@ -55,7 +53,7 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 		},
 	}
 
-	return m.backend.DownloadBase(ctx, base, fingerprint, reporter)
+	return m.backend.DownloadBase(ctx, image, reporter)
 }
 
 func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb) error {
@@ -108,15 +106,15 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 	}
 
 	if sdkSnapshot == "" {
-		var fingerprint string
+		var image workshop.BaseImage
 		st.Lock()
-		err = task.Get("workshop-base-fingerprint", &fingerprint)
+		err = task.Get("workshop-base", &image)
 		st.Unlock()
 		if err != nil {
 			return fmt.Errorf("internal error: %q workshop configuration not found (task ID: %s)", w, task.ID())
 		}
 
-		if err := m.backend.LaunchOrRebuildWorkshop(ctx, &wf, fingerprint); err != nil {
+		if err := m.backend.LaunchOrRebuildWorkshop(ctx, &wf, image); err != nil {
 			return err
 		}
 		// Create workshop base and run directories

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -125,7 +125,8 @@ func (s *workshopHandlers) TestStopPeriodicProgressUpdate(c *check.C) {
 	defer s.state.Unlock()
 	s.createWFile(c, "ws", wsFocal)
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123")
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
 	c.Check(err, check.IsNil)
 
 	t1, err := s.wrkmgr.StopMany(s.ctx, []string{"ws"}, s.project.ProjectId)
@@ -166,8 +167,9 @@ func (s *workshopHandlers) TestUndoStash(c *check.C) {
 		{Name: "test", Channel: "latest/stable"},
 		{Name: "test2", Channel: "latest/stable"},
 	}}
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
 
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123")
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
 	c.Check(err, check.IsNil)
 
 	chg := s.state.NewChange("sample", "...")
@@ -223,7 +225,8 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
 
 	for _, wf := range wFiles {
-		err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, "fakeimage123")
+		image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+		err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
 		c.Check(err, check.IsNil)
 
 		// create content directories
@@ -300,7 +303,7 @@ func (s *workshopHandlers) TestCreateWorkshopNoWorkshopConfigurationFound(c *che
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("create-workshop", "...")
 	setWorkshopProject("ws", s.project, t1)
-	t1.Set("workshop-base-fingerprint", "fakeimage123")
+	t1.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
@@ -323,7 +326,7 @@ func (s *workshopHandlers) TestCreateWorkshopWithSystemSdk(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("create-workshop", "...")
 	t1.Set("workshop-file", wsJammy)
-	t1.Set("workshop-base-fingerprint", "fakeimage123")
+	t1.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
@@ -351,7 +354,7 @@ func (s *workshopHandlers) TestCreateWorkshopCleanup(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("create-workshop", "...")
 	t1.Set("workshop-file", wsJammy)
-	t1.Set("workshop-base-fingerprint", "fakeimage123")
+	t1.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
@@ -382,7 +385,8 @@ func (s *workshopHandlers) TestRebuildWorkshopNoCleanup(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("rebuild-workshop", "...")
 	t1.Set("workshop-file", wsJammy)
-	t1.Set("workshop-base-fingerprint", "fakeimage999")
+	image := workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage999"}
+	t1.Set("workshop-base", image)
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
@@ -398,16 +402,16 @@ func (s *workshopHandlers) TestRebuildWorkshopNoCleanup(c *check.C) {
 	c.Check(chg.Err(), check.ErrorMatches, `(?s).*\(fs is unavailable\)`)
 	ws, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	c.Check(ws.BaseFingerprint, check.Equals, "fakeimage999")
+	c.Check(ws.Image, check.Equals, image)
 }
 
 func (s *workshopHandlers) TestDownloadBase(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	s.backend.DownloadBaseCallback = func(ctx context.Context, base, fingerprint string, report *progress.Reporter) error {
-		c.Check(base, check.Equals, "ubuntu@22.04")
-		c.Check(fingerprint, check.Equals, "fakeimage1234")
+	s.backend.DownloadBaseCallback = func(ctx context.Context, image workshop.BaseImage, report *progress.Reporter) error {
+		c.Check(image.Name, check.Equals, "ubuntu@22.04")
+		c.Check(image.Fingerprint, check.Equals, "fakeimage1234")
 		report.Report("download finished", 100, 100)
 		return nil
 	}
@@ -416,12 +420,10 @@ func (s *workshopHandlers) TestDownloadBase(c *check.C) {
 	}()
 
 	s.createWFile(c, "ws", wsJammy)
-	wf := &workshop.File{Name: "ws", Base: "ubuntu@22.04"}
 
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("download-base", "...")
-	t1.Set("workshop-base", wf.Base)
-	t1.Set("workshop-base-fingerprint", "fakeimage1234")
+	t1.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage1234"})
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -296,7 +296,7 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	c.Check(projectCache, testutil.FileAbsent)
 }
 
-func (s *workshopHandlers) TestCreateWorkshopNoWorkshopConfigurationFound(c *check.C) {
+func (s *workshopHandlers) TestCreateWorkshopNoWorkshopDefinitionFound(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -315,7 +315,7 @@ func (s *workshopHandlers) TestCreateWorkshopNoWorkshopConfigurationFound(c *che
 	s.state.Lock()
 
 	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*internal error: "ws" workshop configuration not found.*`)
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*internal error: "ws" workshop definition not found.*`)
 }
 
 func (s *workshopHandlers) TestCreateWorkshopWithSystemSdk(c *check.C) {

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -93,7 +93,8 @@ func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@22.04"}
-	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, "fakeimage123")
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, image)
 	c.Assert(err, check.IsNil)
 
 	workshop, err := s.backend.Workshop(s.ctx, ws)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -106,11 +106,11 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		if err != nil {
 			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
-		setups, err := validateSdkResults(projectId, req.file, localSdks)
+		localSetups, err := validateSdkMeta(projectId, req.file, localSdks)
 		if err != nil {
 			return nil, fmt.Errorf("cannot launch %q: %w", name, err)
 		}
-		sdks := ordered(req.installOrder, req.storeSdks, setups)
+		sdks := ordered(req.installOrder, req.storeSdks, localSetups)
 
 		tasks := launch(w.state, req.file, req.fileText, req.image, sdks, project)
 		taskset = append(taskset, tasks)
@@ -171,7 +171,7 @@ func (w *WorkshopManager) findRemoteArtifacts(ctx context.Context, project works
 		if err != nil {
 			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
 		}
-		setups, err := validateSdkResults(project.ProjectId, file, sdks)
+		setups, err := validateSdkMeta(project.ProjectId, file, sdks)
 		if err != nil {
 			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
 		}
@@ -188,8 +188,8 @@ func (w *WorkshopManager) findRemoteArtifacts(ctx context.Context, project works
 	return reqs, nil
 }
 
-func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.SdkResult, error) {
-	result, err := system.SystemSdkResult()
+func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *workshop.File) ([]sdk.Meta, error) {
+	systemMeta, err := system.SystemSdkMeta()
 	if err != nil {
 		return nil, err
 	}
@@ -203,13 +203,13 @@ func findStoreSdks(sto sdk.Store, ctx context.Context, projectid string, file *w
 		acts = append(acts, act)
 	}
 
-	results, err := sto.SdkAction(ctx, acts)
+	sdks, err := sto.SdkAction(ctx, acts)
 	if err != nil {
 		return nil, err
 	}
 
-	results = slices.Insert(results, 0, *result)
-	return results, nil
+	sdks = slices.Insert(sdks, 0, *systemMeta)
+	return sdks, nil
 }
 
 type localSdkFinder struct {
@@ -220,31 +220,31 @@ type localSdkFinder struct {
 	sdkVolumes  []workshop.VolumeInfo
 }
 
-func (s *localSdkFinder) findLocalSdks(ctx context.Context, wp *workshop.Workshop, file *workshop.File) ([]sdk.SdkResult, error) {
-	localSdks := []sdk.SdkResult{}
+func (s *localSdkFinder) findLocalSdks(ctx context.Context, wp *workshop.Workshop, file *workshop.File) ([]sdk.Meta, error) {
+	localSdks := []sdk.Meta{}
 
 	for _, sd := range file.Sdks {
-		result, err := s.maybeFindLocalSdk(ctx, wp, file, sd)
+		meta, err := s.maybeFindLocalSdk(ctx, wp, file, sd)
 		if err != nil {
 			return nil, err
 		}
-		if result != nil {
-			localSdks = append(localSdks, *result)
+		if meta != nil {
+			localSdks = append(localSdks, *meta)
 		}
 	}
 
-	result, err := s.maybeFindSketchSdk(wp, file.Name)
+	meta, err := s.maybeFindSketchSdk(wp, file.Name)
 	if err != nil {
 		return nil, err
 	}
-	if result != nil {
-		localSdks = append(localSdks, *result)
+	if meta != nil {
+		localSdks = append(localSdks, *meta)
 	}
 
 	return localSdks, nil
 }
 
-func (s *localSdkFinder) maybeFindLocalSdk(ctx context.Context, wp *workshop.Workshop, file *workshop.File, sd workshop.SdkRecord) (*sdk.SdkResult, error) {
+func (s *localSdkFinder) maybeFindLocalSdk(ctx context.Context, wp *workshop.Workshop, file *workshop.File, sd workshop.SdkRecord) (*sdk.Meta, error) {
 	switch sd.Source {
 	case sdk.TrySource:
 		return s.findTrySdk(ctx, file.Base, sd.Name)
@@ -255,7 +255,7 @@ func (s *localSdkFinder) maybeFindLocalSdk(ctx context.Context, wp *workshop.Wor
 	}
 }
 
-func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.SdkResult, error) {
+func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.Meta, error) {
 	trydir := workshop.TrySdkDir(s.userDataDir, sk)
 	root, err := os.OpenRoot(trydir)
 	if err != nil {
@@ -295,7 +295,7 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.
 				Revision: volume.Revision,
 				Sha3_384: volume.Sha3_384,
 			}
-			return &sdk.SdkResult{Setup: setup, SdkYAML: volume.Metadata}, nil
+			return &sdk.Meta{Setup: setup, SdkYAML: volume.Metadata}, nil
 		}
 	}
 
@@ -317,7 +317,7 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.
 		Revision: volume.Revision,
 		Sha3_384: volume.Sha3_384,
 	}
-	return &sdk.SdkResult{Setup: setup, SdkYAML: volume.Metadata}, nil
+	return &sdk.Meta{Setup: setup, SdkYAML: volume.Metadata}, nil
 }
 
 func (s *localSdkFinder) volumes(ctx context.Context) ([]workshop.VolumeInfo, error) {
@@ -388,12 +388,12 @@ func prependRootPath(root *os.Root, err error) error {
 	return err
 }
 
-func (s *localSdkFinder) findInProjectSdk(wp *workshop.Workshop, w, sk string) (*sdk.SdkResult, error) {
+func (s *localSdkFinder) findInProjectSdk(wp *workshop.Workshop, w, sk string) (*sdk.Meta, error) {
 	sdkdir := workshop.ProjectSdkPath(s.project.Path, sk)
 	return s.commitRevision(wp, w, sk, sdk.ProjectSource, sdkdir)
 }
 
-func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (*sdk.SdkResult, error) {
+func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (*sdk.Meta, error) {
 	sketchdir := workshop.SketchSdkCurrent(s.userDataDir, s.project.ProjectId, w)
 
 	recs, err := os.ReadDir(sketchdir)
@@ -418,7 +418,7 @@ func (s *localSdkFinder) maybeFindSketchSdk(wp *workshop.Workshop, w string) (*s
 	return s.commitRevision(wp, w, sdk.Sketch, sdk.SketchSource, sketchdir)
 }
 
-func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk string, source sdk.Source, path string) (*sdk.SdkResult, error) {
+func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk string, source sdk.Source, path string) (*sdk.Meta, error) {
 	var installed sdk.Revision
 	if wp != nil {
 		installed = wp.Sdks[sk].Revision
@@ -441,10 +441,10 @@ func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk string, sou
 		Revision: revision,
 		Sha3_384: digest,
 	}
-	return &sdk.SdkResult{Setup: setup, SdkYAML: string(sdkYaml)}, nil
+	return &sdk.Meta{Setup: setup, SdkYAML: string(sdkYaml)}, nil
 }
 
-func validateSdkResults(projectId string, file *workshop.File, sdks []sdk.SdkResult) ([]sdk.Setup, error) {
+func validateSdkMeta(projectId string, file *workshop.File, sdks []sdk.Meta) ([]sdk.Setup, error) {
 	setups := make([]sdk.Setup, 0, len(sdks))
 	for _, s := range sdks {
 		if s.Sha3_384 == "" {
@@ -695,11 +695,11 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 			if err != nil {
 				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 			}
-			setups, err := validateSdkResults(projectId, req.file, localSdks)
+			localSetups, err := validateSdkMeta(projectId, req.file, localSdks)
 			if err != nil {
 				return nil, fmt.Errorf("cannot refresh %q: %w", name, err)
 			}
-			sdks := ordered(req.installOrder, req.storeSdks, setups)
+			sdks := ordered(req.installOrder, req.storeSdks, localSetups)
 
 			plan := resolveRefresh(wp, req.file, req.image, sdks)
 			if plan.HasUpdates() {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -724,7 +723,12 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 				return nil, fmt.Errorf("cannot refresh %q: invalid workshop file: %w", name, err)
 			}
 
-			sdks := wp.SdksByInstallOrder()
+			installed := wp.SdksByInstallOrder()
+			sdks := make([]sdk.Setup, 0, len(installed))
+			for _, sk := range installed {
+				sdks = append(sdks, sk.Setup)
+			}
+
 			plan := resolveRefresh(wp, wp.File, wp.Image, sdks)
 			tasks := refresh(w.state, plan, wp, wp.File, string(fileBlob))
 			taskset = append(taskset, tasks)
@@ -829,7 +833,7 @@ func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, image workshop
 			}
 			// Has this SDK had any updates?
 			// If so, break the loop as the rest require to be reinstalled.
-			if maybeRefresh(w.Sdks[s.Name], s) {
+			if maybeRefresh(w.Sdks[s.Name].Setup, s) {
 				break
 			}
 
@@ -840,20 +844,21 @@ func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, image workshop
 	}
 
 	for _, s := range candidates[len(plan.intact):] {
-		if installed, exist := w.Sdks[s.Name]; exist {
+		installed, exist := w.Sdks[s.Name]
+		if exist {
 			plan.refresh = append(plan.refresh, s)
-			plan.remove = append(plan.remove, installed)
+			plan.remove = append(plan.remove, installed.Setup)
 		} else {
 			plan.install = append(plan.install, s)
 		}
 	}
 
 	// SDKs that only exist in the previous workshop are to be removed.
-	for _, rec := range w.Sdks {
-		if !slices.ContainsFunc(candidates, func(r sdk.Setup) bool {
-			return r.Name == rec.Name
+	for _, s := range w.Sdks {
+		if !slices.ContainsFunc(candidates, func(c sdk.Setup) bool {
+			return c.Name == s.Name
 		}) {
-			plan.remove = append(plan.remove, rec)
+			plan.remove = append(plan.remove, s.Setup)
 		}
 	}
 
@@ -1250,13 +1255,18 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 		removeSet.AddAll(ts)
 	}
 
-	disconnectSet := disconnectSdks(st, slices.Collect(maps.Values(w.Sdks)))
+	sdks := make([]sdk.Setup, 0, len(w.Sdks))
+	for _, sk := range w.Sdks {
+		sdks = append(sdks, sk.Setup)
+	}
+
+	disconnectSet := disconnectSdks(st, sdks)
 	addTaskSet(disconnectSet)
 
 	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", w.Name))
 	addTaskSet(state.NewTaskSet(discard))
 
-	unregister, _ := unregisterSdks(st, slices.Collect(maps.Values(w.Sdks)))
+	unregister, _ := unregisterSdks(st, sdks)
 	addTaskSet(unregister)
 
 	remove := st.NewTask("remove-workshop", fmt.Sprintf("Remove %q workshop", w.Name))

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -290,8 +290,13 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.
 		}
 
 		if volume.Sha3_384 == digest {
-			setup := sdk.Setup{Name: volume.Sdk, Source: sdk.TrySource, Revision: volume.Revision}
-			return &sdk.SdkResult{Setup: setup, Sha3_384: volume.Sha3_384, SdkYAML: volume.Metadata}, nil
+			setup := sdk.Setup{
+				Name:     volume.Sdk,
+				Source:   sdk.TrySource,
+				Revision: volume.Revision,
+				Sha3_384: volume.Sha3_384,
+			}
+			return &sdk.SdkResult{Setup: setup, SdkYAML: volume.Metadata}, nil
 		}
 	}
 
@@ -307,8 +312,13 @@ func (s *localSdkFinder) findTrySdk(ctx context.Context, base, sk string) (*sdk.
 	if err := s.importVolume(ctx, volume, file); err != nil {
 		return nil, err
 	}
-	setup := sdk.Setup{Name: volume.Sdk, Source: sdk.TrySource, Revision: volume.Revision}
-	return &sdk.SdkResult{Setup: setup, Sha3_384: volume.Sha3_384, SdkYAML: volume.Metadata}, nil
+	setup := sdk.Setup{
+		Name:     volume.Sdk,
+		Source:   sdk.TrySource,
+		Revision: volume.Revision,
+		Sha3_384: volume.Sha3_384,
+	}
+	return &sdk.SdkResult{Setup: setup, SdkYAML: volume.Metadata}, nil
 }
 
 func (s *localSdkFinder) volumes(ctx context.Context) ([]workshop.VolumeInfo, error) {
@@ -426,8 +436,13 @@ func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk string, sou
 		return nil, fmt.Errorf("invalid %q SDK: %w", sk, err)
 	}
 
-	setup := sdk.Setup{Name: sk, Source: source, Revision: revision}
-	return &sdk.SdkResult{Setup: setup, Sha3_384: digest, SdkYAML: string(sdkYaml)}, nil
+	setup := sdk.Setup{
+		Name:     sk,
+		Source:   source,
+		Revision: revision,
+		Sha3_384: digest,
+	}
+	return &sdk.SdkResult{Setup: setup, SdkYAML: string(sdkYaml)}, nil
 }
 
 func validateSdkResults(projectId string, file *workshop.File, sdks []sdk.SdkResult) ([]sdk.Setup, error) {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -113,7 +113,7 @@ func (w *WorkshopManager) LaunchMany(ctx context.Context, names []string, projec
 		}
 		sdks := ordered(req.installOrder, req.storeSdks, setups)
 
-		tasks := launch(w.state, req.file, req.fileText, req.baseFingerprint, sdks, project)
+		tasks := launch(w.state, req.file, req.fileText, req.image, sdks, project)
 		taskset = append(taskset, tasks)
 	}
 	return taskset, nil
@@ -124,8 +124,8 @@ type workshopReq struct {
 	file *workshop.File
 	// Marshalled file (to prevent data loss when passing through the state).
 	fileText string
-	// Up to date base image identifier.
-	baseFingerprint string
+	// Up to date base image.
+	image workshop.BaseImage
 	// All possible SDKs (including sketch) in installation order.
 	installOrder []string
 	// Up to date SDK setups from the store.
@@ -154,7 +154,7 @@ func (w *WorkshopManager) findRemoteArtifacts(ctx context.Context, project works
 			return nil, fmt.Errorf("cannot %s %q: invalid workshop file: %w", action, name, err)
 		}
 
-		fingerprint, err := w.backend.GetBase(ctx, file.Base)
+		image, err := w.backend.GetBase(ctx, file.Base)
 		if err != nil {
 			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
 		}
@@ -177,11 +177,11 @@ func (w *WorkshopManager) findRemoteArtifacts(ctx context.Context, project works
 			return nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
 		}
 		req := workshopReq{
-			file:            file,
-			fileText:        string(fileBlob),
-			baseFingerprint: fingerprint,
-			installOrder:    installOrder,
-			storeSdks:       setups,
+			file:         file,
+			fileText:     string(fileBlob),
+			image:        image,
+			installOrder: installOrder,
+			storeSdks:    setups,
 		}
 		reqs = append(reqs, req)
 	}
@@ -461,11 +461,10 @@ func ordered(order []string, setups ...[]sdk.Setup) []sdk.Setup {
 	return ordered
 }
 
-func retrieveBase(st *state.State, file *workshop.File, fingerprint string) *state.Task {
-	base := st.NewTask("download-base", fmt.Sprintf("Download %q base image", file.Base))
-	base.Set("workshop-base", file.Base)
-	base.Set("workshop-base-fingerprint", fingerprint)
-	return base
+func retrieveBase(st *state.State, image workshop.BaseImage) *state.Task {
+	download := st.NewTask("download-base", fmt.Sprintf("Download %q base image", image.Name))
+	download.Set("workshop-base", image)
+	return download
 }
 
 func retrieveSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string]string) {
@@ -522,7 +521,7 @@ func installSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]str
 	return all
 }
 
-func launchWorkshop(st *state.State, name string, fileText string, fingerprint string) *state.TaskSet {
+func launchWorkshop(st *state.State, name string, fileText string, image workshop.BaseImage) *state.TaskSet {
 	construct := state.NewTaskSet()
 
 	var prev *state.Task
@@ -537,7 +536,7 @@ func launchWorkshop(st *state.State, name string, fileText string, fingerprint s
 	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", name))
 	addTask(create)
 	create.Set("workshop-file", fileText)
-	create.Set("workshop-base-fingerprint", fingerprint)
+	create.Set("workshop-base", image)
 
 	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", name))
 	addTask(start)
@@ -545,7 +544,7 @@ func launchWorkshop(st *state.State, name string, fileText string, fingerprint s
 	return construct
 }
 
-func rebuildWorkshop(st *state.State, name string, fileText string, sdkSnapshot string, fingerprint string) *state.TaskSet {
+func rebuildWorkshop(st *state.State, name string, fileText string, sdkSnapshot string, image workshop.BaseImage) *state.TaskSet {
 	construct := state.NewTaskSet()
 
 	var prev *state.Task
@@ -570,9 +569,8 @@ func rebuildWorkshop(st *state.State, name string, fileText string, sdkSnapshot 
 
 	if sdkSnapshot != "" {
 		create.Set("sdk-snapshot", sdkSnapshot)
-	}
-	if fingerprint != "" {
-		create.Set("workshop-base-fingerprint", fingerprint)
+	} else {
+		create.Set("workshop-base", image)
 	}
 
 	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", name))
@@ -581,7 +579,7 @@ func rebuildWorkshop(st *state.State, name string, fileText string, sdkSnapshot 
 	return construct
 }
 
-func launch(st *state.State, file *workshop.File, fileText string, fingerprint string, sdks []sdk.Setup, project workshop.Project) *state.TaskSet {
+func launch(st *state.State, file *workshop.File, fileText string, image workshop.BaseImage, sdks []sdk.Setup, project workshop.Project) *state.TaskSet {
 	var prevInstall *state.TaskSet
 	all := state.NewTaskSet()
 
@@ -598,7 +596,7 @@ func launch(st *state.State, file *workshop.File, fileText string, fingerprint s
 		all.AddAll(ts)
 	}
 
-	base := retrieveBase(st, file, fingerprint)
+	base := retrieveBase(st, image)
 	retrieve, rmap := retrieveSdks(st, sdks)
 	retrieve.AddTask(base)
 	addTaskSet(retrieve)
@@ -606,7 +604,7 @@ func launch(st *state.State, file *workshop.File, fileText string, fingerprint s
 	createDirs := st.NewTask("create-workshop-storage", fmt.Sprintf("Create %q storage directories", file.Name))
 	addTaskSet(state.NewTaskSet(createDirs))
 
-	create := launchWorkshop(st, file.Name, fileText, fingerprint)
+	create := launchWorkshop(st, file.Name, fileText, image)
 	addTaskSet(create)
 
 	install := installSdks(st, sdks, rmap)
@@ -689,7 +687,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 			}
 			sdks := ordered(req.installOrder, req.storeSdks, setups)
 
-			plan := resolveRefresh(wp, req.file, req.baseFingerprint, sdks)
+			plan := resolveRefresh(wp, req.file, req.image, sdks)
 			if plan.HasUpdates() {
 				tasks := refresh(w.state, plan, wp, req.file, req.fileText)
 				taskset = append(taskset, tasks)
@@ -712,7 +710,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, projectId string, nam
 			}
 
 			sdks := wp.SdksByInstallOrder()
-			plan := resolveRefresh(wp, wp.File, wp.BaseFingerprint, sdks)
+			plan := resolveRefresh(wp, wp.File, wp.Image, sdks)
 			tasks := refresh(w.state, plan, wp, wp.File, string(fileBlob))
 			taskset = append(taskset, tasks)
 		}
@@ -751,7 +749,7 @@ func maybeRefresh(installed, candidate sdk.Setup) bool {
 }
 
 type refreshPlan struct {
-	baseFingerprint string
+	image workshop.BaseImage
 
 	install []sdk.Setup
 	intact  []sdk.Setup
@@ -794,21 +792,21 @@ func (p refreshPlan) HasUpdates() bool {
 	return len(p.InstallOrRefresh()) > 0 || len(p.remove) > 0 || p.workshopDefinitionUpdated
 }
 
-func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, fingerprint string, candidates []sdk.Setup) *refreshPlan {
+func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, image workshop.BaseImage, candidates []sdk.Setup) *refreshPlan {
 	plan := &refreshPlan{
-		baseFingerprint: fingerprint,
-		install:         make([]sdk.Setup, 0),
-		intact:          make([]sdk.Setup, 0),
-		refresh:         make([]sdk.Setup, 0),
-		remove:          make([]sdk.Setup, 0),
-		installOrder:    make([]string, 0),
-		installedOrder:  make([]string, 0),
+		image:          image,
+		install:        make([]sdk.Setup, 0),
+		intact:         make([]sdk.Setup, 0),
+		refresh:        make([]sdk.Setup, 0),
+		remove:         make([]sdk.Setup, 0),
+		installOrder:   make([]string, 0),
+		installedOrder: make([]string, 0),
 	}
 
 	// Restore the order of SDKs installed in the running workshop.
 	installed := w.SdksByInstallOrder()
 
-	if w.File.Base == newfile.Base && w.BaseFingerprint == fingerprint {
+	if w.Image == image {
 		for ci, s := range candidates {
 			// Do we have this SDK in the same order as in the running workshop?
 			if ci >= len(installed) || installed[ci].Name != s.Name {
@@ -878,7 +876,7 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 	var base *state.Task
 	if plan.sdkSnapshot == "" {
 		// Create download-base first so the task IDs are in a nice order.
-		base = retrieveBase(st, file, plan.baseFingerprint)
+		base = retrieveBase(st, plan.image)
 	}
 	retrieve, rmap := retrieveSdks(st, plan.InstallOrRefresh())
 	if base != nil {
@@ -907,7 +905,7 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 	stash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
 	addTaskSet(state.NewTaskSet(stash))
 
-	rebuild := rebuildWorkshop(st, file.Name, fileText, plan.sdkSnapshot, plan.baseFingerprint)
+	rebuild := rebuildWorkshop(st, file.Name, fileText, plan.sdkSnapshot, plan.image)
 	addTaskSet(rebuild)
 
 	// Re-register intact SDKs (the workshop definition can change plugs and slots).

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -433,7 +433,7 @@ func (s *localSdkFinder) commitRevision(wp *workshop.Workshop, w, sk string, sou
 func validateSdkResults(projectId string, file *workshop.File, sdks []sdk.SdkResult) ([]sdk.Setup, error) {
 	setups := make([]sdk.Setup, 0, len(sdks))
 	for _, s := range sdks {
-		if s.MD5 == "" && s.Sha3_384 == "" {
+		if s.Sha3_384 == "" {
 			return nil, fmt.Errorf("internal error: hash not found for %q SDK", s.Name)
 		}
 		if err := workshop.ValidateSdkInfo(projectId, file, s.Name, s.SdkYAML); err != nil {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -82,7 +82,8 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@20.04", Sdks: sdks}
-	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, "fakeimage123")
+	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, image)
 	c.Assert(err, check.IsNil)
 
 	w, err := s.backend.Workshop(s.ctx, ws)

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -3,6 +3,8 @@ package workshopstate_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha3"
+	"encoding/hex"
 	"fmt"
 	"html/template"
 	"os"
@@ -94,8 +96,17 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	defer wfs.Close()
 
 	for _, sd := range sdks {
-		s.writeSDKMetaFile(c, wfs, sd.Name, fmt.Sprintf(sdkTemplate, sd.Name))
-		c.Assert(w.AddSdk(s.ctx, sdk.Setup{Name: sd.Name, Source: sdk.StoreSource, Channel: sd.Channel}), check.IsNil)
+		sdkYaml := fmt.Sprintf(sdkTemplate, sd.Name)
+		s.writeSDKMetaFile(c, wfs, sd.Name, sdkYaml)
+		digest := sha3.Sum384([]byte(sdkYaml))
+		setup := sdk.Setup{
+			Name:     sd.Name,
+			Channel:  sd.Channel,
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(1),
+			Sha3_384: hex.EncodeToString(digest[:]),
+		}
+		c.Assert(w.AddSdk(s.ctx, setup), check.IsNil)
 	}
 }
 

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -16,12 +16,11 @@ import (
 )
 
 type Setup struct {
-	Name        string     `json:"name"`
-	Channel     string     `json:"channel,omitempty"`
-	Source      Source     `json:"source,omitempty"`
-	Revision    Revision   `json:"revision"`
-	Sha3_384    string     `json:"sha3-384"`
-	InstallTime *time.Time `json:"install-time"`
+	Name     string   `json:"name"`
+	Channel  string   `json:"channel,omitempty"`
+	Source   Source   `json:"source,omitempty"`
+	Revision Revision `json:"revision"`
+	Sha3_384 string   `json:"sha3-384"`
 }
 
 func (s *Setup) Filepath() string {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -15,6 +15,11 @@ import (
 	"github.com/canonical/workshop/internal/metautil"
 )
 
+type Meta struct {
+	Setup
+	SdkYAML string
+}
+
 type Setup struct {
 	Name     string   `json:"name"`
 	Channel  string   `json:"channel,omitempty"`

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -20,6 +20,7 @@ type Setup struct {
 	Channel     string     `json:"channel,omitempty"`
 	Source      Source     `json:"source,omitempty"`
 	Revision    Revision   `json:"revision"`
+	Sha3_384    string     `json:"sha3-384"`
 	InstallTime *time.Time `json:"install-time"`
 }
 

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -2,11 +2,9 @@ package sdk
 
 import (
 	"context"
-	"crypto/md5"
 	"crypto/sha3"
 	"encoding/hex"
 	"fmt"
-	"hash"
 	"sync"
 
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -27,7 +25,6 @@ func (s StoreAction) String() string {
 type SdkResult struct {
 	Setup
 	Sha3_384 string
-	MD5      string
 	SdkYAML  string
 }
 
@@ -139,20 +136,9 @@ func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progre
 		return nil, err
 	}
 
-	var hash hash.Hash
-	if IsSystem(setup.Name) {
-		hash = sha3.New384()
-	} else {
-		hash = md5.New()
-	}
-	fmt.Fprintf(hash, "%s:%s:%s:%s", setup.Name, source, setup.Channel, setup.Revision)
-	digest := hex.EncodeToString(hash.Sum(nil))
+	sum := sha3.Sum384(fmt.Appendf(nil, "%s:%s:%s:%s", setup.Name, source, setup.Channel, setup.Revision))
+	digest := hex.EncodeToString(sum[:])
 
-	result := &SdkResult{Setup: setup, SdkYAML: "name: " + setup.Name}
-	if IsSystem(setup.Name) {
-		result.Sha3_384 = digest
-	} else {
-		result.MD5 = digest
-	}
+	result := &SdkResult{Setup: setup, Sha3_384: digest, SdkYAML: "name: " + setup.Name}
 	return result, nil
 }

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -19,11 +19,6 @@ func (s StoreAction) String() string {
 	return [...]string{"install", "refresh"}[s]
 }
 
-type SdkResult struct {
-	Setup
-	SdkYAML string
-}
-
 type SdkAction struct {
 	ProjectId string
 	Workshop  string
@@ -61,8 +56,8 @@ func StoreService(st *state.State) Store {
 }
 
 type Store interface {
-	SdkAction(ctx context.Context, actions []SdkAction) ([]SdkResult, error)
-	DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*SdkResult, error)
+	SdkAction(ctx context.Context, actions []SdkAction) ([]Meta, error)
+	DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error)
 }
 
 func NewFakeStore() Store {
@@ -85,11 +80,11 @@ type FakeStore struct {
 	downloadLock  sync.Mutex
 	DownloadCalls []TestDownloadCall
 
-	ActionCallback   func(ctx context.Context, actions []SdkAction) ([]SdkResult, error)
+	ActionCallback   func(ctx context.Context, actions []SdkAction) ([]Meta, error)
 	DownloadCallback func(ctx context.Context, setup Setup, report *progress.Reporter) error
 }
 
-func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, actions []SdkAction) ([]SdkResult, error)) func() {
+func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, actions []SdkAction) ([]Meta, error)) func() {
 	old := f.ActionCallback
 	f.ActionCallback = fa
 	return func() {
@@ -105,7 +100,7 @@ func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup
 	}
 }
 
-func (f *FakeStore) SdkAction(ctx context.Context, actions []SdkAction) ([]SdkResult, error) {
+func (f *FakeStore) SdkAction(ctx context.Context, actions []SdkAction) ([]Meta, error) {
 	f.ActionCalls = append(f.ActionCalls, TestActionCall{
 		Actions: actions,
 	})
@@ -115,7 +110,7 @@ func (f *FakeStore) SdkAction(ctx context.Context, actions []SdkAction) ([]SdkRe
 	return nil, nil
 }
 
-func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*SdkResult, error) {
+func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error) {
 	f.downloadLock.Lock()
 	defer f.downloadLock.Unlock()
 	f.DownloadCalls = append(f.DownloadCalls, TestDownloadCall{
@@ -127,5 +122,5 @@ func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progre
 		}
 	}
 
-	return &SdkResult{Setup: setup, SdkYAML: "name: " + setup.Name}, nil
+	return &Meta{Setup: setup, SdkYAML: "name: " + setup.Name}, nil
 }

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -2,9 +2,6 @@ package sdk
 
 import (
 	"context"
-	"crypto/sha3"
-	"encoding/hex"
-	"fmt"
 	"sync"
 
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -24,8 +21,7 @@ func (s StoreAction) String() string {
 
 type SdkResult struct {
 	Setup
-	Sha3_384 string
-	SdkYAML  string
+	SdkYAML string
 }
 
 type SdkAction struct {
@@ -131,14 +127,5 @@ func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progre
 		}
 	}
 
-	source, err := setup.Source.MarshalText()
-	if err != nil {
-		return nil, err
-	}
-
-	sum := sha3.Sum384(fmt.Appendf(nil, "%s:%s:%s:%s", setup.Name, source, setup.Channel, setup.Revision))
-	digest := hex.EncodeToString(sum[:])
-
-	result := &SdkResult{Setup: setup, Sha3_384: digest, SdkYAML: "name: " + setup.Name}
-	return result, nil
+	return &SdkResult{Setup: setup, SdkYAML: "name: " + setup.Name}, nil
 }

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -29,12 +29,17 @@ var (
 const SystemSdkDigest = "5891a3a98ed62339c5c24ded56de52a18873bd73ba8e1e03725376e7fc89c7560944b5fb7260c288b17e115e538d7da6"
 
 func SystemSdkResult() (*sdk.SdkResult, error) {
-	setup := sdk.Setup{Name: "system", Source: sdk.SystemSource, Revision: SystemSdkRevision}
+	setup := sdk.Setup{
+		Name:     "system",
+		Source:   sdk.SystemSource,
+		Revision: SystemSdkRevision,
+		Sha3_384: SystemSdkDigest,
+	}
 	sdkYaml, err := SystemSdkFs.ReadFile("meta/sdk.yaml")
 	if err != nil {
 		return nil, err
 	}
-	return &sdk.SdkResult{Setup: setup, Sha3_384: SystemSdkDigest, SdkYAML: string(sdkYaml)}, nil
+	return &sdk.SdkResult{Setup: setup, SdkYAML: string(sdkYaml)}, nil
 }
 
 func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error) {

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -28,7 +28,7 @@ var (
 // Update the system SDK revision number when this hash changes.
 const SystemSdkDigest = "5891a3a98ed62339c5c24ded56de52a18873bd73ba8e1e03725376e7fc89c7560944b5fb7260c288b17e115e538d7da6"
 
-func SystemSdkResult() (*sdk.SdkResult, error) {
+func SystemSdkMeta() (*sdk.Meta, error) {
 	setup := sdk.Setup{
 		Name:     "system",
 		Source:   sdk.SystemSource,
@@ -39,10 +39,10 @@ func SystemSdkResult() (*sdk.SdkResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &sdk.SdkResult{Setup: setup, SdkYAML: string(sdkYaml)}, nil
+	return &sdk.Meta{Setup: setup, SdkYAML: string(sdkYaml)}, nil
 }
 
-func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error) {
+func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error) {
 	fl, err := sdk.OpenLock(setup.Name)
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResu
 	target := setup.Filepath()
 	if osutil.FileExists(target) {
 		logger.Debugf("System SDK on Retrieve: SDK found locally: %s", target)
-		return SystemSdkResult()
+		return SystemSdkMeta()
 	}
 
 	if setup.Revision != SystemSdkRevision {
@@ -97,7 +97,7 @@ func retrieveSystemSdk(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResu
 	}
 
 	r.Success()
-	return SystemSdkResult()
+	return SystemSdkMeta()
 }
 
 // Like w.AddFs(fsys) but ensures the user always has write permissions.
@@ -155,7 +155,7 @@ func addWritableFS(w *tar.Writer, fsys fs.FS) error {
 	})
 }
 
-func FakeRetrieveSystemSdk(f func(setup sdk.Setup, report *progress.Reporter) (*sdk.SdkResult, error)) func() {
+func FakeRetrieveSystemSdk(f func(setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error)) func() {
 	oldRetrieveSystemSdk := RetrieveSystemSdk
 	RetrieveSystemSdk = f
 	return func() { RetrieveSystemSdk = oldRetrieveSystemSdk }

--- a/internal/sdk/system/system_test.go
+++ b/internal/sdk/system/system_test.go
@@ -44,11 +44,15 @@ func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 		done = d
 		total = t
 	}}
-	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision}
+	setup := sdk.Setup{
+		Name:     sdk.System.String(),
+		Source:   sdk.SystemSource,
+		Revision: system.SystemSdkRevision,
+		Sha3_384: system.SystemSdkDigest,
+	}
 	result, err := system.RetrieveSystemSdk(setup, report)
 	c.Assert(err, check.IsNil)
 	c.Check(result.Setup, check.Equals, setup)
-	c.Check(result.Sha3_384, check.Equals, system.SystemSdkDigest)
 	c.Check(result.SdkYAML, check.Not(check.Equals), "")
 	c.Check(done, testutil.IntGreaterThan, 0)
 	c.Check(total, testutil.IntGreaterThan, 0)
@@ -68,7 +72,12 @@ func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 }
 
 func (s *systemSdk) TestRetrieveSystemSdkWrongRevision(c *check.C) {
-	setup := sdk.Setup{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: sdk.R(system.SystemSdkRevision.N - 1)}
+	setup := sdk.Setup{
+		Name:     sdk.System.String(),
+		Source:   sdk.SystemSource,
+		Revision: sdk.R(system.SystemSdkRevision.N - 1),
+		Sha3_384: "6b499970ebf370d4dbc4e9a005c042dee003c19a9420a78944bcbf32653d257f80f7c56bad55b4c967dca68a1ea92be7",
+	}
 	_, err := system.RetrieveSystemSdk(setup, nil)
 	c.Check(err, check.ErrorMatches, fmt.Sprintf(`system SDK \(%s\) not available`, setup.Revision))
 

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -91,8 +91,6 @@ type VolumeSetup struct {
 	Kind string
 	// Hash of tarball used to create volume.
 	Sha3_384 string
-	// MD5 hash of tarball used to create volume (TODO: remove during Store migration).
-	MD5 string
 	// Name of SDK associated with volume, if any.
 	Sdk string
 	// Revision of SDK associated with volume, if any.

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -136,13 +136,18 @@ type VolumeManager interface {
 	Volume(ctx context.Context, name string) (VolumeInfo, error)
 }
 
+type BaseImage struct {
+	// Base name (e.g. ubuntu@24.04).
+	Name string `json:"name"`
+	// Base image identifier, typically a hash.
+	Fingerprint string `json:"fingerprint"`
+}
+
 type BaseImageManager interface {
-	// Lookup the latest image for the given base. On success, returns a
-	// string that uniquely identifies the latest image. This can be
-	// passed to DownloadBase and LaunchOrRebuildWorkshop.
-	GetBase(ctx context.Context, base string) (string, error)
-	// Download the base image with the given fingerprint.
-	DownloadBase(ctx context.Context, base, fingerprint string, report *progress.Reporter) error
+	// Lookup the latest image for the given base.
+	GetBase(ctx context.Context, base string) (BaseImage, error)
+	// Download the given base image.
+	DownloadBase(ctx context.Context, image BaseImage, report *progress.Reporter) error
 }
 
 type ExecArgs struct {
@@ -207,7 +212,7 @@ type Backend interface {
 	// configuration and devices of the rebuilt workshop will be reset to the
 	// default one. The given base fingerprint is combined with `file.Base` to
 	// determine the exact base image to use.
-	LaunchOrRebuildWorkshop(ctx context.Context, file *File, baseFingerprint string) error
+	LaunchOrRebuildWorkshop(ctx context.Context, file *File, image BaseImage) error
 
 	// Delete workshop. Stop the workshop forcefully if not in Stopped before deleting
 	RemoveWorkshop(ctx context.Context, name string) error

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -203,7 +203,7 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 	ws.Config[workshop.ConfigWorkshopSdks] = `{}`
 	ws.Devices = make(map[string]map[string]string)
 
-	ws.Sdks = make(map[string]sdk.Setup)
+	ws.Sdks = make(map[string]workshop.SdkInstallation)
 	ws.Profiles = make(map[string]workshop.SdkProfile, 0)
 
 	return nil
@@ -371,11 +371,11 @@ func (f *FakeWorkshopBackend) Workshop(ctx context.Context, name string) (*works
 		return nil, workshop.ErrWorkshopNotLaunched
 	}
 
-	var c map[string]sdk.Setup
-	if err := json.Unmarshal([]byte(f.Workshops[projectId][name].Config[workshop.ConfigWorkshopSdks]), &c); err != nil {
+	var sdks map[string]workshop.SdkInstallation
+	if err := json.Unmarshal([]byte(f.Workshops[projectId][name].Config[workshop.ConfigWorkshopSdks]), &sdks); err != nil {
 		return nil, err
 	}
-	wp.Sdks = c
+	wp.Sdks = sdks
 	return wp.Workshop, nil
 }
 
@@ -731,7 +731,7 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, sk string, file
 	}
 
 	sdks := wp.SdksByInstallOrder()
-	lastIntact := slices.IndexFunc(sdks, func(s sdk.Setup) bool { return s.Name == sk })
+	lastIntact := slices.IndexFunc(sdks, func(s workshop.SdkInstallation) bool { return s.Name == sk })
 	if lastIntact < 0 {
 		return fmt.Errorf("invalid snapshot %q", sk)
 	}
@@ -749,15 +749,15 @@ func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, sk string, file
 	}
 
 	// Remove SDKs from after the snapshot.
-	for _, setup := range unwantedSdks {
-		delete(wp.Sdks, setup.Name)
+	for _, u := range unwantedSdks {
+		delete(wp.Sdks, u.Name)
 		// Restore would detach the volume attached after the snapshot.
-		if setup.IsVolume() {
-			if err = s.DetachVolume(ctx, name, sdk.VolumeName(setup.Name, setup.Revision)); err != nil {
+		if u.IsVolume() {
+			if err = s.DetachVolume(ctx, name, sdk.VolumeName(u.Name, u.Revision)); err != nil {
 				return err
 			}
 		} else {
-			if err = fs.RemoveAll(sdk.SdkDir(setup.Name)); err != nil {
+			if err = fs.RemoveAll(sdk.SdkDir(u.Name)); err != nil {
 				return err
 			}
 		}

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -40,8 +40,7 @@ type FsCall struct {
 }
 
 type DownloadCall struct {
-	Base        string
-	Fingerprint string
+	Image workshop.BaseImage
 }
 
 type AttachVolumeCall struct {
@@ -90,8 +89,8 @@ type FakeWorkshopBackend struct {
 	WorkshopFsCalls    []*FsCall
 
 	baseLock             sync.Mutex
-	GetBaseCallback      func(ctx context.Context, base string) (string, error)
-	DownloadBaseCallback func(ctx context.Context, base, fingerprint string, report *progress.Reporter) error
+	GetBaseCallback      func(ctx context.Context, base string) (workshop.BaseImage, error)
+	DownloadBaseCallback func(ctx context.Context, image workshop.BaseImage, report *progress.Reporter) error
 	DownloadBaseCalls    []*DownloadCall
 
 	AttachVolumeCalls []AttachVolumeCall
@@ -161,7 +160,7 @@ func (f *FakeWorkshopBackend) project(user, id string) *workshop.Project {
 	return nil
 }
 
-func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, baseFingerprint string) error {
+func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, image workshop.BaseImage) error {
 	user, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -182,14 +181,14 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 		// rebuild the workshop
 		ws = wpe
 		ws.File = file
-		ws.BaseFingerprint = baseFingerprint
+		ws.Image = image
 	} else {
 		ws.Workshop = &workshop.Workshop{Backend: f,
-			Name:            file.Name,
-			Running:         false,
-			Project:         *prj,
-			BaseFingerprint: baseFingerprint,
-			File:            file,
+			Name:    file.Name,
+			Running: false,
+			Project: *prj,
+			Image:   image,
+			File:    file,
 		}
 		f.Workshops[projectId][file.Name] = ws
 	}
@@ -693,23 +692,23 @@ func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, 
 	return userName, projectId, nil
 }
 
-func (b *FakeWorkshopBackend) GetBase(ctx context.Context, base string) (string, error) {
+func (b *FakeWorkshopBackend) GetBase(ctx context.Context, base string) (workshop.BaseImage, error) {
 	b.baseLock.Lock()
 	defer b.baseLock.Unlock()
 
 	if b.GetBaseCallback != nil {
 		return b.GetBaseCallback(ctx, base)
 	}
-	return "fakeimage123", nil
+	return workshop.BaseImage{Name: base, Fingerprint: "fakeimage123"}, nil
 }
 
-func (b *FakeWorkshopBackend) DownloadBase(ctx context.Context, base, fingerprint string, report *progress.Reporter) error {
+func (b *FakeWorkshopBackend) DownloadBase(ctx context.Context, image workshop.BaseImage, report *progress.Reporter) error {
 	b.baseLock.Lock()
 	defer b.baseLock.Unlock()
 
-	b.DownloadBaseCalls = append(b.DownloadBaseCalls, &DownloadCall{Base: base, Fingerprint: fingerprint})
+	b.DownloadBaseCalls = append(b.DownloadBaseCalls, &DownloadCall{Image: image})
 	if b.DownloadBaseCallback != nil {
-		return b.DownloadBaseCallback(ctx, base, fingerprint, report)
+		return b.DownloadBaseCallback(ctx, image, report)
 	}
 	return nil
 }

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -26,7 +26,6 @@ import (
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
-	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/syscheck"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -839,7 +838,7 @@ func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p wo
 		Fingerprint: inst.Config[workshop.ConfigWorkshopBaseFingerprint],
 	}
 
-	sdks := map[string]sdk.Setup{}
+	sdks := map[string]workshop.SdkInstallation{}
 	buf, exist := inst.Config[workshop.ConfigWorkshopSdks]
 	if exist {
 		if err := json.Unmarshal([]byte(buf), &sdks); err != nil {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -274,7 +274,7 @@ func New() (*Backend, error) {
 	return &server, nil
 }
 
-func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, baseFingerprint string) error {
+func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, image workshop.BaseImage) error {
 	var err error
 
 	conn, layerConn, err := s.layerClients(ctx)
@@ -298,14 +298,14 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		return err
 	}
 
-	config, err := s.workshopConfig(projectId, usr.Uid, usr.Gid, file, baseFingerprint)
+	config, err := s.workshopConfig(projectId, usr.Uid, usr.Gid, file, image.Fingerprint)
 	if err != nil {
 		return err
 	}
 	devices := defaultDevices(projectId, file.Name)
 	source := api.InstanceSource{
 		Type:        api.SourceTypeImage,
-		Fingerprint: baseFingerprint,
+		Fingerprint: image.Fingerprint,
 	}
 
 	inst, _, err := conn.GetInstanceFull(InstanceName(file.Name, projectId))
@@ -834,6 +834,11 @@ func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p wo
 		return nil, fmt.Errorf("cannot load workshop: %v", err)
 	}
 
+	image := workshop.BaseImage{
+		Name:        f.Base,
+		Fingerprint: inst.Config[workshop.ConfigWorkshopBaseFingerprint],
+	}
+
 	sdks := map[string]sdk.Setup{}
 	buf, exist := inst.Config[workshop.ConfigWorkshopSdks]
 	if exist {
@@ -856,14 +861,14 @@ func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p wo
 	}
 
 	return &workshop.Workshop{
-		Backend:         b,
-		Project:         p,
-		Name:            f.Name,
-		BaseFingerprint: inst.Config[workshop.ConfigWorkshopBaseFingerprint],
-		Running:         inst.StatusCode == api.Running || inst.StatusCode == api.Ready,
-		Sdks:            sdks,
-		Profiles:        profs,
-		File:            f,
+		Backend:  b,
+		Project:  p,
+		Name:     f.Name,
+		Image:    image,
+		Running:  inst.StatusCode == api.Running || inst.StatusCode == api.Ready,
+		Sdks:     sdks,
+		Profiles: profs,
+		File:     f,
 	}, nil
 }
 

--- a/internal/workshop/lxd/lxd_backend_layers.go
+++ b/internal/workshop/lxd/lxd_backend_layers.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/revert"
-	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -262,7 +261,7 @@ func (s *Backend) layerNamesAfter(layerConn lxd.InstanceServer, pid, w, sk strin
 	}
 
 	// Find the installed SDKs at the time of the snapshot.
-	sdks := map[string]sdk.Setup{}
+	sdks := map[string]workshop.SdkInstallation{}
 	buf, exist := layers[idx].Config[workshop.ConfigWorkshopSdks]
 	if exist {
 		if err := json.Unmarshal([]byte(buf), &sdks); err != nil {

--- a/internal/workshop/lxd/lxd_backend_volume.go
+++ b/internal/workshop/lxd/lxd_backend_volume.go
@@ -337,9 +337,6 @@ func volumeSetupToConfig(info workshop.VolumeSetup) map[string]string {
 	if info.Sha3_384 != "" {
 		config["user.sha3-384"] = info.Sha3_384
 	}
-	if info.MD5 != "" {
-		config["user.md5"] = info.MD5
-	}
 	if info.Sdk != "" {
 		config["user.sdk.name"] = info.Sdk
 	}
@@ -387,7 +384,6 @@ func volumeToInfo(volume *api.StorageVolume, lxdProject string, size uint64) wor
 			Name:     volume.Name,
 			Kind:     volume.Config["user.kind"],
 			Sha3_384: volume.Config["user.sha3-384"],
-			MD5:      volume.Config["user.md5"],
 			Sdk:      volume.Config["user.sdk.name"],
 			Revision: revision,
 			Metadata: volume.Config["user.sdk.meta"],

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/progress"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 var (
@@ -26,31 +27,31 @@ var (
 	imageServer          = "simplestreams:https://cloud-images.ubuntu.com/releases"
 )
 
-func (b *Backend) GetBase(ctx context.Context, base string) (string, error) {
+func (b *Backend) GetBase(ctx context.Context, base string) (workshop.BaseImage, error) {
 	source, err := baseImageSource(base)
 	if err != nil {
-		return "", err
+		return workshop.BaseImage{}, err
 	}
 
 	imageServer, err := connectImageServer(*source)
 	if err != nil {
-		return "", err
+		return workshop.BaseImage{}, err
 	}
 	defer imageServer.Disconnect()
 
 	alias, _, err := imageServer.GetImageAliasType(source.ImageType, source.Alias)
 	if err != nil {
-		return "", fmt.Errorf("base %q not found: %w", base, err)
+		return workshop.BaseImage{}, fmt.Errorf("base %q not found: %w", base, err)
 	}
 
-	return alias.Target, nil
+	return workshop.BaseImage{Name: base, Fingerprint: alias.Target}, nil
 }
 
-func (b *Backend) DownloadBase(ctx context.Context, base, fingerprint string, report *progress.Reporter) error {
+func (b *Backend) DownloadBase(ctx context.Context, image workshop.BaseImage, report *progress.Reporter) error {
 	defer func() {
 		if report != nil {
 			imageLock.Lock()
-			if op, exist := currentDownloads[fingerprint]; exist {
+			if op, exist := currentDownloads[image.Fingerprint]; exist {
 				op.RemoveReporter(report.Name)
 			}
 			imageLock.Unlock()
@@ -58,7 +59,7 @@ func (b *Backend) DownloadBase(ctx context.Context, base, fingerprint string, re
 	}()
 
 	imageLock.Lock()
-	op, exist := currentDownloads[fingerprint]
+	op, exist := currentDownloads[image.Fingerprint]
 	if exist {
 		if report != nil {
 			op.AddReporter(report)
@@ -71,25 +72,25 @@ func (b *Backend) DownloadBase(ctx context.Context, base, fingerprint string, re
 	if report != nil {
 		op.AddReporter(report)
 	}
-	currentDownloads[fingerprint] = op
+	currentDownloads[image.Fingerprint] = op
 	imageLock.Unlock()
 
-	go b.tryDownloadBase(ctx, op, base, fingerprint)
+	go b.tryDownloadBase(ctx, op, image)
 
 	return waitDownloadOp(ctx, op)
 }
 
-func (b *Backend) tryDownloadBase(ctx context.Context, op *downloadOp, base, fingerprint string) {
-	op.err = b.downloadBase(ctx, op, base, fingerprint)
+func (b *Backend) tryDownloadBase(ctx context.Context, op *downloadOp, image workshop.BaseImage) {
+	op.err = b.downloadBase(ctx, op, image)
 	close(op.waitCh)
 
 	imageLock.Lock()
-	delete(currentDownloads, fingerprint)
+	delete(currentDownloads, image.Fingerprint)
 	imageLock.Unlock()
 }
 
-func (b *Backend) downloadBase(ctx context.Context, op *downloadOp, base, fingerprint string) error {
-	source, err := baseImageSource(base)
+func (b *Backend) downloadBase(ctx context.Context, op *downloadOp, image workshop.BaseImage) error {
+	source, err := baseImageSource(image.Name)
 	if err != nil {
 		return err
 	}
@@ -102,18 +103,18 @@ func (b *Backend) downloadBase(ctx context.Context, op *downloadOp, base, finger
 
 	// TODO: Remove this query once LXD starts reporting more detailed
 	// progress information.
-	image, _, err := imageServer.GetImage(fingerprint)
+	imageInfo, _, err := imageServer.GetImage(image.Fingerprint)
 	if err != nil {
-		return fmt.Errorf("%q download failed: %w", base, err)
+		return fmt.Errorf("%q download failed: %w", image.Name, err)
 	}
 
 	req := api.ImagesPost{
 		ImagePut: api.ImagePut{
-			Properties: map[string]string{"workshop-base": base},
+			Properties: map[string]string{"workshop-base": image.Name},
 		},
 		Source: &api.ImagesPostSource{
 			ImageSource: *source,
-			Fingerprint: fingerprint,
+			Fingerprint: image.Fingerprint,
 			Type:        api.SourceTypeImage,
 		},
 	}
@@ -124,8 +125,8 @@ func (b *Backend) downloadBase(ctx context.Context, op *downloadOp, base, finger
 	}
 	req.Source.Certificate = info.Certificate
 
-	if !image.Public && source.Protocol != "simplestreams" {
-		secret, err := imageServer.GetImageSecret(fingerprint)
+	if !imageInfo.Public && source.Protocol != "simplestreams" {
+		secret, err := imageServer.GetImageSecret(image.Fingerprint)
 		if err != nil {
 			return err
 		}
@@ -154,20 +155,20 @@ func (b *Backend) downloadBase(ctx context.Context, op *downloadOp, base, finger
 
 	copyop, err := conn.CreateImage(req, nil)
 	if err != nil {
-		return fmt.Errorf("%q download failed: %w", base, err)
+		return fmt.Errorf("%q download failed: %w", image.Name, err)
 	}
 
 	copyop.AddHandler(func(o api.Operation) {
-		if o.Metadata == nil || image.Size <= 0 {
+		if o.Metadata == nil || imageInfo.Size <= 0 {
 			return
 		}
-		if upd := handleImageUpdate(o.Metadata, int(image.Size)); upd != nil {
+		if upd := handleImageUpdate(o.Metadata, int(imageInfo.Size)); upd != nil {
 			op.Update(*upd)
 		}
 	})
 
 	if err := copyop.Wait(); err != nil {
-		return fmt.Errorf("%q download failed: %w", base, err)
+		return fmt.Errorf("%q download failed: %w", image.Name, err)
 	}
 
 	return nil

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -85,9 +85,9 @@ func CreateTestContext(username, projectId string) context.Context {
 }
 
 func LaunchTestWorkshop(c *check.C, ctx context.Context, bd workshop.Backend, dir string) {
-	fingerprint, err := bd.GetBase(ctx, "ubuntu@24.04")
+	image, err := bd.GetBase(ctx, "ubuntu@24.04")
 	c.Assert(err, check.IsNil)
-	err = bd.DownloadBase(ctx, "ubuntu@24.04", fingerprint, nil)
+	err = bd.DownloadBase(ctx, image, nil)
 	c.Assert(err, check.IsNil)
 
 	wf := &workshop.File{
@@ -114,7 +114,7 @@ printf '%s\n' "$@"
 	_, _, err = bd.CreateOrLoadProject(ctx, dir)
 	c.Assert(err, check.IsNil)
 
-	err = bd.LaunchOrRebuildWorkshop(ctx, wf, fingerprint)
+	err = bd.LaunchOrRebuildWorkshop(ctx, wf, image)
 	c.Assert(err, check.IsNil)
 
 	err = bd.StartWorkshop(ctx, "test")

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -301,7 +301,6 @@ func (f *wsOps) TestLxdBackendStorageVolumeAddRemove(c *check.C) {
 		Name:     "test",
 		Kind:     "testkind",
 		Sha3_384: "abc123",
-		MD5:      "ab12",
 	}
 	err := f.bd.CreateVolume(f.ctx, volume)
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -136,11 +136,11 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 		Name: "test",
 		Base: "ubuntu@22.04",
 	}
-	fingerprint, err := f.bd.GetBase(f.ctx, wf.Base)
+	image, err := f.bd.GetBase(f.ctx, wf.Base)
 	c.Assert(err, check.IsNil)
-	err = f.bd.DownloadBase(f.ctx, wf.Base, fingerprint, nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
-	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, fingerprint)
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, image)
 	c.Assert(err, check.IsNil)
 
 	// Check snapshots are gone.
@@ -505,14 +505,15 @@ func (f *wsOps) TestLxdBackendDownloadBase(c *check.C) {
 	// ensure there is no image in LXD storage
 	f.deleteImages(c, "ubuntu@22.04")
 
-	fingerprint, err := f.bd.GetBase(f.ctx, "ubuntu@22.04")
+	image, err := f.bd.GetBase(f.ctx, "ubuntu@22.04")
 	c.Assert(err, check.IsNil)
-	c.Assert(fingerprint, check.Not(check.Equals), "")
+	c.Check(image.Name, check.Equals, "ubuntu@22.04")
+	c.Assert(image.Fingerprint, check.Not(check.Equals), "")
 
 	var wg sync.WaitGroup
 	for range 5 {
 		wg.Go(func() {
-			err := f.bd.DownloadBase(f.ctx, "ubuntu@22.04", fingerprint, nil)
+			err := f.bd.DownloadBase(f.ctx, image, nil)
 			c.Check(err, check.IsNil)
 		})
 	}
@@ -522,10 +523,10 @@ func (f *wsOps) TestLxdBackendDownloadBase(c *check.C) {
 	c.Assert(images, check.HasLen, 1)
 	c.Check(images[0].AutoUpdate, check.Equals, false)
 	c.Check(images[0].Cached, check.Equals, false)
-	c.Check(images[0].Fingerprint, check.Equals, fingerprint)
+	c.Check(images[0].Fingerprint, check.Equals, image.Fingerprint)
 
 	// Check behaviour when image already downloaded.
-	err = f.bd.DownloadBase(f.ctx, "ubuntu@22.04", fingerprint, nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Check(err, check.IsNil)
 
 	images2 := f.listWorkshopImages(c, "ubuntu@22.04")
@@ -534,19 +535,22 @@ func (f *wsOps) TestLxdBackendDownloadBase(c *check.C) {
 }
 
 func (f *wsOps) TestLxdBackendGetOrDownloadMalformedBase(c *check.C) {
-	_, err := f.bd.GetBase(f.ctx, "ubuntu:24.04")
+	image := workshop.BaseImage{Name: "ubuntu:24.04", Fingerprint: ""}
+	_, err := f.bd.GetBase(f.ctx, image.Name)
 	c.Check(err, check.ErrorMatches, `invalid base "ubuntu:24.04" \(expected <NAME>@<VERSION>\)`)
-	err = f.bd.DownloadBase(f.ctx, "ubuntu:24.04", "", nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Check(err, check.ErrorMatches, `invalid base "ubuntu:24.04" \(expected <NAME>@<VERSION>\)`)
 
-	_, err = f.bd.GetBase(f.ctx, "ubuntu@")
+	image.Name = "ubuntu@"
+	_, err = f.bd.GetBase(f.ctx, image.Name)
 	c.Check(err, check.ErrorMatches, `invalid base "ubuntu@" \(expected <NAME>@<VERSION>\)`)
-	err = f.bd.DownloadBase(f.ctx, "ubuntu@", "", nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Check(err, check.ErrorMatches, `invalid base "ubuntu@" \(expected <NAME>@<VERSION>\)`)
 
-	_, err = f.bd.GetBase(f.ctx, "canonical@ubuntu@24.04")
+	image.Name = "canonical@ubuntu@24.04"
+	_, err = f.bd.GetBase(f.ctx, image.Name)
 	c.Check(err, check.ErrorMatches, `invalid base "canonical@ubuntu@24.04" \(expected <NAME>@<VERSION>\)`)
-	err = f.bd.DownloadBase(f.ctx, "canonical@ubuntu@24.04", "", nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Check(err, check.ErrorMatches, `invalid base "canonical@ubuntu@24.04" \(expected <NAME>@<VERSION>\)`)
 }
 
@@ -554,24 +558,28 @@ func (f *wsOps) TestLxdBackendDownloadBaseImageNotFound(c *check.C) {
 	_, err := f.bd.GetBase(f.ctx, "ubuntu@1.01")
 	c.Check(err, check.ErrorMatches, `base "ubuntu@1.01" not found.*`)
 
-	err = f.bd.DownloadBase(f.ctx, "ubuntu@22.04", "##################", nil)
+	image := workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "##################"}
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Check(err, check.ErrorMatches, `"ubuntu@22.04" download failed.*`)
 }
 
 func (f *wsOps) TestLxdBackendDownloadProtocolNotSupported(c *check.C) {
 	defer lxdbackend.FakeImageServer("https://cloud-images.ubuntu.com/minimal/releases")()
 
-	_, err := f.bd.GetBase(f.ctx, "ubuntu@20.04")
+	image := workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: ""}
+	_, err := f.bd.GetBase(f.ctx, image.Name)
 	c.Check(err, check.ErrorMatches, `unknown image server URL prefix \(supported: simplestreams, lxd\)`)
-	err = f.bd.DownloadBase(f.ctx, "ubuntu@20.04", "", nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Check(err, check.ErrorMatches, `unknown image server URL prefix \(supported: simplestreams, lxd\)`)
 }
 
 func (f *wsOps) TestLxdBackendDownloadConcurrentErrors(c *check.C) {
+	image := workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "##################"}
+
 	var wg sync.WaitGroup
 	for range 5 {
 		wg.Go(func() {
-			err := f.bd.DownloadBase(f.ctx, "ubuntu@22.04", "##################", nil)
+			err := f.bd.DownloadBase(f.ctx, image, nil)
 			c.Check(err, check.ErrorMatches, `"ubuntu@22.04" download failed.*`)
 		})
 	}
@@ -582,9 +590,10 @@ func (f *wsOps) TestLxdBackendDownloadBaseResumeAfterCancellation(c *check.C) {
 	// ensure there is no image in LXD storage
 	f.deleteImages(c, "ubuntu@22.04")
 
-	fingerprint, err := f.bd.GetBase(f.ctx, "ubuntu@22.04")
+	image, err := f.bd.GetBase(f.ctx, "ubuntu@22.04")
 	c.Assert(err, check.IsNil)
-	c.Assert(fingerprint, check.Not(check.Equals), "")
+	c.Check(image.Name, check.Equals, "ubuntu@22.04")
+	c.Assert(image.Fingerprint, check.Not(check.Equals), "")
 
 	wcancel, cancel := context.WithCancel(f.ctx)
 	defer cancel()
@@ -599,7 +608,7 @@ func (f *wsOps) TestLxdBackendDownloadBaseResumeAfterCancellation(c *check.C) {
 					once.Do(func() { cancel() })
 				},
 			}
-			err := f.bd.DownloadBase(wcancel, "ubuntu@22.04", fingerprint, r)
+			err := f.bd.DownloadBase(wcancel, image, r)
 			c.Check(err, testutil.ErrorIs, context.Canceled)
 		})
 	}
@@ -607,14 +616,14 @@ func (f *wsOps) TestLxdBackendDownloadBaseResumeAfterCancellation(c *check.C) {
 
 	// attempt to download after interruption (must pickup an ongoing operation
 	// and wait for it).
-	err = f.bd.DownloadBase(f.ctx, "ubuntu@22.04", fingerprint, nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
 
 	images := f.listWorkshopImages(c, "ubuntu@22.04")
 	c.Assert(images, check.HasLen, 1)
 	c.Check(images[0].AutoUpdate, check.Equals, false)
 	c.Check(images[0].Cached, check.Equals, false)
-	c.Check(images[0].Fingerprint, check.Equals, fingerprint)
+	c.Check(images[0].Fingerprint, check.Equals, image.Fingerprint)
 }
 
 func (f *wsOps) TestLxdBackendDownloadMultipleBasesConcurrently(c *check.C) {
@@ -628,12 +637,13 @@ func (f *wsOps) TestLxdBackendDownloadMultipleBasesConcurrently(c *check.C) {
 	var wg sync.WaitGroup
 	for i, b := range workshop.SupportedBases {
 		wg.Go(func() {
-			fingerprint, err := f.bd.GetBase(f.ctx, b)
+			image, err := f.bd.GetBase(f.ctx, b)
 			c.Assert(err, check.IsNil)
-			c.Assert(fingerprint, check.Not(check.Equals), "")
-			fingerprints[i] = fingerprint
+			c.Check(image.Name, check.Equals, b)
+			c.Assert(image.Fingerprint, check.Not(check.Equals), "")
+			fingerprints[i] = image.Fingerprint
 
-			err = f.bd.DownloadBase(f.ctx, b, fingerprint, nil)
+			err = f.bd.DownloadBase(f.ctx, image, nil)
 			c.Assert(err, check.IsNil)
 		})
 	}
@@ -667,10 +677,11 @@ func (f *wsOps) TestLxdBackendReuseDownloadedBase(c *check.C) {
 		images := f.listAllImages(c, "ubuntu@22.04")
 		c.Assert(images, check.HasLen, 0)
 
-		fingerprint, err := f.bd.GetBase(f.ctx, "ubuntu@22.04")
+		image, err := f.bd.GetBase(f.ctx, "ubuntu@22.04")
 		c.Assert(err, check.IsNil)
-		c.Assert(fingerprint, check.Not(check.Equals), "")
-		err = f.bd.DownloadBase(f.ctx, "ubuntu@22.04", fingerprint, nil)
+		c.Check(image.Name, check.Equals, "ubuntu@22.04")
+		c.Assert(image.Fingerprint, check.Not(check.Equals), "")
+		err = f.bd.DownloadBase(f.ctx, image, nil)
 		c.Assert(err, check.IsNil)
 
 		images = f.listAllImages(c, "ubuntu@22.04")
@@ -679,7 +690,7 @@ func (f *wsOps) TestLxdBackendReuseDownloadedBase(c *check.C) {
 
 		c.Check(imageDownloaded.AutoUpdate, check.Equals, false)
 		c.Check(imageDownloaded.Cached, check.Equals, false)
-		c.Check(imageDownloaded.Fingerprint, check.Equals, fingerprint)
+		c.Check(imageDownloaded.Fingerprint, check.Equals, image.Fingerprint)
 		c.Check(imageDownloaded.Properties["workshop-base"], check.Equals, "ubuntu@22.04")
 		c.Check(imageDownloaded.UpdateSource, check.IsNil)
 
@@ -690,7 +701,7 @@ func (f *wsOps) TestLxdBackendReuseDownloadedBase(c *check.C) {
 		c.Assert(cleanup.Run(), check.IsNil)
 
 		images = f.listAllImages(c, "ubuntu@22.04")
-		if len(images) > 1 || images[0].Fingerprint != fingerprint {
+		if len(images) > 1 || images[0].Fingerprint != image.Fingerprint {
 			// Alias was just updated, try again.
 			continue
 		}
@@ -729,7 +740,8 @@ func (f *wsOps) TestLxdBackendReuseCachedBase(c *check.C) {
 	c.Check(ok, check.Equals, false)
 	c.Check(imageCached.UpdateSource, check.NotNil)
 
-	err := f.bd.DownloadBase(f.ctx, "ubuntu@22.04", imageCached.Fingerprint, nil)
+	image := workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: imageCached.Fingerprint}
+	err := f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
 
 	images = f.listAllImages(c, "ubuntu@22.04")
@@ -770,19 +782,19 @@ func (f *wsOps) TestLxdBackendWorkshopStartFailed(c *check.C) {
 }
 
 func (f *wsOps) TestLxdBackendWorkshopLaunch(c *check.C) {
-	fingerprint, err := f.bd.GetBase(f.ctx, "ubuntu@24.04")
+	image, err := f.bd.GetBase(f.ctx, "ubuntu@24.04")
 	c.Assert(err, check.IsNil)
-	err = f.bd.DownloadBase(f.ctx, "ubuntu@24.04", fingerprint, nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
 
 	wf := &workshop.File{Name: "test", Base: "ubuntu@24.04"}
-	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, fingerprint)
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, image)
 	c.Assert(err, check.IsNil)
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
 	w, err := f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
-	c.Check(w.BaseFingerprint, check.Equals, fingerprint)
+	c.Check(w.Image, check.Equals, image)
 }
 
 func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {
@@ -804,11 +816,11 @@ func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {
 		Name: "test",
 		Base: "ubuntu@22.04",
 	}
-	fingerprint, err := f.bd.GetBase(f.ctx, "ubuntu@22.04")
+	image, err := f.bd.GetBase(f.ctx, "ubuntu@22.04")
 	c.Assert(err, check.IsNil)
-	err = f.bd.DownloadBase(f.ctx, "ubuntu@22.04", fingerprint, nil)
+	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
-	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, fingerprint)
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, image)
 	c.Assert(err, check.IsNil)
 
 	// Start workshop.
@@ -820,7 +832,7 @@ func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {
 	rebuilt := f.workshopMetadata(c, "test")
 	c.Check(rebuilt.config["image.workshop-base"], check.Equals, "ubuntu@22.04")
 	c.Check(rebuilt.config["user.workshop.file"], check.Equals, "name: test\nbase: ubuntu@22.04\n")
-	c.Check(rebuilt.config["user.workshop.base-fingerprint"], check.Equals, fingerprint)
+	c.Check(rebuilt.config["user.workshop.base-fingerprint"], check.Equals, image.Fingerprint)
 	maps.DeleteFunc(rebuilt.config, func(k, v string) bool { return modifiedByRebuild(k) })
 	c.Check(rebuilt.config, check.DeepEquals, original.config)
 	c.Check(rebuilt.devices, check.DeepEquals, original.devices)
@@ -841,7 +853,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 
 	w, err := f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
-	fingerprint := w.BaseFingerprint
+	image := w.Image
 
 	sdkfs := c.MkDir()
 	setup := sdk.Setup{
@@ -905,7 +917,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 	// Check that Restore uses the provided "user.workshop.file," keeps its
 	// base fingerprint and removes "test-sdk-2" setup from the workshop.
 	c.Check(w.File, check.DeepEquals, wf)
-	c.Check(w.BaseFingerprint, check.Equals, fingerprint)
+	c.Check(w.Image, check.Equals, image)
 	c.Check(w.Sdks, check.HasLen, 1)
 	c.Check(w.Sdks[setup2.Name], check.DeepEquals, sdk.Setup{})
 

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -924,7 +924,8 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 	c.Check(w.File, check.DeepEquals, wf)
 	c.Check(w.Image, check.Equals, image)
 	c.Check(w.Sdks, check.HasLen, 1)
-	c.Check(w.Sdks[setup2.Name], check.DeepEquals, sdk.Setup{})
+	_, ok := w.Sdks[setup2.Name]
+	c.Check(ok, check.Equals, false)
 
 	// Check that "test-sdk-2" volume is not present in the workshop filesystem
 	// anymore.

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -857,8 +857,9 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 	sdkfs := c.MkDir()
 	setup := sdk.Setup{
 		Name:     "test-sdk",
+		Source:   sdk.ProjectSource,
 		Revision: sdk.R(5),
-		Source:   sdk.StoreSource,
+		Sha3_384: "d024fbe91c6b99d0064306d52006c17a5d0406822ff253fbbe6a934ca9be50d3ff9a6ec3bac3be8396006029a1ff453a",
 	}
 	err = w.AddSdk(f.ctx, setup)
 	c.Assert(err, check.IsNil)
@@ -895,7 +896,12 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 	// Attach the SDK volume as "test-sdk-2" to the workshop after the snapshot
 	// to immitate further SDK configuration changes. These should be gone after
 	// Restore.
-	setup2 := sdk.Setup{Name: "test-sdk-2", Revision: sdk.R(5)}
+	setup2 := sdk.Setup{
+		Name:     "test-sdk-2",
+		Source:   sdk.TrySource,
+		Revision: sdk.R(5),
+		Sha3_384: "d4089378c26310627268153caa216240311f2a3193c778e96ed6dd895dc10c82db50f4f39676b29d23d9813b21e14b9b",
+	}
 	err = w.AddSdk(f.ctx, setup2)
 	c.Assert(err, check.IsNil)
 	err = f.bd.AttachVolume(f.ctx, "test", volume.Name, sdk.SdkDir(setup2.Name), true)

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -31,10 +31,10 @@ type Workshop struct {
 	Project Project
 	// Workshop file that was used to launch it; it may be out of sync with the
 	// file in the project directory due to user's edits, etc.
-	File            *File
-	Name            string
-	BaseFingerprint string
-	Running         bool
+	File    *File
+	Name    string
+	Image   BaseImage
+	Running bool
 	// Installed SDKs.
 	Sdks map[string]sdk.Setup
 	// Workshop devices installed.

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -36,23 +36,23 @@ type Workshop struct {
 	Image   BaseImage
 	Running bool
 	// Installed SDKs.
-	Sdks map[string]sdk.Setup
+	Sdks map[string]SdkInstallation
 	// Workshop devices installed.
 	Profiles map[string]SdkProfile
 }
 
+type SdkInstallation struct {
+	sdk.Setup
+	InstallTime time.Time `json:"install-time"`
+}
+
 // Associate an SDK with the workshop by adding the SDK to the Sdks field.
 func (w *Workshop) AddSdk(ctx context.Context, s sdk.Setup) error {
-	now := InstallTimeNow()
-	s.InstallTime = &now
-
-	_, exist := w.Sdks[s.Name]
-	if exist {
+	if _, exist := w.Sdks[s.Name]; exist {
 		return fmt.Errorf("%q SDK is already installed", s.Name)
-	} else {
-		w.Sdks[s.Name] = s
 	}
 
+	w.Sdks[s.Name] = SdkInstallation{Setup: s, InstallTime: InstallTimeNow()}
 	value, err := json.Marshal(w.Sdks)
 	if err != nil {
 		return err
@@ -136,17 +136,17 @@ func ValidateSdkInfo(projectId string, file *File, name, sdkYaml string) error {
 
 // Reads information about the installed SDK from its meta file.
 func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, error) {
-	setup, ok := w.Sdks[sdkName]
+	sk, ok := w.Sdks[sdkName]
 	if !ok {
 		return nil, fmt.Errorf("SDK %q is not installed in %q workshop", sdkName, w.Name)
 	}
 
 	var err error
 	var meta string
-	if setup.IsVolume() {
-		meta, err = w.metaFromVolume(ctx, setup)
+	if sk.IsVolume() {
+		meta, err = w.metaFromVolume(ctx, sk.Setup)
 	} else {
-		meta, err = w.metaFromFile(ctx, setup)
+		meta, err = w.metaFromFile(ctx, sk.Setup)
 	}
 
 	if err != nil {
@@ -161,9 +161,9 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 		return nil, fmt.Errorf("SDK must be named %q (now: %q)", sdkName, info.Name)
 	}
 
-	info.Revision = setup.Revision
-	info.Channel = setup.Channel
-	info.Source = setup.Source
+	info.Revision = sk.Revision
+	info.Channel = sk.Channel
+	info.Source = sk.Source
 
 	// Now add changes defined for this SDK in the workshop file (e.g. plug
 	// binds, slots).
@@ -234,7 +234,7 @@ func (w *Workshop) SdkInfosByInstallOrder(ctx context.Context) ([]*sdk.Info, err
 }
 
 // Returns the list of SDKs of the workshop sorted by installation order.
-func (w *Workshop) SdksByInstallOrder() []sdk.Setup {
+func (w *Workshop) SdksByInstallOrder() []SdkInstallation {
 	// Sort the SDKs in installation order.
 	orderMap := make(map[string]int)
 	for i, v := range w.File.Sdks {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -109,7 +109,7 @@ func (w *Workshop) metaFromFile(ctx context.Context, setup sdk.Setup) (string, e
 	userDataDir := UserDataRootDir(usr.HomeDir, env)
 
 	sdkDir := LocalSdkDir(userDataDir, w.Project.ProjectId, w.Name, setup.Name)
-	metapath := filepath.Join(sdkDir, setup.Revision.String(), "meta", "sdk.yaml")
+	metapath := filepath.Join(sdkDir, setup.Sha3_384, "meta", "sdk.yaml")
 
 	meta, err := os.ReadFile(metapath)
 	return string(meta), err

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -108,17 +108,32 @@ func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
 
 	w := workshop.Workshop{File: file, Name: "test-workshop"}
 	w.Sdks = map[string]sdk.Setup{
-		"test-sdk-1": {Name: "test-sdk-1", Revision: sdk.R(1), Channel: "latest/stable"},
-		"test-sdk-2": {Name: "test-sdk-2", Revision: sdk.R(1), Channel: "latest/edge"},
-		"system":     {Name: "system", Source: sdk.SystemSource, Revision: sdk.R(1)},
-		"sketch":     {Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-3)},
+		"test-sdk-1": {
+			Name:     "test-sdk-1",
+			Channel:  "latest/stable",
+			Revision: sdk.R(1),
+			Sha3_384: "84fa7f3d2e556fe410132260dfacb67d4cbbfb36ecfc26dfcef3f247524122d58c992902def9b52b88da0d6ec0efad05",
+		},
+		"test-sdk-2": {
+			Name:     "test-sdk-2",
+			Channel:  "latest/edge",
+			Revision: sdk.R(1),
+			Sha3_384: "d4089378c26310627268153caa216240311f2a3193c778e96ed6dd895dc10c82db50f4f39676b29d23d9813b21e14b9b",
+		},
+		"system": {
+			Name:     "system",
+			Source:   sdk.SystemSource,
+			Revision: sdk.R(1),
+			Sha3_384: "6b499970ebf370d4dbc4e9a005c042dee003c19a9420a78944bcbf32653d257f80f7c56bad55b4c967dca68a1ea92be7",
+		},
+		"sketch": {
+			Name:     "sketch",
+			Source:   sdk.SketchSource,
+			Revision: sdk.R(-3),
+			Sha3_384: "dd4b5a4cba8539e858e5fdcc318e46d9a2940439b0d8e7bd9c6bfc8b474f410d91aee43f5d4e18cb2c1b7dbaaba06fc3",
+		},
 	}
 
 	sdks := w.SdksByInstallOrder()
-	c.Assert(sdks, check.DeepEquals, []sdk.Setup{
-		{Name: "system", Source: sdk.SystemSource, Revision: sdk.R(1)},
-		{Name: "test-sdk-1", Revision: sdk.R(1), Channel: "latest/stable"},
-		{Name: "test-sdk-2", Revision: sdk.R(1), Channel: "latest/edge"},
-		{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-3)},
-	})
+	c.Assert(sdks, check.DeepEquals, []sdk.Setup{w.Sdks["system"], w.Sdks["test-sdk-1"], w.Sdks["test-sdk-2"], w.Sdks["sketch"]})
 }

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -107,33 +107,41 @@ func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	w := workshop.Workshop{File: file, Name: "test-workshop"}
-	w.Sdks = map[string]sdk.Setup{
+	w.Sdks = map[string]workshop.SdkInstallation{
 		"test-sdk-1": {
-			Name:     "test-sdk-1",
-			Channel:  "latest/stable",
-			Revision: sdk.R(1),
-			Sha3_384: "84fa7f3d2e556fe410132260dfacb67d4cbbfb36ecfc26dfcef3f247524122d58c992902def9b52b88da0d6ec0efad05",
+			Setup: sdk.Setup{
+				Name:     "test-sdk-1",
+				Channel:  "latest/stable",
+				Revision: sdk.R(1),
+				Sha3_384: "84fa7f3d2e556fe410132260dfacb67d4cbbfb36ecfc26dfcef3f247524122d58c992902def9b52b88da0d6ec0efad05",
+			},
 		},
 		"test-sdk-2": {
-			Name:     "test-sdk-2",
-			Channel:  "latest/edge",
-			Revision: sdk.R(1),
-			Sha3_384: "d4089378c26310627268153caa216240311f2a3193c778e96ed6dd895dc10c82db50f4f39676b29d23d9813b21e14b9b",
+			Setup: sdk.Setup{
+				Name:     "test-sdk-2",
+				Channel:  "latest/edge",
+				Revision: sdk.R(1),
+				Sha3_384: "d4089378c26310627268153caa216240311f2a3193c778e96ed6dd895dc10c82db50f4f39676b29d23d9813b21e14b9b",
+			},
 		},
 		"system": {
-			Name:     "system",
-			Source:   sdk.SystemSource,
-			Revision: sdk.R(1),
-			Sha3_384: "6b499970ebf370d4dbc4e9a005c042dee003c19a9420a78944bcbf32653d257f80f7c56bad55b4c967dca68a1ea92be7",
+			Setup: sdk.Setup{
+				Name:     "system",
+				Source:   sdk.SystemSource,
+				Revision: sdk.R(1),
+				Sha3_384: "6b499970ebf370d4dbc4e9a005c042dee003c19a9420a78944bcbf32653d257f80f7c56bad55b4c967dca68a1ea92be7",
+			},
 		},
 		"sketch": {
-			Name:     "sketch",
-			Source:   sdk.SketchSource,
-			Revision: sdk.R(-3),
-			Sha3_384: "dd4b5a4cba8539e858e5fdcc318e46d9a2940439b0d8e7bd9c6bfc8b474f410d91aee43f5d4e18cb2c1b7dbaaba06fc3",
+			Setup: sdk.Setup{
+				Name:     "sketch",
+				Source:   sdk.SketchSource,
+				Revision: sdk.R(-3),
+				Sha3_384: "dd4b5a4cba8539e858e5fdcc318e46d9a2940439b0d8e7bd9c6bfc8b474f410d91aee43f5d4e18cb2c1b7dbaaba06fc3",
+			},
 		},
 	}
 
 	sdks := w.SdksByInstallOrder()
-	c.Assert(sdks, check.DeepEquals, []sdk.Setup{w.Sdks["system"], w.Sdks["test-sdk-1"], w.Sdks["test-sdk-2"], w.Sdks["sketch"]})
+	c.Assert(sdks, check.DeepEquals, []workshop.SdkInstallation{w.Sdks["system"], w.Sdks["test-sdk-1"], w.Sdks["test-sdk-2"], w.Sdks["sketch"]})
 }


### PR DESCRIPTION
# Description

My aim was to introduce a struct which captures the ingredients that go into a workshop snapshot. This will be used in the `workshop.Backend` API to create, lookup and restore snapshots. Ultimately it should look something like:
```go
type Layers struct {
    Image BaseImage
    Sdks  []Sdk
}

type BaseImage {
    Name        string
    Fingerprint string
}

type Sdk {
    Name     string
    Source   string
    Revision Revision
    Hash     string
}
```

Both `Name` and `Revision` aren't strictly necessary, but make debugging easier. Also `Source` can be more coarse, e.g. there's no need to distinguish between `try` and Store SDKs. I plan to include `Name`s in the layer hash, to reduce the blast radius of hash collisions.

This PR introduces a `BaseImage` struct as above, and adjusts `sdk.Setup` to be closer to the `Sdk` struct. `sdk.Setup` now includes hashes and doesn't include the install time. It won't be easy to remove `Channel` until we migrate to the actual Store.

I also took the opportunity to rename `sdk.SdkResult` to `sdk.Meta` and consolidate some similar types used in tests. It's now just `sdk.Setup` together with the SDK YAML file.

This is likely to break existing workshops due to changes to `sdk.Setup`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
