### PR TITLE
Doc: Add GH action to update SDK schema

### DIFF
--- a/.github/workflows/doc-cover.yaml
+++ b/.github/workflows/doc-cover.yaml
@@ -38,10 +38,10 @@ jobs:
             git config --global user.email 'github-actions[bot]@users.noreply.github.com'
             
             git add .
-            git commit -m "Update doc coverage map"
+            git commit -m "Doc: Update doc coverage map"
             git push --set-upstream origin $pr_branch
 
-            gh pr create --title "Update doc coverage map" --body "This PR updates the documentation coverage map." --base main
+            gh pr create --title "Doc: Update doc coverage map" --body "This PR updates the documentation coverage map." --base main
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/doc-cover.yaml
+++ b/.github/workflows/doc-cover.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/doc-update-sdk-schema.yml
+++ b/.github/workflows/doc-update-sdk-schema.yml
@@ -45,10 +45,10 @@ jobs:
             git config --global user.email 'github-actions[bot]@users.noreply.github.com'
             
             git add .
-            git commit -m "Update SDK schema"
+            git commit -m "Doc: Update SDK schema"
             git push --set-upstream origin $pr_branch
 
-            gh pr create --title "Update SDK schema" --body "This PR updates the SDK schema." --base main
+            gh pr create --title "Doc: Update SDK schema" --body "This PR updates the SDK schema." --base main
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/doc-update-sdk-schema.yml
+++ b/.github/workflows/doc-update-sdk-schema.yml
@@ -1,0 +1,54 @@
+name: Update SDK schema
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-schema:
+    name: Update SDK schema
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Workshop
+        uses: actions/checkout@v6
+
+      - name: Checkout Sdkcraft
+        uses: actions/checkout@v6
+        with:
+          repository: canonical/sdkcraft
+          token: ${{ secrets.GH_SDKCRAFT }}
+          path: sdkcraft
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Generate Schema
+        run: |
+          cd sdkcraft
+          uv run python sdkcraft/models/project.py
+          mv schema.json ../docs/reference/definition-files/schema-sdk.json
+
+      - name: Check for changes, commit, and create PR if any
+        run: |
+          if git diff --exit-code; then
+            echo "No changes detected, skipping commit and PR creation."
+          else
+            pr_branch="docs/sdk-schema-$(date +'%Y%m%d%H%M%S')"
+            git checkout -b $pr_branch
+            
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            
+            git add .
+            git commit -m "Update SDK schema"
+            git push --set-upstream origin $pr_branch
+
+            gh pr create --title "Update SDK schema" --body "This PR updates the SDK schema." --base main
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Used existing approach from `doc-cover.yaml` to introduce a counterpart to #580 that relies on an existing `sdkcraft` mechanism to generate the schema JSON.