### PR TITLE
Handle EBUSY when remounting across filesystems

### DIFF
--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -1059,11 +1059,14 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 					if errno == syscall.EXDEV {
 						return fmt.Errorf("sources %q and %q are not on the same mounted filesystem; workshop must be stopped to remount safely", oldSource, source)
 					}
+					if errno == syscall.EBUSY {
+						return fmt.Errorf("source %q appears to be in use; workshop must be stopped to remount safely", source)
+					}
 					return err
 				} else {
 					// if the workshop is stopped, we can perform a remount safely
 					// (other fs or non-empty dir), otherwise, return the error
-					if errno != syscall.ENOTEMPTY && errno != syscall.EXDEV {
+					if errno != syscall.ENOTEMPTY && errno != syscall.EXDEV && errno != syscall.EBUSY {
 						return err
 					}
 				}


### PR DESCRIPTION
# Description

Fixes #577.

Some filesystems report `EBUSY` rather than `EXDEV` when Workshop attempts to remount a plug over them. This was initially reported for `9p` in a multipass VM. I was able to reproduce in a LXD VM by disabling `virtiofs` (by bind-mounting a file over `/snap/lxd/current/bin/virtiofsd` to remove its execute permissions). An easier way to reproduce is to try to remount something over `/boot` in a LXD VM with Ubuntu 24.04.

I'm not sure if `EBUSY` always indicates a different filesystem, will try to look into it a bit more before I mark this as ready.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
