### PR TITLE
Simplify sketch template

### DIFF
--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -39,8 +39,8 @@ func (c *CmdRoot) Command() *cobra.Command {
 			Title: "Create new workshops; start, stop, update or delete existing ones:",
 		},
 		&cobra.Group{
-			ID:    "warnings",
-			Title: "List and acknowledge warnings:",
+			ID:    "sketch",
+			Title: "Customize a workshop:",
 		},
 		&cobra.Group{
 			ID:    "explore-troubleshoot",
@@ -59,8 +59,8 @@ func (c *CmdRoot) Command() *cobra.Command {
 			Title: "Run commands inside a workshop:",
 		},
 		&cobra.Group{
-			ID:    "sketch",
-			Title: "Sketch SDKs under a workshop:",
+			ID:    "warnings",
+			Title: "List and acknowledge warnings:",
 		},
 		&cobra.Group{
 			ID:    "misc",

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -35,35 +35,35 @@ func (c *CmdSketch) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "sketch-sdk [--stash|--restore|--eject|--remove] [<WORKSHOP>]",
 		Args:  cobra.MaximumNArgs(1),
-		Short: "Edit the sketch SDK and graft it onto the workshop",
-		Long: `
-This opens the "sketch" SDK definition in the default text editor,
-enabling rapid experiments and tweaks at the SDK level.
-
-Saving the definition and exiting the editor causes a refresh,
-which installs the configured "sketch" SDK in the workshop.
+		Short: "Customize a workshop",
+		Long: `The command opens the sketch SDK template in the default text editor.
+Add customizations by editing the template, then save and exit 
+the editor to apply the changes to the workshop.
 
 The "--stash" and "--restore" options respectively stash the SDK,
 reversing the changes, and quickly restore it to the workshop.
-The "--eject" option moves the SDK definition into the project directory,
-so it can be added to multiple workshops or shared with others.
-The "--remove" option removes the SDK permanently.
+
+To make these customizations persistent,
+run "workshop sketch-sdk --eject".
+This saves the SDK definition under .workshop/ in the project directory,
+so it can be committed to your repository.
+
+The sketch SDK is intended for experiments and prototyping iterations.
 
 Notes:
+- You can only have one sketch SDK per workshop at a time.
 
-- The "sketch" SDK doesn't appear in the workshop definition
-  and cannot include build-time data such as parts.
-
-- In addition to hooks, the "sketch" SDK can use interfaces
-  by defining plugs and slots.
+- Run "workshop info" to list all SDKs currently installed
+  in the workshop, including the sketch SDK if present.
 `,
 		Example: `
 Edit the sketch SDK definition for the "nimble" workshop
 and apply it after saving by automatically refreshing the workshop:
 $ workshop sketch-sdk nimble
 
-The name is optional if the project has only one workshop:
-$ workshop sketch-sdk
+Save the sketch SDK for the "nimble" workshop
+as a project SDK named "tools":
+$ workshop sketch-sdk nimble --eject --name tools
 
 Stash the sketch SDK, temporarily reverting the changes in the workshop:
 $ workshop sketch-sdk nimble --stash`,
@@ -90,10 +90,10 @@ type SketchFile struct {
 	Hooks map[string]string `yaml:"hooks,omitempty"`
 }
 
-var sketchTemplate = `# For details: https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/sdks/#sketch-sdk
+var sketchTemplate = `# For details: https://canonical-workshop.readthedocs-hosted.com/latest/explanation/sdks/sdks/#sketch-sdk
 name: sketch
 hooks:
-  # Use 'setup-base' to customize the base image 
+  # Use 'setup-base' to customize the base image
   setup-base: |
     # apt-get update
     # apt-get install build-essential
@@ -104,14 +104,14 @@ hooks:
 
 
 plugs:
-  # Use this to mount a host directory to the workshop
+  # Use this configuration to mount a host directory to the workshop
   # models:
   #   interface: mount
   #   workshop-target: /home/workshop/models
 
 
 slots:
-  # Use this to expose a port, then add a corresponding system SDK plug.
+  # Use this configuration to expose a port, then add a corresponding system SDK plug
   # More details: https://canonical-workshop.readthedocs-hosted.com/latest/how-to/customize-workshops/forward-ports/
   # my-web-server:
   #   interface: tunnel
@@ -610,7 +610,7 @@ func (c *CmdSketches) Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "sketches",
 		Args:  cobra.ExactArgs(0),
-		Short: "List sketches",
+		Short: "List project sketch SDKs",
 		Long: `
 This command enumerates all sketches in the project, printing a compact list:
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -90,40 +90,30 @@ type SketchFile struct {
 	Hooks map[string]string `yaml:"hooks,omitempty"`
 }
 
-var sketchTemplate = `# Sketch SDK for %s
-# Sketch SDK provides local customization of this specific workshop.
-
-# To read more about the sketch SDK and its syntax, see:
-# https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/sdks/#sketch-sdk
+var sketchTemplate = `# For details: https://canonical-workshop.readthedocs-hosted.com/en/latest/explanation/sdks/sdks/#sketch-sdk
 name: sketch
 hooks:
-  # EXAMPLE: setup-base runs once at workshop launch; use it to install some packages.
-  # setup-base: |
+  # Use 'setup-base' to customize the base image 
+  setup-base: |
     # apt-get update
-    # apt-get install PACKAGE...
-    # snap install SNAP...
-  # EXAMPLE: setup-project runs after connecting plugs and slots; use it to install the project environment.
-  # setup-project: |
-    # go mod download
+    # apt-get install build-essential
+
+  # Use 'setup-project' for project-specific logic, after plugs and slots are connected
+  setup-project: |
     # uv sync
-  # EXAMPLE: check-health runs after entire SDK setup completes; run "workshopctl set-health okay" if OK.
-  # check-health: |
-    # if CHECK_HEALTH_COMMAND ; then
-    #   workshopctl set-health okay
-    # else
-    #   workshopctl set-health --code=installation-failed error "Installation failed"
-    # fi
+
+
 plugs:
-  # EXAMPLE: forward your SSH agent into the workshop, enabling "git push" inside the workshop.
-  # ssh-agent:
-  #   interface: ssh-agent
-  # EXAMPLE: expose well-known config file locations to the workshop
-  # vs-code-settings:
+  # Use this to mount a host directory to the workshop
+  # models:
   #   interface: mount
-  #   workshop-target: /home/workshop/.config/Code/User
+  #   workshop-target: /home/workshop/models
+
+
 slots:
-  # EXAMPLE: expose SDK services to the host
-  # dashboard:
+  # Use this to expose a port, then add a corresponding system SDK plug.
+  # More details: https://canonical-workshop.readthedocs-hosted.com/latest/how-to/customize-workshops/forward-ports/
+  # my-web-server:
   #   interface: tunnel
   #   endpoint: 8080
 `
@@ -514,7 +504,7 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 		return nil
 	}
 
-	if err = editSketchSdk(sketchdir, wp.Path); err != nil {
+	if err = editSketchSdk(sketchdir); err != nil {
 		return fmt.Errorf("cannot sketch: %w", err)
 	}
 
@@ -530,15 +520,14 @@ func (c *CmdSketch) Run(cmd *cobra.Command, av []string) error {
 	return nil
 }
 
-func editSketchSdk(sketchdir, workshopFile string) error {
+func editSketchSdk(sketchdir string) error {
 	content, err := os.ReadFile(filepath.Join(sketchdir, "sdk.yaml"))
 	if errors.Is(err, os.ErrNotExist) {
 		if err := os.MkdirAll(sketchdir, 0755); err != nil {
 			return err
 		}
 
-		// Format sketch SDK template header.
-		content = fmt.Appendf(nil, sketchTemplate, workshopFile)
+		content = []byte(sketchTemplate)
 	} else if err != nil {
 		return err
 	}

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -197,12 +197,11 @@ func (m *workshopSketch) mockSketchesHappyPath(c *check.C, resp string) {
 	})
 }
 
-func (m *workshopSketch) TestSketchSdkMetaOnlySuccess(c *check.C) {
+func (m *workshopSketch) TestSketchSdkDefaultTemplateSuccess(c *check.C) {
 	cmd := &CmdSketch{root: &CmdRoot{}}
 
 	m.mockSketchHappyRefreshPath(c, "ws", "wait-on-error")
 
-	sketchContent := fmt.Sprintf(sketchTemplate, "/home/project/.workshop/ws.yaml")
 	restore := MockTextEditor(func(inPath string, inContent []byte) ([]byte, error) {
 		if inPath != "" {
 			c.Assert(writeSketchSdk(inPath, inContent), check.IsNil)
@@ -215,8 +214,9 @@ func (m *workshopSketch) TestSketchSdkMetaOnlySuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	current := workshop.SketchSdkCurrent(m.userDataDir, m.prjId, "ws")
-	c.Assert(filepath.Join(current, "sdk.yaml"), testutil.FileEquals, sketchContent)
-	c.Assert(filepath.Join(current, "hooks"), testutil.FileAbsent)
+	c.Assert(filepath.Join(current, "sdk.yaml"), testutil.FileEquals, sketchTemplate)
+	c.Assert(filepath.Join(current, "hooks", "setup-base"), testutil.FileEquals, "# apt-get update\n# apt-get install build-essential\n")
+	c.Assert(filepath.Join(current, "hooks", "setup-project"), testutil.FileEquals, "# uv sync\n")
 }
 
 func (m *workshopSketch) TestSketchSdkSuccess(c *check.C) {

--- a/tests/docs-tutorial/part-3/task.yaml
+++ b/tests/docs-tutorial/part-3/task.yaml
@@ -22,8 +22,7 @@ execute: |
   ## Start sketching
 
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  1/^hooks:$/a
-    setup-project: |
+  1/^    # uv sync$/c
       source /var/lib/workshop/sdk/jupyter/venv/bin/activate
       pip install jupyter-console requests
   .
@@ -33,7 +32,7 @@ execute: |
   workshop_exec info | yq '.sdks["sketch"].installed' | MATCH '\(x1\)$'
 
   workshop_exec exec nimble -- ollama pull tinyllama
-  workshop_exec exec nimble -- sh -c "cat run-ollama.py | /var/lib/workshop/sdk/jupyter/venv/bin/jupyter console --simple-prompt"
+  workshop_exec exec nimble -- /var/lib/workshop/sdk/jupyter/venv/bin/python /project/run-ollama.py
 
 
   ## Stash and restore

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -80,6 +80,8 @@ EOF
 
     retry 5 snap install --classic --channel=1.25/stable go
     retry 5 snap install yq
+    
+    chown -R ubuntu:ubuntu /workshop
 }
 
 function setup_workshop() {

--- a/tests/main/sketch-sdk/task.yaml
+++ b/tests/main/sketch-sdk/task.yaml
@@ -26,8 +26,7 @@ execute: |
 
   echo "Add setup-base"
   sudo TERM=ansi EDITOR=ex -u ubuntu -- workshop sketch-sdk <<EOF
-  1/^hooks:$/a
-    setup-base: |
+  1/^    # apt-get update$/c
       mkdir -p /home/workshop/ws-sketch-test
   .
   wq


### PR DESCRIPTION
# Description

Updated sketch SDK default template and reworked relevant CLI documentation. It does not look like that we can get rid of the sketch SDK name field in the template as it is a default name used by workshop to identify the SDK in the workshop definition (if present). Moreover, adding a name if not provided does not look handy either as it would require editing the template and then having to deal with the added name in the following sketch iterations.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [x] Headings and titles accurately describe the content.
* [x] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [x] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [x] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
