### PR TITLE
Drop config and devices from SDK snapshots

### DIFF
--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -91,8 +91,8 @@ func (s *apiSuite) workshopFile(ws string, sdks []*sdk.Info) *workshop.File {
 func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop.Workshop {
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
 	wf := s.workshopFile(w, []*sdk.Info{info})
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	wp, err := s.b.Workshop(s.ctx, w)
 	c.Check(err, check.IsNil)
@@ -127,8 +127,8 @@ func (s *apiSuite) mockInstalledSDKBoundPlug(c *check.C, yaml string, w string, 
 		Name:      to}
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
 	wf := s.workshopFile(w, []*sdk.Info{info})
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 	wp, err := s.b.Workshop(s.ctx, w)
 	c.Check(err, check.IsNil)
 	return wp

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -26,9 +26,9 @@ func (s *apiSuite) setupExec(c *check.C) *Command {
 	s.createWFile(c, "ws", wsYaml)
 
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Actions: map[string]workshop.Action{"lint": "\n\n\ngolangci-lint run\n"}}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
 
-	err := s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image)
+	err := s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
 	wp, err := s.b.Workshop(s.ctx, "ws")

--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -180,12 +180,12 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 	s.createWFile(c, "lerobot", "name: lerobot\nbase: ubuntu@20.04\n")
 
 	wf := &workshop.File{Name: "nav2", Base: "ubuntu@20.04"}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	wf = &workshop.File{Name: "lerobot", Base: "ubuntu@20.04"}
-	image = workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
+	snapshot = workshop.BaseOnly(wf.Base, "fakeimage123")
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	// Add SDK setups with channels so the endpoint can report channels.
 	meta := sdk.Meta{
@@ -275,8 +275,8 @@ func (s *apiSuite) TestSdkInfoGetInvalidMetadata(c *check.C) {
 
 	s.createWFile(c, "ws", "name: ws\nbase: ubuntu@20.04\n")
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, image), check.IsNil)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	meta := sdk.Meta{
 		Setup: sdk.Setup{

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -105,17 +105,14 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	s.secBackend = &ifacetest.TestSecurityBackend{BackendName: "api-suite"}
 	s.restoreSecBackend = ifacestate.MockSecurityBackends([]interfaces.SecurityBackend{s.secBackend})
 
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		if name != "testuser" {
-			return nil, nil, user.UnknownUserError("not found")
-		}
-		return s.user, nil, nil
-	})
 	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
 		if name != "testuser" {
 			return nil, user.UnknownUserError("not found")
 		}
 		return s.user, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
 	})
 }
 
@@ -127,6 +124,7 @@ func (s *apiSuite) TearDownTest(c *check.C) {
 	s.restoreRetrieve()
 	s.restoreProjectId()
 	s.restoreUserEnv()
+	s.restoreUserLookup()
 	s.restoreTime()
 	s.restoreSanitize()
 	s.restoreSecBackend()

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1747,6 +1747,35 @@ func (s *apiSuite) ensureSdkVolumesAfterCooldown(c *check.C, want []string) {
 	}
 }
 
+type launchOrRebuild struct {
+	file string
+	sdks []string
+}
+
+func (s *apiSuite) checkLaunchOrRebuildCalls(c *check.C, name string, args []launchOrRebuild) {
+	wpCalls := []fakebackend.LaunchOrRebuildCall{}
+	for _, sc := range s.b.LaunchOrRebuildCalls {
+		if sc.Workshop == name {
+			wpCalls = append(wpCalls, sc)
+		}
+	}
+
+	c.Assert(wpCalls, check.HasLen, len(args))
+
+	for i, arg := range args {
+		cached := wpCalls[i].Snapshot.Sdks
+		c.Assert(cached, check.HasLen, len(arg.sdks))
+		for j, sk := range arg.sdks {
+			c.Check(cached[j].Name, check.Equals, sk)
+		}
+
+		var f workshop.File
+		err := yaml.Unmarshal([]byte(arg.file), &f)
+		c.Assert(err, check.IsNil)
+		c.Assert(wpCalls[i].File, check.DeepEquals, &f)
+	}
+}
+
 func (s *apiSuite) checkSnapshotCalls(c *check.C, name string, sdks []string) {
 	wpCalls := []fakebackend.SnapshotCall{}
 	for _, sc := range s.b.SnapshotCalls {
@@ -1759,26 +1788,6 @@ func (s *apiSuite) checkSnapshotCalls(c *check.C, name string, sdks []string) {
 
 	for i, sk := range sdks {
 		c.Assert(wpCalls[i].Sdk, check.Equals, sk)
-	}
-}
-
-func (s *apiSuite) checkRestoreCalls(c *check.C, name string, sdks []string, files []string) {
-	wpCalls := []fakebackend.RestoreCall{}
-	for _, sc := range s.b.RestoreCalls {
-		if sc.Workshop == name {
-			wpCalls = append(wpCalls, sc)
-		}
-	}
-
-	c.Assert(wpCalls, check.HasLen, len(sdks))
-
-	for i, sk := range sdks {
-		c.Assert(wpCalls[i].Sdk, check.Equals, sk)
-
-		var f workshop.File
-		err := yaml.Unmarshal([]byte(files[i]), &f)
-		c.Assert(err, check.IsNil)
-		c.Assert(wpCalls[i].File, check.DeepEquals, &f)
 	}
 }
 
@@ -1915,9 +1924,17 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		"mount-conflict",
 	})
 
-	s.checkRestoreCalls(c, "basic", nil, nil)
-	s.checkRestoreCalls(c, "somebound", nil, nil)
-	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_allremoved})
+	s.checkLaunchOrRebuildCalls(c, "basic", []launchOrRebuild{
+		{basic, nil},
+	})
+
+	s.checkLaunchOrRebuildCalls(c, "somebound", []launchOrRebuild{
+		{somebound, nil},
+	})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_allremoved, []string{"system"}},
+	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "mount-conflict-1"})
 }
@@ -1999,7 +2016,10 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic_refreshed})
+	s.checkLaunchOrRebuildCalls(c, "basic", []launchOrRebuild{
+		{basic, nil},
+		{basic_refreshed, []string{"system"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
@@ -2079,7 +2099,10 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 		"test-sdk",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_extended})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_extended, []string{"system"}},
+	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1", "test-sdk-3-1"})
 }
@@ -2152,7 +2175,10 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk"}, []string{manysdks_minusone})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_minusone, []string{"system", "test-sdk"}},
+	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"test-sdk-1", "system-1"})
 }
@@ -2231,7 +2257,10 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_newchan})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_newchan, []string{"system"}},
+	})
 }
 
 func updateSdkStoreRev(name string, rev int, meta string) func() {
@@ -2321,7 +2350,10 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks, []string{"system"}},
+	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{
 		"system-1",
@@ -2574,7 +2606,10 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_try})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks_try, nil},
+		{manysdks_try, []string{"system"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
@@ -2683,7 +2718,10 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"system"}, []string{manysdks_project})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks_project, nil},
+		{manysdks_project, []string{"system"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
@@ -2759,7 +2797,10 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks_connsadded})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_connsadded, []string{"system", "test-sdk", "test-sdk-2"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
@@ -2837,7 +2878,10 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks_plugadded})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_plugadded, []string{"system", "test-sdk", "test-sdk-2"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
@@ -2908,7 +2952,10 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk"}, []string{manysdks_system_extended})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_system_extended, []string{"system", "test-sdk"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
@@ -2984,7 +3031,10 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks_plugadded, nil},
+		{manysdks, []string{"system", "test-sdk", "test-sdk-2"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
@@ -3058,7 +3108,9 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", nil, nil)
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1"})
 }
@@ -3134,7 +3186,10 @@ func (s *apiSuite) TestRefreshRestore(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks, []string{"system", "test-sdk", "test-sdk-2"}},
+	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1"})
 }
@@ -3215,7 +3270,10 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_newbase, nil},
+	})
 }
 
 func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
@@ -3310,7 +3368,10 @@ func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks, nil},
+	})
 }
 
 func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
@@ -3381,7 +3442,10 @@ func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
 		"test-sdk",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{}, []string{})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks_system, nil},
+		{manysdks_minusone, nil},
+	})
 }
 
 func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
@@ -3445,7 +3509,10 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "basic", []string{"system"}, []string{basic})
+	s.checkLaunchOrRebuildCalls(c, "basic", []launchOrRebuild{
+		{basic_refreshed, nil},
+		{basic, []string{"system"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
@@ -3522,7 +3589,10 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 		"test-sdk-2",
 	})
 
-	s.checkRestoreCalls(c, "manysdks", []string{"test-sdk-2"}, []string{manysdks_broken})
+	s.checkLaunchOrRebuildCalls(c, "manysdks", []launchOrRebuild{
+		{manysdks, nil},
+		{manysdks_broken, []string{"system", "test-sdk", "test-sdk-2"}},
+	})
 }
 
 func (s *apiSuite) TestRefreshNoRefreshInProgress(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -493,8 +493,8 @@ func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string) {
 	<-change.Ready()
 
 	st.Lock()
+	defer st.Unlock()
 	c.Assert(change.Err(), check.IsNil)
-	st.Unlock()
 }
 
 func (s *apiSuite) TestGetWorkshops(c *check.C) {

--- a/internal/interfaces/builtin/camera_test.go
+++ b/internal/interfaces/builtin/camera_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 type cameraSuite struct {
-	iface          interfaces.Interface
-	projectId      string
-	restoreUserEnv func()
+	iface             interfaces.Interface
+	projectId         string
+	restoreUserLookup func()
+	restoreUserEnv    func()
 }
 
 var _ = check.Suite(&cameraSuite{
@@ -25,13 +26,17 @@ var _ = check.Suite(&cameraSuite{
 
 func (s *cameraSuite) SetUpSuite(c *check.C) {
 	s.projectId = "42424242"
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, nil, nil
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &testuser, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
 	})
 }
 
 func (s *cameraSuite) TearDownSuite(c *check.C) {
 	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 func (s *cameraSuite) TestName(c *check.C) {

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -18,6 +18,8 @@ import (
 type desktopSuite struct {
 	iface     interfaces.Interface
 	projectId string
+
+	restoreUserLookup func()
 }
 
 var _ = check.Suite(&desktopSuite{
@@ -27,6 +29,14 @@ var _ = check.Suite(&desktopSuite{
 func (s *desktopSuite) SetUpSuite(c *check.C) {
 	s.projectId = "42424242"
 	testuser.HomeDir = c.MkDir()
+
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &testuser, nil
+	})
+}
+
+func (s *desktopSuite) TearDownSuite(c *check.C) {
+	s.restoreUserLookup()
 }
 
 func (s *desktopSuite) TestName(c *check.C) {
@@ -39,8 +49,8 @@ func (s *desktopSuite) TestInterfaces(c *check.C) {
 
 func (s *desktopSuite) TestDesktopInterfaceWayland(c *check.C) {
 	env := map[string]string{"XDG_RUNTIME_DIR": "/tmp", "WAYLAND_DISPLAY": "wayland-1"}
-	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, env, nil
+	defer osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return env, nil
 	})()
 
 	plug := builtin.MockPlug(c, `name: consumer
@@ -76,8 +86,8 @@ slots:
 
 func (s *desktopSuite) TestDesktopInterfaceX11(c *check.C) {
 	env := map[string]string{"DISPLAY": ":0"}
-	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, env, nil
+	defer osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return env, nil
 	})()
 
 	plug := builtin.MockPlug(c, `name: consumer
@@ -113,8 +123,8 @@ slots:
 
 func (s *desktopSuite) TestDesktopInterfaceBoth(c *check.C) {
 	env := map[string]string{"DISPLAY": ":2.0", "WAYLAND_DISPLAY": "/var/run/wayland-0"}
-	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, env, nil
+	defer osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return env, nil
 	})()
 
 	plug := builtin.MockPlug(c, `name: consumer
@@ -159,8 +169,8 @@ slots:
 
 func (s *desktopSuite) TestDesktopInterfaceXauth(c *check.C) {
 	env := map[string]string{"DISPLAY": ":0", "XAUTHORITY": "/tmp/.Xauthority"}
-	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, env, nil
+	defer osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return env, nil
 	})()
 
 	plug := builtin.MockPlug(c, `name: consumer
@@ -195,8 +205,8 @@ slots:
 
 func (s *desktopSuite) TestDesktopInterfaceXauthFail(c *check.C) {
 	env := map[string]string{"DISPLAY": ":0"}
-	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, env, nil
+	defer osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return env, nil
 	})()
 
 	plug := builtin.MockPlug(c, `name: consumer
@@ -223,8 +233,8 @@ slots:
 
 func (s *desktopSuite) TestDesktopEnvWaylandFail(c *check.C) {
 	env := map[string]string{}
-	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, env, nil
+	defer osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return env, nil
 	})()
 
 	plug := builtin.MockPlug(c, `name: consumer
@@ -249,8 +259,8 @@ slots:
 
 func (s *desktopSuite) TestDesktopEnvXDGFail(c *check.C) {
 	env := map[string]string{"XDG_RUNTIME_DIR": "", "WAYLAND_DISPLAY": "wayland-7"}
-	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, env, nil
+	defer osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return env, nil
 	})()
 
 	plug := builtin.MockPlug(c, `name: consumer
@@ -275,8 +285,8 @@ slots:
 
 func (s *desktopSuite) TestDesktopEnvX11Fail(c *check.C) {
 	env := map[string]string{"DISPLAY": "remote:0"}
-	defer osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, env, nil
+	defer osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return env, nil
 	})()
 
 	plug := builtin.MockPlug(c, `name: consumer

--- a/internal/interfaces/builtin/gpu_test.go
+++ b/internal/interfaces/builtin/gpu_test.go
@@ -14,9 +14,11 @@ import (
 )
 
 type gpuSuite struct {
-	iface          interfaces.Interface
-	projectId      string
-	restoreUserEnv func()
+	iface     interfaces.Interface
+	projectId string
+
+	restoreUserLookup func()
+	restoreUserEnv    func()
 }
 
 var _ = check.Suite(&gpuSuite{
@@ -25,13 +27,17 @@ var _ = check.Suite(&gpuSuite{
 
 func (s *gpuSuite) SetUpSuite(c *check.C) {
 	s.projectId = "42424242"
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, nil, nil
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &testuser, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
 	})
 }
 
 func (s *gpuSuite) TearDownSuite(c *check.C) {
 	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 func (s *gpuSuite) TestName(c *check.C) {

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -38,10 +38,12 @@ import (
 )
 
 type mountSuite struct {
-	iface          interfaces.Interface
-	projectId      string
-	restoreUserEnv func()
-	env            map[string]string
+	iface     interfaces.Interface
+	projectId string
+	env       map[string]string
+
+	restoreUserLookup func()
+	restoreUserEnv    func()
 }
 
 func Test(t *testing.T) {
@@ -56,13 +58,17 @@ func (s *mountSuite) SetUpSuite(c *check.C) {
 	s.projectId = "42424242"
 	testuser.HomeDir = c.MkDir()
 	s.env = make(map[string]string)
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, s.env, nil
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &testuser, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return s.env, nil
 	})
 }
 
 func (s *mountSuite) TearDownSuite(c *check.C) {
 	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 func (s *mountSuite) TestName(c *check.C) {

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -14,9 +14,11 @@ import (
 )
 
 type sshAgentSuite struct {
-	iface          interfaces.Interface
-	projectId      string
-	restoreUserEnv func()
+	iface     interfaces.Interface
+	projectId string
+
+	restoreUserLookup func()
+	restoreUserEnv    func()
 }
 
 var _ = check.Suite(&sshAgentSuite{
@@ -26,13 +28,17 @@ var _ = check.Suite(&sshAgentSuite{
 func (s *sshAgentSuite) SetUpTest(c *check.C) {
 	s.projectId = "42424242"
 	testuser.HomeDir = c.MkDir()
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, map[string]string{"SSH_AUTH_SOCK": "/tmp/dir/ssh"}, nil
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &testuser, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return map[string]string{"SSH_AUTH_SOCK": "/tmp/dir/ssh"}, nil
 	})
 }
 
 func (s *sshAgentSuite) TearDownTest(c *check.C) {
 	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 func (s *sshAgentSuite) TestName(c *check.C) {

--- a/internal/interfaces/builtin/tunnel_test.go
+++ b/internal/interfaces/builtin/tunnel_test.go
@@ -39,9 +39,11 @@ import (
 )
 
 type tunnelSuite struct {
-	iface          interfaces.Interface
-	projectId      string
-	restoreUserEnv func()
+	iface     interfaces.Interface
+	projectId string
+
+	restoreUserLookup func()
+	restoreUserEnv    func()
 }
 
 var _ = check.Suite(&tunnelSuite{
@@ -51,13 +53,17 @@ var _ = check.Suite(&tunnelSuite{
 func (s *tunnelSuite) SetUpSuite(c *check.C) {
 	s.projectId = "42424242"
 	testuser.HomeDir = c.MkDir()
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &testuser, nil, nil
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &testuser, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
 	})
 }
 
 func (s *tunnelSuite) TearDownSuite(c *check.C) {
 	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 func (s *tunnelSuite) TestName(c *check.C) {

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -33,7 +33,6 @@ var (
 	UserLookup        = user.Lookup
 	UserLookupGroup   = user.LookupGroup
 	UserEnv           = userEnvironment
-	UserAndEnv        = userAndEnv
 	CurrentUserAndEnv = currentUserAndEnv
 	Timezone          = timezone
 )
@@ -174,7 +173,7 @@ func UserMaybeSudoUser() (*user.User, error) {
 	return real, nil
 }
 
-func userAndEnv(name string) (*user.User, map[string]string, error) {
+func UserAndEnv(name string) (*user.User, map[string]string, error) {
 	usr, err := UserLookup(name)
 	if err != nil {
 		return nil, nil, err
@@ -253,13 +252,6 @@ func FakeUserEnvironment(f func(user *user.User) (map[string]string, error)) fun
 	UserEnv = f
 	return func() {
 		UserEnv = userEnvironment
-	}
-}
-
-func FakeUserAndEnv(f func(name string) (*user.User, map[string]string, error)) func() {
-	UserAndEnv = f
-	return func() {
-		UserAndEnv = userAndEnv
 	}
 }
 

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -113,8 +113,8 @@ var (
 
 func (s *healthSuite) launchWorkshopWithSDKs(c *check.C, sdks []workshop.SdkRecord, hooks map[string]map[string]string) *workshop.Workshop {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: sdks}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
@@ -201,11 +201,11 @@ func (s *healthSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("launch", "test")
-	task := s.state.NewTask("create-workshop", "test task")
-	task.Set("workshop", "ws")
-	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
-	task.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("project-id", s.project.ProjectId)
+	task := s.state.NewTask("create-workshop", "test task")
+	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
+	task.Set("snapshot", workshop.BaseOnly("ubuntu@20.04", "fakeimage123"))
+	setWorkshopProject("ws", s.project, task)
 	chg.AddTask(task)
 
 	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
@@ -222,12 +222,12 @@ func (s *healthSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("refresh", "test")
+	chg.Set("project-id", s.project.ProjectId)
 	chg.SetStatus(state.WaitStatus)
 	task := s.state.NewTask("create-workshop", "test task")
-	task.Set("workshop", "ws")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
-	task.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
-	chg.Set("project-id", s.project.ProjectId)
+	task.Set("snapshot", workshop.BaseOnly("ubuntu@20.04", "fakeimage123"))
+	setWorkshopProject("ws", s.project, task)
 	chg.AddTask(task)
 
 	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
@@ -244,6 +244,7 @@ func (s *healthSuite) TestWorkshopHealthSdkHealth(c *check.C) {
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("launch", "test")
+	chg.Set("project-id", s.project.ProjectId)
 	task := s.state.NewTask("run-hook", "test task")
 	healthCheck := healthstate.HealthCheck{
 		Sdk:         "one",
@@ -252,8 +253,7 @@ func (s *healthSuite) TestWorkshopHealthSdkHealth(c *check.C) {
 		Code:        "how-much-longer",
 	}
 	task.Set("health", healthCheck)
-	task.Set("workshop", "ws")
-	chg.Set("project-id", s.project.ProjectId)
+	setWorkshopProject("ws", s.project, task)
 	chg.AddTask(task)
 
 	workshop := s.launchWorkshopWithSDKs(c, oneSdk, nil)
@@ -285,12 +285,12 @@ func (s *healthSuite) TestCheckStatusPending(c *check.C) {
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("refresh", "test")
+	chg.Set("project-id", s.project.ProjectId)
 	chg.SetStatus(state.DoingStatus)
 	task := s.state.NewTask("create-workshop", "test task")
-	task.Set("workshop", "ws")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
-	task.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
-	chg.Set("project-id", s.project.ProjectId)
+	task.Set("snapshot", workshop.BaseOnly("ubuntu@20.04", "fakeimage123"))
+	setWorkshopProject("ws", s.project, task)
 	chg.AddTask(task)
 
 	workshop := s.launchWorkshopWithSDKs(c, nil, nil)
@@ -309,12 +309,12 @@ func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("refresh", "test")
+	chg.Set("project-id", s.project.ProjectId)
 	chg.SetStatus(state.WaitStatus)
 	task := s.state.NewTask("create-workshop", "test task")
-	task.Set("workshop", "ws")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
-	task.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
-	chg.Set("project-id", s.project.ProjectId)
+	task.Set("snapshot", workshop.BaseOnly("ubuntu@20.04", "fakeimage123"))
+	setWorkshopProject("ws", s.project, task)
 	chg.AddTask(task)
 
 	workshop := s.launchWorkshopWithSDKs(c, nil, nil)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -101,8 +101,8 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 
 	// Launch a workshop provinding no hooks
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 
 	s.state.Unlock()
@@ -522,8 +522,8 @@ func (s *hookSuite) TestHookWithMultipleHandlersIsError(c *check.C) {
 
 func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{{Name: "one", Channel: "latest/stable"}}}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -30,8 +30,8 @@ type interfaceHandlersSuite struct {
 	restoreSimple            func()
 	restoreDeny              func()
 	restoreSecurtityBackends func()
-	restoreUserEnv           func()
 	restoreUserLookup        func()
+	restoreUserEnv           func()
 }
 
 var _ = check.Suite(&interfaceHandlersSuite{})
@@ -157,6 +157,21 @@ func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 	s.restoreSimple = builtin.MockInterface(simpleIface{name: "mock-network"})
 	s.restoreDeny = builtin.MockInterface(denyAutoIface{name: "mock-ssh-agent"})
 
+	// Real UID and GID are required to create source directories on remount.
+	// TODO: make filesystem operations more secure (e.g. drop privileges if possible) and easy to test.
+	actual, err := user.Current()
+	c.Assert(err, check.IsNil)
+	s.user = &user.User{Username: "testuser", HomeDir: c.MkDir(), Uid: actual.Uid, Gid: actual.Gid}
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		if name != "testuser" {
+			return nil, user.UnknownUserError("not found")
+		}
+		return s.user, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
+
 	s.mgr = ifacestate.New(s.state, s.runner)
 	c.Assert(s.mgr, check.NotNil)
 
@@ -171,26 +186,8 @@ func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 
 	s.o.AddManager(s.mgr)
 	s.o.AddManager(s.runner)
-	err := s.o.StartUp()
+	err = s.o.StartUp()
 	c.Assert(err, check.IsNil)
-
-	// Real UID and GID are required to create source directories on remount.
-	// TODO: make filesystem operations more secure (e.g. drop privileges if possible) and easy to test.
-	actual, err := user.Current()
-	c.Assert(err, check.IsNil)
-	s.user = &user.User{Username: "testuser", HomeDir: c.MkDir(), Uid: actual.Uid, Gid: actual.Gid}
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		if name != "testuser" {
-			return nil, nil, user.UnknownUserError("not found")
-		}
-		return s.user, nil, nil
-	})
-	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
-		if name != "testuser" {
-			return nil, user.UnknownUserError("not found")
-		}
-		return s.user, nil
-	})
 }
 
 func (s *interfaceHandlersSuite) TearDownTest(c *check.C) {

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -124,8 +124,8 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []sdk
 	err = yaml.Unmarshal(workshopFile.Bytes(), &wf)
 	c.Assert(err, check.IsNil)
 
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	err = s.wsbackend.LaunchOrRebuildWorkshop(ctx, &wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err = s.wsbackend.LaunchOrRebuildWorkshop(ctx, &wf, snapshot)
 	c.Assert(err, check.IsNil)
 
 	wsfs, err := s.wsbackend.WorkshopFs(ctx, ws)

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"os/user"
 	"path/filepath"
 	"slices"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -34,7 +36,9 @@ type interfaceManagerSuite struct {
 	prj        workshop.Project
 	secBackend *ifacetest.TestSecurityBackend
 
-	restoreProjectId func()
+	restoreProjectId  func()
+	restoreUserLookup func()
+	restoreUserEnv    func()
 }
 
 var _ = check.Suite(&interfaceManagerSuite{})
@@ -42,6 +46,13 @@ var _ = check.Suite(&interfaceManagerSuite{})
 func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
 	var err error
+
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return nil, user.UnknownUserError("not found")
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
 
 	s.o = overlord.Fake()
 	s.state = s.o.State()
@@ -67,6 +78,8 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 
 func (s *interfaceManagerSuite) TearDownTest(c *check.C) {
 	s.restoreProjectId()
+	s.restoreUserEnv()
+	s.restoreUserLookup()
 	s.BaseTest.TearDownTest(c)
 }
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -148,8 +148,8 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 		{Name: "test", Channel: "latest/stable"},
 		{Name: "test-broken", Channel: "latest/stable"},
 	}}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 }
 

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -80,11 +80,11 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 		return fmt.Errorf("invalid workshop file: %w", err)
 	}
 
-	var sdkSnapshot string
+	var snapshot workshop.Snapshot
 	st.Lock()
-	err = task.Get("sdk-snapshot", &sdkSnapshot)
+	err = task.Get("snapshot", &snapshot)
 	st.Unlock()
-	if err != nil && !errors.Is(err, state.ErrNoState) {
+	if err != nil {
 		return fmt.Errorf("internal error: %q workshop snapshot not found (task ID: %s)", w, task.ID())
 	}
 
@@ -105,30 +105,18 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 		})
 	}
 
-	if sdkSnapshot == "" {
-		var image workshop.BaseImage
-		st.Lock()
-		err = task.Get("workshop-base", &image)
-		st.Unlock()
-		if err != nil {
-			return fmt.Errorf("internal error: %q workshop base image not found (task ID: %s)", w, task.ID())
-		}
+	if err := m.backend.LaunchOrRebuildWorkshop(ctx, &wf, snapshot); err != nil {
+		return err
+	}
 
-		if err := m.backend.LaunchOrRebuildWorkshop(ctx, &wf, image); err != nil {
-			return err
-		}
+	if snapshot.IsBase() {
 		// Create workshop base and run directories
 		fs, err := m.backend.WorkshopFs(ctx, wf.Name)
 		if err != nil {
 			return err
 		}
 		defer fs.Close()
-
 		if err = fs.MkdirAll(dirs.WorkshopRunDir, 0755); err != nil {
-			return err
-		}
-	} else {
-		if err = m.backend.Restore(ctx, w, sdkSnapshot, &wf); err != nil {
 			return err
 		}
 	}

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -131,8 +131,8 @@ func (s *workshopHandlers) TestStopPeriodicProgressUpdate(c *check.C) {
 	defer s.state.Unlock()
 	s.createWFile(c, "ws", wsFocal)
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 
 	t1, err := s.wrkmgr.StopMany(s.ctx, []string{"ws"}, s.project.ProjectId)
@@ -173,9 +173,9 @@ func (s *workshopHandlers) TestUndoStash(c *check.C) {
 		{Name: "test", Channel: "latest/stable"},
 		{Name: "test2", Channel: "latest/stable"},
 	}}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
 
-	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 
 	chg := s.state.NewChange("sample", "...")
@@ -223,8 +223,8 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
 
 	for _, wf := range wFiles {
-		image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-		err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, image)
+		snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+		err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 		c.Check(err, check.IsNil)
 
 		// create content directories
@@ -300,8 +300,8 @@ func (s *workshopHandlers) TestCreateWorkshopNoWorkshopDefinitionFound(c *check.
 
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("create-workshop", "...")
+	t1.Set("snapshot", workshop.BaseOnly("ubuntu@22.04", "fakeimage123"))
 	setWorkshopProject("ws", s.project, t1)
-	t1.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
@@ -324,7 +324,7 @@ func (s *workshopHandlers) TestCreateWorkshopWithSystemSdk(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("create-workshop", "...")
 	t1.Set("workshop-file", wsJammy)
-	t1.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
+	t1.Set("snapshot", workshop.BaseOnly("ubuntu@22.04", "fakeimage123"))
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
@@ -352,7 +352,7 @@ func (s *workshopHandlers) TestCreateWorkshopCleanup(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("create-workshop", "...")
 	t1.Set("workshop-file", wsJammy)
-	t1.Set("workshop-base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
+	t1.Set("snapshot", workshop.BaseOnly("ubuntu@22.04", "fakeimage123"))
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
@@ -383,8 +383,8 @@ func (s *workshopHandlers) TestRebuildWorkshopNoCleanup(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("rebuild-workshop", "...")
 	t1.Set("workshop-file", wsJammy)
-	image := workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage999"}
-	t1.Set("workshop-base", image)
+	snapshot := workshop.BaseOnly("ubuntu@22.04", "fakeimage123")
+	t1.Set("snapshot", snapshot)
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
@@ -400,7 +400,7 @@ func (s *workshopHandlers) TestRebuildWorkshopNoCleanup(c *check.C) {
 	c.Check(chg.Err(), check.ErrorMatches, `(?s).*\(fs is unavailable\)`)
 	ws, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
-	c.Check(ws.Image, check.Equals, image)
+	c.Check(ws.Image, check.Equals, snapshot.Image)
 }
 
 func (s *workshopHandlers) TestDownloadBase(c *check.C) {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -32,15 +32,17 @@ base: ubuntu@22.04
 `
 
 type workshopHandlers struct {
-	backend        *fakebackend.FakeWorkshopBackend
-	state          *state.State
-	runner         *state.TaskRunner
-	se             *overlord.StateEngine
-	wrkmgr         *workshopstate.WorkshopManager
-	ctx            context.Context
-	project        workshop.Project
-	user           *user.User
-	restoreUserEnv func()
+	backend *fakebackend.FakeWorkshopBackend
+	state   *state.State
+	runner  *state.TaskRunner
+	se      *overlord.StateEngine
+	wrkmgr  *workshopstate.WorkshopManager
+	ctx     context.Context
+	project workshop.Project
+	user    *user.User
+
+	restoreUserLookup func()
+	restoreUserEnv    func()
 }
 
 var _ = check.Suite(&workshopHandlers{})
@@ -88,11 +90,14 @@ func (s *workshopHandlers) SetUpTest(c *check.C) {
 		Uid:     actual.Uid,
 		Gid:     actual.Gid,
 	}
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
 		if name != "testuser" {
-			return nil, nil, user.UnknownUserError("not found")
+			return nil, user.UnknownUserError("not found")
 		}
-		return s.user, nil, nil
+		return s.user, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
 	})
 
 	s.state = state.New(nil)
@@ -118,6 +123,7 @@ func (s *workshopHandlers) SetUpTest(c *check.C) {
 
 func (s *workshopHandlers) TearDownTest(c *check.C) {
 	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 func (s *workshopHandlers) TestStopPeriodicProgressUpdate(c *check.C) {
@@ -198,14 +204,6 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	cacheDir := dirs.CacheDir
 	dirs.SetCacheDir(c.MkDir())
 	defer dirs.SetCacheDir(cacheDir)
-
-	restoreUserLookup := osutil.FakeUserLookup(func(name string) (*user.User, error) {
-		if name != "testuser" {
-			return nil, user.UnknownUserError("not found")
-		}
-		return s.user, nil
-	})
-	defer restoreUserLookup()
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -29,7 +29,8 @@ type managerSuite struct {
 	ctx     context.Context
 	project workshop.Project
 
-	restoreUserEnv func()
+	restoreUserEnv    func()
+	restoreUserLookup func()
 }
 
 var _ = check.Suite(&managerSuite{})
@@ -43,8 +44,11 @@ func (s *managerSuite) SetUpTest(c *check.C) {
 	s.runner = state.NewTaskRunner(s.state)
 	s.manager = workshopstate.New(s.state, s.runner)
 	ctx := context.WithValue(context.TODO(), workshop.ContextUser, "testuser")
-	s.restoreUserEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return &user.User{HomeDir: c.MkDir()}, nil, nil
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &user.User{HomeDir: c.MkDir()}, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
 	})
 
 	project, _, err := s.backend.CreateOrLoadProject(ctx, c.MkDir())
@@ -56,6 +60,7 @@ func (s *managerSuite) SetUpTest(c *check.C) {
 
 func (s *managerSuite) TearDownTest(c *check.C) {
 	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 func (s *managerSuite) TestAddHandlers(c *check.C) {

--- a/internal/overlord/workshopstate/manager_test.go
+++ b/internal/overlord/workshopstate/manager_test.go
@@ -99,8 +99,8 @@ func (s *managerSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@22.04"}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, snapshot)
 	c.Assert(err, check.IsNil)
 
 	workshop, err := s.backend.Workshop(s.ctx, ws)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -523,62 +523,57 @@ func installSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]str
 	return all
 }
 
-func launchWorkshop(st *state.State, name string, fileText string, image workshop.BaseImage) *state.TaskSet {
-	construct := state.NewTaskSet()
+// Like installSdks but we skip setup-base and snapshot-sdk after restoring
+// from a snapshot which already contains the setup-base modifications.
+func reinstallSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
+	all := state.NewTaskSet()
 
 	var prev *state.Task
 	addTask := func(t *state.Task) {
-		construct.AddTask(t)
+		all.AddTask(t)
 		if prev != nil {
 			t.WaitFor(prev)
 		}
 		prev = t
 	}
 
-	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", name))
-	addTask(create)
-	create.Set("workshop-file", fileText)
-	create.Set("workshop-base", image)
+	for _, setup := range sdks {
+		retrieveTask := retrieveTasks[setup.Name]
 
-	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", name))
-	addTask(start)
+		install := sdkstate.Install(st, setup.Name, retrieveTask)
+		addTask(install)
 
-	return construct
+		register := sdkstate.Register(st, setup.Name, retrieveTask)
+		addTask(register)
+	}
+	return all
 }
 
-func rebuildWorkshop(st *state.State, name string, fileText string, sdkSnapshot string, image workshop.BaseImage) *state.TaskSet {
-	construct := state.NewTaskSet()
+func launchWorkshop(st *state.State, name string, fileText string, snapshot workshop.Snapshot) *state.TaskSet {
+	create := st.NewTask("create-workshop", fmt.Sprintf("Create new %q workshop", name))
+	create.Set("workshop-file", fileText)
+	create.Set("snapshot", snapshot)
+	return state.NewTaskSet(create)
+}
 
-	var prev *state.Task
-	addTask := func(t *state.Task) {
-		construct.AddTask(t)
-		if prev != nil {
-			t.WaitFor(prev)
-		}
-		prev = t
-	}
-
+func rebuildWorkshop(st *state.State, name string, fileText string, snapshot workshop.Snapshot) *state.TaskSet {
 	var summary string
-	if sdkSnapshot == "" {
+	if snapshot.IsBase() {
 		summary = fmt.Sprintf("Rebuild %q workshop", name)
 	} else {
-		summary = fmt.Sprintf("Restore %q workshop from %q snapshot", name, sdkSnapshot)
+		last := snapshot.Sdks[len(snapshot.Sdks)-1].Name
+		summary = fmt.Sprintf("Restore %q workshop from %q snapshot", name, last)
 	}
 
 	create := st.NewTask("rebuild-workshop", summary)
-	addTask(create)
 	create.Set("workshop-file", fileText)
+	create.Set("snapshot", snapshot)
+	return state.NewTaskSet(create)
+}
 
-	if sdkSnapshot != "" {
-		create.Set("sdk-snapshot", sdkSnapshot)
-	} else {
-		create.Set("workshop-base", image)
-	}
-
+func startWorkshop(st *state.State, name string) *state.TaskSet {
 	start := st.NewTask("start-workshop", fmt.Sprintf("Start %q workshop", name))
-	addTask(start)
-
-	return construct
+	return state.NewTaskSet(start)
 }
 
 func launch(st *state.State, file *workshop.File, fileText string, image workshop.BaseImage, sdks []sdk.Setup, project workshop.Project) *state.TaskSet {
@@ -606,8 +601,12 @@ func launch(st *state.State, file *workshop.File, fileText string, image worksho
 	createDirs := st.NewTask("create-workshop-storage", fmt.Sprintf("Create %q storage directories", file.Name))
 	addTaskSet(state.NewTaskSet(createDirs))
 
-	create := launchWorkshop(st, file.Name, fileText, image)
+	snapshot := workshop.Snapshot{Image: image}
+	create := launchWorkshop(st, file.Name, fileText, snapshot)
 	addTaskSet(create)
+
+	start := startWorkshop(st, file.Name)
+	addTaskSet(start)
 
 	install := installSdks(st, sdks, rmap)
 	addTaskSet(install)
@@ -766,7 +765,6 @@ type refreshPlan struct {
 	refresh []sdk.Setup
 	remove  []sdk.Setup
 
-	sdkSnapshot    string
 	installOrder   []string
 	installedOrder []string
 
@@ -828,9 +826,8 @@ func resolveRefresh(w *workshop.Workshop, newfile *workshop.File, image workshop
 				break
 			}
 
-			plan.intact = append(plan.intact, s)
 			// No updates to the SDK - reuse its snapshot and keep looking.
-			plan.sdkSnapshot = s.Name
+			plan.intact = append(plan.intact, s)
 		}
 	}
 
@@ -884,10 +881,12 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 		prev = ts
 	}
 
+	snapshot := workshop.SdkSnapshot(plan.image, plan.Intact())
+
 	var base *state.Task
-	if plan.sdkSnapshot == "" {
+	if snapshot.IsBase() {
 		// Create download-base first so the task IDs are in a nice order.
-		base = retrieveBase(st, plan.image)
+		base = retrieveBase(st, snapshot.Image)
 	}
 	retrieve, rmap := retrieveSdks(st, plan.InstallOrRefresh())
 	if base != nil {
@@ -916,12 +915,16 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 	stash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
 	addTaskSet(state.NewTaskSet(stash))
 
-	rebuild := rebuildWorkshop(st, file.Name, fileText, plan.sdkSnapshot, plan.image)
+	rebuild := rebuildWorkshop(st, file.Name, fileText, snapshot)
 	addTaskSet(rebuild)
 
-	// Re-register intact SDKs (the workshop definition can change plugs and slots).
-	register := registerSdks(st, plan.Intact(), umap)
-	addTaskSet(register)
+	// Reinstall intact SDKs. The workshop definition can change plugs and
+	// slots, and SDKs need to be mounted after restoring a snapshot.
+	reinstall := reinstallSdks(st, plan.Intact(), umap)
+	addTaskSet(reinstall)
+
+	start := startWorkshop(st, file.Name)
+	addTaskSet(start)
 
 	// Install updated SDKs to the rebuilt workshop.
 	install := installSdks(st, plan.InstallOrRefresh(), rmap)
@@ -1005,21 +1008,6 @@ func autoconnectSdks(st *state.State, w string, sdks []sdk.Setup) *state.TaskSet
 		prev = autoconnect
 	}
 	return autoconnectSet
-}
-
-func registerSdks(st *state.State, sdks []sdk.Setup, retrieveTasks map[string]string) *state.TaskSet {
-	prev := (*state.Task)(nil)
-	registerSet := state.NewTaskSet()
-	for _, s := range sdks {
-		register := sdkstate.Register(st, s.Name, retrieveTasks[s.Name])
-		registerSet.AddTask(register)
-
-		if prev != nil {
-			register.WaitFor(prev)
-		}
-		prev = register
-	}
-	return registerSet
 }
 
 func unregisterSdks(st *state.State, sdks []sdk.Setup) (*state.TaskSet, map[string]string) {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -88,8 +88,8 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@20.04", Sdks: sdks}
-	image := workshop.BaseImage{Name: wf.Base, Fingerprint: "fakeimage123"}
-	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, image)
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, snapshot)
 	c.Assert(err, check.IsNil)
 
 	for _, sd := range sdks {

--- a/internal/sdk/revision.go
+++ b/internal/sdk/revision.go
@@ -50,6 +50,18 @@ func (r Revision) Store() bool {
 	return r.N > 0
 }
 
+func (r Revision) MarshalText() ([]byte, error) {
+	return []byte(r.String()), nil
+}
+
+func (r *Revision) UnmarshalText(text []byte) error {
+	parsed, err := ParseRevision(string(text))
+	if err == nil {
+		*r = parsed
+	}
+	return err
+}
+
 func (r Revision) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + r.String() + `"`), nil
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -95,6 +95,16 @@ func (s Source) NeedsRetrieve() bool {
 	return s == StoreSource || s == SystemSource
 }
 
+type Id struct {
+	Name     string
+	Sha3_384 string
+	IsVolume bool
+}
+
+func SetupId(setup Setup) Id {
+	return Id{Name: setup.Name, Sha3_384: setup.Sha3_384, IsVolume: setup.IsVolume()}
+}
+
 type sdkYaml struct {
 	Name        string                 `yaml:"name"`
 	Base        string                 `yaml:"base"`

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -93,6 +93,34 @@ type BaseImageManager interface {
 	DownloadBase(ctx context.Context, image BaseImage, report *progress.Reporter) error
 }
 
+// Snapshot identifies a workshop snapshot without depending on
+// backend-specific details. For example snapshot names in LXD are subject to
+// length limits and a restricted character set.
+type Snapshot struct {
+	Image BaseImage
+	Sdks  []sdk.Id
+}
+
+// BaseOnly identifies a "snapshot" which consists of a base image only.
+func BaseOnly(name, fingerprint string) Snapshot {
+	return Snapshot{Image: BaseImage{Name: name, Fingerprint: fingerprint}}
+}
+
+// SdkSnapshot identifies a snapshot consisting of a base image and a sequence
+// of installed SDKs.
+func SdkSnapshot(image BaseImage, sdks []sdk.Setup) Snapshot {
+	snapshot := Snapshot{Image: image, Sdks: make([]sdk.Id, 0, len(sdks))}
+	for _, s := range sdks {
+		snapshot.Sdks = append(snapshot.Sdks, sdk.SetupId(s))
+	}
+	return snapshot
+}
+
+// IsBase returns whether the snapshot is just a base image.
+func (s Snapshot) IsBase() bool {
+	return len(s.Sdks) == 0
+}
+
 type SdkManager interface {
 	// Import an SDK tarball as a new volume.
 	ImportSdk(ctx context.Context, meta sdk.Meta, tarball *os.File) error
@@ -143,7 +171,6 @@ type Backend interface {
 	Stash
 	BaseImageManager
 	SdkManager
-	Snapshot
 
 	// The backend will attempt to load a project for the given path
 	// using its mapping between the path and a project id. If the project
@@ -165,12 +192,15 @@ type Backend interface {
 	// Returns a list of workshops for the project in context.
 	ProjectWorkshops(ctx context.Context) ([]*Workshop, error)
 
-	// Launch a barebone workshop instance. If the workshop exists, wipe out its
-	// rootfs and rebuild it from the workshop file's base image. The
-	// configuration and devices of the rebuilt workshop will be reset to the
-	// default one. The given base fingerprint is combined with `file.Base` to
-	// determine the exact base image to use.
-	LaunchOrRebuildWorkshop(ctx context.Context, file *File, image BaseImage) error
+	// Launch a clean workshop instance. If the workshop exists, wipe out
+	// its rootfs and rebuild it from the given snapshot (which may be just
+	// a base image). Configuration and devices of the rebuilt workshop
+	// will be reset to the default one.
+	LaunchOrRebuildWorkshop(ctx context.Context, file *File, snapshot Snapshot) error
+
+	// Create a snapshot of the workshop's rootfs. Should be called after
+	// installing the given SDK.
+	Snapshot(ctx context.Context, workshop, sk string) error
 
 	// Delete workshop. Stop the workshop forcefully if not in Stopped before deleting
 	RemoveWorkshop(ctx context.Context, name string) error
@@ -204,11 +234,6 @@ type Backend interface {
 	// and redirect its IO using args.ExecControls. ExecContext.Environment will
 	// contain full (actual)
 	Exec(ctx context.Context, name string, args *Execution) (ExecContext, error)
-}
-
-type Snapshot interface {
-	Snapshot(ctx context.Context, workshop, sk string) error
-	Restore(ctx context.Context, workshop, sk string, file *File) error
 }
 
 type cachedBackendKey struct{}

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -613,7 +613,11 @@ func (b *FakeWorkshopBackend) InstallSdk(ctx context.Context, name string, setup
 		return fmt.Errorf("%q SDK is already installed", setup.Name)
 	}
 
-	wp.Sdks[setup.Name] = workshop.SdkInstallation{Setup: setup, InstallTime: workshop.InstallTimeNow()}
+	wp.Sdks[setup.Name] = workshop.SdkInstallation{
+		Setup:        setup,
+		InstallOrder: len(wp.Sdks) + 1,
+		InstallTime:  workshop.InstallTimeNow(),
+	}
 
 	userDataDir := filepath.Join(b.BaseDir, "share")
 	mount := workshop.SdkMount(userDataDir, projectId, name, setup)

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/x-go/strutil"
 
 	"github.com/canonical/workshop/internal/fsutil"
 	"github.com/canonical/workshop/internal/progress"
@@ -65,10 +67,10 @@ type SnapshotCall struct {
 	Sdk      string
 }
 
-type RestoreCall struct {
+type LaunchOrRebuildCall struct {
 	Workshop string
-	Sdk      string
 	File     *workshop.File
+	Snapshot workshop.Snapshot
 }
 
 type WorkshopFsCallback func(ctx context.Context, name string) (fsutil.Fs, error)
@@ -101,11 +103,10 @@ type FakeWorkshopBackend struct {
 
 	AttachVolumeCalls []AttachVolumeCall
 
-	snapshotLock     sync.Mutex
-	SnapshotCalls    []SnapshotCall
-	SnapshotCallback func(ctx context.Context, workshop string, snapid string) error
-	RestoreCalls     []RestoreCall
-	RestoreCallback  func(ctx context.Context, workshop string, snapid string, File *workshop.File) error
+	snapshotLock         sync.Mutex
+	LaunchOrRebuildCalls []LaunchOrRebuildCall
+	SnapshotCalls        []SnapshotCall
+	SnapshotCallback     func(ctx context.Context, workshop string, snapid string) error
 
 	BaseDir string
 }
@@ -163,7 +164,7 @@ func (f *FakeWorkshopBackend) project(user, id string) *workshop.Project {
 	return nil
 }
 
-func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, image workshop.BaseImage) error {
+func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, snapshot workshop.Snapshot) error {
 	user, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
@@ -177,45 +178,88 @@ func (f *FakeWorkshopBackend) LaunchOrRebuildWorkshop(ctx context.Context, file 
 	}
 	ws, ok := f.Workshops[projectId][file.Name]
 	if !ok {
-		ws = &FakeWorkshop{}
+		ws = &FakeWorkshop{Devices: map[string]map[string]string{}}
 		f.Workshops[projectId][file.Name] = ws
 	}
 	f.workshopLock.Unlock()
 
 	if ok {
-		// Remove SDKs.
-		sdks := ws.SdksByInstallOrder()
-		slices.Reverse(sdks)
-		for _, setup := range sdks {
-			if err := f.UninstallSdk(ctx, file.Name, setup.Setup); err != nil {
-				return err
-			}
+		if err := f.rebuildWorkshop(ctx, file, snapshot, ws); err != nil {
+			return err
 		}
-
-		// rebuild the workshop
-		ws.File = file
-		ws.Image = image
+	} else if !snapshot.IsBase() {
+		return fmt.Errorf("%q SDK is intact but workshop not launched", snapshot.Sdks[0].Name)
 	} else {
 		ws.Workshop = &workshop.Workshop{Backend: f,
-			Name:    file.Name,
-			Running: false,
-			Project: *prj,
-			Image:   image,
-			File:    file,
+			Name:     file.Name,
+			Running:  false,
+			Project:  *prj,
+			Image:    snapshot.Image,
+			File:     file,
+			Sdks:     map[string]workshop.SdkInstallation{},
+			Profiles: map[string]workshop.SdkProfile{},
 		}
 	}
 
-	wfspath, err := os.MkdirTemp(f.BaseDir, "*")
-	if err != nil {
-		return err
+	if snapshot.IsBase() {
+		wfspath, err := os.MkdirTemp(f.BaseDir, "*")
+		if err != nil {
+			return err
+		}
+		ws.WorkshopFilesystem = fsutil.NewBasePathFs(wfspath)
 	}
-	ws.WorkshopFilesystem = fsutil.NewBasePathFs(wfspath)
 
-	ws.Devices = make(map[string]map[string]string)
+	f.snapshotLock.Lock()
+	defer f.snapshotLock.Unlock()
 
-	ws.Sdks = make(map[string]workshop.SdkInstallation)
-	ws.Profiles = make(map[string]workshop.SdkProfile, 0)
+	call := LaunchOrRebuildCall{Workshop: ws.Name, File: file, Snapshot: snapshot}
+	f.LaunchOrRebuildCalls = append(f.LaunchOrRebuildCalls, call)
+	return nil
+}
 
+func (f *FakeWorkshopBackend) rebuildWorkshop(ctx context.Context, file *workshop.File, snapshot workshop.Snapshot, ws *FakeWorkshop) error {
+	// Remove project mount
+	if _, ok := ws.Devices[workshop.ConfigProjectPathDevice]; ok {
+		if err := f.RemoveWorkshopMount(ctx, ws.Name, workshop.ConfigProjectPathDevice); err != nil {
+			return err
+		}
+	}
+
+	// Sanity check for devices and profiles
+	if len(ws.Profiles) > 0 {
+		names := strutil.Quoted(slices.Collect(maps.Keys(ws.Profiles)))
+		return fmt.Errorf("interfaces must be disconnected before building workshop: %s", names)
+	}
+	devices := slices.Collect(maps.Keys(ws.Devices))
+	devices = slices.DeleteFunc(devices, func(name string) bool {
+		return strings.HasPrefix(name, "sdk.")
+	})
+	if len(devices) > 0 {
+		names := strutil.Quoted(devices)
+		return fmt.Errorf("devices must be detached before rebuilding workshop: %s", names)
+	}
+
+	// Sanity check for intact SDKs.
+	if !snapshot.IsBase() && ws.Image != snapshot.Image {
+		return fmt.Errorf("%q SDK is intact but base image has changed", snapshot.Sdks[0].Name)
+	}
+	sdks := ws.SdksByInstallOrder()
+	for i, sk := range snapshot.Sdks {
+		if i >= len(sdks) || sk != sdk.SetupId(sdks[i].Setup) {
+			return fmt.Errorf("%q SDK is intact but doesn't match installed version", sk.Name)
+		}
+	}
+
+	// Remove SDKs.
+	slices.Reverse(sdks)
+	for _, setup := range sdks {
+		if err := f.UninstallSdk(ctx, ws.Name, setup.Setup); err != nil {
+			return err
+		}
+	}
+
+	ws.File = file
+	ws.Image = snapshot.Image
 	return nil
 }
 
@@ -486,6 +530,8 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	stashed := *wp
 	stashed.Workshop = &wcpy
 	stashed.Name = "stash-" + name
+	wcpy.Sdks = maps.Clone(wcpy.Sdks)
+	wcpy.Profiles = maps.Clone(wcpy.Profiles)
 
 	s.StashedWorkshops[projectId][stashed.Name] = &stashed
 	return nil
@@ -734,50 +780,6 @@ func (s *FakeWorkshopBackend) Snapshot(ctx context.Context, name, sk string) err
 	s.SnapshotCalls = append(s.SnapshotCalls, SnapshotCall{Workshop: name, Sdk: sk})
 	if s.SnapshotCallback != nil {
 		return s.SnapshotCallback(ctx, name, sk)
-	}
-	return nil
-}
-
-func (s *FakeWorkshopBackend) Restore(ctx context.Context, name, sk string, file *workshop.File) error {
-	wp, err := s.Workshop(ctx, name)
-	if err != nil {
-		return err
-	}
-
-	sdks := wp.SdksByInstallOrder()
-	lastIntact := slices.IndexFunc(sdks, func(s workshop.SdkInstallation) bool { return s.Name == sk })
-	if lastIntact < 0 {
-		return fmt.Errorf("invalid snapshot %q", sk)
-	}
-	unwantedSdks := sdks[lastIntact+1:]
-	slices.Reverse(unwantedSdks)
-
-	fs, err := s.WorkshopFs(ctx, name)
-	if err != nil {
-		return err
-	}
-	defer fs.Close()
-
-	// Remove project mount
-	if err := fs.RemoveIfExists(workshop.WorkshopProjectPath); err != nil {
-		return err
-	}
-
-	// Remove SDKs from after the snapshot.
-	for _, u := range unwantedSdks {
-		if err := s.UninstallSdk(ctx, name, u.Setup); err != nil {
-			return err
-		}
-	}
-
-	wp.File = file
-
-	s.snapshotLock.Lock()
-	defer s.snapshotLock.Unlock()
-
-	s.RestoreCalls = append(s.RestoreCalls, RestoreCall{Workshop: name, Sdk: sk, File: file})
-	if s.RestoreCallback != nil {
-		return s.RestoreCallback(ctx, name, sk, file)
 	}
 	return nil
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -632,7 +632,7 @@ func (s *FakeWorkshopBackend) attachVolume(ctx context.Context, name string, mou
 	s.volumeLock.Lock()
 	defer s.volumeLock.Unlock()
 
-	s.AttachVolumeCalls = append(s.AttachVolumeCalls, AttachVolumeCall{Workshop: name, Name: mount.Name})
+	s.AttachVolumeCalls = append(s.AttachVolumeCalls, AttachVolumeCall{Workshop: name, Name: mount.What})
 
 	wfs, err := s.WorkshopFs(ctx, name)
 	if err != nil {
@@ -678,11 +678,12 @@ func (b *FakeWorkshopBackend) UninstallSdk(ctx context.Context, name string, set
 	b.workshopLock.Unlock()
 	delete(wp.Sdks, setup.Name)
 
-	what := sdk.VolumeName(setup.Name, setup.Revision)
 	if setup.IsVolume() {
+		what := sdk.VolumeName(setup.Name, setup.Revision)
 		where := sdk.SdkDir(setup.Name)
 		return b.detachVolume(ctx, name, what, where)
 	}
+	what := workshop.SdkDeviceName(setup.Name)
 	return b.RemoveWorkshopMount(ctx, name, what)
 }
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -5,7 +5,6 @@ import (
 	"cmp"
 	"context"
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -805,10 +804,13 @@ func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p wo
 	}
 
 	sdks := map[string]workshop.SdkInstallation{}
-	buf, exist := inst.Config[workshop.ConfigWorkshopSdks]
-	if exist {
-		if err := json.Unmarshal([]byte(buf), &sdks); err != nil {
+	for key, device := range inst.Devices {
+		s, err := maybeSdkInstallation(key, device)
+		if err != nil {
 			return nil, err
+		}
+		if s != nil {
+			sdks[s.Name] = *s
 		}
 	}
 
@@ -1159,7 +1161,6 @@ runcmd:
 		"user.workshop.name":             file.Name,
 		"user.workshop.file":             string(f),
 		"user.workshop.base-fingerprint": baseFingerprint,
-		"user.workshop.sdks":             "{}",
 		"nvidia.driver.capabilities":     cfgNvidiaDriverCapabilities,
 		"nvidia.runtime":                 cfgNvidiaRuntime,
 		// LXC appears to have a race condition wherein a proxy device mounted in

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -274,9 +274,7 @@ func New() (*Backend, error) {
 	return &server, nil
 }
 
-func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, image workshop.BaseImage) error {
-	var err error
-
+func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, snapshot workshop.Snapshot) error {
 	conn, layerConn, err := s.layerClients(ctx)
 	if err != nil {
 		return err
@@ -298,93 +296,93 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		return err
 	}
 
-	config, err := s.workshopConfig(projectId, usr.Uid, usr.Gid, file, image.Fingerprint)
+	config, err := s.workshopConfig(projectId, usr.Uid, usr.Gid, file, snapshot.Image.Fingerprint)
 	if err != nil {
 		return err
 	}
-	devices := defaultDevices(projectId, file.Name)
-	source := api.InstanceSource{
-		Type:        api.SourceTypeImage,
-		Fingerprint: image.Fingerprint,
+	req := api.InstancesPost{
+		InstancePut: api.InstancePut{
+			Config:  config,
+			Devices: defaultDevices(projectId, file.Name),
+		},
+		Name: InstanceName(file.Name, projectId),
+		Type: api.InstanceTypeContainer,
 	}
 
-	inst, _, err := conn.GetInstanceFull(InstanceName(file.Name, projectId))
-	switch {
-	case err != nil && !api.StatusErrorCheck(err, http.StatusNotFound):
-		return err
-	case err != nil && api.StatusErrorCheck(err, http.StatusNotFound):
-		// Create a new workshop.
-		req := api.InstancesPost{
-			InstancePut: api.InstancePut{
-				Devices: devices,
-				Config:  config,
-			},
-			Name:   InstanceName(file.Name, projectId),
-			Type:   api.InstanceTypeContainer,
-			Source: source,
+	if snapshot.IsBase() {
+		req.Source = api.InstanceSource{
+			Type:        api.SourceTypeImage,
+			Fingerprint: snapshot.Image.Fingerprint,
 		}
+		if err := s.launchOrRebuildFromImage(conn, layerConn, req); err != nil {
+			return err
+		}
+		return s.patchInstance(ctx, file.Name, file.Base)
+	}
+
+	return s.launchOrRebuildFromLayer(conn, layerConn, req, snapshot.Sdks)
+}
+
+func (s *Backend) launchOrRebuildFromImage(conn, layerConn lxd.InstanceServer, req api.InstancesPost) error {
+	inst, _, err := conn.GetInstance(req.Name)
+	if api.StatusErrorCheck(err, http.StatusNotFound) {
+		// Create a new workshop.
 		op, err := conn.CreateInstance(req)
 		if err != nil {
 			return err
 		}
-		if err := op.Wait(); err != nil {
-			return err
-		}
-
-		return s.patchInstance(ctx, file.Name, file.Base)
-	default:
-		// Rebuild the existing workshop.
-		snapshots, err := s.layerNames(layerConn, projectId, file.Name, "sdk")
-		if err != nil {
-			return err
-		}
-
-		for _, snapshot := range snapshots {
-			if err := s.deleteLayer(layerConn, snapshot); err != nil {
-				return err
-			}
-		}
-
-		op, err := conn.RebuildInstance(inst.Name, api.InstanceRebuildPost{Source: source})
-		if err != nil {
-			return err
-		}
-		if err = op.Wait(); err != nil {
-			return err
-		}
-
-		// When rebuilding an instance from an image, LXD resets the
-		// image-related options: image.* and volatile.base_image. It
-		// also sets volatile.uuid.generation to volatile.uuid. The
-		// former seems to be unused for containers. Finally, it clears
-		// volatile.idmap.next and volatile.last_state.idmap. We are
-		// responsible for resetting the remaining options. Workshop
-		// only touches the options present in the default config, so
-		// we overwrite these options and assume everything else is
-		// managed by LXD. If we remove an option from the default
-		// config, we should also remove it from the config below.
-		rebuilt, etag, err := conn.GetInstance(inst.Name)
-		if err != nil {
-			return err
-		}
-
-		if rebuilt.Config == nil {
-			rebuilt.Config = config
-		} else {
-			maps.Copy(rebuilt.Config, config)
-		}
-		rebuilt.Devices = devices
-
-		op, err = conn.UpdateInstance(rebuilt.Name, rebuilt.Writable(), etag)
-		if err != nil {
-			return err
-		}
-		if err := op.Wait(); err != nil {
-			return err
-		}
-
-		return s.patchInstance(ctx, file.Name, file.Base)
+		return op.Wait()
 	}
+	if err != nil {
+		return err
+	}
+
+	// Rebuild the existing workshop.
+	projectId := inst.Config[workshop.ConfigProjectId]
+	name := inst.Config[workshop.ConfigWorkshopName]
+
+	snapshots, err := s.layerNames(layerConn, projectId, name, "sdk")
+	if err != nil {
+		return err
+	}
+	for _, snapshot := range snapshots {
+		if err := s.deleteLayer(layerConn, snapshot); err != nil {
+			return err
+		}
+	}
+
+	op, err := conn.RebuildInstance(inst.Name, api.InstanceRebuildPost{Source: req.Source})
+	if err != nil {
+		return err
+	}
+	if err = op.Wait(); err != nil {
+		return err
+	}
+
+	rebuilt, etag, err := conn.GetInstance(inst.Name)
+	if err != nil {
+		return err
+	}
+
+	// When rebuilding an instance from an image, LXD resets the image
+	// properties and volatile.base_image. It also copies volatile.uuid
+	// over volatile.uuid.generation. The latter seems to be unused for
+	// containers. Finally, it clears volatile.idmap.next and
+	// volatile.last_state.idmap. All other options are unchanged. We
+	// preserve the LXD-managed options and forget the other ones.
+	req.Config = maps.Clone(req.Config)
+	for k, v := range rebuilt.Config {
+		if _, ok := req.Config[k]; !ok && optionDomain(k) != customOption {
+			req.Config[k] = v
+		}
+	}
+
+	req.Architecture = rebuilt.Architecture
+	op, err = conn.UpdateInstance(rebuilt.Name, req.InstancePut, etag)
+	if err != nil {
+		return err
+	}
+	return op.Wait()
 }
 
 //go:embed snap-confine.old

--- a/internal/workshop/lxd/lxd_backend_layers.go
+++ b/internal/workshop/lxd/lxd_backend_layers.go
@@ -13,12 +13,45 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/revert"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
+
+// Classifies LXD config options into different domains which describe who is
+// responsible for them and how they (should) behave when copying an instance.
+type configDomain int
+
+const (
+	// Properties unique to a single instance. These are managed by LXD and
+	// not shared with instance copies, e.g. volatile.uuid.
+	uniqueProperty configDomain = iota
+	// Properties managed by LXD and shared with copies, e.g. image.os.
+	sharedProperty
+	// Options managed by Workshop. Includes instance config options like
+	// boot.autostart and workshop metadata like user.workshop.project-id.
+	customOption
+)
+
+// Classifies options by key. Based on LXD's InstanceIncludeWhenCopying.
+func optionDomain(key string) configDomain {
+	if strings.HasPrefix(key, "image.") {
+		return sharedProperty
+	}
+
+	suffix, found := strings.CutPrefix(key, "volatile.")
+	if !found {
+		return customOption
+	}
+	switch suffix {
+	case "base_image", "last_state.idmap":
+		return sharedProperty
+	default:
+		return uniqueProperty
+	}
+}
 
 func (s *Backend) Snapshot(ctx context.Context, name, sk string) error {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
@@ -32,25 +65,89 @@ func (s *Backend) Snapshot(ctx context.Context, name, sk string) error {
 	}
 	defer conn.Disconnect()
 
-	// Copy workshop to preserve setup-base results for the SDK.
-	instance := InstanceName(name, projectId)
+	inst, _, err := conn.GetInstance(InstanceName(name, projectId))
+	if err != nil {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return workshop.ErrWorkshopNotLaunched
+		}
+		return err
+	}
+
+	f, err := workshopFile(inst.Config)
+	if err != nil {
+		return fmt.Errorf("cannot load workshop: %v", err)
+	}
+	image := workshop.BaseImage{
+		Name:        f.Base,
+		Fingerprint: inst.Config[workshop.ConfigWorkshopBaseFingerprint],
+	}
+
+	// Override all writable attributes. The snapshot is essentially a base
+	// image but is stored more efficiently. Config options and devices are
+	// reconstructed from scratch during launch and refresh.
+	config := configOverrides(projectId, name, sk, image, inst.Config)
+	devices, err := deviceOverrides(inst.Devices)
+	if err != nil {
+		return err
+	}
+	inst.SetWritable(api.InstancePut{
+		Architecture: inst.Architecture,
+		Config:       config,
+		Devices:      devices,
+		Profiles:     []string{},
+	})
+
 	snapshot, err := sdkLayerName(sk)
 	if err != nil {
 		return err
 	}
-	config := map[string]string{
-		// The SDK can be deduced from user.workshop.file together with
-		// user.workshop.sdks, but we add a standalone option to make
-		// it easier to find during Restore.
-		"user.workshop.sdk": sk,
-		// Mark the copy as an SDK layer to avoid ambiguity.
-		"user.workshop.layer-type": "sdk",
+	args := lxd.InstanceCopyArgs{Name: snapshot, InstanceOnly: true}
+	rop, err := layerConn.CopyInstance(conn, *inst, &args)
+	if err != nil {
+		return err
 	}
-	// We could exclude user.workshop.file since Restore will override it,
-	// but doing that requires additional LXD API calls, and there's no
-	// harm in keeping it around.
-	var exclude []string
-	return s.copyInstance(conn, layerConn, instance, snapshot, false, config, exclude)
+	return rop.Wait()
+}
+
+func configOverrides(pid, name, sk string, image workshop.BaseImage, config map[string]string) map[string]string {
+	// LXD will handle the options it owns. We remove all options set by
+	// Workshop, except for a handful that identify the snapshot. We also
+	// add security.protection.start to prevent it from starting.
+	overrides := map[string]string{
+		"security.protection.start":            "true",
+		workshop.ConfigProjectId:               pid,
+		workshop.ConfigWorkshopName:            name,
+		workshop.ConfigWorkshopBase:            image.Name,
+		workshop.ConfigWorkshopBaseFingerprint: image.Fingerprint,
+		workshop.ConfigWorkshopLayerType:       "sdk",
+		workshop.ConfigWorkshopSdk:             sk,
+	}
+	for k := range config {
+		if _, ok := overrides[k]; !ok && optionDomain(k) == customOption {
+			overrides[k] = ""
+		}
+	}
+	return overrides
+}
+
+func deviceOverrides(devices map[string]map[string]string) (map[string]map[string]string, error) {
+	// There's no easy way to remove these, so we make do by setting them
+	// to {"type": "none"}. For SDKs we remember all metadata which might
+	// affect the snapshot.
+	overrides := make(map[string]map[string]string, len(devices))
+	none := map[string]string{"type": "none"}
+	for key, device := range devices {
+		s, err := maybeSdkInstallation(key, device)
+		if err != nil {
+			return nil, err
+		}
+		if s != nil {
+			overrides[key] = sdkToSnapshotDevice(s.InstallOrder, sdk.SetupId(s.Setup))
+		} else if key != "root" {
+			overrides[key] = none
+		}
+	}
+	return overrides, nil
 }
 
 // Generates a random suffix for the SDK, to avoid clashing with SDK layers
@@ -65,44 +162,114 @@ func sdkLayerName(sk string) (string, error) {
 	return sk + "-" + hex.EncodeToString(bytes), nil
 }
 
-func (s *Backend) Restore(ctx context.Context, name, sk string, file *workshop.File) error {
-	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
-	if !ok {
-		return fmt.Errorf("context key project-id not found")
-	}
+func (s *Backend) launchOrRebuildFromLayer(conn, layerConn lxd.InstanceServer, req api.InstancesPost, sdks []sdk.Id) error {
+	projectId := req.Config[workshop.ConfigProjectId]
+	name := req.Config[workshop.ConfigWorkshopName]
 
-	f, err := yaml.Marshal(file)
+	// Find snapshots to keep and remove.
+	lastSdk := sdks[len(sdks)-1].Name
+	layerName, obstacles, err := s.layerNamesAfter(layerConn, projectId, name, lastSdk)
 	if err != nil {
 		return err
 	}
 
-	conn, layerConn, err := s.layerClients(ctx)
+	layer, _, err := layerConn.GetInstance(layerName)
 	if err != nil {
 		return err
 	}
-	defer conn.Disconnect()
+	// Snapshots should only contain the requested devices and SDK mounts.
+	for key, device := range layer.Devices {
+		installOrder, s, err := maybeSdkId(key, device)
+		if err != nil {
+			return err
+		}
+		if s != nil {
+			if 0 < installOrder && installOrder <= len(sdks) && sdks[installOrder-1] == *s {
+				// SDK will be reinstalled as a separate task.
+				continue
+			}
+			return fmt.Errorf("internal error: snapshot %q has unexpected %q SDK", layer.Name, s.Name)
+		} else if _, ok := req.Devices[key]; !ok {
+			return fmt.Errorf("internal error: snapshot %q has unexpected device %q", layer.Name, key)
+		}
+	}
 
-	// Find the snapshot itself and any newer snapshots.
-	snapshot, obstacles, err := s.layerNamesAfter(layerConn, projectId, name, sk)
-	if err != nil {
-		return err
-	}
 	// Remove the newer snapshots, as LXD would do. This is not necessary
 	// to "restore the snapshot," i.e. replace the volume with a new one,
 	// but we want to avoid having two snapshots for the same SDK and
 	// workshop until we introduce a way to distinguish them.
-	for _, layer := range obstacles {
-		if err := s.deleteLayer(layerConn, layer); err != nil {
+	for _, obstacle := range obstacles {
+		if err := s.deleteLayer(layerConn, obstacle); err != nil {
 			return err
 		}
 	}
 
-	instance := InstanceName(name, projectId)
-	// Update the workshop definition, similar to LaunchOrRebuildWorkshop.
-	config := map[string]string{workshop.ConfigWorkshopFile: string(f)}
-	// Avoid copying the options which we added when taking the snapshot.
-	exclude := []string{"user.workshop.sdk", "user.workshop.layer-type"}
-	return s.copyInstance(layerConn, conn, snapshot, instance, true, config, exclude)
+	overrides := overrideLayer(*layer, req.InstancePut)
+	args := lxd.InstanceCopyArgs{
+		Name:         req.Name,
+		InstanceOnly: true,
+		Refresh:      true,
+	}
+	rop, err := conn.CopyInstance(layerConn, overrides, &args)
+	if err != nil {
+		return err
+	}
+	if err = rop.Wait(); err != nil {
+		return err
+	}
+
+	// If the workshop already existed, it still has the old config options
+	// and devices. If it did not exist, the config and devices are mostly
+	// correct, but we still need to remove placeholder SDK devices.
+	inst, etag, err := conn.GetInstance(req.Name)
+	if err != nil {
+		return err
+	}
+	req.Config = mergeOptions(req.Config, layer.Config, inst.Config)
+	req.Architecture = inst.Architecture
+	op, err := conn.UpdateInstance(req.Name, req.InstancePut, etag)
+	if err != nil {
+		return err
+	}
+	return op.Wait()
+}
+
+func overrideLayer(layer api.Instance, req api.InstancePut) api.Instance {
+	// Set all requested options and remove snapshot options that aren't
+	// managed by LXD.
+	req.Config = maps.Clone(req.Config)
+	for k := range layer.Config {
+		if _, ok := req.Config[k]; !ok && optionDomain(k) == customOption {
+			req.Config[k] = ""
+		}
+	}
+	// Ensure LXD doesn't copy profiles from the snapshot.
+	if req.Profiles == nil {
+		req.Profiles = []string{}
+	}
+	req.Architecture = layer.Architecture
+	layer.SetWritable(req)
+	return layer
+}
+
+func mergeOptions(req, source, target map[string]string) map[string]string {
+	// Start with requested options.
+	result := maps.Clone(req)
+	// Next, add LXD-managed options we want to preserve from the workshop.
+	// Ideally some of these probably shouldn't be preserved. See
+	// https://github.com/canonical/lxd/issues/16667.
+	for k, v := range target {
+		if _, ok := result[k]; !ok && optionDomain(k) == uniqueProperty {
+			result[k] = v
+		}
+	}
+	// Finally, copy the remaining LXD-managed options from the snapshot.
+	for k, v := range source {
+		if _, ok := result[k]; !ok && optionDomain(k) == sharedProperty {
+			result[k] = v
+		}
+	}
+	return result
 }
 
 func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
@@ -139,8 +306,8 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	// layer type to distinguish the backups from the originals.
 	for _, layer := range layers {
 		newname := "stash-" + layer
-		config := map[string]string{"user.workshop.layer-type": "stash-sdk"}
-		if err := s.copyInstance(layerConn, layerConn, layer, newname, false, config, nil); err != nil {
+		config := map[string]string{workshop.ConfigWorkshopLayerType: "stash-sdk"}
+		if err := s.copyInstance(layerConn, layerConn, layer, newname, false, config); err != nil {
 			return err
 		}
 		rev.Add(func() {
@@ -154,8 +321,8 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	instance := InstanceName(name, projectId)
 	stashed := instanceStashName(name, projectId)
 	// Mark the copy as a stash to avoid confusing it with an SDK layer.
-	config := map[string]string{"user.workshop.layer-type": "stash"}
-	if err := s.copyInstance(conn, layerConn, instance, stashed, false, config, nil); err != nil {
+	config := map[string]string{workshop.ConfigWorkshopLayerType: "stash"}
+	if err := s.copyInstance(conn, layerConn, instance, stashed, false, config); err != nil {
 		return err
 	}
 
@@ -203,8 +370,8 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 			continue
 		}
 		// Restore the original layer type (stash-sdk -> sdk).
-		config := map[string]string{"user.workshop.layer-type": "sdk"}
-		if err := s.copyInstance(layerConn, layerConn, layer, name, false, config, nil); err != nil {
+		config := map[string]string{workshop.ConfigWorkshopLayerType: "sdk"}
+		if err := s.copyInstance(layerConn, layerConn, layer, name, false, config); err != nil {
 			return err
 		}
 	}
@@ -212,9 +379,9 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 	// Restore the workshop itself.
 	instance := InstanceName(name, projectId)
 	stash := instanceStashName(name, projectId)
-	// Avoid copying the option which we added when stashing.
-	exclude := []string{"user.workshop.layer-type"}
-	if err := s.copyInstance(layerConn, conn, stash, instance, true, nil, exclude); err != nil {
+	// Avoid restoring the option which we added when stashing.
+	config := map[string]string{workshop.ConfigWorkshopLayerType: ""}
+	if err := s.copyInstance(layerConn, conn, stash, instance, true, config); err != nil {
 		return err
 	}
 
@@ -253,17 +420,17 @@ func (s *Backend) layerNamesAfter(layerConn lxd.InstanceServer, pid, w, sk strin
 	}
 
 	idx := slices.IndexFunc(layers, func(inst api.Instance) bool {
-		return inst.Config["user.workshop.sdk"] == sk
+		return inst.Config[workshop.ConfigWorkshopSdk] == sk
 	})
 	if idx < 0 {
-		return "", nil, fmt.Errorf("%q SDK snapshot not found in workshop %q", sk, w)
+		return "", nil, fmt.Errorf("%q SDK snapshot not found in %q workshop", sk, w)
 	}
 	devices := layers[idx].Devices
 
 	// Any SDK which wasn't installed must have been added later.
 	obstacles := make([]string, 0, len(layers))
 	for _, layer := range layers {
-		device := workshop.SdkDeviceName(layer.Config["user.workshop.sdk"])
+		device := workshop.SdkDeviceName(layer.Config[workshop.ConfigWorkshopSdk])
 		if _, ok := devices[device]; !ok {
 			obstacles = append(obstacles, layer.Name)
 		}
@@ -281,7 +448,7 @@ func (s *Backend) layerNamesAfter(layerConn lxd.InstanceServer, pid, w, sk strin
 // using the config argument. To prevent an option from being copied over, add
 // it to the exclude list. The boot.autostart option is always set to false in
 // the copy: the source instance might be running but the copy won't be.
-func (s *Backend) copyInstance(src, dst lxd.InstanceServer, srcName, dstName string, refresh bool, config map[string]string, exclude []string) error {
+func (s *Backend) copyInstance(src, dst lxd.InstanceServer, srcName, dstName string, refresh bool, config map[string]string) error {
 	if config == nil {
 		config = map[string]string{}
 	}
@@ -316,39 +483,41 @@ func (s *Backend) copyInstance(src, dst lxd.InstanceServer, srcName, dstName str
 		return err
 	}
 
-	if !refresh && len(exclude) == 0 {
-		// LXD created a new instance with copied config and devices,
-		// and we don't need to go back and remove any options.
+	if !refresh {
+		// LXD created a new instance with copied config and devices.
 		return nil
 	}
 
-	// We're in one of the following scenarios:
-	// - LXD replaced an existing instance's root disk, but it's our job to
-	//   copy the config and devices.
-	// - LXD created a new instance with copied config and devices, but we
-	//   didn't want it to copy some of the config options.
+	// Otherwise, LXD replaced an existing instance's root disk, and it's
+	// our job to copy the config and devices.
 	dstInst, etag, err := dst.GetInstance(dstName)
 	if err != nil {
 		return err
 	}
 
-	// Remove all options that aren't managed by LXD. The ones we do want
-	// to set are added below. Ideally, some LXD-managed options should
-	// also be removed. See https://github.com/canonical/lxd/issues/16667.
-	maps.DeleteFunc(dstInst.Config, func(k, v string) bool { return includeWhenCopying(k) })
+	// Remove all options that aren't unique to the target. The ones we do
+	// want to set are added below. Ideally, we should also remove some
+	// unique ones. See https://github.com/canonical/lxd/issues/16667.
+	maps.DeleteFunc(dstInst.Config, func(k, v string) bool { return optionDomain(k) != uniqueProperty })
 
-	// Add all options from the source, except for those managed by LXD or
-	// excluded by the caller. Then add config overrides.
-	maps.DeleteFunc(srcInst.Config, func(k, v string) bool { return !includeWhenCopying(k) || slices.Contains(exclude, k) })
-	if srcInst.Config == nil {
-		srcInst.Config = config
-	} else {
-		maps.Copy(srcInst.Config, config)
-	}
+	// Add all options from the source, except ones unique to the target.
+	maps.DeleteFunc(srcInst.Config, func(k, v string) bool { return optionDomain(k) == uniqueProperty })
 	if dstInst.Config == nil {
 		dstInst.Config = srcInst.Config
 	} else {
 		maps.Copy(dstInst.Config, srcInst.Config)
+	}
+
+	// Process config overrides.
+	if dstInst.Config == nil {
+		dstInst.Config = map[string]string{}
+	}
+	for k, v := range config {
+		if v == "" {
+			delete(dstInst.Config, k)
+		} else {
+			dstInst.Config[k] = v
+		}
 	}
 
 	dstInst.Devices = srcInst.Devices
@@ -358,14 +527,6 @@ func (s *Backend) copyInstance(src, dst lxd.InstanceServer, srcName, dstName str
 		return err
 	}
 	return op.Wait()
-}
-
-// Based on LXD's InstanceIncludeWhenCopying. These are the options which
-// CopyInstance adds to a newly created instance by default (i.e. when
-// api.Instance.Config is empty).
-func includeWhenCopying(key string) bool {
-	suffix, found := strings.CutPrefix(key, "volatile.")
-	return !found || slices.Contains([]string{"base_image", "last_state.idmap"}, suffix)
 }
 
 func (s *Backend) RemoveWorkshopStash(ctx context.Context, name string) error {

--- a/internal/workshop/lxd/lxd_backend_layers.go
+++ b/internal/workshop/lxd/lxd_backend_layers.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"net/http"
@@ -259,20 +258,13 @@ func (s *Backend) layerNamesAfter(layerConn lxd.InstanceServer, pid, w, sk strin
 	if idx < 0 {
 		return "", nil, fmt.Errorf("%q SDK snapshot not found in workshop %q", sk, w)
 	}
-
-	// Find the installed SDKs at the time of the snapshot.
-	sdks := map[string]workshop.SdkInstallation{}
-	buf, exist := layers[idx].Config[workshop.ConfigWorkshopSdks]
-	if exist {
-		if err := json.Unmarshal([]byte(buf), &sdks); err != nil {
-			return "", nil, err
-		}
-	}
+	devices := layers[idx].Devices
 
 	// Any SDK which wasn't installed must have been added later.
 	obstacles := make([]string, 0, len(layers))
 	for _, layer := range layers {
-		if _, ok := sdks[layer.Config["user.workshop.sdk"]]; !ok {
+		device := workshop.SdkDeviceName(layer.Config["user.workshop.sdk"])
+		if _, ok := devices[device]; !ok {
 			obstacles = append(obstacles, layer.Name)
 		}
 	}

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	lxd "github.com/canonical/lxd/client"
@@ -401,7 +402,23 @@ func (s *Backend) InstallSdk(ctx context.Context, name string, setup sdk.Setup) 
 	if _, exist := inst.Devices[mount.Name]; exist {
 		return fmt.Errorf("%q SDK is already installed", setup.Name)
 	}
-	installation := workshop.SdkInstallation{Setup: setup, InstallTime: workshop.InstallTimeNow()}
+
+	maxInstallOrder := 0
+	for key, device := range inst.Devices {
+		s, err := maybeSdkInstallation(key, device)
+		if err != nil {
+			return err
+		}
+		if s != nil {
+			maxInstallOrder = max(maxInstallOrder, s.InstallOrder)
+		}
+	}
+
+	installation := workshop.SdkInstallation{
+		Setup:        setup,
+		InstallOrder: maxInstallOrder + 1,
+		InstallTime:  workshop.InstallTimeNow(),
+	}
 	device, err := sdkToLxdDisk(installation, mount)
 	if err != nil {
 		return err
@@ -431,6 +448,7 @@ func sdkToLxdDisk(sk workshop.SdkInstallation, mount workshop.Mount) (map[string
 	device["user.sdk.channel"] = sk.Channel
 	device["user.sdk.revision"] = sk.Revision.String()
 	device["user.sdk.sha3-384"] = sk.Sha3_384
+	device["user.sdk.install-order"] = strconv.FormatInt(int64(sk.InstallOrder), 10)
 
 	source, err := sk.Source.MarshalText()
 	if err != nil {
@@ -453,12 +471,17 @@ func maybeSdkInstallation(key string, device map[string]string) (*workshop.SdkIn
 		return nil, nil
 	}
 
+	installOrder, err := strconv.ParseInt(device["user.sdk.install-order"], 10, 0)
+	if err != nil {
+		return nil, err
+	}
 	s := &workshop.SdkInstallation{
 		Setup: sdk.Setup{
 			Name:     name,
 			Channel:  device["user.sdk.channel"],
 			Sha3_384: device["user.sdk.sha3-384"],
 		},
+		InstallOrder: int(installOrder),
 	}
 	if err := s.Source.UnmarshalText([]byte(device["user.sdk.source"])); err != nil {
 		return nil, err

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -496,6 +496,39 @@ func maybeSdkInstallation(key string, device map[string]string) (*workshop.SdkIn
 	return s, nil
 }
 
+func sdkToSnapshotDevice(installOrder int, sk sdk.Id) map[string]string {
+	return map[string]string{
+		"type":                   "none",
+		"user.sdk.sha3-384":      sk.Sha3_384,
+		"user.sdk.is-volume":     strconv.FormatBool(sk.IsVolume),
+		"user.sdk.install-order": strconv.FormatInt(int64(installOrder), 10),
+	}
+}
+
+func maybeSdkId(key string, device map[string]string) (int, *sdk.Id, error) {
+	name, found := strings.CutPrefix(key, workshop.SdkDeviceName(""))
+	if !found {
+		return 0, nil, nil
+	}
+
+	isVolume, err := strconv.ParseBool(device["user.sdk.is-volume"])
+	if err != nil {
+		return 0, nil, err
+	}
+	s := &sdk.Id{
+		Name:     name,
+		Sha3_384: device["user.sdk.sha3-384"],
+		IsVolume: isVolume,
+	}
+
+	installOrder, err := strconv.ParseInt(device["user.sdk.install-order"], 10, 0)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return int(installOrder), s, nil
+}
+
 func (s *Backend) UninstallSdk(ctx context.Context, name string, setup sdk.Setup) error {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -465,7 +465,7 @@ func (s *Backend) UninstallSdk(ctx context.Context, name string, setup sdk.Setup
 		return err
 	}
 
-	delete(inst.Devices, sdk.VolumeName(setup.Name, setup.Revision))
+	delete(inst.Devices, workshop.SdkDeviceName(setup.Name))
 
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
 	if err != nil {

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -2,7 +2,6 @@ package lxdbackend
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -399,11 +398,15 @@ func (s *Backend) InstallSdk(ctx context.Context, name string, setup sdk.Setup) 
 		return err
 	}
 
-	inst.Devices[mount.Name] = mountToLxdDisk(mount)
-
-	if err := addSdk(inst.Config, setup); err != nil {
+	if _, exist := inst.Devices[mount.Name]; exist {
+		return fmt.Errorf("%q SDK is already installed", setup.Name)
+	}
+	installation := workshop.SdkInstallation{Setup: setup, InstallTime: workshop.InstallTimeNow()}
+	device, err := sdkToLxdDisk(installation, mount)
+	if err != nil {
 		return err
 	}
+	inst.Devices[mount.Name] = device
 
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
 	if err != nil {
@@ -422,26 +425,52 @@ func (s *Backend) mkdir(ctx context.Context, name string, path string) error {
 	return fs.MkdirAll(path, 0755)
 }
 
-func addSdk(config map[string]string, setup sdk.Setup) error {
-	var sdks map[string]workshop.SdkInstallation
-	value, exist := config[workshop.ConfigWorkshopSdks]
-	if !exist {
-		sdks = map[string]workshop.SdkInstallation{}
-	} else if err := json.Unmarshal([]byte(value), &sdks); err != nil {
-		return err
-	} else if _, exist := sdks[setup.Name]; exist {
-		return fmt.Errorf("%q SDK is already installed", setup.Name)
-	}
+func sdkToLxdDisk(sk workshop.SdkInstallation, mount workshop.Mount) (map[string]string, error) {
+	device := mountToLxdDisk(mount)
 
-	sdks[setup.Name] = workshop.SdkInstallation{Setup: setup, InstallTime: workshop.InstallTimeNow()}
+	device["user.sdk.channel"] = sk.Channel
+	device["user.sdk.revision"] = sk.Revision.String()
+	device["user.sdk.sha3-384"] = sk.Sha3_384
 
-	buf, err := json.Marshal(sdks)
+	source, err := sk.Source.MarshalText()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	config[workshop.ConfigWorkshopSdks] = string(buf)
+	device["user.sdk.source"] = string(source)
 
-	return nil
+	installTime, err := sk.InstallTime.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	device["user.sdk.install-time"] = string(installTime)
+
+	return device, nil
+}
+
+func maybeSdkInstallation(key string, device map[string]string) (*workshop.SdkInstallation, error) {
+	name, found := strings.CutPrefix(key, workshop.SdkDeviceName(""))
+	if !found {
+		return nil, nil
+	}
+
+	s := &workshop.SdkInstallation{
+		Setup: sdk.Setup{
+			Name:     name,
+			Channel:  device["user.sdk.channel"],
+			Sha3_384: device["user.sdk.sha3-384"],
+		},
+	}
+	if err := s.Source.UnmarshalText([]byte(device["user.sdk.source"])); err != nil {
+		return nil, err
+	}
+	if err := s.Revision.UnmarshalText([]byte(device["user.sdk.revision"])); err != nil {
+		return nil, err
+	}
+	if err := s.InstallTime.UnmarshalText([]byte(device["user.sdk.install-time"])); err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
 
 func (s *Backend) UninstallSdk(ctx context.Context, name string, setup sdk.Setup) error {
@@ -461,10 +490,6 @@ func (s *Backend) UninstallSdk(ctx context.Context, name string, setup sdk.Setup
 		return err
 	}
 
-	if err := removeSdk(inst.Config, setup.Name); err != nil {
-		return err
-	}
-
 	delete(inst.Devices, workshop.SdkDeviceName(setup.Name))
 
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
@@ -472,26 +497,4 @@ func (s *Backend) UninstallSdk(ctx context.Context, name string, setup sdk.Setup
 		return err
 	}
 	return op.WaitContext(ctx)
-}
-
-func removeSdk(config map[string]string, sk string) error {
-	var sdks map[string]workshop.SdkInstallation
-	value, exist := config[workshop.ConfigWorkshopSdks]
-	if !exist {
-		return nil
-	}
-
-	if err := json.Unmarshal([]byte(value), &sdks); err != nil {
-		return err
-	}
-
-	delete(sdks, sk)
-
-	buf, err := json.Marshal(sdks)
-	if err != nil {
-		return err
-	}
-	config[workshop.ConfigWorkshopSdks] = string(buf)
-
-	return nil
 }

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -115,7 +115,8 @@ printf '%s\n' "$@"
 	_, _, err = bd.CreateOrLoadProject(ctx, dir)
 	c.Assert(err, check.IsNil)
 
-	err = bd.LaunchOrRebuildWorkshop(ctx, wf, image)
+	snapshot := workshop.Snapshot{Image: image}
+	err = bd.LaunchOrRebuildWorkshop(ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
 	err = bd.StartWorkshop(ctx, "test")

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -145,7 +145,8 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
-	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, image)
+	snapshot := workshop.Snapshot{Image: image}
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
 	// Check snapshots are gone.
@@ -764,7 +765,8 @@ func (f *wsOps) TestLxdBackendWorkshopLaunch(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	wf := &workshop.File{Name: "test", Base: "ubuntu@24.04"}
-	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, image)
+	snapshot := workshop.Snapshot{Image: image}
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
@@ -796,7 +798,8 @@ func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
-	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, image)
+	snapshot := workshop.Snapshot{Image: image}
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
 	// Start workshop.
@@ -859,6 +862,13 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 	c.Assert(err, check.IsNil)
 	defer func() { c.Check(f.bd.UninstallSdk(f.ctx, "test", meta.Setup), check.IsNil) }()
 
+	// Check that "test-sdk" directory is mounted.
+	fs, err := f.bd.WorkshopFs(f.ctx, "test")
+	c.Assert(err, check.IsNil)
+	_, err = fs.Stat(sdk.SdkMetaPath(meta.Name))
+	fs.Close()
+	c.Check(err, check.IsNil)
+
 	info, err := f.bd.Sdk(f.ctx, meta.Setup)
 	c.Assert(err, check.IsNil)
 	saved := meta
@@ -879,7 +889,8 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 	c.Assert(err, check.IsNil)
 
 	wf := &workshop.File{Name: "test", Base: "ubuntu@24.04"}
-	err = f.bd.Restore(f.ctx, "test", "test-sdk", wf)
+	snapshot := workshop.SdkSnapshot(w.Image, []sdk.Setup{meta.Setup})
+	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
 	w, err = f.bd.Workshop(f.ctx, "test")
@@ -887,18 +898,20 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 	c.Check(w.Running, check.Equals, false)
 
 	// Check that Restore uses the provided "user.workshop.file," keeps its
-	// base fingerprint and removes "test-sdk-2" setup from the workshop.
+	// base fingerprint and removes both SDKs from the workshop.
 	c.Check(w.File, check.DeepEquals, wf)
 	c.Check(w.Image, check.Equals, image)
-	c.Check(w.Sdks, check.HasLen, 1)
-	_, ok := w.Sdks[meta2.Name]
-	c.Check(ok, check.Equals, false)
+	c.Check(w.Sdks, check.HasLen, 0)
 
-	// Check that "test-sdk-2" volume is not present in the workshop filesystem
-	// anymore.
-	fs, err := f.bd.WorkshopFs(f.ctx, "test")
+	fs, err = f.bd.WorkshopFs(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 	defer fs.Close()
+	// Check that "test-sdk" directory is present but not mounted.
+	_, err = fs.Stat(sdk.SdkDir(meta.Name))
+	c.Check(err, check.IsNil)
+	_, err = fs.Stat(sdk.SdkMetaPath(meta.Name))
+	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
+	// Check that "test-sdk-2" directory is not present in the filesystem.
 	_, err = fs.Stat(sdk.SdkDir(meta2.Name))
 	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
 }

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -36,8 +36,8 @@ type wsOps struct {
 	ctx                context.Context
 	usr                *user.User
 	project            workshop.Project
-	restoreLookupUsr   func()
-	restoreUserAndEnv  func()
+	restoreUserLookup  func()
+	restoreUserEnv     func()
 	restoreNewId       func()
 	restoreDevices     func()
 	restoreImageServer func()
@@ -64,11 +64,11 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 
 	f.restoreDevices = workshop.FakeDefaultDevices(helper.DefaultTestDevices)
 	f.restoreImageServer = lxdbackend.FakeImageServer(helper.MinimalImageServer)
-	f.restoreLookupUsr = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+	f.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
 		return f.usr, nil
 	})
-	f.restoreUserAndEnv = osutil.FakeUserAndEnv(func(name string) (*user.User, map[string]string, error) {
-		return f.usr, nil, nil
+	f.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
 	})
 	f.restoreNewId = testutil.FakeFunc(func() (string, error) {
 		return f.project.ProjectId, nil
@@ -82,8 +82,8 @@ func (f *wsOps) TearDownSuite(c *check.C) {
 
 	helper.CleanupLxdProject(c, lxdclient, "workshop."+f.usr.Username)
 	helper.CleanupLxdProject(c, lxdclient, "workshop-layers."+f.usr.Username)
-	f.restoreLookupUsr()
-	f.restoreUserAndEnv()
+	f.restoreUserEnv()
+	f.restoreUserLookup()
 	f.restoreNewId()
 
 	f.restoreDevices()

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -1,13 +1,13 @@
 package workshop
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/canonical/workshop/internal/arch"
@@ -42,7 +42,9 @@ type Workshop struct {
 
 type SdkInstallation struct {
 	sdk.Setup
-	InstallTime time.Time `json:"install-time"`
+	// 1-based index of SDK installation (0 is reserved for the base).
+	InstallOrder int       `json:"install-order"`
+	InstallTime  time.Time `json:"install-time"`
 }
 
 func SdkDeviceName(sk string) string {
@@ -173,49 +175,21 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 // parsed from its sdk.yaml, such as base, plugs, slots, etc.
 func (w *Workshop) SdkInfosByInstallOrder(ctx context.Context) ([]*sdk.Info, error) {
 	var infos = make([]*sdk.Info, 0, len(w.Sdks))
-	for _, sdk := range w.Sdks {
+	for _, sdk := range w.SdksByInstallOrder() {
 		info, err := w.SdkInfo(ctx, sdk.Name)
 		if err != nil {
 			return nil, err
 		}
 		infos = append(infos, info)
 	}
-
-	orderMap := make(map[string]int)
-	for i, v := range w.File.Sdks {
-		orderMap[v.Name] = i
-	}
-
-	// The workshop definition which defines the install order may or may not
-	// contain the system SDK declared in an arbitrary place. Therefore, we have
-	// to make sure that the system SDK goes first and the sketch SDK goes last.
-	orderMap[sdk.System.String()] = -1
-	orderMap[sdk.Sketch] = len(w.File.Sdks)
-	sort.Slice(infos, func(i, j int) bool {
-		return orderMap[infos[i].Name] < orderMap[infos[j].Name]
-	})
-
 	return infos, nil
 }
 
 // Returns the list of SDKs of the workshop sorted by installation order.
 func (w *Workshop) SdksByInstallOrder() []SdkInstallation {
-	// Sort the SDKs in installation order.
-	orderMap := make(map[string]int)
-	for i, v := range w.File.Sdks {
-		orderMap[v.Name] = i
-	}
-	// The workshop definition which defines the install order may or may not
-	// contain the system SDK declared in an arbitrary place. Therefore, we have
-	// to make sure that the system SDK goes first and the sketch SDK goes last.
-	orderMap[sdk.System.String()] = -1
-	orderMap[sdk.Sketch] = len(w.File.Sdks)
-	sdks := slices.Collect(maps.Values(w.Sdks))
-	sort.Slice(sdks, func(i, j int) bool {
-		return orderMap[sdks[i].Name] < orderMap[sdks[j].Name]
+	return slices.SortedFunc(maps.Values(w.Sdks), func(a, b SdkInstallation) int {
+		return cmp.Compare(a.InstallOrder, b.InstallOrder)
 	})
-
-	return sdks
 }
 
 // Mounts returns a map of active SDK mounts for the workshop.

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -19,7 +19,6 @@ var (
 	ConfigProjectId               = "user.workshop.project-id"
 	ConfigWorkshopFile            = "user.workshop.file"
 	ConfigWorkshopBaseFingerprint = "user.workshop.base-fingerprint"
-	ConfigWorkshopSdks            = "user.workshop.sdks"
 	ConfigProjectPathDevice       = "workshop.project"
 	ConfigStateStorageDevice      = "workshop.state-storage"
 )

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -17,8 +17,12 @@ import (
 
 var (
 	ConfigProjectId               = "user.workshop.project-id"
+	ConfigWorkshopName            = "user.workshop.name"
 	ConfigWorkshopFile            = "user.workshop.file"
+	ConfigWorkshopBase            = "user.workshop.base"
 	ConfigWorkshopBaseFingerprint = "user.workshop.base-fingerprint"
+	ConfigWorkshopSdk             = "user.workshop.sdk"
+	ConfigWorkshopLayerType       = "user.workshop.layer-type"
 	ConfigProjectPathDevice       = "workshop.project"
 	ConfigStateStorageDevice      = "workshop.state-storage"
 )

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -46,6 +46,10 @@ type SdkInstallation struct {
 	InstallTime time.Time `json:"install-time"`
 }
 
+func SdkDeviceName(sk string) string {
+	return "sdk." + sk
+}
+
 func (w *Workshop) metaFromVolume(ctx context.Context, setup sdk.Setup) (string, error) {
 	vinfo, err := w.Backend.Sdk(ctx, setup)
 	if err != nil {

--- a/internal/workshop/workshop_dirs.go
+++ b/internal/workshop/workshop_dirs.go
@@ -98,7 +98,7 @@ func SdkSourcePath(userDataDir string, project Project, w, sk string, source sdk
 
 func SdkMount(userDataDir, pid, w string, setup sdk.Setup) Mount {
 	mount := Mount{
-		Name:      sdk.VolumeName(setup.Name, setup.Revision),
+		Name:      SdkDeviceName(setup.Name),
 		Where:     sdk.SdkDir(setup.Name),
 		MakeWhere: true,
 		ReadOnly:  true,

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -115,6 +115,7 @@ func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
 				Revision: sdk.R(1),
 				Sha3_384: "84fa7f3d2e556fe410132260dfacb67d4cbbfb36ecfc26dfcef3f247524122d58c992902def9b52b88da0d6ec0efad05",
 			},
+			InstallOrder: 2,
 		},
 		"test-sdk-2": {
 			Setup: sdk.Setup{
@@ -123,6 +124,7 @@ func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
 				Revision: sdk.R(1),
 				Sha3_384: "d4089378c26310627268153caa216240311f2a3193c778e96ed6dd895dc10c82db50f4f39676b29d23d9813b21e14b9b",
 			},
+			InstallOrder: 3,
 		},
 		"system": {
 			Setup: sdk.Setup{
@@ -131,6 +133,7 @@ func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
 				Revision: sdk.R(1),
 				Sha3_384: "6b499970ebf370d4dbc4e9a005c042dee003c19a9420a78944bcbf32653d257f80f7c56bad55b4c967dca68a1ea92be7",
 			},
+			InstallOrder: 1,
 		},
 		"sketch": {
 			Setup: sdk.Setup{
@@ -139,6 +142,7 @@ func (f *workshopSuite) TestSdkSetupsByInstallOrder(c *check.C) {
 				Revision: sdk.R(-3),
 				Sha3_384: "dd4b5a4cba8539e858e5fdcc318e46d9a2940439b0d8e7bd9c6bfc8b474f410d91aee43f5d4e18cb2c1b7dbaaba06fc3",
 			},
+			InstallOrder: 4,
 		},
 	}
 


### PR DESCRIPTION
# Description

- Renames SDK disk devices to `sdk.<NAME>`.
- Stores SDK metadata as `user.sdk.*` properties of these devices, removing the need for `user.workshop.sdks`.
- Removes most config options from workshop snapshots. The devices are replaced by `{"type": "none"}`. SDK devices retain a minimal amount of metadata.

This makes the snapshots behave more like base images, so I was able to merge `Restore` into `LaunchOrRebuildWorkshop` and share a little bit of code between them.

It is likely to break existing workshops.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
