### PR TITLE
Fix cloud-config hash

### DIFF
--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -16,7 +16,7 @@ launched:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '330c760a65aca63023c834efb6f0f89e6da683c15b54a635dede4a6b55f7677e2efd244a70f33e0b246eaaf6999a9394'
+    user.user-data: '0ae722cce9cce59600fc0f0a37db6fece6d6c698169f2a74d960a14d7ea20702b53abbefc69478bd967614e430832122'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -55,7 +55,7 @@ started:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '330c760a65aca63023c834efb6f0f89e6da683c15b54a635dede4a6b55f7677e2efd244a70f33e0b246eaaf6999a9394'
+    user.user-data: '0ae722cce9cce59600fc0f0a37db6fece6d6c698169f2a74d960a14d7ea20702b53abbefc69478bd967614e430832122'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -94,7 +94,7 @@ sdk-attached:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '330c760a65aca63023c834efb6f0f89e6da683c15b54a635dede4a6b55f7677e2efd244a70f33e0b246eaaf6999a9394'
+    user.user-data: '0ae722cce9cce59600fc0f0a37db6fece6d6c698169f2a74d960a14d7ea20702b53abbefc69478bd967614e430832122'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -144,7 +144,7 @@ sdk-mounted:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '330c760a65aca63023c834efb6f0f89e6da683c15b54a635dede4a6b55f7677e2efd244a70f33e0b246eaaf6999a9394'
+    user.user-data: '0ae722cce9cce59600fc0f0a37db6fece6d6c698169f2a74d960a14d7ea20702b53abbefc69478bd967614e430832122'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''


### PR DESCRIPTION
# Description

The snapshot tests were merged at roughly the same time as WSL support. The latter adjusted some whitespace in cloud-config, requiring an update for the cloud-config hash in the snapshot tests.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
