### PR TITLE
Revert workaround for sdkcraft clean error

### DIFF
--- a/tests/docs-tutorial/part-4/task.yaml
+++ b/tests/docs-tutorial/part-4/task.yaml
@@ -15,8 +15,5 @@ execute: |
   mv ../{sdkcraft.yaml,ollama.service} .
   mkdir hooks
   mv ../{setup-base,save-state,restore-state,check-health,setup-project} hooks/
-  # TODO: remove when fixed: https://github.com/canonical/craft-providers/issues/856
-  if lxc project info sdkcraft &>/dev/null; then
-    run_sdkcraft clean
-  fi
+  run_sdkcraft clean
   run_sdkcraft try


### PR DESCRIPTION
# Description

Follow up to https://github.com/canonical/sdkcraft/pull/206.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
