### PR TITLE
Address some issues with new Xauthority implementation

### DIFF
--- a/internal/fsutil/fs.go
+++ b/internal/fsutil/fs.go
@@ -230,6 +230,35 @@ func (f Fs) AtomicWriteTo(source io.WriterTo, target string, perm os.FileMode) e
 	return nil
 }
 
+// SymlinkForce creates a symlink `new` pointing to `old`. If `new` already
+// exists it is atomically overwritten.
+func (f Fs) SymlinkForce(old, new string) error {
+	rev := revert.New()
+	defer rev.Fail()
+
+	prefix := new + "."
+	suffix := "~"
+
+	for range 10000 {
+		name := prefix + nextRandom() + suffix
+		if err := f.Symlink(old, name); errors.Is(err, os.ErrExist) {
+			continue
+		} else if err != nil {
+			return err
+		}
+
+		rev.Add(func() { _ = f.Remove(name) })
+
+		if err := f.Rename(name, new); err != nil {
+			return err
+		}
+
+		rev.Success()
+		return nil
+	}
+	return &os.PathError{Op: "symlink", Path: prefix + "*" + suffix, Err: os.ErrExist}
+}
+
 // ReadFile reads the named file and returns the contents.
 func (f Fs) ReadFile(path string) ([]byte, error) {
 	file, err := f.Open(path)

--- a/internal/fsutil/fs_test.go
+++ b/internal/fsutil/fs_test.go
@@ -140,6 +140,14 @@ func (n *nameCollisionFs) OpenFile(path string, flag int, perm os.FileMode) (fsu
 	return n.FsBackend.OpenFile(path, flag, perm)
 }
 
+func (n *nameCollisionFs) Symlink(path, link string) error {
+	if n.collisions > 0 {
+		n.collisions--
+		return os.ErrExist
+	}
+	return n.FsBackend.Symlink(path, link)
+}
+
 func (f *fsSuite) TestCreateTemp(c *check.C) {
 	file, err := f.fs.CreateTemp("", "test.*.png", 0666)
 	c.Assert(err, check.IsNil)
@@ -234,6 +242,50 @@ func (f *fsSuite) TestAtomicWriteRenameFailed(c *check.C) {
 
 	c.Check(f.path, testutil.DirEquals, []string{"drwxrwxr-x file"})
 	c.Check(filepath.Join(f.path, "file"), testutil.DirEquals, []string{})
+}
+
+func (f *fsSuite) TestSymlinkForce(c *check.C) {
+	err := f.fs.SymlinkForce("one", "link")
+	c.Assert(err, check.IsNil)
+	target, err := f.fs.Readlink("link")
+	c.Assert(err, check.IsNil)
+	c.Check(target, check.Equals, filepath.Join(f.path, "one"))
+	c.Check(f.path, testutil.DirEquals, []string{"Lrwxrwxrwx link"})
+
+	err = f.fs.SymlinkForce("two", "link")
+	c.Assert(err, check.IsNil)
+	target, err = f.fs.Readlink("link")
+	c.Assert(err, check.IsNil)
+	c.Check(target, check.Equals, filepath.Join(f.path, "two"))
+	c.Check(f.path, testutil.DirEquals, []string{"Lrwxrwxrwx link"})
+}
+
+func (f *fsSuite) TestSymlinkForceNoDirectory(c *check.C) {
+	err := f.fs.SymlinkForce("three", "dir/link")
+	c.Check(err, testutil.ErrorIs, os.ErrNotExist)
+	c.Check(f.path, testutil.DirEquals, []string{})
+}
+
+func (f *fsSuite) TestSymlinkForceRenameFailed(c *check.C) {
+	c.Assert(f.fs.Mkdir("link", os.ModePerm), check.IsNil)
+	err := f.fs.SymlinkForce("four", "link")
+	c.Check(err, testutil.ErrorIs, os.ErrExist)
+	c.Check(f.path, testutil.DirEquals, []string{"drwxrwxr-x link"})
+}
+
+func (f *fsSuite) TestSymlinkForceCollisions(c *check.C) {
+	fs := fsutil.Fs{FsBackend: &nameCollisionFs{f.fs.FsBackend, 5}}
+	err := fs.SymlinkForce("five", "link")
+	c.Assert(err, check.IsNil)
+	target, err := f.fs.Readlink("link")
+	c.Assert(err, check.IsNil)
+	c.Check(target, check.Equals, filepath.Join(f.path, "five"))
+	c.Check(f.path, testutil.DirEquals, []string{"Lrwxrwxrwx link"})
+
+	fs = fsutil.Fs{FsBackend: &nameCollisionFs{f.fs.FsBackend, 10000}}
+	err = fs.SymlinkForce("six", "clash")
+	c.Assert(err, check.ErrorMatches, `symlink clash\.\*~: file already exists`)
+	c.Check(f.path, testutil.DirEquals, []string{"Lrwxrwxrwx link"})
 }
 
 func (f *fsSuite) TestReadFileNoDirectory(c *check.C) {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -413,7 +413,7 @@ func setupDesktop(conn lxd.InstanceServer, fs fsutil.Fs, user *user.User, env ma
 		return err
 	}
 
-	if envVars["XAUTHORITY"] == "" {
+	if env["XAUTHORITY"] == "" {
 		return nil
 	}
 	if err := setupXauthority(conn, fs, pid, w); err != nil {
@@ -471,10 +471,9 @@ func desktopEnvironment(user *user.User, env map[string]string, dev workshop.Des
 	// is the responsibility of the interface manager.
 	xauth := env["XAUTHORITY"]
 	if xauth != "" {
+		envVars["XAUTHORITY"] = "/tmp/.Xauthority"
 		if err := x11.MigrateXauthority(user, xauth); err != nil {
 			logger.Noticef("cannot migrate Xauthority file for user %s, X11 applications may not work: %v", user.Username, err)
-		} else {
-			envVars["XAUTHORITY"] = "/tmp/.Xauthority"
 		}
 	}
 

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -616,7 +616,7 @@ func removeUnit(fs fsutil.Fs, path string) error {
 }
 
 func installUnit(fs fsutil.Fs, path, target string) error {
-	return fs.Symlink(filepath.Join(unitDir, path), filepath.Join(unitDir, target+".wants", filepath.Base(path)))
+	return fs.SymlinkForce(filepath.Join(unitDir, path), filepath.Join(unitDir, target+".wants", filepath.Base(path)))
 }
 
 func uninstallUnit(fs fsutil.Fs, path, target string) error {

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -534,10 +534,10 @@ Wants=watch-xauthority.path
 // Xauthority cookie for snapd, namely:
 //  1. Snapd requires the Xauth cookie to be in a directory visible to snaps,
 //     however there is a special case for /tmp in which snapd will migrate the
-//     cookie for us, guaranteeing it's visibility.
+//     cookie for us, guaranteeing its visibility.
 //  2. Snapd explicitly checks the provided cookie for symlinks, this means
 //     that we can only make a copy of the cookie
-//  2. Mounts in dynamic filesystems (ie. /tmp) are generally advised
+//  3. Mounts in dynamic filesystems (ie. /tmp) are generally advised
 //     against for LXD
 //
 // Since we create these units before the Xauthority cookie is mounted, we


### PR DESCRIPTION
# Description

Addresses some of copilot's comments on #653:
- Enabling the `watch-xauthority.path` unit is now idempotent, while remaining atomic
- We start watching the Xauthority file even if it doesn't exist (yet) due to a failed migration
- Fix some typos

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
