### PR TITLE
Add hyperlinks to long file paths in workshop info

### DIFF
--- a/cmd/internal/cmdutil/color.go
+++ b/cmd/internal/cmdutil/color.go
@@ -126,6 +126,14 @@ type Escapes struct {
 	Tick, Dash, Ellipsis, UpArrow, Star string
 }
 
+// EmptyDash returns a YAML-safe dash if the string is empty; otherwise returns the string.
+func (e *Escapes) EmptyDash(s string) string {
+	if s == "" {
+		return e.Dash
+	}
+	return s
+}
+
 func (e *Escapes) MakeLink(text, url, fallback string) string {
 	if e.hyperlink == "" {
 		return fallback

--- a/cmd/internal/cmdutil/color.go
+++ b/cmd/internal/cmdutil/color.go
@@ -33,11 +33,13 @@ type UnicodeMixin struct {
 func (ux UnicodeMixin) addUnicodeChars(esc *Escapes) {
 	if canUnicode(ux.Unicode) {
 		esc.Dash = "–" // that's an en dash (so yaml is happy)
+		esc.Ellipsis = "…"
 		esc.UpArrow = "↑"
 		esc.Tick = "✓"
 		esc.Star = "✪"
 	} else {
 		esc.Dash = "--" // two dashes keeps yaml happy also
+		esc.Ellipsis = "..."
 		esc.UpArrow = "^"
 		esc.Tick = "**"
 		esc.Star = "*"
@@ -118,7 +120,17 @@ type Escapes struct {
 	Bold         string
 	End          string
 
-	Tick, Dash, UpArrow, Star string
+	hyperlink  string
+	terminator string
+
+	Tick, Dash, Ellipsis, UpArrow, Star string
+}
+
+func (e *Escapes) MakeLink(text, url, fallback string) string {
+	if e.hyperlink == "" {
+		return fallback
+	}
+	return e.hyperlink + url + e.terminator + text + e.hyperlink + e.terminator
 }
 
 var (
@@ -127,6 +139,8 @@ var (
 		BrightYellow: "\033[93m",
 		Bold:         "\033[1m",
 		End:          "\033[0m",
+		hyperlink:    "\033]8;;",
+		terminator:   "\033\\",
 	}
 
 	mono = Escapes{
@@ -134,6 +148,8 @@ var (
 		BrightYellow: "\033[2m", // dim
 		Bold:         "\033[1m",
 		End:          "\033[0m",
+		hyperlink:    "\033]8;;",
+		terminator:   "\033\\",
 	}
 
 	noesc = Escapes{}

--- a/cmd/internal/cmdutil/color.go
+++ b/cmd/internal/cmdutil/color.go
@@ -126,14 +126,6 @@ type Escapes struct {
 	Tick, Dash, Ellipsis, UpArrow, Star string
 }
 
-// EmptyDash returns a YAML-safe dash if the string is empty; otherwise returns the string.
-func (e *Escapes) EmptyDash(s string) string {
-	if s == "" {
-		return e.Dash
-	}
-	return s
-}
-
 func (e *Escapes) MakeLink(text, url, fallback string) string {
 	if e.hyperlink == "" {
 		return fallback

--- a/cmd/internal/cmdutil/color.go
+++ b/cmd/internal/cmdutil/color.go
@@ -17,7 +17,7 @@
  *
  */
 
-package main
+package cmdutil
 
 import (
 	"os"
@@ -26,38 +26,36 @@ import (
 	"golang.org/x/term"
 )
 
-var isStdinTTY = term.IsTerminal(0)
-
-type unicodeMixin struct {
+type UnicodeMixin struct {
 	Unicode string
 }
 
-func (ux unicodeMixin) addUnicodeChars(esc *escapes) {
+func (ux UnicodeMixin) addUnicodeChars(esc *Escapes) {
 	if canUnicode(ux.Unicode) {
-		esc.dash = "–" // that's an en dash (so yaml is happy)
-		esc.uparrow = "↑"
-		esc.tick = "✓"
-		esc.star = "✪"
+		esc.Dash = "–" // that's an en dash (so yaml is happy)
+		esc.UpArrow = "↑"
+		esc.Tick = "✓"
+		esc.Star = "✪"
 	} else {
-		esc.dash = "--" // two dashes keeps yaml happy also
-		esc.uparrow = "^"
-		esc.tick = "**"
-		esc.star = "*"
+		esc.Dash = "--" // two dashes keeps yaml happy also
+		esc.UpArrow = "^"
+		esc.Tick = "**"
+		esc.Star = "*"
 	}
 }
 
-func (ux unicodeMixin) getEscapes() *escapes {
-	esc := &escapes{}
+func (ux UnicodeMixin) GetEscapes() *Escapes {
+	esc := &Escapes{}
 	ux.addUnicodeChars(esc)
 	return esc
 }
 
-type colorMixin struct {
+type ColorMixin struct {
 	Color string
-	unicodeMixin
+	UnicodeMixin
 }
 
-func (mx colorMixin) getEscapes() *escapes {
+func (mx ColorMixin) GetEscapes() *Escapes {
 	esc := colorTable(mx.Color)
 	mx.addUnicodeChars(&esc)
 	return &esc
@@ -89,7 +87,7 @@ func canUnicode(mode string) bool {
 
 var isStdoutTTY = term.IsTerminal(1)
 
-func colorTable(mode string) escapes {
+func colorTable(mode string) Escapes {
 	switch mode {
 	case "always":
 		return color
@@ -114,29 +112,29 @@ func colorTable(mode string) escapes {
 	return color
 }
 
-type escapes struct {
-	green        string
-	brightYellow string
-	bold         string
-	end          string
+type Escapes struct {
+	Green        string
+	BrightYellow string
+	Bold         string
+	End          string
 
-	tick, dash, uparrow, star string
+	Tick, Dash, UpArrow, Star string
 }
 
 var (
-	color = escapes{
-		green:        "\033[32m",
-		brightYellow: "\033[93m",
-		bold:         "\033[1m",
-		end:          "\033[0m",
+	color = Escapes{
+		Green:        "\033[32m",
+		BrightYellow: "\033[93m",
+		Bold:         "\033[1m",
+		End:          "\033[0m",
 	}
 
-	mono = escapes{
-		green:        "\033[1m", // bold
-		brightYellow: "\033[2m", // dim
-		bold:         "\033[1m",
-		end:          "\033[0m",
+	mono = Escapes{
+		Green:        "\033[1m", // bold
+		BrightYellow: "\033[2m", // dim
+		Bold:         "\033[1m",
+		End:          "\033[0m",
 	}
 
-	noesc = escapes{}
+	noesc = Escapes{}
 )

--- a/cmd/internal/cmdutil/color_test.go
+++ b/cmd/internal/cmdutil/color_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package main
+package cmdutil
 
 import (
 	"os"
@@ -26,9 +26,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-type colorSuite struct {
-	BaseWorkshopSuite
-}
+type colorSuite struct{}
 
 var _ = check.Suite(&colorSuite{})
 

--- a/cmd/internal/cmdutil/export_test.go
+++ b/cmd/internal/cmdutil/export_test.go
@@ -1,0 +1,17 @@
+package cmdutil
+
+var (
+	CanUnicode      = canUnicode
+	ColorTable      = colorTable
+	MonoColorTable  = mono
+	ColorColorTable = color
+	NoEscColorTable = noesc
+)
+
+func MockIsStdoutTTY(t bool) (restore func()) {
+	oldIsStdoutTTY := isStdoutTTY
+	isStdoutTTY = t
+	return func() {
+		isStdoutTTY = oldIsStdoutTTY
+	}
+}

--- a/cmd/internal/cmdutil/util.go
+++ b/cmd/internal/cmdutil/util.go
@@ -2,7 +2,10 @@ package cmdutil
 
 import (
 	"os"
+	"strconv"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // ContractHome makes a path nicer and shorter by contracting $HOME to '~'.
@@ -26,4 +29,29 @@ func EmptyDash(s string) string {
 		return "-"
 	}
 	return s
+}
+
+// EscapeYAMLScalar returns a YAML scalar which unmarshals to the given string.
+// The intended use case is to escape user-provided data when pretty-printing
+// YAML using a tabwriter. In the typical case it returns `s` unmodified. The
+// result should be escaped with \xff before passing to a tabwriter. See
+// https://pkg.go.dev/text/tabwriter#pkg-constants.
+func EscapeYAMLScalar(s string) string {
+	if strings.ContainsRune(s, '\n') {
+		// YAML library sometimes produces invalid multi-line scalars.
+		// See https://github.com/yaml/go-yaml/issues/76. More examples
+		// can be found in the seed corpus for FuzzEscapeYAMLScalar. We
+		// fall back to quotes to make the string fit on one line.
+		// Originally I used json.Marshal here but it doesn't escape
+		// \x7f, which seems to be required by YAML. Luckily Go only
+		// uses standard escape sequences and YAML supports \x??.
+		return strconv.Quote(s)
+	}
+
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		// This is likely unreachable, fall back to above approach.
+		return strconv.Quote(s)
+	}
+	return strings.TrimSuffix(string(data), "\n")
 }

--- a/cmd/internal/cmdutil/util_test.go
+++ b/cmd/internal/cmdutil/util_test.go
@@ -1,11 +1,18 @@
 package cmdutil
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"text/tabwriter"
+	"unicode/utf8"
 
 	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
 )
 
 type cmdUtil struct {
@@ -25,4 +32,71 @@ func (m *cmdUtil) TestHomeDirectoryPathContraction(c *check.C) {
 	c.Assert(r, check.Equals, "~")
 	r = ContractHome("/sys")
 	c.Assert(r, check.Equals, "/sys")
+}
+
+func FuzzEscapeYAMLScalar(f *testing.F) {
+	// Some examples we expect to see in `workshop info`.
+	f.Add("dev", uint32(13111961))
+	f.Add("-", uint32(12966890))
+	f.Add("–", uint32(13148641))
+	f.Add("~/project", uint32(14853889))
+	f.Add("[::1]:8080", uint32(2130201))
+	f.Add("@socket", uint32(8336348))
+	// Tricky cases found by the fuzzer.
+	f.Add("\n", uint32(3667180))
+	f.Add("\n0", uint32(115407))
+	f.Add("0\n\n", uint32(7803534))
+	f.Add("0\t\n", uint32(5590977))
+	f.Add("\t0\n", uint32(3785866))
+	// Prevents using json.Marshal to escape multiline strings.
+	f.Add("\n\x7f", uint32(3830174))
+	// This one only appears if mixing YAML v3 and v4.
+	f.Add("0b+0", uint32(14161959))
+
+	f.Fuzz(func(t *testing.T, s string, lengths uint32) {
+		if !utf8.ValidString(s) {
+			t.SkipNow()
+		}
+
+		// Generate example YAML, e.g.
+		// aaa: xxxxx
+		// bb: "\x7x\n\n"
+		// ccccc: zzz
+		// The lengths of surrounding keys and values are determined by
+		// the lowest 24 bits of `lengths`, to attempt to approximate
+		// a real-world scenario.
+		a := strings.Repeat("a", int(lengths&0xf)+1)
+		lengths >>= 4
+		b := strings.Repeat("b", int(lengths&0xf)+1)
+		lengths >>= 4
+		c := strings.Repeat("c", int(lengths&0xf)+1)
+		lengths >>= 4
+
+		x := strings.Repeat("x", int(lengths&0x3f)+1)
+		lengths >>= 6
+		z := strings.Repeat("z", int(lengths&0x3f)+1)
+
+		var out bytes.Buffer
+		w := tabwriter.NewWriter(&out, 4, 3, 2, ' ', tabwriter.StripEscape)
+		tabescape := []byte{tabwriter.Escape}
+
+		fmt.Fprintf(w, "%s:\t%s\n", a, x)
+		fmt.Fprintf(w, "%s:\t%s%s%s\n", b, tabescape, EscapeYAMLScalar(s), tabescape)
+		fmt.Fprintf(w, "%s:\t%s\n", c, z)
+
+		w.Flush()
+		var result any
+		if err := yaml.Unmarshal(out.Bytes(), &result); err != nil {
+			t.Fatalf("cannot unmarshal %q: %v", s, err)
+		}
+
+		expected := map[string]any{
+			a: x,
+			b: s,
+			c: z,
+		}
+		if !reflect.DeepEqual(result, expected) {
+			t.Errorf("unexpected YAML round trip for %q", s)
+		}
+	})
 }

--- a/cmd/internal/cmdutil/util_test.go
+++ b/cmd/internal/cmdutil/util_test.go
@@ -3,16 +3,19 @@ package cmdutil
 import (
 	"os"
 	"path/filepath"
+	"testing"
 
 	"gopkg.in/check.v1"
 )
 
-type cmdUtils struct {
+type cmdUtil struct {
 }
 
-var _ = check.Suite(&cmdUtils{})
+func Test(t *testing.T) { check.TestingT(t) }
 
-func (m *cmdUtils) TestHomeDirectoryPathContraction(c *check.C) {
+var _ = check.Suite(&cmdUtil{})
+
+func (m *cmdUtil) TestHomeDirectoryPathContraction(c *check.C) {
 	home, _ := os.UserHomeDir()
 	r := ContractHome(filepath.Join(home, "test"))
 	c.Assert(r, check.Equals, "~/test")

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -16,6 +16,7 @@ import (
 )
 
 type CmdInfo struct {
+	cmdutil.ColorMixin
 	root *CmdRoot
 }
 
@@ -57,8 +58,10 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		return cmp.Compare(a.ProjectPath, b.ProjectPath)
 	})
 
+	esc := c.GetEscapes()
+
 	fmt.Fprintf(Stdout, "name: %s\n", info.Name)
-	fmt.Fprintf(Stdout, "summary: %s\n", cmdutil.EmptyDash(info.Summary))
+	fmt.Fprintf(Stdout, "summary: %s\n", esc.EmptyDash(info.Summary))
 
 	if info.Description != "" {
 		fmt.Fprintln(Stdout, "description: |")
@@ -68,7 +71,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 			fmt.Fprintf(Stdout, "  %s\n", line)
 		}
 	} else {
-		fmt.Fprintln(Stdout, "description: -")
+		fmt.Fprintf(Stdout, "description: %s", esc.Dash)
 	}
 
 	if len(info.Installed) > 0 {

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -59,25 +59,33 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	})
 
 	esc := c.GetEscapes()
+	escape := func(s string) []byte {
+		if s == "" || s == "-" {
+			s = esc.Dash
+		}
+		s = cmdutil.EscapeYAMLScalar(s)
+		e := []byte{tabwriter.Escape}
+		return fmt.Appendf(nil, "%s%s%s", e, s, e)
+	}
 
-	fmt.Fprintf(Stdout, "name: %s\n", info.Name)
-	fmt.Fprintf(Stdout, "summary: %s\n", esc.EmptyDash(info.Summary))
+	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
+	fmt.Fprintf(w, "name:\t%s\n", info.Name)
+	fmt.Fprintf(w, "summary:\t%s\n", escape(info.Summary))
 
 	if info.Description != "" {
-		fmt.Fprintln(Stdout, "description: |")
+		fmt.Fprintln(w, "description: |")
 		description := strings.TrimSuffix(info.Description, "\n")
 		lines := strings.Split(description, "\n")
 		for _, line := range lines {
-			fmt.Fprintf(Stdout, "  %s\n", line)
+			fmt.Fprintf(w, "  %s\n", line)
 		}
 	} else {
-		fmt.Fprintf(Stdout, "description: %s", esc.Dash)
+		fmt.Fprintf(w, "description:\t%s", esc.Dash)
 	}
 
 	if len(info.Installed) > 0 {
-		fmt.Fprintln(Stdout, "installed:")
+		fmt.Fprintln(w, "installed:")
 	}
-	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', 0)
 	for _, it := range info.Installed {
 		project := cmdutil.ContractHome(it.ProjectPath)
 		channel := cmdutil.EmptyDash(it.Channel)

--- a/cmd/sdk/info_test.go
+++ b/cmd/sdk/info_test.go
@@ -67,8 +67,8 @@ func (s *sdkSuite) TestInfo(c *check.C) {
 	cmd.SetArgs([]string{"info", "openvino"})
 	c.Assert(cmd.Execute(), check.IsNil)
 
-	want := fmt.Sprintf(`name: openvino
-summary: ROS2 development environment
+	want := fmt.Sprintf(`name:     openvino
+summary:  ROS2 development environment
 description: |
   Longer description
   can be multiline.

--- a/cmd/sdk/list.go
+++ b/cmd/sdk/list.go
@@ -58,7 +58,7 @@ func (c *CmdList) Run(cmd *cobra.Command, _ []string) error {
 		return cmp.Compare(a.Name, b.Name)
 	})
 
-	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', 0)
+	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
 	maxSize := 0
 	for _, sdk := range sdks {
 		szl := len(units.GetByteSizeString(int64(sdk.Size), 2))

--- a/cmd/workshop/export_test.go
+++ b/cmd/workshop/export_test.go
@@ -1,39 +1,9 @@
 package main
 
 var (
-	CanUnicode           = canUnicode
-	ColorTable           = colorTable
-	MonoColorTable       = mono
-	ColorColorTable      = color
-	NoEscColorTable      = noesc
-	ColorMixinGetEscapes = (colorMixin).getEscapes
-
 	MaybePresentWarnings  = maybePresentWarnings
 	WriteWarningTimestamp = writeWarningTimestamp
 )
-
-func MockIsStdoutTTY(t bool) (restore func()) {
-	oldIsStdoutTTY := isStdoutTTY
-	isStdoutTTY = t
-	return func() {
-		isStdoutTTY = oldIsStdoutTTY
-	}
-}
-
-func MockIsStdinTTY(t bool) (restore func()) {
-	oldIsStdinTTY := isStdinTTY
-	isStdinTTY = t
-	return func() {
-		isStdinTTY = oldIsStdinTTY
-	}
-}
-
-func ColorMixin(cmode, umode string) colorMixin {
-	return colorMixin{
-		Color:        cmode,
-		unicodeMixin: unicodeMixin{Unicode: umode},
-	}
-}
 
 func MockTextEditor(f func(inPath string, inContent []byte) ([]byte, error)) (restore func()) {
 	old := runTextEditor

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -116,6 +117,14 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	esc := c.GetEscapes()
+	escape := func(s string) []byte {
+		if s == "" || s == "-" {
+			s = esc.Dash
+		}
+		s = cmdutil.EscapeYAMLScalar(s)
+		e := []byte{tabwriter.Escape}
+		return fmt.Appendf(nil, "%s%s%s", e, s, e)
+	}
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = ""
@@ -124,7 +133,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	w := tabWriter()
 	fmt.Fprintf(w, "name:\t%s\n", workshop.Name)
 	fmt.Fprintf(w, "base:\t%s\n", workshop.Base)
-	fmt.Fprintf(w, "project:\t%s\n", cmdutil.ContractHome(project.Path))
+	fmt.Fprintf(w, "project:\t%s\n", escape(cmdutil.ContractHome(project.Path)))
 	fmt.Fprintf(w, "status:\t%s\n", strings.ToLower(workshop.Status))
 
 	// get the workshop notes
@@ -138,7 +147,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	// combine notes from workshop and its SDKs
-	notesFormatted := esc.EmptyDash(strings.Join(notes, ","))
+	notesFormatted := escape(strings.Join(notes, ","))
 	fmt.Fprintf(w, "notes:\t%s\n", notesFormatted)
 
 	if len(workshop.Sdks) > 0 {
@@ -158,7 +167,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 			// Tracking info is always the same for the system SDK. Omit it to
 			// highlight the difference between it and a regular type SDK.
 			if !sdk.IsSystem(sk.Name) {
-				fmt.Fprintf(w, "    tracking:\t%s\n", esc.EmptyDash(tracking))
+				fmt.Fprintf(w, "    tracking:\t%s\n", escape(tracking))
 			}
 
 			var buildTime string
@@ -171,7 +180,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 			}
 			fmt.Fprintf(w, "    installed:%s%s\t(%s)\n", version, buildTime, sk.Revision)
 			if sk.Health != nil {
-				fmt.Fprintf(w, "    message:\t%s\n", sk.Health.Message)
+				fmt.Fprintf(w, "    message:\t%s\n", escape(sk.Health.Message))
 			}
 
 			if len(sk.Mounts) > 0 {
@@ -180,17 +189,17 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 				for _, mount := range sk.Mounts {
 					text := shortenDefaultPath(mount.HostSource, xdg, esc)
 					link := "file://" + hostname + mount.HostSource
-					fallback := cmdutil.ContractHome(mount.HostSource)
+					fallback := string(escape(cmdutil.ContractHome(mount.HostSource)))
 					if mount.HostSource != "" {
 						fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
 						fmt.Fprintf(w, "        host-source:\t%s\n", esc.MakeLink(text, link, fallback))
-						fmt.Fprintf(w, "        workshop-target:\t%s\n", mount.WorkshopTarget)
+						fmt.Fprintf(w, "        workshop-target:\t%s\n", escape(mount.WorkshopTarget))
 						continue
 					}
 					if mount.WorkshopSource != "" {
 						fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
-						fmt.Fprintf(w, "        workshop-source:\t%s\n", mount.WorkshopSource)
-						fmt.Fprintf(w, "        workshop-target:\t%s\n", mount.WorkshopTarget)
+						fmt.Fprintf(w, "        workshop-source:\t%s\n", escape(mount.WorkshopSource))
+						fmt.Fprintf(w, "        workshop-target:\t%s\n", escape(mount.WorkshopTarget))
 						continue
 					}
 				}
@@ -203,8 +212,8 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 				})
 				for _, tunnel := range sk.Tunnels {
 					fmt.Fprintf(w, "      %s:\n", tunnel.Plug.Name)
-					fmt.Fprintf(w, "        from:\t%s\n", formatEndpoint(tunnel.From))
-					fmt.Fprintf(w, "        to:\t%s\n", formatEndpoint(tunnel.To))
+					fmt.Fprintf(w, "        from:\t%s\n", escape(formatEndpoint(tunnel.From)))
+					fmt.Fprintf(w, "        to:\t%s\n", escape(formatEndpoint(tunnel.To)))
 				}
 			}
 		}

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -20,7 +20,7 @@ import (
 )
 
 type CmdInfo struct {
-	waitMixin
+	cmdutil.ColorMixin
 	root *CmdRoot
 }
 
@@ -67,13 +67,13 @@ $ workshop info`,
 //
 // becomes:
 //
-//	.../17942561/mount/go/mod-cache
-func shortenDefaultPath(source, xdg string) string {
+//	…/17942561/mount/go/mod-cache
+func shortenDefaultPath(source, xdg string, esc *cmdutil.Escapes) string {
 	defaultPathPrefix := filepath.Join(xdg, "workshop", "id")
 	if after, ok := strings.CutPrefix(source, defaultPathPrefix); ok {
-		return "..." + after
+		return esc.Ellipsis + after
 	}
-	return source
+	return cmdutil.ContractHome(source)
 }
 
 func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
@@ -115,10 +115,16 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
+	esc := c.GetEscapes()
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = ""
+	}
+
 	w := tabWriter()
 	fmt.Fprintf(w, "name:\t%s\n", workshop.Name)
 	fmt.Fprintf(w, "base:\t%s\n", workshop.Base)
-	fmt.Fprintf(w, "project:\t%s\n", project.Path)
+	fmt.Fprintf(w, "project:\t%s\n", cmdutil.ContractHome(project.Path))
 	fmt.Fprintf(w, "status:\t%s\n", strings.ToLower(workshop.Status))
 
 	// get the workshop notes
@@ -172,10 +178,12 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 				fmt.Fprintf(w, "    mounts:\n")
 				slices.SortFunc(sk.Mounts, func(a, b *client.Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
 				for _, mount := range sk.Mounts {
-					hostSource := shortenDefaultPath(mount.HostSource, xdg)
+					text := shortenDefaultPath(mount.HostSource, xdg, esc)
+					link := "file://" + hostname + mount.HostSource
+					fallback := cmdutil.ContractHome(mount.HostSource)
 					if mount.HostSource != "" {
 						fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
-						fmt.Fprintf(w, "        host-source:\t%s\n", hostSource)
+						fmt.Fprintf(w, "        host-source:\t%s\n", esc.MakeLink(text, link, fallback))
 						fmt.Fprintf(w, "        workshop-target:\t%s\n", mount.WorkshopTarget)
 						continue
 					}

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -138,7 +138,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	// combine notes from workshop and its SDKs
-	notesFormatted := cmdutil.EmptyDash(strings.Join(notes, ","))
+	notesFormatted := esc.EmptyDash(strings.Join(notes, ","))
 	fmt.Fprintf(w, "notes:\t%s\n", notesFormatted)
 
 	if len(workshop.Sdks) > 0 {
@@ -158,7 +158,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 			// Tracking info is always the same for the system SDK. Omit it to
 			// highlight the difference between it and a regular type SDK.
 			if !sdk.IsSystem(sk.Name) {
-				fmt.Fprintf(w, "    tracking:\t%s\n", cmdutil.EmptyDash(tracking))
+				fmt.Fprintf(w, "    tracking:\t%s\n", esc.EmptyDash(tracking))
 			}
 
 			var buildTime string

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -188,7 +188,7 @@ var mockWorkshopWithMountsOutput = `name:     ws
 base:     ubuntu@22.04
 project:  %s
 status:   ready
-notes:    -
+notes:    --
 sdks:
   go:
     tracking:   latest/edge
@@ -368,7 +368,7 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkTunnels(c *check.C) {
 base:     ubuntu@22.04
 project:  %s
 status:   ready
-notes:    -
+notes:    --
 sdks:
   system:
     installed:  \(1\)

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -195,7 +195,7 @@ sdks:
     installed:  1.8.0  2017-02-19  \(1\)
     mounts:
       plug-default:
-        host-source:      .../17942561/ws/mount/go/mod-cache
+        host-source:      %s/workshop/id/17942561/ws/mount/go/mod-cache
         workshop-target:  /home/workshop/target
       plug-name:
         host-source:      /home/user/src
@@ -233,7 +233,7 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkMountsXdgUnset(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{workshop})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir))
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir, "~/.local/share"))
 	c.Check(n, check.Equals, 2)
 }
 
@@ -268,7 +268,7 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkMountsXdgSet(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{workshop})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir))
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir, "~/xdghomedir"))
 	c.Check(n, check.Equals, 2)
 }
 

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -322,12 +322,12 @@ var mockWorkshopWithTunnels = `{
             },
             "from": {
               "protocol": "tcp",
-              "host": "0.0.0.0",
+              "host": "::",
               "port": 12345
             },
             "to": {
               "protocol": "unix",
-              "path": "/run/snap-proxy.socket"
+              "path": "@snap-proxy"
             }
           }
         ]
@@ -381,8 +381,8 @@ sdks:
     installed:  1.8.0  2017-02-19  \(1\)
     tunnels:
       snap-cache:
-        from:  0.0.0.0:12345/tcp
-        to:    /run/snap-proxy.socket
+        from:  '\[::\]:12345/tcp'
+        to:    '@snap-proxy'
 `, m.prjDir, user.Uid))
 	c.Check(n, check.Equals, 2)
 }

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -171,5 +171,5 @@ func workshopEntry(w *client.WorkshopInfo, p client.Project) []string {
 
 func tabWriter() *tabwriter.Writer {
 	/* Tab writer uses the same formatting as snap list */
-	return tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', 0)
+	return tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
 }

--- a/cmd/workshop/wait.go
+++ b/cmd/workshop/wait.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/cmd/internal/cmdutil"
 	"github.com/canonical/workshop/internal/progress"
 )
 
@@ -41,7 +42,7 @@ type waitMixin struct {
 	skipAbort bool
 
 	verbose bool
-	colorMixin
+	cmdutil.ColorMixin
 }
 
 var errNoWait = errors.New("no wait for op")
@@ -206,7 +207,7 @@ func (wmx waitMixin) maybeShowLogs(pb progress.Meter, chg *client.Change) {
 	tasks := slices.Clone(chg.Tasks)
 	slices.SortFunc(tasks, sortByReady)
 
-	esc := wmx.getEscapes()
+	esc := wmx.GetEscapes()
 	for _, t := range tasks {
 		if t.Status == "Doing" || t.Status == "Done" || t.Status == "Error" {
 			cur := seenLines[t.ID]
@@ -221,7 +222,7 @@ func (wmx waitMixin) maybeShowLogs(pb progress.Meter, chg *client.Change) {
 			// We have shown all the task's logs and since it's in Done,
 			// there'll be now new lines.
 			if !summarised && t.Status == "Done" {
-				pb.Notify(esc.green + esc.tick + esc.end + " " + t.Summary)
+				pb.Notify(esc.Green + esc.Tick + esc.End + " " + t.Summary)
 				summarisedIds[t.ID] = true
 			}
 		}

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -37,12 +37,13 @@ import (
 	"golang.org/x/term"
 
 	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/cmd/internal/cmdutil"
 	"github.com/canonical/workshop/internal/osutil"
 )
 
 type CmdWarnings struct {
 	timeMixin
-	unicodeMixin
+	cmdutil.UnicodeMixin
 	root    *CmdRoot
 	All     bool
 	Verbose bool
@@ -188,7 +189,7 @@ func (c *CmdWarnings) Run(cmd *cobra.Command, av []string) error {
 		termWidth = 100
 	}
 
-	esc := c.getEscapes()
+	esc := c.GetEscapes()
 	w := tabWriter()
 	for i, warning := range warnings {
 		if i > 0 {
@@ -199,7 +200,7 @@ func (c *CmdWarnings) Run(cmd *cobra.Command, av []string) error {
 		}
 		fmt.Fprintf(w, "last-occurrence:\t%s\n", c.fmtTime(warning.LastAdded))
 		if c.Verbose {
-			lastShown := esc.dash
+			lastShown := esc.Dash
 			if !warning.LastShown.IsZero() {
 				lastShown = c.fmtTime(warning.LastShown)
 			}

--- a/tests/docs-tutorial/part-3/task.yaml
+++ b/tests/docs-tutorial/part-3/task.yaml
@@ -29,7 +29,7 @@ execute: |
   wq
   EOF
 
-  workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
 
   # workshop_exec exec nimble -- "source /var/lib/workshop/sdk/jupyter/venv/bin/activate && jupyter console -h"
 

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -20,7 +20,7 @@ execute: |
   check_original_binding
 
   echo "Check bound mount plugs use host directories of the plug they are bound to"
-  workshop_exec info | grep -v notes > mounts.log
+  workshop_exec info > mounts.log
   yq '.sdks["test-sdk-multiple-plugs"].mounts["one"]' < mounts.log | MATCH "^host-source:.*test-sdk-mount/one"
   yq '.sdks["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*test-sdk-multiple-plugs/two"
 
@@ -39,7 +39,7 @@ execute: |
   echo "Check remount affects all bound plugs"
   new_source="/home/ubuntu/remount-bound-test"
   workshop_exec remount ws-bind/test-sdk-mount:two "$new_source"
-  workshop_exec info | grep -v notes > mounts.log
+  workshop_exec info > mounts.log
   yq '.sdks["test-sdk-multiple-plugs"].mounts["two"]' < mounts.log | MATCH "^host-source:.*~/remount-bound-test"
   yq '.sdks["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*~/remount-bound-test"
 

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -40,8 +40,8 @@ execute: |
   new_source="/home/ubuntu/remount-bound-test"
   workshop_exec remount ws-bind/test-sdk-mount:two "$new_source"
   workshop_exec info | grep -v notes > mounts.log
-  yq '.sdks["test-sdk-multiple-plugs"].mounts["two"]' < mounts.log | MATCH "^host-source:.*$new_source"
-  yq '.sdks["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*$new_source"
+  yq '.sdks["test-sdk-multiple-plugs"].mounts["two"]' < mounts.log | MATCH "^host-source:.*~/remount-bound-test"
+  yq '.sdks["test-sdk-mount"].mounts["two"]' < mounts.log | MATCH "^host-source:.*~/remount-bound-test"
 
   echo "Check refresh respects binding"
   sed -i -e "0,/stable/s/stable/edge/" workshop.yaml

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -7,8 +7,8 @@ execute: |
   workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-basic[[:space:]]*Ready[[:space:]]*-"
   
   # Ensure there is one installed SDK that was provided in the workshop definition
-  workshop_exec info | grep -v notes | yq ".sdks | length == 1"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].tracking' | MATCH "latest/stable"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '^1\.0[[:space:]]+2025-04-03[[:space:]]+\([[:digit:]]+\)$'
+  workshop_exec info | yq ".sdks | length == 1"
+  workshop_exec info | yq '.sdks["test-sdk-basic"].tracking' | MATCH "latest/stable"
+  workshop_exec info | yq '.sdks["test-sdk-basic"].installed' | MATCH '^1\.0[[:space:]]+2025-04-03[[:space:]]+\([[:digit:]]+\)$'
 
   workshop_exec remove

--- a/tests/main/project-sdks/task.yaml
+++ b/tests/main/project-sdks/task.yaml
@@ -28,12 +28,12 @@ execute: |
   cd moved
   workshop_exec exec -- test -d /one/two/three
 
-  workshop_exec info | grep -v notes | yq '.sdks["one"].tracking' | MATCH "^$PWD/\\.workshop/one\$"
-  workshop_exec info | grep -v notes | yq '.sdks["one"].installed' | MATCH '\(x1\)$'
-  workshop_exec info | grep -v notes | yq '.sdks["two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
-  workshop_exec info | grep -v notes | yq '.sdks["two"].installed' | MATCH '\(x1\)$'
-  workshop_exec info | grep -v notes | yq '.sdks["three"].tracking' | MATCH "^$PWD/\\.workshop/three\$"
-  workshop_exec info | grep -v notes | yq '.sdks["three"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["one"].tracking' | MATCH "^$PWD/\\.workshop/one\$"
+  workshop_exec info | yq '.sdks["one"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
+  workshop_exec info | yq '.sdks["two"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["three"].tracking' | MATCH "^$PWD/\\.workshop/three\$"
+  workshop_exec info | yq '.sdks["three"].installed' | MATCH '\(x1\)$'
 
   echo "Break second SDK"
   echo false >> .workshop/two/sdk/hooks/setup-base
@@ -41,8 +41,8 @@ execute: |
   workshop_exec exec -- test -d /one/two/three
   workshop_exec exec -- test ! -f /restored-state
 
-  workshop_exec info | grep -v notes | yq '.sdks["two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
-  workshop_exec info | grep -v notes | yq '.sdks["two"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["two"].tracking' | MATCH "^$PWD/\\.workshop/two\$"
+  workshop_exec info | yq '.sdks["two"].installed' | MATCH '\(x1\)$'
 
   echo "Fix second SDK"
   sed 's@false@mkdir /two@' -i .workshop/two/sdk/hooks/setup-base
@@ -51,9 +51,9 @@ execute: |
   workshop_exec exec -- test -d /two
   workshop_exec exec -- test -f /restored-state
 
-  workshop_exec info | grep -v notes | yq '.sdks["one"].installed' | MATCH '\(x1\)$'
-  workshop_exec info | grep -v notes | yq '.sdks["two"].installed' | MATCH '\(x3\)$'
-  workshop_exec info | grep -v notes | yq '.sdks["three"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["one"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["two"].installed' | MATCH '\(x3\)$'
+  workshop_exec info | yq '.sdks["three"].installed' | MATCH '\(x1\)$'
 
   echo "Add a new plug"
   sed 's@ssh-agent@camera@' -i .workshop/one/sdk.yaml

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -14,11 +14,11 @@ execute: |
   test -d "$new_source"
 
   echo "Remount: check workshop info output"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*~/one"
+  workshop_exec info | yq '.sdks["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*~/one"
 
   echo "Remount: plugs remount sources are preserved after refresh"
   workshop_exec refresh
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*~/one"
+  workshop_exec info | yq '.sdks["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*~/one"
 
   echo "Remount: the new source is not empty"  
   workshop_exec remount ws-remount/test-sdk-mount:one /home/ubuntu  | MATCH '.*(source "/home/ubuntu" is not empty; workshop must be stopped to remount safely)'
@@ -27,9 +27,9 @@ execute: |
   new_source="/home/ubuntu/two"
   workshop_exec stop
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/two"
+  workshop_exec info | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/two"
   workshop_exec start
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/two"
+  workshop_exec info | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/two"
   test -d "$new_source"
 
   echo "Remount: new source is on a different filesystem"
@@ -41,7 +41,7 @@ execute: |
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path" | MATCH '.*(sources "/home/ubuntu/two" and "/home/ubuntu/other-fs/new" are not on the same mounted filesystem; workshop must be stopped to remount safely)'
   workshop_exec stop
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/other-fs/new"
+  workshop_exec info | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/other-fs/new"
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source"
   workshop_exec start
 

--- a/tests/main/remount/task.yaml
+++ b/tests/main/remount/task.yaml
@@ -14,11 +14,11 @@ execute: |
   test -d "$new_source"
 
   echo "Remount: check workshop info output"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*~/one"
 
   echo "Remount: plugs remount sources are preserved after refresh"
   workshop_exec refresh
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*$new_source"
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["one"]' | MATCH "^host-source:.*~/one"
 
   echo "Remount: the new source is not empty"  
   workshop_exec remount ws-remount/test-sdk-mount:one /home/ubuntu  | MATCH '.*(source "/home/ubuntu" is not empty; workshop must be stopped to remount safely)'
@@ -27,9 +27,9 @@ execute: |
   new_source="/home/ubuntu/two"
   workshop_exec stop
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/two"
   workshop_exec start
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$new_source"
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/two"
   test -d "$new_source"
 
   echo "Remount: new source is on a different filesystem"
@@ -41,7 +41,7 @@ execute: |
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path" | MATCH '.*(sources "/home/ubuntu/two" and "/home/ubuntu/other-fs/new" are not on the same mounted filesystem; workshop must be stopped to remount safely)'
   workshop_exec stop
   workshop_exec remount ws-remount/test-sdk-mount:two "$otherfs_path"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*$otherfs_path"
+  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-mount"].mounts["two"]' | MATCH "^host-source:.*~/other-fs/new"
   workshop_exec remount ws-remount/test-sdk-mount:two "$new_source"
   workshop_exec start
 

--- a/tests/main/sdk-info/header.txt
+++ b/tests/main/sdk-info/header.txt
@@ -1,5 +1,5 @@
-name: test-sdk-info
-summary: test-sdk-info summary
+name:     test-sdk-info
+summary:  test-sdk-info summary
 description: |
   test-sdk-info description
 installed:

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -13,16 +13,16 @@ execute: |
   q
   EOF
 
-  workshop_exec info | grep -v notes | yq '.sdks["sketch"].tracking' | MATCH '^~/.local/share/workshop/id/.*/ws-sketch/sdk/sketch'
-  workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["sketch"].tracking' | MATCH '^~/.local/share/workshop/id/.*/ws-sketch/sdk/sketch'
+  workshop_exec info | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
 
   echo "Stash current sketch SDK"
   workshop_exec sketch-sdk --stash
-  workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | NOMATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["sketch"].installed' | NOMATCH '\(x1\)$'
 
   echo "Restore sketch SDK"
   workshop_exec sketch-sdk --restore
-  workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
 
   echo "Add setup-base"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
@@ -33,7 +33,7 @@ execute: |
   wq
   EOF
 
-  workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x2\)$'
+  workshop_exec info | yq '.sdks["sketch"].installed' | MATCH '\(x2\)$'
 
   echo "Check refresh is not run if no updates to the sketch"
   output="$(sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
@@ -41,7 +41,7 @@ execute: |
   EOF
   )"
   [ -z "$output" ]
-  workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x2\)$'
+  workshop_exec info | yq '.sdks["sketch"].installed' | MATCH '\(x2\)$'
 
 
   echo "Add a new mount"
@@ -54,7 +54,7 @@ execute: |
   wq
   EOF
 
-  workshop_exec info | grep -v notes | yq '.sdks["sketch"].installed' | MATCH '\(x3\)$'
+  workshop_exec info | yq '.sdks["sketch"].installed' | MATCH '\(x3\)$'
   workshop_exec connections ws-sketch | MATCH "*.ws-sketch/sketch:sketch-plug.*:mount"
   workshop_exec exec -- mountpoint /home/workshop/ws-sketch-test
 

--- a/tests/main/try-sdks/task.yaml
+++ b/tests/main/try-sdks/task.yaml
@@ -18,21 +18,21 @@ execute: |
   workshop_exec launch
   workshop_exec exec -- findmnt /var/lib/workshop/sdk/test-sdk-basic | MATCH 'workshop/custom/default_test-sdk-basic-x1'
   try_area_contracted="~${try_area#*ubuntu}"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].tracking' | MATCH "^${try_area_contracted}\$"
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["test-sdk-basic"].tracking' | MATCH "^${try_area_contracted}\$"
+  workshop_exec info | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
 
   echo "Check try and in-project SDKs can share revision numbers"
   sed 's/try-test-sdk-basic/project-test-sdk-basic/' -i .workshop/dev.yaml
   workshop_exec exec -- test ! -f /in-project-marker
   workshop_exec refresh
   workshop_exec exec -- test -f /in-project-marker
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
 
   echo "Check existing try revisions are reused"
   sed 's/project-test-sdk-basic/try-test-sdk-basic/' -i .workshop/dev.yaml
   workshop_exec refresh
   workshop_exec exec -- test ! -f /in-project-marker
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
+  workshop_exec info | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x1\)$'
 
   echo "Check SDKs in try area can be updated"
   sudo -u ubuntu cp "$store_area/latest/edge/test-sdk-basic.sdk" "$try_area/test-sdk-basic_all.sdk"
@@ -40,5 +40,5 @@ execute: |
   sudo -u ubuntu cp "$store_area/latest/edge/sdk.yaml" "$try_area/test-sdk-basic_all.sdk.yaml"
 
   workshop_exec refresh
-  workshop_exec info | grep -v notes | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x2\)$'
+  workshop_exec info | yq '.sdks["test-sdk-basic"].installed' | MATCH '\(x2\)$'
   workshop_exec exec -- cat /var/lib/workshop/sdk/test-sdk-basic/sdk/hooks/setup-base | MATCH 'setup-base v2'


### PR DESCRIPTION
# Description

In `workshop info`, we abbreviate default `host-source` paths, since they are quite long. By attaching a hyperlink to the path, the user can see the full path if interested, and even click on it to open a file browser.

Most terminals support hyperlinks (https://github.com/Alhadis/OSC8-Adoption/) but not all display the full path on hover. I was hoping to update VTE to hide some details (`file://<HOSTNAME>`) but it seems like this has to be done on a per-terminal basis.

When the output is not a TTY, or colours are disabled in some way, the full path is now displayed (starting with `~` usually). In links the ellipsis is a single rune instead of `...`, to make it clear this is something Workshop added and not something like the parent directory shortcut `..`.

I also took the opportunity to improve a longstanding issue where `workshop info` doesn't typically print valid YAML. We use en dashes in place of ASCII dashes to avoid the most common issue. User-provided input is now escaped. I added some fuzzing to ensure this works reliably. It fixes tunnel endpoints which use IPv6 or abstract unix sockets. However, I haven't applied the escaping everywhere it might be needed. For example in `workshop info` there are lines like `installed: <VERSION> <BUILD TIME> (<REVISION>)` and there are no restrictions on `<VERSION>`.

Finally, `sdk info` now uses a `tabwriter` for all fields, not just the last ones.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
