### PR TITLE
Improve and document ShellCheck

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: shellcheck
         run: |
-          git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck --external-sources
+          git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck --check-sourced --external-sources
           snapd-testing-tools/utils/spread-shellcheck tests/integration
 
       - name: Print error message

--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -25,7 +25,7 @@ actions:
     golangci-lint run
     golangci-lint run --new-from-rev='HEAD~' --config=.golangci.incremental.yaml
   shellcheck: |
-    git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck
+    git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck --check-sourced --external-sources
     /opt/snapd-testing-tools/utils/spread-shellcheck tests/integration
   cover: |
     go test -covermode=count -coverpkg=./... -coverprofile=coverage.out ./...

--- a/docs/explanation/sdks/concepts.rst
+++ b/docs/explanation/sdks/concepts.rst
@@ -79,7 +79,8 @@ understanding the events that trigger them can help you with troubleshooting.
 When you define an SDK,
 its hooks should be placed in the :file:`hooks/` subdirectory
 next to the :ref:`definition <exp_sdk_definition>`;
-|sdk_markup| validates and packages them along with the :file:`.yaml` file.
+|sdk_markup| lints them with `ShellCheck <https://www.shellcheck.net/>`_
+and packages them along with the :file:`.yaml` file.
 
 
 .. _exp_workshopctl:

--- a/docs/explanation/workshops/concepts.rst
+++ b/docs/explanation/workshops/concepts.rst
@@ -298,7 +298,7 @@ intended as utility helpers for a development environment:
      lint: |
        golangci-lint run  --out-format=colored-line-number -c .golangci.yaml
      shellcheck: |
-       git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck
+       git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck --check-sourced --external-sources
      unit: |
        go test ./...
      cover: |

--- a/docs/how-to/customize-workshops/add-actions.rst
+++ b/docs/how-to/customize-workshops/add-actions.rst
@@ -41,7 +41,7 @@ from the :ref:`tut_sketch_sdks` tutorial section:
      lint: |
        golangci-lint run --out-format=colored-line-number -c .golangci.yaml
      shellcheck: |
-       git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck
+       git ls-files | file --mime-type -Nnf- | grep shellscript | cut -f1 -d: | xargs shellcheck --check-sourced --external-sources
 
 
 Unlike changes in SDK layout or base,

--- a/snap/local/hooks/configure
+++ b/snap/local/hooks/configure
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # shellcheck source=snap/local/lib/completion
 . "$SNAP/snap/lib/completion"

--- a/snap/local/hooks/post-refresh
+++ b/snap/local/hooks/post-refresh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # shellcheck source=snap/local/lib/lxc-utils
 . "$SNAP/snap/lib/lxc-utils"

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # Allow the script to run without snap.
 if [ -n "$SNAP" ]; then


### PR DESCRIPTION
# Description

Follow up to https://github.com/canonical/sdkcraft/pull/199.

Adds ShellCheck to the hook documentation, and ensures we run `shellcheck` on sourced scripts in addition to top-level scripts.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
