### PR TITLE
Replace interface{} with any

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -44,7 +44,7 @@ type Change struct {
 var ErrNoData = fmt.Errorf("data entry not found")
 
 // Get unmarshals into value the kind-specific data with the provided key.
-func (c *Change) Get(key string, value interface{}) error {
+func (c *Change) Get(key string, value any) error {
 	raw := c.data[key]
 	if raw == nil {
 		return ErrNoData
@@ -69,7 +69,7 @@ type Task struct {
 }
 
 // Get unmarshals into value the kind-specific data with the provided key.
-func (t *Task) Get(key string, value interface{}) error {
+func (t *Task) Get(key string, value any) error {
 	raw := t.Data[key]
 	if raw == nil {
 		return ErrNoData

--- a/client/client.go
+++ b/client/client.go
@@ -57,7 +57,7 @@ func (s SocketNotFoundError) Unwrap() error {
 
 // decodeWithNumber decodes input data using json.Decoder, ensuring numbers are preserved
 // via json.Number data type. It errors out on invalid json or any excess input.
-func decodeWithNumber(r io.Reader, value interface{}) error {
+func decodeWithNumber(r io.Reader, value any) error {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()
 	if err := dec.Decode(&value); err != nil {
@@ -129,7 +129,7 @@ type clientWebsocket interface {
 }
 
 type jsonWriter interface {
-	WriteJSON(v interface{}) error
+	WriteJSON(v any) error
 }
 
 func New(config *Config) (*Client, error) {
@@ -295,7 +295,7 @@ func (client *Client) Hijack(f func(*http.Request) (*http.Response, error)) {
 // do performs a request and decodes the resulting json into the given
 // value. It's low-level, for testing/experimenting only; you should
 // usually use a higher level interface that builds on this.
-func (client *Client) do(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) error {
+func (client *Client) do(method, path string, query url.Values, headers map[string]string, body io.Reader, v any) error {
 	retry := time.NewTicker(doRetry)
 	defer retry.Stop()
 	timeout := time.After(doTimeout)
@@ -327,7 +327,7 @@ func (client *Client) do(method, path string, query url.Values, headers map[stri
 	return nil
 }
 
-func decodeInto(reader io.Reader, v interface{}) error {
+func decodeInto(reader io.Reader, v any) error {
 	dec := json.NewDecoder(reader)
 	if err := dec.Decode(v); err != nil {
 		r := dec.Buffered()
@@ -346,7 +346,7 @@ func decodeInto(reader io.Reader, v interface{}) error {
 // which produces json.Numbers instead of float64 types for numbers.
 //
 //nolint:unparam // Match related function signatures for consistency.
-func (client *Client) doSync(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) (*ResultInfo, error) {
+func (client *Client) doSync(method, path string, query url.Values, headers map[string]string, body io.Reader, v any) (*ResultInfo, error) {
 	var rsp response
 	if err := client.do(method, path, query, headers, body, &rsp); err != nil {
 		return nil, err
@@ -422,9 +422,9 @@ type response struct {
 
 // Error is the real value of response.Result when an error occurs.
 type Error struct {
-	Kind    string      `json:"kind"`
-	Value   interface{} `json:"value"`
-	Message string      `json:"message"`
+	Kind    string `json:"kind"`
+	Value   any    `json:"value"`
+	Message string `json:"message"`
 
 	StatusCode int
 }
@@ -511,12 +511,12 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 }
 
 type debugAction struct {
-	Action string      `json:"action"`
-	Params interface{} `json:"params,omitempty"`
+	Action string `json:"action"`
+	Params any    `json:"params,omitempty"`
 }
 
 // DebugPost sends a POST debug action to the server with the provided parameters.
-func (client *Client) DebugPost(action string, params interface{}, result interface{}) error {
+func (client *Client) DebugPost(action string, params any, result any) error {
 	body, err := json.Marshal(debugAction{
 		Action: action,
 		Params: params,
@@ -530,7 +530,7 @@ func (client *Client) DebugPost(action string, params interface{}, result interf
 }
 
 // DebugGet sends a GET debug action to the server with the provided parameters.
-func (client *Client) DebugGet(action string, result interface{}, params map[string]string) error {
+func (client *Client) DebugGet(action string, result any, params map[string]string) error {
 	urlParams := url.Values{"action": []string{action}}
 	for k, v := range params {
 		urlParams.Set(k, v)

--- a/client/connections.go
+++ b/client/connections.go
@@ -33,9 +33,9 @@ type Connection struct {
 	// Manual is set for connections that were established manually.
 	Manual bool `json:"manual"`
 	// SlotAttrs is the list of attributes of the slot side of the connection.
-	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`
+	SlotAttrs map[string]any `json:"slot-attrs,omitempty"`
 	// PlugAttrs is the list of attributes of the plug side of the connection.
-	PlugAttrs map[string]interface{} `json:"plug-attrs,omitempty"`
+	PlugAttrs map[string]any `json:"plug-attrs,omitempty"`
 }
 
 // Connections contains information about connections, as well as related plugs

--- a/client/connections_test.go
+++ b/client/connections_test.go
@@ -308,22 +308,22 @@ func (cs *clientSuite) TestClientConnect(c *check.C) {
 	id, err := cs.cli.Connect("b8639dea", "consumer-ws", "consumer", "plug", "b8639dea", "producer-ws", "producer", "slot", nil)
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "42")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "connect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "b8639dea",
 				"workshop":   "consumer-ws",
 				"sdk":        "consumer",
 				"plug":       "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "b8639dea",
 				"workshop":   "producer-ws",
 				"sdk":        "producer",
@@ -345,22 +345,22 @@ func (cs *clientSuite) TestClientDisconnect(c *check.C) {
 	id, err := cs.cli.Disconnect("b8639dea", "consumer-ws", "consumer", "plug", "b8639dea", "producer-ws", "producer", "slot", opts)
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "42")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "disconnect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "b8639dea",
 				"workshop":   "consumer-ws",
 				"sdk":        "consumer",
 				"plug":       "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "b8639dea",
 				"workshop":   "producer-ws",
 				"sdk":        "producer",
@@ -382,23 +382,23 @@ func (cs *clientSuite) TestClientDisconnectForget(c *check.C) {
 	id, err := cs.cli.Disconnect("b8639dea", "consumer-ws", "consumer", "plug", "b8639dea", "producer-ws", "producer", "slot", opts)
 	c.Assert(err, check.IsNil)
 	c.Check(id, check.Equals, "42")
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"action": "disconnect",
 		"forget": true,
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "b8639dea",
 				"workshop":   "consumer-ws",
 				"sdk":        "consumer",
 				"plug":       "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "b8639dea",
 				"workshop":   "producer-ws",
 				"sdk":        "producer",

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -99,8 +99,8 @@ func (s *execSuite) TestExitZero(c *C) {
 		Command: []string{"true"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"true"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"true"},
 	})
 	err := s.wait(c, process)
 	c.Assert(err, IsNil)
@@ -111,8 +111,8 @@ func (s *execSuite) TestExitNonZero(c *C) {
 		Command: []string{"false"},
 	}
 	process, reqBody := s.exec(c, opts, 1)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"false"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"false"},
 	})
 	err := s.wait(c, process)
 	exitError, ok := err.(*client.ExitError)
@@ -126,8 +126,8 @@ func (s *execSuite) TestTimeout(c *C) {
 		Timeout: time.Second,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"sleep", "3"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"sleep", "3"},
 		"timeout": "1s",
 	})
 	err := s.wait(c, process)
@@ -150,9 +150,9 @@ func (s *execSuite) TestOtherOptions(c *C) {
 		Stderr:      io.Discard,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command":     []interface{}{"echo", "foo"},
-		"environment": map[string]interface{}{"K1": "V1", "K2": "V2"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command":     []any{"echo", "foo"},
+		"environment": map[string]any{"K1": "V1", "K2": "V2"},
 		"working-dir": "WD",
 		"user-id":     1000.0,
 		"group-id":    2000.0,
@@ -169,8 +169,8 @@ func (s *execSuite) TestWaitChangeError(c *C) {
 		Command: []string{"foo"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"foo"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"foo"},
 	})
 
 	// Make /v1/changes/{id}/wait return a "change error"
@@ -194,8 +194,8 @@ func (s *execSuite) TestWaitTasksError(c *C) {
 		Command: []string{"foo"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"foo"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"foo"},
 	})
 
 	// Make /v1/changes/{id}/wait return no tasks
@@ -218,8 +218,8 @@ func (s *execSuite) TestWaitExitCodeError(c *C) {
 		Command: []string{"foo"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"foo"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"foo"},
 	})
 
 	// Make /v1/changes/{id}/wait return no exit code
@@ -246,8 +246,8 @@ func (s *execSuite) TestSendSignal(c *C) {
 		Command: []string{"server"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"server"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"server"},
 	})
 	err := process.SendSignal(syscall.SIGHUP)
 	c.Assert(err, IsNil)
@@ -264,8 +264,8 @@ func (s *execSuite) TestSendResize(c *C) {
 		Command: []string{"server"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"server"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"server"},
 	})
 	err := process.SendResize(150, 50)
 	c.Assert(err, IsNil)
@@ -290,8 +290,8 @@ func (s *execSuite) TestOutputCombinedForInteractive(c *C) {
 		Interactive: true,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command":     []interface{}{"/bin/sh", "-c", "echo OUT; echo ERR >err"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command":     []any{"/bin/sh", "-c", "echo OUT; echo ERR >err"},
 		"interactive": true,
 	})
 	err := s.wait(c, process)
@@ -316,8 +316,8 @@ func (s *execSuite) TestOutputSplitForNonInteractive(c *C) {
 		Stderr:  &stderr,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"/bin/sh", "-c", "echo OUT; echo ERR >err"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"/bin/sh", "-c", "echo OUT; echo ERR >err"},
 	})
 	err := s.wait(c, process)
 	c.Assert(err, IsNil)
@@ -337,8 +337,8 @@ func (s *execSuite) TestStdinAndStdout(c *C) {
 		Stdout:  &stdout,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"awk", "{ print toupper($0) }"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"awk", "{ print toupper($0) }"},
 	})
 	err := s.wait(c, process)
 	c.Assert(err, IsNil)
@@ -355,8 +355,8 @@ func (s *execSuite) TestAction(c *C) {
 		Action:  true,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"tests"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"tests"},
 		"action":  true,
 	})
 	err := s.wait(c, process)
@@ -396,7 +396,7 @@ func (w *testWebsocket) Close() error {
 	return nil
 }
 
-func (w *testWebsocket) WriteJSON(v interface{}) error {
+func (w *testWebsocket) WriteJSON(v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -405,7 +405,7 @@ func (w *testWebsocket) WriteJSON(v interface{}) error {
 	return nil
 }
 
-func (s *execSuite) exec(c *C, opts *client.ExecOptions, exitCode int) (process *client.ExecProcess, requestBody map[string]interface{}) {
+func (s *execSuite) exec(c *C, opts *client.ExecOptions, exitCode int) (process *client.ExecProcess, requestBody map[string]any) {
 	if opts.Action {
 		s.addRunResponses("123", exitCode)
 	} else {

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -28,7 +28,7 @@ func (client *Client) SetDoer(d doer) {
 	client.doer = d
 }
 
-func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) error {
+func (client *Client) Do(method, path string, query url.Values, body io.Reader, v any) error {
 	return client.do(method, path, query, nil, body, v)
 }
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -26,15 +26,15 @@ import (
 
 // Plug represents the potential of a given snap to connect to a slot.
 type Plug struct {
-	ProjectId   string                 `json:"project-id"`
-	Workshop    string                 `json:"workshop"`
-	Sdk         string                 `json:"sdk"`
-	Name        string                 `json:"plug"`
-	Interface   string                 `json:"interface,omitempty"`
-	Attrs       map[string]interface{} `json:"attrs,omitempty"`
-	Label       string                 `json:"label,omitempty"`
-	Bind        *PlugRef               `json:"bind,omitempty"`
-	Connections []SlotRef              `json:"connections,omitempty"`
+	ProjectId   string         `json:"project-id"`
+	Workshop    string         `json:"workshop"`
+	Sdk         string         `json:"sdk"`
+	Name        string         `json:"plug"`
+	Interface   string         `json:"interface,omitempty"`
+	Attrs       map[string]any `json:"attrs,omitempty"`
+	Label       string         `json:"label,omitempty"`
+	Bind        *PlugRef       `json:"bind,omitempty"`
+	Connections []SlotRef      `json:"connections,omitempty"`
 }
 
 func (p *Plug) Ref() PlugRef {
@@ -51,14 +51,14 @@ type PlugRef struct {
 
 // Slot represents a capacity offered by a snap.
 type Slot struct {
-	ProjectId   string                 `json:"project-id"`
-	Workshop    string                 `json:"workshop"`
-	Sdk         string                 `json:"sdk"`
-	Name        string                 `json:"slot"`
-	Interface   string                 `json:"interface,omitempty"`
-	Attrs       map[string]interface{} `json:"attrs,omitempty"`
-	Label       string                 `json:"label,omitempty"`
-	Connections []PlugRef              `json:"connections,omitempty"`
+	ProjectId   string         `json:"project-id"`
+	Workshop    string         `json:"workshop"`
+	Sdk         string         `json:"sdk"`
+	Name        string         `json:"slot"`
+	Interface   string         `json:"interface,omitempty"`
+	Attrs       map[string]any `json:"attrs,omitempty"`
+	Label       string         `json:"label,omitempty"`
+	Connections []PlugRef      `json:"connections,omitempty"`
 }
 
 // SlotRef is a reference to a slot.

--- a/client/warnings_test.go
+++ b/client/warnings_test.go
@@ -108,7 +108,7 @@ func (cs *clientSuite) TestOkay(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Query(), check.HasLen, 0)
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 	c.Check(body, check.HasLen, 2)
 	c.Check(body["action"], check.Equals, "okay")

--- a/client/workshopctl_test.go
+++ b/client/workshopctl_test.go
@@ -58,13 +58,13 @@ func (cs *clientSuite) TestClientRunWorkshoctl(c *check.C) {
 	c.Check(string(stdout), check.Equals, "test stdout")
 	c.Check(string(stderr), check.Equals, "test stderr")
 
-	var body map[string]interface{}
+	var body map[string]any
 	decoder := json.NewDecoder(cs.req.Body)
 	err = decoder.Decode(&body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
 		"context-id": "1234ABCD",
-		"args":       []interface{}{"foo", "bar"},
+		"args":       []any{"foo", "bar"},
 
 		// json byte-stream is b64 encoded
 		"stdin": base64.StdEncoding.EncodeToString([]byte("some-input")),

--- a/cmd/internal/cmdutil/color_test.go
+++ b/cmd/internal/cmdutil/color_test.go
@@ -98,7 +98,7 @@ func (s *colorSuite) TestColorTable(c *check.C) {
 	type T struct {
 		isTTY         bool
 		noColor, term string
-		expected      interface{}
+		expected      any
 		desc          string
 	}
 

--- a/cmd/sdk/info_test.go
+++ b/cmd/sdk/info_test.go
@@ -52,7 +52,7 @@ func (s *sdkSuite) TestInfo(c *check.C) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, check.Equals, "GET")
 		c.Assert(r.URL.Path, check.Equals, "/v1/sdks/openvino")
-		body := map[string]interface{}{
+		body := map[string]any{
 			"type":   "sync",
 			"result": resp,
 		}

--- a/cmd/sdk/list_test.go
+++ b/cmd/sdk/list_test.go
@@ -54,7 +54,7 @@ func (s *sdkSuite) TestList(c *check.C) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, check.Equals, "GET")
 		c.Assert(r.URL.Path, check.Equals, "/v1/sdks")
-		body := map[string]interface{}{
+		body := map[string]any{
 			"type":   "sync",
 			"result": sdks,
 		}

--- a/cmd/workshop/connect_test.go
+++ b/cmd/workshop/connect_test.go
@@ -48,18 +48,18 @@ func (m *connectSuite) TestConnectAcrossWorkshops(c *check.C) {
 
 func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 	cmd := &CmdConnect{root: &CmdRoot{}}
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "connect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk",
 				"plug":       "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "system",
@@ -96,18 +96,18 @@ func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	n = 0
-	body = map[string]interface{}{
+	body = map[string]any{
 		"action": "connect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk",
 				"plug":       "plug2",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk-2",
@@ -120,18 +120,18 @@ func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	n = 0
-	body = map[string]interface{}{
+	body = map[string]any{
 		"action": "connect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk",
 				"plug":       "plug2",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk-2",
@@ -146,18 +146,18 @@ func (m *connectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 
 func (m *connectSuite) TestDisconnectSlotNotProvided(c *check.C) {
 	cmd := &CmdConnect{root: &CmdRoot{}}
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "connect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk",
 				"plug":       "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "system",

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -63,7 +63,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnected(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -156,7 +156,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -210,7 +210,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -358,7 +358,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -497,7 +497,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -632,7 +632,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -763,7 +763,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -834,7 +834,7 @@ func (s *connectionsSuite) TestConnectionsOnlyDisconnected(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -874,7 +874,7 @@ func (s *connectionsSuite) TestConnectionsFiltering(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})
@@ -1112,7 +1112,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *check.C) {
 			body, err := io.ReadAll(r.Body)
 			c.Check(err, check.IsNil)
 			c.Check(body, check.DeepEquals, []byte{})
-			EncodeResponseBody(c, w, map[string]interface{}{
+			EncodeResponseBody(c, w, map[string]any{
 				"type":   "sync",
 				"result": result,
 			})

--- a/cmd/workshop/disconnect_test.go
+++ b/cmd/workshop/disconnect_test.go
@@ -27,18 +27,18 @@ func (m *disconnectSuite) SetUpTest(c *check.C) {
 
 func (m *disconnectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 	cmd := &CmdDisconnect{root: &CmdRoot{}}
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "disconnect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk",
 				"plug":       "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "system",
@@ -75,18 +75,18 @@ func (m *disconnectSuite) TestDisconnectPlugAndSlotProvided(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	n = 0
-	body = map[string]interface{}{
+	body = map[string]any{
 		"action": "disconnect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk",
 				"plug":       "plug2",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk-2",
@@ -103,18 +103,18 @@ func (m *disconnectSuite) TestDisconnectPlugOrSlotProvided(c *check.C) {
 	cmd := &CmdDisconnect{root: &CmdRoot{}}
 
 	n := 0
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "disconnect",
-		"plugs": []interface{}{
-			map[string]interface{}{
+		"plugs": []any{
+			map[string]any{
 				"project-id": "42424242",
 				"workshop":   "ws",
 				"sdk":        "sdk",
 				"plug":       "plug",
 			},
 		},
-		"slots": []interface{}{
-			map[string]interface{}{
+		"slots": []any{
+			map[string]any{
 				"project-id": "",
 				"workshop":   "",
 				"sdk":        "",

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -72,8 +72,8 @@ func (m *workshopLaunch) TestLaunchWaitOnErrorFailed(c *check.C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "launch",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "wait-on-error"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "launch",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "wait-on-error"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 3:
@@ -109,8 +109,8 @@ func (m *workshopLaunch) TestLaunchWaitOnErrorAbortedSuccessfully(c *check.C) {
 		case 2:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "launch",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "abort"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "launch",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "abort"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 3:
@@ -143,8 +143,8 @@ func (m *workshopLaunch) TestLaunchWaitOnErrorContinuedSuccessfully(c *check.C) 
 		case 2:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "launch",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "continue"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "launch",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "continue"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 3:

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -180,8 +180,8 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "wait-on-error", "refresh-option": "restore"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "wait-on-error", "refresh-option": "restore"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 4:
@@ -218,8 +218,8 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorAbortedSuccessfully(c *check.C) 
 		case 2:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "abort"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "abort"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 3:
@@ -253,8 +253,8 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C
 		case 2:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "continue"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "continue"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 3:

--- a/cmd/workshop/remount_test.go
+++ b/cmd/workshop/remount_test.go
@@ -28,9 +28,9 @@ func (m *remountSuite) SetUpTest(c *check.C) {
 
 func (m *remountSuite) TestRemountSuccess(c *check.C) {
 	cmd := &CmdRemount{root: &CmdRoot{}}
-	body := map[string]interface{}{
+	body := map[string]any{
 		"action": "remount",
-		"plug": map[string]interface{}{
+		"plug": map[string]any{
 			"project-id": "42424242",
 			"workshop":   "ws",
 			"sdk":        "sdk",

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -188,15 +188,15 @@ func (m *BaseWorkshopSuite) connectionsRedirectHelper(c *check.C, conns client.C
 }
 
 // EncodeResponseBody writes JSON-serialized body to the response writer.
-func EncodeResponseBody(c *check.C, w http.ResponseWriter, body interface{}) {
+func EncodeResponseBody(c *check.C, w http.ResponseWriter, body any) {
 	encoder := json.NewEncoder(w)
 	err := encoder.Encode(body)
 	c.Assert(err, check.IsNil)
 }
 
 // DecodedRequestBody returns the JSON-decoded body of the request.
-func DecodedRequestBody(c *check.C, r *http.Request) map[string]interface{} {
-	var body map[string]interface{}
+func DecodedRequestBody(c *check.C, r *http.Request) map[string]any {
+	var body map[string]any
 	decoder := json.NewDecoder(r.Body)
 	decoder.UseNumber()
 	err := decoder.Decode(&body)

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -84,10 +84,10 @@ $ workshop sketch-sdk nimble --stash`,
 }
 
 type SketchFile struct {
-	Name  string                 `yaml:"name"`
-	Plugs map[string]interface{} `yaml:"plugs,omitempty"`
-	Slots map[string]interface{} `yaml:"slots,omitempty"`
-	Hooks map[string]string      `yaml:"hooks,omitempty"`
+	Name  string            `yaml:"name"`
+	Plugs map[string]any    `yaml:"plugs,omitempty"`
+	Slots map[string]any    `yaml:"slots,omitempty"`
+	Hooks map[string]string `yaml:"hooks,omitempty"`
 }
 
 var sketchTemplate = `# Sketch SDK for %s

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -162,8 +162,8 @@ func (m *workshopSketch) mockSketchHappyRefreshPath(c *check.C, refreshname stri
 		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{refreshname}, "options": map[string]interface{}{"mode": mode, "refresh-option": "update"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+				"names": []any{refreshname}, "options": map[string]any{"mode": mode, "refresh-option": "update"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 4:
@@ -415,11 +415,11 @@ func (m *workshopSketch) TestSketchSdkFixRefreshError(c *check.C) {
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 
 			if mode == "wait-on-error" {
-				c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-					"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode, "refresh-option": "update"}})
+				c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+					"names": []any{name}, "options": map[string]any{"mode": mode, "refresh-option": "update"}})
 			} else {
-				c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-					"names": []interface{}{name}, "options": map[string]interface{}{"mode": mode}})
+				c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+					"names": []any{name}, "options": map[string]any{"mode": mode}})
 			}
 			w.WriteHeader(202)
 			fmt.Fprintln(w, response)
@@ -545,8 +545,8 @@ func (m *workshopSketch) TestSketchSdkStashRevertOnFail(c *check.C) {
 		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "transactional", "refresh-option": "update"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "transactional", "refresh-option": "update"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 4:
@@ -798,8 +798,8 @@ func (m *workshopSketch) TestSketchSdkRemoveRevertOnFail(c *check.C) {
 		case 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
-			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "refresh",
-				"names": []interface{}{"ws"}, "options": map[string]interface{}{"mode": "transactional", "refresh-option": "update"}})
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "transactional", "refresh-option": "update"}})
 			w.WriteHeader(202)
 			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
 		case 4:

--- a/cmd/workshop/warnings_test.go
+++ b/cmd/workshop/warnings_test.go
@@ -168,7 +168,7 @@ func (s *warningSuite) TestOkay(c *check.C) {
 		}
 		c.Check(r.URL.Path, check.Equals, "/v1/warnings")
 		c.Check(r.URL.Query(), check.HasLen, 0)
-		c.Assert(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{"action": "okay", "timestamp": t0.Format(time.RFC3339Nano)})
+		c.Assert(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "okay", "timestamp": t0.Format(time.RFC3339Nano)})
 		c.Check(r.Method, check.Equals, "POST")
 		w.WriteHeader(200)
 		fmt.Fprintln(w, `{

--- a/cmd/workshop/yaml_test.go
+++ b/cmd/workshop/yaml_test.go
@@ -89,7 +89,7 @@ one:
 	c.Check(contains(document, nodes.One.Nest.C.Node), check.Equals, true)
 }
 
-func unmarshalAndDecode(c *check.C, v interface{}, content string) *yaml.Node {
+func unmarshalAndDecode(c *check.C, v any, content string) *yaml.Node {
 	var document yaml.Node
 	c.Assert(yaml.Unmarshal([]byte(content), &document), check.IsNil)
 	c.Assert(document.Decode(v), check.IsNil)
@@ -439,7 +439,7 @@ b:
 	checkRemoveNodes(c, before, after, &maps, &maps.B)
 }
 
-func checkRemoveNodes(c *check.C, before, after string, v interface{}, nodeRefs ...*NodeRef) {
+func checkRemoveNodes(c *check.C, before, after string, v any, nodeRefs ...*NodeRef) {
 	document := unmarshalAndDecode(c, v, before)
 
 	nodes := make([]*yaml.Node, 0, len(nodeRefs))

--- a/cmd/workshopctl/main.go
+++ b/cmd/workshopctl/main.go
@@ -50,7 +50,7 @@ func main() {
 		if e, ok := err.(*client.Error); ok {
 			switch e.Kind {
 			case client.ErrorKindUnsuccessful:
-				if errRes, ok := e.Value.(map[string]interface{}); ok {
+				if errRes, ok := e.Value.(map[string]any); ok {
 					if stdout, ok := errRes["stdout"].(string); ok {
 						os.Stdout.Write([]byte(stdout))
 					}

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -1192,7 +1192,7 @@ import "github.com/canonical/workshop/internal/overlord/state"
 
 // Store persistent data that survives restarts
 func saveConnectionState(st *state.State) error {
-    conns := map[string]interface{}{
+    conns := map[string]any{
         "workshop/sdk:plug": "workshop/system:slot",
     }
     st.Set("conns", conns)
@@ -1200,8 +1200,8 @@ func saveConnectionState(st *state.State) error {
 }
 
 // Retrieve persistent data
-func loadConnectionState(st *state.State) (map[string]interface{}, error) {
-    var conns map[string]interface{}
+func loadConnectionState(st *state.State) (map[string]any, error) {
+    var conns map[string]any
     err := st.Get("conns", &conns)
     if err != nil && err != state.ErrNoState {
         return nil, err
@@ -1230,7 +1230,7 @@ func getStore(st *state.State) (*Store, error) {
 
 ```go
 // Don't do manual JSON serialization for state
-func saveState(path string, data interface{}) error {
+func saveState(path string, data any) error {
     json, _ := json.Marshal(data)
     return os.WriteFile(path, json, 0644)
 }

--- a/internal/asserts/asserts.go
+++ b/internal/asserts/asserts.go
@@ -394,10 +394,10 @@ type Assertion interface {
 	AuthorityID() string
 
 	// Header retrieves the header with name
-	Header(name string) interface{}
+	Header(name string) any
 
 	// Headers returns the complete headers
-	Headers() map[string]interface{}
+	Headers() map[string]any
 
 	// HeaderString retrieves the string value of header with name or ""
 	HeaderString(name string) string
@@ -434,7 +434,7 @@ const MediaType = "application/x.ubuntu.assertion"
 
 // assertionBase is the concrete base to hold representation data for actual assertions.
 type assertionBase struct {
-	headers map[string]interface{}
+	headers map[string]any
 	body    []byte
 	// parsed format iteration
 	format int
@@ -480,7 +480,7 @@ func (ab *assertionBase) AuthorityID() string {
 }
 
 // Header returns the value of an header by name.
-func (ab *assertionBase) Header(name string) interface{} {
+func (ab *assertionBase) Header(name string) any {
 	v := ab.headers[name]
 	if v == nil {
 		return nil
@@ -489,7 +489,7 @@ func (ab *assertionBase) Header(name string) interface{} {
 }
 
 // Headers returns the complete headers.
-func (ab *assertionBase) Headers() map[string]interface{} {
+func (ab *assertionBase) Headers() map[string]any {
 	return copyHeaders(ab.headers)
 }
 
@@ -815,7 +815,7 @@ func (d *Decoder) Decode() (Assertion, error) {
 	return assemble(headers, finalBody, finalContent, finalSig)
 }
 
-func checkIteration(headers map[string]interface{}, name string) (int, error) {
+func checkIteration(headers map[string]any, name string) (int, error) {
 	iternum, err := checkIntWithDefault(headers, name, 0)
 	if err != nil {
 		return -1, err
@@ -826,16 +826,16 @@ func checkIteration(headers map[string]interface{}, name string) (int, error) {
 	return iternum, nil
 }
 
-func checkFormat(headers map[string]interface{}) (int, error) {
+func checkFormat(headers map[string]any) (int, error) {
 	return checkIteration(headers, "format")
 }
 
-func checkRevision(headers map[string]interface{}) (int, error) {
+func checkRevision(headers map[string]any) (int, error) {
 	return checkIteration(headers, "revision")
 }
 
 // Assemble assembles an assertion from its components.
-func Assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
+func Assemble(headers map[string]any, body, content, signature []byte) (Assertion, error) {
 	err := checkHeaders(headers)
 	if err != nil {
 		return nil, err
@@ -843,14 +843,14 @@ func Assemble(headers map[string]interface{}, body, content, signature []byte) (
 	return assemble(headers, body, content, signature)
 }
 
-func checkAuthority(_ *AssertionType, headers map[string]interface{}) error {
+func checkAuthority(_ *AssertionType, headers map[string]any) error {
 	if _, err := checkNotEmptyString(headers, "authority-id"); err != nil {
 		return err
 	}
 	return nil
 }
 
-func checkNoAuthority(assertType *AssertionType, headers map[string]interface{}) error {
+func checkNoAuthority(assertType *AssertionType, headers map[string]any) error {
 	if _, ok := headers["authority-id"]; ok {
 		return fmt.Errorf("%q assertion cannot have authority-id set", assertType.Name)
 	}
@@ -858,7 +858,7 @@ func checkNoAuthority(assertType *AssertionType, headers map[string]interface{})
 }
 
 // assemble is the internal variant of Assemble, assumes headers are already checked for supported types
-func assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
+func assemble(headers map[string]any, body, content, signature []byte) (Assertion, error) {
 	length, err := checkIntWithDefault(headers, "body-length", 0)
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)

--- a/internal/asserts/asserts_test.go
+++ b/internal/asserts/asserts_test.go
@@ -784,7 +784,7 @@ func (as *assertsSuite) TestHeaders(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	hs := a.Headers()
-	c.Check(hs, check.DeepEquals, map[string]interface{}{
+	c.Check(hs, check.DeepEquals, map[string]any{
 		"type":              "test-only",
 		"authority-id":      "auth-id2",
 		"primary-key":       "abc",
@@ -849,7 +849,7 @@ func (as *assertsSuite) TestAssembleHeadersCheck(c *check.C) {
 		"authority-id: auth-id2\n" +
 		"primary-key: abc\n" +
 		"revision: 5")
-	headers := map[string]interface{}{
+	headers := map[string]any{
 		"type":         "test-only",
 		"authority-id": "auth-id2",
 		"primary-key":  "abc",

--- a/internal/asserts/constraint.go
+++ b/internal/asserts/constraint.go
@@ -44,7 +44,7 @@ type attrMatchingContext struct {
 }
 
 type attrMatcher interface {
-	match(apath string, v interface{}, ctx *attrMatchingContext) error
+	match(apath string, v any, ctx *attrMatchingContext) error
 
 	feature(flabel string) bool
 }
@@ -91,11 +91,11 @@ func (cc compileContext) alt(alt int) compileContext {
 }
 
 // compileAttrMatcher compiles an attrMatcher derived from constraints,
-func compileAttrMatcher(cc compileContext, constraints interface{}) (attrMatcher, error) {
+func compileAttrMatcher(cc compileContext, constraints any) (attrMatcher, error) {
 	switch x := constraints.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		return compileMapAttrMatcher(cc, x)
-	case []interface{}:
+	case []any:
 		if cc.wasAlt {
 			return nil, fmt.Errorf("cannot nest alternative constraints directly at %q", cc)
 		}
@@ -124,7 +124,7 @@ func compileAttrMatcher(cc compileContext, constraints interface{}) (attrMatcher
 
 type mapAttrMatcher map[string]attrMatcher
 
-func compileMapAttrMatcher(cc compileContext, m map[string]interface{}) (attrMatcher, error) {
+func compileMapAttrMatcher(cc compileContext, m map[string]any) (attrMatcher, error) {
 	matcher := make(mapAttrMatcher)
 	for k, constraint := range m {
 		matcher1, err := compileAttrMatcher(cc.keyEntry(k), constraint)
@@ -136,7 +136,7 @@ func compileMapAttrMatcher(cc compileContext, m map[string]interface{}) (attrMat
 	return matcher, nil
 }
 
-func matchEntry(apath, k string, matcher1 attrMatcher, v interface{}, ctx *attrMatchingContext) error {
+func matchEntry(apath, k string, matcher1 attrMatcher, v any, ctx *attrMatchingContext) error {
 	apath = chain(apath, k)
 	// every entry matcher expects the attribute to be set except for $MISSING
 	if _, ok := matcher1.(missingAttrMatcher); !ok && v == nil {
@@ -148,7 +148,7 @@ func matchEntry(apath, k string, matcher1 attrMatcher, v interface{}, ctx *attrM
 	return nil
 }
 
-func matchList(apath string, matcher attrMatcher, l []interface{}, ctx *attrMatchingContext) error {
+func matchList(apath string, matcher attrMatcher, l []any, ctx *attrMatchingContext) error {
 	for i, elem := range l {
 		if err := matcher.match(chain(apath, strconv.Itoa(i)), elem, ctx); err != nil {
 			return err
@@ -166,7 +166,7 @@ func (matcher mapAttrMatcher) feature(flabel string) bool {
 	return false
 }
 
-func (matcher mapAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+func (matcher mapAttrMatcher) match(apath string, v any, ctx *attrMatchingContext) error {
 	switch x := v.(type) {
 	case Attrer:
 		// we get Atter from root-level Check (apath is "")
@@ -176,13 +176,13 @@ func (matcher mapAttrMatcher) match(apath string, v interface{}, ctx *attrMatchi
 				return err
 			}
 		}
-	case map[string]interface{}: // maps in attributes look like this
+	case map[string]any: // maps in attributes look like this
 		for k, matcher1 := range matcher {
 			if err := matchEntry(apath, k, matcher1, x[k], ctx); err != nil {
 				return err
 			}
 		}
-	case []interface{}:
+	case []any:
 		return matchList(apath, matcher, x, ctx)
 	default:
 		return fmt.Errorf("%s %q must be a map", ctx.attrWord, apath)
@@ -196,7 +196,7 @@ func (matcher missingAttrMatcher) feature(flabel string) bool {
 	return flabel == dollarAttrConstraintsFeature
 }
 
-func (matcher missingAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+func (matcher missingAttrMatcher) match(apath string, v any, ctx *attrMatchingContext) error {
 	if v != nil {
 		return fmt.Errorf("%s %q is constrained to be missing but is set", ctx.attrWord, apath)
 	}
@@ -242,11 +242,11 @@ func (matcher evalAttrMatcher) feature(flabel string) bool {
 	return flabel == dollarAttrConstraintsFeature
 }
 
-func (matcher evalAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+func (matcher evalAttrMatcher) match(apath string, v any, ctx *attrMatchingContext) error {
 	if ctx.helper == nil {
 		return fmt.Errorf("%s %q cannot be matched without context", ctx.attrWord, apath)
 	}
-	var comp func(string) (interface{}, error)
+	var comp func(string) (any, error)
 	switch matcher.op {
 	case "SLOT":
 		comp = ctx.helper.SlotAttr
@@ -279,7 +279,7 @@ func (matcher regexpAttrMatcher) feature(flabel string) bool {
 	return false
 }
 
-func (matcher regexpAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+func (matcher regexpAttrMatcher) match(apath string, v any, ctx *attrMatchingContext) error {
 	var s string
 	switch x := v.(type) {
 	case string:
@@ -288,7 +288,7 @@ func (matcher regexpAttrMatcher) match(apath string, v interface{}, ctx *attrMat
 		s = strconv.FormatBool(x)
 	case int64:
 		s = strconv.FormatInt(x, 10)
-	case []interface{}:
+	case []any:
 		return matchList(apath, matcher, x, ctx)
 	default:
 		return fmt.Errorf("%s %q must be a scalar or list", ctx.attrWord, apath)
@@ -304,7 +304,7 @@ type altAttrMatcher struct {
 	alts []attrMatcher
 }
 
-func compileAltAttrMatcher(cc compileContext, l []interface{}) (attrMatcher, error) {
+func compileAltAttrMatcher(cc compileContext, l []any) (attrMatcher, error) {
 	alts := make([]attrMatcher, len(l))
 	for i, constraint := range l {
 		matcher1, err := compileAttrMatcher(cc.alt(i), constraint)
@@ -329,11 +329,11 @@ func (matcher altAttrMatcher) feature(flabel string) bool {
 	return false
 }
 
-func (matcher altAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+func (matcher altAttrMatcher) match(apath string, v any, ctx *attrMatchingContext) error {
 	// if the value is a list apply the alternative matcher to each element
 	// like we do for other matchers
 	switch x := v.(type) {
-	case []interface{}:
+	case []any:
 		return matchList(apath, matcher, x, ctx)
 	default:
 	}

--- a/internal/asserts/constraint_test.go
+++ b/internal/asserts/constraint_test.go
@@ -37,8 +37,8 @@ type attrMatcherSuite struct {
 
 var _ = Suite(&attrMatcherSuite{})
 
-func vals(yml string) map[string]interface{} {
-	var vs map[string]interface{}
+func vals(yml string) map[string]any {
+	var vs map[string]any
 	err := yaml.Unmarshal([]byte(yml), &vs)
 	if err != nil {
 		panic(err)
@@ -47,7 +47,7 @@ func vals(yml string) map[string]interface{} {
 	if err != nil {
 		panic(err)
 	}
-	return v.(map[string]interface{})
+	return v.(map[string]any)
 }
 
 func (s *attrMatcherSuite) SetUpTest(c *C) {
@@ -60,10 +60,10 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
   bar: BAR`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"foo": "FOO",
 		"bar": "BAR",
 		"baz": "BAZ",
@@ -71,7 +71,7 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
 	err = domatch(values, nil)
 	c.Check(err, IsNil)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"foo": "FOO",
 		"bar": "BAZ",
 		"baz": "BAZ",
@@ -79,7 +79,7 @@ func (s *attrMatcherSuite) TestSimple(c *C) {
 	err = domatch(values, nil)
 	c.Check(err, ErrorMatches, `field "bar" value "BAZ" does not match \^\(BAR\)\$`)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"foo": "FOO",
 		"baz": "BAZ",
 	}
@@ -92,34 +92,34 @@ func (s *attrMatcherSuite) TestSimpleAnchorsVsRegexpAlt(c *C) {
   bar: BAR|BAZ`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"bar": "BAR",
 	}
 	err = domatch(values, nil)
 	c.Check(err, IsNil)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"bar": "BARR",
 	}
 	err = domatch(values, nil)
 	c.Check(err, ErrorMatches, `field "bar" value "BARR" does not match \^\(BAR|BAZ\)\$`)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"bar": "BBAZ",
 	}
 	err = domatch(values, nil)
 	c.Check(err, ErrorMatches, `field "bar" value "BAZZ" does not match \^\(BAR|BAZ\)\$`)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"bar": "BABAZ",
 	}
 	err = domatch(values, nil)
 	c.Check(err, ErrorMatches, `field "bar" value "BABAZ" does not match \^\(BAR|BAZ\)\$`)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"bar": "BARAZ",
 	}
 	err = domatch(values, nil)
@@ -134,7 +134,7 @@ func (s *attrMatcherSuite) TestNested(c *C) {
     bar2: BAR2`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -189,7 +189,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
 	domatch, err := asserts.CompileAttrMatcher(m["attrs"], nil)
 	c.Assert(err, IsNil)
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"foo": "FOO",
 		"bar": "BAR",
 		"baz": "BAZ",
@@ -197,7 +197,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
 	err = domatch(values, nil)
 	c.Check(err, IsNil)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"foo": "FOO",
 		"bar": "BAZ",
 		"baz": "BAZ",
@@ -205,7 +205,7 @@ func (s *attrMatcherSuite) TestAlternative(c *C) {
 	err = domatch(values, nil)
 	c.Check(err, IsNil)
 
-	values = map[string]interface{}{
+	values = map[string]any{
 		"foo": "FOO",
 		"bar": "BARR",
 		"baz": "BAR",
@@ -224,7 +224,7 @@ func (s *attrMatcherSuite) TestNestedAlternative(c *C) {
       - BAR22`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -262,7 +262,7 @@ write:
   write: /var/(tmp|lib/workshopd/snapshots)`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(toMatch, nil)
@@ -274,7 +274,7 @@ write:
     - /var/lib/workshopd/snapshots`))
 	c.Assert(err, IsNil)
 
-	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatchLst, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatchLst(toMatch, nil)
@@ -294,7 +294,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
       options: rw|bind|nodev`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(toMatch, nil)
@@ -316,7 +316,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, IsNil)
 
-	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatchExtensive, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatchExtensive(toMatch, nil)
@@ -338,7 +338,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, IsNil)
 
-	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatchExtensiveNoMatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatchExtensiveNoMatch(toMatch, nil)
@@ -351,7 +351,7 @@ func (s *attrMatcherSuite) TestOtherScalars(c *C) {
   bar: true`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -360,7 +360,7 @@ bar: true
 `), nil)
 	c.Check(err, IsNil)
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"foo": int64(1),
 		"bar": true,
 	}
@@ -372,33 +372,33 @@ func (s *attrMatcherSuite) TestCompileErrors(c *C) {
 	_, err := asserts.CompileAttrMatcher(1, nil)
 	c.Check(err, ErrorMatches, `top constraint must be a key-value map, regexp or a list of alternative constraints: 1`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+	_, err = asserts.CompileAttrMatcher(map[string]any{
 		"foo": 1,
 	}, nil)
 	c.Check(err, ErrorMatches, `constraint "foo" must be a key-value map, regexp or a list of alternative constraints: 1`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+	_, err = asserts.CompileAttrMatcher(map[string]any{
 		"foo": "[",
 	}, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\[": error parsing regexp:.*`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
-		"foo": []interface{}{"foo", "["},
+	_, err = asserts.CompileAttrMatcher(map[string]any{
+		"foo": []any{"foo", "["},
 	}, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo/alt#2/" constraint "\[": error parsing regexp:.*`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
-		"foo": []interface{}{"foo", []interface{}{"bar", "baz"}},
+	_, err = asserts.CompileAttrMatcher(map[string]any{
+		"foo": []any{"foo", []any{"bar", "baz"}},
 	}, nil)
 	c.Check(err, ErrorMatches, `cannot nest alternative constraints directly at "foo/alt#2/"`)
 
 	_, err = asserts.CompileAttrMatcher("FOO", nil)
 	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
 
-	_, err = asserts.CompileAttrMatcher([]interface{}{"FOO"}, nil)
+	_, err = asserts.CompileAttrMatcher([]any{"FOO"}, nil)
 	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
 
-	_, err = asserts.CompileAttrMatcher(map[string]interface{}{
+	_, err = asserts.CompileAttrMatcher(map[string]any{
 		"foo": "$FOO()",
 	}, nil)
 	c.Check(err, ErrorMatches, `cannot compile "foo" constraint "\$FOO\(\)": no \$OP\(\) constraints supported`)
@@ -413,7 +413,7 @@ func (s *attrMatcherSuite) TestCompileErrors(c *C) {
 	}
 
 	for _, wrong := range wrongDollarConstraints {
-		_, err := asserts.CompileAttrMatcher(map[string]interface{}{
+		_, err := asserts.CompileAttrMatcher(map[string]any{
 			"foo": wrong,
 		}, []string{"SLOT", "OP"})
 		if wrong != "$SLOT(x,y)" {
@@ -430,7 +430,7 @@ func (s *attrMatcherSuite) TestMatchingListsSimple(c *C) {
   foo: /foo/.*`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -449,7 +449,7 @@ func (s *attrMatcherSuite) TestMissingCheck(c *C) {
   foo: $MISSING`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -470,7 +470,7 @@ func (s *attrMatcherSuite) TestEvalCheck(c *C) {
   bar: $PLUG(bar.baz)`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), []string{"SLOT", "PLUG"})
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), []string{"SLOT", "PLUG"})
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`
@@ -480,7 +480,7 @@ bar: bar
 	c.Check(err, ErrorMatches, `field "(foo|bar)" cannot be matched without context`)
 
 	calls := make(map[[2]string]bool)
-	comp1 := func(op string, arg string) (interface{}, error) {
+	comp1 := func(op string, arg string) (any, error) {
 		calls[[2]string{op, arg}] = true
 		return arg, nil
 	}
@@ -496,7 +496,7 @@ bar: bar.baz
 		{"plug", "bar.baz"}: true,
 	})
 
-	comp2 := func(op string, arg string) (interface{}, error) {
+	comp2 := func(op string, arg string) (any, error) {
 		if op == "plug" {
 			return nil, fmt.Errorf("boom")
 		}
@@ -509,7 +509,7 @@ bar: bar.baz
 `), testEvalAttr{comp2})
 	c.Check(err, ErrorMatches, `field "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
 
-	comp3 := func(op string, arg string) (interface{}, error) {
+	comp3 := func(op string, arg string) (any, error) {
 		if op == "slot" {
 			return "other-value", nil
 		}
@@ -529,7 +529,7 @@ func (s *attrMatcherSuite) TestMatchingListsMap(c *C) {
     p: /foo/.*`))
 	c.Assert(err, IsNil)
 
-	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]interface{}), nil)
+	domatch, err := asserts.CompileAttrMatcher(m["attrs"].(map[string]any), nil)
 	c.Assert(err, IsNil)
 
 	err = domatch(vals(`

--- a/internal/asserts/export_test.go
+++ b/internal/asserts/export_test.go
@@ -69,7 +69,7 @@ func NewDecoderStressed(r io.Reader, bufSize, maxHeadersSize, maxBodySize, maxSi
 	}).initBuffer()
 }
 
-func CompileAttrMatcher(constraints interface{}, allowedOperations []string) (func(attrs map[string]interface{}, helper AttrMatchContext) error, error) {
+func CompileAttrMatcher(constraints any, allowedOperations []string) (func(attrs map[string]any, helper AttrMatchContext) error, error) {
 	// XXX adjust
 	cc := compileContext{
 		opts: &compileAttrMatcherOptions{
@@ -80,7 +80,7 @@ func CompileAttrMatcher(constraints interface{}, allowedOperations []string) (fu
 	if err != nil {
 		return nil, err
 	}
-	domatch := func(attrs map[string]interface{}, helper AttrMatchContext) error {
+	domatch := func(attrs map[string]any, helper AttrMatchContext) error {
 		return matcher.match("", attrs, &attrMatchingContext{
 			attrWord: "field",
 			helper:   helper,

--- a/internal/asserts/header_checks.go
+++ b/internal/asserts/header_checks.go
@@ -31,7 +31,7 @@ import (
 
 // common checks used when decoding/assembling assertions
 
-func checkExistsStringWhat(m map[string]interface{}, name, what string) (string, error) {
+func checkExistsStringWhat(m map[string]any, name, what string) (string, error) {
 	value, ok := m[name]
 	if !ok {
 		return "", fmt.Errorf("%q %s is mandatory", name, what)
@@ -43,11 +43,11 @@ func checkExistsStringWhat(m map[string]interface{}, name, what string) (string,
 	return s, nil
 }
 
-func checkNotEmptyString(headers map[string]interface{}, name string) (string, error) {
+func checkNotEmptyString(headers map[string]any, name string) (string, error) {
 	return checkNotEmptyStringWhat(headers, name, "header")
 }
 
-func checkNotEmptyStringWhat(m map[string]interface{}, name, what string) (string, error) {
+func checkNotEmptyStringWhat(m map[string]any, name, what string) (string, error) {
 	s, err := checkExistsStringWhat(m, name, what)
 	if err != nil {
 		return "", err
@@ -58,7 +58,7 @@ func checkNotEmptyStringWhat(m map[string]interface{}, name, what string) (strin
 	return s, nil
 }
 
-func checkPrimaryKey(headers map[string]interface{}, primKey string) (string, error) {
+func checkPrimaryKey(headers map[string]any, primKey string) (string, error) {
 	value, err := checkNotEmptyString(headers, primKey)
 	if err != nil {
 		return "", err
@@ -72,7 +72,7 @@ func checkPrimaryKey(headers map[string]interface{}, primKey string) (string, er
 // use 'defl' default if missing
 //
 //nolint:unparam // Copied from snapd.
-func checkIntWithDefault(headers map[string]interface{}, name string, defl int) (int, error) {
+func checkIntWithDefault(headers map[string]any, name string, defl int) (int, error) {
 	value, ok := headers[name]
 	if !ok {
 		return defl, nil
@@ -94,7 +94,7 @@ func (e intSyntaxError) Error() string {
 	return string(e)
 }
 
-func atoi(valueStr, whichFmt string, whichArgs ...interface{}) (int, error) {
+func atoi(valueStr, whichFmt string, whichArgs ...any) (int, error) {
 	value, err := strconv.Atoi(valueStr)
 	if err != nil {
 		which := fmt.Sprintf(whichFmt, whichArgs...)
@@ -113,11 +113,11 @@ func prefixZeros(s string) bool {
 	return strings.HasPrefix(s, "0") && s != "0"
 }
 
-func checkRFC3339Date(headers map[string]interface{}, name string) (time.Time, error) {
+func checkRFC3339Date(headers map[string]any, name string) (time.Time, error) {
 	return checkRFC3339DateWhat(headers, name, "header")
 }
 
-func checkRFC3339DateWhat(m map[string]interface{}, name, what string) (time.Time, error) {
+func checkRFC3339DateWhat(m map[string]any, name, what string) (time.Time, error) {
 	dateStr, err := checkNotEmptyStringWhat(m, name, what)
 	if err != nil {
 		return time.Time{}, err
@@ -129,11 +129,11 @@ func checkRFC3339DateWhat(m map[string]interface{}, name, what string) (time.Tim
 	return date, nil
 }
 
-func checkDigest(headers map[string]interface{}, name string, h crypto.Hash) ([]byte, error) {
+func checkDigest(headers map[string]any, name string, h crypto.Hash) ([]byte, error) {
 	return checkDigestWhat(headers, name, h, "header")
 }
 
-func checkDigestWhat(headers map[string]interface{}, name string, h crypto.Hash, what string) ([]byte, error) {
+func checkDigestWhat(headers map[string]any, name string, h crypto.Hash, what string) ([]byte, error) {
 	digestStr, err := checkNotEmptyStringWhat(headers, name, what)
 	if err != nil {
 		return nil, err
@@ -153,12 +153,12 @@ func checkDigestWhat(headers map[string]interface{}, name string, h crypto.Hash,
 // if `m` has an entry for `name` and it isn't a `[]string`, an error is returned
 // if pattern is not nil, all the strings must match that pattern, otherwise an error is returned
 // `what` is a descriptor, used for error messages
-func checkStringListInMap(m map[string]interface{}, name, what string, pattern *regexp.Regexp) ([]string, error) {
+func checkStringListInMap(m map[string]any, name, what string, pattern *regexp.Regexp) ([]string, error) {
 	value, ok := m[name]
 	if !ok {
 		return nil, nil
 	}
-	lst, ok := value.([]interface{})
+	lst, ok := value.([]any)
 	if !ok {
 		return nil, fmt.Errorf("%s must be a list of strings", what)
 	}
@@ -179,16 +179,16 @@ func checkStringListInMap(m map[string]interface{}, name, what string, pattern *
 	return res, nil
 }
 
-func checkMap(headers map[string]interface{}, name string) (map[string]interface{}, error) {
+func checkMap(headers map[string]any, name string) (map[string]any, error) {
 	return checkMapWhat(headers, name, "header")
 }
 
-func checkMapWhat(m map[string]interface{}, name, what string) (map[string]interface{}, error) {
+func checkMapWhat(m map[string]any, name, what string) (map[string]any, error) {
 	value, ok := m[name]
 	if !ok {
 		return nil, nil
 	}
-	mv, ok := value.(map[string]interface{})
+	mv, ok := value.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("%q %s must be a map", name, what)
 	}

--- a/internal/asserts/headers.go
+++ b/internal/asserts/headers.go
@@ -35,11 +35,11 @@ var (
 	headerNameValidity = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 )
 
-func parseHeaders(head []byte) (map[string]interface{}, error) {
+func parseHeaders(head []byte) (map[string]any, error) {
 	if !utf8.Valid(head) {
 		return nil, fmt.Errorf("header is not utf8")
 	}
-	headers := make(map[string]interface{})
+	headers := make(map[string]any)
 	lines := strings.Split(string(head), "\n")
 	for i := 0; i < len(lines); {
 		entry := lines[i]
@@ -53,7 +53,7 @@ func parseHeaders(head []byte) (map[string]interface{}, error) {
 		}
 
 		consumed := nameValueSplit + 1
-		var value interface{}
+		var value any
 		var err error
 		value, i, err = parseEntry(consumed, i, lines, 0)
 		if err != nil {
@@ -80,7 +80,7 @@ func nestingPrefix(baseIndent int, prefix string) string {
 	return strings.Repeat(" ", baseIndent) + prefix
 }
 
-func parseEntry(consumedByIntro int, first int, lines []string, baseIndent int) (value interface{}, firstAfter int, err error) {
+func parseEntry(consumedByIntro int, first int, lines []string, baseIndent int) (value any, firstAfter int, err error) {
 	entry := lines[first]
 	i := first + 1
 	if consumedByIntro == len(entry) {
@@ -109,7 +109,7 @@ func parseEntry(consumedByIntro int, first int, lines []string, baseIndent int) 
 	return entry[consumedByIntro+1:], i, nil
 }
 
-func parseMultilineText(first int, lines []string, baseIndent int) (value interface{}, firstAfter int, err error) {
+func parseMultilineText(first int, lines []string, baseIndent int) (value any, firstAfter int, err error) {
 	size := 0
 	i := first
 	j := i
@@ -144,15 +144,15 @@ func parseMultilineText(first int, lines []string, baseIndent int) (value interf
 	return valueBuf.String(), i, nil
 }
 
-func parseList(first int, lines []string, baseIndent int) (value interface{}, firstAfter int, err error) {
-	lst := []interface{}(nil)
+func parseList(first int, lines []string, baseIndent int) (value any, firstAfter int, err error) {
+	lst := []any(nil)
 	j := first
 	prefix := nestingPrefix(baseIndent, listPrefix)
 	for j < len(lines) {
 		if !strings.HasPrefix(lines[j], prefix) {
 			return lst, j, nil
 		}
-		var v interface{}
+		var v any
 		var err error
 		v, j, err = parseEntry(len(prefix), j, lines, baseIndent+len(listPrefix)-1)
 		if err != nil {
@@ -163,8 +163,8 @@ func parseList(first int, lines []string, baseIndent int) (value interface{}, fi
 	return lst, j, nil
 }
 
-func parseMap(first int, lines []string, baseIndent int) (value interface{}, firstAfter int, err error) {
-	m := make(map[string]interface{})
+func parseMap(first int, lines []string, baseIndent int) (value any, firstAfter int, err error) {
+	m := make(map[string]any)
 	j := first
 	prefix := nestingPrefix(baseIndent, commonPrefix)
 	for j < len(lines) {
@@ -183,7 +183,7 @@ func parseMap(first int, lines []string, baseIndent int) (value interface{}, fir
 		}
 
 		consumed := keyValueSplit + 1
-		var value interface{}
+		var value any
 		var err error
 		value, j, err = parseEntry(len(prefix)+consumed, j, lines, len(prefix))
 		if err != nil {
@@ -200,11 +200,11 @@ func parseMap(first int, lines []string, baseIndent int) (value interface{}, fir
 }
 
 // checkHeader checks that the header values are strings, or nested lists or maps with strings as the only scalars
-func checkHeader(v interface{}) error {
+func checkHeader(v any) error {
 	switch x := v.(type) {
 	case string:
 		return nil
-	case []interface{}:
+	case []any:
 		for _, elem := range x {
 			err := checkHeader(elem)
 			if err != nil {
@@ -212,7 +212,7 @@ func checkHeader(v interface{}) error {
 			}
 		}
 		return nil
-	case map[string]interface{}:
+	case map[string]any:
 		for _, elem := range x {
 			err := checkHeader(elem)
 			if err != nil {
@@ -226,7 +226,7 @@ func checkHeader(v interface{}) error {
 }
 
 // checkHeaders checks that headers are of expected types
-func checkHeaders(headers map[string]interface{}) error {
+func checkHeaders(headers map[string]any) error {
 	for name, value := range headers {
 		err := checkHeader(value)
 		if err != nil {
@@ -237,18 +237,18 @@ func checkHeaders(headers map[string]interface{}) error {
 }
 
 // copyHeader helps deep copying header values to defend against external mutations
-func copyHeader(v interface{}) interface{} {
+func copyHeader(v any) any {
 	switch x := v.(type) {
 	case string:
 		return x
-	case []interface{}:
-		res := make([]interface{}, len(x))
+	case []any:
+		res := make([]any, len(x))
 		for i, elem := range x {
 			res[i] = copyHeader(elem)
 		}
 		return res
-	case map[string]interface{}:
-		res := make(map[string]interface{}, len(x))
+	case map[string]any:
+		res := make(map[string]any, len(x))
 		for name, value := range x {
 			if value == nil {
 				continue // normalize nils out
@@ -262,6 +262,6 @@ func copyHeader(v interface{}) interface{} {
 }
 
 // copyHeader helps deep copying headers to defend against external mutations
-func copyHeaders(headers map[string]interface{}) map[string]interface{} {
-	return copyHeader(headers).(map[string]interface{})
+func copyHeaders(headers map[string]any) map[string]any {
+	return copyHeader(headers).(map[string]any)
 }

--- a/internal/asserts/headers_test.go
+++ b/internal/asserts/headers_test.go
@@ -33,7 +33,7 @@ func (s *headersSuite) TestParseHeadersSimple(c *check.C) {
 	m, err := asserts.ParseHeaders([]byte(`foo: 1
 bar: baz`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
 		"foo": "1",
 		"bar": "baz",
 	})
@@ -45,7 +45,7 @@ func (s *headersSuite) TestParseHeadersMultiline(c *check.C) {
     
 bar: baz`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
 		"foo": "abc\n",
 		"bar": "baz",
 	})
@@ -54,7 +54,7 @@ bar: baz`))
 bar:
     baz`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
 		"foo": "1",
 		"bar": "baz",
 	})
@@ -64,7 +64,7 @@ bar:
     baz
     `))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
 		"foo": "1",
 		"bar": "baz\n",
 	})
@@ -75,7 +75,7 @@ bar:
     
     baz2`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
 		"foo": "1",
 		"bar": "baz\n\nbaz2",
 	})
@@ -88,8 +88,8 @@ func (s *headersSuite) TestParseHeadersSimpleList(c *check.C) {
   - z
 bar: baz`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"foo": []interface{}{"x", "y", "z"},
+	c.Check(m, check.DeepEquals, map[string]any{
+		"foo": []any{"x", "y", "z"},
 		"bar": "baz",
 	})
 }
@@ -104,8 +104,8 @@ func (s *headersSuite) TestParseHeadersListNestedMultiline(c *check.C) {
   - z
 bar: baz`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"foo": []interface{}{"x", "y1\ny2\n", "z"},
+	c.Check(m, check.DeepEquals, map[string]any{
+		"foo": []any{"x", "y1\ny2\n", "z"},
 		"bar": "baz",
 	})
 
@@ -119,8 +119,8 @@ foo:
       y2
       `))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"foo": []interface{}{[]interface{}{"u1", "u2"}, "y1\ny2\n"},
+	c.Check(m, check.DeepEquals, map[string]any{
+		"foo": []any{[]any{"u1", "u2"}, "y1\ny2\n"},
 		"bar": "baz",
 	})
 }
@@ -132,8 +132,8 @@ func (s *headersSuite) TestParseHeadersSimpleMap(c *check.C) {
   z5: 
 bar: baz`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"foo": map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
+		"foo": map[string]any{
 			"x":  "X",
 			"yy": "YY",
 			"z5": "",
@@ -153,11 +153,11 @@ func (s *headersSuite) TestParseHeadersMapNestedMultiline(c *check.C) {
     - u2
 bar: baz`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"foo": map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
+		"foo": map[string]any{
 			"x":  "X",
 			"yy": "YY1\nYY2",
-			"u":  []interface{}{"u1", "u2"},
+			"u":  []any{"u1", "u2"},
 		},
 		"bar": "baz",
 	})
@@ -166,9 +166,9 @@ bar: baz`))
   two:
     three: `))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"one": map[string]interface{}{
-			"two": map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
+		"one": map[string]any{
+			"two": map[string]any{
 				"three": "",
 			},
 		},
@@ -178,8 +178,8 @@ bar: baz`))
   two:
       three`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"one": map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
+		"one": map[string]any{
 			"two": "three",
 		},
 	})
@@ -188,9 +188,9 @@ bar: baz`))
   lev1:
     lev2: x`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"map-within-map": map[string]interface{}{
-			"lev1": map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
+		"map-within-map": map[string]any{
+			"lev1": map[string]any{
 				"lev2": "x",
 			},
 		},
@@ -203,13 +203,13 @@ bar: baz`))
   -
     entry: bar`))
 	c.Assert(err, check.IsNil)
-	c.Check(m, check.DeepEquals, map[string]interface{}{
-		"list-of-maps": []interface{}{
-			map[string]interface{}{
+	c.Check(m, check.DeepEquals, map[string]any{
+		"list-of-maps": []any{
+			map[string]any{
 				"entry": "foo",
 				"bar":   "baz",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"entry": "bar",
 			},
 		},

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	defaultOutcome = map[string]interface{}{
+	defaultOutcome = map[string]any{
 		"allow-installation":    "true",
 		"allow-connection":      "true",
 		"allow-auto-connection": "true",
@@ -18,7 +18,7 @@ var (
 		"deny-auto-connection":  "false",
 	}
 
-	invertedOutcome = map[string]interface{}{
+	invertedOutcome = map[string]any{
 		"allow-installation":    "false",
 		"allow-connection":      "false",
 		"allow-auto-connection": "false",
@@ -226,7 +226,7 @@ var (
 	validSpecialNameConstraint = regexp.MustCompile(`^\$[A-Z][A-Z0-9_]*$`)
 )
 
-func compileNameMatcher(whichName string, v interface{}) (nameMatcher, error) {
+func compileNameMatcher(whichName string, v any) (nameMatcher, error) {
 	s, ok := v.(string)
 	if !ok {
 		return nil, fmt.Errorf("%s constraint entry must be a regexp or special $ value", whichName)
@@ -276,8 +276,8 @@ type NameConstraints struct {
 	matchers []nameMatcher
 }
 
-func compileNameConstraints(whichName string, constraints interface{}) (*NameConstraints, error) {
-	l, ok := constraints.([]interface{})
+func compileNameConstraints(whichName string, constraints any) (*NameConstraints, error) {
+	l, ok := constraints.([]any)
 	if !ok {
 		return nil, fmt.Errorf("%s constraints must be a list of regexps and special $ values", whichName)
 	}
@@ -385,7 +385,7 @@ func compileSlotConnectionConstraints(context *subruleContext, cDef constraintsD
 	return slotConnCstrs, nil
 }
 
-func compileSideArityConstraint(context *subruleContext, which string, v interface{}) (SideArityConstraint, error) {
+func compileSideArityConstraint(context *subruleContext, which string, v any) (SideArityConstraint, error) {
 	var a SideArityConstraint
 	if context.installation() || !context.allow() {
 		return a, fmt.Errorf("%v cannot specify a %v constraint, they apply only to allow-*connection", context, which)
@@ -417,14 +417,14 @@ func (matcher fixedAttrMatcher) feature(flabel string) bool {
 	return false
 }
 
-func (matcher fixedAttrMatcher) match(apath string, v interface{}, ctx *attrMatchingContext) error {
+func (matcher fixedAttrMatcher) match(apath string, v any, ctx *attrMatchingContext) error {
 	return matcher.result
 }
 
 // AttrMatchContext has contextual helpers for evaluating attribute constraints.
 type AttrMatchContext interface {
-	PlugAttr(arg string) (interface{}, error)
-	SlotAttr(arg string) (interface{}, error)
+	PlugAttr(arg string) (any, error)
+	SlotAttr(arg string) (any, error)
 }
 
 // AttributeConstraints implements a set of constraints on the attributes of a slot or plug.
@@ -446,7 +446,7 @@ func (c *AttributeConstraints) Check(attrer Attrer, helper AttrMatchContext) err
 
 // compileAttributeConstraints checks and compiles a mapping or list
 // from the assertion format into AttributeConstraints.
-func compileAttributeConstraints(constraints interface{}) (*AttributeConstraints, error) {
+func compileAttributeConstraints(constraints any) (*AttributeConstraints, error) {
 	cc := compileContext{
 		opts: &compileAttrMatcherOptions{
 			allowedOperations: []string{"SLOT", "PLUG"},
@@ -466,7 +466,7 @@ var (
 
 // Attrer reflects part of the Attrer interface (see interfaces.Attrer).
 type Attrer interface {
-	Lookup(path string) (interface{}, bool)
+	Lookup(path string) (any, bool)
 }
 
 func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target constraintsHolder, nameConstraints, attrConstraints, idConstraints []string) error {
@@ -772,7 +772,7 @@ var plugRuleCompilers = map[string]subruleCompiler{
 	"deny-auto-connection":  compilePlugConnectionConstraints,
 }
 
-func compilePlugRule(interfaceName string, rule interface{}) (*PlugRule, error) {
+func compilePlugRule(interfaceName string, rule any) (*PlugRule, error) {
 	context := fmt.Sprintf("plug rule for interface %q", interfaceName)
 	plugRule := &PlugRule{
 		Interface: interfaceName,
@@ -825,7 +825,7 @@ func (c *subruleContext) autoConnection() bool {
 }
 
 type constraintsDef struct {
-	cMap   map[string]interface{}
+	cMap   map[string]any
 	invert bool
 }
 
@@ -850,7 +850,7 @@ var slotRuleCompilers = map[string]subruleCompiler{
 	"deny-auto-connection":  compileSlotConnectionConstraints,
 }
 
-func compileSlotRule(interfaceName string, rule interface{}) (*SlotRule, error) {
+func compileSlotRule(interfaceName string, rule any) (*SlotRule, error) {
 	context := fmt.Sprintf("slot rule for interface %q", interfaceName)
 	slotRule := &SlotRule{
 		Interface: interfaceName,
@@ -862,9 +862,9 @@ func compileSlotRule(interfaceName string, rule interface{}) (*SlotRule, error) 
 	return slotRule, nil
 }
 
-func checkMapOrShortcut(v interface{}) (m map[string]interface{}, invert bool, err error) {
+func checkMapOrShortcut(v any) (m map[string]any, invert bool, err error) {
 	switch x := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		return x, false, nil
 	case string:
 		switch x {
@@ -877,7 +877,7 @@ func checkMapOrShortcut(v interface{}) (m map[string]interface{}, invert bool, e
 	return nil, false, errors.New("unexpected type")
 }
 
-func baseCompileRule(context string, rule interface{}, target rule, subrules []string, compilers map[string]subruleCompiler, defaultOutcome, invertedOutcome map[string]interface{}) error {
+func baseCompileRule(context string, rule any, target rule, subrules []string, compilers map[string]subruleCompiler, defaultOutcome, invertedOutcome map[string]any) error {
 	rMap, invert, err := checkMapOrShortcut(rule)
 	if err != nil {
 		return fmt.Errorf("%s must be a map or one of the shortcuts 'true' or 'false'", context)
@@ -892,18 +892,18 @@ func baseCompileRule(context string, rule interface{}, target rule, subrules []s
 	// compile and set subrules
 	for _, subrule := range subrules {
 		v := rMap[subrule]
-		var lst []interface{}
+		var lst []any
 		alternatives := false
 		switch x := v.(type) {
 		case nil:
 			v = defaultOutcome[subrule]
 			defaultUsed++
-		case []interface{}:
+		case []any:
 			alternatives = true
 			lst = x
 		}
 		if lst == nil { // v is map or a string, checked below
-			lst = []interface{}{v}
+			lst = []any{v}
 		}
 		compiler := compilers[subrule]
 		if compiler == nil {

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -53,22 +53,22 @@ type attrConstraintsSuite struct {
 	testutil.BaseTest
 }
 
-type attrerObject map[string]interface{}
+type attrerObject map[string]any
 
-func (o attrerObject) Lookup(path string) (interface{}, bool) {
+func (o attrerObject) Lookup(path string) (any, bool) {
 	v, ok := o[path]
 	return v, ok
 }
 
 func attrs(yml string) *attrerObject {
-	var attrs map[string]interface{}
+	var attrs map[string]any
 	err := yaml.Unmarshal([]byte(yml), &attrs)
 	if err != nil {
 		panic(err)
 	}
-	sdkYaml, err := yaml.Marshal(map[string]interface{}{
+	sdkYaml, err := yaml.Marshal(map[string]any{
 		"name": "sample",
-		"plugs": map[string]interface{}{
+		"plugs": map[string]any{
 			"plug": attrs,
 		},
 	})
@@ -102,10 +102,10 @@ func (s *attrConstraintsSuite) TestSimple(c *check.C) {
   bar: BAR`))
 	c.Assert(err, check.IsNil)
 
-	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
-	plug := attrerObject(map[string]interface{}{
+	plug := attrerObject(map[string]any{
 		"foo": "FOO",
 		"bar": "BAR",
 		"baz": "BAZ",
@@ -113,7 +113,7 @@ func (s *attrConstraintsSuite) TestSimple(c *check.C) {
 	err = cstrs.Check(plug, nil)
 	c.Check(err, check.IsNil)
 
-	plug = attrerObject(map[string]interface{}{
+	plug = attrerObject(map[string]any{
 		"foo": "FOO",
 		"bar": "BAZ",
 		"baz": "BAZ",
@@ -121,7 +121,7 @@ func (s *attrConstraintsSuite) TestSimple(c *check.C) {
 	err = cstrs.Check(plug, nil)
 	c.Check(err, check.ErrorMatches, `attribute "bar" value "BAZ" does not match \^\(BAR\)\$`)
 
-	plug = attrerObject(map[string]interface{}{
+	plug = attrerObject(map[string]any{
 		"foo": "FOO",
 		"baz": "BAZ",
 	})
@@ -134,7 +134,7 @@ func (s *attrConstraintsSuite) TestMissingCheck(c *check.C) {
   foo: $MISSING`))
 	c.Assert(err, check.IsNil)
 
-	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
 	c.Assert(err, check.IsNil)
 	c.Check(asserts.RuleFeature(cstrs, "dollar-attr-constraints"), check.Equals, true)
 }
@@ -147,7 +147,7 @@ func (s *attrConstraintsSuite) TestNested(c *check.C) {
     bar2: BAR2`))
 	c.Assert(err, check.IsNil)
 
-	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	err = cstrs.Check(attrs(`
@@ -202,7 +202,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
       options: rw|bind|nodev`))
 	c.Assert(err, check.IsNil)
 
-	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	err = cstrs.Check(toMatch, nil)
@@ -224,7 +224,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, check.IsNil)
 
-	cstrsExtensive, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	cstrsExtensive, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	err = cstrsExtensive.Check(toMatch, nil)
@@ -246,7 +246,7 @@ mnt: [{what: "/dev/x*", where: "/foo/*", options: ["rw", "nodev"]}, {what: "/bar
         - bind`))
 	c.Assert(err, check.IsNil)
 
-	cstrsExtensiveNoMatch, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	cstrsExtensiveNoMatch, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	err = cstrsExtensiveNoMatch.Check(toMatch, nil)
@@ -259,7 +259,7 @@ func (s *attrConstraintsSuite) TestOtherScalars(c *check.C) {
   bar: true`))
 	c.Assert(err, check.IsNil)
 
-	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	err = cstrs.Check(attrs(`
@@ -270,7 +270,7 @@ bar: true
 }
 
 func (s *attrConstraintsSuite) TestCompileErrors(c *check.C) {
-	_, err := asserts.CompileAttributeConstraints(map[string]interface{}{
+	_, err := asserts.CompileAttributeConstraints(map[string]any{
 		"foo": "[",
 	})
 	c.Check(err, check.ErrorMatches, `cannot compile "foo" constraint "\[": error parsing regexp:.*`)
@@ -278,7 +278,7 @@ func (s *attrConstraintsSuite) TestCompileErrors(c *check.C) {
 	_, err = asserts.CompileAttributeConstraints("FOO")
 	c.Check(err, check.ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
 
-	_, err = asserts.CompileAttributeConstraints([]interface{}{"FOO"})
+	_, err = asserts.CompileAttributeConstraints([]any{"FOO"})
 	c.Check(err, check.ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
 
 	wrongDollarConstraints := []string{
@@ -289,7 +289,7 @@ func (s *attrConstraintsSuite) TestCompileErrors(c *check.C) {
 	}
 
 	for _, wrong := range wrongDollarConstraints {
-		_, err := asserts.CompileAttributeConstraints(map[string]interface{}{
+		_, err := asserts.CompileAttributeConstraints(map[string]any{
 			"foo": wrong,
 		})
 		c.Check(err, check.ErrorMatches, fmt.Sprintf(`cannot compile "foo" constraint "%s": not a valid \$SLOT\(\)/\$PLUG\(\) constraint`, regexp.QuoteMeta(wrong)))
@@ -298,14 +298,14 @@ func (s *attrConstraintsSuite) TestCompileErrors(c *check.C) {
 }
 
 type testEvalAttr struct {
-	comp func(side string, arg string) (interface{}, error)
+	comp func(side string, arg string) (any, error)
 }
 
-func (ca testEvalAttr) SlotAttr(arg string) (interface{}, error) {
+func (ca testEvalAttr) SlotAttr(arg string) (any, error) {
 	return ca.comp("slot", arg)
 }
 
-func (ca testEvalAttr) PlugAttr(arg string) (interface{}, error) {
+func (ca testEvalAttr) PlugAttr(arg string) (any, error) {
 	return ca.comp("plug", arg)
 }
 
@@ -315,7 +315,7 @@ func (s *attrConstraintsSuite) TestEvalCheck(c *check.C) {
   bar: $PLUG(bar.baz)`))
 	c.Assert(err, check.IsNil)
 
-	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]interface{}))
+	cstrs, err := asserts.CompileAttributeConstraints(m["attrs"].(map[string]any))
 	c.Assert(err, check.IsNil)
 	c.Check(asserts.RuleFeature(cstrs, "dollar-attr-constraints"), check.Equals, true)
 
@@ -326,7 +326,7 @@ bar: bar
 	c.Check(err, check.ErrorMatches, `attribute "(foo|bar)" cannot be matched without context`)
 
 	calls := make(map[[2]string]bool)
-	comp1 := func(op string, arg string) (interface{}, error) {
+	comp1 := func(op string, arg string) (any, error) {
 		calls[[2]string{op, arg}] = true
 		return arg, nil
 	}
@@ -342,7 +342,7 @@ bar: bar.baz
 		{"plug", "bar.baz"}: true,
 	})
 
-	comp2 := func(op string, arg string) (interface{}, error) {
+	comp2 := func(op string, arg string) (any, error) {
 		if op == "plug" {
 			return nil, fmt.Errorf("boom")
 		}
@@ -355,7 +355,7 @@ bar: bar.baz
 `), testEvalAttr{comp2})
 	c.Check(err, check.ErrorMatches, `attribute "bar" constraint \$PLUG\(bar\.baz\) cannot be evaluated: boom`)
 
-	comp3 := func(op string, arg string) (interface{}, error) {
+	comp3 := func(op string, arg string) (any, error) {
 		if op == "slot" {
 			return "other-value", nil
 		}
@@ -376,11 +376,11 @@ func (s *attrConstraintsSuite) TestNeverMatchAttributeConstraints(c *check.C) {
 type plugSlotRulesSuite struct{}
 
 func checkAttrs(c *check.C, attrs *asserts.AttributeConstraints, witness, expected string) {
-	plug := attrerObject(map[string]interface{}{
+	plug := attrerObject(map[string]any{
 		witness: "XYZ",
 	})
 	c.Check(attrs.Check(plug, nil), check.ErrorMatches, fmt.Sprintf(`attribute "%s".*does not match.*`, witness))
-	plug = attrerObject(map[string]interface{}{
+	plug = attrerObject(map[string]any{
 		witness: expected,
 	})
 	c.Check(attrs.Check(plug, nil), check.IsNil)
@@ -416,7 +416,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleAllAllowDenyStanzas(c *check.C) 
       sa6: SA6`))
 	c.Assert(err, check.IsNil)
 
-	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	c.Check(rule.Interface, check.Equals, "iface")
@@ -495,7 +495,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleAllAllowDenyOrStanzas(c *check.C
         pa6: PA6alt`))
 	c.Assert(err, check.IsNil)
 
-	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	c.Check(rule.Interface, check.Equals, "iface")
@@ -562,7 +562,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleShortcutFalse(c *check.C) {
 }
 
 func (s *plugSlotRulesSuite) TestCompilePlugRuleDefaults(c *check.C) {
-	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
+	rule, err := asserts.CompilePlugRule("iface", map[string]any{
 		"deny-auto-connection": "true",
 	})
 	c.Assert(err, check.IsNil)
@@ -584,9 +584,9 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleDefaults(c *check.C) {
 }
 
 func (s *plugSlotRulesSuite) TestCompilePlugRuleInstalationConstraintsIDConstraints(c *check.C) {
-	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
-		"allow-installation": map[string]interface{}{
-			"plug-sdk-type": []interface{}{sdk.System.String(), sdk.Regular.String()},
+	rule, err := asserts.CompilePlugRule("iface", map[string]any{
+		"allow-installation": map[string]any{
+			"plug-sdk-type": []any{sdk.System.String(), sdk.Regular.String()},
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -601,7 +601,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsPlugNames
   allow-installation: true`))
 	c.Assert(err, check.IsNil)
 
-	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	c.Check(rule.AllowInstallation[0].PlugNames, check.IsNil)
@@ -630,7 +630,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsPlugNames
 		m, err = asserts.ParseHeaders([]byte(t.rule))
 		c.Assert(err, check.IsNil)
 
-		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 		c.Assert(err, check.IsNil)
 
 		for _, matching := range t.matching {
@@ -643,10 +643,10 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsPlugNames
 }
 
 func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsIDConstraints(c *check.C) {
-	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
-		"allow-connection": map[string]interface{}{
-			"plug-sdk-type": []interface{}{sdk.Regular.String()},
-			"slot-sdk-type": []interface{}{sdk.System.String(), sdk.Regular.String()},
+	rule, err := asserts.CompilePlugRule("iface", map[string]any{
+		"allow-connection": map[string]any{
+			"plug-sdk-type": []any{sdk.Regular.String()},
+			"slot-sdk-type": []any{sdk.System.String(), sdk.Regular.String()},
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -662,7 +662,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsPlugNamesSl
   allow-connection: true`))
 	c.Assert(err, check.IsNil)
 
-	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	c.Check(rule.AllowConnection[0].PlugNames, check.IsNil)
@@ -700,7 +700,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsPlugNamesSl
 		m, err = asserts.ParseHeaders([]byte(t.rule))
 		c.Assert(err, check.IsNil)
 
-		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 		c.Assert(err, check.IsNil)
 
 		for _, matching := range t.matching {
@@ -722,7 +722,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsSideArityCo
   allow-auto-connection: true`))
 	c.Assert(err, check.IsNil)
 
-	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+	rule, err := asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	// defaults
@@ -754,7 +754,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsSideArityCo
 		m, err = asserts.ParseHeaders([]byte(t))
 		c.Assert(err, check.IsNil)
 
-		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 		c.Assert(err, check.IsNil)
 
 		c.Check(rule.AllowConnection[0].SlotsPerPlug.Any(), check.Equals, true)
@@ -787,7 +787,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsSideArityCo
 		m, err = asserts.ParseHeaders([]byte(t.rule))
 		c.Assert(err, check.IsNil)
 
-		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]interface{}))
+		rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 		c.Assert(err, check.IsNil)
 
 		c.Check(rule.AllowAutoConnection[0].SlotsPerPlug, check.Equals, t.slotsPerPlug)
@@ -796,9 +796,9 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsSideArityCo
 }
 
 func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsAttributesDefault(c *check.C) {
-	rule, err := asserts.CompilePlugRule("iface", map[string]interface{}{
-		"allow-connection": map[string]interface{}{
-			"slot-sdk-type": []interface{}{"regular"},
+	rule, err := asserts.CompilePlugRule("iface", map[string]any{
+		"allow-connection": map[string]any{
+			"slot-sdk-type": []any{"regular"},
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -901,12 +901,12 @@ func (s *plugSlotRulesSuite) TestPlugRuleFeatures(c *check.C) {
 
 	for _, combo := range combos {
 		for _, attrConstrPrefix := range combo.constraintsPrefixes {
-			attrConstraintMap := map[string]interface{}{
+			attrConstraintMap := map[string]any{
 				"a":     "ATTR",
-				"other": []interface{}{"x", "y"},
+				"other": []any{"x", "y"},
 			}
-			ruleMap := map[string]interface{}{
-				combo.subrule: map[string]interface{}{
+			ruleMap := map[string]any{
+				combo.subrule: map[string]any{
 					attrConstrPrefix + "attributes": attrConstraintMap,
 				},
 			}
@@ -924,7 +924,7 @@ func (s *plugSlotRulesSuite) TestPlugRuleFeatures(c *check.C) {
 			c.Check(asserts.RuleFeature(rule, "dollar-attr-constraints"), check.Equals, true, check.Commentf("%v", ruleMap))
 
 			// covers also alternation
-			attrConstraintMap["a"] = []interface{}{"$SLOT(a)"}
+			attrConstraintMap["a"] = []any{"$SLOT(a)"}
 			rule, err = asserts.CompilePlugRule("iface", ruleMap)
 			c.Assert(err, check.IsNil)
 			c.Check(asserts.RuleFeature(rule, "dollar-attr-constraints"), check.Equals, true, check.Commentf("%v", ruleMap))
@@ -935,9 +935,9 @@ func (s *plugSlotRulesSuite) TestPlugRuleFeatures(c *check.C) {
 		}
 
 		for _, nameConstrPrefix := range combo.constraintsPrefixes {
-			ruleMap := map[string]interface{}{
-				combo.subrule: map[string]interface{}{
-					nameConstrPrefix + "names": []interface{}{"foo"},
+			ruleMap := map[string]any{
+				combo.subrule: map[string]any{
+					nameConstrPrefix + "names": []any{"foo"},
 				},
 			}
 
@@ -953,7 +953,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsSlotNames
   allow-installation: true`))
 	c.Assert(err, check.IsNil)
 
-	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	c.Check(rule.AllowInstallation[0].SlotNames, check.IsNil)
@@ -982,7 +982,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsSlotNames
 		m, err = asserts.ParseHeaders([]byte(t.rule))
 		c.Assert(err, check.IsNil)
 
-		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 		c.Assert(err, check.IsNil)
 
 		for _, matching := range t.matching {
@@ -999,7 +999,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsPlugNamesSl
   allow-connection: true`))
 	c.Assert(err, check.IsNil)
 
-	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	c.Check(rule.AllowConnection[0].PlugNames, check.IsNil)
@@ -1037,7 +1037,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsPlugNamesSl
 		m, err = asserts.ParseHeaders([]byte(t.rule))
 		c.Assert(err, check.IsNil)
 
-		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 		c.Assert(err, check.IsNil)
 
 		for _, matching := range t.matching {
@@ -1055,9 +1055,9 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsPlugNamesSl
 }
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstraints(c *check.C) {
-	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
-		"allow-installation": map[string]interface{}{
-			"slot-sdk-type": []interface{}{sdk.System.String(), sdk.Regular.String()},
+	rule, err := asserts.CompileSlotRule("iface", map[string]any{
+		"allow-installation": map[string]any{
+			"slot-sdk-type": []any{sdk.System.String(), sdk.Regular.String()},
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -1068,10 +1068,10 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsIDConstra
 }
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsIDConstraints(c *check.C) {
-	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
-		"allow-connection": map[string]interface{}{
-			"plug-sdk-type": []interface{}{sdk.Regular.String()},
-			"slot-sdk-type": []interface{}{sdk.System.String()},
+	rule, err := asserts.CompileSlotRule("iface", map[string]any{
+		"allow-connection": map[string]any{
+			"plug-sdk-type": []any{sdk.Regular.String()},
+			"slot-sdk-type": []any{sdk.System.String()},
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -1101,7 +1101,7 @@ func checkBoolSlotConnConstraints(c *check.C, subrule string, cstrs []*asserts.S
 }
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleDefaults(c *check.C) {
-	rule, err := asserts.CompileSlotRule("iface", map[string]interface{}{
+	rule, err := asserts.CompileSlotRule("iface", map[string]any{
 		"deny-auto-connection": "true",
 	})
 	c.Assert(err, check.IsNil)
@@ -1125,7 +1125,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsSideArityCo
   allow-auto-connection: true`))
 	c.Assert(err, check.IsNil)
 
-	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+	rule, err := asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, check.IsNil)
 
 	// defaults
@@ -1157,7 +1157,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsSideArityCo
 		m, err = asserts.ParseHeaders([]byte(t))
 		c.Assert(err, check.IsNil)
 
-		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 		c.Assert(err, check.IsNil)
 
 		c.Check(rule.AllowConnection[0].SlotsPerPlug.Any(), check.Equals, true)
@@ -1190,7 +1190,7 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsSideArityCo
 		m, err = asserts.ParseHeaders([]byte(t.rule))
 		c.Assert(err, check.IsNil)
 
-		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]interface{}))
+		rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 		c.Assert(err, check.IsNil)
 
 		c.Assert(rule.AllowAutoConnection[0].SlotsPerPlug, check.Equals, t.slotsPerPlug)
@@ -1285,24 +1285,24 @@ func (s *nameConstraintsSuite) TestCompileErrors(c *check.C) {
 	_, err := asserts.CompileNameConstraints("slot-names", "true")
 	c.Check(err, check.ErrorMatches, `slot-names constraints must be a list of regexps and special \$ values`)
 
-	_, err = asserts.CompileNameConstraints("slot-names", []interface{}{map[string]interface{}{"foo": "bar"}})
+	_, err = asserts.CompileNameConstraints("slot-names", []any{map[string]any{"foo": "bar"}})
 	c.Check(err, check.ErrorMatches, `slot-names constraint entry must be a regexp or special \$ value`)
 
-	_, err = asserts.CompileNameConstraints("plug-names", []interface{}{"["})
+	_, err = asserts.CompileNameConstraints("plug-names", []any{"["})
 	c.Check(err, check.ErrorMatches, `cannot compile plug-names constraint entry "\[":.*`)
 
-	_, err = asserts.CompileNameConstraints("plug-names", []interface{}{"$"})
+	_, err = asserts.CompileNameConstraints("plug-names", []any{"$"})
 	c.Check(err, check.ErrorMatches, `plug-names constraint entry special value "\$" is invalid`)
 
-	_, err = asserts.CompileNameConstraints("slot-names", []interface{}{"$12"})
+	_, err = asserts.CompileNameConstraints("slot-names", []any{"$12"})
 	c.Check(err, check.ErrorMatches, `slot-names constraint entry special value "\$12" is invalid`)
 
-	_, err = asserts.CompileNameConstraints("plug-names", []interface{}{"a b"})
+	_, err = asserts.CompileNameConstraints("plug-names", []any{"a b"})
 	c.Check(err, check.ErrorMatches, `plug-names constraint entry regexp contains unexpected spaces`)
 }
 
 func (s *nameConstraintsSuite) TestCheck(c *check.C) {
-	nc, err := asserts.CompileNameConstraints("slot-names", []interface{}{"foo[0-9]", "bar"})
+	nc, err := asserts.CompileNameConstraints("slot-names", []any{"foo[0-9]", "bar"})
 	c.Assert(err, check.IsNil)
 
 	for _, matching := range []string{"foo0", "foo1", "bar"} {
@@ -1316,7 +1316,7 @@ func (s *nameConstraintsSuite) TestCheck(c *check.C) {
 }
 
 func (s *nameConstraintsSuite) TestCheckSpecial(c *check.C) {
-	nc, err := asserts.CompileNameConstraints("slot-names", []interface{}{"$INTERFACE"})
+	nc, err := asserts.CompileNameConstraints("slot-names", []any{"$INTERFACE"})
 	c.Assert(err, check.IsNil)
 
 	c.Check(nc.Check("slot name", "foo", nil), check.ErrorMatches, `slot name "foo" does not match constraints`)

--- a/internal/asserts/sdk_asserts.go
+++ b/internal/asserts/sdk_asserts.go
@@ -27,7 +27,7 @@ import (
 	_ "golang.org/x/crypto/sha3"
 )
 
-func compilePlugRules(plugs map[string]interface{}, compiled func(iface string, plugRule *PlugRule)) error {
+func compilePlugRules(plugs map[string]any, compiled func(iface string, plugRule *PlugRule)) error {
 	for iface, rule := range plugs {
 		plugRule, err := compilePlugRule(iface, rule)
 		if err != nil {
@@ -38,7 +38,7 @@ func compilePlugRules(plugs map[string]interface{}, compiled func(iface string, 
 	return nil
 }
 
-func compileSlotRules(slots map[string]interface{}, compiled func(iface string, slotRule *SlotRule)) error {
+func compileSlotRules(slots map[string]any, compiled func(iface string, slotRule *SlotRule)) error {
 	for iface, rule := range slots {
 		slotRule, err := compileSlotRule(iface, rule)
 		if err != nil {
@@ -132,7 +132,7 @@ func BuiltinBaseDeclaration() *BaseDeclaration {
 
 var (
 	builtinBaseDeclarationCheckOrder      = []string{"type", "authority-id", "series"}
-	builtinBaseDeclarationExpectedHeaders = map[string]interface{}{
+	builtinBaseDeclarationExpectedHeaders = map[string]any{
 		"type":         "base-declaration",
 		"authority-id": "canonical",
 		"series":       "1",

--- a/internal/daemon/api_changes_test.go
+++ b/internal/daemon/api_changes_test.go
@@ -274,13 +274,13 @@ func (s *apiSuite) TestStateChangeDoingTimes(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	st.Lock()
 	doingTime := float64(task.DoingTime().Nanoseconds())
 	st.Unlock()
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"id":         chg.ID(),
 		"kind":       "doing",
 		"summary":    "launch...",
@@ -288,13 +288,13 @@ func (s *apiSuite) TestStateChangeDoingTimes(c *check.C) {
 		"ready":      true,
 		"spawn-time": "2016-04-21T01:02:03Z",
 		"ready-time": "2016-04-21T01:02:03Z",
-		"tasks": []interface{}{
-			map[string]interface{}{
+		"tasks": []any{
+			map[string]any{
 				"id":         task.ID(),
 				"kind":       "doing-test",
 				"summary":    "...",
 				"status":     "Done",
-				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},
+				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 				"ready-time": "2016-04-21T01:02:03Z",
 				"doing-time": doingTime,
@@ -334,10 +334,10 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"id":         ids[0],
 		"kind":       "launch",
 		"summary":    "launch...",
@@ -345,29 +345,29 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 		"ready":      false,
 		"spawn-time": "2016-04-21T01:02:03Z",
 		"project-id": "123",
-		"tasks": []interface{}{
-			map[string]interface{}{
+		"tasks": []any{
+			map[string]any{
 				"id":         ids[2],
 				"kind":       "create-workshop",
 				"summary":    "1...",
 				"status":     "Do",
-				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"log":        []any{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"foo": "bar",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":         ids[3],
 				"kind":       "run-hook",
 				"summary":    "2...",
 				"status":     "Do",
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 			},
 		},
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"n": float64(42),
 		},
 	})
@@ -408,10 +408,10 @@ func (s *apiSuite) TestStateChangeVerbose(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"id":         ids[0],
 		"kind":       "launch",
 		"summary":    "launch...",
@@ -419,30 +419,30 @@ func (s *apiSuite) TestStateChangeVerbose(c *check.C) {
 		"ready":      false,
 		"spawn-time": "2016-04-21T01:02:03Z",
 		"project-id": "123",
-		"tasks": []interface{}{
-			map[string]interface{}{
+		"tasks": []any{
+			map[string]any{
 				"id":         ids[2],
 				"kind":       "create-workshop",
 				"summary":    "1...",
 				"status":     "Do",
-				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"log":        []any{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"foo": "bar",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":         ids[3],
 				"kind":       "run-hook",
 				"summary":    "2...",
 				"status":     "Do",
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
-				"log":        []interface{}{"verbose task output line", "second line"},
+				"log":        []any{"verbose task output line", "second line"},
 			},
 		},
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"n": float64(42),
 		},
 	})
@@ -486,10 +486,10 @@ func (s *apiSuite) TestStateChangeAbort(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"id":         ids[0],
 		"kind":       "launch",
 		"summary":    "launch...",
@@ -498,23 +498,23 @@ func (s *apiSuite) TestStateChangeAbort(c *check.C) {
 		"spawn-time": "2016-04-21T01:02:03Z",
 		"ready-time": "2016-04-21T01:02:03Z",
 		"project-id": "123",
-		"tasks": []interface{}{
-			map[string]interface{}{
+		"tasks": []any{
+			map[string]any{
 				"id":         ids[2],
 				"kind":       "create-workshop",
 				"summary":    "1...",
 				"status":     "Hold",
-				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
-				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},
+				"log":        []any{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 				"ready-time": "2016-04-21T01:02:03Z",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":         ids[3],
 				"kind":       "run-hook",
 				"summary":    "2...",
 				"status":     "Hold",
-				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},
+				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 				"ready-time": "2016-04-21T01:02:03Z",
 			},
@@ -552,10 +552,10 @@ func (s *apiSuite) TestStateChangeAbortIsReady(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"message": fmt.Sprintf("cannot abort change %s with nothing pending", ids[0]),
 	})
 }
@@ -591,10 +591,10 @@ func (s *apiSuite) TestWaitChangeSuccess(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err := json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	result := body["result"].(map[string]interface{})
+	result := body["result"].(map[string]any)
 	c.Check(result["id"].(string), check.Equals, changeID)
 	c.Check(result["kind"].(string), check.Equals, "exec")
 	c.Check(result["ready"].(bool), check.Equals, true)

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -93,8 +93,8 @@ func (b byPlugRef) Less(i, j int) bool {
 
 // mergeAttrs merges attributes from 2 disjoint sets of static and dynamic slot or
 // plug attributes into a single map.
-func mergeAttrs(one map[string]interface{}, other map[string]interface{}) map[string]interface{} {
-	merged := make(map[string]interface{}, len(one)+len(other))
+func mergeAttrs(one map[string]any, other map[string]any) map[string]any {
+	merged := make(map[string]any, len(one)+len(other))
 	for k, v := range one {
 		merged[k] = v
 	}

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -134,7 +134,7 @@ func (s *apiSuite) mockInstalledSDKBoundPlug(c *check.C, yaml string, w string, 
 	return wp
 }
 
-func (s *apiSuite) testConnectionsConnected(c *check.C, d *Daemon, query string, connsState map[string]interface{}, repoConnected []string, expected map[string]interface{}) {
+func (s *apiSuite) testConnectionsConnected(c *check.C, d *Daemon, query string, connsState map[string]any, repoConnected []string, expected map[string]any) {
 	repo := d.Overlord().InterfaceManager().Repository()
 	for crefStr, cstate := range connsState {
 		// if repoConnected is defined, then given connection must be on
@@ -145,7 +145,7 @@ func (s *apiSuite) testConnectionsConnected(c *check.C, d *Daemon, query string,
 		}
 		cref, err := interfaces.ParseConnRef(crefStr)
 		c.Assert(err, check.IsNil)
-		conn := cstate.(map[string]interface{})
+		conn := cstate.(map[string]any)
 		if undesiredRaw, ok := conn["undesired"]; ok {
 			undesired, ok := undesiredRaw.(bool)
 			c.Assert(ok, check.Equals, true, check.Commentf("unexpected value for key 'undesired': %v", cstate))
@@ -154,10 +154,10 @@ func (s *apiSuite) testConnectionsConnected(c *check.C, d *Daemon, query string,
 				continue
 			}
 		}
-		staticPlugAttrs, _ := conn["plug-static"].(map[string]interface{})
-		dynamicPlugAttrs, _ := conn["plug-dynamic"].(map[string]interface{})
-		staticSlotAttrs, _ := conn["slot-static"].(map[string]interface{})
-		dynamicSlotAttrs, _ := conn["slot-dynamic"].(map[string]interface{})
+		staticPlugAttrs, _ := conn["plug-static"].(map[string]any)
+		dynamicPlugAttrs, _ := conn["plug-dynamic"].(map[string]any)
+		staticSlotAttrs, _ := conn["slot-static"].(map[string]any)
+		dynamicSlotAttrs, _ := conn["slot-dynamic"].(map[string]any)
 		_, err = repo.Connect(cref, staticPlugAttrs, dynamicPlugAttrs, staticSlotAttrs, dynamicSlotAttrs, nil)
 		c.Assert(err, check.IsNil)
 	}
@@ -170,14 +170,14 @@ func (s *apiSuite) testConnectionsConnected(c *check.C, d *Daemon, query string,
 	s.testConnections(c, query, expected)
 }
 
-func (s *apiSuite) testConnections(c *check.C, query string, expected map[string]interface{}) {
+func (s *apiSuite) testConnections(c *check.C, query string, expected map[string]any) {
 	cmd := apiCmd("/v1/connections")
 	req, err := s.createProjectsRequest("GET", query, nil)
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	v1GetConnections(cmd, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 200)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, expected)
@@ -191,11 +191,11 @@ func (s *apiSuite) TestConnectionsUnhappy(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1GetConnections(cmd, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "unsupported select qualifier"},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -205,21 +205,21 @@ func (s *apiSuite) TestConnectionsUnhappy(c *check.C) {
 
 func (s *apiSuite) TestConnectionsEmpty(c *check.C) {
 	s.daemon(c)
-	s.testConnections(c, "/v2/connections?project-id=b8639dea", map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"plugs":       []interface{}{},
-			"slots":       []interface{}{},
+	s.testConnections(c, "/v2/connections?project-id=b8639dea", map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"plugs":       []any{},
+			"slots":       []any{},
 		},
 		"status":      "OK",
 		"status-code": 200.0,
 		"type":        "sync",
 	})
-	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"plugs":       []interface{}{},
-			"slots":       []interface{}{},
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all", map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"plugs":       []any{},
+			"slots":       []any{},
 		},
 		"status":      "OK",
 		"status-code": 200.0,
@@ -235,11 +235,11 @@ func (s *apiSuite) TestConnectionsNotFound(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1GetConnections(cmd, req, nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 404)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `cannot access workshop "not-found": workshop not launched`,
 		},
 		"status":      "Not Found",
@@ -257,28 +257,28 @@ func (s *apiSuite) TestConnectionsUnconnected(c *check.C) {
 	s.mockInstalledSDK(c, consumerYaml, "ws-consumer")
 	s.mockInstalledSDK(c, producerYaml, "ws-producer")
 
-	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"plugs": []interface{}{
-				map[string]interface{}{
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all", map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"plugs": []any{
+				map[string]any{
 					"project-id": s.project.ProjectId,
 					"workshop":   "ws-consumer",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": s.project.ProjectId,
 					"workshop":   "ws-producer",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
@@ -298,86 +298,86 @@ func (s *apiSuite) TestConnectionsByWorkshopName(c *check.C) {
 	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
-	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&workshop=producer-ws", map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"slots": []interface{}{
-				map[string]interface{}{
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&workshop=producer-ws", map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"slots": []any{
+				map[string]any{
 					"project-id": s.project.ProjectId,
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
-			"plugs": []interface{}{},
+			"plugs": []any{},
 		},
 		"status":      "OK",
 		"status-code": 200.0,
 		"type":        "sync",
 	})
 
-	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&workshop=consumer-ws", map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"plugs": []interface{}{
-				map[string]interface{}{
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&workshop=consumer-ws", map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"plugs": []any{
+				map[string]any{
 					"project-id": s.project.ProjectId,
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
-			"slots": []interface{}{},
+			"slots": []any{},
 		},
 		"status":      "OK",
 		"status-code": 200.0,
 		"type":        "sync",
 	})
 
-	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&workshop=producer-ws", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&workshop=producer-ws", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 		},
-	}, nil, map[string]interface{}{
-		"result": map[string]interface{}{
-			"plugs": []interface{}{
-				map[string]interface{}{
+	}, nil, map[string]any{
+		"result": map[string]any{
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					},
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
 					},
 				},
 			},
-			"established": []interface{}{
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+			"established": []any{
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"manual":    true,
 					"interface": "test",
 				},
@@ -399,49 +399,49 @@ func (s *apiSuite) TestConnectionsMissingPlugSlotFilteredOut(c *check.C) {
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
 	for _, missingPlugOrSlot := range []string{"b8639dea/consumer-ws/consumer:plug2 b8639dea/producer-ws/producer:slot", "b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot2"} {
-		s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&workshop=producer-ws", map[string]interface{}{
-			"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+		s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&workshop=producer-ws", map[string]any{
+			"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 				"interface": "test",
 			},
-			missingPlugOrSlot: map[string]interface{}{
+			missingPlugOrSlot: map[string]any{
 				"interface": "test",
 			},
 		},
 			[]string{"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot"},
-			map[string]interface{}{
-				"result": map[string]interface{}{
-					"plugs": []interface{}{
-						map[string]interface{}{
+			map[string]any{
+				"result": map[string]any{
+					"plugs": []any{
+						map[string]any{
 							"project-id": "b8639dea",
 							"workshop":   "consumer-ws",
 							"sdk":        "consumer",
 							"plug":       "plug",
 							"interface":  "test",
-							"attrs":      map[string]interface{}{"key": "value"},
+							"attrs":      map[string]any{"key": "value"},
 							"label":      "label",
-							"connections": []interface{}{
-								map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+							"connections": []any{
+								map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 							},
 						},
 					},
-					"slots": []interface{}{
-						map[string]interface{}{
+					"slots": []any{
+						map[string]any{
 							"project-id": "b8639dea",
 							"workshop":   "producer-ws",
 							"sdk":        "producer",
 							"slot":       "slot",
 							"interface":  "test",
-							"attrs":      map[string]interface{}{"key": "value"},
+							"attrs":      map[string]any{"key": "value"},
 							"label":      "label",
-							"connections": []interface{}{
-								map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+							"connections": []any{
+								map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
 							},
 						},
 					},
-					"established": []interface{}{
-						map[string]interface{}{
-							"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-							"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"established": []any{
+						map[string]any{
+							"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+							"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 							"manual":    true,
 							"interface": "test",
 						},
@@ -485,28 +485,28 @@ plugs:
 	s.mockInstalledSDK(c, differentConsumerYaml, "consumer-diff-ws")
 	s.mockInstalledSDK(c, differentProducerYaml, "producer-diff-ws")
 
-	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&interface=test", map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"plugs": []interface{}{
-				map[string]interface{}{
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&interface=test", map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
@@ -515,28 +515,28 @@ plugs:
 		"status-code": 200.0,
 		"type":        "sync",
 	})
-	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&interface=different", map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"plugs": []interface{}{
-				map[string]interface{}{
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&select=all&interface=different", map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-diff-ws",
 					"sdk":        "different-consumer",
 					"plug":       "plug",
 					"interface":  "different",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-diff-ws",
 					"sdk":        "different-producer",
 					"slot":       "slot",
 					"interface":  "different",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
@@ -547,44 +547,44 @@ plugs:
 	})
 
 	// modifies state internally
-	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&interfaces=test", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&interfaces=test", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 		},
-	}, nil, map[string]interface{}{
-		"result": map[string]interface{}{
-			"plugs": []interface{}{
-				map[string]interface{}{
+	}, nil, map[string]any{
+		"result": map[string]any{
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					},
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
 					},
 				},
 			},
-			"established": []interface{}{
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+			"established": []any{
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"manual":    true,
 					"interface": "test",
 				},
@@ -595,11 +595,11 @@ plugs:
 		"type":        "sync",
 	})
 	// use state modified by previous call
-	s.testConnections(c, "/v2/connections?project-id=b8639dea&interface=different", map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"slots":       []interface{}{},
-			"plugs":       []interface{}{},
+	s.testConnections(c, "/v2/connections?project-id=b8639dea&interface=different", map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"slots":       []any{},
+			"plugs":       []any{},
 		},
 		"status":      "OK",
 		"status-code": 200.0,
@@ -616,44 +616,44 @@ func (s *apiSuite) TestConnectionsDefaultManual(c *check.C) {
 	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
-	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 		},
-	}, nil, map[string]interface{}{
-		"result": map[string]interface{}{
-			"plugs": []interface{}{
-				map[string]interface{}{
+	}, nil, map[string]any{
+		"result": map[string]any{
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					},
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
 					},
 				},
 			},
-			"established": []interface{}{
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+			"established": []any{
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"manual":    true,
 					"interface": "test",
 				},
@@ -674,63 +674,63 @@ func (s *apiSuite) TestConnectionsDefaultAuto(c *check.C) {
 	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
-	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"key": "value",
 			},
-			"plug-dynamic": map[string]interface{}{
+			"plug-dynamic": map[string]any{
 				"foo-plug-dynamic": "bar-dynamic",
 			},
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"key": "value",
 			},
-			"slot-dynamic": map[string]interface{}{
+			"slot-dynamic": map[string]any{
 				"foo-slot-dynamic": "bar-dynamic",
 			},
 		},
-	}, nil, map[string]interface{}{
-		"result": map[string]interface{}{
-			"plugs": []interface{}{
-				map[string]interface{}{
+	}, nil, map[string]any{
+		"result": map[string]any{
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					},
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
 					},
 				},
 			},
-			"established": []interface{}{
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+			"established": []any{
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"interface": "test",
-					"plug-attrs": map[string]interface{}{
+					"plug-attrs": map[string]any{
 						"key":              "value",
 						"foo-plug-dynamic": "bar-dynamic",
 					},
-					"slot-attrs": map[string]interface{}{
+					"slot-attrs": map[string]any{
 						"key":              "value",
 						"foo-slot-dynamic": "bar-dynamic",
 					},
@@ -752,73 +752,73 @@ func (s *apiSuite) TestConnectionsBoundPlug(c *check.C) {
 	s.mockInstalledSDKBoundPlug(c, consumerYamlManyPlugs, "consumer-ws", "plug", "plug2")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
-	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&select=all", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"key": "value",
 			},
-			"plug-dynamic": map[string]interface{}{
+			"plug-dynamic": map[string]any{
 				"foo-plug-dynamic": "bar-dynamic",
 			},
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"key": "value",
 			},
-			"slot-dynamic": map[string]interface{}{
+			"slot-dynamic": map[string]any{
 				"foo-slot-dynamic": "bar-dynamic",
 			},
 		},
-	}, nil, map[string]interface{}{
-		"result": map[string]interface{}{
-			"plugs": []interface{}{
-				map[string]interface{}{
+	}, nil, map[string]any{
+		"result": map[string]any{
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"bind":       map[string]interface{}{"plug": "plug2", "project-id": "b8639dea", "sdk": "consumer", "workshop": "consumer-ws"},
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"bind":       map[string]any{"plug": "plug2", "project-id": "b8639dea", "sdk": "consumer", "workshop": "consumer-ws"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug2",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value2"},
+					"attrs":      map[string]any{"key": "value2"},
 					"label":      "label2",
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
 					},
 				},
 			},
-			"established": []interface{}{
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+			"established": []any{
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"interface": "test",
-					"plug-attrs": map[string]interface{}{
+					"plug-attrs": map[string]any{
 						"key":              "value",
 						"foo-plug-dynamic": "bar-dynamic",
 					},
-					"slot-attrs": map[string]interface{}{
+					"slot-attrs": map[string]any{
 						"key":              "value",
 						"foo-slot-dynamic": "bar-dynamic",
 					},
@@ -840,41 +840,41 @@ func (s *apiSuite) TestConnectionsAll(c *check.C) {
 	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
-	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&select=all", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea&select=all", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
 			"undesired": true,
 		},
-	}, nil, map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"plugs": []interface{}{
-				map[string]interface{}{
+	}, nil, map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
 				},
 			},
-			"undesired": []interface{}{
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+			"undesired": []any{
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"manual":    true,
 					"interface": "test",
 				},
@@ -895,17 +895,17 @@ func (s *apiSuite) TestConnectionsOnlyConnected(c *check.C) {
 	s.mockInstalledSDK(c, consumerYaml, "consumer-ws")
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
-	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
 			"undesired": true,
 		},
-	}, nil, map[string]interface{}{
-		"result": map[string]interface{}{
-			"established": []interface{}{},
-			"plugs":       []interface{}{},
-			"slots":       []interface{}{},
+	}, nil, map[string]any{
+		"result": map[string]any{
+			"established": []any{},
+			"plugs":       []any{},
+			"slots":       []any{},
 		},
 		"status":      "OK",
 		"status-code": 200.0,
@@ -944,111 +944,111 @@ slots:
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 	s.mockInstalledSDK(c, anotherProducerYaml, "another-producer-ws")
 
-	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	s.testConnectionsConnected(c, d, "/v2/connections?project-id=b8639dea", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
 		},
-		"b8639dea/consumer-ws-def/another-consumer-def:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+		"b8639dea/consumer-ws-def/another-consumer-def:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
 		},
-		"b8639dea/consumer-ws-abc/another-consumer-abc:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+		"b8639dea/consumer-ws-abc/another-consumer-abc:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
 		},
-		"b8639dea/consumer-ws-def/another-consumer-def:plug b8639dea/another-producer-ws/another-producer:slot": map[string]interface{}{
+		"b8639dea/consumer-ws-def/another-consumer-def:plug b8639dea/another-producer-ws/another-producer:slot": map[string]any{
 			"interface": "test",
 			"auto":      true,
 		},
-	}, nil, map[string]interface{}{
-		"result": map[string]interface{}{
-			"plugs": []interface{}{
-				map[string]interface{}{
+	}, nil, map[string]any{
+		"result": map[string]any{
+			"plugs": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws",
 					"sdk":        "consumer",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws-abc",
 					"sdk":        "another-consumer-abc",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "consumer-ws-def",
 					"sdk":        "another-consumer-def",
 					"plug":       "plug",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "another-producer-ws", "sdk": "another-producer", "slot": "slot"},
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "another-producer-ws", "sdk": "another-producer", "slot": "slot"},
+						map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					},
 				},
 			},
-			"slots": []interface{}{
-				map[string]interface{}{
+			"slots": []any{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "another-producer-ws",
 					"sdk":        "another-producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"project-id": "b8639dea",
 					"workshop":   "producer-ws",
 					"sdk":        "producer",
 					"slot":       "slot",
 					"interface":  "test",
-					"attrs":      map[string]interface{}{"key": "value"},
+					"attrs":      map[string]any{"key": "value"},
 					"label":      "label",
-					"connections": []interface{}{
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-abc", "sdk": "another-consumer-abc", "plug": "plug"},
-						map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
+					"connections": []any{
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws-abc", "sdk": "another-consumer-abc", "plug": "plug"},
+						map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
 					},
 				},
 			},
-			"established": []interface{}{
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+			"established": []any{
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws", "sdk": "consumer", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"interface": "test",
 				},
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-abc", "sdk": "another-consumer-abc", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws-abc", "sdk": "another-consumer-abc", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"interface": "test",
 				},
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "another-producer-ws", "sdk": "another-producer", "slot": "slot"},
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "another-producer-ws", "sdk": "another-producer", "slot": "slot"},
 					"interface": "test",
 				},
-				map[string]interface{}{
-					"plug":      map[string]interface{}{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
-					"slot":      map[string]interface{}{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
+				map[string]any{
+					"plug":      map[string]any{"project-id": "b8639dea", "workshop": "consumer-ws-def", "sdk": "another-consumer-def", "plug": "plug"},
+					"slot":      map[string]any{"project-id": "b8639dea", "workshop": "producer-ws", "sdk": "producer", "slot": "slot"},
 					"interface": "test",
 				},
 			},
@@ -1087,7 +1087,7 @@ func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -1145,7 +1145,7 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -1177,22 +1177,22 @@ func (s *apiSuite) TestConnectBoundPlugSuccess(c *check.C) {
 	}
 	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{mainConn, boundConn})
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.d.state.Lock()
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 2)
 	c.Assert(conns, check.DeepEquals,
-		map[string]interface{}{
-			"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+		map[string]any{
+			"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 				"interface":   "test",
-				"plug-static": map[string]interface{}{"key": "value"},
-				"slot-static": map[string]interface{}{"key": "value"},
+				"plug-static": map[string]any{"key": "value"},
+				"slot-static": map[string]any{"key": "value"},
 			},
-			"b8639dea/consumer-ws/consumer:plug2 b8639dea/producer-ws/producer:slot": map[string]interface{}{
+			"b8639dea/consumer-ws/consumer:plug2 b8639dea/producer-ws/producer:slot": map[string]any{
 				"interface":    "test",
-				"plug-static":  map[string]interface{}{"key": "value2"},
-				"slot-static":  map[string]interface{}{"key": "value"},
-				"plug-dynamic": map[string]interface{}{"bind": "b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot"},
+				"plug-static":  map[string]any{"key": "value2"},
+				"slot-static":  map[string]any{"key": "value"},
+				"plug-dynamic": map[string]any{"bind": "b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot"},
 			},
 		})
 	s.d.state.Unlock()
@@ -1236,11 +1236,11 @@ slots:
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `cannot connect "consumer-ws/consumer:plug" ("test" interface) to "producer-ws/producer:slot" ("different" interface)`,
 		},
 		"status":      "Bad Request",
@@ -1275,11 +1275,11 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `SDK "consumer-ws/consumer" has no plug named "missingplug"`,
 		},
 		"status":      "Bad Request",
@@ -1314,11 +1314,11 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `SDK "producer-ws/producer" has no slot named "missingslot"`,
 		},
 		"status":      "Bad Request",
@@ -1344,8 +1344,8 @@ func (s *apiSuite) TestConnectAlreadyConnected(c *check.C) {
 	}
 	st := d.Overlord().State()
 	st.Lock()
-	st.Set("conns", map[string]interface{}{
-		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+	st.Set("conns", map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 			"interface": "test",
 		},
 	})
@@ -1371,7 +1371,7 @@ func (s *apiSuite) TestConnectAlreadyConnected(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	json.Unmarshal(rec.Body.Bytes(), &body)
 	id := body["change"].(string)
 
@@ -1421,11 +1421,11 @@ func (s *apiSuite) TestConnectFailureOnConflict(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `cannot connect "producer-ws/producer:slot": other changes in progress`,
 		},
 		"status":      "Bad Request",
@@ -1473,7 +1473,7 @@ func (s *apiSuite) TestConnectWarnOnExec(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -1532,14 +1532,14 @@ func (s *apiSuite) testDisconnect(c *check.C, pW, pSdk, pName string, sW, sSdk, 
 	wp.File.Sdks[0].Plugs = opts.bind
 	s.mockInstalledSDK(c, producerYaml, "producer-ws")
 
-	conns := map[string]interface{}{}
+	conns := map[string]any{}
 	connRef := s.connect(c, "plug")
-	conns[connRef.ID()] = map[string]interface{}{"interface": "test", "auto": opts.auto}
+	conns[connRef.ID()] = map[string]any{"interface": "test", "auto": opts.auto}
 
 	for n := range opts.bind {
 		cRef := s.connect(c, n)
-		conns[cRef.ID()] = map[string]interface{}{"interface": "test", "auto": opts.auto,
-			"plug-dynamic": map[string]interface{}{"bind": connRef.ID()}}
+		conns[cRef.ID()] = map[string]any{"interface": "test", "auto": opts.auto,
+			"plug-dynamic": map[string]any{"bind": connRef.ID()}}
 	}
 
 	st := d.Overlord().State()
@@ -1565,7 +1565,7 @@ func (s *apiSuite) testDisconnect(c *check.C, pW, pSdk, pName string, sW, sSdk, 
 	cmd := apiCmd("/v1/connections")
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 	id := body["change"].(string)
@@ -1591,7 +1591,7 @@ func (s *apiSuite) testDisconnect(c *check.C, pW, pSdk, pName string, sW, sSdk, 
 func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", &disconnectOpts{})
 	s.d.state.Lock()
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
 	s.d.state.Unlock()
@@ -1600,12 +1600,12 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 func (s *apiSuite) TestDisconnectPlugAutoSuccess(c *check.C) {
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", &disconnectOpts{auto: true})
 	s.d.state.Lock()
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 1)
 	c.Assert(conns, check.DeepEquals,
-		map[string]interface{}{
-			"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]interface{}{
+		map[string]any{
+			"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
 				"auto": true, "interface": "test", "undesired": true,
 			}})
 	s.d.state.Unlock()
@@ -1618,7 +1618,7 @@ func (s *apiSuite) TestDisconnectPlugForgetSuccess(c *check.C) {
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
 	s.d.state.Unlock()
@@ -1632,7 +1632,7 @@ func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
 	s.d.state.Unlock()
@@ -1646,7 +1646,7 @@ func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
 	}
 	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
 	s.d.state.Unlock()
@@ -1660,7 +1660,7 @@ func (s *apiSuite) TestDisconnectBoundPlugSlaveSuccess(c *check.C) {
 	}
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug2", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.d.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
 	s.d.state.Unlock()
@@ -1705,11 +1705,11 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `SDK "consumer-ws/consumer" has no plug named "missingplug"`,
 		},
 		"status":      "Bad Request",
@@ -1750,13 +1750,13 @@ func (s *apiSuite) testDisconnectFailureNoWorkshop(c *check.C, installedWorkshop
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 404)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
 
 	if producer {
-		c.Check(body, check.DeepEquals, map[string]interface{}{
-			"result": map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
+			"result": map[string]any{
 				"message": `cannot access workshop "consumer-ws": workshop not launched`,
 			},
 			"status":      "Not Found",
@@ -1764,8 +1764,8 @@ func (s *apiSuite) testDisconnectFailureNoWorkshop(c *check.C, installedWorkshop
 			"type":        "error",
 		})
 	} else {
-		c.Check(body, check.DeepEquals, map[string]interface{}{
-			"result": map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
+			"result": map[string]any{
 				"message": `cannot access workshop "producer-ws": workshop not launched`,
 			},
 			"status":      "Not Found",
@@ -1806,11 +1806,11 @@ func (s *apiSuite) TestDisconnectPlugNothingToDo(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "nothing to do",
 		},
 		"status":      "Bad Request",
@@ -1842,11 +1842,11 @@ func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `cannot disconnect "consumer-ws/consumer:plug" from "producer-ws/producer:slot": not connected`,
 		},
 		"status":      "Bad Request",
@@ -1879,11 +1879,11 @@ func (s *apiSuite) TestDisconnectForgetPlugFailureNotConnected(c *check.C) {
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `cannot forget connection between "consumer-ws/consumer:plug" and "producer-ws/producer:slot": not connected`,
 		},
 		"status":      "Bad Request",
@@ -1933,11 +1933,11 @@ func (s *apiSuite) TestDisconnectFailureOnConflict(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `cannot disconnect "consumer-ws/consumer:plug": other changes in progress`,
 		},
 		"status":      "Bad Request",
@@ -1955,11 +1955,11 @@ func (s *apiSuite) TestUnsupportedInterfaceRequest(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "cannot decode request body into an interface action: invalid character 'g' looking for beginning of value",
 		},
 		"status":      "Bad Request",
@@ -1980,11 +1980,11 @@ func (s *apiSuite) TestMissingInterfaceAction(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": "interface action not specified",
 		},
 		"status":      "Bad Request",
@@ -2005,11 +2005,11 @@ func (s *apiSuite) TestUnsupportedInterfaceAction(c *check.C) {
 	rec := httptest.NewRecorder()
 	v1PostConnections(cmd, req.WithContext(s.ctx), nil).ServeHTTP(rec, req)
 	c.Check(rec.Code, check.Equals, 400)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body, check.DeepEquals, map[string]interface{}{
-		"result": map[string]interface{}{
+	c.Check(body, check.DeepEquals, map[string]any{
+		"result": map[string]any{
 			"message": `unsupported interface action: "foo"`,
 		},
 		"status":      "Bad Request",

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -160,7 +160,7 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 	if idx < 0 {
 		return statusInternalError(`cannot find "exec" task`)
 	}
-	result := map[string]interface{}{
+	result := map[string]any{
 		"task-id": tasks[idx].ID(),
 	}
 

--- a/internal/daemon/api_json.go
+++ b/internal/daemon/api_json.go
@@ -25,27 +25,27 @@ import (
 
 // plugJSON aids in marshaling snap.PlugInfo into JSON.
 type plugJSON struct {
-	ProjectId string                 `json:"project-id"`
-	Workshop  string                 `json:"workshop"`
-	Sdk       string                 `json:"sdk"`
-	Name      string                 `json:"plug"`
-	Interface string                 `json:"interface,omitempty"`
-	Attrs     map[string]interface{} `json:"attrs,omitempty"`
-	Label     string                 `json:"label,omitempty"`
-	Bind      *sdk.PlugRef           `json:"bind,omitempty"`
+	ProjectId string         `json:"project-id"`
+	Workshop  string         `json:"workshop"`
+	Sdk       string         `json:"sdk"`
+	Name      string         `json:"plug"`
+	Interface string         `json:"interface,omitempty"`
+	Attrs     map[string]any `json:"attrs,omitempty"`
+	Label     string         `json:"label,omitempty"`
+	Bind      *sdk.PlugRef   `json:"bind,omitempty"`
 	// Connections are synthesized, they are not on the original type.
 	Connections []sdk.SlotRef `json:"connections,omitempty"`
 }
 
 // slotJSON aids in marshaling snap.SlotInfo into JSON.
 type slotJSON struct {
-	ProjectId string                 `json:"project-id"`
-	Workshop  string                 `json:"workshop"`
-	Sdk       string                 `json:"sdk"`
-	Name      string                 `json:"slot"`
-	Interface string                 `json:"interface,omitempty"`
-	Attrs     map[string]interface{} `json:"attrs,omitempty"`
-	Label     string                 `json:"label,omitempty"`
+	ProjectId string         `json:"project-id"`
+	Workshop  string         `json:"workshop"`
+	Sdk       string         `json:"sdk"`
+	Name      string         `json:"slot"`
+	Interface string         `json:"interface,omitempty"`
+	Attrs     map[string]any `json:"attrs,omitempty"`
+	Label     string         `json:"label,omitempty"`
 	// Connections are synthesized, they are not on the original type.
 	Connections []sdk.PlugRef `json:"connections,omitempty"`
 }
@@ -61,12 +61,12 @@ type interfaceAction struct {
 // connectionsJSON aids in marshalling information about a single connection
 // into JSON
 type connectionJSON struct {
-	Slot      sdk.SlotRef            `json:"slot"`
-	Plug      sdk.PlugRef            `json:"plug"`
-	Interface string                 `json:"interface"`
-	Manual    bool                   `json:"manual,omitempty"`
-	SlotAttrs map[string]interface{} `json:"slot-attrs,omitempty"`
-	PlugAttrs map[string]interface{} `json:"plug-attrs,omitempty"`
+	Slot      sdk.SlotRef    `json:"slot"`
+	Plug      sdk.PlugRef    `json:"plug"`
+	Interface string         `json:"interface"`
+	Manual    bool           `json:"manual,omitempty"`
+	SlotAttrs map[string]any `json:"slot-attrs,omitempty"`
+	PlugAttrs map[string]any `json:"plug-attrs,omitempty"`
 }
 
 // connectionsJSON aids in marshaling connections into JSON.

--- a/internal/daemon/api_warnings_test.go
+++ b/internal/daemon/api_warnings_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 )
 
-func (s *apiSuite) testWarnings(c *check.C, all bool, body io.Reader) (calls string, result interface{}) {
+func (s *apiSuite) testWarnings(c *check.C, all bool, body io.Reader) (calls string, result any) {
 	s.daemon(c)
 
 	okayWarns := func(*state.State, time.Time) int { calls += "ok"; return 0 }

--- a/internal/daemon/api_workshop_mount_test.go
+++ b/internal/daemon/api_workshop_mount_test.go
@@ -104,7 +104,7 @@ func (s *apiSuite) TestWorkshopRemountBoundPlugSuccess(c *check.C) {
 	s.runMountTest(c, "manysdks", requests, expected)
 	conn, err := repo.Connection(ref[0])
 	c.Assert(err, check.IsNil)
-	c.Assert(conn.Slot.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"host-source": src})
+	c.Assert(conn.Slot.DynamicAttrs(), check.DeepEquals, map[string]any{"host-source": src})
 }
 
 func (s *apiSuite) TestWorkshopRemountNoWorkshop(c *check.C) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -209,7 +209,7 @@ func (c *Command) canAccess(r *http.Request, user *userState) accessResult {
 	return accessUnauthorized
 }
 
-func userFromRequest(_ interface{}, _ *http.Request) (*userState, error) {
+func userFromRequest(_ any, _ *http.Request) (*userState, error) {
 	return nil, nil
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -905,7 +905,7 @@ func (s *daemonSuite) TestRestartExpectedRebootOK(c *check.C) {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	var v interface{}
+	var v any
 	// these were cleared
 	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
 	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)
@@ -929,7 +929,7 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *check.C) {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	var v interface{}
+	var v any
 	// these were cleared
 	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
 	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -42,7 +42,7 @@ type resp struct {
 	Status           int          `json:"status-code"`
 	Type             ResponseType `json:"type"`
 	Change           string       `json:"change,omitempty"`
-	Result           interface{}  `json:"result,omitempty"`
+	Result           any          `json:"result,omitempty"`
 	WarningTimestamp *time.Time   `json:"warning-timestamp,omitempty"`
 	WarningCount     int          `json:"warning-count,omitempty"`
 	Maintenance      *errorResult `json:"maintenance,omitempty"`
@@ -53,7 +53,7 @@ type respJSON struct {
 	Status           int          `json:"status-code"`
 	StatusText       string       `json:"status,omitempty"`
 	Change           string       `json:"change,omitempty"`
-	Result           interface{}  `json:"result,omitempty"`
+	Result           any          `json:"result,omitempty"`
 	WarningTimestamp *time.Time   `json:"warning-timestamp,omitempty"`
 	WarningCount     int          `json:"warning-count,omitempty"`
 	Maintenance      *errorResult `json:"maintenance,omitempty"`
@@ -101,7 +101,7 @@ func (r *resp) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 	hdr := w.Header()
 	if r.Status == 202 || r.Status == 201 {
-		if m, ok := r.Result.(map[string]interface{}); ok {
+		if m, ok := r.Result.(map[string]any); ok {
 			if location, ok := m["resource"]; ok {
 				if location, ok := location.(string); ok && location != "" {
 					hdr.Set("Location", location)
@@ -128,7 +128,7 @@ const (
 	errorKindNoUpdatesAvailable = errorKind("no-updates-available")
 )
 
-type errorValue interface{}
+type errorValue any
 
 type errorResult struct {
 	Message string     `json:"message"` // note no omitempty
@@ -136,7 +136,7 @@ type errorResult struct {
 	Value   errorValue `json:"value,omitempty"`
 }
 
-func SyncResponse(result interface{}, status int) Response {
+func SyncResponse(result any, status int) Response {
 	if err, ok := result.(error); ok {
 		return statusInternalError("internal error: %w", err)
 	}
@@ -152,7 +152,7 @@ func SyncResponse(result interface{}, status int) Response {
 	}
 }
 
-func AsyncResponse(result map[string]interface{}, change string) Response {
+func AsyncResponse(result map[string]any, change string) Response {
 	return &resp{
 		Type:   ResponseTypeAsync,
 		Status: 202,
@@ -172,7 +172,7 @@ func (f fileResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func makeErrorResponder(status int) errorResponder {
-	return func(format string, v ...interface{}) Response {
+	return func(format string, v ...any) Response {
 		res := &errorResult{}
 		response := &resp{
 			Type:   ResponseTypeError,
@@ -198,7 +198,7 @@ func makeErrorResponder(status int) errorResponder {
 
 // errorResponder is a callable that produces an error Response.
 // e.g., InternalError("something broke: %v", err), etc.
-type errorResponder func(string, ...interface{}) Response
+type errorResponder func(string, ...any) Response
 
 // Standard error responses.
 var (

--- a/internal/daemon/response_test.go
+++ b/internal/daemon/response_test.go
@@ -34,7 +34,7 @@ func (s *responseSuite) TestRespSetsLocationIfAccepted(c *check.C) {
 
 	rsp := &resp{
 		Status: 202,
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}
@@ -49,7 +49,7 @@ func (s *responseSuite) TestRespSetsLocationIfCreated(c *check.C) {
 
 	rsp := &resp{
 		Status: 201,
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}
@@ -64,7 +64,7 @@ func (s *responseSuite) TestRespDoesNotSetLocationIfOther(c *check.C) {
 
 	rsp := &resp{
 		Status: 418, // I'm a teapot
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -142,7 +142,7 @@ func (iface *mountInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 	return nil
 }
 
-func parseBool(attrs map[string]interface{}, key string, fallback bool) (bool, error) {
+func parseBool(attrs map[string]any, key string, fallback bool) (bool, error) {
 	object, ok := attrs[key]
 	if !ok {
 		attrs[key] = fallback
@@ -164,7 +164,7 @@ func parseBool(attrs map[string]interface{}, key string, fallback bool) (bool, e
 	}
 }
 
-func parseInt(attrs map[string]interface{}, key string, fallback int64) (int64, error) {
+func parseInt(attrs map[string]any, key string, fallback int64) (int64, error) {
 	object, ok := attrs[key]
 	if !ok {
 		attrs[key] = fallback
@@ -204,7 +204,7 @@ func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 	return err
 }
 
-func parseMountPath(attrs map[string]interface{}, kind, key string, sk string) (string, error) {
+func parseMountPath(attrs map[string]any, kind, key string, sk string) (string, error) {
 	attr, exist := attrs[key]
 	if !exist {
 		return "", fmt.Errorf("mount %s must contain %q", kind, key)

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -97,7 +97,7 @@ func (iface *tunnelInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 		return err
 	}
 	if plug.Attrs == nil {
-		plug.Attrs = make(map[string]interface{})
+		plug.Attrs = make(map[string]any)
 	}
 	plug.Attrs["endpoint"] = address
 
@@ -116,7 +116,7 @@ func (iface *tunnelInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 		return err
 	}
 	if slot.Attrs == nil {
-		slot.Attrs = make(map[string]interface{})
+		slot.Attrs = make(map[string]any)
 	}
 	slot.Attrs["endpoint"] = address
 

--- a/internal/interfaces/connection.go
+++ b/internal/interfaces/connection.go
@@ -36,8 +36,8 @@ type Connection struct {
 // ConnectedPlug represents a plug that is connected to a slot.
 type ConnectedPlug struct {
 	plugInfo     *sdk.PlugInfo
-	staticAttrs  map[string]interface{}
-	dynamicAttrs map[string]interface{}
+	staticAttrs  map[string]any
+	dynamicAttrs map[string]any
 }
 
 func (p *ConnectedPlug) CheckBound() (*ConnRef, bool) {
@@ -60,22 +60,22 @@ func (p *ConnectedPlug) CheckBound() (*ConnRef, bool) {
 // ConnectedSlot represents a slot that is connected to a plug.
 type ConnectedSlot struct {
 	slotInfo     *sdk.SlotInfo
-	staticAttrs  map[string]interface{}
-	dynamicAttrs map[string]interface{}
+	staticAttrs  map[string]any
+	dynamicAttrs map[string]any
 }
 
 // Attrer is an interface with Attr getter method common
 // to ConnectedSlot, ConnectedPlug, PlugInfo and SlotInfo types.
 type Attrer interface {
 	// Attr returns attribute value for given path, or an error. Dotted paths are supported.
-	Attr(path string, value interface{}) error
+	Attr(path string, value any) error
 	// Lookup returns attribute value for given path, or false. Dotted paths are supported.
-	Lookup(path string) (value interface{}, ok bool)
+	Lookup(path string) (value any, ok bool)
 }
 
 // NewConnectedSlot creates an object representing a connected slot.
-func NewConnectedSlot(slot *sdk.SlotInfo, staticAttrs, dynamicAttrs map[string]interface{}) *ConnectedSlot {
-	var static map[string]interface{}
+func NewConnectedSlot(slot *sdk.SlotInfo, staticAttrs, dynamicAttrs map[string]any) *ConnectedSlot {
+	var static map[string]any
 	if staticAttrs != nil {
 		static = staticAttrs
 	} else {
@@ -84,13 +84,13 @@ func NewConnectedSlot(slot *sdk.SlotInfo, staticAttrs, dynamicAttrs map[string]i
 	return &ConnectedSlot{
 		slotInfo:     slot,
 		staticAttrs:  utils.CopyAttributes(static),
-		dynamicAttrs: utils.NormalizeInterfaceAttributes(dynamicAttrs).(map[string]interface{}),
+		dynamicAttrs: utils.NormalizeInterfaceAttributes(dynamicAttrs).(map[string]any),
 	}
 }
 
 // NewConnectedPlug creates an object representing a connected plug.
-func NewConnectedPlug(plug *sdk.PlugInfo, staticAttrs, dynamicAttrs map[string]interface{}) *ConnectedPlug {
-	var static map[string]interface{}
+func NewConnectedPlug(plug *sdk.PlugInfo, staticAttrs, dynamicAttrs map[string]any) *ConnectedPlug {
+	var static map[string]any
 	if staticAttrs != nil {
 		static = staticAttrs
 	} else {
@@ -99,7 +99,7 @@ func NewConnectedPlug(plug *sdk.PlugInfo, staticAttrs, dynamicAttrs map[string]i
 	return &ConnectedPlug{
 		plugInfo:     plug,
 		staticAttrs:  utils.CopyAttributes(static),
-		dynamicAttrs: utils.NormalizeInterfaceAttributes(dynamicAttrs).(map[string]interface{}),
+		dynamicAttrs: utils.NormalizeInterfaceAttributes(dynamicAttrs).(map[string]any),
 	}
 }
 
@@ -119,28 +119,28 @@ func (plug *ConnectedPlug) Sdk() *sdk.Info {
 }
 
 // StaticAttr returns a static attribute with the given key, or error if attribute doesn't exist.
-func (plug *ConnectedPlug) StaticAttr(key string, val interface{}) error {
+func (plug *ConnectedPlug) StaticAttr(key string, val any) error {
 	return plug.getAttribute(nil, key, val)
 }
 
 // StaticAttrs returns all static attributes.
-func (plug *ConnectedPlug) StaticAttrs() map[string]interface{} {
+func (plug *ConnectedPlug) StaticAttrs() map[string]any {
 	return utils.CopyAttributes(plug.staticAttrs)
 }
 
 // DynamicAttrs returns all dynamic attributes.
-func (plug *ConnectedPlug) DynamicAttrs() map[string]interface{} {
+func (plug *ConnectedPlug) DynamicAttrs() map[string]any {
 	return utils.CopyAttributes(plug.dynamicAttrs)
 }
 
 // Attr returns a dynamic attribute with the given name. It falls back to returning static
 // attribute if dynamic one doesn't exist. Error is returned if neither dynamic nor static
 // attribute exist.
-func (plug *ConnectedPlug) Attr(key string, val interface{}) error {
+func (plug *ConnectedPlug) Attr(key string, val any) error {
 	return plug.getAttribute(plug.dynamicAttrs, key, val)
 }
 
-func (plug *ConnectedPlug) getAttribute(dynamicAttrs map[string]interface{}, key string, val interface{}) error {
+func (plug *ConnectedPlug) getAttribute(dynamicAttrs map[string]any, key string, val any) error {
 	v, ok := metautil.LookupAttr(plug.staticAttrs, dynamicAttrs, key)
 	if !ok {
 		ref := plug.Ref()
@@ -153,17 +153,17 @@ func (plug *ConnectedPlug) getAttribute(dynamicAttrs map[string]interface{}, key
 	return nil
 }
 
-func (plug *ConnectedPlug) Lookup(path string) (interface{}, bool) {
+func (plug *ConnectedPlug) Lookup(path string) (any, bool) {
 	return metautil.LookupAttr(plug.staticAttrs, plug.dynamicAttrs, path)
 }
 
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
-func (plug *ConnectedPlug) SetAttr(key string, value interface{}) error {
+func (plug *ConnectedPlug) SetAttr(key string, value any) error {
 	if _, ok := plug.staticAttrs[key]; ok {
 		return fmt.Errorf("cannot change attribute %q as it was statically specified in the %q SDK details", key, plug.plugInfo.Sdk.Name)
 	}
 	if plug.dynamicAttrs == nil {
-		plug.dynamicAttrs = make(map[string]interface{})
+		plug.dynamicAttrs = make(map[string]any)
 	}
 	plug.dynamicAttrs[key] = utils.NormalizeInterfaceAttributes(value)
 	return nil
@@ -190,28 +190,28 @@ func (slot *ConnectedSlot) Sdk() *sdk.Info {
 }
 
 // StaticAttr returns a static attribute with the given key, or error if attribute doesn't exist.
-func (slot *ConnectedSlot) StaticAttr(key string, val interface{}) error {
+func (slot *ConnectedSlot) StaticAttr(key string, val any) error {
 	return slot.getAttribute(nil, key, val)
 }
 
 // StaticAttrs returns all static attributes.
-func (slot *ConnectedSlot) StaticAttrs() map[string]interface{} {
+func (slot *ConnectedSlot) StaticAttrs() map[string]any {
 	return utils.CopyAttributes(slot.staticAttrs)
 }
 
 // DynamicAttrs returns all dynamic attributes.
-func (slot *ConnectedSlot) DynamicAttrs() map[string]interface{} {
+func (slot *ConnectedSlot) DynamicAttrs() map[string]any {
 	return utils.CopyAttributes(slot.dynamicAttrs)
 }
 
 // Attr returns a dynamic attribute with the given name. It falls back to returning static
 // attribute if dynamic one doesn't exist. Error is returned if neither dynamic nor static
 // attribute exist.
-func (slot *ConnectedSlot) Attr(key string, val interface{}) error {
+func (slot *ConnectedSlot) Attr(key string, val any) error {
 	return slot.getAttribute(slot.dynamicAttrs, key, val)
 }
 
-func (slot *ConnectedSlot) getAttribute(dynamicAttrs map[string]interface{}, key string, val interface{}) error {
+func (slot *ConnectedSlot) getAttribute(dynamicAttrs map[string]any, key string, val any) error {
 	v, ok := metautil.LookupAttr(slot.staticAttrs, dynamicAttrs, key)
 	if !ok {
 		ref := slot.Ref()
@@ -224,17 +224,17 @@ func (slot *ConnectedSlot) getAttribute(dynamicAttrs map[string]interface{}, key
 	return nil
 }
 
-func (slot *ConnectedSlot) Lookup(path string) (interface{}, bool) {
+func (slot *ConnectedSlot) Lookup(path string) (any, bool) {
 	return metautil.LookupAttr(slot.staticAttrs, slot.dynamicAttrs, path)
 }
 
 // SetAttr sets the given dynamic attribute. Error is returned if the key is already used by a static attribute.
-func (slot *ConnectedSlot) SetAttr(key string, value interface{}) error {
+func (slot *ConnectedSlot) SetAttr(key string, value any) error {
 	if _, ok := slot.staticAttrs[key]; ok {
 		return fmt.Errorf("cannot change attribute %q as it was statically specified in the %q SDK details", key, slot.slotInfo.Sdk.Name)
 	}
 	if slot.dynamicAttrs == nil {
-		slot.dynamicAttrs = make(map[string]interface{})
+		slot.dynamicAttrs = make(map[string]any)
 	}
 	slot.dynamicAttrs[key] = utils.NormalizeInterfaceAttributes(value)
 	return nil

--- a/internal/interfaces/connection_test.go
+++ b/internal/interfaces/connection_test.go
@@ -85,10 +85,10 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 	c.Assert(slot.StaticAttr("unknown", &val), check.ErrorMatches, `attribute "unknown" not found for slot "ws/producer:slot"`)
 
 	attrs := slot.StaticAttrs()
-	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
+	c.Assert(attrs, check.DeepEquals, map[string]any{
 		"attr":    "value",
 		"number":  int64(100),
-		"complex": map[string]interface{}{"a": "b"},
+		"complex": map[string]any{"a": "b"},
 	})
 	slot.StaticAttr("attr", &val)
 	c.Assert(val, check.Equals, "value")
@@ -98,7 +98,7 @@ func (s *connSuite) TestStaticSlotAttrs(c *check.C) {
 	c.Check(slot.StaticAttr("attr", val), check.ErrorMatches, `invalid attribute "attr" for slot "ws/producer:slot": internal error: value must be a pointer`)
 
 	// static attributes passed via args take precedence over slot.Attrs
-	slot2 := interfaces.NewConnectedSlot(s.slot, map[string]interface{}{"foo": "bar"}, nil)
+	slot2 := interfaces.NewConnectedSlot(s.slot, map[string]any{"foo": "bar"}, nil)
 	slot2.StaticAttr("foo", &val)
 	c.Assert(val, check.Equals, "bar")
 }
@@ -124,9 +124,9 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 	c.Assert(plug.StaticAttr("unknown", &val), check.ErrorMatches, `attribute "unknown" not found for plug "ws/consumer:plug"`)
 
 	attrs := plug.StaticAttrs()
-	c.Assert(attrs, check.DeepEquals, map[string]interface{}{
+	c.Assert(attrs, check.DeepEquals, map[string]any{
 		"attr":    "value",
-		"complex": map[string]interface{}{"c": "d"},
+		"complex": map[string]any{"c": "d"},
 	})
 	plug.StaticAttr("attr", &val)
 	c.Assert(val, check.Equals, "value")
@@ -136,13 +136,13 @@ func (s *connSuite) TestStaticPlugAttrs(c *check.C) {
 	c.Check(plug.StaticAttr("attr", val), check.ErrorMatches, `invalid attribute "attr" for plug "ws/consumer:plug": internal error: value must be a pointer`)
 
 	// static attributes passed via args take precedence over plug.Attrs
-	plug2 := interfaces.NewConnectedPlug(s.plug, map[string]interface{}{"foo": "bar"}, nil)
+	plug2 := interfaces.NewConnectedPlug(s.plug, map[string]any{"foo": "bar"}, nil)
 	plug2.StaticAttr("foo", &val)
 	c.Assert(val, check.Equals, "bar")
 }
 
 func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"foo":    "bar",
 		"number": int(101),
 	}
@@ -151,7 +151,7 @@ func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
 
 	var strVal string
 	var intVal int64
-	var mapVal map[string]interface{}
+	var mapVal map[string]any
 
 	c.Assert(slot.Attr("foo", &strVal), check.IsNil)
 	c.Assert(strVal, check.Equals, "bar")
@@ -162,7 +162,7 @@ func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
 	c.Assert(slot.Attr("number", &intVal), check.IsNil)
 	c.Assert(intVal, check.Equals, int64(101))
 
-	err := slot.SetAttr("other", map[string]interface{}{"number-two": int(222)})
+	err := slot.SetAttr("other", map[string]any{"number-two": int(222)})
 	c.Assert(err, check.IsNil)
 	c.Assert(slot.Attr("other", &mapVal), check.IsNil)
 	num := mapVal["number-two"]
@@ -174,8 +174,8 @@ func (s *connSuite) TestDynamicSlotAttrs(c *check.C) {
 }
 
 func (s *connSuite) TestDottedPathSlot(c *check.C) {
-	attrs := map[string]interface{}{
-		"nested": map[string]interface{}{
+	attrs := map[string]any{
+		"nested": map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -205,9 +205,9 @@ func (s *connSuite) TestDottedPathSlot(c *check.C) {
 }
 
 func (s *connSuite) TestDottedPathPlug(c *check.C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"a": "b",
-		"nested": map[string]interface{}{
+		"nested": map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -247,7 +247,7 @@ func (s *connSuite) TestDottedPathPlug(c *check.C) {
 }
 
 func (s *connSuite) TestLookupFailure(c *check.C) {
-	attrs := map[string]interface{}{}
+	attrs := map[string]any{}
 
 	slot := interfaces.NewConnectedSlot(s.slot, nil, attrs)
 	c.Assert(slot, check.NotNil)
@@ -264,7 +264,7 @@ func (s *connSuite) TestLookupFailure(c *check.C) {
 }
 
 func (s *connSuite) TestDynamicPlugAttrs(c *check.C) {
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"foo":    "bar",
 		"number": int(100),
 	}
@@ -273,7 +273,7 @@ func (s *connSuite) TestDynamicPlugAttrs(c *check.C) {
 
 	var strVal string
 	var intVal int64
-	var mapVal map[string]interface{}
+	var mapVal map[string]any
 
 	c.Assert(plug.Attr("foo", &strVal), check.IsNil)
 	c.Assert(strVal, check.Equals, "bar")
@@ -284,7 +284,7 @@ func (s *connSuite) TestDynamicPlugAttrs(c *check.C) {
 	c.Assert(plug.Attr("number", &intVal), check.IsNil)
 	c.Assert(intVal, check.Equals, int64(100))
 
-	err := plug.SetAttr("other", map[string]interface{}{"number-two": int(222)})
+	err := plug.SetAttr("other", map[string]any{"number-two": int(222)})
 	c.Assert(err, check.IsNil)
 	c.Assert(plug.Attr("other", &mapVal), check.IsNil)
 	num := mapVal["number-two"]
@@ -296,7 +296,7 @@ func (s *connSuite) TestDynamicPlugAttrs(c *check.C) {
 }
 
 func (s *connSuite) TestOverwriteStaticAttrError(c *check.C) {
-	attrs := map[string]interface{}{}
+	attrs := map[string]any{}
 
 	plug := interfaces.NewConnectedPlug(s.plug, nil, attrs)
 	c.Assert(plug, check.NotNil)
@@ -313,45 +313,45 @@ func (s *connSuite) TestOverwriteStaticAttrError(c *check.C) {
 }
 
 func (s *connSuite) TestCopyAttributes(c *check.C) {
-	orig := map[string]interface{}{
+	orig := map[string]any{
 		"a": "A",
 		"b": true,
 		"c": int(100),
-		"d": []interface{}{"x", "y", true},
-		"e": map[string]interface{}{"e1": "E1"},
+		"d": []any{"x", "y", true},
+		"e": map[string]any{"e1": "E1"},
 	}
 
 	cpy := utils.CopyAttributes(orig)
 	c.Check(cpy, check.DeepEquals, orig)
 
-	cpy["d"].([]interface{})[0] = 999
-	c.Check(orig["d"].([]interface{})[0], check.Equals, "x")
-	cpy["e"].(map[string]interface{})["e1"] = "x"
-	c.Check(orig["e"].(map[string]interface{})["e1"], check.Equals, "E1")
+	cpy["d"].([]any)[0] = 999
+	c.Check(orig["d"].([]any)[0], check.Equals, "x")
+	cpy["e"].(map[string]any)["e1"] = "x"
+	c.Check(orig["e"].(map[string]any)["e1"], check.Equals, "E1")
 }
 
 func (s *connSuite) TestNewConnectedPlugExplicitStaticAttrs(c *check.C) {
-	staticAttrs := map[string]interface{}{
+	staticAttrs := map[string]any{
 		"baz": "boom",
 	}
-	dynAttrs := map[string]interface{}{
+	dynAttrs := map[string]any{
 		"foo": "bar",
 	}
 	plug := interfaces.NewConnectedPlug(s.plug, staticAttrs, dynAttrs)
 	c.Assert(plug, check.NotNil)
-	c.Assert(plug.StaticAttrs(), check.DeepEquals, map[string]interface{}{"baz": "boom"})
-	c.Assert(plug.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(plug.StaticAttrs(), check.DeepEquals, map[string]any{"baz": "boom"})
+	c.Assert(plug.DynamicAttrs(), check.DeepEquals, map[string]any{"foo": "bar"})
 }
 
 func (s *connSuite) TestNewConnectedSlotExplicitStaticAttrs(c *check.C) {
-	staticAttrs := map[string]interface{}{
+	staticAttrs := map[string]any{
 		"baz": "boom",
 	}
-	dynAttrs := map[string]interface{}{
+	dynAttrs := map[string]any{
 		"foo": "bar",
 	}
 	slot := interfaces.NewConnectedSlot(s.slot, staticAttrs, dynAttrs)
 	c.Assert(slot, check.NotNil)
-	c.Assert(slot.StaticAttrs(), check.DeepEquals, map[string]interface{}{"baz": "boom"})
-	c.Assert(slot.DynamicAttrs(), check.DeepEquals, map[string]interface{}{"foo": "bar"})
+	c.Assert(slot.StaticAttrs(), check.DeepEquals, map[string]any{"baz": "boom"})
+	c.Assert(slot.DynamicAttrs(), check.DeepEquals, map[string]any{"foo": "bar"})
 }

--- a/internal/interfaces/policy/policy.go
+++ b/internal/interfaces/policy/policy.go
@@ -103,7 +103,7 @@ type ConnectCandidate struct {
 	BaseDeclaration *asserts.BaseDeclaration
 }
 
-func nestedGet(which string, attrs interfaces.Attrer, path string) (interface{}, error) {
+func nestedGet(which string, attrs interfaces.Attrer, path string) (any, error) {
 	val, ok := attrs.Lookup(path)
 	if !ok {
 		return nil, fmt.Errorf("%s attribute %q not found", which, path)
@@ -111,11 +111,11 @@ func nestedGet(which string, attrs interfaces.Attrer, path string) (interface{},
 	return val, nil
 }
 
-func (connc *ConnectCandidate) PlugAttr(arg string) (interface{}, error) {
+func (connc *ConnectCandidate) PlugAttr(arg string) (any, error) {
 	return nestedGet("plug", connc.Plug, arg)
 }
 
-func (connc *ConnectCandidate) SlotAttr(arg string) (interface{}, error) {
+func (connc *ConnectCandidate) SlotAttr(arg string) (any, error) {
 	return nestedGet("slot", connc.Slot, arg)
 }
 func (connc *ConnectCandidate) checkPlugRule(kind string, rule *asserts.PlugRule) (interfaces.SideArity, error) {

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -468,7 +468,7 @@ type PolicyFunc func(*ConnectedPlug, *ConnectedSlot) (bool, error)
 // Connect establishes a connection between a plug and a slot.
 // The plug and the slot must have the same interface.
 // When connections are reloaded policyCheck is null (we don't check policy again).
-func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, slotStaticAttrs, slotDynamicAttrs map[string]interface{}, policyCheck PolicyFunc) (*Connection, error) {
+func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, slotStaticAttrs, slotDynamicAttrs map[string]any, policyCheck PolicyFunc) (*Connection, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -1502,8 +1502,8 @@ func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
 	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2")
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
-	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
-	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+	plugDynAttrs := map[string]any{"attr1": "val1"}
+	slotDynAttrs := map[string]any{"attr1": "val1"}
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
 	conn, err := s.emptyRepo.Connect(&ConnRef{
@@ -1515,10 +1515,10 @@ func (s *RepositorySuite) TestBeforeConnectValidation(c *C) {
 	c.Assert(conn.Plug, NotNil)
 	c.Assert(conn.Slot, NotNil)
 
-	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, map[string]interface{}{"attr0": "val0"})
-	c.Assert(conn.Plug.DynamicAttrs(), DeepEquals, map[string]interface{}{"attr1": "val1-validated"})
-	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, map[string]interface{}{"attr0": "val0"})
-	c.Assert(conn.Slot.DynamicAttrs(), DeepEquals, map[string]interface{}{"attr1": "val1-validated"})
+	c.Assert(conn.Plug.StaticAttrs(), DeepEquals, map[string]any{"attr0": "val0"})
+	c.Assert(conn.Plug.DynamicAttrs(), DeepEquals, map[string]any{"attr1": "val1-validated"})
+	c.Assert(conn.Slot.StaticAttrs(), DeepEquals, map[string]any{"attr0": "val0"})
+	c.Assert(conn.Slot.DynamicAttrs(), DeepEquals, map[string]any{"attr1": "val1-validated"})
 }
 
 func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
@@ -1538,8 +1538,8 @@ func (s *RepositorySuite) TestBeforeConnectValidationFailure(c *C) {
 	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2")
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
-	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
-	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+	plugDynAttrs := map[string]any{"attr1": "val1"}
+	slotDynAttrs := map[string]any{"attr1": "val1"}
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) { return true, nil }
 
@@ -1564,8 +1564,8 @@ func (s *RepositorySuite) TestBeforeConnectValidationPolicyCheckFailure(c *C) {
 	s2 := sdk.MockInfo(c, ifacehooksSnap2, s.projectId, "ws-s2")
 	c.Assert(s.emptyRepo.AddSdk(s2), IsNil)
 
-	plugDynAttrs := map[string]interface{}{"attr1": "val1"}
-	slotDynAttrs := map[string]interface{}{"attr1": "val1"}
+	plugDynAttrs := map[string]any{"attr1": "val1"}
+	slotDynAttrs := map[string]any{"attr1": "val1"}
 
 	policyCheck := func(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) {
 		return false, fmt.Errorf("policy check failed")
@@ -1617,8 +1617,8 @@ func (s *RepositorySuite) TestConnectWithStaticAttrs(c *C) {
 
 	connRef := NewConnRef(s.plug, s.slot)
 
-	plugAttrs := map[string]interface{}{"foo": "bar"}
-	slotAttrs := map[string]interface{}{"boo": "baz"}
+	plugAttrs := map[string]any{"foo": "bar"}
+	slotAttrs := map[string]any{"boo": "baz"}
 	_, err := s.testRepo.Connect(connRef, plugAttrs, nil, slotAttrs, nil, nil)
 	c.Assert(err, IsNil)
 

--- a/internal/interfaces/utils/utils.go
+++ b/internal/interfaces/utils/utils.go
@@ -26,21 +26,21 @@ import (
 // NormalizeInterfaceAttributes normalises types of an attribute values.
 // The following transformations are applied: int -> int64, float32 -> float64.
 // The normalisation proceeds recursively through maps and slices.
-func NormalizeInterfaceAttributes(value interface{}) interface{} {
+func NormalizeInterfaceAttributes(value any) any {
 	// Normalize ints/floats using their 64-bit variants.
 	switch v := value.(type) {
 	case int:
 		return int64(v)
 	case float32:
 		return float64(v)
-	case []interface{}:
-		vc := make([]interface{}, len(v))
+	case []any:
+		vc := make([]any, len(v))
 		for i, el := range v {
 			vc[i] = NormalizeInterfaceAttributes(el)
 		}
 		return vc
-	case map[string]interface{}:
-		vc := make(map[string]interface{}, len(v))
+	case map[string]any:
+		vc := make(map[string]any, len(v))
 		for key, item := range v {
 			vc[key] = NormalizeInterfaceAttributes(item)
 		}
@@ -57,22 +57,22 @@ func NormalizeInterfaceAttributes(value interface{}) interface{} {
 }
 
 // CopyAttributes makes a deep copy of the attributes map.
-func CopyAttributes(value map[string]interface{}) map[string]interface{} {
-	return copyRecursive(value).(map[string]interface{})
+func CopyAttributes(value map[string]any) map[string]any {
+	return copyRecursive(value).(map[string]any)
 }
 
-func copyRecursive(value interface{}) interface{} {
+func copyRecursive(value any) any {
 	// note: ensure all the mutable types (or types that need a conversion)
 	// are handled here.
 	switch v := value.(type) {
-	case []interface{}:
-		arr := make([]interface{}, len(v))
+	case []any:
+		arr := make([]any, len(v))
 		for i, el := range v {
 			arr[i] = copyRecursive(el)
 		}
 		return arr
-	case map[string]interface{}:
-		mp := make(map[string]interface{}, len(v))
+	case map[string]any:
+		mp := make(map[string]any, len(v))
 		for key, item := range v {
 			mp[key] = copyRecursive(item)
 		}

--- a/internal/interfaces/utils/utils_test.go
+++ b/internal/interfaces/utils/utils_test.go
@@ -45,38 +45,38 @@ func (s *utilsSuite) TestNormalizeInterfaceAttributes(c *C) {
 	// Funny that, I noticed it only because of missing test coverage.
 	c.Assert(normalize(float32(3.14)), Equals, float64(3.140000104904175))
 	c.Assert(normalize("banana"), Equals, "banana")
-	c.Assert(normalize([]interface{}{42, 3.14, "banana", json.Number("21"), json.Number("0.5")}), DeepEquals,
-		[]interface{}{int64(42), float64(3.14), "banana", int64(21), float64(0.5)})
-	c.Assert(normalize(map[string]interface{}{"i": 42, "f": 3.14, "s": "banana"}),
-		DeepEquals, map[string]interface{}{"i": int64(42), "f": float64(3.14), "s": "banana"})
+	c.Assert(normalize([]any{42, 3.14, "banana", json.Number("21"), json.Number("0.5")}), DeepEquals,
+		[]any{int64(42), float64(3.14), "banana", int64(21), float64(0.5)})
+	c.Assert(normalize(map[string]any{"i": 42, "f": 3.14, "s": "banana"}),
+		DeepEquals, map[string]any{"i": int64(42), "f": float64(3.14), "s": "banana"})
 	c.Assert(normalize(json.Number("1")), Equals, int64(1))
 	c.Assert(normalize(json.Number("2.5")), Equals, float64(2.5))
 
 	// Normalize doesn't mutate slices it is given
-	sliceIn := []interface{}{42}
+	sliceIn := []any{42}
 	sliceOut := normalize(sliceIn)
-	c.Assert(sliceIn, DeepEquals, []interface{}{42})
-	c.Assert(sliceOut, DeepEquals, []interface{}{int64(42)})
+	c.Assert(sliceIn, DeepEquals, []any{42})
+	c.Assert(sliceOut, DeepEquals, []any{int64(42)})
 
 	// Normalize doesn't mutate maps it is given
-	mapIn := map[string]interface{}{"i": 42}
+	mapIn := map[string]any{"i": 42}
 	mapOut := normalize(mapIn)
-	c.Assert(mapIn, DeepEquals, map[string]interface{}{"i": 42})
-	c.Assert(mapOut, DeepEquals, map[string]interface{}{"i": int64(42)})
+	c.Assert(mapIn, DeepEquals, map[string]any{"i": 42})
+	c.Assert(mapOut, DeepEquals, map[string]any{"i": int64(42)})
 }
 
 func (s *utilsSuite) TestCopyAttributes(c *C) {
 	cpattr := utils.CopyAttributes
 
-	attrsIn := map[string]interface{}{"i": 42}
+	attrsIn := map[string]any{"i": 42}
 	attrsOut := cpattr(attrsIn)
 	attrsIn["i"] = "changed"
-	c.Assert(attrsIn, DeepEquals, map[string]interface{}{"i": "changed"})
-	c.Assert(attrsOut, DeepEquals, map[string]interface{}{"i": 42})
+	c.Assert(attrsIn, DeepEquals, map[string]any{"i": "changed"})
+	c.Assert(attrsOut, DeepEquals, map[string]any{"i": 42})
 
-	attrsIn = map[string]interface{}{"ao": []interface{}{1, 2, 3}}
+	attrsIn = map[string]any{"ao": []any{1, 2, 3}}
 	attrsOut = cpattr(attrsIn)
-	attrsIn["ao"].([]interface{})[1] = "changed"
-	c.Assert(attrsIn, DeepEquals, map[string]interface{}{"ao": []interface{}{1, "changed", 3}})
-	c.Assert(attrsOut, DeepEquals, map[string]interface{}{"ao": []interface{}{1, 2, 3}})
+	attrsIn["ao"].([]any)[1] = "changed"
+	c.Assert(attrsIn, DeepEquals, map[string]any{"ao": []any{1, "changed", 3}})
+	c.Assert(attrsOut, DeepEquals, map[string]any{"ao": []any{1, 2, 3}})
 }

--- a/internal/jsonutil/json.go
+++ b/internal/jsonutil/json.go
@@ -30,7 +30,7 @@ import (
 
 // DecodeWithNumber decodes input data using json.Decoder, ensuring numbers are preserved
 // via json.Number data type. It errors out on invalid json or any excess input.
-func DecodeWithNumber(r io.Reader, value interface{}) error {
+func DecodeWithNumber(r io.Reader, value any) error {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()
 	if err := dec.Decode(&value); err != nil {
@@ -46,7 +46,7 @@ func DecodeWithNumber(r io.Reader, value interface{}) error {
 // and returns a list of the fields in the struct that are JSON-tagged
 // and whose tag is not in the list of exceptions.
 // The struct can be nil.
-func StructFields(s interface{}, exceptions ...string) []string {
+func StructFields(s any, exceptions ...string) []string {
 	st := reflect.TypeOf(s).Elem()
 	num := st.NumField()
 	fields := make([]string, 0, num)

--- a/internal/jsonutil/json_test.go
+++ b/internal/jsonutil/json_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&utilSuite{})
 
 func (s *utilSuite) TestDecodeError(c *C) {
 	input := "{]"
-	var output interface{}
+	var output any
 	err := jsonutil.DecodeWithNumber(strings.NewReader(input), &output)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `invalid character ']' looking for beginning of object key string`)
@@ -45,7 +45,7 @@ func (s *utilSuite) TestDecodeError(c *C) {
 
 func (s *utilSuite) TestDecodeErrorOnExcessData(c *C) {
 	input := "1000000000[1,2]"
-	var output interface{}
+	var output any
 	err := jsonutil.DecodeWithNumber(strings.NewReader(input), &output)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot parse json value`)
@@ -53,10 +53,10 @@ func (s *utilSuite) TestDecodeErrorOnExcessData(c *C) {
 
 func (s *utilSuite) TestDecodeSuccess(c *C) {
 	input := `{"a":1000000000, "b": 1.2, "c": "foo", "d":null}`
-	var output interface{}
+	var output any
 	err := jsonutil.DecodeWithNumber(strings.NewReader(input), &output)
 	c.Assert(err, IsNil)
-	c.Assert(output, DeepEquals, map[string]interface{}{
+	c.Assert(output, DeepEquals, map[string]any{
 		"a": json.Number("1000000000"),
 		"b": json.Number("1.2"),
 		"c": "foo",

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -62,7 +62,7 @@ var (
 )
 
 // Panicf notifies the user and then panics
-func Panicf(format string, v ...interface{}) {
+func Panicf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 
 	lock.Lock()
@@ -73,7 +73,7 @@ func Panicf(format string, v ...interface{}) {
 }
 
 // Noticef notifies the user of something
-func Noticef(format string, v ...interface{}) {
+func Noticef(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 
 	lock.Lock()
@@ -83,7 +83,7 @@ func Noticef(format string, v ...interface{}) {
 }
 
 // Debugf records something in the debug log
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 
 	lock.Lock()
@@ -93,7 +93,7 @@ func Debugf(format string, v ...interface{}) {
 }
 
 // NoGuardDebugf records something in the debug log
-func NoGuardDebugf(format string, v ...interface{}) {
+func NoGuardDebugf(format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 
 	lock.Lock()

--- a/internal/metautil/normalize.go
+++ b/internal/metautil/normalize.go
@@ -25,8 +25,8 @@ import (
 )
 
 // NormalizeValue validates values and returns a normalized version of it
-// (map[interface{}]interface{} is turned into map[string]interface{})
-func NormalizeValue(v interface{}) (interface{}, error) {
+// (map[any]any is turned into map[string]any)
+func NormalizeValue(v any) (any, error) {
 	switch x := v.(type) {
 	case string:
 		return x, nil
@@ -40,8 +40,8 @@ func NormalizeValue(v interface{}) (interface{}, error) {
 		return x, nil
 	case float32:
 		return float64(x), nil
-	case []interface{}:
-		l := make([]interface{}, len(x))
+	case []any:
+		l := make([]any, len(x))
 		for i, el := range x {
 			el, err := NormalizeValue(el)
 			if err != nil {
@@ -50,8 +50,8 @@ func NormalizeValue(v interface{}) (interface{}, error) {
 			l[i] = el
 		}
 		return l, nil
-	case map[interface{}]interface{}:
-		m := make(map[string]interface{}, len(x))
+	case map[any]any:
+		m := make(map[string]any, len(x))
 		for k, item := range x {
 			kStr, ok := k.(string)
 			if !ok {
@@ -64,8 +64,8 @@ func NormalizeValue(v interface{}) (interface{}, error) {
 			m[kStr] = item
 		}
 		return m, nil
-	case map[string]interface{}:
-		m := make(map[string]interface{}, len(x))
+	case map[string]any:
+		m := make(map[string]any, len(x))
 		for k, item := range x {
 			item, err := NormalizeValue(item)
 			if err != nil {

--- a/internal/metautil/normalize_test.go
+++ b/internal/metautil/normalize_test.go
@@ -36,8 +36,8 @@ func Test(t *testing.T) { TestingT(t) }
 
 func (s *normalizeTestSuite) TestNormalize(c *C) {
 	for _, tc := range []struct {
-		v   interface{}
-		exp interface{}
+		v   any
+		exp any
 		err string
 	}{
 		{v: "foo", exp: "foo"},
@@ -47,18 +47,18 @@ func (s *normalizeTestSuite) TestNormalize(c *C) {
 		{v: 0.5, exp: float64(0.5)},
 		{v: float32(0.5), exp: float64(0.5)},
 		{v: float64(0.5), exp: float64(0.5)},
-		{v: []interface{}{1, 0.5, "foo"}, exp: []interface{}{int64(1), float64(0.5), "foo"}},
-		{v: map[string]interface{}{"foo": 1}, exp: map[string]interface{}{"foo": int64(1)}},
-		{v: map[interface{}]interface{}{"foo": 1}, exp: map[string]interface{}{"foo": int64(1)}},
+		{v: []any{1, 0.5, "foo"}, exp: []any{int64(1), float64(0.5), "foo"}},
+		{v: map[string]any{"foo": 1}, exp: map[string]any{"foo": int64(1)}},
+		{v: map[any]any{"foo": 1}, exp: map[string]any{"foo": int64(1)}},
 		{
-			v:   map[interface{}]interface{}{"foo": map[interface{}]interface{}{"bar": 0.5}},
-			exp: map[string]interface{}{"foo": map[string]interface{}{"bar": float64(0.5)}},
+			v:   map[any]any{"foo": map[any]any{"bar": 0.5}},
+			exp: map[string]any{"foo": map[string]any{"bar": float64(0.5)}},
 		},
 		{v: uint(1), err: "invalid scalar: 1"},
-		{v: map[interface{}]interface{}{2: 1}, err: "non-string key: 2"},
-		{v: []interface{}{uint(1)}, err: "invalid scalar: 1"},
-		{v: map[string]interface{}{"foo": uint(1)}, err: "invalid scalar: 1"},
-		{v: map[interface{}]interface{}{"foo": uint(1)}, err: "invalid scalar: 1"},
+		{v: map[any]any{2: 1}, err: "non-string key: 2"},
+		{v: []any{uint(1)}, err: "invalid scalar: 1"},
+		{v: map[string]any{"foo": uint(1)}, err: "invalid scalar: 1"},
+		{v: map[any]any{"foo": uint(1)}, err: "invalid scalar: 1"},
 	} {
 		res, err := metautil.NormalizeValue(tc.v)
 		if tc.err == "" {

--- a/internal/metautil/path_lookup.go
+++ b/internal/metautil/path_lookup.go
@@ -21,13 +21,13 @@ package metautil
 
 import "strings"
 
-func LookupAttr(static, dynamic map[string]interface{}, path string) (interface{}, bool) {
+func LookupAttr(static, dynamic map[string]any, path string) (any, bool) {
 	parts := strings.FieldsFunc(path, func(r rune) bool { return r == '.' })
 	if len(parts) == 0 {
 		return nil, false
 	}
 
-	var v interface{}
+	var v any
 	if _, ok := dynamic[parts[0]]; ok {
 		v = dynamic
 	} else {
@@ -35,7 +35,7 @@ func LookupAttr(static, dynamic map[string]interface{}, path string) (interface{
 	}
 
 	for _, part := range parts {
-		m, ok := v.(map[string]interface{})
+		m, ok := v.(map[string]any)
 		if !ok {
 			return nil, false
 		}

--- a/internal/metautil/type_conversions_test.go
+++ b/internal/metautil/type_conversions_test.go
@@ -34,8 +34,8 @@ var _ = Suite(&conversionssSuite{})
 
 func (s *conversionssSuite) TestConvertHappy(c *C) {
 	data := []struct {
-		inputValue    interface{}
-		expectedValue interface{}
+		inputValue    any
+		expectedValue any
 	}{
 		// Basic types
 		{"a string", "a string"},
@@ -51,11 +51,11 @@ func (s *conversionssSuite) TestConvertHappy(c *C) {
 		{[]int{24, 42}, []int{24, 42}},
 
 		// Complex types with conversion
-		{[]interface{}{"one", "two"}, []string{"one", "two"}},
-		{[]interface{}{24, 42}, []int{24, 42}},
-		{[]interface{}{[]string{"one"}, []string{"two"}}, [][]string{{"one"}, {"two"}}},
-		{[]interface{}{map[string]int{"one": 1}, map[string]int{"two": 2}}, []map[string]int{{"one": 1}, {"two": 2}}},
-		{map[interface{}]interface{}{"one": 1, "two": 2}, map[string]int{"one": 1, "two": 2}},
+		{[]any{"one", "two"}, []string{"one", "two"}},
+		{[]any{24, 42}, []int{24, 42}},
+		{[]any{[]string{"one"}, []string{"two"}}, [][]string{{"one"}, {"two"}}},
+		{[]any{map[string]int{"one": 1}, map[string]int{"two": 2}}, []map[string]int{{"one": 1}, {"two": 2}}},
+		{map[any]any{"one": 1, "two": 2}, map[string]int{"one": 1, "two": 2}},
 	}
 
 	for _, testData := range data {
@@ -72,7 +72,7 @@ func (s *conversionssSuite) TestConvertHappy(c *C) {
 func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 	t := reflect.TypeOf
 	data := []struct {
-		inputValue    interface{}
+		inputValue    any
 		outputType    reflect.Type
 		expectedError string
 	}{
@@ -86,13 +86,13 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 		{math.Nextafter(math.MaxInt64, math.Inf(1)), t(int64(0)), `cannot convert value "[0-9.]*e\+18" into a int64`},
 
 		// Complex types
-		{[]interface{}{"one", "two", 3}, t([]string{}), `cannot convert value "3" into a string`},
-		{[]interface{}{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
+		{[]any{"one", "two", 3}, t([]string{}), `cannot convert value "3" into a string`},
+		{[]any{1, "two", 3}, t([]int{}), `cannot convert value "two" into a int`},
 		{[]int{1, 2}, t([]string{}), `cannot convert value "1" into a string`},
 		{[]int{1, 2}, t(1), `cannot convert value "\[1 2\]" into a int`},
-		{map[interface{}]interface{}{"one": 1}, t(map[int]int{}), `cannot convert value "one" into a int`},
-		{map[interface{}]interface{}{1: 2}, t(map[int]string{}), `cannot convert value "2" into a string`},
-		{map[interface{}]interface{}{"one": 1}, t([]string{}), `cannot convert value "map\[one:1\]" into a \[\]string`},
+		{map[any]any{"one": 1}, t(map[int]int{}), `cannot convert value "one" into a int`},
+		{map[any]any{1: 2}, t(map[int]string{}), `cannot convert value "2" into a string`},
+		{map[any]any{"one": 1}, t([]string{}), `cannot convert value "map\[one:1\]" into a \[\]string`},
 	}
 
 	for _, testData := range data {
@@ -107,7 +107,7 @@ func (s *conversionssSuite) TestConvertUnhappy(c *C) {
 }
 
 func (s *conversionssSuite) TestSetValueFromAttributeHappy(c *C) {
-	interfaceArray := []interface{}{12, -3}
+	interfaceArray := []any{12, -3}
 	var outputValue []int
 	err := metautil.SetValueFromAttribute(interfaceArray, &outputValue)
 	c.Assert(err, IsNil)
@@ -117,8 +117,8 @@ func (s *conversionssSuite) TestSetValueFromAttributeHappy(c *C) {
 func (s *conversionssSuite) TestSetValueFromAttributeUnhappy(c *C) {
 	var outputBool bool
 	data := []struct {
-		inputValue    interface{}
-		outputValue   interface{}
+		inputValue    any
+		outputValue   any
 		expectedError string
 	}{
 		// error if output value parameter is not a pointer

--- a/internal/osutil/cp_test.go
+++ b/internal/osutil/cp_test.go
@@ -187,7 +187,7 @@ func (mockstat) Size() int64        { return 42 }
 func (mockstat) Mode() os.FileMode  { return 0644 }
 func (mockstat) ModTime() time.Time { return time.Now() }
 func (mockstat) IsDir() bool        { return false }
-func (mockstat) Sys() interface{}   { return nil }
+func (mockstat) Sys() any           { return nil }
 
 func (s *cpSuite) TestCopySpecialFileSimple(c *C) {
 	sync := testutil.FakeCommand(c, "sync", "")

--- a/internal/osutil/kcmdline.go
+++ b/internal/osutil/kcmdline.go
@@ -208,7 +208,7 @@ type KernelArgument struct {
 }
 
 // UnmarshalYAML implements the Unmarshaler interface.
-func (ka *KernelArgument) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ka *KernelArgument) UnmarshalYAML(unmarshal func(any) error) error {
 	var arg string
 	if err := unmarshal(&arg); err != nil {
 		return errors.New("cannot unmarshal kernel argument")

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -301,7 +301,7 @@ func setExitCode(task *state.Task, exitCode int) {
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
-	task.Set("api-data", map[string]interface{}{
+	task.Set("api-data", map[string]any{
 		"exit-code": exitCode,
 	})
 }

--- a/internal/overlord/hookstate/context.go
+++ b/internal/overlord/hookstate/context.go
@@ -44,7 +44,7 @@ type Context struct {
 	id      string
 	handler Handler
 
-	cache  map[interface{}]interface{}
+	cache  map[any]any
 	onDone []func() error
 
 	mutex        sync.Mutex
@@ -70,7 +70,7 @@ func NewContext(task *state.Task, state *state.State, setup *HookSetup, handler 
 		setup:   setup,
 		id:      contextID,
 		handler: handler,
-		cache:   make(map[interface{}]interface{}),
+		cache:   make(map[any]any),
 	}, nil
 }
 
@@ -135,7 +135,7 @@ func (c *Context) writing() {
 // Set associates value with key. The provided value must properly marshal and
 // unmarshal with encoding/json. Note that the context needs to be locked and
 // unlocked by the caller.
-func (c *Context) Set(key string, value interface{}) {
+func (c *Context) Set(key string, value any) {
 	c.writing()
 
 	var data map[string]*json.RawMessage
@@ -167,7 +167,7 @@ func (c *Context) Set(key string, value interface{}) {
 // Get unmarshals the stored value associated with the provided key into the
 // value parameter. Note that the context needs to be locked/unlocked by the
 // caller.
-func (c *Context) Get(key string, value interface{}) error {
+func (c *Context) Get(key string, value any) error {
 	c.reading()
 
 	var data map[string]*json.RawMessage
@@ -203,7 +203,7 @@ func (c *Context) State() *state.State {
 // Cached returns the cached value associated with the provided key. It returns
 // nil if there is no entry for key. Note that the context needs to be locked
 // and unlocked by the caller.
-func (c *Context) Cached(key interface{}) interface{} {
+func (c *Context) Cached(key any) any {
 	c.reading()
 
 	return c.cache[key]
@@ -211,7 +211,7 @@ func (c *Context) Cached(key interface{}) interface{} {
 
 // Cache associates value with key. The cached value is not persisted. Note that
 // the context needs to be locked/unlocked by the caller.
-func (c *Context) Cache(key, value interface{}) {
+func (c *Context) Cache(key, value any) {
 	c.writing()
 
 	c.cache[key] = value
@@ -263,7 +263,7 @@ func (c *Context) ChangeID() string {
 // or the task log.
 //
 // Context must be locked.
-func (c *Context) Logf(fmt string, args ...interface{}) {
+func (c *Context) Logf(fmt string, args ...any) {
 	c.writing()
 	if c.IsEphemeral() {
 		logger.Noticef(fmt, args...)
@@ -276,7 +276,7 @@ func (c *Context) Logf(fmt string, args ...interface{}) {
 // ephemeral contexts or the task log.
 //
 // Context must be locked.
-func (c *Context) Errorf(format string, args ...interface{}) {
+func (c *Context) Errorf(format string, args ...any) {
 	c.writing()
 	if c.IsEphemeral() {
 		// XXX: loger has no Errorf() :/

--- a/internal/overlord/hookstate/context_test.go
+++ b/internal/overlord/hookstate/context_test.go
@@ -75,7 +75,7 @@ func (s *contextSuite) TestSetAndGetNumber(c *C) {
 
 	s.context.Set("num", 1234567890)
 
-	var output interface{}
+	var output any
 	c.Check(s.context.Get("num", &output), IsNil)
 	c.Assert(output, Equals, json.Number("1234567890"))
 }

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -53,7 +53,7 @@ func (c *baseCommand) setStdout(w io.Writer) {
 	c.stdout = w
 }
 
-func (c *baseCommand) printf(format string, a ...interface{}) (int, error) {
+func (c *baseCommand) printf(format string, a ...any) (int, error) {
 	if c.stdout != nil {
 		return fmt.Fprintf(c.stdout, format, a...)
 	}
@@ -64,7 +64,7 @@ func (c *baseCommand) setStderr(w io.Writer) {
 	c.stderr = w
 }
 
-func (c *baseCommand) errorf(format string, a ...interface{}) (int, error) {
+func (c *baseCommand) errorf(format string, a ...any) (int, error) {
 	if c.stderr != nil {
 		return fmt.Fprintf(c.stderr, format, a...)
 	}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -125,7 +125,7 @@ func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]str
 	return candidates
 }
 
-func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, plugDynamic, slotDynamic map[string]map[string]interface{}) *state.TaskSet {
+func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, plugDynamic, slotDynamic map[string]map[string]any) *state.TaskSet {
 
 	connectTs := state.NewTaskSet()
 	var affected = map[sdk.Ref]bool{}
@@ -188,8 +188,8 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 
 	var connectRefs = []*interfaces.ConnRef{}
 	var wconns = workshopConns(wp)
-	var plugDynamic = make(map[string]map[string]interface{})
-	var slotDynamic = make(map[string]map[string]interface{})
+	var plugDynamic = make(map[string]map[string]any)
+	var slotDynamic = make(map[string]map[string]any)
 
 	for _, plug := range info.Plugs {
 		ref := plug.Ref()
@@ -206,7 +206,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
 			if slotDynamic[connRef.ID()] == nil {
-				slotDynamic[connRef.ID()] = make(map[string]interface{})
+				slotDynamic[connRef.ID()] = make(map[string]any)
 			}
 
 			// remounts may be not nil when a previously existing mount
@@ -224,7 +224,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
 				if _, ok := conns[slref.ID()]; !ok {
 					connectRefs = append(connectRefs, slref)
-					plugDynamic[slref.ID()] = make(map[string]interface{})
+					plugDynamic[slref.ID()] = make(map[string]any)
 					plugDynamic[slref.ID()]["bind"] = connRef.ID()
 				}
 			}
@@ -254,7 +254,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 
 			connRef := interfaces.NewConnRef(plug, slot)
 			if slotDynamic[connRef.ID()] == nil {
-				slotDynamic[connRef.ID()] = make(map[string]interface{})
+				slotDynamic[connRef.ID()] = make(map[string]any)
 			}
 
 			// remounts may be not nil when a previously existing mount
@@ -272,7 +272,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
 				if _, ok := conns[slref.ID()]; !ok {
 					connectRefs = append(connectRefs, slref)
-					plugDynamic[slref.ID()] = make(map[string]interface{})
+					plugDynamic[slref.ID()] = make(map[string]any)
 					plugDynamic[slref.ID()]["bind"] = connRef.ID()
 				}
 			}
@@ -465,7 +465,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 		return fmt.Errorf("SDK %q has no slot named %q", slotRef.SdkRef().ShortRef(), slotRef.Name)
 	}
 
-	var plugDynamicAttrs, slotDynamicAttrs map[string]interface{}
+	var plugDynamicAttrs, slotDynamicAttrs map[string]any
 	if err = task.Get("plug-dynamic", &plugDynamicAttrs); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -268,13 +268,13 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.state.Get("conns", &conns)
-	c.Assert(conns, check.DeepEquals, map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
+	c.Assert(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
 			"interface":   "mock-network",
 			"auto":        true,
-			"plug-static": map[string]interface{}{"attribute": "one"},
+			"plug-static": map[string]any{"attribute": "one"},
 		},
 	})
 
@@ -315,29 +315,29 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 	c.Check(ref, check.HasLen, 4)
 	c.Check(err, check.IsNil)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.state.Get("conns", &conns)
-	c.Check(conns, check.DeepEquals, map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
 			"interface":   "mock-network",
 			"auto":        true,
-			"plug-static": map[string]interface{}{"attribute": "one"},
+			"plug-static": map[string]any{"attribute": "one"},
 		},
-		"42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot": map[string]interface{}{
+		"42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot": map[string]any{
 			"interface":   "mock-network",
 			"auto":        true,
-			"plug-static": map[string]interface{}{"attribute": "two"},
+			"plug-static": map[string]any{"attribute": "two"},
 		},
-		"42424242/ws/consumer:plug3 42424242/ws-producer/producer:slot": map[string]interface{}{
+		"42424242/ws/consumer:plug3 42424242/ws-producer/producer:slot": map[string]any{
 			"interface":   "mock-network",
 			"auto":        true,
-			"plug-static": map[string]interface{}{"attribute": "three"},
+			"plug-static": map[string]any{"attribute": "three"},
 		},
-		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]interface{}{
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]any{
 			"interface":    "mock-network",
 			"auto":         true,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"bind": "42424242/ws/consumer:plug 42424242/ws-producer/producer:slot"},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"bind": "42424242/ws/consumer:plug 42424242/ws-producer/producer:slot"},
 		},
 	})
 
@@ -423,7 +423,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 	c.Assert(ref, check.HasLen, 0)
 	c.Assert(err, check.IsNil)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.HasLen, 0)
 }
@@ -523,9 +523,9 @@ func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.
 	// Validate
 	c.Assert(repo.Plugs(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 0)
 
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.state.Get("conns", &conns)
-	c.Assert(conns, check.DeepEquals, map[string]interface{}(nil))
+	c.Assert(conns, check.DeepEquals, map[string]any(nil))
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 }
@@ -566,14 +566,14 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 
 	// Validate
 	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
-	var conns map[string]interface{}
+	var conns map[string]any
 	s.state.Get("conns", &conns)
-	c.Assert(conns, check.DeepEquals, map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]interface{}{
+	c.Assert(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
 			"interface":    "mock-network",
 			"auto":         true,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"slot-dynamic": map[string]interface{}{"host-source": "/old/source"},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"slot-dynamic": map[string]any{"host-source": "/old/source"},
 		},
 	})
 
@@ -661,16 +661,16 @@ slots:
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, systemYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
 
-	dynamic := map[string]interface{}{}
+	dynamic := map[string]any{}
 	if source != "" {
 		dynamic["host-source"] = source
 	}
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount": map[string]any{
 			"interface":    "mount",
 			"auto":         true,
-			"plug-static":  map[string]interface{}{"workshop-target": "/opt"},
+			"plug-static":  map[string]any{"workshop-target": "/opt"},
 			"slot-dynamic": dynamic,
 		},
 	})
@@ -719,10 +719,10 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 		Auto:             true,
 		Interface:        "mount",
 		Undesired:        false,
-		StaticPlugAttrs:  map[string]interface{}{"workshop-target": "/opt"},
-		DynamicPlugAttrs: map[string]interface{}{},
-		StaticSlotAttrs:  map[string]interface{}{},
-		DynamicSlotAttrs: map[string]interface{}{"host-source": newSource}})
+		StaticPlugAttrs:  map[string]any{"workshop-target": "/opt"},
+		DynamicPlugAttrs: map[string]any{},
+		StaticSlotAttrs:  map[string]any{},
+		DynamicSlotAttrs: map[string]any{"host-source": newSource}})
 	c.Assert(conns, check.HasLen, 1)
 }
 
@@ -765,10 +765,10 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 		Auto:             true,
 		Interface:        "mount",
 		Undesired:        false,
-		StaticPlugAttrs:  map[string]interface{}{"workshop-target": "/opt"},
-		DynamicPlugAttrs: map[string]interface{}{},
-		StaticSlotAttrs:  map[string]interface{}{},
-		DynamicSlotAttrs: map[string]interface{}{"host-source": newSource}})
+		StaticPlugAttrs:  map[string]any{"workshop-target": "/opt"},
+		DynamicPlugAttrs: map[string]any{},
+		StaticSlotAttrs:  map[string]any{},
+		DynamicSlotAttrs: map[string]any{"host-source": newSource}})
 	c.Assert(conns, check.HasLen, 1)
 }
 
@@ -1009,12 +1009,12 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	}
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		connRef.ID(): map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		connRef.ID(): map[string]any{
 			"interface":    "mock-network",
 			"auto":         true,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"test-dynamic-attr": "new-dynamic-value"},
 		},
 	})
 	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
@@ -1036,7 +1036,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 
-	var stateConns map[string]interface{}
+	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 0)
 
@@ -1062,11 +1062,11 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	var stateConns map[string]interface{}
+	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 0)
 
-	var attrs map[string]interface{}
+	var attrs map[string]any
 	c.Assert(chg.Get("remounts", &attrs), check.IsNil)
 	c.Assert(attrs, check.HasLen, 1)
 	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount"],
@@ -1092,11 +1092,11 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectIgnoresAutoConnections(c *che
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	var stateConns map[string]interface{}
+	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 0)
 
-	var attrs map[string]interface{}
+	var attrs map[string]any
 	c.Assert(chg.Get("remounts", &attrs), check.NotNil)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
@@ -1177,12 +1177,12 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 	}
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		connRef.ID(): map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		connRef.ID(): map[string]any{
 			"interface":    "mock-network",
 			"auto":         true,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"test-dynamic-attr": "new-dynamic-value"},
 		},
 	})
 	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
@@ -1204,7 +1204,7 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 1)
 	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 
-	var stateConns map[string]interface{}
+	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 1)
 
@@ -1225,11 +1225,11 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnectManualRestored(c *check.C
 	}
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		connRef.ID(): map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		connRef.ID(): map[string]any{
 			"interface":    "mock-network",
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"test-dynamic-attr": "new-dynamic-value"},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"test-dynamic-attr": "new-dynamic-value"},
 		},
 	})
 	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
@@ -1251,7 +1251,7 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnectManualRestored(c *check.C
 	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 1)
 	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
 
-	var stateConns map[string]interface{}
+	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 1)
 
@@ -1286,12 +1286,12 @@ func (s *interfaceHandlersSuite) TestDisconnectSuccess(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
 			"interface":    "mock-network",
 			"auto":         false,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{},
 		},
 	})
 	s.state.Unlock()
@@ -1327,12 +1327,12 @@ func (s *interfaceHandlersSuite) TestDisconnectAuto(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	connRefKey := "42424242/ws/consumer:plug 42424242/ws/producer:slot"
-	s.state.Set("conns", map[string]interface{}{
-		connRefKey: map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		connRefKey: map[string]any{
 			"interface":    "mock-network",
 			"auto":         true,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{},
 		},
 	})
 	s.state.Unlock()
@@ -1373,12 +1373,12 @@ func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	connRefKey := "42424242/ws/consumer:plug 42424242/ws/producer:slot"
-	s.state.Set("conns", map[string]interface{}{
-		connRefKey: map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		connRefKey: map[string]any{
 			"interface":    "mock-network",
 			"auto":         true,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{},
 		},
 	})
 	s.state.Unlock()
@@ -1417,12 +1417,12 @@ func (s *interfaceHandlersSuite) TestUndoDisconnect(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
 			"interface":    "mock-network",
 			"auto":         false,
-			"plug-static":  map[string]interface{}{"attribute": "one"},
-			"plug-dynamic": map[string]interface{}{"bind": "42424242/ws/consumer:plug2 42424242/ws/producer:slot"},
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"bind": "42424242/ws/consumer:plug2 42424242/ws/producer:slot"},
 		},
 	})
 	s.state.Unlock()
@@ -1466,8 +1466,8 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectUndesiredSuccess(c *check.C) 
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
-	conn := map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+	conn := map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
 			"interface": "mock-network",
 			"auto":      true,
 			"undesired": true,
@@ -1505,7 +1505,7 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectUndesiredSuccess(c *check.C) 
 	c.Assert(err, check.IsNil)
 	c.Assert(prods, check.HasLen, 0)
 
-	conns := map[string]interface{}{}
+	conns := map[string]any{}
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.DeepEquals, conn)
 
@@ -1625,7 +1625,7 @@ func (s *interfaceHandlersSuite) TestConnectSetsPlugDynamicAttrs(c *check.C) {
 	chg := s.connectChange("ws", false, true)
 	s.state.Lock()
 	tsk := chg.Tasks()[0]
-	tsk.Set("plug-dynamic", map[string]interface{}{"dynamic": "value"})
+	tsk.Set("plug-dynamic", map[string]any{"dynamic": "value"})
 	tsk.Set("delayed-setup-profile", false)
 	s.state.Unlock()
 
@@ -1691,10 +1691,10 @@ func (s *interfaceHandlersSuite) TestConnectAuto(c *check.C) {
 		"42424242/ws/consumer:plug 42424242/ws/producer:slot": {
 			Auto:             true,
 			Interface:        "mock-network",
-			StaticPlugAttrs:  map[string]interface{}{"attribute": "one"},
-			DynamicPlugAttrs: map[string]interface{}{},
-			StaticSlotAttrs:  map[string]interface{}{},
-			DynamicSlotAttrs: map[string]interface{}{},
+			StaticPlugAttrs:  map[string]any{"attribute": "one"},
+			DynamicPlugAttrs: map[string]any{},
+			StaticSlotAttrs:  map[string]any{},
+			DynamicSlotAttrs: map[string]any{},
 		},
 	})
 }
@@ -1707,8 +1707,8 @@ func (s *interfaceHandlersSuite) TestUndoConnectUndesired(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
 			"auto":      true,
 			"interface": "mock-network",
 			"undesired": true,
@@ -1787,23 +1787,23 @@ func (s *interfaceHandlersSuite) TestDiscardConnsSuccess(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
 			"auto":      true,
 			"interface": "mock-network",
 			"undesired": true,
 		},
-		"42424242/ws-1/consumer:plug 42424242/ws-1/producer:slot": map[string]interface{}{
+		"42424242/ws-1/consumer:plug 42424242/ws-1/producer:slot": map[string]any{
 			"auto":      true,
 			"interface": "mock-network",
 			"undesired": true,
 		},
-		"other/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+		"other/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
 			"auto":      true,
 			"interface": "mock-network",
 			"undesired": true,
 		},
-		"other/ws/consumer:plug other/ws/producer:slot": map[string]interface{}{
+		"other/ws/consumer:plug other/ws/producer:slot": map[string]any{
 			"auto":      true,
 			"interface": "mock-network",
 			"undesired": true,
@@ -1858,13 +1858,13 @@ func (s *interfaceHandlersSuite) TestUndoDiscardConnsSuccess(c *check.C) {
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	s.state.Lock()
-	s.state.Set("conns", map[string]interface{}{
-		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
 			"auto":      true,
 			"interface": "mock-network",
 			"undesired": true,
 		},
-		"other/ws/consumer:plug 42424242/ws/producer:slot": map[string]interface{}{
+		"other/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
 			"auto":      true,
 			"interface": "mock-network",
 			"undesired": true,

--- a/internal/overlord/ifacestate/helpers.go
+++ b/internal/overlord/ifacestate/helpers.go
@@ -101,10 +101,10 @@ func getConns(st *state.State) (conns map[string]*schema.ConnState, err error) {
 		if err != nil {
 			return nil, err
 		}
-		cstate.StaticSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticSlotAttrs).(map[string]interface{})
-		cstate.DynamicSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicSlotAttrs).(map[string]interface{})
-		cstate.StaticPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticPlugAttrs).(map[string]interface{})
-		cstate.DynamicPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicPlugAttrs).(map[string]interface{})
+		cstate.StaticSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticSlotAttrs).(map[string]any)
+		cstate.DynamicSlotAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicSlotAttrs).(map[string]any)
+		cstate.StaticPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.StaticPlugAttrs).(map[string]any)
+		cstate.DynamicPlugAttrs = utils.NormalizeInterfaceAttributes(cstate.DynamicPlugAttrs).(map[string]any)
 		remapped[cref.ID()] = cstate
 	}
 	return remapped, nil

--- a/internal/overlord/ifacestate/helpers_test.go
+++ b/internal/overlord/ifacestate/helpers_test.go
@@ -102,11 +102,11 @@ func (s *helpersSuite) TestAutoConnectChecker(c *check.C) {
 func (s *helpersSuite) TestGetConns(c *check.C) {
 	s.st.Lock()
 	defer s.st.Unlock()
-	s.st.Set("conns", map[string]interface{}{
-		"42424242/ws/app:mount 42424242/ws/core:mount": map[string]interface{}{
+	s.st.Set("conns", map[string]any{
+		"42424242/ws/app:mount 42424242/ws/core:mount": map[string]any{
 			"auto":      true,
 			"interface": "mount",
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"number": int(78),
 			},
 		},
@@ -131,11 +131,11 @@ func (s *helpersSuite) TestSetConns(c *check.C) {
 	}
 
 	ifacestate.SetConns(s.st, conns)
-	var readconns map[string]interface{}
+	var readconns map[string]any
 	err := s.st.Get("conns", &readconns)
 	c.Assert(err, check.IsNil)
-	c.Assert(readconns, check.DeepEquals, map[string]interface{}{
-		"42424242/ws/app:mount 42424242/ws/core:mount": map[string]interface{}{
+	c.Assert(readconns, check.DeepEquals, map[string]any{
+		"42424242/ws/app:mount 42424242/ws/core:mount": map[string]any{
 			"auto":      true,
 			"interface": "mount",
 		}})

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -71,10 +71,10 @@ type ConnectionState struct {
 	// Undesired indicates whether the connection, otherwise established
 	// automatically, was explicitly disconnected
 	Undesired        bool
-	StaticPlugAttrs  map[string]interface{}
-	DynamicPlugAttrs map[string]interface{}
-	StaticSlotAttrs  map[string]interface{}
-	DynamicSlotAttrs map[string]interface{}
+	StaticPlugAttrs  map[string]any
+	DynamicPlugAttrs map[string]any
+	StaticSlotAttrs  map[string]any
+	DynamicSlotAttrs map[string]any
 }
 
 // Active returns true if connection is not undesired and not removed by

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -175,14 +175,14 @@ plugs:
 
 	s.state.Lock()
 	key := fmt.Sprintf("%s/ws/consumer:plug %s/ws/system:mount", s.prj.ProjectId, s.prj.ProjectId)
-	s.state.Set("conns", map[string]interface{}{
-		key: map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		key: map[string]any{
 			"interface": "mount",
-			"plug-static": map[string]interface{}{
+			"plug-static": map[string]any{
 				"mount": "foo",
 				"attr":  "stored-value",
 			},
-			"slot-static": map[string]interface{}{
+			"slot-static": map[string]any{
 				"mount": "foo",
 				"attr":  "stored-value",
 			},
@@ -206,12 +206,12 @@ plugs:
 	conn, err := repo.Connection(cref)
 	c.Assert(err, check.IsNil)
 	c.Assert(conn.Plug.Name(), check.Equals, "plug")
-	c.Assert(conn.Plug.StaticAttrs(), check.DeepEquals, map[string]interface{}{
+	c.Assert(conn.Plug.StaticAttrs(), check.DeepEquals, map[string]any{
 		"mount": "foo",
 		"attr":  "stored-value",
 	})
 	c.Assert(conn.Slot.Name(), check.Equals, "mount")
-	c.Assert(conn.Slot.StaticAttrs(), check.DeepEquals, map[string]interface{}{
+	c.Assert(conn.Slot.StaticAttrs(), check.DeepEquals, map[string]any{
 		"mount": "foo",
 		"attr":  "stored-value",
 	})
@@ -244,8 +244,8 @@ slots:
 
 	s.state.Lock()
 	key := fmt.Sprintf("%s/ws/consumer:plug %s/core/producer:slot", s.prj.ProjectId, s.prj.ProjectId)
-	s.state.Set("conns", map[string]interface{}{
-		key: map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		key: map[string]any{
 			"interface": "test",
 			"auto":      true,
 			"undesired": true,
@@ -288,8 +288,8 @@ slots:
 	s.state.Lock()
 	key := fmt.Sprintf("%s/ws/consumer:plug-1 %s/core/producer:slot-1", s.prj.ProjectId, s.prj.ProjectId)
 
-	s.state.Set("conns", map[string]interface{}{
-		key: map[string]interface{}{
+	s.state.Set("conns", map[string]any{
+		key: map[string]any{
 			"interface": "test",
 			"auto":      true,
 		},
@@ -309,16 +309,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *check.C) {
 		"pid/ws/consumer:plug pid/ws/producer:slot": {
 			Interface: "test",
 			Auto:      true,
-			StaticPlugAttrs: map[string]interface{}{
+			StaticPlugAttrs: map[string]any{
 				"attr1": "value1",
 			},
-			DynamicPlugAttrs: map[string]interface{}{
+			DynamicPlugAttrs: map[string]any{
 				"dynamic-number": int64(7),
 			},
-			StaticSlotAttrs: map[string]interface{}{
+			StaticSlotAttrs: map[string]any{
 				"attr2": "value2",
 			},
-			DynamicSlotAttrs: map[string]interface{}{
+			DynamicSlotAttrs: map[string]any{
 				"other-number": int64(9),
 			},
 		}})
@@ -331,16 +331,16 @@ func (s *interfaceManagerSuite) TestConnectionStatesUndesired(c *check.C) {
 			Interface: "test",
 			Auto:      true,
 			Undesired: true,
-			StaticPlugAttrs: map[string]interface{}{
+			StaticPlugAttrs: map[string]any{
 				"attr1": "value1",
 			},
-			DynamicPlugAttrs: map[string]interface{}{
+			DynamicPlugAttrs: map[string]any{
 				"dynamic-number": int64(7),
 			},
-			StaticSlotAttrs: map[string]interface{}{
+			StaticSlotAttrs: map[string]any{
 				"attr2": "value2",
 			},
-			DynamicSlotAttrs: map[string]interface{}{
+			DynamicSlotAttrs: map[string]any{
 				"other-number": int64(9),
 			},
 		}})
@@ -381,8 +381,8 @@ slots:
 	c.Assert(slot, check.NotNil)
 	plug := consumer.Plugs["plug"]
 	c.Assert(plug, check.NotNil)
-	dynamicPlugAttrs := map[string]interface{}{"dynamic-number": 7}
-	dynamicSlotAttrs := map[string]interface{}{"other-number": 9}
+	dynamicPlugAttrs := map[string]any{"dynamic-number": 7}
+	dynamicSlotAttrs := map[string]any{"other-number": 9}
 	// create connection in conns state
 	conn := &interfaces.Connection{
 		Plug: interfaces.NewConnectedPlug(plug, nil, dynamicPlugAttrs),

--- a/internal/overlord/ifacestate/request.go
+++ b/internal/overlord/ifacestate/request.go
@@ -64,7 +64,7 @@ func Connect(st *state.State, plugW *workshop.Workshop, slotW *workshop.Workshop
 		slave.Set("plug", p)
 		slave.Set("delayed-setup-profile", true)
 
-		slave.Set("plug-dynamic", map[string]interface{}{"bind": bref.ID()})
+		slave.Set("plug-dynamic", map[string]any{"bind": bref.ID()})
 
 		slave.WaitFor(prev)
 		prev = slave

--- a/internal/overlord/ifacestate/schema/schema.go
+++ b/internal/overlord/ifacestate/schema/schema.go
@@ -26,9 +26,9 @@ type ConnState struct {
 	Interface string `json:"interface,omitempty" yaml:"interface"`
 	// Undesired tracks connections that were manually disconnected after being auto-connected,
 	// so that they are not automatically reconnected again in the future.
-	Undesired        bool                   `json:"undesired,omitempty" yaml:"undesired"`
-	StaticPlugAttrs  map[string]interface{} `json:"plug-static,omitempty" yaml:"plug-static,omitempty"`
-	DynamicPlugAttrs map[string]interface{} `json:"plug-dynamic,omitempty" yaml:"plug-dynamic,omitempty"`
-	StaticSlotAttrs  map[string]interface{} `json:"slot-static,omitempty" yaml:"slot-static,omitempty"`
-	DynamicSlotAttrs map[string]interface{} `json:"slot-dynamic,omitempty" yaml:"slot-dynamic,omitempty"`
+	Undesired        bool           `json:"undesired,omitempty" yaml:"undesired"`
+	StaticPlugAttrs  map[string]any `json:"plug-static,omitempty" yaml:"plug-static,omitempty"`
+	DynamicPlugAttrs map[string]any `json:"plug-dynamic,omitempty" yaml:"plug-dynamic,omitempty"`
+	StaticSlotAttrs  map[string]any `json:"slot-static,omitempty" yaml:"slot-static,omitempty"`
+	DynamicSlotAttrs map[string]any `json:"slot-dynamic,omitempty" yaml:"slot-dynamic,omitempty"`
 }

--- a/internal/overlord/overlord_test.go
+++ b/internal/overlord/overlord_test.go
@@ -125,13 +125,13 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	d, err := state.MarshalJSON()
 	c.Assert(err, IsNil)
 
-	var got, expected map[string]interface{}
+	var got, expected map[string]any
 	err = json.Unmarshal(d, &got)
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(fakeState, &expected)
 	c.Assert(err, IsNil)
 
-	data, _ := got["data"].(map[string]interface{})
+	data, _ := got["data"].(map[string]any)
 	c.Assert(data, NotNil)
 
 	c.Check(got, DeepEquals, expected)

--- a/internal/overlord/patch/patch_test.go
+++ b/internal/overlord/patch/patch_test.go
@@ -343,7 +343,7 @@ func (s *patchSuite) testMaybeResetPatchLevel6(c *C, snapdVersion, lastVersion s
 	defer st.Unlock()
 	var level, sublevel int
 	var ver string
-	var lastRefresh interface{}
+	var lastRefresh any
 	c.Assert(st.Get("patch-level", &level), IsNil)
 	c.Assert(st.Get("patch-sublevel", &sublevel), IsNil)
 	c.Assert(st.Get("patch-sublevel-last-version", &ver), IsNil)

--- a/internal/overlord/state/change.go
+++ b/internal/overlord/state/change.go
@@ -259,14 +259,14 @@ func (c *Change) Summary() string {
 
 // Set associates value with key for future consulting by managers.
 // The provided value must properly marshal and unmarshal with encoding/json.
-func (c *Change) Set(key string, value interface{}) {
+func (c *Change) Set(key string, value any) {
 	c.state.writing()
 	c.data.set(key, value)
 }
 
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
-func (c *Change) Get(key string, value interface{}) error {
+func (c *Change) Get(key string, value any) error {
 	c.state.reading()
 	return c.data.get(key, value)
 }

--- a/internal/overlord/state/state.go
+++ b/internal/overlord/state/state.go
@@ -43,7 +43,7 @@ type Backend interface {
 
 type customData map[string]*json.RawMessage
 
-func (data customData) get(key string, value interface{}) error {
+func (data customData) get(key string, value any) error {
 	entryJSON := data[key]
 	if entryJSON == nil {
 		return &NoStateError{Key: key}
@@ -59,7 +59,7 @@ func (data customData) has(key string) bool {
 	return data[key] != nil
 }
 
-func (data customData) set(key string, value interface{}) {
+func (data customData) set(key string, value any) {
 	if value == nil {
 		delete(data, key)
 		return
@@ -96,7 +96,7 @@ type State struct {
 
 	modified bool
 
-	cache map[interface{}]interface{}
+	cache map[any]any
 
 	pendingChangeByAttr map[string]func(*Change) bool
 }
@@ -110,7 +110,7 @@ func New(backend Backend) *State {
 		tasks:               make(map[string]*Task),
 		warnings:            make(map[string]*Warning),
 		modified:            true,
-		cache:               make(map[interface{}]interface{}),
+		cache:               make(map[any]any),
 		pendingChangeByAttr: make(map[string]func(*Change) bool),
 	}
 }
@@ -269,7 +269,7 @@ func (e *NoStateError) Is(err error) bool {
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
 // It returns ErrNoState if there is no entry for key.
-func (s *State) Get(key string, value interface{}) error {
+func (s *State) Get(key string, value any) error {
 	s.reading()
 	return s.data.get(key, value)
 }
@@ -282,21 +282,21 @@ func (s *State) Has(key string) bool {
 
 // Set associates value with key for future consulting by managers.
 // The provided value must properly marshal and unmarshal with encoding/json.
-func (s *State) Set(key string, value interface{}) {
+func (s *State) Set(key string, value any) {
 	s.writing()
 	s.data.set(key, value)
 }
 
 // Cached returns the cached value associated with the provided key.
 // It returns nil if there is no entry for key.
-func (s *State) Cached(key interface{}) interface{} {
+func (s *State) Cached(key any) any {
 	s.reading()
 	return s.cache[key]
 }
 
 // Cache associates value with key for future consulting by managers.
 // The cached value is not persisted.
-func (s *State) Cache(key, value interface{}) {
+func (s *State) Cache(key, value any) {
 	s.reading() // Doesn't touch persisted data.
 	if value == nil {
 		delete(s.cache, key)
@@ -475,7 +475,7 @@ NextChange:
 }
 
 // GetMaybeTimings implements timings.GetSaver
-func (s *State) GetMaybeTimings(timings interface{}) error {
+func (s *State) GetMaybeTimings(timings any) error {
 	if err := s.Get("timings", timings); err != nil && !errors.Is(err, ErrNoState) {
 		return err
 	}
@@ -483,7 +483,7 @@ func (s *State) GetMaybeTimings(timings interface{}) error {
 }
 
 // SaveTimings implements timings.GetSaver
-func (s *State) SaveTimings(timings interface{}) {
+func (s *State) SaveTimings(timings any) {
 	s.Set("timings", timings)
 }
 
@@ -499,7 +499,7 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 	}
 	s.backend = backend
 	s.modified = false
-	s.cache = make(map[interface{}]interface{})
+	s.cache = make(map[any]any)
 	s.pendingChangeByAttr = make(map[string]func(*Change) bool)
 	return s, err
 }

--- a/internal/overlord/state/task.go
+++ b/internal/overlord/state/task.go
@@ -416,7 +416,7 @@ func MockTime(now time.Time) (restore func()) {
 	return func() { timeNow = time.Now }
 }
 
-func (t *Task) addLog(kind, format string, args []interface{}) {
+func (t *Task) addLog(kind, format string, args []any) {
 	if len(t.log) > 9 {
 		copy(t.log, t.log[len(t.log)-9:])
 		t.log = t.log[:9]
@@ -445,13 +445,13 @@ func (t *Task) Log() []string {
 }
 
 // Logf logs information about the progress of the task.
-func (t *Task) Logf(format string, args ...interface{}) {
+func (t *Task) Logf(format string, args ...any) {
 	t.state.writing()
 	t.addLog(LogInfo, format, args)
 }
 
 // Errorf logs error information about the progress of the task.
-func (t *Task) Errorf(format string, args ...interface{}) {
+func (t *Task) Errorf(format string, args ...any) {
 	t.state.writing()
 	t.addLog(LogError, format, args)
 }
@@ -464,14 +464,14 @@ func (t *Task) CleanLog() {
 
 // Set associates value with key for future consulting by managers.
 // The provided value must properly marshal and unmarshal with encoding/json.
-func (t *Task) Set(key string, value interface{}) {
+func (t *Task) Set(key string, value any) {
 	t.state.writing()
 	t.data.set(key, value)
 }
 
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
-func (t *Task) Get(key string, value interface{}) error {
+func (t *Task) Get(key string, value any) error {
 	t.state.reading()
 	return t.data.get(key, value)
 }

--- a/internal/overlord/state/warning.go
+++ b/internal/overlord/state/warning.go
@@ -177,7 +177,7 @@ func (s *State) unflattenWarnings(flat []*Warning) {
 // message it'll be added (with its firstAdded and lastAdded set to the
 // current time), otherwise the existing one will have its lastAdded
 // updated.
-func (s *State) Warnf(template string, args ...interface{}) {
+func (s *State) Warnf(template string, args ...any) {
 	var message string
 	if len(args) > 0 {
 		message = fmt.Sprintf(template, args...)

--- a/internal/sdk/revision.go
+++ b/internal/sdk/revision.go
@@ -66,7 +66,7 @@ func (r Revision) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + r.String() + `"`), nil
 }
 
-func (r *Revision) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *Revision) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -74,7 +74,7 @@ func (r *Revision) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return r.UnmarshalJSON([]byte(`"` + s + `"`))
 }
 
-func (r Revision) MarshalYAML() (interface{}, error) {
+func (r Revision) MarshalYAML() (any, error) {
 	return r.String(), nil
 }
 
@@ -117,7 +117,7 @@ func ParseRevision(s string) (Revision, error) {
 // R returns a Revision given an int or a string.
 // Providing an invalid revision type or value causes a runtime panic.
 // See ParseRevision for a polite function that does not panic.
-func R(r interface{}) Revision {
+func R(r any) Revision {
 	switch r := r.(type) {
 	case string:
 		revision, err := ParseRevision(r)

--- a/internal/sdk/revision_test.go
+++ b/internal/sdk/revision_test.go
@@ -144,7 +144,7 @@ func (s revisionSuite) TestParseRevision(c *C) {
 
 func (s *revisionSuite) TestR(c *C) {
 	type testItem struct {
-		v interface{}
+		v any
 		n int
 		e string
 	}

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -106,16 +106,16 @@ func SetupId(setup Setup) Id {
 }
 
 type sdkYaml struct {
-	Name        string                 `yaml:"name"`
-	Base        string                 `yaml:"base"`
-	Arch        string                 `yaml:"architecture"`
-	Version     string                 `yaml:"version,omitempty"`
-	Summary     string                 `yaml:"summary"`
-	Description string                 `yaml:"description"`
-	Type        string                 `yaml:"type"`
-	BuildTime   *time.Time             `yaml:"sdkcraft-started-at,omitempty"`
-	Plugs       map[string]interface{} `yaml:"plugs,omitempty"`
-	Slots       map[string]interface{} `yaml:"slots,omitempty"`
+	Name        string         `yaml:"name"`
+	Base        string         `yaml:"base"`
+	Arch        string         `yaml:"architecture"`
+	Version     string         `yaml:"version,omitempty"`
+	Summary     string         `yaml:"summary"`
+	Description string         `yaml:"description"`
+	Type        string         `yaml:"type"`
+	BuildTime   *time.Time     `yaml:"sdkcraft-started-at,omitempty"`
+	Plugs       map[string]any `yaml:"plugs,omitempty"`
+	Slots       map[string]any `yaml:"slots,omitempty"`
 }
 
 type Type string
@@ -184,7 +184,7 @@ func (i *Info) SetupPlugBinds(binds map[string]PlugRef) error {
 }
 
 // Adds slots defined for this SDK in a workshop file.
-func (i *Info) SetupWorkshopSlots(slots map[string]interface{}) error {
+func (i *Info) SetupWorkshopSlots(slots map[string]any) error {
 	for name, data := range slots {
 		if _, exist := i.Slots[name]; exist {
 			return fmt.Errorf("cannot add slot %q to %q SDK: already exists", name, i.Name)
@@ -207,7 +207,7 @@ func (i *Info) SetupWorkshopSlots(slots map[string]interface{}) error {
 }
 
 // Adds slots defined for this SDK in a workshop file.
-func (i *Info) SetupWorkshopPlugs(plugs map[string]interface{}) error {
+func (i *Info) SetupWorkshopPlugs(plugs map[string]any) error {
 	for name, data := range plugs {
 		if _, exist := i.Plugs[name]; exist {
 			return fmt.Errorf("cannot add plug %q to %q SDK: already exists", name, i.Name)
@@ -326,14 +326,14 @@ func setSlotsFromSdkYaml(y *sdkYaml, sdk *Info) error {
 	return nil
 }
 
-func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, label string, attrs map[string]interface{}, err error) {
+func convertToSlotOrPlugData(plugOrSlot, name string, data any) (iface, label string, attrs map[string]any, err error) {
 	iface = name
 	switch data := data.(type) {
 	case string:
 		return data, "", nil, nil
 	case nil:
 		return name, "", nil, nil
-	case map[string]interface{}:
+	case map[string]any:
 		for key, valueData := range data {
 			if strings.HasPrefix(key, "$") {
 				err := fmt.Errorf("%s %q uses reserved attribute %q", plugOrSlot, name, key)
@@ -360,7 +360,7 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, 
 				label = value
 			default:
 				if attrs == nil {
-					attrs = make(map[string]interface{})
+					attrs = make(map[string]any)
 				}
 				value, err := metautil.NormalizeValue(valueData)
 				if err != nil {
@@ -382,7 +382,7 @@ type SlotInfo struct {
 
 	Name      string
 	Interface string
-	Attrs     map[string]interface{}
+	Attrs     map[string]any
 	Label     string
 }
 
@@ -400,7 +400,7 @@ func (e *AttributeNotFoundError) Error() string {
 
 }
 
-func (slot *SlotInfo) Attr(key string, val interface{}) error {
+func (slot *SlotInfo) Attr(key string, val any) error {
 	v, ok := slot.Lookup(key)
 	if !ok {
 		ref := slot.Ref()
@@ -413,7 +413,7 @@ func (slot *SlotInfo) Attr(key string, val interface{}) error {
 	return nil
 }
 
-func (slot *SlotInfo) Lookup(key string) (interface{}, bool) {
+func (slot *SlotInfo) Lookup(key string) (any, bool) {
 	return metautil.LookupAttr(slot.Attrs, nil, key)
 }
 
@@ -460,11 +460,11 @@ type PlugInfo struct {
 
 	Name      string
 	Interface string
-	Attrs     map[string]interface{}
+	Attrs     map[string]any
 	Label     string
 }
 
-func (plug *PlugInfo) Attr(key string, val interface{}) error {
+func (plug *PlugInfo) Attr(key string, val any) error {
 	v, ok := plug.Lookup(key)
 	if !ok {
 		ref := plug.Ref()
@@ -477,7 +477,7 @@ func (plug *PlugInfo) Attr(key string, val interface{}) error {
 	return nil
 }
 
-func (plug *PlugInfo) Lookup(key string) (interface{}, bool) {
+func (plug *PlugInfo) Lookup(key string) (any, bool) {
 	return metautil.LookupAttr(plug.Attrs, nil, key)
 }
 

--- a/internal/sdk/sdk_test.go
+++ b/internal/sdk/sdk_test.go
@@ -74,7 +74,7 @@ plugs:
 		Sdk:       info,
 		Name:      "training",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"workshop-target": "/project"},
+		Attrs:     map[string]any{"workshop-target": "/project"},
 	})
 }
 
@@ -95,7 +95,7 @@ slots:
 		Sdk:       info,
 		Name:      "training",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"workshop-source": "/project"},
+		Attrs:     map[string]any{"workshop-source": "/project"},
 	})
 }
 
@@ -119,10 +119,10 @@ plugs:
 		Sdk:       info,
 		Name:      "iface",
 		Interface: "complex",
-		Attrs: map[string]interface{}{
+		Attrs: map[string]any{
 			"i": int64(3),
-			"l": []interface{}{int64(1), int64(2), int64(3)},
-			"m": map[string]interface{}{"a": "A", "b": "B"},
+			"l": []any{int64(1), int64(2), int64(3)},
+			"m": map[string]any{"a": "A", "b": "B"},
 		},
 	})
 }
@@ -157,7 +157,7 @@ plugs:
 		Sdk:       info,
 		Name:      "mount",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Attrs:     map[string]any{"ipv6-aware": true},
 	})
 }
 
@@ -327,7 +327,7 @@ slots:
 		Sdk:       info,
 		Name:      "net",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Attrs:     map[string]any{"ipv6-aware": true},
 	})
 }
 
@@ -350,10 +350,10 @@ slots:
 		Sdk:       info,
 		Name:      "iface",
 		Interface: "complex",
-		Attrs: map[string]interface{}{
+		Attrs: map[string]any{
 			"i": int64(3),
-			"l": []interface{}{int64(1), int64(2)},
-			"m": map[string]interface{}{"a": "A"},
+			"l": []any{int64(1), int64(2)},
+			"m": map[string]any{"a": "A"},
 		},
 	})
 }
@@ -388,7 +388,7 @@ slots:
 		Sdk:       info,
 		Name:      "mount",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Attrs:     map[string]any{"ipv6-aware": true},
 	})
 }
 
@@ -508,10 +508,10 @@ slots:
 		Sdk:       info,
 		Name:      "training",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"workshop-source": "/project"},
+		Attrs:     map[string]any{"workshop-source": "/project"},
 	})
-	slots := map[string]interface{}{
-		"cache": map[string]interface{}{
+	slots := map[string]any{
+		"cache": map[string]any{
 			"interface":       "mount",
 			"workshop-source": "/var/cache",
 		},
@@ -524,7 +524,7 @@ slots:
 		Sdk:       info,
 		Name:      "cache",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"workshop-source": "/var/cache"},
+		Attrs:     map[string]any{"workshop-source": "/var/cache"},
 	})
 }
 
@@ -545,10 +545,10 @@ slots:
 		Sdk:       info,
 		Name:      "training",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"workshop-source": "/project"},
+		Attrs:     map[string]any{"workshop-source": "/project"},
 	})
-	slots := map[string]interface{}{
-		"training": map[string]interface{}{
+	slots := map[string]any{
+		"training": map[string]any{
 			"workshop-source": "/data",
 		},
 	}
@@ -573,10 +573,10 @@ plugs:
 		Sdk:       info,
 		Name:      "training",
 		Interface: "mount",
-		Attrs:     map[string]interface{}{"workshop-target": "/project"},
+		Attrs:     map[string]any{"workshop-target": "/project"},
 	})
-	plugs := map[string]interface{}{
-		"training": map[string]interface{}{
+	plugs := map[string]any{
+		"training": map[string]any{
 			"workshop-target": "/data",
 		},
 	}

--- a/internal/testutil/base.go
+++ b/internal/testutil/base.go
@@ -48,7 +48,7 @@ func (s *BaseTest) AddCleanup(f func()) {
 }
 
 // Backup the specified list of elements before further mocking.
-func Backup(mockablesByPtr ...interface{}) (restore func()) {
+func Backup(mockablesByPtr ...any) (restore func()) {
 	backup := backupMockables(mockablesByPtr)
 
 	return func() {
@@ -59,7 +59,7 @@ func Backup(mockablesByPtr ...interface{}) (restore func()) {
 	}
 }
 
-func backupMockables(mockablesByPtr []interface{}) (backup []*reflect.Value) {
+func backupMockables(mockablesByPtr []any) (backup []*reflect.Value) {
 	backup = make([]*reflect.Value, len(mockablesByPtr))
 
 	for i, ptr := range mockablesByPtr {

--- a/internal/testutil/containschecker.go
+++ b/internal/testutil/containschecker.go
@@ -37,7 +37,7 @@ var Contains check.Checker = &containsChecker{
 	&check.CheckerInfo{Name: "Contains", Params: []string{"container", "elem"}},
 }
 
-func commonEquals(container, elem interface{}, result *bool, error *string) bool {
+func commonEquals(container, elem any, result *bool, error *string) bool {
 	containerV := reflect.ValueOf(container)
 	elemV := reflect.ValueOf(elem)
 	switch containerV.Kind() {
@@ -76,7 +76,7 @@ func commonEquals(container, elem interface{}, result *bool, error *string) bool
 	return false
 }
 
-func (c *containsChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *containsChecker) Check(params []any, names []string) (result bool, error string) {
 	defer func() {
 		if v := recover(); v != nil {
 			result = false
@@ -122,7 +122,7 @@ var DeepContains check.Checker = &deepContainsChecker{
 	&check.CheckerInfo{Name: "DeepContains", Params: []string{"container", "elem"}},
 }
 
-func (c *deepContainsChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *deepContainsChecker) Check(params []any, names []string) (result bool, error string) {
 	container := params[0]
 	elem := params[1]
 	if commonEquals(container, elem, &result, &error) {
@@ -162,7 +162,7 @@ var DeepUnsortedMatches check.Checker = &deepUnsortedMatchChecker{
 	&check.CheckerInfo{Name: "DeepUnsortedMatches", Params: []string{"container1", "container2"}},
 }
 
-func (c *deepUnsortedMatchChecker) Check(params []interface{}, _ []string) (bool, string) {
+func (c *deepUnsortedMatchChecker) Check(params []any, _ []string) (bool, string) {
 	container1 := reflect.ValueOf(params[0])
 	container2 := reflect.ValueOf(params[1])
 

--- a/internal/testutil/dircontentchecker.go
+++ b/internal/testutil/dircontentchecker.go
@@ -36,7 +36,7 @@ var DirEquals check.Checker = &dirContentChecker{
 	CheckerInfo: &check.CheckerInfo{Name: "DirEquals", Params: []string{"directory", "contents"}},
 }
 
-func (c *dirContentChecker) Check(params []interface{}, names []string) (bool, string) {
+func (c *dirContentChecker) Check(params []any, names []string) (bool, string) {
 	var infos []os.FileInfo
 	switch dir := params[0].(type) {
 	case string:
@@ -71,5 +71,5 @@ func (c *dirContentChecker) Check(params []interface{}, names []string) (bool, s
 		obtained = append(obtained, fmt.Sprintf("%s %s", info.Mode().String(), info.Name()))
 	}
 
-	return check.DeepEquals.Check([]interface{}{obtained, params[1]}, names)
+	return check.DeepEquals.Check([]any{obtained, params[1]}, names)
 }

--- a/internal/testutil/errorischecker.go
+++ b/internal/testutil/errorischecker.go
@@ -34,7 +34,7 @@ type errorIsChecker struct {
 	*check.CheckerInfo
 }
 
-func (*errorIsChecker) Check(params []interface{}, names []string) (result bool, errMsg string) {
+func (*errorIsChecker) Check(params []any, names []string) (result bool, errMsg string) {
 	if params[0] == nil {
 		return params[1] == nil, ""
 	}

--- a/internal/testutil/errorischecker_test.go
+++ b/internal/testutil/errorischecker_test.go
@@ -62,11 +62,11 @@ func (*errorIsCheckerSuite) TestErrorIsCheckFails(c *C) {
 }
 
 func (*errorIsCheckerSuite) TestErrorIsWithInvalidArguments(c *C) {
-	res, errMsg := ErrorIs.Check([]interface{}{"", errors.New("")}, []string{"error", "target"})
+	res, errMsg := ErrorIs.Check([]any{"", errors.New("")}, []string{"error", "target"})
 	c.Assert(res, Equals, false)
 	c.Assert(errMsg, Equals, "first argument must be an error")
 
-	res, errMsg = ErrorIs.Check([]interface{}{errors.New(""), ""}, []string{"error", "target"})
+	res, errMsg = ErrorIs.Check([]any{errors.New(""), ""}, []string{"error", "target"})
 	c.Assert(res, Equals, false)
 	c.Assert(errMsg, Equals, "second argument must be an error")
 }

--- a/internal/testutil/filecontentchecker.go
+++ b/internal/testutil/filecontentchecker.go
@@ -48,7 +48,7 @@ var FileMatches check.Checker = &fileContentChecker{
 	CheckerInfo: &check.CheckerInfo{Name: "FileMatches", Params: []string{"filename", "regex"}},
 }
 
-func (c *fileContentChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *fileContentChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "Filename must be a string"
@@ -67,7 +67,7 @@ func (c *fileContentChecker) Check(params []interface{}, names []string) (result
 	return fileContentCheck(filename, params[1], c.exact)
 }
 
-func fileContentCheck(filename string, content interface{}, exact bool) (result bool, error string) {
+func fileContentCheck(filename string, content any, exact bool) (result bool, error string) {
 	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return false, fmt.Sprintf("Cannot read file %q: %v", filename, err)

--- a/internal/testutil/filepresencechecker.go
+++ b/internal/testutil/filepresencechecker.go
@@ -38,7 +38,7 @@ var FileAbsent check.Checker = &filePresenceChecker{
 	present:     false,
 }
 
-func (c *filePresenceChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *filePresenceChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "filename must be a string"

--- a/internal/testutil/intcheckers.go
+++ b/internal/testutil/intcheckers.go
@@ -25,7 +25,7 @@ type intChecker struct {
 	rel string
 }
 
-func (checker *intChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (checker *intChecker) Check(params []any, names []string) (result bool, error string) {
 	a, ok := params[0].(int)
 	if !ok {
 		return false, "left-hand-side argument must be an int"

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -36,7 +36,7 @@ func testInfo(c *check.C, checker check.Checker, name string, paramNames []strin
 	}
 }
 
-func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...interface{}) {
+func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...any) {
 	info := checker.Info()
 	if len(params) != len(info.Params) {
 		c.Fatalf("unexpected param count in test; expected %d got %d", len(info.Params), len(params))

--- a/internal/timings/state.go
+++ b/internal/timings/state.go
@@ -64,7 +64,7 @@ var timeDuration = func(start, end time.Time) time.Duration {
 
 // flatten flattens nested measurements into a single list within rootTimingJson.NestedTimings
 // and calculates total duration.
-func (t *Timings) flatten() interface{} {
+func (t *Timings) flatten() any {
 	var hasChangeID, hasTaskID bool
 	if t.tags != nil {
 		_, hasChangeID = t.tags["change-id"]
@@ -119,9 +119,9 @@ func flattenRecursive(data *rootTimingsJSON, timings []*Span, nestLevel int, max
 type GetSaver interface {
 	// GetMaybeTimings gets the saved timings.
 	// It will not return an error if none were saved yet.
-	GetMaybeTimings(timings interface{}) error
+	GetMaybeTimings(timings any) error
 	// SaveTimings saves the given timings.
-	SaveTimings(timings interface{})
+	SaveTimings(timings any)
 }
 
 // Save appends Timings data to a timings list in the GetSaver (usually

--- a/internal/timings/timings_test.go
+++ b/internal/timings/timings_test.go
@@ -107,47 +107,47 @@ func (s *timingsSuite) TestSave(c *C) {
 		timing.Save(s.st)
 	}
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
 
-	c.Assert(stateTimings, DeepEquals, []interface{}{
-		map[string]interface{}{
-			"tags":       map[string]interface{}{"change": "12", "task": "3"},
+	c.Assert(stateTimings, DeepEquals, []any{
+		map[string]any{
+			"tags":       map[string]any{"change": "12", "task": "3"},
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "doing something-0",
 					"summary":  "...",
 					"duration": float64(1000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested measurement",
 					"summary":  "...",
 					"duration": float64(2000000)},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(2),
 					"label":    "nested more",
 					"summary":  "...",
 					"duration": float64(3000000)},
 			}},
-		map[string]interface{}{
-			"tags":       map[string]interface{}{"change": "12", "task": "3"},
+		map[string]any{
+			"tags":       map[string]any{"change": "12", "task": "3"},
 			"start-time": "2019-03-11T09:01:00.007Z",
 			"stop-time":  "2019-03-11T09:01:00.012Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "doing something-1",
 					"summary":  "...",
 					"duration": float64(4000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested measurement",
 					"summary":  "...",
 					"duration": float64(5000000)},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(2),
 					"label":    "nested more",
 					"summary":  "...",
@@ -164,7 +164,7 @@ func (s *timingsSuite) TestSaveNoTimings(c *C) {
 	timing := timings.New(nil)
 	timing.Save(s.st)
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	c.Assert(s.st.Get("timings", &stateTimings), testutil.ErrorIs, state.ErrNoState)
 }
 
@@ -181,26 +181,26 @@ func (s *timingsSuite) TestDuration(c *C) {
 	meas.Stop()
 	timing.Save(s.st)
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
 
-	c.Assert(stateTimings, DeepEquals, []interface{}{
-		map[string]interface{}{
+	c.Assert(stateTimings, DeepEquals, []any{
+		map[string]any{
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "foo",
 					"summary":  "...",
 					"duration": float64(5000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested",
 					"summary":  "...",
 					"duration": float64(1000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested sibling",
 					"summary":  "...",
@@ -209,7 +209,7 @@ func (s *timingsSuite) TestDuration(c *C) {
 			}}})
 }
 
-func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expected interface{}) {
+func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expected any) {
 	s.mockDurationThreshold(threshold)
 
 	s.st.Lock()
@@ -225,7 +225,7 @@ func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expe
 	meas.Stop()
 	timing.Save(s.st)
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	if expected == nil {
 		c.Assert(s.st.Get("timings", &stateTimings), testutil.ErrorIs, state.ErrNoState)
 		c.Assert(stateTimings, IsNil)
@@ -236,23 +236,23 @@ func (s *timingsSuite) testDurationThreshold(c *C, threshold time.Duration, expe
 }
 
 func (s *timingsSuite) TestDurationThresholdAll(c *C) {
-	s.testDurationThreshold(c, 0, []interface{}{
-		map[string]interface{}{
+	s.testDurationThreshold(c, 0, []any{
+		map[string]any{
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "main",
 					"summary":  "...",
 					"duration": float64(5000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested",
 					"summary":  "...",
 					"duration": float64(3000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(2),
 					"label":    "nested more",
 					"summary":  "...",
@@ -262,17 +262,17 @@ func (s *timingsSuite) TestDurationThresholdAll(c *C) {
 }
 
 func (s *timingsSuite) TestDurationThreshold(c *C) {
-	s.testDurationThreshold(c, 3000000, []interface{}{
-		map[string]interface{}{
+	s.testDurationThreshold(c, 3000000, []any{
+		map[string]any{
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "main",
 					"summary":  "...",
 					"duration": float64(5000000),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"level":    float64(1),
 					"label":    "nested",
 					"summary":  "...",
@@ -282,12 +282,12 @@ func (s *timingsSuite) TestDurationThreshold(c *C) {
 }
 
 func (s *timingsSuite) TestDurationThresholdRootOnly(c *C) {
-	s.testDurationThreshold(c, 4000000, []interface{}{
-		map[string]interface{}{
+	s.testDurationThreshold(c, 4000000, []any{
+		map[string]any{
 			"start-time": "2019-03-11T09:01:00.001Z",
 			"stop-time":  "2019-03-11T09:01:00.006Z",
-			"timings": []interface{}{
-				map[string]interface{}{
+			"timings": []any{
+				map[string]any{
 					"label":    "main",
 					"summary":  "...",
 					"duration": float64(5000000),
@@ -317,14 +317,14 @@ func (s *timingsSuite) TestPurgeOnSave(c *C) {
 		t.Save(s.st)
 	}
 
-	var stateTimings []interface{}
+	var stateTimings []any
 	c.Assert(s.st.Get("timings", &stateTimings), IsNil)
 
 	// excess timings got dropped
 	c.Assert(stateTimings, HasLen, 3)
-	c.Check(stateTimings[0].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "7"})
-	c.Check(stateTimings[1].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "8"})
-	c.Check(stateTimings[2].(map[string]interface{})["tags"], DeepEquals, map[string]interface{}{"number": "9"})
+	c.Check(stateTimings[0].(map[string]any)["tags"], DeepEquals, map[string]any{"number": "7"})
+	c.Check(stateTimings[1].(map[string]any)["tags"], DeepEquals, map[string]any{"number": "8"})
+	c.Check(stateTimings[2].(map[string]any)["tags"], DeepEquals, map[string]any{"number": "9"})
 }
 
 func (s *timingsSuite) TestGet(c *C) {

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -312,7 +312,7 @@ var (
 // looking for specific progress labels. NOTE: There is no guarantee that the
 // LXD's progress reporting formant won't change; this meta data parser is valid
 // for LXD 6.5.
-func handleImageUpdate(opmeta map[string]interface{}, imsize int) *downloadUpdate {
+func handleImageUpdate(opmeta map[string]any, imsize int) *downloadUpdate {
 	upd, ok := opmeta["download_progress"].(string)
 	if !ok {
 		return nil

--- a/internal/workshop/lxd/lxd_base_manager_test.go
+++ b/internal/workshop/lxd/lxd_base_manager_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (f *LxdBeTests) TestLaunchProgressReporter(c *check.C) {
-	metas := []map[string]interface{}{
+	metas := []map[string]any{
 		{"download_progress": "metadata: 100% (3.01GB/s)"},
 		{"download_progress": "rootfs: 65% (254.2Kb/s)"},
 		{"download_progress": "rootfs delta: 65% (254Kb/s)"},

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -151,7 +151,7 @@ func (w *Workshop) SdkInfo(ctx context.Context, sdkName string) (*sdk.Info, erro
 	}
 
 	binds := map[string]sdk.PlugRef{}
-	plugs := map[string]interface{}{}
+	plugs := map[string]any{}
 	for name, m := range w.File.Sdks[idx].Plugs {
 		if m.Bind == nil {
 			plugs[name] = m.Plug

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -43,7 +43,7 @@ func ProjectSdkPath(project, name string) string {
 
 type PlugOrBind struct {
 	Bind *PlugRef
-	Plug interface{}
+	Plug any
 }
 
 func (p *PlugOrBind) UnmarshalYAML(value *yaml.Node) error {
@@ -53,8 +53,8 @@ func (p *PlugOrBind) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	var plug struct {
-		Bind       *PlugRef               `yaml:"bind"`
-		Attributes map[string]interface{} `yaml:",inline"`
+		Bind       *PlugRef       `yaml:"bind"`
+		Attributes map[string]any `yaml:",inline"`
 	}
 	if err := value.Decode(&plug); err != nil {
 		return err
@@ -72,7 +72,7 @@ func (p *PlugOrBind) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-func (p PlugOrBind) MarshalYAML() (interface{}, error) {
+func (p PlugOrBind) MarshalYAML() (any, error) {
 	if p.Bind == nil {
 		return p.Plug, nil
 	}
@@ -85,7 +85,7 @@ func (p PlugOrBind) MarshalYAML() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return map[string]interface{}{"bind": bind}, nil
+	return map[string]any{"bind": bind}, nil
 }
 
 type PlugRef struct {
@@ -121,19 +121,19 @@ func (b *PlugRef) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-func (b PlugRef) MarshalYAML() (interface{}, error) {
+func (b PlugRef) MarshalYAML() (any, error) {
 	return fmt.Sprintf("%s:%s", b.Sdk, b.Name), nil
 }
 
 type SdkRecord struct {
-	Name    string                 `yaml:"name"`
-	Channel string                 `yaml:"channel,omitempty"`
-	Source  sdk.Source             `yaml:"source,omitempty"`
-	Plugs   map[string]PlugOrBind  `yaml:"plugs,omitempty"`
-	Slots   map[string]interface{} `yaml:"slots,omitempty"`
+	Name    string                `yaml:"name"`
+	Channel string                `yaml:"channel,omitempty"`
+	Source  sdk.Source            `yaml:"source,omitempty"`
+	Plugs   map[string]PlugOrBind `yaml:"plugs,omitempty"`
+	Slots   map[string]any        `yaml:"slots,omitempty"`
 }
 
-func (s SdkRecord) MarshalYAML() (interface{}, error) {
+func (s SdkRecord) MarshalYAML() (any, error) {
 	switch s.Source {
 	case sdk.TrySource:
 		s.Name = fmt.Sprintf("try-%s", s.Name)
@@ -199,7 +199,7 @@ func (a Action) String() string {
 	return script
 }
 
-func (a Action) MarshalYAML() (interface{}, error) {
+func (a Action) MarshalYAML() (any, error) {
 	node := &yaml.Node{}
 	err := node.Encode(a.String())
 	return node, err

--- a/internal/workshop/workshop_file_test.go
+++ b/internal/workshop/workshop_file_test.go
@@ -37,7 +37,7 @@ func (f *workshopFile) SetUpTest(c *check.C) {
 	}
 }
 
-func (f *workshopFile) createWFile(c *check.C, name, yaml string, checkArgs ...interface{}) {
+func (f *workshopFile) createWFile(c *check.C, name, yaml string, checkArgs ...any) {
 	path := workshop.Filepath(f.project.Path, name)
 
 	err := os.MkdirAll(filepath.Dir(path), os.ModePerm)
@@ -338,7 +338,7 @@ sdks:
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, check.DeepEquals, []workshop.SdkRecord{
 		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"db": {Plug: "tunnel"}, "tunnel": {}}},
-		{Name: "etl-sdk", Channel: "latest/stable", Slots: map[string]interface{}{"dashboard": "tunnel", "tunnel": nil}},
+		{Name: "etl-sdk", Channel: "latest/stable", Slots: map[string]any{"dashboard": "tunnel", "tunnel": nil}},
 	})
 }
 
@@ -385,7 +385,7 @@ sdks:
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, check.DeepEquals, []workshop.SdkRecord{
-		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"cache": {Plug: map[string]interface{}{"attr1": "val"}}}},
+		{Name: "data-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"cache": {Plug: map[string]any{"attr1": "val"}}}},
 		{Name: "etl-sdk", Channel: "latest/stable", Plugs: map[string]workshop.PlugOrBind{"data": {Bind: &workshop.PlugRef{Sdk: "data-sdk", Name: "aux"}}}},
 	})
 }
@@ -579,7 +579,7 @@ sdks:
 	file, err := f.project.Workshop("xbert-gpu")
 	c.Assert(err, check.IsNil)
 	c.Assert(file.Sdks, check.DeepEquals, []workshop.SdkRecord{
-		{Name: sdk.System.String(), Source: sdk.SystemSource, Slots: map[string]interface{}{"training-data": map[string]interface{}{"workshop-source": "relative/path"}}}})
+		{Name: sdk.System.String(), Source: sdk.SystemSource, Slots: map[string]any{"training-data": map[string]any{"workshop-source": "relative/path"}}}})
 }
 
 func (f *workshopFile) TestWorkshopConnectionsOK(c *check.C) {


### PR DESCRIPTION
# Description

`any` is a modern alias to `interface{}` as can be seeing in the [Go source code](https://cs.opensource.google/go/go/+/refs/tags/go1.23.0:src/builtin/builtin.go;l=97).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalize symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
