### PR TITLE
Ensure workshop info hyperlinks are valid

### DIFF
--- a/cmd/internal/cmdutil/color.go
+++ b/cmd/internal/cmdutil/color.go
@@ -20,6 +20,7 @@
 package cmdutil
 
 import (
+	"net/url"
 	"os"
 	"strings"
 
@@ -126,11 +127,11 @@ type Escapes struct {
 	Tick, Dash, Ellipsis, UpArrow, Star string
 }
 
-func (e *Escapes) MakeLink(text, url, fallback string) string {
+func (e *Escapes) MakeLink(text string, url *url.URL, fallback string) string {
 	if e.hyperlink == "" {
 		return fallback
 	}
-	return e.hyperlink + url + e.terminator + text + e.hyperlink + e.terminator
+	return e.hyperlink + url.String() + e.terminator + text + e.hyperlink + e.terminator
 }
 
 var (

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -74,7 +75,7 @@ func shortenDefaultPath(source, xdg string, esc *cmdutil.Escapes) string {
 	if after, ok := strings.CutPrefix(source, defaultPathPrefix); ok {
 		return esc.Ellipsis + after
 	}
-	return cmdutil.ContractHome(source)
+	return source
 }
 
 func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
@@ -187,12 +188,15 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 				fmt.Fprintf(w, "    mounts:\n")
 				slices.SortFunc(sk.Mounts, func(a, b *client.Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
 				for _, mount := range sk.Mounts {
-					text := shortenDefaultPath(mount.HostSource, xdg, esc)
-					link := "file://" + hostname + mount.HostSource
-					fallback := string(escape(cmdutil.ContractHome(mount.HostSource)))
+					hostSource := string(escape(cmdutil.ContractHome(mount.HostSource)))
+					shortened := shortenDefaultPath(mount.HostSource, xdg, esc)
+					if shortened != mount.HostSource {
+						link := &url.URL{Scheme: "file", Host: hostname, Path: mount.HostSource}
+						hostSource = esc.MakeLink(shortened, link, hostSource)
+					}
 					if mount.HostSource != "" {
 						fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
-						fmt.Fprintf(w, "        host-source:\t%s\n", esc.MakeLink(text, link, fallback))
+						fmt.Fprintf(w, "        host-source:\t%s\n", hostSource)
 						fmt.Fprintf(w, "        workshop-target:\t%s\n", escape(mount.WorkshopTarget))
 						continue
 					}

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -188,14 +188,14 @@ var mockWorkshopWithMountsOutput = `name:     ws
 base:     ubuntu@22.04
 project:  %s
 status:   ready
-notes:    --
+notes:    %s
 sdks:
   go:
     tracking:   latest/edge
     installed:  1.8.0  2017-02-19  \(1\)
     mounts:
       plug-default:
-        host-source:      %s/workshop/id/17942561/ws/mount/go/mod-cache
+        host-source:      %s
         workshop-target:  /home/workshop/target
       plug-name:
         host-source:      /home/user/src
@@ -233,7 +233,8 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkMountsXdgUnset(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{workshop})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir, "~/.local/share"))
+	hostSource := "~/.local/share/workshop/id/17942561/ws/mount/go/mod-cache"
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir, "--", hostSource))
 	c.Check(n, check.Equals, 2)
 }
 
@@ -251,12 +252,12 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkMountsXdgSet(c *check.C) {
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1:
+		case 1, 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
 			fmt.Fprintln(w, r)
-		case 2:
+		case 2, 4:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/%s", m.prjId, workshop))
 			w.WriteHeader(200)
@@ -268,8 +269,19 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkMountsXdgSet(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{workshop})
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir, "~/xdghomedir"))
+	hostSource := "~/xdghomedir/workshop/id/17942561/ws/mount/go/mod-cache"
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir, "--", hostSource))
 	c.Check(n, check.Equals, 2)
+
+	cmd.Color = "always"
+	cmd.Unicode = "always"
+	m.stdout.Reset()
+
+	err = cmd.Run(cmd.Command(), []string{workshop})
+	c.Assert(err, check.IsNil)
+	hostSource = "\033]8;;file://.*/home/testuser/xdghomedir/workshop/id/17942561/ws/mount/go/mod-cache\033\\\\…/17942561/ws/mount/go/mod-cache\033]8;;\033\\\\"
+	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(mockWorkshopWithMountsOutput, m.prjDir, "–", hostSource))
+	c.Check(n, check.Equals, 4)
 }
 
 var mockWorkshopWithTunnels = `{


### PR DESCRIPTION
# Description

`MakeLink` now takes a URL instead of a string, to encourage escaping URLs properly. Also, we no longer show links if the path was not abbreviated.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
