### PR TITLE
Doc: Fix branch name convention in contributor guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -94,9 +94,9 @@ The messages rarely, if ever, state the type of the commit
 (e.g., ``fix``, ``feat``, etc.);
 these are used for branch naming, for example:
 
-- ``canonical/feat/workspace-start``
-- ``canonical/fix/spread-tests-github``
-- ``canonical/chore/update-lxd``
+- ``feat/workspace-start``
+- ``fix/spread-tests-github``
+- ``chore/update-lxd``
 
 
 Commits that focus on docs must use the ``Doc:`` type prefix


### PR DESCRIPTION
# Description

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
