### PR TITLE
Avoid adding UID and GID to abstract unix socket devices

### DIFF
--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/user"
 	"strconv"
+	"strings"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/osutil"
@@ -199,13 +200,13 @@ func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey stri
 	switch entry.Direction {
 	case workshop.WorkshopToHost:
 		device["bind"] = "instance"
-		if entry.Listen.Protocol == "unix" {
+		if entry.Listen.Protocol == "unix" && !strings.HasPrefix(entry.Listen.Address, "@") {
 			device["uid"] = workshop.User.Uid
 			device["gid"] = workshop.User.Gid
 		}
 	case workshop.HostToWorkshop:
 		device["bind"] = "host"
-		if entry.Listen.Protocol == "unix" {
+		if entry.Listen.Protocol == "unix" && !strings.HasPrefix(entry.Listen.Address, "@") {
 			device["uid"] = s.User.Uid
 			device["gid"] = s.User.Gid
 		}

--- a/tests/main/interface-tunnel/.workshop.yaml
+++ b/tests/main/interface-tunnel/.workshop.yaml
@@ -5,7 +5,7 @@ sdks:
     plugs:
       auto-connect-by-name:
         interface: tunnel
-        endpoint: 9999
+        endpoint: '@workshopacbn'
       conflict:
         interface: tunnel
         endpoint: '0.0.0.0:8000'


### PR DESCRIPTION
# Description

I noticed when testing https://github.com/canonical/workshop/pull/558 that abstract unix sockets don't work in tunnels. Not sure if I broke them or LXD got more strict about validation.

Currently, adding an abstract socket plug results in:
```console
$ workshop connect dev/sketch:abstr dev/system:abstr 
error: cannot perform the following tasks:
- Connect "dev/sketch:abstr" to "dev/system:abstr" (Device validation failed for "sketch_abstr": Only proxy devices for non-abstract unix sockets can carry uid, gid, or mode properties)
```

Workshop:
```yaml
name: dev
base: ubuntu@24.04
sdks:
  - name: system
    slots:
      abstr:
        interface: tunnel
        endpoint: 1234
```

SDK:
```yaml
name: sketch
plugs:
  abstr:
    interface: tunnel
    endpoint: '@foo'
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Or:

* [x] I confirm the PR has no implications for documentation.
