### PR TITLE
Fix issues with cached project IDs

### DIFF
--- a/internal/osutil/io.go
+++ b/internal/osutil/io.go
@@ -94,9 +94,18 @@ func NewAtomicFile(filename string, perm os.FileMode, flags AtomicWriteFlags, ui
 	// aa-enforce. Tools from this package enumerate all profiles by loading
 	// parsing any file found in /etc/apparmor.d/, skipping only very specific
 	// suffixes, such as the one we selected below.
-	tmp := filename + "." + randomString(12) + "~"
-
-	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
+	var tmp string
+	var fd *os.File
+	for range 10000 {
+		tmp = filename + "." + randomString(12) + "~"
+		fd, err = os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -182,7 +182,9 @@ func (t *ProjectTracker) Track(path string) (*Project, TrackResult, error) {
 
 	project, result, err := t.maybeFindProject(path, id)
 	if err == nil && project == nil {
-		return t.createProjectWithId(path, id)
+		// Ignore unrecognised project ID. Restore it from the path or
+		// generate a new one to avoid trusting user input.
+		return t.writeProjectId(path)
 	}
 	return project, result, err
 }
@@ -281,18 +283,6 @@ func (t *ProjectTracker) createProject(path string) (*Project, TrackResult, erro
 		return nil, ProjectError, err
 	}
 
-	t.Projects = append(t.Projects, project)
-	return &project, ProjectAdded, nil
-}
-
-func (t *ProjectTracker) createProjectWithId(path, id string) (*Project, TrackResult, error) {
-	// If there is at least one workshop definition,
-	// we consider the path as a project and use the given ID.
-	if !isProject(path) {
-		return nil, ProjectError, ErrNotProject
-	}
-
-	project := Project{ProjectId: id, Path: path}
 	t.Projects = append(t.Projects, project)
 	return &project, ProjectAdded, nil
 }

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -329,12 +329,6 @@ func isProject(dir string) bool {
 }
 
 func (w *Project) updateLock() error {
-	lock, err := os.Create(LockPath(w.Path))
-	if err != nil {
-		return err
-	}
-	defer lock.Close()
-
 	// get the desired ownership
 	info, err := os.Stat(w.Path)
 	if err != nil {
@@ -346,16 +340,7 @@ func (w *Project) updateLock() error {
 		return err
 	}
 
-	if err = sys.Chown(lock, uid, gid); err != nil {
-		return err
-	}
-
-	_, err = lock.Write([]byte(w.ProjectId))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return osutil.AtomicWriteChown(LockPath(w.Path), strings.NewReader(w.ProjectId), 0666, 0, uid, gid)
 }
 
 func allocateProjectId() (string, error) {

--- a/internal/workshop/project_test.go
+++ b/internal/workshop/project_test.go
@@ -97,7 +97,7 @@ func (p *projectSuite) TestTrackNewProject(c *check.C) {
 	c.Check(project.Path, check.Equals, d)
 	c.Check(project.ProjectId, check.Not(check.Equals), "")
 	c.Check(tracker.Projects, check.HasLen, 1)
-	c.Assert(workshop.LockPath(d), testutil.FilePresent)
+	c.Assert(workshop.LockPath(d), testutil.FileEquals, project.ProjectId)
 
 	// Multi-workshop project
 	d = c.MkDir()
@@ -113,7 +113,7 @@ func (p *projectSuite) TestTrackNewProject(c *check.C) {
 	c.Check(project.Path, check.Equals, d)
 	c.Check(project.ProjectId, check.Not(check.Equals), "")
 	c.Check(tracker.Projects, check.HasLen, 2)
-	c.Assert(workshop.LockPath(d), testutil.FilePresent)
+	c.Assert(workshop.LockPath(d), testutil.FileEquals, project.ProjectId)
 
 	// Mixed convention project
 	d = c.MkDir()
@@ -129,7 +129,7 @@ func (p *projectSuite) TestTrackNewProject(c *check.C) {
 	c.Check(project.Path, check.Equals, d)
 	c.Check(project.ProjectId, check.Not(check.Equals), "")
 	c.Check(tracker.Projects, check.HasLen, 3)
-	c.Assert(workshop.LockPath(d), testutil.FilePresent)
+	c.Assert(workshop.LockPath(d), testutil.FileEquals, project.ProjectId)
 
 	// Invalid project
 	d = c.MkDir()
@@ -153,7 +153,7 @@ func (p *projectSuite) TestTrackNewProject(c *check.C) {
 	c.Check(project.Path, check.Equals, d)
 	c.Check(project.ProjectId, check.Not(check.Equals), "")
 	c.Check(tracker.Projects, check.HasLen, 4)
-	c.Assert(workshop.LockPath(d), testutil.FilePresent)
+	c.Assert(workshop.LockPath(d), testutil.FileEquals, project.ProjectId)
 }
 
 func (p *projectSuite) TestTrackProjectSubDirectory(c *check.C) {
@@ -299,7 +299,7 @@ func (p *projectSuite) TestTrackRecoversProjectIds(c *check.C) {
 	c.Check(result, check.Equals, workshop.ProjectFound)
 	c.Check(project, check.DeepEquals, &expected)
 	c.Check(tracker.Projects, check.DeepEquals, []workshop.Project{expected})
-	c.Assert(workshop.LockPath(d), testutil.FilePresent)
+	c.Assert(workshop.LockPath(d), testutil.FileEquals, project.ProjectId)
 
 	// Unknown directory with .lock file.
 	tracker = workshop.ProjectTracker{}
@@ -315,6 +315,8 @@ func (p *projectSuite) TestTrackRecoversProjectIds(c *check.C) {
 	project, result, err = tracker.Track(d)
 	c.Assert(err, check.IsNil)
 	c.Check(result, check.Equals, workshop.ProjectAdded)
-	c.Check(project, check.DeepEquals, &expected)
-	c.Check(tracker.Projects, check.DeepEquals, []workshop.Project{expected})
+	c.Check(project.Path, check.Equals, expected.Path)
+	c.Check(project.ProjectId, check.Not(check.Equals), "")
+	c.Check(tracker.Projects, check.DeepEquals, []workshop.Project{*project})
+	c.Assert(workshop.LockPath(d), testutil.FileEquals, project.ProjectId)
 }


### PR DESCRIPTION
# Description

A couple of times now users have reported an empty `.workshop.lock` file. In one case this was when using the `9p` remote filesystem. We don't have a reproducer but it's likely caused by the lack of `fsync` when writing the file. This is now fixed.

I also updated the atomic file writing code to retry if there's a random name collision.

Also adjusted the project tracking to essentially ignore the file if it doesn't match an existing project.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
