### PR TITLE
Fix agent metadata

### DIFF
--- a/.github/agents/code-review.agent.md
+++ b/.github/agents/code-review.agent.md
@@ -1,3 +1,8 @@
+---
+name: Code Review Agent
+description: Evaluates code changes for correctness, style adherence, architecture alignment, testing coverage, and documentation completeness
+---
+
 # Code Review Agent
 
 ## Persona

--- a/.github/agents/doc-review.agent.md
+++ b/.github/agents/doc-review.agent.md
@@ -1,3 +1,8 @@
+---
+name: Documentation Review Agent
+description: Technical documentation reviewer and editor applying the Diátaxis framework
+---
+
 # Documentation Review Agent
 
 ## Persona

--- a/.github/agents/doc-schema-update.agent.md
+++ b/.github/agents/doc-schema-update.agent.md
@@ -1,4 +1,9 @@
-Title: Reconcile workshop_file.go Validation Logic with schema.json
+---
+name: Schema Update Agent
+description: Reconciles workshop_file.go validation logic with schema.json
+---
+
+# Schema Update Agent
 
 Mission:
 Ensure that the JSON schema at docs/reference/definition-files/schema.json precisely reflects the validation and parsing rules enforced in internal/workshop/workshop_file.go, correcting only those discrepancies where the Go verification logic clearly requires a different mandatory structure or constraint than what the schema currently defines.


### PR DESCRIPTION
Fixes issue found by @jonathan-conder where CLI and Web versions of Copilot didn't see the custom agents due to missing frontmatter YAML.

Steps to check:

1. Run `copilot` in your command line, then type `/agent` - the list should be now populated.
2. On the web (https://github.com/copilot/agents), the custom agents should be available in the 'crazy frog' dropdown when `canonical/workshop` is selected as the repo: 

<img width="125" height="121" alt="image" src="https://github.com/user-attachments/assets/95c37bb7-54fa-469c-99b5-b1e0a24e777d" />
