### PR TITLE
Run hooks with bash -x during verbose launches and refreshes

### DIFF
--- a/client/projects.go
+++ b/client/projects.go
@@ -15,6 +15,7 @@ type WorkshopActionOptions struct {
 	Mode string `json:"mode,omitempty"`
 	// Supported refresh options: "update", "restore".
 	RefreshOption string `json:"refresh-option,omitempty"`
+	Verbose       bool   `json:"verbose,omitzero"`
 }
 
 type WorkshopActionSetup struct {
@@ -72,23 +73,25 @@ func (client *Client) doWorkshopAction(projectId string, action *WorkshopActionS
 	return client.doAsync("POST", "/v1/projects/"+projectId+"/workshops", nil, nil, &body)
 }
 
-func (client *Client) Launch(projectId string, names []string, mode string) (changeId string, err error) {
+func (client *Client) Launch(projectId string, names []string, mode string, verbose bool) (changeId string, err error) {
 	return client.doWorkshopAction(projectId, &WorkshopActionSetup{
 		Action: "launch",
 		Names:  names,
 		Options: &WorkshopActionOptions{
-			Mode: mode,
+			Mode:    mode,
+			Verbose: verbose,
 		},
 	})
 }
 
-func (client *Client) Refresh(projectId string, names []string, mode string, option string) (changeId string, err error) {
+func (client *Client) Refresh(projectId string, names []string, mode string, option string, verbose bool) (changeId string, err error) {
 	return client.doWorkshopAction(projectId, &WorkshopActionSetup{
 		Action: "refresh",
 		Names:  names,
 		Options: &WorkshopActionOptions{
 			Mode:          mode,
 			RefreshOption: option,
+			Verbose:       verbose,
 		},
 	})
 }

--- a/client/projects_test.go
+++ b/client/projects_test.go
@@ -37,7 +37,7 @@ func (cs *clientSuite) TestClientProject(c *check.C) {
 func (cs *clientSuite) TestClientLaunch(c *check.C) {
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
-	id, err := cs.cli.Launch("42ws42ws", []string{"ws"}, "transactional")
+	id, err := cs.cli.Launch("42ws42ws", []string{"ws"}, "transactional", true)
 
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Assert(id, check.Equals, "24")
@@ -46,13 +46,13 @@ func (cs *clientSuite) TestClientLaunch(c *check.C) {
 	body, err := io.ReadAll(cs.req.Body)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(string(body), check.Matches, `{"names":\["ws"\],"action":"launch",\"options\":{\"mode\":\"transactional\"}}\n`)
+	c.Assert(string(body), check.Matches, `{"names":\["ws"\],"action":"launch","options":{"mode":"transactional","verbose":true}}\n`)
 }
 
 func (cs *clientSuite) TestClientRefresh(c *check.C) {
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
-	id, err := cs.cli.Refresh("42ws42ws", []string{"ws"}, "transactional", "update")
+	id, err := cs.cli.Refresh("42ws42ws", []string{"ws"}, "transactional", "update", false)
 
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Assert(id, check.Equals, "24")

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -116,7 +116,7 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 		mode = "abort"
 	}
 
-	changeId, err := cli.Launch(project.Id, av, mode)
+	changeId, err := cli.Launch(project.Id, av, mode, c.verbose)
 	if err != nil {
 		return err
 	}

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -126,7 +126,7 @@ func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av 
 		}
 	}
 
-	changeId, err := cli.Refresh(project.Id, av, mode, option)
+	changeId, err := cli.Refresh(project.Id, av, mode, option, c.verbose)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/how-to/fix-workshops/debug-issues.rst
+++ b/docs/how-to/fix-workshops/debug-issues.rst
@@ -46,6 +46,9 @@ Suppose something goes wrong during :command:`workshop refresh`:
      Refresh aborted
 
 
+To show more details, try :command:`workshop refresh --verbose`;
+you can also use :option:`!--verbose` with :command:`workshop launch`.
+
 To see the *tasks*, or individual actions,
 during the latest *change*, which is essentially a major workshop update,
 run :command:`workshop tasks` without arguments:

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -499,6 +499,12 @@ in the :file:`/project/` directory.
 
 A hook can signal an error by returning a non-zero exit code;
 a zero code indicates success.
+The options :samp:`errexit` and :samp:`pipefail`
+are set by default,
+so most commands which return a non-zero exit code
+cause the hook to exit with the same code.
+If :option:`!--verbose` is passed to :command:`workshop launch` or :command:`workshop refresh`,
+the option :samp:`xtrace` is also set.
 
 .. note::
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -31,6 +31,7 @@ type actionOpts struct {
 	Mode string `json:"mode"`
 	// Supported refresh options: "update", "restore".
 	RefreshOption string `json:"refresh-option"`
+	Verbose       bool   `json:"verbose"`
 }
 
 type workshopReq struct {
@@ -518,10 +519,12 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		case "launch":
 			change = newWorkshopChange(st, "launch", user, projectId, reqData.Action, reqData.Names)
 			change.Set("wait-setup", conflict.ChangeSetup{Mode: mode.String()})
+			change.Set("verbose", reqData.Options.Verbose)
 			manifests, taskset, err = launch(r.Context(), wsmgr, &reqData, projectId)
 		case "refresh":
 			change = newWorkshopChange(st, "refresh", user, projectId, reqData.Action, reqData.Names)
 			change.Set("wait-setup", conflict.ChangeSetup{Mode: mode.String()})
+			change.Set("verbose", reqData.Options.Verbose)
 			manifests, taskset, err = refresh(r.Context(), wsmgr, &reqData, projectId)
 		case "start":
 			change = newWorkshopChange(st, "start", user, projectId, reqData.Action, reqData.Names)

--- a/internal/daemon/snapshot-format.yaml
+++ b/internal/daemon/snapshot-format.yaml
@@ -57,7 +57,7 @@ test-sdk-2:
     snapshot-sdk: 2
   fs-calls: 10
   exec-calls:
-    - ["bash", "-eo", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
 test-sdk:
   files:
     - drwxr-xr-x var
@@ -78,8 +78,8 @@ test-sdk:
     snapshot-sdk: 3
   fs-calls: 13
   exec-calls:
-    - ["bash", "-eo", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
-    - ["bash", "-eo", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
+    - ["bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
 sketch:
   files:
     - drwxr-xr-x var

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -44,17 +44,42 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
+	var verbose bool
+	st.Lock()
+	err = task.Change().Get("verbose", &verbose)
+	st.Unlock()
+	if errors.Is(err, state.ErrNoState) {
+		verbose = false
+	} else if err != nil {
+		return err
+	}
+
 	hookPath := sdk.SdkHookPath(hook.Sdk, hook.Type())
+
+	command := []string{"bash", "-o", "errexit", "-o", "pipefail"}
+	if verbose {
+		command = append(command, "-o", "xtrace")
+	}
+	if hook.HookType == SetupProject {
+		runAsUser := []string{
+			"sudo",
+			"--user=#" + workshop.User.Uid,
+			"--group=#" + workshop.User.Gid,
+			"--preserve-env",
+			"--",
+			"bash",
+			"-l",
+			"-c",
+			`exec -- "$0" "$@"`,
+		}
+		command = append(runAsUser, command...)
+	}
+	command = append(command, hookPath)
 
 	execArgs := &workshop.ExecArgs{
 		UserId:  0,
 		GroupId: 0,
-		Command: []string{
-			"bash",
-			"-eo",
-			"pipefail",
-			hookPath,
-		},
+		Command: command,
 		Environment: map[string]string{
 			"SDK": sdk.SdkDir(hook.Sdk),
 		},
@@ -97,22 +122,7 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		execArgs.Environment["SDK_STATE_DIR"] = filepath.Join(where, "sdk", hook.Sdk)
 	}
 
-	switch hook.HookType {
-	case SetupProject:
-		execArgs.Command = []string{
-			"sudo",
-			"-u",
-			"#" + workshop.User.Uid,
-			"-g",
-			"#" + workshop.User.Gid,
-			"--preserve-env",
-			"--",
-			"bash",
-			"-elo",
-			"pipefail",
-			hookPath,
-		}
-
+	if hook.HookType == SetupProject {
 		uid, gid, err := osutil.UidGid(&workshop.User)
 		if err != nil {
 			return err
@@ -126,10 +136,9 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		xdgRuntimeDir := filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid)
 		execArgs.Environment["XDG_RUNTIME_DIR"] = xdgRuntimeDir
 		execArgs.Environment["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=" + filepath.Join(xdgRuntimeDir, "bus")
-		return h.executeHook(ctx, task, w, &hook, execArgs)
-	default:
-		return h.executeHook(ctx, task, w, &hook, execArgs)
 	}
+
+	return h.executeHook(ctx, task, w, &hook, execArgs)
 }
 
 type HookLogKey string

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -145,6 +145,7 @@ func (s *hookSuite) TestExecSetupProject(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
+	chg.Set("verbose", true)
 	chg.AddTask(t1)
 
 	s.launchWorkshop(c, "one")
@@ -155,8 +156,25 @@ func (s *hookSuite) TestExecSetupProject(c *check.C) {
 	s.state.Lock()
 	c.Assert(chg.Err(), check.IsNil)
 	c.Assert(s.backend.ExecCalls, check.HasLen, 1)
-	c.Check(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "-u", "#1000", "-g", "#1000", "--preserve-env", "--", "bash", "-elo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/setup-project"})
+	c.Check(s.backend.ExecCalls[0].Args.Command, check.DeepEquals, []string{
+		"sudo",
+		"--user=#1000",
+		"--group=#1000",
+		"--preserve-env",
+		"--",
+		"bash",
+		"-l",
+		"-c",
+		`exec -- "$0" "$@"`,
+		"bash",
+		"-o",
+		"errexit",
+		"-o",
+		"pipefail",
+		"-o",
+		"xtrace",
+		"/var/lib/workshop/sdk/one/sdk/hooks/setup-project",
+	})
 	c.Check(s.backend.ExecCalls[0].Args.WorkDir, check.Equals, "/project")
 }
 
@@ -204,7 +222,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+		[]string{"bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
@@ -227,6 +245,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
+	chg.Set("verbose", true)
 	chg.AddTask(t1)
 
 	s.state.Unlock()
@@ -238,7 +257,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
+		[]string{"bash", "-o", "errexit", "-o", "pipefail", "-o", "xtrace", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
@@ -279,7 +298,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+		[]string{"bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
@@ -319,7 +338,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"bash", "-eo", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
+		[]string{"bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -3,9 +3,12 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   echo "Check workshop can be launched with a basic SDK"
-  workshop_exec launch
+  workshop_exec launch --verbose
   workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-basic[[:space:]]*Ready[[:space:]]*-"
-  
+
+  # Check setup-base is run using bash -x
+  workshop_exec tasks | MATCH "\\+ echo 'setup-base ran successfully\!'\$"
+
   # Ensure there is one installed SDK that was provided in the workshop definition
   workshop_exec info | yq ".sdks | length == 1"
   workshop_exec info | yq '.sdks["test-sdk-basic"].tracking' | MATCH "latest/stable"


### PR DESCRIPTION
# Description

For `workshop launch --verbose` and `workshop refresh --verbose`, we now run hooks using `bash -x`.

The client passes `verbose=true` as an option when requesting a launch or refresh. This is attached to the `Change` and inspected by the `run-hook` handler. It should be a non-breaking change: if `verbose=false` is the same as `verbose` being absent.

For compatibility with `bash -l` in `setup-project` hooks, we now run a second shell (with `-x`) inside the original shell (with `-l`). Otherwise the `-x` applies to `/etc/profile` and anything it sources. I don't think this will significantly change the behaviour, but I'll test against some or all of the reference SDKs to be sure.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
