### PR TITLE
Handle ambiguous workshop exec and run arguments

### DIFF
--- a/client/workshop.go
+++ b/client/workshop.go
@@ -90,6 +90,18 @@ type Remount struct {
 	HostSource string   `json:"host-source"`
 }
 
+type SingleWorkshopError struct {
+	Project string
+	Names   []string
+}
+
+func (e *SingleWorkshopError) Error() string {
+	if len(e.Names) == 0 {
+		return fmt.Sprintf("no workshops found in %q", e.Project)
+	}
+	return fmt.Sprintf("multiple workshops found: %s", strutil.Quoted(e.Names))
+}
+
 func (client *Client) List(opts *ListOptions) ([]*WorkshopInfo, []*WorkshopFile, error) {
 	query := url.Values{}
 	query.Set("state", "available")
@@ -158,11 +170,8 @@ func (client *Client) singleWorkshopOrFile(project *Project) (*WorkshopInfo, *Wo
 		}
 	}
 
-	if len(names) < 1 {
-		return nil, nil, fmt.Errorf("no workshops found in %q", project.Path)
-	}
-	if len(names) > 1 {
-		return nil, nil, fmt.Errorf("multiple workshops found: %s", strutil.Quoted(names))
+	if len(names) != 1 {
+		return nil, nil, &SingleWorkshopError{project.Path, names}
 	}
 
 	var workshop *WorkshopInfo

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/canonical/x-go/strutil/shlex"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/sys/unix"
@@ -62,10 +63,9 @@ type ExecFlags struct {
 }
 
 type ExecArgs struct {
-	workshop string
-	implicit bool
-	command  []string
-	action   bool
+	av            []string
+	argsLenAtDash int
+	action        bool
 }
 
 var shortExecHelp = "Run a command and wait for it to complete"
@@ -90,8 +90,13 @@ To set the mode explicitly, use "-i" or "-I". If neither is supplied,
 
 
 To separate the "exec" subcommand from the command itself,
-use shell syntax such as *--*.
-This syntax is required if the workshop name is omitted.
+use a separator (*--*).
+
+If you omit the separator,
+"exec" treats its first argument as the workshop name.
+If the project has no such workshop
+and the shell is interactive,
+the argument is treated as a command to run in the default workshop.
 
 Notes:
 
@@ -140,9 +145,13 @@ To set the mode explicitly, use "-i" or "-I". If neither is supplied,
 
 
 To separate the "run" subcommand from the action and its arguments,
-use shell syntax such as *--*.
-This syntax is required if the workshop name is omitted
-and the action takes one or more arguments.
+use a separator (*--*).
+
+If you omit the separator,
+"run" treats its first argument as the workshop name.
+If the project has no such workshop
+and the shell is interactive,
+the argument is treated as an action to run in the default workshop.
 
 Notes:
 
@@ -160,26 +169,30 @@ This command enumerates all actions in the workshop, printing a YAML map.
 func (c *CmdExec) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "exec [flags] [<WORKSHOP>] [--] <COMMAND>...",
-		Args:  maybeNameAndCommand,
+		Args:  cobra.MinimumNArgs(1),
 		Short: shortExecHelp,
 		Long:  longExecHelp,
 		Example: `
 Run the "go build main.go" command under the "nimble" workshop
 in the current project directory:
-$ workshop exec nimble go build main.go
+$ workshop exec nimble -- go build main.go
 
 A similar command that sets an environment variable and the working directory:
-$ workshop exec --env GO111MODULE=off -w /project nimble go build -x
+$ workshop exec --env GO111MODULE=off -w /project nimble -- go build -x
+
+Run a command as root (the default is "workshop"):
+$ workshop exec --uid 0 nimble id
 
 Run a custom interactive shell:
 $ workshop exec -I nimble sh
 
-The name is optional if the project has only one workshop
-and a separator is provided:
-$ workshop exec -I -- sh
+If the project has only one workshop, the workshop name is optional:
+$ workshop exec -- sh
 
-Run a command as root (the default is "workshop"):
-$ workshop exec --uid 0 nimble id`,
+If the command doesn't overlap with a workshop name
+and the shell is interactive,
+the separator is also optional:
+$ workshop exec sh`,
 		RunE:              c.Run,
 		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Waiting"}),
 	}
@@ -191,43 +204,23 @@ $ workshop exec --uid 0 nimble id`,
 	return cmd
 }
 
-func maybeNameAndCommand(cmd *cobra.Command, av []string) error {
-	if cmd.ArgsLenAtDash() == 0 {
-		// Workshop name is implicit if -- precedes all positional arguments
-		return cobra.MinimumNArgs(1)(cmd, av)
-	}
-
-	argCount := len(av)
-	if cmd.ArgsLenAtDash() < 0 && slices.Contains(av, "--") {
-		argCount--
-	}
-
-	if argCount < 2 {
-		return fmt.Errorf("requires at least 2 arg(s), only received %d", argCount)
-	}
-	return nil
+func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
+	args := execArgs(av, cmd.ArgsLenAtDash())
+	return exec(c.root, &c.flags, args)
 }
 
-func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
-	args := &ExecArgs{}
-
-	// Infer workshop name if first positional argument is --
-	if cmd.ArgsLenAtDash() == 0 {
-		args.implicit = true
-		args.command = av
-	} else {
-		// Remove first -- if cobra didn't see it
-		if cmd.ArgsLenAtDash() < 0 {
-			if i := slices.Index(av, "--"); i >= 0 {
-				av = slices.Delete(slices.Clone(av), i, i+1)
-			}
-		}
-
-		args.workshop = av[0]
-		args.command = av[1:]
+func execArgs(av []string, argsLenAtDash int) *ExecArgs {
+	args := &ExecArgs{av: av, argsLenAtDash: argsLenAtDash}
+	// With SetInterspersed(false), cobra ignores all but the first
+	// positional argument, so we need to remove `--` manually. We leave
+	// it in if it's part of the command. To summarise:
+	// - workshop exec -- sh: cmd.ArgsLenAtDash() == 0, av == [sh]
+	// - workshop exec ws -- sh: cmd.ArgsLenAtDash() < 0, av == [ws -- sh]
+	if args.argsLenAtDash < 0 && 1 < len(av) && av[1] == "--" {
+		args.av = slices.Delete(slices.Clone(av), 1, 2)
+		args.argsLenAtDash = 1
 	}
-
-	return exec(c.root, &c.flags, args)
+	return args
 }
 
 func (c *CmdShell) Command() *cobra.Command {
@@ -251,27 +244,24 @@ $ workshop shell`,
 }
 
 func (c *CmdShell) Run(cmd *cobra.Command, av []string) error {
-	args := &ExecArgs{command: []string{"bash"}}
-
-	if len(av) > 0 {
-		args.workshop = av[0]
-	} else {
-		args.implicit = true
-	}
-
 	flags := &ExecFlags{
 		WorkingDir: "/project",
 		UserId:     workshop.Uid,
 		GroupId:    workshop.Gid,
 	}
-
+	// With no arguments, we call `exec -- bash`. With one argument, we
+	// call `exec av[0] -- bash`.
+	args := &ExecArgs{
+		av:            append(slices.Clone(av), "bash"),
+		argsLenAtDash: len(av),
+	}
 	return exec(c.root, flags, args)
 }
 
 func (c *CmdRun) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "run [flags] [<WORKSHOP>] [--] <ACTION> <ARGUMENTS>...",
-		Args:  maybeNameAndAction,
+		Args:  cobra.MinimumNArgs(1),
 		Short: shortRunHelp,
 		Long:  longRunHelp,
 		Example: `
@@ -280,15 +270,15 @@ in the current project directory:
 $ workshop run nimble build
 
 A similar command that sets an environment variable and the working directory:
-$ workshop run --env GO111MODULE=off -w /project nimble build
+$ workshop run --env GO111MODULE=off -w /project nimble -- build
 
-The workshop name is optional if the project only has one workshop:
-$ workshop run build
+If the project has only one workshop, the workshop name is optional:
+$ workshop run -- build
 
-Actions can accept arguments,
-if a separator or a workshop name is provided:
-$ workshop run -- build --debug
-`,
+If the action doesn't overlap with a workshop name
+and the shell is interactive,
+the separator is also optional:
+$ workshop run build`,
 		RunE:              c.Run,
 		ValidArgsFunction: c.complete,
 	}
@@ -300,89 +290,77 @@ $ workshop run -- build --debug
 	return cmd
 }
 
-func maybeNameAndAction(cmd *cobra.Command, av []string) error {
-	if cmd.ArgsLenAtDash() == 0 {
-		// Workshop name is implicit if -- precedes all positional arguments
-		return cobra.MinimumNArgs(1)(cmd, av)
-	}
-
-	argCount := len(av)
-	if cmd.ArgsLenAtDash() < 0 && slices.Contains(av, "--") {
-		argCount--
-	}
-
-	if argCount < 1 {
-		return fmt.Errorf("requires at least 1 arg(s), only received %d", argCount)
-	}
-	return nil
-}
-
 func (c *CmdRun) Run(cmd *cobra.Command, av []string) error {
-	args := &ExecArgs{action: true}
-
-	// Infer workshop name if first positional argument is --
-	if cmd.ArgsLenAtDash() == 0 {
-		args.implicit = true
-		args.command = av
-	} else {
-		// Remove first -- if cobra didn't see it
-		if cmd.ArgsLenAtDash() < 0 {
-			if i := slices.Index(av, "--"); i >= 0 {
-				av = slices.Delete(slices.Clone(av), i, i+1)
-			}
-		}
-
-		// Allow `workshop run action`. Passing arguments requires -- though.
-		if len(av) <= 1 {
-			args.implicit = true
-			args.command = av
-		} else {
-			args.workshop = av[0]
-			args.command = av[1:]
-		}
-	}
-
+	args := execArgs(av, cmd.ArgsLenAtDash())
+	args.action = true
 	return exec(c.root, &c.flags, args)
 }
 
-func (c *CmdRun) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	actionIdx := 1
-	dashIdx := len(os.Args) - 2 - len(args)
-	// TODO: Replace with cmd.ArgsLenAtDash() == 0.
+func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// TODO: Replace argsLenAtDash with cmd.ArgsLenAtDash().
 	// See https://github.com/spf13/cobra/issues/1877.
-	if dashIdx >= 0 && os.Args[dashIdx] == "--" {
-		actionIdx = 0
-	} else if actionIdx < len(args) && args[actionIdx] == "--" {
-		actionIdx++
+	argsLenAtDash := -1
+	argsIdx := len(os.Args) - 1 - len(av)
+	if argsIdx > 0 && os.Args[argsIdx-1] == "--" {
+		argsLenAtDash = 0
 	}
+	args := execArgs(av, argsLenAtDash)
 
-	if actionIdx > len(args) {
-		names, directive := c.root.doCompleteWorkshopNames(args, []string{"Ready", "Waiting"})
-
-		// Try action names if no workshop names match partial argument.
-		partialMatch := func(name string) bool {
-			return strings.HasPrefix(name, toComplete)
-		}
-		if directive != cobra.ShellCompDirectiveError && !slices.ContainsFunc(names, partialMatch) {
-			names, directive := completeActions(c.root, args)
-			if directive != cobra.ShellCompDirectiveError {
-				return names, directive
-			}
-
-		}
-
-		return names, directive
-	}
-	if actionIdx < len(args) {
+	// We only complete workshop names and actions. Anything beyond that
+	// must be an argument to the action. The case len(args.av) == 1 and
+	// args.argsLenAtDash < 0 is ambiguous, we check later on.
+	if len(args.av) > 1 || (args.argsLenAtDash == 0 && len(args.av) > 0) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	return completeActions(c.root, args)
+	cli, err := c.root.client()
+	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	project, err := cli.Project(c.root.project())
+	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	// Argument after a separator must be an action.
+	if args.argsLenAtDash >= 0 {
+		return completeActions(cli, project, args.av)
+	}
+
+	workshop, err := cli.SingleWorkshopName(project)
+	if len(args.av) >= 1 {
+		// If there's a single workshop and the first argument isn't
+		// the workshop name, it must be an action and we don't know
+		// how to complete the second argument.
+		if err == nil && args.av[0] != workshop {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		// Otherwise the second argument is an action.
+		return completeActions(cli, project, args.av)
+	}
+	// If there are multiple workshops, first argument must be a workshop name.
+	if err != nil {
+		return completeWorkshopNames(cli, project, args.av, []string{"Ready", "Waiting"})
+	}
+
+	// With a single workshop, complete actions first.
+	actions, directive := completeActions(cli, project, []string{workshop})
+	if directive == cobra.ShellCompDirectiveError {
+		return actions, directive
+	}
+	// If no actions match, but the workshop name does, complete it instead.
+	partialMatch := func(name string) bool { return strings.HasPrefix(name, toComplete) }
+	if !slices.ContainsFunc(actions, partialMatch) && strings.HasPrefix(workshop, toComplete) {
+		return []string{workshop}, cobra.ShellCompDirectiveNoFileComp
+	}
+	return actions, directive
 }
 
-func completeActions(root *CmdRoot, args []string) ([]string, cobra.ShellCompDirective) {
-	actionsCmd := CmdActions{root: root}
-	actions, err := actionsCmd.actions(args)
+func completeActions(cli *client.Client, p *client.Project, args []string) ([]string, cobra.ShellCompDirective) {
+	actions, err := listActions(cli, p, args)
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveError
@@ -421,16 +399,25 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		return err
 	}
 
-	workshop := args.workshop
-	if args.implicit {
-		workshop, err = cli.SingleWorkshopName(project)
-		if err != nil {
-			return err
-		}
+	// Specify Interactive=true if -i is given, or if stdin and stdout are TTYs.
+	stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
+	stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
+	var interactive bool
+	if flags.Interactive {
+		interactive = true
+	} else if flags.NonInteractive {
+		interactive = false
+	} else {
+		interactive = stdinIsTerminal && stdoutIsTerminal
+	}
+
+	workshop, av, err := splitExecArgs(cli, project, interactive, args)
+	if err != nil {
+		return err
 	}
 
 	if args.action {
-		logger.Debugf("Running action %q", args.command)
+		logger.Debugf("Running action %q", av)
 	} else {
 		// Obtain an exec session as close to a real login shell as possible.
 		// This is required as an lxd exec call is a simple namespace exec, and LXD
@@ -449,8 +436,8 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 			"-c",
 			`exec -- "$0" "$@"`,
 		}
-		args.command = append(command, args.command...)
-		logger.Debugf("Running %q", args.command)
+		av = append(command, av...)
+		logger.Debugf("Running %q", av)
 	}
 
 	// Set up environment variables.
@@ -491,19 +478,6 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		env[key] = value
 	}
 
-	stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
-
-	// Specify Interactive=true if -i is given, or if stdin and stdout are TTYs.
-	stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
-	var interactive bool
-	if flags.Interactive {
-		interactive = true
-	} else if flags.NonInteractive {
-		interactive = false
-	} else {
-		interactive = stdinIsTerminal && stdoutIsTerminal
-	}
-
 	// Record terminal state (and restore it before we exit).
 	if interactive && stdinIsTerminal {
 		oldState, err := ptyutil.MakeRaw(unix.Stdin)
@@ -530,7 +504,7 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 	// ls produces access errors, those will not be filtered out to null as LXD
 	// combines stderr and stdout in the interactive mode.
 	opts := &client.ExecOptions{
-		Command:     args.command,
+		Command:     av,
 		Environment: env,
 		Action:      args.action,
 		WorkingDir:  flags.WorkingDir,
@@ -581,6 +555,62 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		// Exit with exit code 0 in this case (same behaviour as ssh).
 		return nil
 	}
+}
+
+// Extract a workshop and the command from the arguments.
+func splitExecArgs(cli *client.Client, project *client.Project, interactive bool, args *ExecArgs) (string, []string, error) {
+	// The first argument is a workshop name if followed by a separator,
+	// but there might not be enough arguments after that.
+	if args.argsLenAtDash == 1 {
+		return splitWorkshopAndCommand(args)
+	}
+
+	workshop, err := cli.SingleWorkshopName(project)
+	// When a separator is the first argument, we always infer the name.
+	if args.argsLenAtDash == 0 {
+		return workshop, args.av, err
+	}
+	// If there's no separator and the first argument doesn't match the
+	// inferred name, it can only be a command. Allowed in interactive mode
+	// since the user likely intended this interpretation. In scripts,
+	// the author may have named a workshop that no longer exists, so we
+	// suggest a more robust approach for non-interactive sessions.
+	if err == nil && workshop != args.av[0] {
+		if interactive {
+			return workshop, args.av, err
+		}
+		action, subject := actionSubject(args.action)
+		suggest := shlex.Join([]string{"workshop", action, "--", args.av[0]})
+		return "", nil, fmt.Errorf(`unclear if %q names a workshop or %s: try "%s"`, args.av[0], subject, suggest)
+	}
+	if err != nil {
+		// Return the error unless there are multiple workshops and the
+		// first argument names one of them.
+		var singleErr *client.SingleWorkshopError
+		if !errors.As(err, &singleErr) || !slices.Contains(singleErr.Names, args.av[0]) {
+			return "", nil, err
+		}
+	}
+
+	// The first argument is a workshop name, but there might not
+	// be enough arguments following it.
+	return splitWorkshopAndCommand(args)
+}
+
+func splitWorkshopAndCommand(args *ExecArgs) (string, []string, error) {
+	if len(args.av) > 1 {
+		return args.av[0], args.av[1:], nil
+	}
+
+	action, subject := actionSubject(args.action)
+	return "", nil, fmt.Errorf("cannot %s %s in %q: must specify %s", action, subject, args.av[0], subject)
+}
+
+func actionSubject(action bool) (string, string) {
+	if action {
+		return "run", "action"
+	}
+	return "exec", "command"
 }
 
 func execControlHandler(process *client.ExecProcess, terminal bool, stop <-chan struct{}, sighup chan<- struct{}) {
@@ -662,7 +692,17 @@ $ workshop actions`,
 }
 
 func (c *CmdActions) Run(cmd *cobra.Command, av []string) error {
-	actions, err := c.actions(av)
+	cli, err := c.root.client()
+	if err != nil {
+		return err
+	}
+
+	p, err := cli.Project(c.root.project())
+	if err != nil {
+		return err
+	}
+
+	actions, err := listActions(cli, p, av)
 	if err != nil || len(actions) == 0 {
 		return err
 	}
@@ -672,17 +712,7 @@ func (c *CmdActions) Run(cmd *cobra.Command, av []string) error {
 	return encoder.Encode(actions)
 }
 
-func (c *CmdActions) actions(av []string) (map[string]client.Action, error) {
-	cli, err := c.root.client()
-	if err != nil {
-		return nil, err
-	}
-
-	p, err := cli.Project(c.root.project())
-	if err != nil {
-		return nil, err
-	}
-
+func listActions(cli *client.Client, p *client.Project, av []string) (map[string]client.Action, error) {
 	if len(av) == 0 {
 		name, err := cli.SingleWorkshopName(p)
 		if err != nil {

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -29,6 +29,9 @@ var mockWorkshopWithActions = `{"type":"sync","status-code":200,"status":"OK","r
 var mockWorkshopActionsError = `{"type":"error","status-code":404,"status":"Not Found","result":{
     "message":"workshop not found"
 }}`
+var mockWorkshopExecError = `{"type":"error","status-code":404,"status":"Not Found","result":{
+    "message":"cannot perform the following tasks:\n- Install action \"foo\" (action not found)"
+}}`
 
 func (m *workshopExec) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
@@ -93,33 +96,150 @@ foo:
 	c.Check(n, check.Equals, 7)
 }
 
-func (m *workshopExec) TestWorkshopRunCompletion(c *check.C) {
-	n := 0
+func (m *workshopExec) TestSingleWorkshopRunErrors(c *check.C) {
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		n++
-		switch n {
-		case 1, 3, 5, 7, 10, 12, 14:
+		switch r.URL.Path {
+		case "/v1/projects":
 			c.Check(r.Method, check.Equals, "POST")
-			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
 			fmt.Fprintln(w, r)
-		case 2, 8, 13, 15:
+		case fmt.Sprintf("/v1/projects/%s/workshops", m.prjId):
 			c.Check(r.Method, check.Equals, "GET")
-			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
 			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
-		case 4, 9, 11, 16:
-			c.Check(r.Method, check.Equals, "GET")
-			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws/actions", m.prjId))
-			w.WriteHeader(200)
-			fmt.Fprintln(w, mockWorkshopWithActions)
-		case 6:
-			c.Check(r.Method, check.Equals, "GET")
-			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/wrong-name/actions", m.prjId))
+		case fmt.Sprintf("/v1/projects/%s/workshops/ws/exec", m.prjId):
+			c.Check(r.Method, check.Equals, "POST")
+			w.WriteHeader(404)
+			fmt.Fprintln(w, mockWorkshopExecError)
+		case fmt.Sprintf("/v1/projects/%s/workshops/foo/exec", m.prjId):
+			c.Check(r.Method, check.Equals, "POST")
 			w.WriteHeader(404)
 			fmt.Fprintln(w, mockWorkshopActionsError)
 		default:
-			c.Errorf("expected 16 calls, now on %d", n)
+			c.Errorf("unexpected API call:", r.URL.Path)
+		}
+	})
+
+	run := &CmdRun{root: &CmdRoot{cwd: m.prjDir}}
+	command := func(args ...string) *cobra.Command {
+		cmd := run.Command()
+		run.flags.Interactive = true
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		cmd.SetArgs(args)
+		return cmd
+	}
+
+	cmd := command("ws")
+	c.Check(cmd.Execute(), check.ErrorMatches, `cannot run action in "ws": must specify action`)
+
+	cmd = command("ws", "foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `(?s).*\(action not found\)`)
+
+	cmd = command("foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `(?s).*\(action not found\)`)
+
+	cmd = command("foo")
+	run.flags.Interactive = false
+	c.Check(cmd.Execute(), check.ErrorMatches, `unclear if "foo" names a workshop or action: try "workshop run -- foo"`)
+
+	cmd = command("--")
+	c.Check(cmd.Execute(), check.ErrorMatches, `requires at least 1 arg\(s\), only received 0`)
+
+	cmd = command("--", "foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `(?s).*\(action not found\)`)
+
+	cmd = command("ws", "--")
+	c.Check(cmd.Execute(), check.ErrorMatches, `cannot run action in "ws": must specify action`)
+
+	cmd = command("foo", "--")
+	c.Check(cmd.Execute(), check.ErrorMatches, `cannot run action in "foo": must specify action`)
+
+	cmd = command("ws", "--", "foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `(?s).*\(action not found\)`)
+
+	cmd = command("foo", "--", "foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `workshop not found`)
+}
+
+func (m *workshopExec) TestMultipleWorkshopRunErrors(c *check.C) {
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/projects":
+			c.Check(r.Method, check.Equals, "POST")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case fmt.Sprintf("/v1/projects/%s/workshops", m.prjId):
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopList2)
+		case fmt.Sprintf("/v1/projects/%s/workshops/ws/exec", m.prjId):
+			c.Check(r.Method, check.Equals, "POST")
+			w.WriteHeader(404)
+			fmt.Fprintln(w, mockWorkshopExecError)
+		case fmt.Sprintf("/v1/projects/%s/workshops/foo/exec", m.prjId):
+			c.Check(r.Method, check.Equals, "POST")
+			w.WriteHeader(404)
+			fmt.Fprintln(w, mockWorkshopActionsError)
+		default:
+			c.Errorf("unexpected API call:", r.URL.Path)
+		}
+	})
+
+	run := &CmdRun{root: &CmdRoot{cwd: m.prjDir}}
+	command := func(args ...string) *cobra.Command {
+		cmd := run.Command()
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		cmd.SetArgs(args)
+		return cmd
+	}
+
+	cmd := command("ws")
+	c.Check(cmd.Execute(), check.ErrorMatches, `cannot run action in "ws": must specify action`)
+
+	cmd = command("ws", "foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `(?s).*\(action not found\)`)
+
+	cmd = command("foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `cannot infer workshop name: multiple workshops found: "ws", "ws2"`)
+
+	cmd = command("--")
+	c.Check(cmd.Execute(), check.ErrorMatches, `requires at least 1 arg\(s\), only received 0`)
+
+	cmd = command("--", "foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `cannot infer workshop name: multiple workshops found: "ws", "ws2"`)
+
+	cmd = command("ws", "--")
+	c.Check(cmd.Execute(), check.ErrorMatches, `cannot run action in "ws": must specify action`)
+
+	cmd = command("foo", "--")
+	c.Check(cmd.Execute(), check.ErrorMatches, `cannot run action in "foo": must specify action`)
+
+	cmd = command("ws", "--", "foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `(?s).*\(action not found\)`)
+
+	cmd = command("foo", "--", "foo")
+	c.Check(cmd.Execute(), check.ErrorMatches, `workshop not found`)
+}
+
+func (m *workshopExec) TestSingleWorkshopRunCompletion(c *check.C) {
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/projects":
+			c.Check(r.Method, check.Equals, "POST")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case fmt.Sprintf("/v1/projects/%s/workshops", m.prjId):
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
+		case fmt.Sprintf("/v1/projects/%s/workshops/ws/actions", m.prjId):
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithActions)
+		default:
+			c.Errorf("unexpected API call:", r.URL.Path)
 		}
 	})
 
@@ -134,17 +254,32 @@ func (m *workshopExec) TestWorkshopRunCompletion(c *check.C) {
 	os.Args = []string{"workshop", "__complete", "run", ""}
 	result, compDirective := run.ValidArgsFunction(run, nil, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+
+	os.Args = []string{"workshop", "__complete", "run", "w"}
+	result, compDirective = run.ValidArgsFunction(run, nil, "w")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(result, check.DeepEquals, []string{"ws"})
+
+	os.Args = []string{"workshop", "__complete", "run", "f"}
+	result, compDirective = run.ValidArgsFunction(run, nil, "f")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+
+	os.Args = []string{"workshop", "__complete", "run", "zyx"}
+	result, compDirective = run.ValidArgsFunction(run, nil, "zyx")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+
+	os.Args = []string{"workshop", "__complete", "run", "foo", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"foo"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"ws"}, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
-
-	os.Args = []string{"workshop", "__complete", "run", "wrong-name", ""}
-	result, compDirective = run.ValidArgsFunction(run, []string{"wrong-name"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveError)
-	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "foo"}, "")
@@ -170,11 +305,77 @@ func (m *workshopExec) TestWorkshopRunCompletion(c *check.C) {
 	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "--", "foo"}, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(result, check.HasLen, 0)
+}
 
-	os.Args = []string{"workshop", "__complete", "run", "f"}
-	result, compDirective = run.ValidArgsFunction(run, nil, "f")
+func (m *workshopExec) TestMultipleWorkshopRunCompletion(c *check.C) {
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/projects":
+			c.Check(r.Method, check.Equals, "POST")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case fmt.Sprintf("/v1/projects/%s/workshops", m.prjId):
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopList2)
+		case fmt.Sprintf("/v1/projects/%s/workshops/ws/actions", m.prjId):
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithActions)
+		case fmt.Sprintf("/v1/projects/%s/workshops/foo/actions", m.prjId):
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(404)
+			fmt.Fprintln(w, mockWorkshopActionsError)
+		default:
+			c.Errorf("unexpected API call:", r.URL.Path)
+		}
+	})
+
+	cmd := &CmdRun{root: &CmdRoot{cwd: m.prjDir}}
+	run := cmd.Command()
+
+	// TODO: remove this workaround once this bug is fixed:
+	// https://github.com/spf13/cobra/issues/1877
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	os.Args = []string{"workshop", "__complete", "run", ""}
+	result, compDirective := run.ValidArgsFunction(run, nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"ws"})
+
+	os.Args = []string{"workshop", "__complete", "run", "foo", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"foo"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveError)
+	c.Check(result, check.HasLen, 0)
+
+	os.Args = []string{"workshop", "__complete", "run", "ws", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"ws"}, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
 
-	c.Check(n, check.Equals, 16)
+	os.Args = []string{"workshop", "__complete", "run", "ws", "foo", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "foo"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.HasLen, 0)
+
+	os.Args = []string{"workshop", "__complete", "run", "--", ""}
+	result, compDirective = run.ValidArgsFunction(run, nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveError)
+	c.Check(result, check.HasLen, 0)
+
+	os.Args = []string{"workshop", "__complete", "run", "--", "foo", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"foo"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.HasLen, 0)
+
+	os.Args = []string{"workshop", "__complete", "run", "ws", "--", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "--"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+
+	os.Args = []string{"workshop", "__complete", "run", "ws", "--", "foo", ""}
+	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "--", "foo"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.HasLen, 0)
 }

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -232,6 +232,10 @@ func (c *CmdRoot) doCompleteWorkshopNames(args []string, status []string) ([]str
 		return nil, cobra.ShellCompDirectiveError
 	}
 
+	return completeWorkshopNames(cli, project, args, status)
+}
+
+func completeWorkshopNames(cli *client.Client, project *client.Project, args []string, status []string) ([]string, cobra.ShellCompDirective) {
 	workshopInfo, _, err := cli.List(&client.ListOptions{ProjectId: project.Id})
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)

--- a/docs/explanation/workshops/concepts.rst
+++ b/docs/explanation/workshops/concepts.rst
@@ -307,7 +307,7 @@ To run these actions, you use the :command:`workshop run` command:
 
 .. code-block:: console
 
-   $ workshop run lint
+   $ workshop run dev -- lint
 
 
 When you thus invoke an action, it's injected into the workshop
@@ -321,7 +321,7 @@ run :command:`workshop actions`:
 
 .. code-block:: console
 
-   $ workshop actions
+   $ workshop actions dev
 
 
 This mechanism avoids the need to maintain helper scripts manually,

--- a/docs/how-to/customize-workshops/add-actions.rst
+++ b/docs/how-to/customize-workshops/add-actions.rst
@@ -52,19 +52,21 @@ Running actions
 ---------------
 
 To execute an action,
-use the :command:`workshop run` command followed by the action name:
+use the :command:`workshop run` command.
+Specify the workshop and its action,
+with an optional separator (:samp:`--`):
 
 .. @artefact workshop run
 
 .. code-block:: console
 
-   $ workshop run lint
+   $ workshop run dev -- lint
 
      main.go:1:
      ./main.go:5:2: "os" imported and not used (typecheck)
      package main
 
-   $ workshop run shellcheck
+   $ workshop run dev shellcheck
    
      In 1.sh line 10:
      cat /etc/passwd | grep root
@@ -73,7 +75,18 @@ use the :command:`workshop run` command followed by the action name:
 
 When you run an action using :command:`workshop run`,
 any additional arguments provided after the action name
-are passed directly to the action itself.
+are passed directly to the action itself:
+
+.. code-block:: console
+
+   $ workshop run dev -- lint --verbose
+
+
+In projects with a single workshop, the workshop name is optional:
+
+.. code-block:: console
+
+   $ workshop run -- lint
 
 
 Conclusion

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -8,13 +8,16 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  echo "Check that one -- prevents further argument parsing"
+  echo "Check exec argument parsing"
+  workshop_exec exec ws-exec -- echo -e '\x66oo' | MATCH foo
   workshop_exec exec ws-exec echo -e '\x66oo' | MATCH foo
   workshop_exec exec -- echo -e '\x66oo' | MATCH foo
-  workshop_exec exec ws-exec -- echo -e '\x66oo' | MATCH foo
-  workshop_exec exec ws-exec echo -- -e '\x66oo' | MATCH foo
-  workshop_exec exec -- echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
+  workshop_exec exec -i echo -e '\x66oo' | MATCH foo
+  ! workshop_exec exec -I echo -e '\x66oo'
   workshop_exec exec ws-exec -- echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
+  workshop_exec exec ws-exec echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
+  workshop_exec exec -- echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
+  ! workshop_exec exec echo -- -e '\x66oo'
 
   echo "Check an environment variable can be set"
   workshop_exec exec --env 'Foo=bar' ws-exec bash -c '[ "$Foo" = bar ]'
@@ -60,24 +63,24 @@ execute: |
   [ "$exitcode" -eq 125 ]
 
   echo "Check actions"
-  workshop_exec run oneline | MATCH '^one line$'
+  workshop_exec run -- oneline | MATCH '^one line$'
   workshop_exec run ws-exec multiline > multiline.log
   MATCH '^multi$' < multiline.log
   MATCH '^line$' < multiline.log
   ! workshop_exec run ws-exec fail
   workshop_exec run -- file | MATCH '^script$'
-  workshop_exec run env | MATCH 'FOO=BAR' 
+  workshop_exec run -- env | MATCH 'FOO=BAR' 
 
   echo "Check actions can be updated without refreshing"
   sed -i 's/one line/1 LINE/g' workshop.yaml
-  workshop_exec run oneline | MATCH '^1 LINE$'
+  workshop_exec run ws-exec oneline | MATCH '^1 LINE$'
   sed -i 's/oneline/line1/' workshop.yaml
-  workshop_exec run line1 | MATCH '^1 LINE$'
+  workshop_exec run -- line1 | MATCH '^1 LINE$'
 
   echo "Check install-action error message"
   workshop_exec exec --uid 0 --gid 0 -- rm -f /var/lib/workshop/run/actions/line1
   workshop_exec exec --uid 0 --gid 0 -- mkdir /var/lib/workshop/run/actions/line1
-  ! workshop_exec run line1 > line1.log
+  ! workshop_exec run ws-exec line1 > line1.log
   MATCH '^error: cannot perform the following tasks:$' < line1.log
   MATCH '^- Install action "line1" \(.*\)$' < line1.log
 


### PR DESCRIPTION
# Description

Using a separator (--) to split the command or action from workshop CLI arguments leaves no room for ambiguity. But users seem to prefer leaving it out, for interactive use. So we now parse arguments like this:

- `workshop exec dev -- bash`: execute "bash" in "dev"
- `workshop exec -- bash`: execute "bash" in the single workshop
- `workshop exec dev bash`: try the first case, but fall back to the second if:
  - the project has a single workshop
  - it's not called `dev`, and
  - stdout is a TTY.

The workshop CLI now ignores `--` if it's not in position 0 or 1. This is mostly to simplify the code, but also these are the only places where it has a special meaning. For reference, `sudo` only considers `--` if it's before the command.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [x] Headings and titles accurately describe the content.
* [x] New and updated pages include correct metadata.
* [x] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [x] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [x] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
