### PR TITLE
Add hash to workshop snapshots

### DIFF
--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -5,11 +5,14 @@ import (
 	"cmp"
 	"context"
 	"crypto/sha3"
+	_ "embed"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -18,6 +21,7 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
 
+	"github.com/canonical/workshop/internal/fsutil"
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
@@ -168,6 +172,16 @@ sdks:
     channel: latest/stable
   - name: test-sdk
     channel: latest/stable
+`
+
+	manysdks_diverse = `name: manysdks
+base: ubuntu@22.04
+sdks:
+  - name: system
+  - name: test-sdk-3
+    channel: latest/stable
+  - name: try-test-sdk-2
+  - name: project-test-sdk
 `
 
 	manysdks_system_extended = `name: manysdks
@@ -1221,6 +1235,267 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1"})
+}
+
+//go:embed snapshot-format.yaml
+var snapshotFormat []byte
+
+// Attempt to specify the filesystem layout of a workshop. Changes to this may
+// invalidate snapshots of existing workshops, so the snapshot format revision
+// number should be bumped to force a full refresh. LXD-specific format is
+// covered by `snapshotSuite.TestLxdBackendSnapshotFormat`. Currently checks
+// all known factors which can influence a snapshot. Unknown factors are tested
+// below by `apiSuite.TestSnapshotIngredients`.
+func (s *apiSuite) TestSnapshotFormat(c *check.C) {
+	s.daemon(c)
+	st := s.d.overlord.State()
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	defer s.store.SetDownloadCallback(storeDownload)()
+	s.createWFile(c, "manysdks", manysdks_diverse)
+
+	s.mockTrySdk(c, "test-sdk-2", "test-sdk-2_all.sdk", testsdk2)
+	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
+	tryDir := workshop.TrySdkDir(userDataDir, "test-sdk-2")
+	setupBase := filepath.Join(tryDir, "test-sdk-2_all.sdk", "sdk", "hooks", "setup-base")
+	err := os.WriteFile(setupBase, nil, 0644)
+	c.Assert(err, check.IsNil)
+
+	s.mockProjectSdk(c, "test-sdk", testsdk)
+	projectDir := workshop.ProjectSdkPath(s.project.Path, "test-sdk")
+	setupBase = filepath.Join(projectDir, "hooks", "setup-base")
+	err = os.WriteFile(setupBase, nil, 0644)
+	c.Assert(err, check.IsNil)
+
+	// Validate completed tasks and rootfs changes at snapshot time.
+	summary := map[string]any{}
+	s.b.SnapshotCallback = func(ctx context.Context, name string, snapshot workshop.Snapshot) error {
+		sk := snapshot.Sdks[len(snapshot.Sdks)-1].Name
+
+		entry := map[string]any{
+			// Collect direct rootfs changes.
+			"files": s.listFiles(c, name),
+			// Check for indirect rootfs changes via tasks. The LXD
+			// integration tests have coverage for create-workshop,
+			// start-workshop, install-sdk and snapshot-sdk. New
+			// tasks may require similar tests, or might make
+			// rootfs changes directly.
+			"tasks": completedPostConstructTasks(c, st),
+		}
+
+		// Count WorkshopFs() calls and list Exec() commands. This
+		// accounts for rootfs changes which don't show up for the fake
+		// backend but do in production.
+		if sk != "sketch" {
+			execCalls := make([][]string, 0, len(s.b.ExecCalls))
+			for _, ec := range s.b.ExecCalls {
+				execCalls = append(execCalls, ec.Args.Command)
+			}
+
+			entry["fs-calls"] = len(s.b.WorkshopFsCalls)
+			entry["exec-calls"] = execCalls
+		}
+
+		summary[sk] = entry
+		return nil
+	}
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.mockSketchSdk(c, "manysdks", `name: sketch
+`)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	// Ensure this test covers all SDK sources.
+	wp, err := s.b.Workshop(s.ctx, "manysdks")
+	c.Assert(err, check.IsNil)
+	sources := map[sdk.Source]bool{}
+	for _, sk := range wp.Sdks {
+		sources[sk.Source] = true
+	}
+	// We assume there are N sources, 0 through N-1. If len(sources) casts
+	// to a valid source it means len(sources) < N and there's at least one
+	// type of source that isn't present in the workshop under test.
+	_, err = sdk.Source(len(sources)).MarshalText()
+	c.Assert(err, check.NotNil)
+
+	// Compare with approved summary.
+	var approved map[string]any
+	err = yaml.Unmarshal(snapshotFormat, &approved)
+	c.Assert(err, check.IsNil)
+	c.Check(summary, testutil.JsonEquals, approved)
+}
+
+//go:embed snapshot-ingredients.yaml
+var snapshotIngredients []byte
+
+// Check that the above test covers a decent variety of inputs and validates
+// all relevant outputs. It's quite crude, using reflection to detect added or
+// modified fields in relevant data types. Expect some false positives.
+func (s *apiSuite) TestSnapshotIngredients(c *check.C) {
+	// Load expected test output.
+	var fields map[string]map[string]any
+	err := yaml.Unmarshal(snapshotIngredients, &fields)
+	c.Assert(err, check.IsNil)
+
+	// Ensure we have coverage for various types of workshops. Currently,
+	// the workshop base and SDKs can influence snapshots. Changing the
+	// base already invalidates snapshots, so the above test focuses on
+	// installing a variety of SDKs. If more fields are added to the
+	// workshop definition, or the SDK records within, the following checks
+	// will fail, and we might need to expand the test.
+	expectFields[workshop.File](c, fields["File"])
+	expectFields[workshop.SdkRecord](c, fields["SdkRecord"])
+
+	// Check for changes to workshop metadata. This is mostly covered by
+	// the LXD tests, but new fields might affect the files and metadata
+	// that we snapshot. In that case we should bump the snapshot format
+	// revision number, and test the format of the new metadata.
+	expectFields[workshop.Workshop](c, fields["Workshop"])
+	expectFields[workshop.BaseImage](c, fields["BaseImage"])
+	expectFields[workshop.SdkInstallation](c, fields["SdkInstallation"])
+	expectFields[sdk.Setup](c, fields["Setup"])
+
+	// Check for changes to the fake backend. For example, Exec() has the
+	// potential to change the workshop's rootfs in production, but the
+	// fake backend makes it a no-op by default. We rely on ExecCalls to
+	// capture these changes. A new field might have similar properties,
+	// and the format tests should take it into account.
+	expectFields[fakebackend.FakeWorkshopBackend](c, fields["FakeWorkshopBackend"])
+	expectFields[fakebackend.FakeWorkshop](c, fields["FakeWorkshop"])
+}
+
+// Like ls -lR for the given workshop's rootfs.
+func (s *apiSuite) listFiles(c *check.C, workshop string) []string {
+	wfs, err := s.b.WorkshopFs(s.ctx, workshop)
+	c.Assert(err, check.IsNil)
+	defer wfs.Close()
+
+	root, err := wfs.FsBackend.(*fsutil.BasePathFs).RealPath("")
+	c.Assert(err, check.IsNil)
+
+	var files []string
+	walk := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		name, err1 := filepath.Rel(root, path)
+		info, err2 := d.Info()
+		if err := cmp.Or(err1, err2); err != nil {
+			return err
+		}
+
+		if name != "." {
+			files = append(files, info.Mode().String()+" "+name)
+		}
+		return nil
+	}
+
+	c.Assert(filepath.WalkDir(root, walk), check.IsNil)
+	return files
+}
+
+// Count completed tasks by kind among those which depend, directly or
+// indirectly, on create-workshop or rebuild-workshop.
+func completedPostConstructTasks(c *check.C, st *state.State) map[string]int {
+	st.Lock()
+	defer st.Unlock()
+
+	// Find current Change (in DoingStatus).
+	changes := st.Changes()
+	idx := slices.IndexFunc(changes, func(c *state.Change) bool {
+		return c.Status() == state.DoingStatus
+	})
+	c.Assert(idx, testutil.IntGreaterEqual, 0)
+	change := changes[idx]
+
+	// Find construct (launch or rebuild) task.
+	tasks := change.Tasks()
+	idx = slices.IndexFunc(tasks, func(t *state.Task) bool {
+		return t.Kind() == "create-workshop" || t.Kind() == "rebuild-workshop"
+	})
+	c.Assert(idx, testutil.IntGreaterEqual, 0)
+	construct := tasks[idx]
+
+	// Count tasks by kind. Only considers tasks in DoneStatus which
+	// wait for `construct` (directly or indirectly).
+	doneCount := map[string]int{}
+
+	stack := []*state.Task{construct}
+	seen := map[string]bool{construct.ID(): true}
+	for len(stack) > 0 {
+		task := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		if task.Status() != state.DoneStatus {
+			continue
+		}
+		doneCount[task.Kind()] += 1
+
+		for _, t := range task.HaltTasks() {
+			if !seen[t.ID()] {
+				seen[t.ID()] = true
+				stack = append(stack, t)
+			}
+		}
+	}
+
+	return doneCount
+}
+
+func expectFields[T any](c *check.C, expected map[string]any) {
+	fields := fieldTypes[T]()
+	for k, v := range expected {
+		if v != nil {
+			continue
+		}
+
+		_, ok := fields[k]
+		c.Check(ok, check.Equals, true, check.Commentf("field %q can be removed", k))
+
+		delete(expected, k)
+		delete(fields, k)
+	}
+	c.Check(fields, testutil.JsonEquals, expected)
+}
+
+func fieldTypes[T any]() map[string]string {
+	st := reflect.TypeFor[T]()
+
+	fields := make(map[string]string, st.NumField())
+	for i := range st.NumField() {
+		field := st.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		fields[field.Name] = field.Type.String()
+	}
+	return fields
 }
 
 func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {

--- a/internal/daemon/snapshot-format.yaml
+++ b/internal/daemon/snapshot-format.yaml
@@ -1,0 +1,100 @@
+# When updating this file, please carefully consider whether the snapshot
+# format revision number needs to be bumped. This file is used by the
+# apiSuite.TestSnapshotFormat test. It records direct changes to workshop and
+# snapshot filesystems, and also gives an overview of the types of tasks that
+# can affect snapshot filesystems. Specific tasks need to be tested in a
+# backend-specific manner.
+system:
+  files:
+    - drwxr-xr-x var
+    - drwxr-xr-x var/lib
+    - drwxr-xr-x var/lib/workshop
+    - drwxr-xr-x var/lib/workshop/run
+    - drwxr-xr-x var/lib/workshop/sdk
+    - Lrwxrwxrwx var/lib/workshop/sdk/system
+  tasks:
+    create-workshop: 1
+    start-workshop: 1
+    install-sdk: 1
+    register-sdk: 1
+    run-hook: 1
+  fs-calls: 4
+  exec-calls: []
+test-sdk-3:
+  files:
+    - drwxr-xr-x var
+    - drwxr-xr-x var/lib
+    - drwxr-xr-x var/lib/workshop
+    - drwxr-xr-x var/lib/workshop/run
+    - drwxr-xr-x var/lib/workshop/sdk
+    - Lrwxrwxrwx var/lib/workshop/sdk/system
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk-3
+  tasks:
+    create-workshop: 1
+    start-workshop: 1
+    install-sdk: 2
+    register-sdk: 2
+    run-hook: 2
+    snapshot-sdk: 1
+  fs-calls: 7
+  exec-calls: []
+test-sdk-2:
+  files:
+    - drwxr-xr-x var
+    - drwxr-xr-x var/lib
+    - drwxr-xr-x var/lib/workshop
+    - drwxr-xr-x var/lib/workshop/run
+    - drwxr-xr-x var/lib/workshop/sdk
+    - Lrwxrwxrwx var/lib/workshop/sdk/system
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk-2
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk-3
+  tasks:
+    create-workshop: 1
+    start-workshop: 1
+    install-sdk: 3
+    register-sdk: 3
+    run-hook: 3
+    snapshot-sdk: 2
+  fs-calls: 10
+  exec-calls:
+    - ["bash", "-eo", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+test-sdk:
+  files:
+    - drwxr-xr-x var
+    - drwxr-xr-x var/lib
+    - drwxr-xr-x var/lib/workshop
+    - drwxr-xr-x var/lib/workshop/run
+    - drwxr-xr-x var/lib/workshop/sdk
+    - Lrwxrwxrwx var/lib/workshop/sdk/system
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk-2
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk-3
+  tasks:
+    create-workshop: 1
+    start-workshop: 1
+    install-sdk: 4
+    register-sdk: 4
+    run-hook: 4
+    snapshot-sdk: 3
+  fs-calls: 13
+  exec-calls:
+    - ["bash", "-eo", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["bash", "-eo", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
+sketch:
+  files:
+    - drwxr-xr-x var
+    - drwxr-xr-x var/lib
+    - drwxr-xr-x var/lib/workshop
+    - drwxr-xr-x var/lib/workshop/run
+    - drwxr-xr-x var/lib/workshop/sdk
+    - Lrwxrwxrwx var/lib/workshop/sdk/sketch
+    - Lrwxrwxrwx var/lib/workshop/sdk/system
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk-2
+    - Lrwxrwxrwx var/lib/workshop/sdk/test-sdk-3
+  tasks:
+    rebuild-workshop: 1
+    start-workshop: 1
+    install-sdk: 5
+    register-sdk: 5
+    run-hook: 1

--- a/internal/daemon/snapshot-ingredients.yaml
+++ b/internal/daemon/snapshot-ingredients.yaml
@@ -1,0 +1,61 @@
+# When updating this file, please carefully consider whether the snapshot
+# format revision number needs to be bumped. This file is used by the
+# apiSuite.TestSnapshotIngredients test. It records the types Workshop uses
+# interally to define or describe workshops. Field types may be omitted if
+# they're irrelevant to the snapshot format. Changes to this file may indicate
+# a need to expand the other snapshot format tests.
+File:
+  Name: string
+  Base: string
+  Sdks: '[]workshop.SdkRecord'
+  Actions:
+  Connections:
+SdkRecord:
+  Name: string
+  Channel: string
+  Source: sdk.Source
+  Plugs:
+  Slots:
+Workshop:
+  Backend:
+  Project: workshop.Project
+  File: '*workshop.File'
+  Name: string
+  Image: workshop.BaseImage
+  Running: bool
+  Sdks: map[string]workshop.SdkInstallation
+  Profiles:
+BaseImage:
+  Name: string
+  Fingerprint: string
+SdkInstallation:
+  Setup: sdk.Setup
+  InstallOrder: int
+  InstallTime: time.Time
+Setup:
+  Name: string
+  Channel: string
+  Source: sdk.Source
+  Revision: sdk.Revision
+  Sha3_384: string
+FakeWorkshopBackend:
+  Workshops: map[string]map[string]*fakebackend.FakeWorkshop
+  StashedWorkshops: map[string]map[string]*fakebackend.FakeWorkshop
+  Volumes:
+  SdkVolumes:
+  ExecCallback:
+  ExecCalls:
+  WorkshopFsCallback:
+  WorkshopFsCalls:
+  GetBaseCallback:
+  DownloadBaseCallback:
+  DownloadBaseCalls:
+  AttachVolumeCalls:
+  LaunchOrRebuildCalls:
+  SnapshotCalls:
+  SnapshotCallback:
+  BaseDir:
+FakeWorkshop:
+  Workshop: '*workshop.Workshop'
+  Devices: map[string]map[string]string
+  WorkshopFilesystem:

--- a/internal/testutil/jsonchecker.go
+++ b/internal/testutil/jsonchecker.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/check.v1"
+)
+
+type jsonEqualChecker struct {
+	*check.CheckerInfo
+}
+
+// JsonEquals compares the obtained and expected values after having serialized
+// them to JSON and deserialized to a generic any type. This avoids trouble
+// comparing types with unexported fields that otherwise would be problematic to
+// set in external packages.
+var JsonEquals check.Checker = &jsonEqualChecker{
+	&check.CheckerInfo{Name: "JsonEqual", Params: []string{"obtained", "expected"}},
+}
+
+func (c *jsonEqualChecker) Check(params []any, names []string) (result bool, error string) {
+	toComparableMap := func(what any) any {
+		b, err := json.Marshal(what)
+		if err != nil {
+			panic("cannot marshal")
+		}
+		var back any
+		if err := json.Unmarshal(b, &back); err != nil {
+			panic(fmt.Sprintf("cannot unmarshal from: %s", string(b)))
+		}
+		return back
+	}
+
+	obtained := toComparableMap(params[0])
+	ref := toComparableMap(params[1])
+
+	return check.DeepEquals.Check([]any{obtained, ref}, names)
+}

--- a/internal/testutil/jsonchecker_test.go
+++ b/internal/testutil/jsonchecker_test.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2021 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil_test
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+type jsonCheckerSuite struct{}
+
+var _ = check.Suite(&jsonCheckerSuite{})
+
+func (*jsonCheckerSuite) TestFilePresent(c *check.C) {
+	testInfo(c, testutil.JsonEquals, "JsonEqual", []string{"obtained", "expected"})
+
+	type subRef struct {
+		Foo    string    `json:"foo"`
+		Baz    []float32 `json:"baz"`
+		hidden bool
+	}
+	type ref struct {
+		Number int      `json:"number"`
+		String string   `json:"string,omitempty"`
+		List   []string `json:"list"`
+		Map    *subRef  `json:"map,omitempty"`
+		hidden bool
+	}
+
+	testCheck(c, testutil.JsonEquals, true, "",
+		map[string]any{
+			"number": 42,
+			"string": "foo",
+			"list":   []string{"123", "456"},
+			"map": map[string]any{
+				"foo": "bar",
+				"baz": []any{0.2, 0.3},
+			},
+		}, ref{
+			Number: 42,
+			String: "foo",
+			List:   []string{"123", "456"},
+			Map: &subRef{
+				Foo: "bar",
+				Baz: []float32{0.2, 0.3},
+				// this is transparent to the checker
+				hidden: true,
+			},
+			// this is transparent to the checker
+			hidden: true,
+		})
+	testCheck(c, testutil.JsonEquals, true, "",
+		map[string]any{
+			"number": 42,
+			"string": "foo",
+			"list":   []any(nil),
+		}, ref{
+			Number: 42,
+			String: "foo",
+		})
+	testCheck(c, testutil.JsonEquals, true, "",
+		map[string]any{
+			"number": 42,
+			"list":   []any(nil),
+		}, ref{
+			Number: 42,
+		})
+	testCheck(c, testutil.JsonEquals, false, "", 12, "12")
+	testCheck(c, testutil.JsonEquals, false, "Difference:\n...     [0]: 12 != 24\n", []int{12}, []int{24})
+	testCheck(c, testutil.JsonEquals, false, "Difference:\n...     [0]: string != float64\n", []string{"abc"}, []int{24})
+}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1155,6 +1155,7 @@ runcmd:
 		"security.nesting":               "true",
 		"user.user-data":                 cloudInitConfig,
 		"user.network-config":            cloudInitNetwork,
+		"user.workshop.format-revision":  SnapshotFormatRevision.String(),
 		"user.workshop.project-id":       projectId,
 		"user.workshop.name":             file.Name,
 		"user.workshop.file":             string(f),

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"crypto/rand"
+	"crypto/sha3"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -65,6 +66,11 @@ func (s *Backend) TakeSnapshot(ctx context.Context, name string, snapshot worksh
 	}
 	sk := snapshot.Sdks[len(snapshot.Sdks)-1].Name
 
+	digest, err := s.HashSnapshot(snapshot)
+	if err != nil {
+		return fmt.Errorf("internal error: hashing snapshot info: %w", err)
+	}
+
 	conn, snapshotConn, err := s.snapshotClients(ctx)
 	if err != nil {
 		return err
@@ -82,7 +88,7 @@ func (s *Backend) TakeSnapshot(ctx context.Context, name string, snapshot worksh
 	// Override all writable attributes. The snapshot is essentially a base
 	// image but is stored more efficiently. Config options and devices are
 	// reconstructed from scratch during launch and refresh.
-	config := configOverrides(projectId, name, sk, snapshot.Image, inst.Config)
+	config := configOverrides(projectId, name, sk, digest, snapshot.Image, inst.Config)
 	devices, err := deviceOverrides(inst.Devices)
 	if err != nil {
 		return err
@@ -106,7 +112,7 @@ func (s *Backend) TakeSnapshot(ctx context.Context, name string, snapshot worksh
 	return rop.Wait()
 }
 
-func configOverrides(pid, name, sk string, image workshop.BaseImage, config map[string]string) map[string]string {
+func configOverrides(pid, name, sk, digest string, image workshop.BaseImage, config map[string]string) map[string]string {
 	// LXD will handle the options it owns. We remove all options set by
 	// Workshop, except for a handful that identify the snapshot. We also
 	// add security.protection.start to prevent it from starting.
@@ -117,6 +123,8 @@ func configOverrides(pid, name, sk string, image workshop.BaseImage, config map[
 		workshop.ConfigWorkshopBase:            image.Name,
 		workshop.ConfigWorkshopBaseFingerprint: image.Fingerprint,
 		workshop.ConfigWorkshopSnapshotType:    "sdk",
+		workshop.ConfigWorkshopSnapshotFormat:  SnapshotFormatRevision.String(),
+		workshop.ConfigWorkshopSha3_384:        digest,
 		workshop.ConfigWorkshopSdk:             sk,
 	}
 	for k := range config {
@@ -578,4 +586,48 @@ func (s *Backend) snapshotClients(ctx context.Context) (lxd.InstanceServer, lxd.
 	}
 
 	return conn, conn.UseProject(project), nil
+}
+
+// Hard coded number which represents the current "snapshot format," i.e. the
+// contents of the rootfs after installing a certain sequence of SDKs. This can
+// be influenced by a number of factors, including:
+// - Default workshop config (e.g. cloud-config)
+// - Default workshop devices (e.g. apt cache)
+// - SDK config and devices (e.g. volume mounts)
+// - Direct modifications (e.g. mkdir /var/lib/workshop/run)
+// If something like this changes, bump the revision number so that workshops
+// constructed using the next release of Workshop see the changes.
+var SnapshotFormatRevision = sdk.R(1)
+
+func (s *Backend) HashSnapshot(snapshot workshop.Snapshot) (string, error) {
+	digest, err := hex.DecodeString(snapshot.Image.Fingerprint)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha3.New384()
+	if _, err := fmt.Fprintf(hash, "%s %s\x00%s", SnapshotFormatRevision, snapshot.Image.Name, digest); err != nil {
+		return "", err
+	}
+
+	for _, sk := range snapshot.Sdks {
+		// Different types of SDKs result in different workshops. There
+		// are really only two types: those which use SDK volumes and
+		// those which use local directories.
+		kind := "local"
+		if sk.IsVolume {
+			kind = "volume"
+		}
+
+		digest, err := hex.DecodeString(sk.Sha3_384)
+		if err != nil {
+			return "", err
+		}
+
+		if _, err := fmt.Fprintf(hash, "%s %s\x00%s", kind, sk.Name, digest); err != nil {
+			return "", err
+		}
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -1,0 +1,230 @@
+# When updating this file, please carefully consider whether the snapshot
+# format revision number needs to be bumped. This file is used by the
+# snapshotSuite.TestLxdBackendSnapshotFormat test. It records the writable
+# parts of workshops and snapshots at each step from launch to snapshot.
+# Changes to this file may or may not influence the snapshot format. For
+# instance the cloud-init config (user.user-data) is likely to modify files
+# and therefore change the snapshot format. Other options like boot.autostart
+# are omitted from snapshots and have no effect.
+launched:
+  architecture: ''
+  config:
+    boot.autostart: 'false'
+    raw.idmap: |-
+      uid 1000 1000
+      gid 1000 1000
+    raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
+    security.nesting: 'true'
+    user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
+    user.user-data: '330c760a65aca63023c834efb6f0f89e6da683c15b54a635dede4a6b55f7677e2efd244a70f33e0b246eaaf6999a9394'
+    user.workshop.name: test
+    user.workshop.project-id: '42424242'
+  description: ''
+  devices:
+    cache.apt:
+      path: /var/cache/apt/archives
+      readonly: 'false'
+      type: disk
+    root:
+      path: /
+      pool: workshop
+      type: disk
+    workshop.network:
+      name: eth0
+      network: workshopbr0
+      type: nic
+    workshop.socket:
+      bind: instance
+      listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
+      mode: '0666'
+      type: proxy
+    workshop.workshopctl:
+      path: /usr/bin/workshopctl
+      readonly: 'true'
+      type: disk
+  ephemeral: false
+  profiles: [default]
+  stateful: false
+started:
+  architecture: ''
+  config:
+    boot.autostart: 'true'
+    raw.idmap: |-
+      uid 1000 1000
+      gid 1000 1000
+    raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
+    security.nesting: 'true'
+    user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
+    user.user-data: '330c760a65aca63023c834efb6f0f89e6da683c15b54a635dede4a6b55f7677e2efd244a70f33e0b246eaaf6999a9394'
+    user.workshop.name: test
+    user.workshop.project-id: '42424242'
+  description: ''
+  devices:
+    cache.apt:
+      path: /var/cache/apt/archives
+      readonly: 'false'
+      type: disk
+    root:
+      path: /
+      pool: workshop
+      type: disk
+    workshop.network:
+      name: eth0
+      network: workshopbr0
+      type: nic
+    workshop.socket:
+      bind: instance
+      listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
+      mode: '0666'
+      type: proxy
+    workshop.workshopctl:
+      path: /usr/bin/workshopctl
+      readonly: 'true'
+      type: disk
+  ephemeral: false
+  profiles: [default]
+  stateful: false
+sdk-attached:
+  architecture: ''
+  config:
+    boot.autostart: 'true'
+    raw.idmap: |-
+      uid 1000 1000
+      gid 1000 1000
+    raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
+    security.nesting: 'true'
+    user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
+    user.user-data: '330c760a65aca63023c834efb6f0f89e6da683c15b54a635dede4a6b55f7677e2efd244a70f33e0b246eaaf6999a9394'
+    user.workshop.name: test
+    user.workshop.project-id: '42424242'
+  description: ''
+  devices:
+    cache.apt:
+      path: /var/cache/apt/archives
+      readonly: 'false'
+      type: disk
+    root:
+      path: /
+      pool: workshop
+      type: disk
+    sdk.store-sdk:
+      path: /var/lib/workshop/sdk/store-sdk
+      pool: workshop
+      readonly: 'true'
+      source: store-sdk-23
+      type: disk
+      user.sdk.channel: latest/stable
+      user.sdk.install-order: '1'
+      user.sdk.revision: '23'
+      user.sdk.sha3-384: '18b8ce233667942e94e1f5bdd22bcd516c4a375030a359a5bb09220b416d215fffda138d8d45eaab419ae2403c81ec5d'
+      user.sdk.source: store
+    workshop.network:
+      name: eth0
+      network: workshopbr0
+      type: nic
+    workshop.socket:
+      bind: instance
+      listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
+      mode: '0666'
+      type: proxy
+    workshop.workshopctl:
+      path: /usr/bin/workshopctl
+      readonly: 'true'
+      type: disk
+  ephemeral: false
+  profiles: [default]
+  stateful: false
+sdk-mounted:
+  architecture: ''
+  config:
+    boot.autostart: 'true'
+    raw.idmap: |-
+      uid 1000 1000
+      gid 1000 1000
+    raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
+    security.nesting: 'true'
+    user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
+    user.user-data: '330c760a65aca63023c834efb6f0f89e6da683c15b54a635dede4a6b55f7677e2efd244a70f33e0b246eaaf6999a9394'
+    user.workshop.name: test
+    user.workshop.project-id: '42424242'
+  description: ''
+  devices:
+    cache.apt:
+      path: /var/cache/apt/archives
+      readonly: 'false'
+      type: disk
+    root:
+      path: /
+      pool: workshop
+      type: disk
+    sdk.store-sdk:
+      path: /var/lib/workshop/sdk/store-sdk
+      pool: workshop
+      readonly: 'true'
+      source: store-sdk-23
+      type: disk
+      user.sdk.channel: latest/stable
+      user.sdk.install-order: '1'
+      user.sdk.revision: '23'
+      user.sdk.sha3-384: '18b8ce233667942e94e1f5bdd22bcd516c4a375030a359a5bb09220b416d215fffda138d8d45eaab419ae2403c81ec5d'
+      user.sdk.source: store
+    sdk.local-sdk:
+      path: /var/lib/workshop/sdk/local-sdk
+      readonly: 'true'
+      type: disk
+      user.sdk.install-order: '2'
+      user.sdk.revision: 'x34'
+      user.sdk.sha3-384: 'dc00101dfd688cdc058e31d3b82e680df123f85935f741fabcb8f0dfd29d80612f131db8487621abad7ee856223bede1'
+      user.sdk.source: project
+    workshop.network:
+      name: eth0
+      network: workshopbr0
+      type: nic
+    workshop.socket:
+      bind: instance
+      listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
+      mode: '0666'
+      type: proxy
+    workshop.workshopctl:
+      path: /usr/bin/workshopctl
+      readonly: 'true'
+      type: disk
+  ephemeral: false
+  profiles: [default]
+  stateful: false
+snapshot:
+  architecture: ''
+  config:
+    security.protection.start: 'true'
+    user.workshop.base: ubuntu@24.04
+    user.workshop.name: test
+    user.workshop.project-id: '42424242'
+    user.workshop.sdk: local-sdk
+    user.workshop.snapshot-type: sdk
+  description: ''
+  devices:
+    cache.apt:
+      type: none
+    root:
+      path: /
+      pool: workshop
+      type: disk
+    sdk.store-sdk:
+      type: none
+      user.sdk.install-order: '1'
+      user.sdk.is-volume: 'true'
+      user.sdk.sha3-384: '18b8ce233667942e94e1f5bdd22bcd516c4a375030a359a5bb09220b416d215fffda138d8d45eaab419ae2403c81ec5d'
+    sdk.local-sdk:
+      type: none
+      user.sdk.install-order: '2'
+      user.sdk.is-volume: 'false'
+      user.sdk.sha3-384: 'dc00101dfd688cdc058e31d3b82e680df123f85935f741fabcb8f0dfd29d80612f131db8487621abad7ee856223bede1'
+    workshop.network:
+      type: none
+    workshop.socket:
+      type: none
+    workshop.workshopctl:
+      type: none
+  ephemeral: false
+  profiles: []
+  stateful: false

--- a/internal/workshop/lxd/tests/integration/snapshot_test.go
+++ b/internal/workshop/lxd/tests/integration/snapshot_test.go
@@ -1,0 +1,308 @@
+//go:build integration
+
+package lxdbackend_integration_test
+
+import (
+	"context"
+	"crypto/sha3"
+	_ "embed"
+	"encoding/hex"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+
+	lxd "github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/shared/api"
+	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshop"
+	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
+	"github.com/canonical/workshop/internal/workshop/lxd/tests/helper"
+)
+
+type snapshotSuite struct {
+	usr     *user.User
+	project workshop.Project
+	ctx     context.Context
+
+	restoreLookupUsr   func()
+	restoreUserEnv     func()
+	restoreImageServer func()
+
+	bd *lxdbackend.Backend
+}
+
+var _ = check.Suite(&snapshotSuite{})
+
+func (s *snapshotSuite) SetUpSuite(c *check.C) {
+	s.usr = &user.User{Username: "testuser", Uid: "1000", Gid: "1000", HomeDir: c.MkDir()}
+	s.project = workshop.Project{
+		ProjectId: "42424242",
+		Path:      c.MkDir(),
+	}
+	s.ctx = helper.CreateTestContext(s.usr.Username, s.project.ProjectId)
+
+	s.restoreLookupUsr = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return s.usr, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
+	s.restoreImageServer = lxdbackend.FakeImageServer(helper.MinimalImageServer)
+
+	dirs.SetRootDir(c.MkDir())
+	dirs.SetCacheDir(c.MkDir())
+	dirs.ExecDir = c.MkDir()
+	dirs.SocketPath = filepath.Join(dirs.BaseDir, "workshop.socket")
+	c.Assert(dirs.CreateDirs(), check.IsNil)
+	c.Assert(os.MkdirAll(workshop.AptCacheDir(s.project.ProjectId, "test"), 0755), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirs.ExecDir, "workshopctl"), nil, 0644), check.IsNil)
+
+	var err error
+	s.bd, err = lxdbackend.New()
+	c.Assert(err, check.IsNil)
+
+	conn, err := s.bd.LxdClient(s.ctx)
+	c.Assert(err, check.IsNil)
+	defer conn.Disconnect()
+}
+
+func (s *snapshotSuite) TearDownSuite(c *check.C) {
+	conn, err := s.bd.LxdClient(s.ctx)
+	c.Check(err, check.IsNil)
+	defer conn.Disconnect()
+
+	helper.CleanupLxdProject(c, conn, "workshop."+s.usr.Username)
+	helper.CleanupLxdProject(c, conn, "workshop-snapshots."+s.usr.Username)
+
+	s.restoreLookupUsr()
+	s.restoreUserEnv()
+	s.restoreImageServer()
+}
+
+//go:embed snapshot-format.yaml
+var snapshotFormat []byte
+
+// Attempt to specify the filesystem layout of a snapshot. Changes to this may
+// invalidate snapshots of existing workshops, so the snapshot format revision
+// number should be bumped to force a full refresh. This test is mainly
+// concerned with workshop config and devices. While these aren't generally
+// copied to snapshots, they can influence the filesystem before the snapshot
+// is taken (e.g. cloud-config). Direct changes to the filesystem and other
+// backend-agnostic conventions are covered by `apiSuite.TestSnapshotFormat`.
+func (s *snapshotSuite) TestLxdBackendSnapshotFormat(c *check.C) {
+	var format map[string]any
+	err := yaml.Unmarshal(snapshotFormat, &format)
+	c.Assert(err, check.IsNil)
+
+	// Launch workshop.
+	image, err := s.bd.GetBase(s.ctx, "ubuntu@24.04")
+	c.Assert(err, check.IsNil)
+	err = s.bd.DownloadBase(s.ctx, image, nil)
+	c.Assert(err, check.IsNil)
+	wf := &workshop.File{
+		Name: "test",
+		Base: "ubuntu@24.04",
+		Sdks: []workshop.SdkRecord{
+			{Name: "store-sdk", Channel: "latest/stable"},
+			{Name: "local-sdk", Source: sdk.ProjectSource},
+		},
+	}
+	snapshot := workshop.Snapshot{Image: image}
+	err = s.bd.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
+	c.Assert(err, check.IsNil)
+	defer helper.RemoveTestWorkshop(c, s.ctx, s.bd)
+
+	// Validate post-launch metadata.
+	launched := s.workshopFormat(c, wf, snapshot)
+	c.Check(launched, testutil.JsonEquals, format["launched"])
+
+	// Start workshop. Run dir is needed for workshop.socket.
+	fs, err := s.bd.WorkshopFs(s.ctx, wf.Name)
+	c.Assert(err, check.IsNil)
+	err = fs.MkdirAll(dirs.WorkshopRunDir, 0755)
+	fs.Close()
+	c.Assert(err, check.IsNil)
+	err = s.bd.StartWorkshop(s.ctx, wf.Name)
+	c.Assert(err, check.IsNil)
+
+	// Validate post-start metadata.
+	started := s.workshopFormat(c, wf, snapshot)
+	c.Check(started, testutil.JsonEquals, format["started"])
+
+	// Install Store SDK.
+	meta := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "store-sdk",
+			Channel:  "latest/stable",
+			Revision: sdk.R(23),
+			Sha3_384: "18b8ce233667942e94e1f5bdd22bcd516c4a375030a359a5bb09220b416d215fffda138d8d45eaab419ae2403c81ec5d",
+		},
+		SdkYAML: `name: store-sdk
+`,
+	}
+	helper.MockSdkVolume(c, s.ctx, s.bd, meta)
+	defer func() { _ = s.bd.DeleteSdk(s.ctx, meta.Setup) }()
+	err = s.bd.InstallSdk(s.ctx, wf.Name, meta.Setup)
+	c.Assert(err, check.IsNil)
+	defer func() { _ = s.bd.UninstallSdk(s.ctx, wf.Name, meta.Name) }()
+
+	// Validate post-install metadata.
+	snapshot.Sdks = append(snapshot.Sdks, sdk.SetupId(meta.Setup))
+	sdkAttached := s.workshopFormat(c, wf, snapshot)
+	c.Check(sdkAttached, testutil.JsonEquals, format["sdk-attached"])
+
+	// Install in-project SDK.
+	setup2 := sdk.Setup{
+		Name:     "local-sdk",
+		Source:   sdk.ProjectSource,
+		Revision: sdk.R(-34),
+		Sha3_384: "dc00101dfd688cdc058e31d3b82e680df123f85935f741fabcb8f0dfd29d80612f131db8487621abad7ee856223bede1",
+	}
+	userDataDir := workshop.UserDataRootDir(s.usr.HomeDir, nil)
+	sdkDir := workshop.LocalSdkDir(userDataDir, s.project.ProjectId, wf.Name, setup2.Name)
+	err = os.MkdirAll(filepath.Join(sdkDir, setup2.Sha3_384), 0755)
+	c.Assert(err, check.IsNil)
+	err = s.bd.InstallSdk(s.ctx, wf.Name, setup2)
+	c.Assert(err, check.IsNil)
+
+	// Validate post-install metadata.
+	snapshot.Sdks = append(snapshot.Sdks, sdk.SetupId(setup2))
+	sdkMounted := s.workshopFormat(c, wf, snapshot)
+	c.Check(sdkMounted, testutil.JsonEquals, format["sdk-mounted"])
+
+	// Snapshot workshop.
+	err = s.bd.TakeSnapshot(s.ctx, wf.Name, snapshot)
+	c.Assert(err, check.IsNil)
+
+	// Validate snapshot metadata.
+	sdkSnapshot := s.snapshotFormat(c, wf.Name, snapshot)
+	c.Check(sdkSnapshot, testutil.JsonEquals, format["snapshot"])
+}
+
+func (s *snapshotSuite) workshopFormat(c *check.C, file *workshop.File, snapshot workshop.Snapshot) api.InstancePut {
+	conn, err := s.bd.LxdClient(s.ctx)
+	c.Assert(err, check.IsNil)
+	defer conn.Disconnect()
+
+	name := lxdbackend.InstanceName(file.Name, s.project.ProjectId)
+	inst := fullInstance(c, conn, name).Writable()
+
+	// Remove architecture to make the test hardware-agnostic. It already
+	// affects the base image fingerprint so we don't need to worry about
+	// it too much.
+	inst.Architecture = ""
+
+	// Remove config options which aren't constant.
+	for k := range inst.Config {
+		if strings.HasPrefix(k, "volatile.") || strings.HasPrefix(k, "image.") {
+			delete(inst.Config, k)
+		}
+	}
+	c.Check(inst.Config["user.workshop.base-fingerprint"], check.Equals, snapshot.Image.Fingerprint)
+	delete(inst.Config, "user.workshop.base-fingerprint")
+
+	// Marshalling might be nondeterministic.
+	var wf workshop.File
+	c.Assert(yaml.Unmarshal([]byte(inst.Config["user.workshop.file"]), &wf), check.IsNil)
+	c.Check(&wf, check.DeepEquals, file)
+	delete(inst.Config, "user.workshop.file")
+
+	// Avoid having to update the saved configs when bumping the revision.
+	c.Check(inst.Config["user.workshop.format-revision"], check.Equals, lxdbackend.SnapshotFormatRevision.String())
+	delete(inst.Config, "user.workshop.format-revision")
+
+	// Hardware-dependent, not much influence on snapshots.
+	delete(inst.Config, "nvidia.driver.capabilities")
+	delete(inst.Config, "nvidia.runtime")
+
+	// These ones are a bit long, replace with hash for readability.
+	digest := sha3.Sum384([]byte(inst.Config["user.network-config"]))
+	inst.Config["user.network-config"] = hex.EncodeToString(digest[:])
+	digest = sha3.Sum384([]byte(inst.Config["user.user-data"]))
+	inst.Config["user.user-data"] = hex.EncodeToString(digest[:])
+
+	// Host paths of default devices can change without affecting the
+	// workshop, so we exclude them from the hash. Other device options
+	// should be included in case they influence the rootfs.
+	delete(inst.Devices["workshop.workshopctl"], "source")
+	delete(inst.Devices["cache.apt"], "source")
+	delete(inst.Devices["workshop.socket"], "connect")
+
+	for _, sk := range snapshot.Sdks {
+		device := inst.Devices[workshop.SdkDeviceName(sk.Name)]
+		var installTime time.Time
+		c.Assert(installTime.UnmarshalText([]byte(device["user.sdk.install-time"])), check.IsNil)
+		c.Check(installTime.IsZero(), check.Equals, false)
+		delete(device, "user.sdk.install-time")
+
+		if _, ok := device["pool"]; !ok {
+			delete(device, "source")
+		}
+	}
+
+	return inst
+}
+
+func (s *snapshotSuite) snapshotFormat(c *check.C, name string, snapshot workshop.Snapshot) api.InstancePut {
+	conn, err := s.bd.LxdClient(s.ctx)
+	c.Assert(err, check.IsNil)
+	defer conn.Disconnect()
+	snapshotConn := conn.UseProject("workshop-snapshots." + s.usr.Username)
+
+	sk := snapshot.Sdks[len(snapshot.Sdks)-1].Name
+	snapshotName := s.snapshotName(c, snapshotConn, name, sk)
+	defer func() {
+		// TODO: move to main test once backend gets a RemoveSnapshot API.
+		op, err := snapshotConn.DeleteInstance(snapshotName)
+		c.Assert(err, check.IsNil)
+		c.Assert(op.Wait(), check.IsNil)
+	}()
+
+	inst := fullInstance(c, snapshotConn, snapshotName).Writable()
+
+	// Remove architecture to make the test hardware-agnostic. It already
+	// affects the base image fingerprint so we don't need to worry about
+	// it too much.
+	inst.Architecture = ""
+
+	// Remove config options which aren't constant.
+	for k := range inst.Config {
+		if strings.HasPrefix(k, "volatile.") || strings.HasPrefix(k, "image.") {
+			delete(inst.Config, k)
+		}
+	}
+	c.Check(inst.Config["user.workshop.base-fingerprint"], check.Equals, snapshot.Image.Fingerprint)
+	delete(inst.Config, "user.workshop.base-fingerprint")
+
+	digest, err := s.bd.HashSnapshot(snapshot)
+	c.Assert(err, check.IsNil)
+
+	// Avoid having to update the saved configs when bumping the revision.
+	c.Check(inst.Config["user.workshop.format-revision"], check.Equals, lxdbackend.SnapshotFormatRevision.String())
+	delete(inst.Config, "user.workshop.format-revision")
+	c.Check(inst.Config["user.workshop.sha3-384"], check.Equals, digest)
+	delete(inst.Config, "user.workshop.sha3-384")
+
+	return inst
+}
+
+func (s *snapshotSuite) snapshotName(c *check.C, snapshotConn lxd.InstanceServer, w, sk string) string {
+	filters := []string{
+		"config.user.workshop.project-id=" + s.project.ProjectId,
+		"config.user.workshop.name=" + w,
+		"config.user.workshop.snapshot-type=sdk",
+		"config.user.workshop.sdk=" + sk,
+	}
+	snapshots, err := snapshotConn.GetInstancesWithFilter(api.InstanceTypeContainer, filters)
+	c.Assert(err, check.IsNil)
+	c.Assert(snapshots, check.HasLen, 1)
+	return snapshots[0].Name
+}

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -97,11 +97,6 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
-	// Collect workshop metadata.
-	f.waitForNetwork(c, "test")
-	preStash := f.workshopMetadata(c, "test")
-	c.Check(preStash.addresses, check.Not(check.HasLen), 0)
-
 	// Create some snapshots.
 	snapshot := workshop.Snapshot{
 		Image: workshop.BaseImage{
@@ -127,6 +122,11 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 
 	snapshots := f.listSnapshots(c, "test", false)
 	c.Check(snapshots, testutil.DeepUnsortedMatches, []string{"test-sdk-1", "test-sdk-2"})
+
+	// Collect workshop metadata.
+	f.waitForNetwork(c, "test")
+	preStash := f.workshopMetadata(c, "test")
+	c.Check(preStash.addresses, check.Not(check.HasLen), 0)
 
 	// Stash workshop.
 	err = f.bd.StashWorkshop(f.ctx, "test")
@@ -231,11 +231,17 @@ func (f *wsOps) stashMetadata(c *check.C, name string) metadata {
 }
 
 func instanceMetadata(c *check.C, conn lxd.InstanceServer, name string) metadata {
+	inst := fullInstance(c, conn, name)
+	return metadata{inst.Config, inst.Devices, ipAddresses(inst)}
+}
+
+func fullInstance(c *check.C, conn lxd.InstanceServer, name string) *api.InstanceFull {
 	inst, _, err := conn.GetInstanceFull(name)
 	c.Assert(err, check.IsNil)
 
 	maps.DeleteFunc(inst.Config, func(k, v string) bool { return !includeWhenCopying(k) })
-	return metadata{inst.Config, inst.Devices, ipAddresses(inst)}
+
+	return inst
 }
 
 func includeWhenCopying(key string) bool {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -23,6 +23,8 @@ var (
 	ConfigWorkshopBaseFingerprint = "user.workshop.base-fingerprint"
 	ConfigWorkshopSdk             = "user.workshop.sdk"
 	ConfigWorkshopSnapshotType    = "user.workshop.snapshot-type"
+	ConfigWorkshopSnapshotFormat  = "user.workshop.format-revision"
+	ConfigWorkshopSha3_384        = "user.workshop.sha3-384"
 	ConfigProjectPathDevice       = "workshop.project"
 	ConfigStateStorageDevice      = "workshop.state-storage"
 )

--- a/tests/integration/workshop-snapshots/task.yaml
+++ b/tests/integration/workshop-snapshots/task.yaml
@@ -1,0 +1,10 @@
+summary: Run LXD integration tests for workshop snapshots
+
+execute: |
+  rm -rf cover
+  mkdir cover
+
+  go test -cover "$SPREAD_PATH"/internal/workshop/lxd/tests/integration -timeout=30m -tags=integration -check.v -check.f snapshotSuite -coverpkg=github.com/canonical/workshop/internal/workshop/lxd -args -test.gocoverdir="$PWD"/cover
+
+artifacts:
+  - cover

--- a/tests/main/try-sdks/task.yaml
+++ b/tests/main/try-sdks/task.yaml
@@ -12,7 +12,7 @@ execute: |
   try_area='/home/ubuntu/.local/share/workshop/try/test-sdk-basic'
   sudo -u ubuntu mkdir -p "$try_area"
   sudo -u ubuntu cp "$store_area/latest/stable/test-sdk-basic.sdk" "$try_area/test-sdk-basic_all.sdk"
-  echo fakehash | sudo -u ubuntu tee "$try_area/test-sdk-basic_all.sdk.sha3-384"
+  echo 50aae25a070e742e9ea72a4bd3ed419f5a0a34391e294c4b619ed5659b041b7bfc872c4070811e4fba4084bcf15d8fe8 | sudo -u ubuntu tee "$try_area/test-sdk-basic_all.sdk.sha3-384"
   sudo -u ubuntu cp "$store_area/latest/stable/sdk.yaml" "$try_area/test-sdk-basic_all.sdk.yaml"
 
   workshop_exec launch
@@ -36,7 +36,7 @@ execute: |
 
   echo "Check SDKs in try area can be updated"
   sudo -u ubuntu cp "$store_area/latest/edge/test-sdk-basic.sdk" "$try_area/test-sdk-basic_all.sdk"
-  echo fakehash2 | sudo -u ubuntu tee "$try_area/test-sdk-basic_all.sdk.sha3-384"
+  echo fccdbd97fa7d51053e0e6a9db8e3fc81bbce19aaa4d578072b9bb53527b45a80f30781c97c9fb830670b9141fdf8df19 | sudo -u ubuntu tee "$try_area/test-sdk-basic_all.sdk.sha3-384"
   sudo -u ubuntu cp "$store_area/latest/edge/sdk.yaml" "$try_area/test-sdk-basic_all.sdk.yaml"
 
   workshop_exec refresh


### PR DESCRIPTION
# Description

Based on https://github.com/canonical/workshop/pull/617.

Adds a `user.workshop.sha3-384` config option to SDK snapshots, with the goal that other workshops should be able to make use of them if they plan on installing SDKs which would lead to the same snapshot. Computing the hash is easy enough, similar to the existing `osutil.HashDirEntries`.

The tricky part is invalidating the hash when we (or LXD) make backwards-incompatible changes. Each hash takes into account a hard-coded number: `lxdbackend.SnapshotFormatRevision`. We need to bump this number each time we make such changes. I've added some tests which try to ensure we don't forget about it.

I tried to make the tests comprehensive while remaining as simple as possible, at the cost of a potentially high false positive rate. Remains to be seen how annoying this will be. The tests all generate an ad-hoc data structure and compare it with an embedded YAML file. If updating these files becomes too onerous we can look at adding a script to generate them automatically. I don't think it should be automated away to the extent that we forget to update the revision number, though.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
