### PR TITLE
Fix and prevent future bugs in launch and refresh

### DIFF
--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -967,35 +967,53 @@ func (s *apiSuite) createWFile(c *check.C, name, yaml string) {
 	c.Assert(err, check.IsNil)
 }
 
-func storeDownloadWithSaveRestore(ctx context.Context, setup sdk.Setup, report *progress.Reporter) error {
-	if err := storeDownload(ctx, setup, report); err != nil || setup.Source == sdk.SystemSource {
-		return err
+func storeDownloadWithSaveRestore(ctx context.Context, setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error) {
+	meta, err := storeDownload(ctx, setup, report)
+	if err != nil || setup.Source == sdk.SystemSource {
+		return meta, err
 	}
 	hooksdir := filepath.Join(setup.Filepath(), "sdk", "hooks")
 	if err := os.WriteFile(filepath.Join(hooksdir, "save-state"), nil, 0o644); err != nil {
-		return err
+		return nil, err
 	}
-	return os.WriteFile(filepath.Join(hooksdir, "restore-state"), nil, 0o644)
+	if err := os.WriteFile(filepath.Join(hooksdir, "restore-state"), nil, 0o644); err != nil {
+		return nil, err
+	}
+	return meta, nil
 }
 
-func storeDownload(ctx context.Context, setup sdk.Setup, report *progress.Reporter) error {
+func storeDownload(ctx context.Context, setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error) {
 	// Emulate store action behaviour which would reuse the existing SDK if
 	// present.
 	sdkdir := setup.Filepath()
 	_, isDir, err := osutil.ExistsIsDir(sdkdir)
 	if isDir {
-		return nil
+		sdkYaml := "name: " + setup.Name
+		content, err := os.ReadFile(filepath.Join(sdkdir, "meta", "sdk.yaml"))
+		if err == nil {
+			sdkYaml = string(content)
+		}
+		return &sdk.Meta{Setup: setup, SdkYAML: sdkYaml}, nil
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if setup.Source == sdk.SystemSource {
-		return os.CopyFS(sdkdir, system.SystemSdkFs)
+		if err := os.CopyFS(sdkdir, system.SystemSdkFs); err != nil {
+			return nil, err
+		}
+		return system.SystemSdkMeta()
 	}
+
 	metadir := filepath.Join(sdkdir, "meta")
 	hooksdir := filepath.Join(sdkdir, "sdk", "hooks")
-	return mockSdk(metadir, hooksdir, apiSuiteSdks[setup.Name].SdkYAML)
+	sdkYaml := apiSuiteSdks[setup.Name].SdkYAML
+	if err := mockSdk(metadir, hooksdir, sdkYaml); err != nil {
+		return nil, err
+	}
+
+	return &sdk.Meta{Setup: setup, SdkYAML: sdkYaml}, nil
 }
 
 func storeAction(ctx context.Context, actions []sdk.SdkAction) ([]sdk.Meta, error) {

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -33,6 +33,7 @@ type interfaceManagerSuite struct {
 	runner     *state.TaskRunner
 	ctx        context.Context
 	wsbackend  workshop.Backend
+	user       *user.User
 	prj        workshop.Project
 	secBackend *ifacetest.TestSecurityBackend
 
@@ -47,8 +48,12 @@ func (s *interfaceManagerSuite) SetUpTest(c *check.C) {
 	s.BaseTest.SetUpTest(c)
 	var err error
 
+	s.user = &user.User{Username: "testuser", HomeDir: c.MkDir()}
 	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
-		return nil, user.UnknownUserError("not found")
+		if name != "testuser" {
+			return nil, user.UnknownUserError("not found")
+		}
+		return s.user, nil
 	})
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
+	"github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/testutil"
@@ -348,6 +350,73 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 	}
 
 	c.Check(entries, check.DeepEquals, []string{"drwxr-xr-x meta/", "-rw-r--r-- meta/sdk.yaml"})
+}
+
+// This tests that we correctly handle the case where the Store is updated
+// after SdkAction but before DownloadSdk. Should be able to remove when we
+// switch over to the real Store.
+func (s *sdkStateSuite) TestRetrieveUpdatedSdk(c *check.C) {
+	store := sdk.NewFakeStore()
+	sdk.ReplaceStore(s.state, store)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	oldSdks := []sdk.Setup{{
+		Name:     "dependency",
+		Channel:  "latest/stable",
+		Revision: sdk.R(10),
+		Sha3_384: "71843b99f85547fbe99fec9caf39f9ead64bc59de11447f9c2065597af88ccc5d5239f3b83a7e82a79582eff5f3868e8",
+	}, {
+		Name:     "test",
+		Channel:  "6/edge",
+		Revision: sdk.R(100),
+		Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+	}, {
+		Name:     "project",
+		Source:   sdk.ProjectSource,
+		Revision: sdk.R(-5),
+		Sha3_384: "6b1715cb90ce493a4f7f0c6745ad8155eac1874075d06c23fcba628b1276b6a0b093ef1b1969be891a1cfbc9345ffc5a",
+	}}
+	newSdk := sdk.Setup{
+		Name:     "test",
+		Channel:  "6/edge",
+		Revision: sdk.R(101),
+		Sha3_384: "805b5d3a5b935a255100653612b26c117ee280e3f522b69743ade2b907e566e716a8c8dcd706255577b0bc7dcd9eeeeb",
+	}
+
+	restore := store.SetDownloadCallback(func(ctx context.Context, setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error) {
+		if setup == oldSdks[1] {
+			if err := os.MkdirAll(newSdk.Filepath(), 0755); err != nil {
+				return nil, err
+			}
+			return &sdk.Meta{Setup: newSdk, SdkYAML: "name: test\n"}, nil
+		}
+		return nil, os.ErrNotExist
+	})
+	defer restore()
+
+	t := s.state.NewTask("retrieve-sdk", "retrieve")
+	t.Set("sdk", oldSdks[1].Name)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t)
+	chg.Set("user", "testuser")
+	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@24.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_sdks", oldSdks)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	c.Assert(s.se.Ensure(), check.IsNil)
+	s.se.Wait()
+	s.state.Lock()
+	c.Assert(chg.Err(), check.IsNil)
+
+	sdks, err := handlersetup.WorkshopSdks(chg, "ws")
+	c.Assert(err, check.IsNil)
+	c.Check(sdks[0], check.Equals, oldSdks[0])
+	c.Check(sdks[1], check.Equals, newSdk)
+	c.Check(sdks[2], check.Equals, oldSdks[2])
 }
 
 func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -37,9 +38,12 @@ type sdkStateSuite struct {
 	sdkmgr      *sdkstate.SdkManager
 	repo        *interfaces.Repository
 	ctx         context.Context
+	user        *user.User
 	project     workshop.Project
 	installTime time.Time
 
+	restoreUserLookup  func()
+	restoreUserEnv     func()
 	restoreProjectId   func()
 	restoreInstallTime func()
 }
@@ -102,6 +106,17 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 
 	ctx := context.WithValue(context.TODO(), workshop.ContextProjectId, "projectId")
 	s.ctx = context.WithValue(ctx, workshop.ContextUser, "testuser")
+
+	s.user = &user.User{Username: "testuser", HomeDir: c.MkDir()}
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		if name != "testuser" {
+			return nil, user.UnknownUserError("not found")
+		}
+		return s.user, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
 
 	s.backend, err = fakebackend.New(c.MkDir())
 	c.Check(err, check.IsNil)
@@ -174,6 +189,8 @@ func mockIface(c *check.C, repo *interfaces.Repository, iface interfaces.Interfa
 }
 
 func (s *sdkStateSuite) TearDownTest(c *check.C) {
+	s.restoreUserLookup()
+	s.restoreUserEnv()
 	s.restoreProjectId()
 	s.restoreInstallTime()
 }

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -283,6 +283,17 @@ func (a *artifactFinder) findLocalSdks(ctx context.Context, current *Manifest, l
 	}
 	if meta != nil {
 		sdks = append(sdks, *meta)
+	} else {
+		// If there's no sketch SDK, it's usually fine. But in rare
+		// cases (e.g. plug binding) the user might add the sketch SDK
+		// to the workshop definition. We shouldn't just ignore it,
+		// since it makes it harder to reason about the list of SDKs.
+		idx := slices.IndexFunc(latest.Sdks, func(s workshop.SdkRecord) bool {
+			return s.Source == sdk.SketchSource
+		})
+		if idx >= 0 {
+			return nil, fmt.Errorf("%q SDK not found, but appears in workshop definition", latest.Sdks[idx].Name)
+		}
 	}
 
 	return validateSdkMeta(a.project.ProjectId, latest, sdks)

--- a/internal/overlord/workshopstate/manifest_test.go
+++ b/internal/overlord/workshopstate/manifest_test.go
@@ -870,6 +870,21 @@ func (s *manifestSuite) TestLaunchRemovesSketchSdk(c *check.C) {
 	c.Check(stashdir, testutil.FilePresent)
 }
 
+func (s *manifestSuite) TestRefreshRespectsExplicitSketchSdk(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	sdks := []workshop.SdkRecord{{
+		Name:   "sketch",
+		Source: sdk.SketchSource,
+		Plugs:  map[string]workshop.PlugOrBind{"ssh-agent": {Plug: nil}},
+	}}
+	s.launchWorkshopWithSDKs(c, "test-1", "ubuntu@20.04", sdks)
+
+	_, _, err := s.manager.RefreshManifests(s.ctx, s.project, []string{"test-1"}, conflict.RefreshUpdate)
+	c.Check(err, check.ErrorMatches, `cannot refresh "test-1": "sketch" SDK not found, but appears in workshop definition`)
+}
+
 func (s *manifestSuite) TestRefreshSortsSdks(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -219,10 +219,10 @@ func launch(st *state.State, project workshop.Project, manifest Manifest) *state
 func (w *WorkshopManager) RefreshMany(project workshop.Project, current, latest []Manifest, option conflict.RefreshOption) ([]*state.TaskSet, error) {
 	tasksets := make([]*state.TaskSet, 0, len(latest))
 
-	for i, manifest := range latest {
-		plan := resolveRefresh(current[i], manifest)
-		if option == conflict.RefreshRestore || plan.HasUpdates() {
-			tasks := refresh(w.state, project, plan, manifest.File)
+	for i := range latest {
+		plan := resolveRefresh(current[i], latest[i])
+		if option == conflict.RefreshRestore || plan.HasUpdates(current[i].File, latest[i].File) {
+			tasks := refresh(w.state, project, plan, latest[i].File)
 			tasksets = append(tasksets, tasks)
 		}
 	}
@@ -269,10 +269,6 @@ type refreshPlan struct {
 
 	installOrder   []string
 	installedOrder []string
-
-	// Indicates if the Workshop definition was updated, i.e. if any new plugs,
-	// slots or connections were added.
-	workshopDefinitionUpdated bool
 }
 
 func (p refreshPlan) InstallOrRefresh() []sdk.Setup {
@@ -298,8 +294,55 @@ func (p refreshPlan) InstallIntactOrRefresh() []sdk.Setup {
 	return ordered(p.installOrder, p.install, p.refresh, p.intact)
 }
 
-func (p refreshPlan) HasUpdates() bool {
-	return len(p.InstallOrRefresh()) > 0 || len(p.remove) > 0 || p.workshopDefinitionUpdated
+func (p refreshPlan) HasUpdates(current, latest *workshop.File) bool {
+	if len(p.InstallOrRefresh()) > 0 || len(p.remove) > 0 {
+		return true
+	}
+
+	for _, sk := range p.intact {
+		a := sdkAdditions(current.Sdks, sk.Name)
+		b := sdkAdditions(latest.Sdks, sk.Name)
+		if !reflect.DeepEqual(a, b) {
+			return true
+		}
+	}
+
+	if len(current.Connections) != len(latest.Connections) {
+		return true
+	}
+	seen := make([]bool, len(latest.Connections))
+out:
+	for _, conn := range current.Connections {
+		for i, other := range latest.Connections {
+			if !seen[i] && conn == other {
+				seen[i] = true
+				continue out
+			}
+		}
+		return true
+	}
+
+	return false
+}
+
+// Determine workshop-specific adjustments for the given SDK. Currently this is
+// determined by plugs and slots.
+func sdkAdditions(sdks []workshop.SdkRecord, name string) workshop.SdkRecord {
+	idx := slices.IndexFunc(sdks, func(s workshop.SdkRecord) bool {
+		return s.Name == name
+	})
+	if idx < 0 {
+		// Likely system or sketch SDK.
+		return workshop.SdkRecord{}
+	}
+
+	// It's better to refresh too often than to ignore the user's changes,
+	// so return a partial record instead of extracting plugs and slots.
+	sk := sdks[idx]
+	sk.Name = ""
+	sk.Channel = ""
+	sk.Source = sdk.StoreSource
+	return sk
 }
 
 func resolveRefresh(current, latest Manifest) *refreshPlan {
@@ -360,9 +403,6 @@ func resolveRefresh(current, latest Manifest) *refreshPlan {
 	for _, s := range latest.Sdks {
 		plan.installOrder = append(plan.installOrder, s.Name)
 	}
-
-	plan.workshopDefinitionUpdated = !reflect.DeepEqual(current.File.Sdks, latest.File.Sdks) ||
-		!reflect.DeepEqual(current.File.Connections, latest.File.Connections)
 
 	return plan
 }

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -10,11 +10,14 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
@@ -130,6 +133,169 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 		s.importSdkVolume(c, meta)
 		c.Assert(s.backend.InstallSdk(s.ctx, ws, meta.Setup), check.IsNil)
 	}
+}
+
+func (s *requestSuite) TestRefreshHasUpdates(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	file := `name: dev
+base: ubuntu@22.04
+sdks:
+  - name: system
+    slots:
+      postgres:
+        interface: tunnel
+        endpoint: 5432
+  - name: node
+    channel: latest/stable
+  - name: vscode-remote
+    channel: latest/edge
+  - name: sketch
+    plugs:
+      db:
+        interface: tunnel
+        endpoint: 5432
+    slots:
+      tmpfs:
+        interface: mount
+        workshop-source: /mnt
+connections:
+  - plug: sketch:db
+    slot: system:postgres
+  - plug: node:npm-cache
+    slot: sketch:tmpfs
+  - plug: node:yarn-cache
+    slot: sketch:tmpfs
+`
+
+	var oldf, newf workshop.File
+	err := yaml.Unmarshal([]byte(file), &oldf)
+	c.Assert(err, check.IsNil)
+	err = yaml.Unmarshal([]byte(file), &newf)
+	c.Assert(err, check.IsNil)
+
+	current := []workshopstate.Manifest{{
+		File:  &oldf,
+		Image: workshop.BaseImage{Name: newf.Base, Fingerprint: "fakeimage123"},
+		Sdks: []sdk.Setup{
+			{Name: "system", Source: sdk.SystemSource, Revision: sdk.R(1), Sha3_384: "6b499970ebf370d4dbc4e9a005c042dee003c19a9420a78944bcbf32653d257f80f7c56bad55b4c967dca68a1ea92be7"},
+			{Name: "node", Channel: "latest/stable", Revision: sdk.R(42), Sha3_384: "4656e208fe96c2b29f30e2341ede0c5e1600657ee89e27ed9b382a27069804897095dc76f3d5123deac41608e70bca1d"},
+			{Name: "vscode-remote", Channel: "latest/edge", Revision: sdk.R(8), Sha3_384: "5083cf36b902ced693c34a47fe0437916dd812d1e7b1b6b9685984bab5dc23acf812cc2d7f7578c322e1a2fbdcff068d"},
+			{Name: "sketch", Source: sdk.SketchSource, Revision: sdk.R(-2), Sha3_384: "dd4b5a4cba8539e858e5fdcc318e46d9a2940439b0d8e7bd9c6bfc8b474f410d91aee43f5d4e18cb2c1b7dbaaba06fc3"},
+		},
+	}}
+	latest := []workshopstate.Manifest{{
+		File:  &newf,
+		Image: current[0].Image,
+		Sdks:  slices.Clone(current[0].Sdks),
+	}}
+
+	// No updates.
+	ts, err := s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.HasLen, 0)
+
+	// No updates but user requested --restore.
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshRestore)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+
+	// Updated SDK.
+	latest[0].Sdks[1].Revision = sdk.R(43)
+	latest[0].Sdks[1].Sha3_384 = "463f6529595798396cef8c91560f6726e02c00ea2f56e57f14dbff4a3d546a92a87618cd5bd6c148ad6308e7c612e78e"
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	latest[0].Sdks = slices.Clone(current[0].Sdks)
+
+	// Deleted SDK.
+	latest[0].Sdks = latest[0].Sdks[:3]
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	latest[0].Sdks = slices.Clone(current[0].Sdks)
+
+	// Added SDK.
+	current[0].Sdks = slices.Delete(current[0].Sdks, 1, 2)
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	current[0].Sdks = slices.Clone(latest[0].Sdks)
+
+	// Updated plug.
+	plugs := latest[0].File.Sdks[3].Plugs
+	db, ok := plugs["db"]
+	c.Assert(ok, check.Equals, true)
+	plugs["db"] = workshop.PlugOrBind{
+		Plug: map[string]any{
+			"interface": "tunnel",
+			"endpoint":  2345,
+		},
+	}
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	plugs["db"] = db
+
+	// Updated slot.
+	slots := latest[0].File.Sdks[0].Slots
+	postgres, ok := slots["postgres"]
+	c.Assert(ok, check.Equals, true)
+	slots["postgres"] = map[string]any{
+		"interface": "tunnel",
+		"endpoint":  2345,
+	}
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	slots["postgres"] = postgres
+
+	// Rearranged implicit SDKs.
+	sdks := latest[0].File.Sdks
+	sdks[0], sdks[1] = sdks[1], sdks[0]
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.HasLen, 0)
+
+	sdks[1], sdks[3] = sdks[3], sdks[1]
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.HasLen, 0)
+	sdks[0], sdks[1], sdks[3] = sdks[3], sdks[0], sdks[1]
+
+	// Rearranged explicit SDKs.
+	sdks[1], sdks[2] = sdks[2], sdks[1]
+	latest[0].Sdks[1], latest[0].Sdks[2] = latest[0].Sdks[2], latest[0].Sdks[1]
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	latest[0].Sdks[1], latest[0].Sdks[2] = latest[0].Sdks[2], latest[0].Sdks[1]
+	sdks[1], sdks[2] = sdks[2], sdks[1]
+
+	// Deleted connection.
+	connections := latest[0].File.Connections
+	latest[0].File.Connections = latest[0].File.Connections[:2]
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	latest[0].File.Connections = connections
+
+	// Added connection.
+	connections = current[0].File.Connections
+	current[0].File.Connections = current[0].File.Connections[1:]
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	current[0].File.Connections = connections
+
+	// Rearranged connections.
+	connections = latest[0].File.Connections
+	connections[0], connections[1], connections[2] = connections[1], connections[2], connections[0]
+	ts, err = s.mgr.RefreshMany(s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.HasLen, 0)
+	connections[0], connections[1], connections[2] = connections[2], connections[0], connections[1]
 }
 
 func (s *requestSuite) TestStartMany(c *check.C) {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"os/user"
 	"path/filepath"
 	"testing"
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
@@ -22,10 +24,14 @@ import (
 
 type requestSuite struct {
 	state   *state.State
+	user    *user.User
 	project workshop.Project
 	backend workshop.Backend
 	mgr     *workshopstate.WorkshopManager
 	ctx     context.Context
+
+	restoreUserLookup func()
+	restoreUserEnv    func()
 }
 
 var _ = check.Suite(&requestSuite{})
@@ -37,6 +43,17 @@ func (s *requestSuite) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.ctx = context.WithValue(context.Background(), workshop.ContextUser, "testuser")
 
+	s.user = &user.User{Username: "testuser", HomeDir: c.MkDir()}
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		if name != "testuser" {
+			return nil, user.UnknownUserError("not found")
+		}
+		return s.user, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
+
 	s.backend, err = fakebackend.New(c.MkDir())
 	c.Assert(err, check.IsNil)
 	workshop.ReplaceBackend(s.state, s.backend)
@@ -45,6 +62,11 @@ func (s *requestSuite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.project = *project
 	s.ctx = context.WithValue(s.ctx, workshop.ContextProjectId, s.project.ProjectId)
+}
+
+func (s *requestSuite) TearDownTest(c *check.C) {
+	s.restoreUserEnv()
+	s.restoreUserLookup()
 }
 
 var workshopTemplate = `name: %s

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -2,8 +2,6 @@ package sdk
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/canonical/workshop/internal/overlord/state"
@@ -83,7 +81,7 @@ type FakeStore struct {
 	DownloadCalls []TestDownloadCall
 
 	ActionCallback   func(ctx context.Context, actions []SdkAction) ([]Meta, error)
-	DownloadCallback func(ctx context.Context, setup Setup, report *progress.Reporter) error
+	DownloadCallback func(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error)
 }
 
 func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, actions []SdkAction) ([]Meta, error)) func() {
@@ -94,7 +92,7 @@ func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, actions []Sdk
 	}
 }
 
-func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup, report *progress.Reporter) error) func() {
+func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error)) func() {
 	old := f.DownloadCallback
 	f.DownloadCallback = fa
 	return func() {
@@ -119,16 +117,8 @@ func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progre
 		Setup: setup,
 	})
 	if f.DownloadCallback != nil {
-		if err := f.DownloadCallback(ctx, setup, report); err != nil {
-			return nil, err
-		}
+		return f.DownloadCallback(ctx, setup, report)
 	}
 
-	sdkYaml := "name: " + setup.Name
-	content, err := os.ReadFile(filepath.Join(setup.Filepath(), "meta", "sdk.yaml"))
-	if err == nil {
-		sdkYaml = string(content)
-	}
-
-	return &Meta{Setup: setup, SdkYAML: sdkYaml}, nil
+	return &Meta{Setup: setup, SdkYAML: "name: " + setup.Name}, nil
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/x-go/strutil"
 
 	"github.com/canonical/workshop/internal/fsutil"
+	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
@@ -647,7 +648,7 @@ func (s *FakeWorkshopBackend) sdkVolume(name string, volume FakeVolume) workshop
 }
 
 func (b *FakeWorkshopBackend) InstallSdk(ctx context.Context, name string, setup sdk.Setup) error {
-	_, projectId, err := b.userProject(ctx)
+	user, projectId, err := b.userProject(ctx)
 	if err != nil {
 		return err
 	}
@@ -665,7 +666,12 @@ func (b *FakeWorkshopBackend) InstallSdk(ctx context.Context, name string, setup
 		InstallTime:  workshop.InstallTimeNow(),
 	}
 
-	userDataDir := filepath.Join(b.BaseDir, "share")
+	usr, env, err := osutil.UserAndEnv(user)
+	if err != nil {
+		return err
+	}
+	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
+
 	mount := workshop.SdkMount(userDataDir, projectId, name, setup)
 	if mount.Type == workshop.Volume {
 		return b.attachVolume(ctx, name, mount)

--- a/internal/workshop/lxd/tests/integration/workshop_exec_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_exec_test.go
@@ -34,6 +34,7 @@ type wsExec struct {
 	project             workshop.Project
 	lookupUserRestore   func()
 	lookupUserIdRestore func()
+	userEnvRestore      func()
 	newProjectidRestore func()
 	restoreImageServer  func()
 	restoreDevices      func()
@@ -59,6 +60,21 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 	c.Assert(dirs.CreateDirs(), check.IsNil)
 
 	f.restoreImageServer = lxdbackend.FakeImageServer(helper.MinimalImageServer)
+
+	f.usr = &user.User{
+		Username: "testuser",
+		Uid:      "1000",
+		Gid:      "1000",
+	}
+	f.lookupUserRestore = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return f.usr, nil
+	})
+	f.lookupUserIdRestore = testutil.FakeFunc(func(uid string) (*user.User, error) {
+		return f.usr, nil
+	}, &daemon.LookupUserId)
+	f.userEnvRestore = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
 
 	socketPath := c.MkDir() + ".workshop.socket"
 	var err error
@@ -86,24 +102,10 @@ func (f *wsExec) SetUpSuite(c *check.C) {
 		Path:      c.MkDir(),
 	}
 
-	f.usr = &user.User{
-		Username: "testuser",
-		Uid:      "1000",
-		Gid:      "1000",
-	}
-
 	f.ctx = helper.CreateTestContext(f.usr.Username, f.project.ProjectId)
 
 	f.lxdClient, err = f.be.(*lxdbackend.Backend).LxdClient(f.ctx)
 	c.Check(err, check.IsNil)
-
-	f.lookupUserRestore = osutil.FakeUserLookup(func(name string) (*user.User, error) {
-		return f.usr, nil
-	})
-
-	f.lookupUserIdRestore = testutil.FakeFunc(func(uid string) (*user.User, error) {
-		return f.usr, nil
-	}, &daemon.LookupUserId)
 
 	f.restoreDevices = workshop.FakeDefaultDevices(execTestDevices(c.MkDir()))
 
@@ -120,6 +122,7 @@ func (f *wsExec) TearDownSuite(c *check.C) {
 	c.Check(err, check.IsNil)
 	f.lookupUserRestore()
 	f.lookupUserIdRestore()
+	f.userEnvRestore()
 	f.newProjectidRestore()
 	f.restoreImageServer()
 	f.restoreDevices()


### PR DESCRIPTION
# Description

I noticed a few issues while testing the global SDK changes:
- The fake backend mounts in-project SDKs from the wrong location. I think I did this deliberately since it wasn't needed at the time, but it has bitten me a few times now, and a future test will require this to be correct.
- Previously it was possible to list the `sketch` SDK in a workshop definition without the sketch SDK existing. Workshop would just ignore it. This now causes an error.
- Refreshing was a bit too eager (maybe intentional). Now the workshop won't refresh if the system or sketch SDKs are moved around in the workshop definition, or the connections are permuted.

I also came close to breaking `retrieve-sdk` recently, due to a combination of weak typing and no test coverage for the situation where the Store is updated mid-refresh. I added a test to make sure this keeps working until we can handle it properly (using the real Store).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
