### PR TITLE
Fix sdkcraft init usage in tests

### DIFF
--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -305,14 +305,8 @@ that run at different stages of the workshop's lifecycle,
 preparing the SDK for use or preserving its state during updates.
 
 Under :file:`ollama/`,
-create a subdirectory
-named :file:`hooks/`:
-
-.. code-block:: console
-
-   $ mkdir hooks/
-   $ cd hooks/
-
+there is a subdirectory
+named :file:`hooks/`.
 This directory stores all the hooks for an SDK.
 
 
@@ -323,7 +317,7 @@ Build: setup base, project
 .. @artefact setup-project
 
 Under :file:`ollama/hooks/`,
-create a file
+edit the file
 named :file:`setup-base`:
 
 .. code-block:: shell
@@ -339,7 +333,7 @@ and is typically used to install system packages
 and configure the environment.
 
 In the same directory,
-create a file named :file:`setup-project`
+edit the file named :file:`setup-project`
 for Ollama-specific setup:
 
 .. code-block:: shell

--- a/tests/docs-tutorial/part-4/task.yaml
+++ b/tests/docs-tutorial/part-4/task.yaml
@@ -12,8 +12,8 @@ execute: |
   run_sdkcraft --help
   mkdir ollama/ && cd ollama/
   run_sdkcraft init
+  rm hooks/*
   mv ../{sdkcraft.yaml,ollama.service} .
-  mkdir hooks
   mv ../{setup-base,save-state,restore-state,check-health,setup-project} hooks/
   run_sdkcraft clean
   run_sdkcraft try


### PR DESCRIPTION
# Description

Now that `sdkcraft init` creates hooks, the tutorial and tests needed updating.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
