### PR TITLE
Add WSL btrfs storage fallback

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -7,6 +7,7 @@ AUTH
 autosquash
 backend
 basename
+Btrfs
 bugfix
 Caddy
 Caddyfile

--- a/docs/explanation/architecture/components.rst
+++ b/docs/explanation/architecture/components.rst
@@ -235,18 +235,18 @@ used for temporary storage during workshop rebuild operations.
 
 .. _exp_arch_zfs_storage:
 
-ZFS storage
-~~~~~~~~~~~
+Storage backends
+~~~~~~~~~~~~~~~~
 
-|ws_markup| uses ZFS for its storage needs, managed via LXD;
-it requires a minimum pool size of 5 GiB.
+|ws_markup| uses ZFS for storage on Linux,
+with automatic Btrfs fallback on Windows Subsystem for Linux (WSL).
+Storage is managed via LXD and requires a minimum pool size of 5 GiB.
 
-The ZFS pool manages container root filesystems, workshop-specific data volumes,
+The storage backend manages container root filesystems, workshop-specific data volumes,
 cached base images, and snapshots for efficient workshop updates and rollbacks.
 This component provides copy-on-write storage utilization, LZ4 compression,
 and quota management,
 and is utilized by the :ref:`LXD backend <exp_arch_lxd_backend>` for container operations.
-
 
 
 

--- a/docs/reference/workshops.rst
+++ b/docs/reference/workshops.rst
@@ -141,23 +141,26 @@ trigger the refresh mechanism:
 This prevents broken states during major refreshes.
 
 
-ZFS storage and pool size
+Storage pools and drivers
 -------------------------
 
-|ws_markup| stores its containers and data on a ZFS pool by default.
+|ws_markup| stores its containers and data on a storage pool.
+On Linux, |ws_markup| uses ZFS,
+while on Windows Subsystem for Linux it automatically uses Btrfs.
 This approach consolidates container images, :program:`apt` caches, SDKs
 and other workshop content under a single system.
 
 If you need more space or different performance,
-you can resize or tune the ZFS pool (it's named :samp:`workshop`),
-using the :command:`lxc storage` command
+you can resize or tune the storage pool (it's named :samp:`workshop`),
+using the :command:`lxc storage` command
 as suggested in this `LXD documentation section
 <https://documentation.ubuntu.com/lxd/latest/howto/storage_pools/>`_.
 However, day-to-day usage requires little manual intervention.
 
 .. attention::
 
-   Don't use the default ZFS utilities to alter the LXD-managed ZFS pool,
+   Don't use storage driver utilities (such as :command:`zfs` or :command:`btrfs`)
+   directly to alter the LXD-managed storage pool,
    as this may cause issues with LXD.
 
 

--- a/docs/tutorial/part-1-get-started.rst
+++ b/docs/tutorial/part-1-get-started.rst
@@ -94,6 +94,8 @@ To refresh an existing installation:
    Again, refer to LXD documentation
    and your distribution's manuals for guidance.
 
+   |ws_markup| is compatible with Windows Subsystem for Linux (WSL2).
+   On WSL, |ws_markup| automatically uses Btrfs instead of ZFS for storage.
 
 .. _tut_define_launch:
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	storagePool           = "workshop"
-	storagePoolDriver     = "zfs"
 	storagePoolMinimalGiB = 5
 
 	networkName = "workshopbr0"
@@ -41,7 +40,22 @@ const (
 var (
 	checkNvidiaRuntime  = checkNvidia
 	startCommandTimeout = 1 * time.Minute
+	storagePoolDriver   = "zfs"
 )
+
+// isWSL checks if we're running on Windows Subsystem for Linux
+func isWSL() bool {
+	var utsname unix.Utsname
+	if err := unix.Uname(&utsname); err != nil {
+		return false
+	}
+	data := utsname.Release[:]
+	if idx := bytes.IndexByte(data, 0); idx >= 0 {
+		data = data[:idx]
+	}
+	version := strings.ToLower(string(data))
+	return strings.Contains(version, "microsoft") || strings.Contains(version, "wsl2")
+}
 
 type volumeGuard struct {
 	c       chan struct{}
@@ -71,6 +85,10 @@ func init() {
 	volumeGuardsLock.Lock()
 	defer volumeGuardsLock.Unlock()
 	volumeGuards = make(map[string]*volumeGuard)
+
+	if isWSL() {
+		storagePoolDriver = "btrfs"
+	}
 
 	syscheck.RegisterCheck(checkServerCapabilities)
 }
@@ -150,10 +168,10 @@ func checkVersion(version string) error {
 }
 
 func checkStorage(drivers []api.ServerStorageDriverInfo) error {
-	isZfs := func(driver api.ServerStorageDriverInfo) bool {
-		return driver.Name == "zfs"
+	hasDriver := func(driver api.ServerStorageDriverInfo) bool {
+		return driver.Name == storagePoolDriver
 	}
-	if slices.ContainsFunc(drivers, isZfs) {
+	if slices.ContainsFunc(drivers, hasDriver) {
 		return nil
 	}
 
@@ -161,7 +179,7 @@ func checkStorage(drivers []api.ServerStorageDriverInfo) error {
 	//  Error: Error loading "zfs" module: Failed to run: modprobe -b zfs:
 	//  exit status 1 (modprobe: FATAL: Module zfs not found ...)
 	// We keep the first part for consistency, the rest doesn't add much.
-	return errors.New(`suitable storage backend not found: error loading "zfs" module`)
+	return fmt.Errorf(`suitable storage backend not found: error loading %q module`, storagePoolDriver)
 }
 
 func checkServerCapabilities() error {
@@ -244,7 +262,7 @@ func New() (*Backend, error) {
 			logger.Noticef("On Backend.New: set storage pool to the minimal size: %dGiB", storagePoolMinimalGiB)
 		}
 	} else if pools[idx].Driver != storagePoolDriver {
-		return nil, fmt.Errorf("storage pool %q already exists with a different driver: %q", storagePool, pools[idx].Driver)
+		return nil, fmt.Errorf("storage pool %q already exists with a different driver: %q (expected %q)", storagePool, pools[idx].Driver, storagePoolDriver)
 	}
 
 	networks, err := conn.GetNetworks()
@@ -1056,7 +1074,7 @@ users:
 apt:
   conf: |
     # Installed by workshop
-    
+
     # Don't automatically install recommended packages
     APT::Install-Recommends "0";
 


### PR DESCRIPTION
# Description

Workshop will fall back to `btrfs` if on `WSL`. I manually tested these changes on Windows with the following scenarios:
- Launch & remove `ollama` reference workshop.
- Change SDKs order or remove an SDK and refresh.
- Change tunnel connection properties and refresh.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
