### PR TITLE
Make git shortref optional when building snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,8 +65,13 @@ parts:
 
       # Set snap version including git commit hash
       VERSION="$("${CRAFT_PART_INSTALL}/bin/workshop" --version)"
-      COMMIT_HASH="$(git rev-parse --short HEAD)"
-      craftctl set version="${VERSION}-${COMMIT_HASH}"
+      if [ -d .git ]; then
+        VERSION="${VERSION}-$(git rev-parse --short HEAD)"
+      elif [ -f .git ]; then
+        # Likely building from a git worktree
+        VERSION="${VERSION}-dev"
+      fi
+      craftctl set version="${VERSION}"
     stage-packages:
       - zstd
     prime:


### PR DESCRIPTION
# Description

This should re-enable building the snap from a git worktree.

Incidentally, I can't build it locally now that the network-bind plug is gone. I have `snapcraft 8.13.1`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
