### PR TITLE
Upgrade actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: [self-hosted, reactive, amd64, large-tiobe, noble]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Coverage
         uses: actions/download-artifact@v4

--- a/.github/workflows/doc-cover.yaml
+++ b/.github/workflows/doc-cover.yaml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/fixup.yaml
+++ b/.github/workflows/fixup.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: 'tree:0'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,9 +7,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: canonical/snapd-testing-tools
           path: snapd-testing-tools	      

--- a/.github/workflows/markdown-style-checks.yml
+++ b/.github/workflows/markdown-style-checks.yml
@@ -16,7 +16,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Create venv

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - ${{ matrix.runner.arch }}
       - medium
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: canonical/action-build@v1
         id: snapcraft
@@ -39,7 +39,7 @@ jobs:
       - Linux
       - noble
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run Github Trivy FS Action
         uses: aquasecurity/trivy-action@0.33.1

--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -8,11 +8,11 @@ jobs:
       snap_workshop: ${{ steps.snapcraft_workshop.outputs.snap }}
     steps:
       - name: Checkout Workshop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Checkout Sdkcraft
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: canonical/sdkcraft
           show-progress: true
@@ -55,7 +55,7 @@ jobs:
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
       - name: Checkout Workshop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Go

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: actions/setup-go@v5
@@ -27,7 +27,7 @@ jobs:
   race:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: actions/setup-go@v5

--- a/docs/how-to/develop-with-workshops/run-github-actions-locally.rst
+++ b/docs/how-to/develop-with-workshops/run-github-actions-locally.rst
@@ -260,7 +260,7 @@ For example:
      test:
        runs-on: ["${{ inputs.runner || 'ubuntu-latest' }}"]
        steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v6
          - run: make test
 
 
@@ -342,7 +342,7 @@ the runner can be made conditional on the branch name:
        runs-on: ["${{ startsWith(github.ref_name, 'workshop-runner/') && 'workshop' || 'ubuntu-latest' }}"]
 
        steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v6
          - run: make test
 
 


### PR DESCRIPTION
Since it's out of beta: https://github.com/actions/checkout/releases/tag/v6.0.0

# Description

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
