### PR TITLE
Only activate Xauthority path unit when desktop interface is connected

### DIFF
--- a/internal/fsutil/sftp.go
+++ b/internal/fsutil/sftp.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/pkg/sftp"
@@ -19,6 +20,7 @@ const (
 )
 
 var sftpStatusError = regexp.MustCompile(`^sftp: (.*) \([^()]*\)$`)
+var dirNotEmptyError = regexp.MustCompile(`^([a-z]*) .*: directory not empty$`)
 var fileExistsError = regexp.MustCompile(`^([a-z]*) .*: file exists$`)
 
 func NewSftpFs(client *sftp.Client, umask os.FileMode) Fs {
@@ -222,6 +224,10 @@ func maybePathError(op, path string, err error) error {
 
 	if match = fileExistsError.FindStringSubmatch(message); match != nil {
 		return &os.PathError{Op: match[1], Path: path, Err: os.ErrExist}
+	}
+
+	if match = dirNotEmptyError.FindStringSubmatch(message); match != nil {
+		return &os.PathError{Op: match[1], Path: path, Err: syscall.ENOTEMPTY}
 	}
 
 	return errors.New(message)

--- a/internal/fsutil/sftp_test.go
+++ b/internal/fsutil/sftp_test.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"io"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/pkg/sftp"
@@ -151,6 +152,14 @@ func (s *sftpSuite) TestChtimes(c *check.C) {
 func (s *sftpSuite) TestRemove(c *check.C) {
 	err := s.fs.Remove("notexist")
 	c.Assert(err, check.ErrorMatches, `remove notexist: file does not exist`)
+}
+
+func (s *sftpSuite) TestRemoveNotEmpty(c *check.C) {
+	c.Assert(s.fs.Mkdir("testdir", os.ModePerm), check.IsNil)
+	c.Assert(s.fs.WriteFile("testdir/testfile", nil, 0644), check.IsNil)
+
+	err := s.fs.Remove("testdir")
+	c.Assert(err, testutil.ErrorIs, syscall.ENOTEMPTY)
 }
 
 func (s *sftpSuite) TestRemoveAll(c *check.C) {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -320,7 +320,7 @@ func writeMountProfile(fs fsutil.Fs, mounts io.WriterTo) error {
 	return fs.AtomicWriteTo(mounts, "/etc/fstab", 0644)
 }
 
-func runMountCommand(conn lxd.InstanceServer, pid, w string, cmd []string) error {
+func runCommand(conn lxd.InstanceServer, pid, w string, cmd []string) error {
 	c := api.InstanceExecPost{
 		Command:     cmd,
 		Interactive: false,
@@ -350,7 +350,7 @@ func runMountCommand(conn lxd.InstanceServer, pid, w string, cmd []string) error
 }
 
 func unmount(conn lxd.InstanceServer, pid, w string, where string) error {
-	return runMountCommand(conn, pid, w, []string{"umount", where})
+	return runCommand(conn, pid, w, []string{"umount", where})
 }
 
 // 'systemd-fstab-generator' is responsible for creating mount entries from
@@ -359,10 +359,10 @@ func unmount(conn lxd.InstanceServer, pid, w string, where string) error {
 // newly-creaed units by restarting a downstream target (ie. local-fs) see:
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html
 func reloadMounts(conn lxd.InstanceServer, pid, w string) error {
-	if err := runMountCommand(conn, pid, w, []string{"systemctl", "daemon-reload"}); err != nil {
+	if err := runCommand(conn, pid, w, []string{"systemctl", "daemon-reload"}); err != nil {
 		return err
 	}
-	return runMountCommand(conn, pid, w, []string{"systemctl", "restart", "local-fs.target"})
+	return runCommand(conn, pid, w, []string{"systemctl", "restart", "local-fs.target"})
 }
 
 func setupSshAgent(fs fsutil.Fs, prev, next *workshop.SshAgent) error {
@@ -393,12 +393,12 @@ func removeSshAgent(fs fsutil.Fs, prev *workshop.SshAgent) error {
 	return fs.RemoveIfExists(script)
 }
 
-func setupDesktop(fs fsutil.Fs, user *user.User, env map[string]string, prev, next *workshop.Desktop) error {
+func setupDesktop(conn lxd.InstanceServer, fs fsutil.Fs, user *user.User, env map[string]string, pid, w string, prev, next *workshop.Desktop) error {
 	if prev.Equal(next) {
 		return nil
 	}
 	if next == nil {
-		return removeDesktop(fs, prev)
+		return removeDesktop(conn, fs, pid, w, prev)
 	}
 
 	script := "/etc/profile.d/workshop-desktop.sh"
@@ -409,17 +409,27 @@ func setupDesktop(fs fsutil.Fs, user *user.User, env map[string]string, prev, ne
 	}
 
 	envVars := desktopEnvironment(user, env, *next)
-	return fs.AtomicWriteTo(envScript(envVars), script, 0644)
+	if err := fs.AtomicWriteTo(envScript(envVars), script, 0644); err != nil {
+		return err
+	}
+
+	if envVars["XAUTHORITY"] == "" {
+		return nil
+	}
+	if err := setupXauthority(conn, fs, pid, w); err != nil {
+		logger.Noticef("cannot watch Xauthority file for user %s, X11 applications may not work: %v", user.Username, err)
+		_ = removeXauthority(conn, fs, pid, w)
+	}
+	return nil
 }
 
-func removeDesktop(fs fsutil.Fs, prev *workshop.Desktop) error {
+func removeDesktop(conn lxd.InstanceServer, fs fsutil.Fs, pid, w string, prev *workshop.Desktop) error {
 	if prev == nil {
 		return nil
 	}
 
-	script := "/etc/profile.d/workshop-desktop.sh"
-	err := fs.RemoveIfExists(script)
-	err2 := fs.RemoveIfExists("/tmp/.Xauthority")
+	err := fs.RemoveIfExists("/etc/profile.d/workshop-desktop.sh")
+	err2 := removeXauthority(conn, fs, pid, w)
 	return cmp.Or(err, err2)
 }
 
@@ -461,9 +471,10 @@ func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Des
 	// is the responsibility of the interface manager.
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
-		envVars["XAUTHORITY"] = "/tmp/.Xauthority"
 		if err := x11.MigrateXauthority(user, xauth); err != nil {
 			logger.Noticef("cannot migrate Xauthority file for user %s, X11 applications may not work: %v", user.Username, err)
+		} else {
+			envVars["XAUTHORITY"] = "/tmp/.Xauthority"
 		}
 	}
 
@@ -483,6 +494,133 @@ func (e envScript) WriteTo(w io.Writer) (int64, error) {
 		}
 	}
 	return n, nil
+}
+
+const (
+	unitDir = "/etc/systemd/system"
+
+	watchXauthorityPath = `# Managed by workshop, do not remove
+[Unit]
+Description=Watch mounted Xauthority file (required for X11 support)
+Before=watch-xauthority.service
+Wants=watch-xauthority.service
+
+[Path]
+PathChanged=/var/lib/workshop/run/Xauthority/.Xauthority
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	watchXauthorityService = `# Managed by workshop, do not remove
+[Unit]
+Description=Copy mounted Xauthority file to /tmp (required for X11 support)
+ConditionPathExists=/var/lib/workshop/run/Xauthority/.Xauthority
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/install --mode 600 --owner workshop --group workshop --target-directory /tmp /var/lib/workshop/run/Xauthority/.Xauthority
+`
+
+	watchXauthorityConf = `# Managed by workshop, do not remove
+[Unit]
+Before=watch-xauthority.path
+Wants=watch-xauthority.path
+`
+)
+
+// Create a systemd path/service unit pair to copy the Xauthority cookie to
+// /tmp when we mount it in the workshop. This is done to work around file
+// mount ordering complications with lxc and the requirements on the
+// Xauthority cookie for snapd, namely:
+//  1. Snapd requires the Xauth cookie to be in a directory visible to snaps,
+//     however there is a special case for /tmp in which snapd will migrate the
+//     cookie for us, guaranteeing it's visibility.
+//  2. Snapd explicitly checks the provided cookie for symlinks, this means
+//     that we can only make a copy of the cookie
+//  2. Mounts in dynamic filesystems (ie. /tmp) are generally advised
+//     against for LXD
+//
+// Since we create these units before the Xauthority cookie is mounted, we
+// trigger the path unit by overriding the future mount unit. This is difficult
+// due to https://github.com/systemd/systemd/issues/8587; we avoid the issue
+// entirely by not mentioning the mount unit in the other unit files. However,
+// we still suffer from the issue (or a related one) when the workshop is
+// restarted. To restart the path unit on reboots (without starting it now),
+// we manually create a symlink to it in multi-user.target.wants/.
+func setupXauthority(conn lxd.InstanceServer, fs fsutil.Fs, pid, w string) error {
+	if err := fs.MkdirAll(filepath.Join(unitDir, "multi-user.target.wants"), 0755); err != nil {
+		return err
+	}
+	if err := createUnit(fs, watchXauthorityService, "watch-xauthority.service"); err != nil {
+		return err
+	}
+	if err := createUnit(fs, watchXauthorityPath, "watch-xauthority.path"); err != nil {
+		return err
+	}
+	if err := installUnit(fs, "watch-xauthority.path", "multi-user.target"); err != nil {
+		return err
+	}
+	if err := fs.MkdirAll(filepath.Join(unitDir, "var-lib-workshop-run-Xauthority.mount.d"), 0755); err != nil {
+		return err
+	}
+	override := filepath.Join("var-lib-workshop-run-Xauthority.mount.d", "watch-xauthority.conf")
+	if err := createUnit(fs, watchXauthorityConf, override); err != nil {
+		return err
+	}
+	if err := runCommand(conn, pid, w, []string{"systemctl", "daemon-reload"}); err != nil {
+		return err
+	}
+	// We expect the new unit to be stopped, but it's possible that the
+	// previous disconnect failed to stop it. In that case, when the
+	// Xauthority directory is mounted, systemd will not restart the unit.
+	// Stopping it prevents that scenario and is a no-op in the usual case.
+	if err := runCommand(conn, pid, w, []string{"systemctl", "stop", "watch-xauthority.path"}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func removeXauthority(conn lxd.InstanceServer, fs fsutil.Fs, pid, w string) error {
+	// We should only ignore the "Unit watch-xauthority.path not loaded"
+	// error, but the exit status (5) is undocumented and we don't have
+	// easy access to stderr. It's OK to leave it running here since path
+	// units have very little overhead, as long as we restart it when the
+	// desktop interface reconnects.
+	if err := runCommand(conn, pid, w, []string{"systemctl", "stop", "watch-xauthority.path"}); err != nil {
+		logger.Debugf("removeXauthority: %v", err)
+	}
+
+	var err error
+	override := filepath.Join("var-lib-workshop-run-Xauthority.mount.d", "watch-xauthority.conf")
+	err = cmp.Or(err, removeUnit(fs, override))
+	if err2 := fs.RemoveIfExists(filepath.Join(unitDir, "var-lib-workshop-run-Xauthority.mount.d")); !errors.Is(err2, syscall.ENOTEMPTY) {
+		err = cmp.Or(err, err2)
+	}
+	err = cmp.Or(err, uninstallUnit(fs, "watch-xauthority.path", "multi-user.target"))
+	err = cmp.Or(err, removeUnit(fs, "watch-xauthority.path"))
+	err = cmp.Or(err, removeUnit(fs, "watch-xauthority.service"))
+	err = cmp.Or(err, runCommand(conn, pid, w, []string{"systemctl", "daemon-reload"}))
+	err = cmp.Or(err, fs.RemoveIfExists("/tmp/.Xauthority"))
+
+	return err
+}
+
+func createUnit(fs fsutil.Fs, content, path string) error {
+	return fs.AtomicWriteTo(strings.NewReader(content), filepath.Join(unitDir, path), 0644)
+}
+
+func removeUnit(fs fsutil.Fs, path string) error {
+	return fs.RemoveIfExists(filepath.Join(unitDir, path))
+}
+
+func installUnit(fs fsutil.Fs, path, target string) error {
+	return fs.Symlink(filepath.Join(unitDir, path), filepath.Join(unitDir, target+".wants", filepath.Base(path)))
+}
+
+func uninstallUnit(fs fsutil.Fs, path, target string) error {
+	return fs.RemoveIfExists(filepath.Join(unitDir, target+".wants", filepath.Base(path)))
 }
 
 func sftpFs(conn lxd.InstanceServer, pid, w string) (fsutil.Fs, error) {
@@ -570,11 +708,11 @@ func setupProfile(conn lxd.InstanceServer, user *user.User, env map[string]strin
 		}
 	})
 
-	if err := setupDesktop(fs, user, env, prev.Desktop, next.Desktop); err != nil {
+	if err := setupDesktop(conn, fs, user, env, sdkRef.ProjectId, sdkRef.Workshop, prev.Desktop, next.Desktop); err != nil {
 		return nil, err
 	}
 	rev.Add(func() {
-		if reverr := setupDesktop(fs, user, env, next.Desktop, prev.Desktop); reverr != nil {
+		if reverr := setupDesktop(conn, fs, user, env, sdkRef.ProjectId, sdkRef.Workshop, next.Desktop, prev.Desktop); reverr != nil {
 			logger.Noticef("On setupProfile: cannot undo desktop interface changes: %v", reverr)
 		}
 	})
@@ -604,7 +742,7 @@ func cleanupProfile(conn lxd.InstanceServer, sdkRef sdk.Ref) error {
 	defer fs.Close()
 
 	err = removeMounts(conn, fs, sdkRef.ProjectId, sdkRef.Workshop, prof.Mounts)
-	err2 := removeDesktop(fs, prof.Desktop)
+	err2 := removeDesktop(conn, fs, sdkRef.ProjectId, sdkRef.Workshop, prof.Desktop)
 	err3 := removeSshAgent(fs, prof.Agent)
 	return cmp.Or(err, err2, err3)
 }

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1044,21 +1044,6 @@ func checkNvidia() (bool, error) {
 	return nvidiaRuntime, nil
 }
 
-// The following 'write-files' and 'runcmd' sections are for the desktop
-// interface. These create a systemd path/service unit pair to copy the
-// Xauthority cookie to /tmp when we mount it in the workshop. This is done to
-// work around file mount ordering complications with lxc and the requirements
-// on the Xauthority cookie for snapd, namely:
-//  1. Snapd requires the Xauth cookie to be in a directory visible to snaps,
-//     however there is a special case for /tmp in which snapd will migrate
-//     the cookie for us, guaranteeing it's visibility.
-//  2. Snapd explicitly checks the provided cookie for symlinks, this means
-//     that we can only make a copy of the cookie
-//  2. Mounts in dynamic filesystems (ie. /tmp) are genreally advised against
-//     for LXD
-//
-// Although these will be present within every workshop, path units utilise
-// inotify and as such add effectively zero overhead to a workshop launch/start.
 func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File, baseFingerprint string) (map[string]string, error) {
 	cloudInitConfig := `#cloud-config
 users:
@@ -1082,30 +1067,6 @@ apt:
     APT::Get::Assume-Yes "1";
 write_files:
 - content: |
-    # Managed by workshop, do not remove
-    [Unit]
-    Description=Required for x11 support
-
-    [Path]
-    PathModified=/var/lib/workshop/run/Xauthority/.Xauthority
-    Unit=xauth-copy.service
-
-    [Install]
-    WantedBy=multi-user.target
-  path: /etc/systemd/system/xauth-watch.path
-- content: |
-    # Managed by workshop, do not remove
-    [Unit]
-    Description=Required for x11 support; copies Xauthority to /tmp
-
-    [Service]
-    Type=oneshot
-    ExecStart=/bin/bash -c '[ ! -f /var/lib/workshop/run/Xauthority/.Xauthority ] || install --mode 600 --owner workshop --group workshop --target-directory /tmp /var/lib/workshop/run/Xauthority/.Xauthority'
-
-    [Install]
-    WantedBy=multi-user.target
-  path: /etc/systemd/system/xauth-copy.service
-- content: |
     # Workaround for https://bugs.launchpad.net/snapd/+bug/2104066
     [Service]
     Environment=SNAPD_STANDBY_WAIT=1m
@@ -1125,8 +1086,6 @@ runcmd:
   # Create ~/.local/bin so SDKs don't need to source ~/.profile to add it to the PATH.
   - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/.local/bin
   - systemctl daemon-reload
-  - systemctl enable --now xauth-copy.service
-  - systemctl enable --now xauth-watch.path
   - systemctl restart snapd.service
   # Required to load above DHCP config.
   - networkctl reload

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -16,7 +16,7 @@ launched:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '0ae722cce9cce59600fc0f0a37db6fece6d6c698169f2a74d960a14d7ea20702b53abbefc69478bd967614e430832122'
+    user.user-data: '2a997ae6f1d1f450e68ca94a5c4a0d2cd887f1e9e8e7713cf91c49dc3e94f906192af9a31ecf074d52e38f0ad5b4185b'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -55,7 +55,7 @@ started:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '0ae722cce9cce59600fc0f0a37db6fece6d6c698169f2a74d960a14d7ea20702b53abbefc69478bd967614e430832122'
+    user.user-data: '2a997ae6f1d1f450e68ca94a5c4a0d2cd887f1e9e8e7713cf91c49dc3e94f906192af9a31ecf074d52e38f0ad5b4185b'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -94,7 +94,7 @@ sdk-attached:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '0ae722cce9cce59600fc0f0a37db6fece6d6c698169f2a74d960a14d7ea20702b53abbefc69478bd967614e430832122'
+    user.user-data: '2a997ae6f1d1f450e68ca94a5c4a0d2cd887f1e9e8e7713cf91c49dc3e94f906192af9a31ecf074d52e38f0ad5b4185b'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -144,7 +144,7 @@ sdk-mounted:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '0ae722cce9cce59600fc0f0a37db6fece6d6c698169f2a74d960a14d7ea20702b53abbefc69478bd967614e430832122'
+    user.user-data: '2a997ae6f1d1f450e68ca94a5c4a0d2cd887f1e9e8e7713cf91c49dc3e94f906192af9a31ecf074d52e38f0ad5b4185b'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''


### PR DESCRIPTION
# Description

Fixes compatibility with LXD 6.7. The desktop interface should now handle `/tmp/.Xauthority` correctly except in a few edge cases (e.g. the path unit might not trigger an update if the service unit is still running). However, connecting the desktop interface now requires the workshop to be running. This is easy enough to fix but it should be done as part of fixing the same problem for the mount interface (there's no need to call `systemctl daemon-reload` or `systemctl stop` if the workshop is stopped).

Thanks to https://github.com/lxc/lxc/pull/4581, LXC no longer recreates directories before mounting over them. This uncovered a bug in the desktop interface, which relied on the Xauthority directory being created to signal the xauth-watch path unit. Normally inotify continues watching the original directory when something is mounted over it.

To fix the bug, we need to (re)start the path unit after mounting the Xauthority directory. One way would be to split setupProfile + UpdateProfile into preSetupProfile + UpdateProfile + postSetupProfile, or something similar. For now I decided to keep the current structure, since systemd makes it possible to detect new mounts.

When the interface is connected, the path unit is configured to start alongside `var-lib-workshop-run-Xauthority.mount` and `multi-user.target`. Then the profile is updated, which mounts `/var/lib/workshop/run/Xauthority`. This causes systemd to start the path unit. On workshop restart, the path unit is started as part of multi-user.target rather than the mount unit.

The reason we need multi-user.target (when the mount unit still exists after restarting the workshop) is likely an offshoot of https://github.com/systemd/systemd/issues/8587. If it's ever fixed, the code should still work because systemd won't try to start the same unit twice. In the meantime, we can't bind the lifetime of the path unit to the mount using BindsTo or PropagatesStopTo. Instead, we just stop it manually and remove the relevant unit files when the desktop interface disconnects.

For this fix I aimed to not diverge too much from the current implementation, but a few other options might be better if we continue to see X11 usage in Workshop. One would be to run user units on the host to notify `workshopd` when desktop functionality becomes (un)available. Another would be to drop `/tmp` as our Xauthority location. For example snapd seems to support `/run/user/1000/mutter/Xauthority`. That's not what my `mutter` installation uses (for XWayland) though, so I don't know whether it will stick around. In any case, I don't really like the idea of Workshop pretending to be mutter.

# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
