### PR TITLE
Rename layers to snapshots

### DIFF
--- a/docs/explanation/architecture/components.rst
+++ b/docs/explanation/architecture/components.rst
@@ -228,8 +228,8 @@ providing snapshot and restore capabilities for efficient workshop updates.
 |ws_markup| implements user isolation through LXD's project system,
 automatically creating dedicated projects for each user
 following the naming pattern :samp:`workshop.<USERNAME>`.
-Each user project includes a corresponding layers project
-(:samp:`workshop-layers.<USERNAME>`)
+Each user project includes a corresponding snapshots project
+(:samp:`workshop-snapshots.<USERNAME>`)
 used for temporary storage during workshop rebuild operations.
 
 

--- a/docs/how-to/fix-workshops/purge.rst
+++ b/docs/how-to/fix-workshops/purge.rst
@@ -88,12 +88,12 @@ for initial steps on listing and deleting orphaned LXD containers, e.g.:
 
 
 To ensure there are no backup copies of the workshop remaining,
-check the :samp:`workshop-layers.<USERNAME>` project as well:
+check the :samp:`workshop-snapshots.<USERNAME>` project as well:
 
 .. code-block:: console
 
-   $ sudo lxc list --all-projects | grep workshop-layers.<USERNAME>
-   $ sudo lxc delete --project workshop-layers.<USERNAME> <CONTAINER> --force
+   $ sudo lxc list --all-projects | grep workshop-snapshots.<USERNAME>
+   $ sudo lxc delete --project workshop-snapshots.<USERNAME> <CONTAINER> --force
 
 
 In addition to containers,

--- a/internal/interfaces/lxd_device/tests/integration/backend_test.go
+++ b/internal/interfaces/lxd_device/tests/integration/backend_test.go
@@ -119,7 +119,7 @@ func (f *backendDeviceSuite) SetUpTest(c *check.C) {
 func (f *backendDeviceSuite) TearDownTest(c *check.C) {
 	helper.RemoveTestWorkshop(c, f.ctx, f.be)
 	helper.CleanupLxdProject(c, f.client, "workshop."+f.usr.Username)
-	helper.CleanupLxdProject(c, f.client, "workshop-layers."+f.usr.Username)
+	helper.CleanupLxdProject(c, f.client, "workshop-snapshots."+f.usr.Username)
 	f.restoreNewId()
 	f.restoreEnv()
 	f.restoreUser()

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -275,7 +275,7 @@ func New() (*Backend, error) {
 }
 
 func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, snapshot workshop.Snapshot) error {
-	conn, layerConn, err := s.layerClients(ctx)
+	conn, snapshotConn, err := s.snapshotClients(ctx)
 	if err != nil {
 		return err
 	}
@@ -314,16 +314,16 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 			Type:        api.SourceTypeImage,
 			Fingerprint: snapshot.Image.Fingerprint,
 		}
-		if err := s.launchOrRebuildFromImage(conn, layerConn, req); err != nil {
+		if err := s.launchOrRebuildFromImage(conn, snapshotConn, req); err != nil {
 			return err
 		}
 		return s.patchInstance(ctx, file.Name, file.Base)
 	}
 
-	return s.launchOrRebuildFromLayer(conn, layerConn, req, snapshot.Sdks)
+	return s.launchOrRebuildFromSnapshot(conn, snapshotConn, req, snapshot.Sdks)
 }
 
-func (s *Backend) launchOrRebuildFromImage(conn, layerConn lxd.InstanceServer, req api.InstancesPost) error {
+func (s *Backend) launchOrRebuildFromImage(conn, snapshotConn lxd.InstanceServer, req api.InstancesPost) error {
 	inst, _, err := conn.GetInstance(req.Name)
 	if api.StatusErrorCheck(err, http.StatusNotFound) {
 		// Create a new workshop.
@@ -341,12 +341,12 @@ func (s *Backend) launchOrRebuildFromImage(conn, layerConn lxd.InstanceServer, r
 	projectId := inst.Config[workshop.ConfigProjectId]
 	name := inst.Config[workshop.ConfigWorkshopName]
 
-	snapshots, err := s.layerNames(layerConn, projectId, name, "sdk")
+	snapshots, err := s.snapshotNames(snapshotConn, projectId, name, "sdk")
 	if err != nil {
 		return err
 	}
 	for _, snapshot := range snapshots {
-		if err := s.deleteLayer(layerConn, snapshot); err != nil {
+		if err := s.deleteSnapshot(snapshotConn, snapshot); err != nil {
 			return err
 		}
 	}
@@ -892,7 +892,7 @@ func (s *Backend) RemoveWorkshop(ctx context.Context, name string) (err error) {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	conn, layerConn, err := s.layerClients(ctx)
+	conn, snapshotConn, err := s.snapshotClients(ctx)
 	if err != nil {
 		return err
 	}
@@ -903,12 +903,12 @@ func (s *Backend) RemoveWorkshop(ctx context.Context, name string) (err error) {
 		logger.Noticef("On RemoveWorkshop: failed to stop %q workshop: %v", name, err)
 	}
 
-	snapshots, err := s.layerNames(layerConn, projectId, name, "sdk")
+	snapshots, err := s.snapshotNames(snapshotConn, projectId, name, "sdk")
 	if err != nil {
 		logger.Noticef("On RemoveWorkshop: failed to find SDK snapshots for %q workshop: %v", name, err)
 	} else {
 		for _, snapshot := range snapshots {
-			if err := s.deleteLayer(layerConn, snapshot); err != nil {
+			if err := s.deleteSnapshot(snapshotConn, snapshot); err != nil {
 				logger.Noticef("On RemoveWorkshop: failed to delete %q SDK snapshot for %q workshop: %v", snapshot, name, err)
 			}
 		}

--- a/internal/workshop/lxd/lxd_backend_layers.go
+++ b/internal/workshop/lxd/lxd_backend_layers.go
@@ -119,7 +119,7 @@ func configOverrides(pid, name, sk string, image workshop.BaseImage, config map[
 		workshop.ConfigWorkshopName:            name,
 		workshop.ConfigWorkshopBase:            image.Name,
 		workshop.ConfigWorkshopBaseFingerprint: image.Fingerprint,
-		workshop.ConfigWorkshopLayerType:       "sdk",
+		workshop.ConfigWorkshopSnapshotType:    "sdk",
 		workshop.ConfigWorkshopSdk:             sk,
 	}
 	for k := range config {
@@ -306,7 +306,7 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	// layer type to distinguish the backups from the originals.
 	for _, layer := range layers {
 		newname := "stash-" + layer
-		config := map[string]string{workshop.ConfigWorkshopLayerType: "stash-sdk"}
+		config := map[string]string{workshop.ConfigWorkshopSnapshotType: "stash-sdk"}
 		if err := s.copyInstance(layerConn, layerConn, layer, newname, false, config); err != nil {
 			return err
 		}
@@ -321,7 +321,7 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	instance := InstanceName(name, projectId)
 	stashed := instanceStashName(name, projectId)
 	// Mark the copy as a stash to avoid confusing it with an SDK layer.
-	config := map[string]string{workshop.ConfigWorkshopLayerType: "stash"}
+	config := map[string]string{workshop.ConfigWorkshopSnapshotType: "stash"}
 	if err := s.copyInstance(conn, layerConn, instance, stashed, false, config); err != nil {
 		return err
 	}
@@ -370,7 +370,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 			continue
 		}
 		// Restore the original layer type (stash-sdk -> sdk).
-		config := map[string]string{workshop.ConfigWorkshopLayerType: "sdk"}
+		config := map[string]string{workshop.ConfigWorkshopSnapshotType: "sdk"}
 		if err := s.copyInstance(layerConn, layerConn, layer, name, false, config); err != nil {
 			return err
 		}
@@ -380,7 +380,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 	instance := InstanceName(name, projectId)
 	stash := instanceStashName(name, projectId)
 	// Avoid restoring the option which we added when stashing.
-	config := map[string]string{workshop.ConfigWorkshopLayerType: ""}
+	config := map[string]string{workshop.ConfigWorkshopSnapshotType: ""}
 	if err := s.copyInstance(layerConn, conn, stash, instance, true, config); err != nil {
 		return err
 	}
@@ -570,7 +570,7 @@ func (s *Backend) layerClients(ctx context.Context) (lxd.InstanceServer, lxd.Ins
 		return nil, nil, fmt.Errorf("context key %s not found", workshop.ContextUser)
 	}
 
-	project, err := lxdLayersProjectName(user)
+	project, err := lxdSnapshotsProjectName(user)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -46,8 +46,8 @@ func lxdProjectName(user string) (string, error) {
 	return projectName("workshop.", user)
 }
 
-func lxdLayersProjectName(user string) (string, error) {
-	return projectName("workshop-layers.", user)
+func lxdSnapshotsProjectName(user string) (string, error) {
+	return projectName("workshop-snapshots.", user)
 }
 
 // Create LXD projects (storing workshops and layers) for the user if they don't exist.
@@ -74,7 +74,7 @@ func initLxdProject(conn lxd.InstanceServer, project, username string) error {
 	defer rev.Fail()
 	rev.Add(func() { _ = conn.DeleteProject(project, false) })
 
-	layers, err := lxdLayersProjectName(username)
+	layers, err := lxdSnapshotsProjectName(username)
 	if err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -50,7 +50,7 @@ func lxdSnapshotsProjectName(user string) (string, error) {
 	return projectName("workshop-snapshots.", user)
 }
 
-// Create LXD projects (storing workshops and layers) for the user if they don't exist.
+// Create LXD projects (storing workshops and snapshots) for the user if they don't exist.
 func initLxdProject(conn lxd.InstanceServer, project, username string) error {
 	names, err := conn.GetProjectNames()
 	if err != nil {
@@ -74,17 +74,17 @@ func initLxdProject(conn lxd.InstanceServer, project, username string) error {
 	defer rev.Fail()
 	rev.Add(func() { _ = conn.DeleteProject(project, false) })
 
-	layers, err := lxdSnapshotsProjectName(username)
+	snapshots, err := lxdSnapshotsProjectName(username)
 	if err != nil {
 		return err
 	}
-	if !slices.Contains(names, layers) {
+	if !slices.Contains(names, snapshots) {
 		err = conn.CreateProject(api.ProjectsPost{
 			ProjectPut: api.ProjectPut{
 				Config:      lxdProjectConfig(username),
-				Description: fmt.Sprintf(`Workshop layers project for "%s" user`, username),
+				Description: fmt.Sprintf(`Workshop snapshots project for "%s" user`, username),
 			},
-			Name: layers,
+			Name: snapshots,
 		})
 		if err != nil {
 			return err

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -349,7 +349,7 @@ func sdkVolume(volume *api.StorageVolume, lxdProject string, size uint64) (works
 			continue
 		}
 		if projectName != lxdProject {
-			// Ignore SDK layers, and workshops owned by other users.
+			// Ignore SDK snapshots, and workshops owned by other users.
 			continue
 		}
 		wp, pid := workshopProjectId(pathArgs[0])

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -59,7 +59,7 @@ func (s *Backend) Snapshot(ctx context.Context, name, sk string) error {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	conn, layerConn, err := s.layerClients(ctx)
+	conn, snapshotConn, err := s.snapshotClients(ctx)
 	if err != nil {
 		return err
 	}
@@ -97,12 +97,12 @@ func (s *Backend) Snapshot(ctx context.Context, name, sk string) error {
 		Profiles:     []string{},
 	})
 
-	snapshot, err := sdkLayerName(sk)
+	snapshot, err := sdkSnapshotName(sk)
 	if err != nil {
 		return err
 	}
 	args := lxd.InstanceCopyArgs{Name: snapshot, InstanceOnly: true}
-	rop, err := layerConn.CopyInstance(conn, *inst, &args)
+	rop, err := snapshotConn.CopyInstance(conn, *inst, &args)
 	if err != nil {
 		return err
 	}
@@ -150,10 +150,10 @@ func deviceOverrides(devices map[string]map[string]string) (map[string]map[strin
 	return overrides, nil
 }
 
-// Generates a random suffix for the SDK, to avoid clashing with SDK layers
-// from other projects and workshops, while remaining withing the 63 characters
+// Generates a random suffix for the SDK, to avoid clashing with SDK snapshots
+// from other projects and workshops, while remaining within the 63 characters
 // allowed for LXD instance names.
-func sdkLayerName(sk string) (string, error) {
+func sdkSnapshotName(sk string) (string, error) {
 	bytes := make([]byte, 8)
 	_, err := rand.Read(bytes)
 	if err != nil {
@@ -162,23 +162,23 @@ func sdkLayerName(sk string) (string, error) {
 	return sk + "-" + hex.EncodeToString(bytes), nil
 }
 
-func (s *Backend) launchOrRebuildFromLayer(conn, layerConn lxd.InstanceServer, req api.InstancesPost, sdks []sdk.Id) error {
+func (s *Backend) launchOrRebuildFromSnapshot(conn, snapshotConn lxd.InstanceServer, req api.InstancesPost, sdks []sdk.Id) error {
 	projectId := req.Config[workshop.ConfigProjectId]
 	name := req.Config[workshop.ConfigWorkshopName]
 
 	// Find snapshots to keep and remove.
 	lastSdk := sdks[len(sdks)-1].Name
-	layerName, obstacles, err := s.layerNamesAfter(layerConn, projectId, name, lastSdk)
+	snapshotName, obstacles, err := s.snapshotNamesAfter(snapshotConn, projectId, name, lastSdk)
 	if err != nil {
 		return err
 	}
 
-	layer, _, err := layerConn.GetInstance(layerName)
+	snapshot, _, err := snapshotConn.GetInstance(snapshotName)
 	if err != nil {
 		return err
 	}
 	// Snapshots should only contain the requested devices and SDK mounts.
-	for key, device := range layer.Devices {
+	for key, device := range snapshot.Devices {
 		installOrder, s, err := maybeSdkId(key, device)
 		if err != nil {
 			return err
@@ -188,9 +188,9 @@ func (s *Backend) launchOrRebuildFromLayer(conn, layerConn lxd.InstanceServer, r
 				// SDK will be reinstalled as a separate task.
 				continue
 			}
-			return fmt.Errorf("internal error: snapshot %q has unexpected %q SDK", layer.Name, s.Name)
+			return fmt.Errorf("internal error: snapshot %q has unexpected %q SDK", snapshot.Name, s.Name)
 		} else if _, ok := req.Devices[key]; !ok {
-			return fmt.Errorf("internal error: snapshot %q has unexpected device %q", layer.Name, key)
+			return fmt.Errorf("internal error: snapshot %q has unexpected device %q", snapshot.Name, key)
 		}
 	}
 
@@ -199,18 +199,18 @@ func (s *Backend) launchOrRebuildFromLayer(conn, layerConn lxd.InstanceServer, r
 	// but we want to avoid having two snapshots for the same SDK and
 	// workshop until we introduce a way to distinguish them.
 	for _, obstacle := range obstacles {
-		if err := s.deleteLayer(layerConn, obstacle); err != nil {
+		if err := s.deleteSnapshot(snapshotConn, obstacle); err != nil {
 			return err
 		}
 	}
 
-	overrides := overrideLayer(*layer, req.InstancePut)
+	overrides := overrideSnapshot(*snapshot, req.InstancePut)
 	args := lxd.InstanceCopyArgs{
 		Name:         req.Name,
 		InstanceOnly: true,
 		Refresh:      true,
 	}
-	rop, err := conn.CopyInstance(layerConn, overrides, &args)
+	rop, err := conn.CopyInstance(snapshotConn, overrides, &args)
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (s *Backend) launchOrRebuildFromLayer(conn, layerConn lxd.InstanceServer, r
 	if err != nil {
 		return err
 	}
-	req.Config = mergeOptions(req.Config, layer.Config, inst.Config)
+	req.Config = mergeOptions(req.Config, snapshot.Config, inst.Config)
 	req.Architecture = inst.Architecture
 	op, err := conn.UpdateInstance(req.Name, req.InstancePut, etag)
 	if err != nil {
@@ -234,11 +234,11 @@ func (s *Backend) launchOrRebuildFromLayer(conn, layerConn lxd.InstanceServer, r
 	return op.Wait()
 }
 
-func overrideLayer(layer api.Instance, req api.InstancePut) api.Instance {
+func overrideSnapshot(snapshot api.Instance, req api.InstancePut) api.Instance {
 	// Set all requested options and remove snapshot options that aren't
 	// managed by LXD.
 	req.Config = maps.Clone(req.Config)
-	for k := range layer.Config {
+	for k := range snapshot.Config {
 		if _, ok := req.Config[k]; !ok && optionDomain(k) == customOption {
 			req.Config[k] = ""
 		}
@@ -247,9 +247,9 @@ func overrideLayer(layer api.Instance, req api.InstancePut) api.Instance {
 	if req.Profiles == nil {
 		req.Profiles = []string{}
 	}
-	req.Architecture = layer.Architecture
-	layer.SetWritable(req)
-	return layer
+	req.Architecture = snapshot.Architecture
+	snapshot.SetWritable(req)
+	return snapshot
 }
 
 func mergeOptions(req, source, target map[string]string) map[string]string {
@@ -281,7 +281,7 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	conn, layerConn, err := s.layerClients(ctx)
+	conn, snapshotConn, err := s.snapshotClients(ctx)
 	if err != nil {
 		return err
 	}
@@ -297,22 +297,22 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 		}
 	})
 
-	layers, err := s.layerNames(layerConn, projectId, name, "sdk")
+	snapshots, err := s.snapshotNames(snapshotConn, projectId, name, "sdk")
 	if err != nil {
 		return err
 	}
 
-	// Backup the workshop's SDK layers, modifying the instance name and
-	// layer type to distinguish the backups from the originals.
-	for _, layer := range layers {
-		newname := "stash-" + layer
+	// Backup the workshop's SDK snapshots, modifying the instance name and
+	// snapshot type to distinguish the backups from the originals.
+	for _, snapshot := range snapshots {
+		newname := "stash-" + snapshot
 		config := map[string]string{workshop.ConfigWorkshopSnapshotType: "stash-sdk"}
-		if err := s.copyInstance(layerConn, layerConn, layer, newname, false, config); err != nil {
+		if err := s.copyInstance(snapshotConn, snapshotConn, snapshot, newname, false, config); err != nil {
 			return err
 		}
 		rev.Add(func() {
-			if rerr := s.deleteLayer(layerConn, newname); rerr != nil {
-				logger.Noticef("On StashWorkshop: Cannot remove layer %q after failed stash operation: %v", newname, rerr)
+			if rerr := s.deleteSnapshot(snapshotConn, newname); rerr != nil {
+				logger.Noticef("On StashWorkshop: Cannot remove snapshot %q after failed stash operation: %v", newname, rerr)
 			}
 		})
 	}
@@ -320,9 +320,9 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	// Backup the workshop itself.
 	instance := InstanceName(name, projectId)
 	stashed := instanceStashName(name, projectId)
-	// Mark the copy as a stash to avoid confusing it with an SDK layer.
+	// Mark the copy as a stash to avoid confusing it with an SDK snapshot.
 	config := map[string]string{workshop.ConfigWorkshopSnapshotType: "stash"}
-	if err := s.copyInstance(conn, layerConn, instance, stashed, false, config); err != nil {
+	if err := s.copyInstance(conn, snapshotConn, instance, stashed, false, config); err != nil {
 		return err
 	}
 
@@ -336,42 +336,42 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	conn, layerConn, err := s.layerClients(ctx)
+	conn, snapshotConn, err := s.snapshotClients(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Disconnect()
 
-	layers, err := s.layerNames(layerConn, projectId, name, "sdk")
+	snapshots, err := s.snapshotNames(snapshotConn, projectId, name, "sdk")
 	if err != nil {
 		return err
 	}
-	stashLayers, err := s.layerNames(layerConn, projectId, name, "stash-sdk")
+	stashSnapshots, err := s.snapshotNames(snapshotConn, projectId, name, "stash-sdk")
 	if err != nil {
 		return err
 	}
 
-	// Remove the layers that were created after stashing. These are the
+	// Remove the snapshots that were created after stashing. These are the
 	// ones which don't have backups.
-	for _, layer := range layers {
-		if slices.Contains(stashLayers, "stash-"+layer) {
+	for _, snapshot := range snapshots {
+		if slices.Contains(stashSnapshots, "stash-"+snapshot) {
 			continue
 		}
-		if err := s.deleteLayer(layerConn, layer); err != nil {
+		if err := s.deleteSnapshot(snapshotConn, snapshot); err != nil {
 			return err
 		}
 	}
 
-	// Restore the layers that were deleted when restoring an SDK snapshot.
-	// These come from the backups whose source no longer exists.
-	for _, layer := range stashLayers {
-		name := strings.TrimPrefix(layer, "stash-")
-		if slices.Contains(layers, name) {
+	// Restore the snapshots that were deleted when restoring an SDK
+	// snapshot. These come from the backups whose source no longer exists.
+	for _, snapshot := range stashSnapshots {
+		name := strings.TrimPrefix(snapshot, "stash-")
+		if slices.Contains(snapshots, name) {
 			continue
 		}
-		// Restore the original layer type (stash-sdk -> sdk).
+		// Restore the original snapshot type (stash-sdk -> sdk).
 		config := map[string]string{workshop.ConfigWorkshopSnapshotType: "sdk"}
-		if err := s.copyInstance(layerConn, layerConn, layer, name, false, config); err != nil {
+		if err := s.copyInstance(snapshotConn, snapshotConn, snapshot, name, false, config); err != nil {
 			return err
 		}
 	}
@@ -381,62 +381,62 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 	stash := instanceStashName(name, projectId)
 	// Avoid restoring the option which we added when stashing.
 	config := map[string]string{workshop.ConfigWorkshopSnapshotType: ""}
-	if err := s.copyInstance(layerConn, conn, stash, instance, true, config); err != nil {
+	if err := s.copyInstance(snapshotConn, conn, stash, instance, true, config); err != nil {
 		return err
 	}
 
 	return s.startWorkshop(conn, ctx, name)
 }
 
-// Find layer names for all SDKs in the given workshop or stash.
-func (s *Backend) layerNames(layerConn lxd.InstanceServer, pid, w string, kind string) ([]string, error) {
+// Find snapshot names for all SDKs in the given workshop or stash.
+func (s *Backend) snapshotNames(snapshotConn lxd.InstanceServer, pid, w string, kind string) ([]string, error) {
 	filters := []string{
 		"config.user.workshop.project-id=" + pid,
 		"config.user.workshop.name=" + w,
-		"config.user.workshop.layer-type=" + kind,
+		"config.user.workshop.snapshot-type=" + kind,
 	}
-	layers, err := layerConn.GetInstancesWithFilter(api.InstanceTypeContainer, filters)
+	snapshots, err := snapshotConn.GetInstancesWithFilter(api.InstanceTypeContainer, filters)
 	if err != nil {
 		return nil, err
 	}
 
-	names := make([]string, 0, len(layers))
-	for _, layer := range layers {
-		names = append(names, layer.Name)
+	names := make([]string, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		names = append(names, snapshot.Name)
 	}
 	return names, nil
 }
 
-// Find layer name for the given SDK and any subsequent SDKs.
-func (s *Backend) layerNamesAfter(layerConn lxd.InstanceServer, pid, w, sk string) (string, []string, error) {
+// Find snapshot name for the given SDK and any subsequent SDKs.
+func (s *Backend) snapshotNamesAfter(snapshotConn lxd.InstanceServer, pid, w, sk string) (string, []string, error) {
 	filters := []string{
 		"config.user.workshop.project-id=" + pid,
 		"config.user.workshop.name=" + w,
-		"config.user.workshop.layer-type=sdk",
+		"config.user.workshop.snapshot-type=sdk",
 	}
-	layers, err := layerConn.GetInstancesWithFilter(api.InstanceTypeContainer, filters)
+	snapshots, err := snapshotConn.GetInstancesWithFilter(api.InstanceTypeContainer, filters)
 	if err != nil {
 		return "", nil, err
 	}
 
-	idx := slices.IndexFunc(layers, func(inst api.Instance) bool {
+	idx := slices.IndexFunc(snapshots, func(inst api.Instance) bool {
 		return inst.Config[workshop.ConfigWorkshopSdk] == sk
 	})
 	if idx < 0 {
 		return "", nil, fmt.Errorf("%q SDK snapshot not found in %q workshop", sk, w)
 	}
-	devices := layers[idx].Devices
+	devices := snapshots[idx].Devices
 
 	// Any SDK which wasn't installed must have been added later.
-	obstacles := make([]string, 0, len(layers))
-	for _, layer := range layers {
-		device := workshop.SdkDeviceName(layer.Config[workshop.ConfigWorkshopSdk])
+	obstacles := make([]string, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		device := workshop.SdkDeviceName(snapshot.Config[workshop.ConfigWorkshopSdk])
 		if _, ok := devices[device]; !ok {
-			obstacles = append(obstacles, layer.Name)
+			obstacles = append(obstacles, snapshot.Name)
 		}
 	}
 
-	return layers[idx].Name, obstacles, nil
+	return snapshots[idx].Name, obstacles, nil
 }
 
 // Copies an instance from the src server to the dst server. The servers can be
@@ -535,26 +535,26 @@ func (s *Backend) RemoveWorkshopStash(ctx context.Context, name string) error {
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	_, conn, err := s.layerClients(ctx)
+	_, conn, err := s.snapshotClients(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Disconnect()
 
-	layers, err := s.layerNames(conn, projectId, name, "stash-sdk")
+	snapshots, err := s.snapshotNames(conn, projectId, name, "stash-sdk")
 	if err == nil {
-		for _, layer := range layers {
-			err1 := s.deleteLayer(conn, layer)
+		for _, snapshot := range snapshots {
+			err1 := s.deleteSnapshot(conn, snapshot)
 			err = cmp.Or(err, err1)
 		}
 	}
 
-	err1 := s.deleteLayer(conn, instanceStashName(name, projectId))
+	err1 := s.deleteSnapshot(conn, instanceStashName(name, projectId))
 	return cmp.Or(err, err1)
 }
 
-func (s *Backend) deleteLayer(layerConn lxd.InstanceServer, layer string) error {
-	op, err := layerConn.DeleteInstance(layer)
+func (s *Backend) deleteSnapshot(snapshotConn lxd.InstanceServer, snapshot string) error {
+	op, err := snapshotConn.DeleteInstance(snapshot)
 	if err == nil {
 		err = op.Wait()
 	}
@@ -564,7 +564,7 @@ func (s *Backend) deleteLayer(layerConn lxd.InstanceServer, layer string) error 
 	return err
 }
 
-func (s *Backend) layerClients(ctx context.Context) (lxd.InstanceServer, lxd.InstanceServer, error) {
+func (s *Backend) snapshotClients(ctx context.Context) (lxd.InstanceServer, lxd.InstanceServer, error) {
 	user, ok := ctx.Value(workshop.ContextUser).(string)
 	if !ok {
 		return nil, nil, fmt.Errorf("context key %s not found", workshop.ContextUser)

--- a/internal/workshop/lxd/tests/integration/project_test.go
+++ b/internal/workshop/lxd/tests/integration/project_test.go
@@ -45,7 +45,7 @@ func (f *wsProject) SetUpTest(c *check.C) {
 
 func (f *wsProject) TearDownTest(c *check.C) {
 	helper.CleanupLxdProject(c, f.client, "workshop."+f.username)
-	helper.CleanupLxdProject(c, f.client, "workshop-layers."+f.username)
+	helper.CleanupLxdProject(c, f.client, "workshop-snapshots."+f.username)
 	f.client.Disconnect()
 }
 
@@ -319,7 +319,7 @@ func (f *wsProject) TestLxdBackendLoadProjectsAllUsers(c *check.C) {
 
 func (f *wsProject) TestLxdBackendLoadProjectAsDifferentUser(c *check.C) {
 	defer helper.CleanupLxdProject(c, f.client, "workshop.anotheruser")
-	defer helper.CleanupLxdProject(c, f.client, "workshop-layers.anotheruser")
+	defer helper.CleanupLxdProject(c, f.client, "workshop-snapshots.anotheruser")
 
 	// Setup
 	be := lxdbackend.Backend{}
@@ -372,7 +372,7 @@ func (f *wsProject) TestInitLxdProjectFails(c *check.C) {
 	projects, err := f.client.GetProjectNames()
 	c.Assert(err, check.IsNil)
 	c.Assert(projects, check.Not(testutil.Contains), "workshop.test@user")
-	c.Assert(projects, check.Not(testutil.Contains), "workshop-layers.test@user")
+	c.Assert(projects, check.Not(testutil.Contains), "workshop-snapshots.test@user")
 }
 
 func (f *wsProject) TestPosixUsernameAsProjectSuffix(c *check.C) {
@@ -400,7 +400,7 @@ func (f *wsProject) TestPosixUsernameAsProjectSuffix(c *check.C) {
 	projects, err := p.GetProjectNames()
 	c.Assert(err, check.IsNil)
 	c.Assert(projects, testutil.Contains, "workshop.testuser0")
-	c.Assert(projects, testutil.Contains, "workshop-layers.testuser0")
+	c.Assert(projects, testutil.Contains, "workshop-snapshots.testuser0")
 }
 
 func (f *wsProject) TestNonPosixUsernameAsProjectSuffix(c *check.C) {
@@ -428,5 +428,5 @@ func (f *wsProject) TestNonPosixUsernameAsProjectSuffix(c *check.C) {
 	projects, err := p.GetProjectNames()
 	c.Assert(err, check.IsNil)
 	c.Assert(projects, testutil.Contains, "workshop.1001")
-	c.Assert(projects, testutil.Contains, "workshop-layers.1001")
+	c.Assert(projects, testutil.Contains, "workshop-snapshots.1001")
 }

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -124,7 +124,7 @@ func (f *wsExec) TearDownSuite(c *check.C) {
 	f.restoreImageServer()
 	f.restoreDevices()
 	helper.CleanupLxdProject(c, f.lxdClient, "workshop."+f.usr.Username)
-	helper.CleanupLxdProject(c, f.lxdClient, "workshop-layers."+f.usr.Username)
+	helper.CleanupLxdProject(c, f.lxdClient, "workshop-snapshots."+f.usr.Username)
 	f.lxdClient.Disconnect()
 }
 

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -81,7 +81,7 @@ func (f *wsOps) TearDownSuite(c *check.C) {
 	defer lxdclient.Disconnect()
 
 	helper.CleanupLxdProject(c, lxdclient, "workshop."+f.usr.Username)
-	helper.CleanupLxdProject(c, lxdclient, "workshop-layers."+f.usr.Username)
+	helper.CleanupLxdProject(c, lxdclient, "workshop-snapshots."+f.usr.Username)
 	f.restoreUserEnv()
 	f.restoreUserLookup()
 	f.restoreNewId()
@@ -128,8 +128,8 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 
 	stash := f.stashMetadata(c, "test")
 	config = maps.Clone(postStash.config)
-	c.Check(config["user.workshop.layer-type"], check.Equals, "")
-	config["user.workshop.layer-type"] = "stash"
+	c.Check(config["user.workshop.snapshot-type"], check.Equals, "")
+	config["user.workshop.snapshot-type"] = "stash"
 	c.Check(stash.config, check.DeepEquals, config)
 	c.Check(stash.devices, check.DeepEquals, postStash.devices)
 
@@ -207,7 +207,7 @@ func (f *wsOps) stashMetadata(c *check.C, name string) metadata {
 	c.Assert(err, check.IsNil)
 	defer conn.Disconnect()
 
-	conn = conn.UseProject("workshop-layers." + f.usr.Username)
+	conn = conn.UseProject("workshop-snapshots." + f.usr.Username)
 
 	return instanceMetadata(c, conn, "stash-"+lxdbackend.InstanceName(name, f.project.ProjectId))
 }
@@ -246,17 +246,17 @@ func (f *wsOps) listSnapshots(c *check.C, name string, stash bool) []string {
 	c.Assert(err, check.IsNil)
 	defer conn.Disconnect()
 
-	conn = conn.UseProject("workshop-layers." + f.usr.Username)
+	conn = conn.UseProject("workshop-snapshots." + f.usr.Username)
 
-	layerType := "sdk"
+	snapshotType := "sdk"
 	if stash {
-		layerType = "stash-sdk"
+		snapshotType = "stash-sdk"
 	}
 
 	filters := []string{
 		"config.user.workshop.project-id=" + f.project.ProjectId,
 		"config.user.workshop.name=" + name,
-		"config.user.workshop.layer-type=" + layerType,
+		"config.user.workshop.snapshot-type=" + snapshotType,
 	}
 	layers, err := conn.GetInstancesWithFilter(api.InstanceTypeContainer, filters)
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -258,12 +258,12 @@ func (f *wsOps) listSnapshots(c *check.C, name string, stash bool) []string {
 		"config.user.workshop.name=" + name,
 		"config.user.workshop.snapshot-type=" + snapshotType,
 	}
-	layers, err := conn.GetInstancesWithFilter(api.InstanceTypeContainer, filters)
+	snapshots, err := conn.GetInstancesWithFilter(api.InstanceTypeContainer, filters)
 	c.Assert(err, check.IsNil)
 
-	names := make([]string, 0, len(layers))
-	for _, layer := range layers {
-		names = append(names, layer.Config["user.workshop.sdk"])
+	names := make([]string, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		names = append(names, snapshot.Config["user.workshop.sdk"])
 	}
 	return names
 }

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -22,7 +22,7 @@ var (
 	ConfigWorkshopBase            = "user.workshop.base"
 	ConfigWorkshopBaseFingerprint = "user.workshop.base-fingerprint"
 	ConfigWorkshopSdk             = "user.workshop.sdk"
-	ConfigWorkshopLayerType       = "user.workshop.layer-type"
+	ConfigWorkshopSnapshotType    = "user.workshop.snapshot-type"
 	ConfigProjectPathDevice       = "workshop.project"
 	ConfigStateStorageDevice      = "workshop.state-storage"
 )

--- a/snap/local/lib/lxc-utils
+++ b/snap/local/lib/lxc-utils
@@ -4,7 +4,7 @@ run_lxc() {
 }
 
 get_projects() {
-    run_lxc project list -f compact | awk '$1 ~ /^workshop(-layers|-stash)?\..*/ {print $1}'
+    run_lxc project list -f compact | awk '$1 ~ /^workshop(-snapshots|-layers)?\..*/ {print $1}'
 }
 
 remove_instances() {

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -59,12 +59,12 @@ execute: |
     pid=$(cat .workshop.lock)
 
     lxc list \
-      --project workshop-layers.ubuntu \
+      --project workshop-snapshots.ubuntu \
       --format csv \
       --columns user.workshop.sdk \
       user.workshop.project-id="$pid" \
       user.workshop.name=ws-refresh-snapshots \
-      user.workshop.layer-type=sdk
+      user.workshop.snapshot-type=sdk
   }
 
   validate_snapshots() {


### PR DESCRIPTION
# Description

Based on https://github.com/canonical/workshop/pull/563. Layers made sense when we were in limbo between the old implementation, which used LXD and ZFS snapshots explicitly, and the new one. We still use ZFS snapshots implicitly, but as far as the LXD backend is concerned a snapshot is just an instance.

This is likely to break existing workshops. I'm including the old `workshop-layers.*` projects in the snap hook for now, so they are removed properly. The hook no longer includes `workshop-stash.*`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
