### PR TITLE
Inject host timezone into workshop on launch and refresh

### DIFF
--- a/docs/reference/workshops.rst
+++ b/docs/reference/workshops.rst
@@ -87,16 +87,18 @@ At the container launch, |ws_markup| does the following:
 - Spins up the container with mapped user and group IDs,
   configures basic devices like the root disk and network bridge.
 
-- Installs the SDKs, then runs their setup hooks in the container.
+- Installs the SDKs, then runs their :samp:`setup-base` hooks in the container.
 
-- Sets up interface plugs and slots defined by the workshop and its SDKs
-  for extra devices and capabilities.
+- Configures the container's time zone to match the host.
 
 - Maps the project directory on the host to :file:`/project` in the container;
   this allows to transparently work on the host-based files
   using the tools provided by the SDKs.
 
-- Starts the container so it is ready for development tasks.
+- Sets up interface plugs and slots defined by the workshop and its SDKs
+  for extra devices and capabilities.
+
+- Runs :samp:`setup-project` and :samp:`check-health` hooks for all SDKs.
 
 
 Thus, the container is built, or launched in |ws_markup| terms.

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1787,9 +1787,14 @@ func (s *apiSuite) checkRestoreCalls(c *check.C, name string, sdks []string, fil
 func (s *apiSuite) checkHookCalls(c *check.C, name string, sdks []string, hooks []hookstate.WorkshopHookType) {
 	wpCalls := []*fakebackend.ExecCall{}
 	for _, ec := range s.b.ExecCalls {
-		if ec.Name == name {
-			wpCalls = append(wpCalls, ec)
+		if ec.Name != name {
+			continue
 		}
+		if _, isHook := ec.Args.Environment["SDK"]; !isHook {
+			continue
+		}
+
+		wpCalls = append(wpCalls, ec)
 	}
 
 	c.Assert(wpCalls, check.HasLen, len(sdks))

--- a/internal/osutil/exec.go
+++ b/internal/osutil/exec.go
@@ -28,6 +28,9 @@ import (
 	"gopkg.in/tomb.v2"
 )
 
+// Well-known exit status.
+const CommandNotFound = 127
+
 var (
 	cmdWaitTimeout = 5 * time.Second
 

--- a/internal/osutil/integration_test.go
+++ b/internal/osutil/integration_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package osutil_test
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/osutil"
+)
+
+type integrationSuite struct{}
+
+var _ = check.Suite(&integrationSuite{})
+
+func (s *integrationSuite) TestUserAndEnv(c *check.C) {
+	user, env, err := osutil.UserAndEnv("ubuntu")
+	c.Assert(err, check.IsNil)
+
+	c.Check(env["USER"], check.Equals, user.Username)
+	c.Check(env["HOME"], check.Equals, user.HomeDir)
+	c.Check(filepath.Join(dirs.XdgRuntimeDirBase, user.Uid), check.Equals, env["XDG_RUNTIME_DIR"])
+
+	cmd := exec.Command(
+		"systemctl",
+		"--user",
+		"set-environment",
+		fmt.Sprintf("--machine=%s@.host", user.Uid),
+		"FAKE_VARIABLE_FOR_TESTING=fakeValueForTest",
+	)
+	cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+env["XDG_RUNTIME_DIR"])
+	c.Assert(cmd.Run(), check.IsNil)
+
+	_, env, err = osutil.UserAndEnv("ubuntu")
+	c.Assert(err, check.IsNil)
+
+	c.Check(env["FAKE_VARIABLE_FOR_TESTING"], check.Equals, "fakeValueForTest")
+}

--- a/internal/osutil/integration_test.go
+++ b/internal/osutil/integration_test.go
@@ -4,6 +4,7 @@ package osutil_test
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -39,4 +40,17 @@ func (s *integrationSuite) TestUserAndEnv(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Check(env["FAKE_VARIABLE_FOR_TESTING"], check.Equals, "fakeValueForTest")
+}
+
+func (s *integrationSuite) TestTimezone(c *check.C) {
+	timezone, err := osutil.Timezone()
+	c.Assert(err, check.IsNil)
+
+	localtime, err := os.Stat("/etc/localtime")
+	c.Assert(err, check.IsNil)
+
+	zoneinfo, err := os.Stat(filepath.Join("/usr/share/zoneinfo", timezone))
+	c.Assert(err, check.IsNil)
+
+	c.Check(os.SameFile(localtime, zoneinfo), check.Equals, true)
 }

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -204,16 +204,30 @@ func currentUserAndEnv() (*user.User, map[string]string, error) {
 // Returns the environment for the user as set by systemd.
 // This is the equivalent of running 'systemctl --user show-environment'
 func userEnvironment(user *user.User) (map[string]string, error) {
-	cmd := exec.Command("systemctl", "--user", "show-environment", "--machine", fmt.Sprintf("%s@.host", user.Uid))
-	// XDG_RUNTIME_DIR may not be set if a command is invoked by sudo or
-	// systemd-run; set it here to the default location. It is required for
-	// systemctl to work with --user. See:
-	// https://unix.stackexchange.com/questions/346841/why-does-sudo-i-not-set-xdg-runtime-dir-for-the-target-user
-	defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
-	cmd.Env = append(cmd.Env, "XDG_RUNTIME_DIR="+defaultXdg)
+	// When running as the target user, systemctl can connect to the user
+	// bus directly, but this requires XDG_RUNTIME_DIR to be set. Other
+	// users have to use a more complicated connection process via the
+	// --machine argument. It's likely that non-root users won't have
+	// permission to do this, but we leave that up to systemd. In practice
+	// we can define XDG_RUNTIME_DIR and pass --machine in both cases, but
+	// --machine is ignored in the first case (given that it matches the
+	// current user), and XDG_RUNTIME_DIR is incorrect in the second case.
+	// See https://github.com/systemd/systemd/issues/39838.
+	args := []string{"--user", "show-environment"}
+	var env []string
+	uid, err := strconv.ParseInt(user.Uid, 10, 64)
+	if err == nil && uid == int64(os.Geteuid()) {
+		defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
+		env = append(env, "XDG_RUNTIME_DIR="+defaultXdg)
+	} else {
+		args = append(args, fmt.Sprintf("--machine=%s@.host", user.Uid))
+	}
+	cmd := exec.Command("systemctl", args...)
+	cmd.Env = append(cmd.Env, env...)
+
 	out, errOut, err := RunCmd(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("%s", string(errOut))
+		return nil, fmt.Errorf("systemctl show-environment: %s", errOut)
 	}
 
 	// TODO: use --output=json once systemd >= 250.

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -35,6 +35,7 @@ var (
 	UserEnv           = userEnvironment
 	UserAndEnv        = userAndEnv
 	CurrentUserAndEnv = currentUserAndEnv
+	Timezone          = timezone
 )
 
 // RealUser finds the user behind a sudo invocation when root, if applicable
@@ -235,6 +236,19 @@ func userEnvironment(user *user.User) (map[string]string, error) {
 	return parseSystemctlEnvironment(rawEnv)
 }
 
+func timezone() (string, error) {
+	// Compatibility: timedatectl show was added in systemd v239:
+	// https://github.com/systemd/systemd/pull/9250
+	cmd := exec.Command("timedatectl", "show", "--property=Timezone", "--value")
+	out, errOut, err := RunCmd(cmd)
+	if err != nil {
+		return "", fmt.Errorf("timedatectl show: %s", errOut)
+	}
+
+	timezone := strings.TrimSpace(string(out))
+	return timezone, nil
+}
+
 func FakeUserEnvironment(f func(user *user.User) (map[string]string, error)) func() {
 	UserEnv = f
 	return func() {
@@ -273,6 +287,12 @@ func FakeUserLookupGroup(f func(name string) (*user.Group, error)) func() {
 	oldUserLookupGroup := UserLookupGroup
 	UserLookupGroup = f
 	return func() { UserLookupGroup = oldUserLookupGroup }
+}
+
+func FakeTimezone(f func() (string, error)) func() {
+	oldTimezone := Timezone
+	Timezone = f
+	return func() { Timezone = oldTimezone }
 }
 
 // Note: this is best effort, comparing err here with UnknownUserError

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -232,6 +232,73 @@ func removeIfEmpty(path string) error {
 	return err
 }
 
+func (m *WorkshopManager) doConfigureTimezone(task *state.Task, tomb *tomb.Tomb) error {
+	user, prj, w, err := UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
+	defer cancel()
+
+	timezone, err := osutil.Timezone()
+	if err != nil {
+		st := task.State()
+		st.Lock()
+		defer st.Unlock()
+		st.Warnf("cannot determine system time zone: %v", err)
+		return nil
+	}
+
+	// Set /etc/localtime in workshop. Ubuntu 22.04 and below use a patched
+	// systemd that will also write to /etc/timezone.
+	args := workshop.Execution{
+		ExecArgs: workshop.ExecArgs{
+			Command: []string{
+				"timedatectl",
+				"set-timezone",
+				timezone,
+			},
+			WorkDir: "/",
+			Timeout: time.Minute,
+		},
+	}
+	exectx, err := m.backend.Exec(ctx, w, &args)
+	if err != nil {
+		return err
+	}
+	if err := exectx.WaitExecution(ctx); err != nil {
+		return err
+	}
+
+	// Ensure /etc/timezone is updated (for Ubuntu 24.04 and above). It's
+	// looking like Ubuntu 26.04 will remove /etc/timezone, so this command
+	// only affects Ubuntu 24.04. It can be removed when we drop support.
+	args = workshop.Execution{
+		ExecArgs: workshop.ExecArgs{
+			Command: []string{
+				"dpkg-reconfigure",
+				"--frontend=noninteractive",
+				"tzdata",
+			},
+			WorkDir: "/",
+			Timeout: time.Minute,
+		},
+	}
+	exectx, err = m.backend.Exec(ctx, w, &args)
+	if err != nil {
+		return err
+	}
+	err = exectx.WaitExecution(ctx)
+	var errExec *workshop.ErrExec
+	if errors.As(err, &errExec) && errExec.Status == osutil.CommandNotFound {
+		// If dpkg-reconfigure doesn't exist, /etc/timezone probably
+		// doesn't either.
+		err = nil
+	}
+	return err
+}
+
 func (m *WorkshopManager) doMountProject(task *state.Task, tomb *tomb.Tomb) error {
 	user, prj, w, err := UserProjectWorkshop(task)
 	if err != nil {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -148,7 +148,7 @@ func (s *workshopHandlers) TestStopPeriodicProgressUpdate(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -183,7 +183,7 @@ func (s *workshopHandlers) TestUndoStash(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		_ = s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -309,7 +309,7 @@ func (s *workshopHandlers) TestCreateWorkshopNoWorkshopDefinitionFound(c *check.
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -333,7 +333,7 @@ func (s *workshopHandlers) TestCreateWorkshopWithSystemSdk(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -430,7 +430,7 @@ func (s *workshopHandlers) TestDownloadBase(c *check.C) {
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Check(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -440,4 +440,133 @@ func (s *workshopHandlers) TestDownloadBase(c *check.C) {
 	c.Assert(label, check.Equals, "download finished")
 	c.Assert(done, check.Equals, 100)
 	c.Assert(total, check.Equals, 100)
+}
+
+func (s *workshopHandlers) TestConfigureTimezoneBrokenHost(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restoreTimezone := osutil.FakeTimezone(func() (string, error) {
+		return "", errors.New("timedatectl: command not found")
+	})
+	defer restoreTimezone()
+
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("configure-timezone", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	warnings := s.state.AllWarnings()
+	c.Assert(warnings, check.HasLen, 1)
+	c.Check(warnings[0].String(), check.Equals, "cannot determine system time zone: timedatectl: command not found")
+}
+
+func (s *workshopHandlers) TestConfigureTimezoneBrokenWorkshop(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restoreTimezone := osutil.FakeTimezone(func() (string, error) {
+		return "Antarctica/Troll", nil
+	})
+	defer restoreTimezone()
+
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+		return workshop.ExecContext{}, errors.New("timedatectl: command not found")
+	}
+
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("configure-timezone", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Check(chg.Err(), check.ErrorMatches, `(?s).*\(timedatectl: command not found\)`)
+}
+
+func (s *workshopHandlers) TestConfigureTimezoneBrokenDpkg(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restoreTimezone := osutil.FakeTimezone(func() (string, error) {
+		return "Antarctica/Troll", nil
+	})
+	defer restoreTimezone()
+
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+		if args.Command[0] != "dpkg-reconfigure" {
+			return fakebackend.DoExecDefault(ctx, name, args)
+		}
+		return workshop.ExecContext{}, errors.New("dpkg-reconfigure: read only filesystem")
+	}
+
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("configure-timezone", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Check(chg.Err(), check.ErrorMatches, `(?s).*\(dpkg-reconfigure: read only filesystem\)`)
+}
+
+func (s *workshopHandlers) TestConfigureTimezoneMissingDpkg(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	restoreTimezone := osutil.FakeTimezone(func() (string, error) {
+		return "Antarctica/Troll", nil
+	})
+	defer restoreTimezone()
+
+	s.backend.ExecCallback = func(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+		if args.Command[0] != "dpkg-reconfigure" {
+			return fakebackend.DoExecDefault(ctx, name, args)
+		}
+		exectx := workshop.ExecContext{
+			WaitExecution: func(ctx context.Context) error {
+				return &workshop.ErrExec{Status: osutil.CommandNotFound}
+			},
+		}
+		return exectx, nil
+	}
+
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("configure-timezone", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
+	c.Check(s.backend.ExecCalls, check.HasLen, 2)
 }

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -30,6 +30,7 @@ func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	runner.AddHandler("start-workshop", OnDo(manager.doStart), OnUndo(manager.doStop))
 	runner.AddHandler("stop-workshop", OnDo(manager.doStop), OnUndo(manager.doStart))
 	runner.AddHandler("remove-workshop", OnDo(manager.doRemoveWorkshop), nil)
+	runner.AddHandler("configure-timezone", OnDo(manager.doConfigureTimezone), nil)
 	runner.AddHandler("mount-project", OnDo(manager.doMountProject), OnUndo(manager.undoMountProject))
 	runner.AddHandler("create-workshop-storage", OnDo(manager.doCreateWorkshopStorage), OnUndo(manager.doRemoveWorkshopStorage))
 	runner.AddHandler("remove-workshop-storage", OnDo(manager.doRemoveWorkshopStorage), nil)

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -68,6 +68,7 @@ func (s *managerSuite) TestAddHandlers(c *check.C) {
 		"start-workshop",
 		"stop-workshop",
 		"remove-workshop",
+		"configure-timezone",
 		"mount-project",
 		"create-workshop-storage",
 		"remove-workshop-storage",

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -624,6 +624,9 @@ func launch(st *state.State, file *workshop.File, fileText string, image worksho
 	install := installSdks(st, sdks, rmap)
 	addTaskSet(install)
 
+	configureTimezone := st.NewTask("configure-timezone", fmt.Sprintf("Configure %q workshop timezone", file.Name))
+	addTaskSet(state.NewTaskSet(configureTimezone))
+
 	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", project.Path))
 	addTaskSet(state.NewTaskSet(mountProject))
 
@@ -935,6 +938,9 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 	// Install updated SDKs to the rebuilt workshop.
 	install := installSdks(st, plan.InstallOrRefresh(), rmap)
 	addTaskSet(install)
+
+	configureTimezone := st.NewTask("configure-timezone", fmt.Sprintf("Configure %q workshop timezone", file.Name))
+	addTaskSet(state.NewTaskSet(configureTimezone))
 
 	mountProject := st.NewTask("mount-project", fmt.Sprintf("Mount project directory %q", w.Project.Path))
 	addTaskSet(state.NewTaskSet(mountProject))

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -32,7 +32,7 @@ type FakeWorkshop struct {
 
 type ExecCall struct {
 	Name string
-	Args *workshop.Execution
+	Args workshop.Execution
 }
 
 type FsCall struct {
@@ -455,7 +455,7 @@ func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (fsut
 }
 
 func (f *FakeWorkshopBackend) Exec(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
-	f.ExecCalls = append(f.ExecCalls, &ExecCall{name, args})
+	f.ExecCalls = append(f.ExecCalls, &ExecCall{name, *args})
 	return f.ExecCallback(ctx, name, args)
 }
 

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -81,6 +81,7 @@ type FakeWorkshopBackend struct {
 	// the key is a username
 	projects map[string][]workshop.Project
 
+	execLock     sync.Mutex
 	ExecCallback ExecFunc
 	ExecCalls    []*ExecCall
 
@@ -455,7 +456,9 @@ func (s *FakeWorkshopBackend) WorkshopFs(ctx context.Context, name string) (fsut
 }
 
 func (f *FakeWorkshopBackend) Exec(ctx context.Context, name string, args *workshop.Execution) (workshop.ExecContext, error) {
+	f.execLock.Lock()
 	f.ExecCalls = append(f.ExecCalls, &ExecCall{name, *args})
+	f.execLock.Unlock()
 	return f.ExecCallback(ctx, name, args)
 }
 

--- a/tests/integration/osutil/task.yaml
+++ b/tests/integration/osutil/task.yaml
@@ -1,0 +1,14 @@
+summary: Run LXD integration tests for OS utilities
+prepare: |
+  loginctl enable-linger ubuntu
+execute: |
+  # Run as normal user first, then root.
+  sudo -u ubuntu go test "$SPREAD_PATH"/internal/osutil -timeout=30m -tags=integration -check.v -check.f integrationSuite
+
+  rm -rf cover
+  mkdir cover
+
+  go test -cover "$SPREAD_PATH"/internal/osutil/ -timeout=30m -tags=integration -check.v -check.f integrationSuite -coverpkg=github.com/canonical/workshop/internal/osutil -args -test.gocoverdir="$PWD"/cover
+
+artifacts:
+  - cover

--- a/tests/integration/osutil/task.yaml
+++ b/tests/integration/osutil/task.yaml
@@ -1,6 +1,10 @@
 summary: Run LXD integration tests for OS utilities
 prepare: |
   loginctl enable-linger ubuntu
+
+  timedatectl set-timezone Antarctica/Macquarie
+restore: |
+  timedatectl set-timezone Etc/UTC
 execute: |
   # Run as normal user first, then root.
   sudo -u ubuntu go test "$SPREAD_PATH"/internal/osutil -timeout=30m -tags=integration -check.v -check.f integrationSuite

--- a/tests/main/launch/task.yaml
+++ b/tests/main/launch/task.yaml
@@ -1,4 +1,8 @@
 summary: Test launch for the supported workshop bases
+prepare: |
+  timedatectl set-timezone Pacific/Auckland
+restore: |
+  timedatectl set-timezone Etc/UTC
 execute: |
   . "$TESTSLIB"/utils.sh
 
@@ -26,6 +30,8 @@ execute: |
       extract_section DHCPv4 < eth0.log | MATCH '^SendRelease=false$'
       extract_section DHCPv6 < eth0.log | MATCH '^SendRelease=false$'
     fi
+    # ensure timezone is inherited from host
+    workshop_exec exec "$1" timedatectl show | MATCH '^Timezone=Pacific/Auckland$'
     workshop_exec remove "$1"
   }
   


### PR DESCRIPTION
# Description

Adds a new `configure-timezone` task on launch and refresh. It uses systemd's `timedatectl` to query the host's timezone and set the workshop's timezone. To update `/etc/timezone`, it uses `dpkg-reconfigure`. This is only needed for Ubuntu 24.04 at the moment, and won't be needed once support for `/etc/timezone` is dropped entirely.

If `timedatectl` fails on the host (e.g. the user doesn't use `systemd` or uses a very old version of it), the launch or refresh will proceed with a warning. Inside the workshop, I can't imagine much will go wrong when setting the timezone, so I left them as hard errors for now (but if `dpkg-reconfigure` returns `command not found`, we ignore that).

After understanding some `systemd` internals a bit better, I also updated `userEnvironment` to avoid passing extraneous CLI arguments and environment variables.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
