### PR TITLE
Fix some typos

### DIFF
--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -63,7 +63,7 @@ func (c *cmdRun) Command() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&c.CreateDirs, "create-dirs", false, sharedRunEnterOptsHelp["create-dirs"])
-	cmd.Flags().String(c.HTTP, "http", sharedRunEnterOptsHelp["http"])
+	cmd.Flags().StringVar(&c.HTTP, "http", "", sharedRunEnterOptsHelp["http"])
 	cmd.Flags().BoolVar(&c.Verbose, "verbose", false, sharedRunEnterOptsHelp["verbose"])
 
 	return cmd

--- a/internal/arch/arch.go
+++ b/internal/arch/arch.go
@@ -49,7 +49,7 @@ func DpkgArchitecture() string {
 	return string(arch)
 }
 
-// dpkgArchFromGoArch maps a go architecture string to the coresponding
+// dpkgArchFromGoArch maps a go architecture string to the corresponding
 // Debian equivalent architecture string.
 //
 // E.g. the go "386" architecture string maps to the ubuntu "i386"

--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -396,7 +396,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 
 			if !a.Forget {
 				// Ensure the connection exists if it is not going to be
-				// forgotten (if forget is true the conenction may present only
+				// forgotten (if forget is true the connection may present only
 				// in the state and not in the repository).
 				_, err = repo.Connection(connRef)
 				if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -108,7 +108,7 @@ type userState struct{}
 // A ResponseFunc handles one of the individual verbs for a method
 type ResponseFunc func(*Command, *http.Request, *userState) Response
 
-// A Command routes a request to an individual per-verb ResponseFUnc
+// A Command routes a request to an individual per-verb ResponseFunc
 type Command struct {
 	Path       string
 	PathPrefix string
@@ -743,7 +743,7 @@ func (d *Daemon) RebootIsMissing(st *state.State) error {
 	}
 	st.Set("daemon-system-restart-tentative", nTentative)
 	d.state = st
-	logger.Noticef("workshop was restarted while a system restart was expected, workshop will try to schedule and wait for a system restart again (tenative %d/%d)", nTentative, rebootMaxTentatives)
+	logger.Noticef("workshop was restarted while a system restart was expected, workshop will try to schedule and wait for a system restart again (tentative %d/%d)", nTentative, rebootMaxTentatives)
 	return errExpectedReboot
 }
 

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -139,7 +139,7 @@ func (s *Specification) SetDesktop(desktop workshop.Desktop) error {
 func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 	s.Profile.Gpu = &gpu
 
-	// The default workshop user must be able to acces the GPU device.
+	// The default workshop user must be able to access the GPU device.
 	// Workshop assigns the GPU devices to workshop.workshop. A more
 	// traditional way here would be to add dri devices to the video/render
 	// groups, but it requires an additional workshop exec to find out the

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -66,7 +66,7 @@ func OnDo(handler state.HandlerFunc) state.HandlerFunc {
 
 				mode, moderr := conflict.ParseMode(setup.Mode)
 				if moderr != nil {
-					return fmt.Errorf("internal error: unkown change mode: %s", setup.Mode)
+					return fmt.Errorf("internal error: unknown change mode: %s", setup.Mode)
 				}
 
 				if mode == conflict.ChangeWaitOnError {

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -303,7 +303,7 @@ func (m *InterfaceManager) batchDisconnectTasks(p workshop.Project, workshop, sd
 	var prev *state.Task
 	for _, ref := range refs {
 		task := m.state.NewTask("disconnect",
-			fmt.Sprintf("Disconnnect %q from %q", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
+			fmt.Sprintf("Disconnect %q from %q", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
 		task.Set("plug", ref.PlugRef)
 		task.Set("slot", ref.SlotRef)
 		if conn := conns[ref.ID()]; conn != nil && conn.Undesired {

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -267,7 +267,7 @@ func (o *Overlord) loadState(statePath string, restartHandler restart.Handler, b
 	if os.Getpid() == 1 {
 		curBootID, err = randutil.RandomKernelUUID()
 		if err != nil {
-			return nil, fmt.Errorf("fatal: cannot generate psuedo boot-id: %w", err)
+			return nil, fmt.Errorf("fatal: cannot generate pseudo boot-id: %w", err)
 		}
 	}
 

--- a/internal/overlord/patch/patch1.go
+++ b/internal/overlord/patch/patch1.go
@@ -40,7 +40,7 @@ func patch1(s *state.State) error {
 	// it cannot be used to improve the patch in an incompatible way.
 
 	// Be *very* careful when importing code from elsewhere to help
-	// with state setting here. The actual code elsehwere will always
+	// with state setting here. The actual code elsewhere will always
 	// reflect the most recent patch level at tip, but the patch here
 	// needs to move between patch versions OLD and OLD+1, and both
 	// of those will get old and out of sync with tip.

--- a/internal/overlord/state/taskrunner_test.go
+++ b/internal/overlord/state/taskrunner_test.go
@@ -92,7 +92,7 @@ func ensureChange(c *C, r *state.TaskRunner, sb *stateBackend, chg *state.Change
 //
 //	<task>:was-<status>    - set task status before calling ensure (must be sensible)
 //	<task>:(do|undo)-block - block handler until task tomb dies
-//	<task>:(do|undo)-retry - return from handler with with state.Retry
+//	<task>:(do|undo)-retry - return from handler with state.Retry
 //	<task>:(do|undo)-error - return from handler with an error
 //	<task>:...:1,2         - one of the above, and add task to lanes 1 and 2
 //	chg:abort              - call abort on the change

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -206,7 +206,7 @@ func New(rootDir string, mode InstanceMode, rep reporter) Systemd {
 // InstanceMode determines which instance of systemd to control.
 //
 // SystemMode refers to the system instance (i.e. pid 1).  UserMode
-// refers to the the instance launched to manage the user's desktop
+// refers to the instance launched to manage the user's desktop
 // session.  GlobalUserMode controls configuration respected by all
 // user instances on the system.
 //

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -226,7 +226,7 @@ type Backend interface {
 	UninstallSdk(ctx context.Context, name, sk string) error
 
 	// Execute a command in a given workshop. The client should differentiate
-	// between the errors that occured during the execution but not related to
+	// between the errors that occurred during the execution but not related to
 	// the command (i.e. the workshop does not exist) and the errors that were
 	// produced by the command itself (i.e. return code != 0). If the latter, an
 	// instance of ErrExec with the status code will be returned.

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -307,10 +307,10 @@ var (
 )
 
 // handleLaunchUpdate parses a LXD create instance operation metadata and
-// reports the opeartion's progress if available. The LXD metadata is
-// inconsistent between operations that handleLaunchUpdate accomodates by
+// reports the operation's progress if available. The LXD metadata is
+// inconsistent between operations that handleLaunchUpdate accommodates by
 // looking for specific progress labels. NOTE: There is no guarantee that the
-// LXD's progress reporting formant won't change; this meta data parser is valid
+// LXD's progress reporting format won't change; this meta data parser is valid
 // for LXD 6.5.
 func handleImageUpdate(opmeta map[string]any, imsize int) *downloadUpdate {
 	upd, ok := opmeta["download_progress"].(string)

--- a/internal/wsutil/wsutil_linux.go
+++ b/internal/wsutil/wsutil_linux.go
@@ -103,7 +103,7 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 				once.Do(closeChannel)
 			} else if (revents & unix.POLLNVAL) > 0 {
 				logger.Debugf("Detected poll(POLLNVAL) event.")
-				// Well, someone closed the fd havent they? So
+				// Well, someone closed the fd haven't they? So
 				// let's go home.
 				once.Do(closeChannel)
 			}


### PR DESCRIPTION
# Description

In #634 I found a easily-missable typo confusing plugs and slots. I asked copilot to find similar issues just in case. Only came up with one real issue but might as well fix some spelling mistakes too.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
