### PR TITLE
Ensure active connections are always stored in the state

### DIFF
--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -487,7 +487,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 
 	rev.Add(func() {
 		err := m.repo.Disconnect(cref.PlugRef.ProjectId, cref.PlugRef.Workshop, cref.PlugRef.Sdk, cref.PlugRef.Name,
-			cref.SlotRef.ProjectId, cref.PlugRef.Workshop, cref.SlotRef.Sdk, cref.SlotRef.Name)
+			cref.SlotRef.ProjectId, cref.SlotRef.Workshop, cref.SlotRef.Sdk, cref.SlotRef.Name)
 		if err != nil {
 			logger.Noticef("On doConnect: Cannot revert connection %q", cref.ID())
 		}

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -297,7 +297,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 }
 
 func (m *InterfaceManager) batchDisconnectTasks(p workshop.Project, workshop, sdkName string,
-	conns map[string]*schema.ConnState, refs []*interfaces.ConnRef) *state.TaskSet {
+	refs []*interfaces.ConnRef) *state.TaskSet {
 	ts := state.NewTaskSet()
 
 	var prev *state.Task
@@ -306,9 +306,6 @@ func (m *InterfaceManager) batchDisconnectTasks(p workshop.Project, workshop, sd
 			fmt.Sprintf("Disconnnect %q from %q", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
 		task.Set("plug", ref.PlugRef)
 		task.Set("slot", ref.SlotRef)
-		if conn := conns[ref.ID()]; conn != nil && conn.Undesired {
-			continue
-		}
 		task.Set("forget", true)
 
 		if prev != nil {
@@ -365,17 +362,12 @@ func (m *InterfaceManager) doDisconnectInterfaces(task *state.Task, tomb *tomb.T
 		chg.Set("remounts", remounts)
 	}
 
-	conns, err := getConns(m.state)
-	if err != nil {
-		return err
-	}
-
 	connections, err := m.repo.Connections(project.ProjectId, w, s)
 	if err != nil {
 		return err
 	}
 
-	ts := m.batchDisconnectTasks(*project, w, s, conns, connections)
+	ts := m.batchDisconnectTasks(*project, w, s, connections)
 
 	handlersetup.InjectTasks(task, ts)
 	m.state.EnsureBefore(0)

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -749,6 +749,17 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 		return err
 	}
 
+	rev := revert.New()
+	defer rev.Fail()
+
+	rev.Add(func() {
+		err1 := m.repo.Disconnect(cref.PlugRef.ProjectId, cref.PlugRef.Workshop, cref.PlugRef.Sdk, cref.PlugRef.Name,
+			cref.SlotRef.ProjectId, cref.SlotRef.Workshop, cref.SlotRef.Sdk, cref.SlotRef.Name)
+		if err1 != nil {
+			logger.Noticef("On undoDisconnect: Cannot revert connection %q", cref.ID())
+		}
+	})
+
 	for _, ref := range []sdk.Ref{c.Plug.Sdk().Ref(), c.Slot.Sdk().Ref()} {
 		ctx, cancel := handlersetup.BackendContext(tomb, user, ref.ProjectId)
 		defer cancel()
@@ -761,6 +772,8 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 
 	conns[cref.ID()] = &oldconn
 	setConns(st, conns)
+
+	rev.Success()
 	return nil
 }
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -1412,7 +1412,7 @@ func (s *interfaceHandlersSuite) TestDisconnectForgetAuto(c *check.C) {
 
 func (s *interfaceHandlersSuite) TestUndoDisconnect(c *check.C) {
 	// Setup
-	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs, producer})
 	repo := s.mgr.Repository()
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
@@ -1463,7 +1463,7 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectUndesiredSuccess(c *check.C) 
 	// Setup
 	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 	repo := s.mgr.Repository()
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 	s.state.Lock()
 	conn := map[string]any{

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -1513,6 +1513,66 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectUndesiredSuccess(c *check.C) 
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
+func (s *interfaceHandlersSuite) TestUndoDisconnectSetupFailure(c *check.C) {
+	// Setup
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	s.state.Lock()
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"auto":      false,
+		},
+	})
+	s.state.Unlock()
+
+	// Make Setup() fail during undoDisconnect.
+	s.secBackend.SetupCallback = func(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
+		conns, err := repo.Connections(sdkRef.ProjectId, sdkRef.Workshop, sdkRef.Sdk)
+		if err != nil {
+			return err
+		}
+
+		if len(conns) > 0 {
+			return fmt.Errorf("setup failed on reconnect")
+		}
+		return nil
+	}
+
+	chg := s.disconnectChange(c, "ws", false)
+	s.state.Lock()
+	terr := s.state.NewTask("error-trigger", "...")
+	terr.WaitAll(state.NewTaskSet(chg.Tasks()...))
+	chg.AddTask(terr)
+	s.state.Unlock()
+
+	// Execute
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*error-trigger task.*")
+
+	// Validate
+	cons, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Assert(cons, check.HasLen, 0)
+
+	prods, err := repo.Connections(s.prj.ProjectId, "ws", "producer")
+	c.Assert(err, check.IsNil)
+	c.Assert(prods, check.HasLen, 0)
+
+	var conns map[string]any
+	err = s.state.Get("conns", &conns)
+	c.Assert(err, check.IsNil)
+	c.Assert(conns, check.HasLen, 0)
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
 func (s *interfaceHandlersSuite) connectChange(workshop string, auto bool, delayedBacked bool) *state.Change {
 	s.state.Lock()
 	chg := s.state.NewChange("sample", "...")


### PR DESCRIPTION
# Description

Fixes #632 (to the best of my knowledge).

There are a few invariants we want to rely on when working with interfaces:
- Registered SDKs are always installed
- Registered plugs and slots always belong to a registered SDK
- Registered connections always involve registered plugs and slots
- Registered connections are never undesirable
- Registered connections are always recorded in the state

If the last one is broken, removing the workshop will fail, since we attempt to disconnect all registered connections, and the `disconnect` task expects the connection to be in the state.

Currently the undo handler for disconnect breaks this invariant if it fails at a certain point. I fixed that and added a regression test.

If one of the other invariants is broken, it should be possible to violate the last one even after this PR is merged. But I'm pretty sure they're all sound.

Since undesirable connections are never actually connected, there's no need to filter them out when disconnecting. I removed that, since it shouldn't change anything. But on the off chance we connect something undesirable, it's probably a good idea to disconnect it as soon as possible. Also, it means there are fewer scenarios which can break the last invariant.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
