### PR TITLE
Merge register-sdk into install-sdk

### DIFF
--- a/docs/how-to/fix-workshops/debug-issues.rst
+++ b/docs/how-to/fix-workshops/debug-issues.rst
@@ -88,12 +88,11 @@ this time supplying the change ID as the argument:
      Done          28ms  Run hook "save-state" for "go" SDK
      Done          31ms  Disconnect interfaces of "go" SDK
      Done          29ms  Disconnect interfaces of "system" SDK
-     Undone        35ms  Unregister "go" SDK plugs and slots
+     Undone        35ms  Uninstall "go" SDK
      Undone        48ms  Stash previous "dev-volatile" workshop
      Undone        52ms  Restore "dev-volatile" workshop from "system" snapshot
      Undone        41ms  Start "dev-volatile" workshop
      Undone        67ms  Install "go" SDK
-     Undone        33ms  Register "go" SDK plugs and slots
      Error      1m12.5s  Run hook "setup-base" for "go" SDK
      Hold             -  Snapshot "go" SDK installation
      Hold             -  Mount project directory

--- a/internal/daemon/api_changes_test.go
+++ b/internal/daemon/api_changes_test.go
@@ -44,10 +44,10 @@ func setupChanges(st *state.State) []string {
 	chg2 := st.NewChange("remove", "remove...")
 	chg2.Set("workshop", "two")
 	chg2.Set("project-id", "123")
-	t3 := st.NewTask("unregister-sdk", "1...")
+	t3 := st.NewTask("uninstall-sdk", "1...")
 	chg2.AddTask(t3)
 	t3.SetStatus(state.ErrorStatus)
-	t3.Errorf("unregister failed")
+	t3.Errorf("uninstall failed")
 
 	return []string{chg1.ID(), chg2.ID(), t1.ID(), t2.ID(), t3.ID()}
 }
@@ -104,7 +104,7 @@ func (s *apiSuite) TestStateChangesDefaultToAll(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"launch","summary":"launch...","status":"Do","tasks":\[{"id":"\w+","kind":"create-workshop","summary":"1...","status":"Do","log":\["2016-04-21T01:02:03Z INFO l11","2016-04-21T01:02:03Z INFO l12"],"progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}.*],"ready":false,"spawn-time":"2016-04-21T01:02:03Z","project-id":"123"}.*`)
-	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unregister-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unregister failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
+	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"uninstall-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR uninstall failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
 }
 
 func (s *apiSuite) TestStateChangesInProgress(c *check.C) {
@@ -162,7 +162,7 @@ func (s *apiSuite) TestStateChangesAll(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"launch","summary":"launch...","status":"Do","tasks":\[{"id":"\w+","kind":"create-workshop","summary":"1...","status":"Do","log":\["2016-04-21T01:02:03Z INFO l11","2016-04-21T01:02:03Z INFO l12"],"progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}.*],"ready":false,"spawn-time":"2016-04-21T01:02:03Z","project-id":"123"}.*`)
-	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unregister-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unregister failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
+	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"uninstall-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR uninstall failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
 }
 
 func (s *apiSuite) TestStateChangesReady(c *check.C) {
@@ -190,7 +190,7 @@ func (s *apiSuite) TestStateChangesReady(c *check.C) {
 	res, err := rsp.MarshalJSON()
 	c.Assert(err, check.IsNil)
 
-	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"unregister-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR unregister failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
+	c.Check(string(res), check.Matches, `.*{"id":"\w+","kind":"remove","summary":"remove...","status":"Error","tasks":\[{"id":"\w+","kind":"uninstall-sdk","summary":"1...","status":"Error","log":\["2016-04-21T01:02:03Z ERROR uninstall failed"],"progress":{"label":"","done":1,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:03Z"}.*],"ready":true,"err":"[^"]+".*`)
 }
 
 func (s *apiSuite) TestStateChangesForWorkshop(c *check.C) {

--- a/internal/daemon/snapshot-format.yaml
+++ b/internal/daemon/snapshot-format.yaml
@@ -16,7 +16,6 @@ system:
     create-workshop: 1
     start-workshop: 1
     install-sdk: 1
-    register-sdk: 1
     run-hook: 1
   fs-calls: 4
   exec-calls: []
@@ -33,7 +32,6 @@ test-sdk-3:
     create-workshop: 1
     start-workshop: 1
     install-sdk: 2
-    register-sdk: 2
     run-hook: 2
     snapshot-sdk: 1
   fs-calls: 7
@@ -52,7 +50,6 @@ test-sdk-2:
     create-workshop: 1
     start-workshop: 1
     install-sdk: 3
-    register-sdk: 3
     run-hook: 3
     snapshot-sdk: 2
   fs-calls: 10
@@ -73,7 +70,6 @@ test-sdk:
     create-workshop: 1
     start-workshop: 1
     install-sdk: 4
-    register-sdk: 4
     run-hook: 4
     snapshot-sdk: 3
   fs-calls: 13
@@ -96,5 +92,4 @@ sketch:
     rebuild-workshop: 1
     start-workshop: 1
     install-sdk: 5
-    register-sdk: 5
     run-hook: 1

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -1,6 +1,7 @@
 package sdkstate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -14,6 +15,7 @@ import (
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
+	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/sdk/system"
 	"github.com/canonical/workshop/internal/workshop"
@@ -24,15 +26,15 @@ func SdkSetup(task *state.Task, w string) (sdk.Setup, error) {
 	st.Lock()
 	defer st.Unlock()
 
-	// Some tasks, notably unregister-sdk, store the sdk.Setup directly,
-	// since it isn't stored anywhere else. Note that the unregister-sdk
+	// Some tasks, notably uninstall-sdk, store the sdk.Setup directly,
+	// since it isn't stored anywhere else. Note that the uninstall-sdk
 	// handler only needs the SDK name, but the cleanup handler needs more.
 	var setup sdk.Setup
 	if err := task.Get("sdk-setup", &setup); err == nil {
 		return setup, nil
 	}
 
-	// Tasks like install-sdk and register-sdk can reuse the sdk.Setup
+	// Tasks like install-sdk can reuse the sdk.Setup
 	// from the launch or refresh Change.
 	var sk string
 	if err := task.Get("sdk", &sk); err != nil {
@@ -168,7 +170,29 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	return m.backend.InstallSdk(ctx, w, sdkSetup)
+	rev := revert.New()
+	defer rev.Fail()
+
+	if err := m.backend.InstallSdk(ctx, w, sdkSetup); err != nil {
+		return err
+	}
+	cleanupCtx := context.WithoutCancel(ctx)
+	rev.Add(func() {
+		cleanupCtx, cancel := context.WithTimeout(cleanupCtx, 30*time.Second)
+		defer cancel()
+
+		if reverr := m.backend.UninstallSdk(cleanupCtx, w, sdkSetup.Name); reverr != nil {
+			logger.Noticef("On doInstallSdk: cannot uninstall %q SDK on cleanup: %v", sdkSetup.Name, reverr)
+		}
+	})
+
+	// add SDK's plugs and slots
+	if err := m.registerSdk(ctx, w, sdkSetup.Name); err != nil {
+		return err
+	}
+
+	rev.Success()
+	return nil
 }
 
 func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -185,23 +209,31 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	return m.backend.UninstallSdk(ctx, w, sk)
+	rev := revert.New()
+	defer rev.Fail()
+
+	if err := m.repo.RemoveSdk(project.ProjectId, w, sk); err != nil {
+		return err
+	}
+	cleanupCtx := context.WithoutCancel(ctx)
+	rev.Add(func() {
+		cleanupCtx, cancel := context.WithTimeout(cleanupCtx, 30*time.Second)
+		defer cancel()
+
+		if reverr := m.registerSdk(cleanupCtx, w, sk); reverr != nil {
+			logger.Noticef("On doUninstallSdk: cannot re-register %q SDK on cleanup: %v", sk, reverr)
+		}
+	})
+
+	if err := m.backend.UninstallSdk(ctx, w, sk); err != nil {
+		return err
+	}
+
+	rev.Success()
+	return nil
 }
 
-func (m *SdkManager) doRegisterSdk(task *state.Task, tomb *tomb.Tomb) error {
-	user, project, w, err := UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	sk, err := sdkName(task)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
-	defer cancel()
-
+func (m *SdkManager) registerSdk(ctx context.Context, w, sk string) error {
 	wp, err := m.backend.Workshop(ctx, w)
 	if err != nil {
 		return err
@@ -220,22 +252,7 @@ func (m *SdkManager) doRegisterSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	// add SDK's plugs and slots
 	return m.repo.AddSdk(info)
-}
-
-func (m *SdkManager) doUnregisterSdk(task *state.Task, tomb *tomb.Tomb) error {
-	_, project, w, err := UserProjectWorkshop(task)
-	if err != nil {
-		return err
-	}
-
-	sk, err := sdkName(task)
-	if err != nil {
-		return err
-	}
-
-	return m.repo.RemoveSdk(project.ProjectId, w, sk)
 }
 
 func (m *SdkManager) doSnapshotSdk(task *state.Task, tomb *tomb.Tomb) error {
@@ -273,9 +290,9 @@ type SdkVolumeCooldownTimeKey string
 // defined by the sdkVolumeCooldownTime constant.
 //
 // There are multiple scenarios when this cleanup is triggered:
-//   - A workshop was removed and an SDK volume was detached from it (unregister-sdk task)
+//   - A workshop was removed and an SDK volume was detached from it (uninstall-sdk task)
 //   - An SDK volume was detached during a refresh change,
-//     and is no longer used by any other workshop (unregister-sdk or, if refresh failed, install-sdk task)
+//     and is no longer used by any other workshop (uninstall-sdk or, if refresh failed, install-sdk task)
 //   - A workshop launch failed (install-sdk task)
 func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb) error {
 	user, prj, w, err := UserProjectWorkshop(task)
@@ -318,7 +335,7 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		return fmt.Errorf("new cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), task.ReadyTime())
 	} else {
 		// Imagine the situation when a change with multiple tasks that use this
-		// volume is in progress. Every unregister-sdk task will initiate a
+		// volume is in progress. Every uninstall-sdk task will initiate a
 		// cleanup after the change is ready. All cleanups are unarranged and
 		// can run concurrently. We need to ensure that only one of them will
 		// continue to track the volume cooldown time.

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -168,6 +168,12 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
 	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
+
+	wf2 := &workshop.File{Name: "ws2", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{
+		{Name: "test", Channel: "latest/stable"},
+	}}
+	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, wf2, snapshot)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *sdkStateSuite) mockSdk(c *check.C, meta sdk.Meta) {
@@ -247,53 +253,13 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(sdkInfo.Plugs, check.HasLen, 2)
 	c.Assert(sdkInfo.Slots, check.HasLen, 0)
-}
-
-func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-
-	testSdk := sdk.Meta{
-		Setup: sdk.Setup{
-			Name:     "test",
-			Channel:  "latest/stable",
-			Revision: sdk.R(1),
-			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
-		},
-		SdkYAML: sdkYaml,
-	}
-	s.mockSdk(c, testSdk)
-
-	t1 := s.state.NewTask("install-sdk", "test")
-	t1.Set("sdk", testSdk.Name)
-	t2 := s.state.NewTask("register-sdk", "test")
-	t2.Set("sdk", testSdk.Name)
-	t2.WaitFor(t1)
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t1, t2)
-	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{testSdk.Setup})
-	chg.AddTask(t2)
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		c.Check(s.se.Ensure(), check.IsNil)
-		s.se.Wait()
-	}
-	s.state.Lock()
-
-	c.Check(chg.Err(), check.Equals, nil)
 
 	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 2)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.NotNil)
 	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.NotNil)
 }
 
-func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
+func (s *sdkStateSuite) TestDoInstallSdkFailedPolicyCheck(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -310,22 +276,18 @@ func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
 	}
 	s.mockSdk(c, testSdk)
 
-	t1 := s.state.NewTask("install-sdk", "...")
-	t1.Set("sdk", testSdk.Name)
-	t2 := s.state.NewTask("register-sdk", "test-broken")
-	t2.Set("sdk", testSdk.Name)
-	t2.WaitFor(t1)
+	t := s.state.NewTask("install-sdk", "...")
+	t.Set("sdk", testSdk.Name)
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t1, t2)
+	setWorkshopProject("ws", s.project, t)
 	chg.Set("user", "testuser")
 	chg.Set("ws_sdks", []sdk.Setup{testSdk.Setup})
-	chg.AddTask(t2)
-	chg.AddTask(t1)
+	chg.AddTask(t)
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
+		c.Assert(s.se.Ensure(), check.IsNil)
 		s.se.Wait()
 	}
 	s.state.Lock()
@@ -350,7 +312,7 @@ func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
 	c.Check(s.repo.Slots(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
 }
 
-func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
+func (s *sdkStateSuite) TestDoInstallSdkBadInterfacesFound(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -364,19 +326,15 @@ func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
 		SdkYAML: sdkYaml,
 	}
 	s.mockSdk(c, newSdk)
-	t1 := s.state.NewTask("install-sdk", "...")
-	t1.Set("sdk", newSdk.Name)
-	register := s.state.NewTask("register-sdk", "test")
-	register.Set("sdk", newSdk.Name)
-	register.WaitFor(t1)
+	t := s.state.NewTask("install-sdk", "...")
+	t.Set("sdk", newSdk.Name)
 
 	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, register, t1)
+	setWorkshopProject("ws", s.project, t)
 
 	chg.Set("user", "testuser")
 	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
-	chg.AddTask(register)
-	chg.AddTask(t1)
+	chg.AddTask(t)
 
 	s.state.Unlock()
 	for i := 0; i < 6; i = i + 1 {
@@ -396,12 +354,14 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
 	newSdk := sdk.Meta{
 		Setup: sdk.Setup{
-			Name:     "test-2",
+			Name:     "test",
 			Channel:  "latest/stable",
-			Revision: sdk.R(2),
-			Sha3_384: "335783e65660ee5cfeb96b1323585f0c2ad006582c3c3dde89dd62a9f081c24b81e4972c8ce87787531c85e0683479a5",
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
 		},
 		SdkYAML: sdkYaml,
 	}
@@ -431,61 +391,18 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 
 	c.Check(t.Status(), check.Equals, state.UndoneStatus)
 
-	c.Check(s.backend.Volumes, check.HasLen, 1)
-	volume := s.backend.Volumes[sdk.VolumeName(newSdk.Name, newSdk.Revision)]
-	c.Check(volume.Mounts, check.HasLen, 0)
-}
-
-func (s *sdkStateSuite) TestDoUnregisterSdk(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-
-	newSdk := sdk.Meta{
-		Setup: sdk.Setup{
-			Name:     "test",
-			Channel:  "latest/stable",
-			Revision: sdk.R(1),
-			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
-		},
-		SdkYAML: sdkYaml,
-	}
-	s.mockSdk(c, newSdk)
-	t1 := s.state.NewTask("install-sdk", "...")
-	t1.Set("sdk", newSdk.Name)
-	register := s.state.NewTask("register-sdk", "test")
-	register.Set("sdk", newSdk.Name)
-	register.WaitFor(t1)
-
-	terr := s.state.NewTask("error-trigger", "provoking total undo")
-	terr.WaitFor(register)
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, register, t1)
-
-	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
-	chg.AddTask(register)
-	chg.AddTask(terr)
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		c.Check(s.se.Ensure(), check.IsNil)
-		s.se.Wait()
-	}
-	s.state.Lock()
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*provoking total undo \(error out\)`)
+	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
 
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
 	_, ok := props.Sdks["test"]
 	c.Check(ok, check.Equals, false)
-	c.Check(register.Status(), check.Equals, state.UndoneStatus)
 
-	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
-	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
-	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
+	c.Check(s.backend.Volumes, check.HasLen, 1)
+	volume := s.backend.Volumes[sdk.VolumeName(newSdk.Name, newSdk.Revision)]
+	c.Check(volume.Mounts, check.HasLen, 0)
 }
 
 func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
@@ -627,7 +544,7 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 		SdkYAML: sdkYaml,
 	}
 	s.mockSdk(c, oldSdk)
-	t := s.state.NewTask("unregister-sdk", "...")
+	t := s.state.NewTask("uninstall-sdk", "...")
 	t.Set("sdk", oldSdk.Name)
 	t.Set("sdk-setup", oldSdk.Setup)
 
@@ -656,6 +573,8 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 }
 
 func (s *sdkStateSuite) TestSDKVolumeRemovedAfterFailedLaunch(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
 	s.state.Lock()
 	newSdk := sdk.Meta{
 		Setup: sdk.Setup{
@@ -691,12 +610,15 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterFailedLaunch(c *check.C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	c.Assert(t.Status(), check.Equals, state.UndoneStatus)
 	_, err := s.backend.Sdk(s.ctx, newSdk.Setup)
 	c.Assert(err, check.Equals, workshop.ErrVolumeNotFound)
 	c.Assert(t.IsClean(), check.Equals, true)
 }
 
 func (s *sdkStateSuite) TestSDKVolumeExitCleanupAfterSuccessfulLaunch(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
 	s.state.Lock()
 	newSdk := sdk.Meta{
 		Setup: sdk.Setup{
@@ -726,6 +648,7 @@ func (s *sdkStateSuite) TestSDKVolumeExitCleanupAfterSuccessfulLaunch(c *check.C
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	c.Assert(t.Status(), check.Equals, state.DoneStatus)
 	_, err := s.backend.Sdk(s.ctx, newSdk.Setup)
 	c.Assert(err, check.IsNil)
 	c.Assert(t.IsClean(), check.Equals, true)
@@ -744,7 +667,7 @@ func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 		SdkYAML: sdkYaml,
 	}
 	s.mockSdk(c, oldSdk)
-	t := s.state.NewTask("unregister-sdk", "...")
+	t := s.state.NewTask("uninstall-sdk", "...")
 	t.Set("sdk", oldSdk.Name)
 	t.Set("sdk-setup", oldSdk.Setup)
 
@@ -767,6 +690,7 @@ func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
 	// The volume should still exist
 	_, err := s.backend.Sdk(s.ctx, oldSdk.Setup)
 	c.Assert(err, check.IsNil)
@@ -775,6 +699,8 @@ func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 }
 
 func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
 	s.state.Lock()
 	oldSdk := sdk.Meta{
 		Setup: sdk.Setup{
@@ -787,7 +713,7 @@ func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 		SdkYAML: sdkYaml,
 	}
 	s.mockSdk(c, oldSdk)
-	t := s.state.NewTask("unregister-sdk", "...")
+	t := s.state.NewTask("uninstall-sdk", "...")
 	t.Set("sdk", oldSdk.Name)
 	t.Set("sdk-setup", oldSdk.Setup)
 
@@ -801,10 +727,10 @@ func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 
 	other := s.state.NewChange("launch", "...")
 	other.Set("user", "testuser")
-	other.Set("ws_sdks", []sdk.Setup{oldSdk.Setup})
+	other.Set("ws2_sdks", []sdk.Setup{oldSdk.Setup})
 	t2 := s.state.NewTask("install-sdk", "t2")
 	t2.Set("sdk", oldSdk.Name)
-	setWorkshopProject("ws", s.project, t2)
+	setWorkshopProject("ws2", s.project, t2)
 	other.AddTask(t2)
 	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
 
@@ -824,6 +750,8 @@ func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 }
 
 func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePresent(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
 	s.state.Lock()
 	oldSdk := sdk.Meta{
 		Setup: sdk.Setup{
@@ -836,7 +764,7 @@ func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePrese
 		SdkYAML: sdkYaml,
 	}
 	s.mockSdk(c, oldSdk)
-	t := s.state.NewTask("unregister-sdk", "...")
+	t := s.state.NewTask("uninstall-sdk", "...")
 	t.Set("sdk", oldSdk.Name)
 	t.Set("sdk-setup", oldSdk.Setup)
 
@@ -850,13 +778,13 @@ func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePrese
 
 	other := s.state.NewChange("launch", "...")
 	other.Set("user", "testuser")
-	other.Set("ws_sdks", []sdk.Setup{oldSdk.Setup})
+	other.Set("ws2_sdks", []sdk.Setup{oldSdk.Setup})
 	t2 := s.state.NewTask("install-sdk", "t2")
 	t2.Set("sdk", oldSdk.Name)
 	t2.SetToWait(state.DoStatus)
 	t3 := s.state.NewTask("error-trigger", "t3")
 	t3.WaitFor(t2)
-	setWorkshopProject("ws", s.project, t2, t3)
+	setWorkshopProject("ws2", s.project, t2, t3)
 	other.AddTask(t2)
 	other.AddTask(t3)
 
@@ -906,11 +834,11 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 	}
 	s.mockSdk(c, oldSdk)
 
-	t1 := s.state.NewTask("unregister-sdk", "t1")
+	t1 := s.state.NewTask("uninstall-sdk", "t1")
 	t1.Set("sdk", oldSdk.Name)
 	t1.Set("sdk-setup", oldSdk.Setup)
 
-	t2 := s.state.NewTask("unregister-sdk", "t2")
+	t2 := s.state.NewTask("uninstall-sdk", "t2")
 	t2.Set("sdk", oldSdk.Name)
 	t2.Set("sdk-setup", oldSdk.Setup)
 	t2.WaitFor(t1)
@@ -926,8 +854,8 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 
 	chg2 := s.state.NewChange("refresh", "chg2")
 	chg2.Set("user", "testuser")
-	chg2.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
-	setWorkshopProject("ws", s.project, t2)
+	chg2.Set("ws2_sdks", []sdk.Setup{newSdk.Setup})
+	setWorkshopProject("ws2", s.project, t2)
 	chg2.AddTask(t2)
 
 	s.state.Unlock()
@@ -963,7 +891,7 @@ func (s *sdkStateSuite) TestSDKVolumeExitCleanupOnNonvolume(c *check.C) {
 	}
 	s.mockSdk(c, sdkProject)
 
-	t1 := s.state.NewTask("unregister-sdk", "t1")
+	t1 := s.state.NewTask("uninstall-sdk", "t1")
 	t1.Set("sdk", sdkProject.Name)
 	t1.Set("sdk-setup", sdkProject.Setup)
 	chg1 := s.state.NewChange("refresh", "chg1")

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -249,6 +249,149 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	c.Assert(sdkInfo.Slots, check.HasLen, 0)
 }
 
+func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	testSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
+	}
+	s.mockSdk(c, testSdk)
+
+	t1 := s.state.NewTask("install-sdk", "test")
+	t1.Set("sdk", testSdk.Name)
+	t2 := s.state.NewTask("register-sdk", "test")
+	t2.Set("sdk", testSdk.Name)
+	t2.WaitFor(t1)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1, t2)
+	chg.Set("user", "testuser")
+	chg.Set("ws_sdks", []sdk.Setup{testSdk.Setup})
+	chg.AddTask(t2)
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Check(chg.Err(), check.Equals, nil)
+
+	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 2)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.NotNil)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.NotNil)
+}
+
+func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	testSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test-broken",
+			Channel:  "latest/stable",
+			Revision: sdk.R(2),
+			Sha3_384: "eee11792d075bd015406afe6450ac4f5080d78867da10cc5aa9380c383f31b71c8c71d831edd53c67eafc4b745a6bc80",
+		},
+		SdkYAML: sdkYamlViolatesPolicy,
+	}
+	s.mockSdk(c, testSdk)
+
+	t1 := s.state.NewTask("install-sdk", "...")
+	t1.Set("sdk", testSdk.Name)
+	t2 := s.state.NewTask("register-sdk", "test-broken")
+	t2.Set("sdk", testSdk.Name)
+	t2.WaitFor(t1)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1, t2)
+	chg.Set("user", "testuser")
+	chg.Set("ws_sdks", []sdk.Setup{testSdk.Setup})
+	chg.AddTask(t2)
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*installation not allowed by "slot" slot rule of interface "ssh-agent".*`)
+
+	// not in the fs (removed)
+	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	defer wfs.Close()
+	_, err = wfs.Stat(sdk.SdkDir("test-broken"))
+	c.Check(osutil.IsDirNotExist(err), check.Equals, true)
+
+	// not in the SDK list (unlinked)
+	wp, err := s.backend.Workshop(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	_, ok := wp.Sdks["test-broken"]
+	c.Check(ok, check.Equals, false)
+
+	// not in the repo (removed)
+	c.Check(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
+	c.Check(s.repo.Slots(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
+}
+
+func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
+	}
+	s.mockSdk(c, newSdk)
+	t1 := s.state.NewTask("install-sdk", "...")
+	t1.Set("sdk", newSdk.Name)
+	register := s.state.NewTask("register-sdk", "test")
+	register.Set("sdk", newSdk.Name)
+	register.WaitFor(t1)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, register, t1)
+
+	chg.Set("user", "testuser")
+	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.AddTask(register)
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*"test" SDK has bad plugs or slots: plug, plug2 \(unknown interface "test-interface"\).*`)
+
+	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
+}
+
 func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -291,6 +434,58 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	c.Check(s.backend.Volumes, check.HasLen, 1)
 	volume := s.backend.Volumes[sdk.VolumeName(newSdk.Name, newSdk.Revision)]
 	c.Check(volume.Mounts, check.HasLen, 0)
+}
+
+func (s *sdkStateSuite) TestDoUnregisterSdk(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	newSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "test",
+			Channel:  "latest/stable",
+			Revision: sdk.R(1),
+			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
+	}
+	s.mockSdk(c, newSdk)
+	t1 := s.state.NewTask("install-sdk", "...")
+	t1.Set("sdk", newSdk.Name)
+	register := s.state.NewTask("register-sdk", "test")
+	register.Set("sdk", newSdk.Name)
+	register.WaitFor(t1)
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(register)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, register, t1)
+
+	chg.Set("user", "testuser")
+	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.AddTask(register)
+	chg.AddTask(terr)
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for i := 0; i < 6; i = i + 1 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*provoking total undo \(error out\)`)
+
+	props, err := s.backend.Workshop(s.ctx, "ws")
+	c.Assert(err, check.IsNil)
+	_, ok := props.Sdks["test"]
+	c.Check(ok, check.Equals, false)
+	c.Check(register.Status(), check.Equals, state.UndoneStatus)
+
+	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
+	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
 }
 
 func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
@@ -417,201 +612,6 @@ func (s *sdkStateSuite) TestRetrieveUpdatedSdk(c *check.C) {
 	c.Check(sdks[0], check.Equals, oldSdks[0])
 	c.Check(sdks[1], check.Equals, newSdk)
 	c.Check(sdks[2], check.Equals, oldSdks[2])
-}
-
-func (s *sdkStateSuite) TestDoRegisterSdkSuccess(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-
-	testSdk := sdk.Meta{
-		Setup: sdk.Setup{
-			Name:     "test",
-			Channel:  "latest/stable",
-			Revision: sdk.R(1),
-			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
-		},
-		SdkYAML: sdkYaml,
-	}
-	s.mockSdk(c, testSdk)
-
-	t1 := s.state.NewTask("install-sdk", "test")
-	t1.Set("sdk", testSdk.Name)
-	t2 := s.state.NewTask("register-sdk", "test")
-	t2.Set("sdk", testSdk.Name)
-	t2.WaitFor(t1)
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t1, t2)
-	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{testSdk.Setup})
-	chg.AddTask(t2)
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		c.Check(s.se.Ensure(), check.IsNil)
-		s.se.Wait()
-	}
-	s.state.Lock()
-
-	c.Check(chg.Err(), check.Equals, nil)
-
-	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 2)
-	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.NotNil)
-	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.NotNil)
-}
-
-func (s *sdkStateSuite) TestDoRegisterSdkFailedPolicyCheck(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-
-	testSdk := sdk.Meta{
-		Setup: sdk.Setup{
-			Name:     "test-broken",
-			Channel:  "latest/stable",
-			Revision: sdk.R(2),
-			Sha3_384: "eee11792d075bd015406afe6450ac4f5080d78867da10cc5aa9380c383f31b71c8c71d831edd53c67eafc4b745a6bc80",
-		},
-		SdkYAML: sdkYamlViolatesPolicy,
-	}
-	s.mockSdk(c, testSdk)
-
-	t1 := s.state.NewTask("install-sdk", "...")
-	t1.Set("sdk", testSdk.Name)
-	t2 := s.state.NewTask("register-sdk", "test-broken")
-	t2.Set("sdk", testSdk.Name)
-	t2.WaitFor(t1)
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, t1, t2)
-	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{testSdk.Setup})
-	chg.AddTask(t2)
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		s.se.Ensure()
-		s.se.Wait()
-	}
-	s.state.Lock()
-
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*installation not allowed by "slot" slot rule of interface "ssh-agent".*`)
-
-	// not in the fs (removed)
-	wfs, err := s.backend.WorkshopFs(s.ctx, "ws")
-	c.Assert(err, check.IsNil)
-	defer wfs.Close()
-	_, err = wfs.Stat(sdk.SdkDir("test-broken"))
-	c.Check(osutil.IsDirNotExist(err), check.Equals, true)
-
-	// not in the SDK list (unlinked)
-	wp, err := s.backend.Workshop(s.ctx, "ws")
-	c.Assert(err, check.IsNil)
-	_, ok := wp.Sdks["test-broken"]
-	c.Check(ok, check.Equals, false)
-
-	// not in the repo (removed)
-	c.Check(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
-	c.Check(s.repo.Slots(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
-}
-
-func (s *sdkStateSuite) TestDoUnregisterSdk(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
-
-	newSdk := sdk.Meta{
-		Setup: sdk.Setup{
-			Name:     "test",
-			Channel:  "latest/stable",
-			Revision: sdk.R(1),
-			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
-		},
-		SdkYAML: sdkYaml,
-	}
-	s.mockSdk(c, newSdk)
-	t1 := s.state.NewTask("install-sdk", "...")
-	t1.Set("sdk", newSdk.Name)
-	register := s.state.NewTask("register-sdk", "test")
-	register.Set("sdk", newSdk.Name)
-	register.WaitFor(t1)
-
-	terr := s.state.NewTask("error-trigger", "provoking total undo")
-	terr.WaitFor(register)
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, register, t1)
-
-	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
-	chg.AddTask(register)
-	chg.AddTask(terr)
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		c.Check(s.se.Ensure(), check.IsNil)
-		s.se.Wait()
-	}
-	s.state.Lock()
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*provoking total undo \(error out\)`)
-
-	props, err := s.backend.Workshop(s.ctx, "ws")
-	c.Assert(err, check.IsNil)
-	_, ok := props.Sdks["test"]
-	c.Check(ok, check.Equals, false)
-	c.Check(register.Status(), check.Equals, state.UndoneStatus)
-
-	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
-	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
-	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
-}
-
-func (s *sdkStateSuite) TestDoRegisterSdkBadInterfacesFound(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	newSdk := sdk.Meta{
-		Setup: sdk.Setup{
-			Name:     "test",
-			Channel:  "latest/stable",
-			Revision: sdk.R(1),
-			Sha3_384: "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
-		},
-		SdkYAML: sdkYaml,
-	}
-	s.mockSdk(c, newSdk)
-	t1 := s.state.NewTask("install-sdk", "...")
-	t1.Set("sdk", newSdk.Name)
-	register := s.state.NewTask("register-sdk", "test")
-	register.Set("sdk", newSdk.Name)
-	register.WaitFor(t1)
-
-	chg := s.state.NewChange("sample", "...")
-	setWorkshopProject("ws", s.project, register, t1)
-
-	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
-	chg.AddTask(register)
-	chg.AddTask(t1)
-
-	s.state.Unlock()
-	for i := 0; i < 6; i = i + 1 {
-		c.Check(s.se.Ensure(), check.IsNil)
-		s.se.Wait()
-	}
-	s.state.Lock()
-
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*"test" SDK has bad plugs or slots: plug, plug2 \(unknown interface "test-interface"\).*`)
-
-	c.Assert(s.repo.Plugs(s.project.ProjectId, "ws", "test"), check.HasLen, 0)
-	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug"), check.IsNil)
-	c.Assert(s.repo.Plug(s.project.ProjectId, "ws", "test", "plug2"), check.IsNil)
 }
 
 func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -55,12 +55,11 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
 	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), OnUndo(manager.doUninstallSdk))
-	runner.AddHandler("register-sdk", OnDo(manager.doRegisterSdk), OnUndo(manager.doUnregisterSdk))
-	runner.AddHandler("unregister-sdk", OnDo(manager.doUnregisterSdk), OnUndo(manager.doRegisterSdk))
+	runner.AddHandler("uninstall-sdk", OnDo(manager.doUninstallSdk), OnUndo(manager.doInstallSdk))
 	runner.AddHandler("snapshot-sdk", OnDo(manager.doSnapshotSdk), nil)
 
-	runner.AddCleanup("unregister-sdk", manager.doDeleteUnusedSdkVolumes)
 	runner.AddCleanup("install-sdk", manager.doDeleteUnusedSdkVolumes)
+	runner.AddCleanup("uninstall-sdk", manager.doDeleteUnusedSdkVolumes)
 
 	return manager
 }

--- a/internal/overlord/sdkstate/request.go
+++ b/internal/overlord/sdkstate/request.go
@@ -24,17 +24,11 @@ func Install(st *state.State, sdk string) *state.Task {
 	return install
 }
 
-func Register(st *state.State, sdk string) *state.Task {
-	register := st.NewTask("register-sdk", fmt.Sprintf("Register %q SDK plugs and slots", sdk))
-	register.Set("sdk", sdk)
-	return register
-}
-
-func Unregister(st *state.State, setup sdk.Setup) *state.Task {
-	unregister := st.NewTask("unregister-sdk", fmt.Sprintf("Unregister %q SDK plugs and slots", setup.Name))
-	unregister.Set("sdk", setup.Name)
-	unregister.Set("sdk-setup", setup)
-	return unregister
+func Uninstall(st *state.State, setup sdk.Setup) *state.Task {
+	uninstall := st.NewTask("uninstall-sdk", fmt.Sprintf("Uninstall %q SDK", setup.Name))
+	uninstall.Set("sdk", setup.Name)
+	uninstall.Set("sdk-setup", setup)
+	return uninstall
 }
 
 func Snapshot(st *state.State, sdk string) *state.Task {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -446,6 +446,10 @@ func refresh(st *state.State, project workshop.Project, plan *refreshPlan, file 
 	disconnect := disconnectSdks(st, plan.IntactOrRemove())
 	addTaskSet(disconnect)
 
+	stop := st.NewTask("stop-workshop", fmt.Sprintf("Stop %q workshop", file.Name))
+	stop.Set("force", true)
+	addTaskSet(state.NewTaskSet(stop))
+
 	// Remove SDKs from interfaces repository. If refresh fails, the SDKs will be returned
 	// to the repository after restoring the stashed workshop (with the SDKs installed).
 	unregister := unregisterSdks(st, plan.IntactOrRemove())
@@ -773,6 +777,14 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 
 	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", w.Name))
 	addTaskSet(state.NewTaskSet(discard))
+
+	if w.Running {
+		// It's safe to stop if the workshop isn't running, but we
+		// don't want to start it if the Change is undone.
+		stop := st.NewTask("stop-workshop", fmt.Sprintf("Stop %q workshop", w.Name))
+		stop.Set("force", true)
+		addTaskSet(state.NewTaskSet(stop))
+	}
 
 	unregister := unregisterSdks(st, sdks)
 	addTaskSet(unregister)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -94,9 +94,6 @@ func installSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 		install := sdkstate.Install(st, setup.Name)
 		addTask(install)
 
-		register := sdkstate.Register(st, setup.Name)
-		addTask(register)
-
 		hook := hookstate.Hook(st, setup.Name, 0, hookstate.SetupBase)
 		addTask(hook)
 
@@ -123,9 +120,6 @@ func reinstallSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	for _, setup := range sdks {
 		install := sdkstate.Install(st, setup.Name)
 		addTask(install)
-
-		register := sdkstate.Register(st, setup.Name)
-		addTask(register)
 	}
 	return all
 }
@@ -450,10 +444,13 @@ func refresh(st *state.State, project workshop.Project, plan *refreshPlan, file 
 	stop.Set("force", true)
 	addTaskSet(state.NewTaskSet(stop))
 
-	// Remove SDKs from interfaces repository. If refresh fails, the SDKs will be returned
-	// to the repository after restoring the stashed workshop (with the SDKs installed).
-	unregister := unregisterSdks(st, plan.IntactOrRemove())
-	addTaskSet(unregister)
+	// Unmount SDKs and remove plugs and slots from interfaces repository.
+	// In normal circumstances we only need to update the repository. The
+	// SDKs will be implicitly unmounted when rebuilding the workshop. But
+	// the repository is lost when the daemon restarts. It's easier to
+	// reconstruct if we keep it in sync with the installed SDKs.
+	uninstall := uninstallSdks(st, plan.IntactOrRemove())
+	addTaskSet(uninstall)
 
 	stash := st.NewTask("stash-workshop", fmt.Sprintf("Stash previous %q workshop", file.Name))
 	addTaskSet(state.NewTaskSet(stash))
@@ -548,19 +545,19 @@ func autoconnectSdks(st *state.State, w string, sdks []sdk.Setup) *state.TaskSet
 	return autoconnectSet
 }
 
-func unregisterSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
+func uninstallSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	prev := (*state.Task)(nil)
-	unregisterSet := state.NewTaskSet()
+	uninstallSet := state.NewTaskSet()
 	for _, s := range sdks {
-		unregister := sdkstate.Unregister(st, s)
-		unregisterSet.AddTask(unregister)
+		uninstall := sdkstate.Uninstall(st, s)
+		uninstallSet.AddTask(uninstall)
 
 		if prev != nil {
-			unregister.WaitFor(prev)
+			uninstall.WaitFor(prev)
 		}
-		prev = unregister
+		prev = uninstall
 	}
-	return unregisterSet
+	return uninstallSet
 }
 
 func disconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
@@ -786,8 +783,8 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 		addTaskSet(state.NewTaskSet(stop))
 	}
 
-	unregister := unregisterSdks(st, sdks)
-	addTaskSet(unregister)
+	uninstall := uninstallSdks(st, sdks)
+	addTaskSet(uninstall)
 
 	remove := st.NewTask("remove-workshop", fmt.Sprintf("Remove %q workshop", w.Name))
 	addTaskSet(state.NewTaskSet(remove))

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -742,8 +742,8 @@ func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projec
 	}
 
 	taskset := []*state.TaskSet{}
-	for _, name := range workshops {
-		remove := remove(w.state, name, project)
+	for _, wp := range workshops {
+		remove := remove(w.state, wp, project)
 		taskset = append(taskset, remove)
 	}
 	return taskset, nil

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -240,23 +240,9 @@ func (f *FakeWorkshopBackend) rebuildWorkshop(ctx context.Context, file *worksho
 		return fmt.Errorf("devices must be detached before rebuilding workshop: %s", names)
 	}
 
-	// Sanity check for intact SDKs.
+	// Sanity check.
 	if !snapshot.IsBase() && ws.Image != snapshot.Image {
 		return fmt.Errorf("%q SDK is intact but base image has changed", snapshot.Sdks[0].Name)
-	}
-	sdks := ws.SdksByInstallOrder()
-	for i, sk := range snapshot.Sdks {
-		if i >= len(sdks) || sk != sdk.SetupId(sdks[i].Setup) {
-			return fmt.Errorf("%q SDK is intact but doesn't match installed version", sk.Name)
-		}
-	}
-
-	// Remove SDKs.
-	slices.Reverse(sdks)
-	for _, setup := range sdks {
-		if err := f.UninstallSdk(ctx, ws.Name, setup.Name); err != nil {
-			return err
-		}
 	}
 
 	ws.File = file
@@ -265,29 +251,18 @@ func (f *FakeWorkshopBackend) rebuildWorkshop(ctx context.Context, file *worksho
 }
 
 func (f *FakeWorkshopBackend) RemoveWorkshop(ctx context.Context, name string) error {
-	user, projectId, err := f.userProject(ctx)
+	_, projectId, err := f.userProject(ctx)
 	if err != nil {
 		return err
 	}
 
-	prj := f.project(user, projectId)
-
 	f.workshopLock.Lock()
-	wp, ok := f.Workshops[prj.ProjectId][name]
+	_, ok := f.Workshops[projectId][name]
+	delete(f.Workshops[projectId], name)
 	f.workshopLock.Unlock()
 	if !ok {
 		return workshop.ErrWorkshopNotLaunched
 	}
-
-	for _, sk := range wp.Sdks {
-		if err := f.UninstallSdk(ctx, name, sk.Name); err != nil {
-			return err
-		}
-	}
-
-	f.workshopLock.Lock()
-	delete(f.Workshops[prj.ProjectId], name)
-	f.workshopLock.Unlock()
 	return nil
 }
 

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -497,13 +497,15 @@ func (s *FakeWorkshopBackend) UnstashWorkshop(ctx context.Context, name string) 
 	s.workshopLock.Lock()
 	defer s.workshopLock.Unlock()
 
-	wp := s.StashedWorkshops[projectId]["stash-"+name]
-	if wp == nil {
+	stash := s.StashedWorkshops[projectId]["stash-"+name]
+	if stash == nil {
 		return fmt.Errorf("stashed workshop %q not found", name)
 	}
+
+	wp := copyWorkshop(stash)
 	wp.Name = name
-	s.Workshops[projectId][name] = wp
 	wp.Running = true
+	s.Workshops[projectId][name] = wp
 
 	return nil
 }
@@ -521,21 +523,25 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	if wp == nil {
 		return workshop.ErrWorkshopNotLaunched
 	}
+	wp.Running = false
 
 	if s.StashedWorkshops[projectId] == nil {
 		s.StashedWorkshops[projectId] = make(map[string]*FakeWorkshop)
 	}
-	wp.Running = false
 
+	stash := copyWorkshop(wp)
+	stash.Name = "stash-" + name
+	s.StashedWorkshops[projectId][stash.Name] = stash
+	return nil
+}
+
+func copyWorkshop(wp *FakeWorkshop) *FakeWorkshop {
 	wcpy := *wp.Workshop
-	stashed := *wp
-	stashed.Workshop = &wcpy
-	stashed.Name = "stash-" + name
 	wcpy.Sdks = maps.Clone(wcpy.Sdks)
 	wcpy.Profiles = maps.Clone(wcpy.Profiles)
-
-	s.StashedWorkshops[projectId][stashed.Name] = &stashed
-	return nil
+	result := *wp
+	result.Workshop = &wcpy
+	return &result
 }
 
 func (s *FakeWorkshopBackend) userProject(ctx context.Context) (string, string, error) {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -501,10 +501,12 @@ func (s *FakeWorkshopBackend) UnstashWorkshop(ctx context.Context, name string) 
 	if stash == nil {
 		return fmt.Errorf("stashed workshop %q not found", name)
 	}
+	if wp := s.Workshops[projectId][name]; wp != nil && wp.Running {
+		return fmt.Errorf("cannot unstash running %q workshop", name)
+	}
 
 	wp := copyWorkshop(stash)
 	wp.Name = name
-	wp.Running = true
 	s.Workshops[projectId][name] = wp
 
 	return nil
@@ -523,7 +525,9 @@ func (s *FakeWorkshopBackend) StashWorkshop(ctx context.Context, name string) er
 	if wp == nil {
 		return workshop.ErrWorkshopNotLaunched
 	}
-	wp.Running = false
+	if wp.Running {
+		return fmt.Errorf("cannot stash running %q workshop", name)
+	}
 
 	if s.StashedWorkshops[projectId] == nil {
 		s.StashedWorkshops[projectId] = make(map[string]*FakeWorkshop)

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -918,11 +918,6 @@ func (s *Backend) RemoveWorkshop(ctx context.Context, name string) (err error) {
 	}
 	defer conn.Disconnect()
 
-	// ignore possible errors (e.g. container is already stopped)
-	if err = s.stopWorkshop(conn, ctx, name, true); err != nil {
-		logger.Noticef("On RemoveWorkshop: failed to stop %q workshop: %v", name, err)
-	}
-
 	snapshots, err := s.snapshotNames(snapshotConn, projectId, name, "sdk")
 	if err != nil {
 		logger.Noticef("On RemoveWorkshop: failed to find SDK snapshots for %q workshop: %v", name, err)

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -452,17 +452,6 @@ func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Conte
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	inst, etag, err := conn.GetInstance(InstanceName(name, projectId))
-	if err != nil {
-		return err
-	}
-
-	// Do nothing if the instance is already in the desired state
-	if (inst.StatusCode == api.Running && action == "start") ||
-		(inst.StatusCode == api.Stopped && action == "stop") {
-		return nil
-	}
-
 	req := api.InstanceStatePut{
 		Action:  action,
 		Timeout: timeout,
@@ -471,12 +460,28 @@ func (s *Backend) updateInstanceState(conn lxd.InstanceServer, ctx context.Conte
 		Force: timeout == 0,
 	}
 
-	op, err := conn.UpdateInstanceState(inst.Name, req, etag)
-	if err != nil {
-		return err
+	op, err := conn.UpdateInstanceState(InstanceName(name, projectId), req, "")
+	if err == nil {
+		err = op.WaitContext(ctx)
+	}
+	if isAlready(err, action) {
+		err = nil
+	}
+	return err
+}
+
+func isAlready(err error, action string) bool {
+	if err == nil {
+		return false
 	}
 
-	return op.WaitContext(ctx)
+	if action == "start" && err.Error() == "The instance is already running" {
+		return true
+	}
+	if action == "stop" && err.Error() == "The instance is already stopped" {
+		return true
+	}
+	return false
 }
 
 func (s *Backend) StartWorkshop(ctx context.Context, name string) error {
@@ -569,13 +574,10 @@ func (s *Backend) stopWorkshop(conn lxd.InstanceServer, ctx context.Context, nam
 	}
 	if err := s.updateInstanceState(conn, ctx, name, "stop", timeout); err != nil && force {
 		logger.Noticef("On stopWorkshop: failed to stop %q workshop: %v", name, err)
+		return s.updateInstanceState(conn, ctx, name, "stop", 0)
 	} else {
 		return err
 	}
-	if err := s.updateInstanceState(conn, ctx, name, "stop", 0); err != nil && err.Error() != "The instance is already stopped" {
-		return err
-	}
-	return nil
 }
 
 func (s *Backend) setAutoStart(conn lxd.InstanceServer, ctx context.Context, name string, autostart bool) error {

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -278,9 +278,6 @@ func mergeOptions(req, source, target map[string]string) map[string]string {
 }
 
 func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
-	rev := revert.New()
-	defer rev.Fail()
-
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return fmt.Errorf("context key project-id not found")
@@ -292,20 +289,13 @@ func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	}
 	defer conn.Disconnect()
 
-	if err := s.stopWorkshop(conn, ctx, name, true); err != nil {
-		return err
-	}
-
-	rev.Add(func() {
-		if rerr := s.startWorkshop(conn, ctx, name); rerr != nil {
-			logger.Noticef("On StashWorkshop: Cannot restart %q workshop after failed stash operation: %v", name, rerr)
-		}
-	})
-
 	snapshots, err := s.snapshotNames(snapshotConn, projectId, name, "sdk")
 	if err != nil {
 		return err
 	}
+
+	rev := revert.New()
+	defer rev.Fail()
 
 	// Backup the workshop's SDK snapshots, modifying the instance name and
 	// snapshot type to distinguish the backups from the originals.
@@ -386,11 +376,7 @@ func (s *Backend) UnstashWorkshop(ctx context.Context, name string) error {
 	stash := instanceStashName(name, projectId)
 	// Avoid restoring the option which we added when stashing.
 	config := map[string]string{workshop.ConfigWorkshopSnapshotType: ""}
-	if err := s.copyInstance(snapshotConn, conn, stash, instance, true, config); err != nil {
-		return err
-	}
-
-	return s.startWorkshop(conn, ctx, name)
+	return s.copyInstance(snapshotConn, conn, stash, instance, true, config)
 }
 
 // Find snapshot names for all SDKs in the given workshop or stash.

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -124,6 +124,7 @@ printf '%s\n' "$@"
 }
 
 func RemoveTestWorkshop(c *check.C, ctx context.Context, bd workshop.Backend) {
+	_ = bd.StopWorkshop(ctx, "test", true)
 	err := bd.RemoveWorkshop(ctx, "test")
 	c.Assert(err, check.IsNil)
 }

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -818,6 +818,23 @@ func (f *wsOps) TestLxdBackendWorkshopStartFailed(c *check.C) {
 	c.Check(w.Running, check.Equals, false)
 }
 
+func (f *wsOps) TestLxdBackendWorkshopStartStopIdempotent(c *check.C) {
+	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
+
+	err := f.bd.StopWorkshop(f.ctx, "test", true)
+	c.Check(err, check.IsNil)
+
+	err = f.bd.StopWorkshop(f.ctx, "test", true)
+	c.Check(err, check.IsNil)
+
+	err = f.bd.StartWorkshop(f.ctx, "test")
+	c.Check(err, check.IsNil)
+
+	err = f.bd.StartWorkshop(f.ctx, "test")
+	c.Check(err, check.IsNil)
+}
+
 func (f *wsOps) TestLxdBackendWorkshopLaunch(c *check.C) {
 	image, err := f.bd.GetBase(f.ctx, "ubuntu@24.04")
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -128,6 +128,18 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 	preStash := f.workshopMetadata(c, "test")
 	c.Check(preStash.addresses, check.Not(check.HasLen), 0)
 
+	// Stop workshop.
+	err = f.bd.StopWorkshop(f.ctx, "test", true)
+	c.Assert(err, check.IsNil)
+
+	// Validate metadata changes.
+	stopped := f.workshopMetadata(c, "test")
+	config := maps.Clone(stopped.config)
+	c.Check(config["boot.autostart"], check.Equals, "false")
+	config["boot.autostart"] = "true"
+	c.Check(config, check.DeepEquals, preStash.config)
+	c.Check(stopped.devices, check.DeepEquals, preStash.devices)
+
 	// Stash workshop.
 	err = f.bd.StashWorkshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
@@ -138,11 +150,8 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 
 	// Validate metadata changes.
 	postStash := f.workshopMetadata(c, "test")
-	config := maps.Clone(postStash.config)
-	c.Check(config["boot.autostart"], check.Equals, "false")
-	config["boot.autostart"] = "true"
-	c.Check(config, check.DeepEquals, preStash.config)
-	c.Check(postStash.devices, check.DeepEquals, preStash.devices)
+	c.Check(postStash.config, check.DeepEquals, stopped.config)
+	c.Check(postStash.devices, check.DeepEquals, stopped.devices)
 
 	stash := f.stashMetadata(c, "test")
 	config = maps.Clone(postStash.config)
@@ -173,6 +182,8 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 
 	// Unstash workshop.
 	err = f.bd.UnstashWorkshop(f.ctx, "test")
+	c.Assert(err, check.IsNil)
+	err = f.bd.StartWorkshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 
 	// Validate workshop metadata.
@@ -323,10 +334,12 @@ func (f *wsOps) TestLxdBackendWorkshopStashRemove(c *check.C) {
 	c.Check(snapshots, testutil.DeepUnsortedMatches, []string{"test-sdk-1", "test-sdk-2"})
 
 	// Execute
+	err = f.bd.StopWorkshop(f.ctx, "test", true)
+	c.Assert(err, check.IsNil)
 	err = f.bd.StashWorkshop(f.ctx, "test")
+	c.Assert(err, check.IsNil)
 
 	// Validate
-	c.Assert(err, check.IsNil)
 	_, err = f.bd.Workshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 	snapshots = f.listSnapshots(c, "test", true)
@@ -488,6 +501,8 @@ func (f *wsOps) TestLxdBackendDeleteWorkshop(c *check.C) {
 	c.Check(snapshots, testutil.DeepUnsortedMatches, []string{"test-sdk-1", "test-sdk-2"})
 
 	// Validate
+	err = f.bd.StopWorkshop(f.ctx, "test", true)
+	c.Assert(err, check.IsNil)
 	err = f.bd.RemoveWorkshop(f.ctx, "test")
 	c.Assert(err, check.IsNil)
 	_, err = f.bd.Workshop(f.ctx, "test")


### PR DESCRIPTION
# Description

Merges the `register-sdk` Task into `install-sdk`. Introduces `uninstall-sdk` to replace `unregister-sdk`. This resolves the remaining issue with invariants being violated that I mentioned in https://github.com/canonical/workshop/pull/634. Specifically, this prevents the `InterfaceManager` startup from registering SDKs that were already unregistered but not yet uninstalled.

Uninstalling SDKs unmounts them from the workshop, which is observable from within the workshop (unlike unregistering them). So we need to stop the workshop before doing so. We should probably stop it a bit earlier, before disconnecting the SDKs, because some system services might also rely on these connections. But the interfaces will probably need to be updated to ensure this works.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
