### PR TITLE
Resolve workshop cleanup issues

### DIFF
--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -45,7 +45,6 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	hookPath := sdk.SdkHookPath(hook.Sdk, hook.Type())
-	stateDir := filepath.Join(dirs.WorkshopStateDir, "sdk", hook.Sdk)
 
 	execArgs := &workshop.ExecArgs{
 		UserId:  0,
@@ -64,12 +63,26 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	if hook.HookType == SaveState || hook.HookType == RestoreState {
-		execArgs.Environment["SDK_STATE_DIR"] = stateDir
+		what := workshop.StateStorageDir(prj.ProjectId, w)
+		where := dirs.WorkshopStateDir
+
+		usr, err := osutil.UserLookup(user)
+		if err != nil {
+			return err
+		}
+		uid, gid, err := osutil.UidGid(usr)
+		if err != nil {
+			return err
+		}
+		sdkStateDir := filepath.Join(what, "sdk", hook.Sdk)
+		if err := osutil.MkdirAllChown(sdkStateDir, 0755, uid, gid); err != nil {
+			return err
+		}
 
 		mount := workshop.Mount{
 			Name:  workshop.ConfigStateStorageDevice,
 			Type:  workshop.HostWorkshop,
-			What:  workshop.StateStorageDir(prj.ProjectId, w),
+			What:  what,
 			Where: dirs.WorkshopStateDir,
 		}
 		if err := h.backend.AddWorkshopMount(ctx, w, mount); err != nil {
@@ -80,37 +93,11 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 				logger.Noticef("RunHook on Do: Cannot unmount state storage %q: %v", mount.What, err1)
 			}
 		}()
+
+		execArgs.Environment["SDK_STATE_DIR"] = filepath.Join(where, "sdk", hook.Sdk)
 	}
 
 	switch hook.HookType {
-	case SaveState:
-		fs, err := h.backend.WorkshopFs(ctx, w)
-		if err != nil {
-			return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
-		}
-		err = fs.MkdirAll(stateDir, 0755)
-		fs.Close()
-		if err != nil {
-			return fmt.Errorf("cannot run hook \"save-state\" for %q SDK: %v", hook.Sdk, err)
-		}
-
-		return h.executeHook(ctx, task, w, &hook, execArgs)
-	case RestoreState:
-		fs, err := h.backend.WorkshopFs(ctx, w)
-		if err != nil {
-			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
-		}
-		info, err := fs.Stat(stateDir)
-		fs.Close()
-		if err != nil {
-			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: %v", hook.Sdk, err)
-		}
-
-		if !info.IsDir() {
-			return fmt.Errorf("cannot run hook \"restore-state\" for %q SDK: state storage path is not a directory", hook.Sdk)
-		}
-
-		return h.executeHook(ctx, task, w, &hook, execArgs)
 	case SetupProject:
 		execArgs.Command = []string{
 			"sudo",

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate/hooktest"
@@ -28,9 +30,13 @@ type hookSuite struct {
 	runner      *state.TaskRunner
 	se          *overlord.StateEngine
 	hookmgr     *hookstate.HookManager
+	user        *user.User
 	ctx         context.Context
 	project     workshop.Project
 	mockHandler *hooktest.MockHandler
+
+	restoreUserEnv    func()
+	restoreUserLookup func()
 }
 
 var _ = check.Suite(&hookSuite{})
@@ -63,6 +69,18 @@ func (s *hookSuite) SetUpTest(c *check.C) {
 	s.project = *project
 	s.ctx = context.WithValue(ctx, workshop.ContextProjectId, s.project.ProjectId)
 
+	// Real UID and GID are required to create SDK state storage directories.
+	// TODO: make filesystem operations more secure (e.g. drop privileges if possible) and easy to test.
+	actual, err := user.Current()
+	c.Assert(err, check.IsNil)
+	s.user = &user.User{Username: "testuser", HomeDir: c.MkDir(), Uid: actual.Uid, Gid: actual.Gid}
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return s.user, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
+
 	s.state = state.New(nil)
 	s.runner = state.NewTaskRunner(s.state)
 	workshop.ReplaceBackend(s.state, s.backend)
@@ -86,6 +104,11 @@ func (s *hookSuite) SetUpTest(c *check.C) {
 	s.se.AddManager(s.runner)
 	err = s.se.StartUp()
 	c.Check(err, check.IsNil)
+}
+
+func (s *hookSuite) TearDownTest(c *check.C) {
+	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -167,11 +167,25 @@ func (m *WorkshopManager) doRemoveWorkshopStorage(task *state.Task, tomb *tomb.T
 		return err
 	}
 
-	return errors.Join(
-		m.cleanupWorkshopUserData(user, prj.ProjectId, w),
-		m.cleanupWorkshopCache(prj.ProjectId, w),
-		m.cleanupWorkshopData(prj.ProjectId, w),
-	)
+	if err := m.cleanupWorkshopUserData(user, prj.ProjectId, w); err != nil {
+		task.State().Lock()
+		task.Logf("cannot remove %q workshop user data: %v", w, err)
+		task.State().Unlock()
+	}
+
+	if err := m.cleanupWorkshopCache(prj.ProjectId, w); err != nil {
+		task.State().Lock()
+		task.Logf("cannot remove %q workshop cache: %v", w, err)
+		task.State().Unlock()
+	}
+
+	if err := m.cleanupWorkshopData(prj.ProjectId, w); err != nil {
+		task.State().Lock()
+		task.Logf("cannot remove %q workshop data: %v", w, err)
+		task.State().Unlock()
+	}
+
+	return nil
 }
 
 func (m *WorkshopManager) cleanupWorkshopUserData(user, projectId, w string) error {
@@ -381,7 +395,13 @@ func (m *WorkshopManager) doRemoveWorkshopStash(task *state.Task, tomb *tomb.Tom
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
 
-	return m.backend.RemoveWorkshopStash(ctx, w)
+	if err := m.backend.RemoveWorkshopStash(ctx, w); err != nil {
+		task.State().Lock()
+		task.Logf("cannot remove %q workshop stash: %v", w, err)
+		task.State().Unlock()
+	}
+
+	return nil
 }
 
 func (m *WorkshopManager) doStashWorkshop(task *state.Task, tomb *tomb.Tomb) error {
@@ -452,5 +472,11 @@ func (m *WorkshopManager) doRemoveStateStorage(task *state.Task, tomb *tomb.Tomb
 	}
 
 	storage := workshop.StateStorageDir(prj.ProjectId, w)
-	return os.RemoveAll(storage)
+	if err := os.RemoveAll(storage); err != nil {
+		task.State().Lock()
+		task.Logf("cannot remove %q workshop state storage: %v", w, err)
+		task.State().Unlock()
+	}
+
+	return nil
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -956,11 +956,9 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 
 	if len(plan.IntactOrRefresh()) > 0 {
 		removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
-		removeStateStorage.WaitFor(last)
+		addTaskSet(state.NewTaskSet(removeStateStorage))
 		removeStateStorage.JoinLane(cleanupLane)
 		refresh.MarkEdge(removeStateStorage, EdgeRefreshFirstCleanupTask)
-
-		refresh.AddTask(removeStateStorage)
 	}
 
 	// remove the workshop from stash after the state storage was detached
@@ -976,14 +974,11 @@ func refresh(st *state.State, plan *refreshPlan, w *workshop.Workshop, file *wor
 	// all the cleanup tasks are extracted into a separate lane. If
 	// any problem happens, the workshops that had finished their
 	// refresh will not be affected.
+	addTaskSet(state.NewTaskSet(removeStash))
 	removeStash.JoinLane(cleanupLane)
-	removeStash.WaitFor(last)
-
 	if refresh.MaybeEdge(EdgeRefreshFirstCleanupTask) == nil {
 		refresh.MarkEdge(removeStash, EdgeRefreshFirstCleanupTask)
 	}
-
-	refresh.AddTask(removeStash)
 
 	for _, task := range refresh.Tasks() {
 		task.Set("workshop", file.Name)


### PR DESCRIPTION
# Description

Now that state storage directories are mounted from the host instead of a volume, we should create them on the host instead of inside the workshop. This avoids permissions issues when the directories are created as the workshop's `root` user and the daemon is running as an unprivileged user.

If Workshop fails to remove the state storage directories, or other workshop-related directories, or the stash, it should not prevent the other cleanup tasks from running. The errors will be logged in `workshop tasks`. If the lack of cleanup causes issues for future launches or refreshes, the change will fail early on and with any luck the user will check the logs.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
