### PR TITLE
Doc: update sdk channels to 24.04 and workshop base to ubuntu@24.04

### DIFF
--- a/docs/tutorial/part-1-get-started.rst
+++ b/docs/tutorial/part-1-get-started.rst
@@ -156,15 +156,15 @@ create a workshop definition named :file:`workshop.yaml`:
    :emphasize-lines: 4,5
 
    name: dev
-   base: ubuntu@24.04
+   base: ubuntu@22.04
    sdks:
      - name: ollama
-       channel: 24.04/edge
+       channel: 22.04/edge
 
 
 Here, the SDK is referenced as :samp:`ollama`,
 and the specific version to retrieve from the SDK Store
-comes from the :samp:`24.04/edge` channel.
+comes from the :samp:`22.04/edge` channel.
 
 To confirm that |ws_markup| sees the definition,
 list the workshops in the project directory:
@@ -228,7 +228,7 @@ to see what went into your workshop:
    $ workshop info
 
      name:     dev
-     base:     ubuntu@24.04
+     base:     ubuntu@22.04
      project:  /home/user/ollama-python-project
      status:   ready
      notes:    -
@@ -236,8 +236,8 @@ to see what went into your workshop:
        system:
          installed:  (1)
        ollama:
-         tracking:   24.04/edge
-         installed:  0.9.6  2025-07-21  (516)
+         tracking:   22.04/edge
+         installed:  0.9.6  2025-11-19  (981)
          mounts:
            models:
              host-source:      .../6b79e889/dev/mount/ollama/models
@@ -323,6 +323,9 @@ are updated by their publishers.
 Alternatively,
 you may have changed the definition to switch bases,
 add and remove SDKs, or toggle their channels.
+A good example is:
+when a new Ubuntu LTS is available and by consequence,
+a new base image is published;
 In either case,
 you must refresh the workshop to apply the updates.
 
@@ -334,10 +337,10 @@ and refresh the workshop:
    :emphasize-lines: 2,5
 
    name: dev
-   base: ubuntu@22.04
+   base: ubuntu@24.04
    sdks:
      - name: ollama
-       channel: 22.04/edge
+       channel: 24.04/edge
 
 .. @artefact workshop refresh
 
@@ -434,9 +437,9 @@ who's also named :samp:`workshop`:
 
      ...
      Distributor ID: Ubuntu
-     Description:    Ubuntu 22.04.5 LTS
-     Release:        22.04
-     Codename:       jammy
+     Description:    Ubuntu 24.04.3 LTS
+     Release:        24.04
+     Codename:       noble
 
    workshop@dev-6b79e889:/project$ exit
 
@@ -504,9 +507,9 @@ pass the change ID to the command:
    $ workshop tasks 33
 
      Status   Duration  Summary
-     Done    2m17.389s  Download "ubuntu@22.04" base image
+     Done    2m17.389s  Download "ubuntu@24.04" base image
      Done        113ms  Retrieve "system" SDK
-     Done    2m59.777s  Retrieve "ollama" SDK from channel "22.04/edge"
+     Done    2m59.777s  Retrieve "ollama" SDK from channel "24.04/edge"
      Done        443ms  Create SDK state storage
      Done        581ms  Run hook "save-state" for "system" SDK
      Done        449ms  Run hook "save-state" for "ollama" SDK

--- a/docs/tutorial/part-1-get-started.rst
+++ b/docs/tutorial/part-1-get-started.rst
@@ -323,9 +323,9 @@ are updated by their publishers.
 Alternatively,
 you may have changed the definition to switch bases,
 add and remove SDKs, or toggle their channels.
-A good example is:
-when a new Ubuntu LTS is available and by consequence,
-a new base image is published;
+A good example is when a new Ubuntu LTS version is released and,
+as a result,
+a new base image becomes available.
 In either case,
 you must refresh the workshop to apply the updates.
 

--- a/docs/tutorial/part-2-work-with-interfaces.rst
+++ b/docs/tutorial/part-2-work-with-interfaces.rst
@@ -101,7 +101,7 @@ you can remount to a directory in your home:
    $ workshop info
 
      name:     dev
-     base:     ubuntu@22.04
+     base:     ubuntu@24.04
      project:  /home/user/ollama-python-project
      status:   ready
      notes:    -
@@ -109,8 +109,8 @@ you can remount to a directory in your home:
        system:
          installed:  (1)
        ollama:
-         tracking:   22.04/edge
-         installed:  0.9.6  2025-08-12  (690)
+         tracking:   24.04/edge
+         installed:  0.9.6  2025-11-19  (214)
          mounts:
            models:
              host-source:      /home/user/.ollama/models
@@ -143,12 +143,12 @@ to run Jupyter notebooks with the Ollama models:
    :emphasize-lines: 6,7
 
    name: dev
-   base: ubuntu@22.04
+   base: ubuntu@24.04
    sdks:
      - name: ollama
-       channel: 22.04/edge
+       channel: 24.04/edge
      - name: jupyter
-       channel: 22.04/edge
+       channel: 24.04/edge
 
 
 .. code-block:: console
@@ -170,12 +170,12 @@ to the host system at a port of your choice (here, :samp:`8989`):
    :emphasize-lines: 8-12
 
    name: dev
-   base: ubuntu@22.04
+   base: ubuntu@24.04
    sdks:
      - name: ollama
-       channel: 22.04/edge
+       channel: 24.04/edge
      - name: jupyter
-       channel: 22.04/edge
+       channel: 24.04/edge
      - name: system
        plugs:
          jupyter:

--- a/docs/tutorial/part-3-sketch-sdks.rst
+++ b/docs/tutorial/part-3-sketch-sdks.rst
@@ -45,12 +45,12 @@ when we discussed :ref:`tut_work_with_interfaces`:
    :caption: workshop.yaml
 
    name: dev
-   base: ubuntu@22.04
+   base: ubuntu@24.04
    sdks:
      - name: ollama
-       channel: 22.04/edge
+       channel: 24.04/edge
      - name: jupyter
-       channel: 22.04/edge
+       channel: 24.04/edge
      - name: system
        plugs:
          jupyter:


### PR DESCRIPTION
# Description

These changes ensure that all tutorials consistently uses the Noble variant.

When following the second tutorial, I've found an inconsistency with the first one: the ollama sdk channel is set as `22.04/edge` and the workshop base is set as `ubuntu@22.04`. While on the first one, channel and base are set to `24.04`.

So, this gives this mismatched base x channel error when trying to add Jupyter and refresh:

```
error: cannot refresh "dev": "jupyter" SDK has "ubuntu@22.04" base; required: "ubuntu@24.04"
"dev" refresh aborted
```

By having this workshop.yaml file:

```yaml
name: dev
base: ubuntu@24.04
sdks:
  - name: ollama
    channel: 24.04/edge
  - name: jupyter
    channel: 22.04/edge
```

<!--
# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [ ] I confirm the PR has no implications for documentation.
-->