### PR TITLE
Update SDKcraft tutorial

### DIFF
--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -556,12 +556,6 @@ The resulting SDK can be accessed by |ws_markup| as follows:
 Note that the workshop :samp:`base`
 must match one of the SDK's supported :samp:`platforms`.
 
-.. note::
-
-   Currently, you can't use unpublished SDKs in a workshop.
-   However, the :ref:`sketch SDK <tut_sketch_sdks>` and in-project SDKs provide
-   a subset of |sdk_markup|'s functionality.
-
 
 Summary
 -------

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -198,7 +198,7 @@ create a file named :file:`ollama.service`:
 
    [Unit]
    Description=Ollama Service
-   After=network-online.target
+   After=network.target
 
    [Service]
    ExecStart=/bin/bash -lc "ollama serve"
@@ -206,7 +206,7 @@ create a file named :file:`ollama.service`:
    RestartSec=3
 
    [Install]
-   WantedBy=multi-user.target
+   WantedBy=default.target
 
 
 This defines how the Ollama daemon should run:
@@ -412,12 +412,11 @@ Finally, create a hook named :file:`check-health`:
 .. code-block:: shell
    :caption: check-health
 
-   output=$(sudo -u workshop --login ollama list 2>&1)
-   if [[ $? -eq 0 ]]; then
-     workshopctl set-health okay
-     exit 0
+   if ! output=$(sudo -u workshop --login ollama list 2>&1); then
+     workshopctl set-health error "$output"
+     exit
    fi
-   workshopctl set-health error "$output"
+   workshopctl set-health okay
 
 
 It checks whether the Ollama installation is functional

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -507,8 +507,9 @@ To use it in a workshop, add a prefix: :samp:`try-<NAME>`:
 .. code-block:: yaml
    :caption: workshop.yaml
 
+   name: dev
+   base: ubuntu@24.04
    sdks:
-     # ...
      - name: try-ollama
 
 

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -327,20 +327,14 @@ named :file:`setup-base`:
 
 
 It runs when the workshop is launched or refreshed,
-installing system packages and preparing the workshop for use.
+and is typically used to install system packages
+and configure the environment.
 
 .. note::
 
    For workshops,
    :command:`apt` is configured to exclude recommended or suggested packages
    and answer 'yes' to all confirmation prompts.
-
-   Also, the use of :command:`sudo -u workshop` here is important
-   because only the :samp:`setup-project` hook runs as a normal user by default;
-   other hooks, like :samp:`setup-base`, run as root.
-   Running commands as the non-root user
-   helps preserve the correct environment variables and file ownership,
-   and can be easier than adjusting permissions afterwards.
 
 
 In the same directory,
@@ -434,6 +428,15 @@ You can also set the health to :samp:`waiting`
 to signal that the hook should be retried for a few seconds.
 Unless the hook sets the health to a different value during such a retry,
 the health is eventually set to :samp:`error` automatically.
+
+.. note::
+
+   The use of :command:`sudo -u workshop` here is important
+   because only the :samp:`setup-project` hook runs as a normal user by default;
+   other hooks, like :samp:`check-health`, run as root.
+   Running commands as the non-root user
+   helps preserve the correct environment variables and file ownership,
+   and can be easier than adjusting permissions afterwards.
 
 
 .. _how_sdkcraft_build_sdk:

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -122,12 +122,12 @@ to explore what goes into an SDK.
 Update metadata
 ---------------
 
-Update the metadata in :file:`sdk.yaml`,
-adjusting its :samp:`name`, :samp:`summary` and :samp:`description`:
+Update the metadata in :file:`sdk.yaml`
+to describe Ollama
+and build SDKs for several platforms:
 
 .. code-block:: yaml
    :caption: sdk.yaml
-   :emphasize-lines: 1,4-6
 
    name: ollama
    version: "0.9.6"


### PR DESCRIPTION
# Description

I went through this to see if I could reproduce an issue. No luck on that but I noticed a few things that could be improved:
- No need to emphasise certain parts of the `sdk.yaml` when all lines have changed.
- The `ollama.service` file is outdated.
- The note about `apt` and `sudo -u` is irrelevant here. Maybe there's somewhere else we could move it though.
- The `check-health` hook doesn't work as intended. See https://github.com/canonical/sdks/pull/76.
- The `workshop.yaml` for trying out Ollama was abbreviated before showing the full file later on. It's short so we can just show the full thing twice.
- The note about unpublished SDKs is outdated since we have `sdkcraft try` now.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
