### PR TITLE
Retry snap install/refresh commands in CI tests

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,6 +41,8 @@ apps:
     environment:
       WORKSHOP_SOCKET: $SNAP_COMMON/workshop/workshop.socket
     command: bin/sdk
+    aliases:
+      - sdk
 parts:
   workshop:
     plugin: go

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -6,9 +6,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 function setup_lxd() {
     if snap list lxd >/dev/null; then
-        snap refresh --channel=6/stable lxd
+        retry 5 snap refresh --channel=6/stable lxd
     else
-        snap install --channel=6/stable lxd
+        retry 5 snap install --channel=6/stable lxd
     fi
     lxd waitready --timeout=180
 
@@ -72,8 +72,8 @@ EOF
 
     setup_lxd
 
-    snap install --classic --channel=1.25/stable go
-    snap install yq
+    retry 5 snap install --classic --channel=1.25/stable go
+    retry 5 snap install yq
 }
 
 function setup_workshop() {

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -1,19 +1,19 @@
 summary: Test workshopd checks LXD compatibility
 priority: -101
 execute: |
-  . "$TESTSLIB"/utils.sh
+  . "$TESTSLIB"/utils.sh  
 
   workshop_exec list | MATCH "^.+[[:space:]]+comp-check[[:space:]]+Off[[:space:]]+-$"
 
   snap remove lxd --purge
-  snap install lxd --channel=5.21/stable
+  retry 5 snap install lxd --channel=5.21/stable
   lxd waitready
   snap restart workshop
   ! workshop_exec list 2>&1 > error.log
   MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.3.\*$" < error.log
 
   snap remove lxd --purge
-  snap install lxd --channel=6/stable
+  retry 5 snap install lxd --channel=6/stable
   lxd waitready
   snap restart workshop
   workshop_exec list | MATCH "^.+[[:space:]]+comp-check[[:space:]]+Off[[:space:]]+-$"


### PR DESCRIPTION
- Retry `snap install` in CI scripts
- Add an alias for the `sdk` command to the workshop's snap