### PR TITLE
Use LXD candidate track inside spread VMs

### DIFF
--- a/.github/workflows/lxd-candidate-check.yaml
+++ b/.github/workflows/lxd-candidate-check.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, x64, xlarge]
     steps:
       - name: Install LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@v1
         with:
           channel: 6/candidate
       - name: Cleanup job workspace
@@ -34,17 +34,17 @@ jobs:
           go-version: "1.25"
           cache: false
       - name: Download Workshop Snap
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v7
         with:
           name: snap_workshop
           path: ${{ github.workspace }}/tests/
       - name: Download Sdkcraft Snap
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v7
         with:
           name: snap_sdkcraft
           path: ${{ github.workspace }}/tests/
       - name: Download spread binary
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v7
         with:
           name: spread_binary
           path: /usr/local/bin

--- a/.github/workflows/lxd-candidate-check.yaml
+++ b/.github/workflows/lxd-candidate-check.yaml
@@ -53,6 +53,11 @@ jobs:
       - name: Set LXD storage size
         run: |
           lxc storage set default volume.size=32GB
+      - name: Override LXD channel
+        run: |
+          cat <<EOF >>tests/lib/.env
+          LXD_CHANNEL='6/candidate'
+          EOF
       - name: Run spread
         run: |
           mkdir ${{ github.workspace }}.cover

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, linux, jammy, x64, xlarge]
     steps:
       - name: Install LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@v1
         with:
           channel: 6/stable
       - name: Cleanup job workspace

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -4,11 +4,17 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/retry.sh"
 
+# Allow CI jobs to override environment.
+LXD_CHANNEL='6/stable'
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    . "$SCRIPT_DIR/.env"
+fi
+
 function setup_lxd() {
     if snap list lxd >/dev/null; then
-        retry 5 snap refresh --channel=6/stable lxd
+        retry 5 snap refresh --channel="$LXD_CHANNEL" lxd
     else
-        retry 5 snap install --channel=6/stable lxd
+        retry 5 snap install --channel="$LXD_CHANNEL" lxd
     fi
     lxd waitready --timeout=180
 

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -5,6 +5,8 @@ execute: |
 
   workshop_exec list | MATCH "^.+[[:space:]]+comp-check[[:space:]]+Off[[:space:]]+-$"
 
+  oldchannel=$(snap info lxd | yq -r .tracking)
+
   snap remove lxd --purge
   retry 5 snap install lxd --channel=5.21/stable
   lxd waitready
@@ -13,7 +15,7 @@ execute: |
   MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.3.\*$" < error.log
 
   snap remove lxd --purge
-  retry 5 snap install lxd --channel=6/stable
+  retry 5 snap install lxd --channel="$oldchannel"
   lxd waitready
   snap restart workshop
   workshop_exec list | MATCH "^.+[[:space:]]+comp-check[[:space:]]+Off[[:space:]]+-$"


### PR DESCRIPTION
# Description

Previously the candidate was only used to launch the VMs themselves. This will still help us catch LXD issues early, but the real goal is to test whether Workshop is compatible with upcoming LXD changes. I considered using spread variants for this, but it means we'd have to specify the variant all the time, e.g. when running locally. Instead I just modified the project that we pass to spread, via a `.env` file.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
