### PR TITLE
Rename and fix some things in preparation for the Store

### DIFF
--- a/client/sdks.go
+++ b/client/sdks.go
@@ -4,11 +4,11 @@ import "time"
 
 // SdkVolume represents SDK volume summary returned by the daemon.
 type SdkVolume struct {
-	Name      string     `json:"name"`
-	Version   string     `json:"version,omitempty"`
-	Revision  string     `json:"revision"`
-	BuildTime *time.Time `json:"build-time,omitempty"`
-	Size      uint64     `json:"size,omitempty"`
+	Name     string     `json:"name"`
+	Version  string     `json:"version,omitempty"`
+	Revision string     `json:"revision"`
+	BuiltAt  *time.Time `json:"built-at,omitempty"`
+	Size     uint64     `json:"size,omitempty"`
 }
 
 type SdkInstalled struct {

--- a/client/workshop.go
+++ b/client/workshop.go
@@ -44,8 +44,8 @@ type Sdk struct {
 	Channel     string       `json:"channel"`
 	Source      string       `json:"source"`
 	Revision    string       `json:"revision"`
-	BuildTime   time.Time    `json:"build-time"`
-	InstallTime time.Time    `json:"install-time"`
+	BuiltAt     time.Time    `json:"built-at"`
+	InstalledAt time.Time    `json:"installed-at"`
 	Health      *HealthCheck `json:"health-check,omitempty"`
 	Mounts      []*Mount     `json:"mounts,omitempty"`
 	Tunnels     []*Tunnel    `json:"tunnels,omitempty"`

--- a/client/workshop_test.go
+++ b/client/workshop_test.go
@@ -16,7 +16,7 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 		"project-id":"42ws42ws",
 		"status":"Ready",
 		"notes":["missing-project"],
-		"sdks":[{"name":"go","channel":"latest/stable","revision":"453","install-time":"2023-04-25T01:02:03Z","health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"}}]
+		"sdks":[{"name":"go","channel":"latest/stable","revision":"453","installed-at":"2023-04-25T01:02:03Z","health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"}}]
 	}]}}`
 	workshops, _, err := cs.cli.List(&client.ListOptions{ProjectId: "42ws42ws"})
 	c.Assert(err, check.IsNil)
@@ -32,7 +32,7 @@ func (cs *clientSuite) TestClientListProjectWorkshops(c *check.C) {
 					Name:        "go",
 					Channel:     "latest/stable",
 					Revision:    "453",
-					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+					InstalledAt: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 					Health: &client.HealthCheck{
 						Timestamp: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 						Message:   "hello from health-check",
@@ -136,8 +136,8 @@ func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
 		"version":"1.20.3",
 		"channel":"latest/stable",
 		"revision":"453",
-		"build-time":"2023-04-06T04:51:36.152964Z", 
-		"install-time":"2023-04-25T01:02:03Z", 
+		"built-at":"2023-04-06T04:51:36.152964Z",
+		"installed-at":"2023-04-25T01:02:03Z",
 		"health-check":{"timestamp":"2023-04-25T01:02:03Z", "message":"hello from health-check", "code":"check-waiting"},
 		"mounts":[{"host-source":"/home/user/src","workshop-target":"/home/workshop/target", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name"}},{"workshop-source":"/home","workshop-target":"/mnt", "plug":{"project-id":"42ws42ws","workshop":"workshop","sdk":"go","plug":"plug-name-2"}}]
 	}],"path":"/home/projects/.workshop/workshop.yaml"}}`
@@ -155,8 +155,8 @@ func (cs *clientSuite) TestClientProjectWorkshop(c *check.C) {
 					Version:     "1.20.3",
 					Channel:     "latest/stable",
 					Revision:    "453",
-					BuildTime:   time.Date(2023, 04, 6, 4, 51, 36, 152964000, time.UTC),
-					InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+					BuiltAt:     time.Date(2023, 04, 6, 4, 51, 36, 152964000, time.UTC),
+					InstalledAt: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 					Health: &client.HealthCheck{
 						Timestamp: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 						Message:   "hello from health-check",

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -89,7 +89,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	for _, it := range info.Installed {
 		project := cmdutil.ContractHome(it.ProjectPath)
 		channel := cmdutil.EmptyDash(it.Channel)
-		date := formatDate(it.BuildTime)
+		date := formatDate(it.BuiltAt)
 		fmt.Fprintf(w, "  %s:\t%s\t%s\t%s\t(%s)\t%s\n",
 			project, it.Workshop, channel, date, it.Revision, units.GetByteSizeString(int64(it.Size), 2))
 	}

--- a/cmd/sdk/info_test.go
+++ b/cmd/sdk/info_test.go
@@ -31,9 +31,9 @@ func (s *sdkSuite) TestInfo(c *check.C) {
 				Workshop:    "ci",
 				Channel:     "latest/stable",
 				SdkVolume: client.SdkVolume{
-					Revision:  "85",
-					BuildTime: &d1,
-					Size:      109 * 1024 * 1024,
+					Revision: "85",
+					BuiltAt:  &d1,
+					Size:     109 * 1024 * 1024,
 				},
 			},
 			{
@@ -41,9 +41,9 @@ func (s *sdkSuite) TestInfo(c *check.C) {
 				Workshop:    "dev",
 				Channel:     "latest/edge",
 				SdkVolume: client.SdkVolume{
-					Revision:  "82",
-					BuildTime: &d2,
-					Size:      102 * 1024 * 1024,
+					Revision: "82",
+					BuiltAt:  &d2,
+					Size:     102 * 1024 * 1024,
 				},
 			},
 		},

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -160,8 +160,8 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 			revision, err := sdk.ParseRevision(sk.Revision)
 			if err == nil && revision.Local() {
 				tracking = cmdutil.ContractHome(sk.Source)
-				if sk.BuildTime.IsZero() {
-					sk.BuildTime = sk.InstallTime
+				if sk.BuiltAt.IsZero() {
+					sk.BuiltAt = sk.InstalledAt
 				}
 			}
 
@@ -171,15 +171,15 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 				fmt.Fprintf(w, "    tracking:\t%s\n", escape(tracking))
 			}
 
-			var buildTime string
-			if !sk.BuildTime.IsZero() {
-				buildTime = "\t" + sk.BuildTime.Format(time.DateOnly)
+			var builtAt string
+			if !sk.BuiltAt.IsZero() {
+				builtAt = "\t" + sk.BuiltAt.Format(time.DateOnly)
 			}
 			var version string
 			if sk.Version != "" {
 				version = "\t" + sk.Version
 			}
-			fmt.Fprintf(w, "    installed:%s%s\t(%s)\n", version, buildTime, sk.Revision)
+			fmt.Fprintf(w, "    installed:%s%s\t(%s)\n", version, builtAt, sk.Revision)
 			if sk.Health != nil {
 				fmt.Fprintf(w, "    message:\t%s\n", escape(sk.Health.Message))
 			}

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -34,13 +34,13 @@ var mockWorkshopWithSdks = `{"type":"sync","status-code":200,"status":"OK","resu
       "version":"1.8.0",
       "channel":"latest/edge",
       "revision":"1",
-      "build-time":"2017-02-19T17:23:05.592623Z",
-      "install-time":"2017-03-22T09:01:00.0Z"
+      "built-at":"2017-02-19T17:23:05.592623Z",
+      "installed-at":"2017-03-22T09:01:00.0Z"
     },{  
       "name":"sketch",
       "source":"%s/.local/share/workshop/id/42424242/ws/sdk/sketch/current",
       "revision":"x1",
-      "install-time":"2017-03-22T09:01:00.0Z"
+      "installed-at":"2017-03-22T09:01:00.0Z"
     }],
     "notes":["missing-project"],
     "path":"/home/project/.workshop/ws.yaml"
@@ -106,8 +106,8 @@ var mockWorkshopWithHealth = `{"type":"sync","status-code":200,"status":"OK","re
         "version":"1.8.0",
         "channel":"latest/edge",
         "revision":"1",
-        "build-time":"2017-02-19T17:23:05.592623Z",
-        "install-time":"2017-03-22T09:01:00.0Z",
+        "built-at":"2017-02-19T17:23:05.592623Z",
+        "installed-at":"2017-03-22T09:01:00.0Z",
         "health-check":{"message":"Waiting for all required modules to be installed","code":"try-later"}
     }]
 }}`
@@ -160,8 +160,8 @@ var mockWorkshopWithMounts = `{"type":"sync","status-code":200,"status":"OK","re
         "version":"1.8.0",
         "channel":"latest/edge",
         "revision":"1",
-        "build-time":"2017-02-19T17:23:05.592623Z",
-        "install-time":"2017-03-22T09:01:00.0Z",
+        "built-at":"2017-02-19T17:23:05.592623Z",
+        "installed-at":"2017-03-22T09:01:00.0Z",
         "mounts":[{
             "host-source":"/home/user/src",
             "workshop-target":"/home/workshop/target", 
@@ -322,8 +322,8 @@ var mockWorkshopWithTunnels = `{
         "version": "1.8.0",
         "channel": "latest/edge",
         "revision": "1",
-        "build-time": "2017-02-19T17:23:05.592623Z",
-        "install-time": "2017-03-22T09:01:00.0Z",
+        "built-at": "2017-02-19T17:23:05.592623Z",
+        "installed-at": "2017-03-22T09:01:00.0Z",
         "tunnels": [
           {
             "plug": {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -34,13 +34,13 @@ var mockWorkshopWithSdksReady = `{"type":"sync","status-code":200,"status":"OK",
       "version":"1.8.0",
       "channel":"latest/edge",
       "revision":"1",
-      "build-time":"2017-02-19T17:23:05.592623Z",
-      "install-time":"2017-03-22T09:01:00.0Z"
+      "built-at":"2017-02-19T17:23:05.592623Z",
+      "installed-at":"2017-03-22T09:01:00.0Z"
     },{
       "name":"sketch",
       "source":"/home/.local/share/workshop/id/42424242/ws/sdk/sketch/current",
       "revision":"x1",
-      "install-time":"2017-03-22T09:01:00.0Z"
+      "installed-at":"2017-03-22T09:01:00.0Z"
     }],
     "path":"/home/project/.workshop/ws.yaml"
 }}`
@@ -56,13 +56,13 @@ var mockWorkshopWithSdksWaiting = `{"type":"sync","status-code":200,"status":"OK
       "version":"1.8.0",
       "channel":"latest/edge",
       "revision":"1",
-      "build-time":"2017-02-19T17:23:05.592623Z",
-      "install-time":"2017-03-22T09:01:00.0Z"
+      "built-at":"2017-02-19T17:23:05.592623Z",
+      "installed-at":"2017-03-22T09:01:00.0Z"
     },{
       "name":"sketch",
       "source":"/home/.local/share/workshop/id/42424242/ws/sdk/sketch/current",
       "revision":"x2",
-      "install-time":"2017-03-22T09:01:00.0Z"
+      "installed-at":"2017-03-22T09:01:00.0Z"
     }],
     "path":"/home/project/.workshop/ws.yaml"
 }}`
@@ -77,7 +77,7 @@ var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK
             "name":"sketch",
             "source":"/home/.local/share/workshop/id/42424242/ws/sdk/sketch/current",
             "revision":"x1",
-            "install-time":"2017-03-22T09:01:00.0Z"
+            "installed-at":"2017-03-22T09:01:00.0Z"
         }]
         },{
         "name":"nosketch",
@@ -93,7 +93,7 @@ var mockWorkshopsListWithSketch = `{"type":"sync","status-code":200,"status":"OK
             "name":"sketch",
             "source":"/home/.local/share/workshop/id/42424242/both/sdk/sketch/current",
             "revision":"x3",
-            "install-time":"2017-03-22T09:01:00.0Z"
+            "installed-at":"2017-03-22T09:01:00.0Z"
         }]
         },{
         "name":"none",

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -380,7 +380,7 @@ adding ``/storage/v1/`` as the path:
 
 .. code-block:: console
 
-   sudo snap set workshop store.url=http://localhost:8080/storage/v1/
+   sudo snap set workshop gcs.url=http://localhost:8080/storage/v1/
    sudo snap restart workshop
 
 
@@ -394,7 +394,7 @@ To go back to the default store:
 
 .. code-block:: console
 
-   sudo snap set workshop store.url=""
+   sudo snap set workshop gcs.url=""
 
 
 Workshop will now use the default URL.

--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -30,7 +30,7 @@ func (s *apiSuite) TestSdksGetOk(c *check.C) {
 		SdkYAML: `name: ollama
 version: 1.0-053c828
 summary: Large language model runtime
-sdkcraft-started-at: 2024-11-25T00:00:00Z
+sdkcraft-started-at: 2024-11-25T00:00:00+00:00
 `,
 	}
 	s.importSdkVolume(c, meta, 109*1024*1024)
@@ -44,7 +44,7 @@ sdkcraft-started-at: 2024-11-25T00:00:00Z
 		SdkYAML: `name: openvino
 version: 2.1-084c8c8
 summary: Intel OpenVINO toolkit
-sdkcraft-started-at: 2024-11-20T00:00:00Z
+sdkcraft-started-at: 2024-11-20T00:00:00+00:00
 `,
 	}
 	s.importSdkVolume(c, meta, 112*1024*1024)
@@ -200,7 +200,7 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 version: 2.1-084c8c8
 summary: Intel OpenVINO toolkit
 description: Accelerated toolkit
-sdkcraft-started-at: 2024-11-20T00:00:00Z
+sdkcraft-started-at: 2024-11-20T00:00:00+00:00
 `,
 	}
 	s.importSdkVolume(c, meta, 112*1024*1024)
@@ -218,7 +218,7 @@ sdkcraft-started-at: 2024-11-20T00:00:00Z
 version: 2.0
 summary: Intel OpenVINO toolkit (legacy)
 description: Legacy release
-sdkcraft-started-at: 2024-11-25T00:00:00Z
+sdkcraft-started-at: 2024-11-25T00:00:00+00:00
 `,
 	}
 	s.importSdkVolume(c, meta, 101*1024*1024)

--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -100,18 +100,18 @@ summary: ROS2 SDK
 	opHigh := time.Date(2024, 11, 20, 0, 0, 0, 0, time.UTC).UTC().Round(0)
 	c.Assert(result, testutil.DeepUnsortedMatches, []sdkstate.SdkVolume{
 		{
-			Name:      "ollama",
-			Version:   "1.0-053c828",
-			Revision:  "82",
-			BuildTime: &olBuild,
-			Size:      109 * 1024 * 1024,
+			Name:     "ollama",
+			Version:  "1.0-053c828",
+			Revision: "82",
+			BuiltAt:  &olBuild,
+			Size:     109 * 1024 * 1024,
 		},
 		{
-			Name:      "openvino",
-			Version:   "2.1-084c8c8",
-			Revision:  "85",
-			BuildTime: &opHigh,
-			Size:      112 * 1024 * 1024,
+			Name:     "openvino",
+			Version:  "2.1-084c8c8",
+			Revision: "85",
+			BuiltAt:  &opHigh,
+			Size:     112 * 1024 * 1024,
 		},
 		{
 			Name:     "openvino",
@@ -248,11 +248,11 @@ sdkcraft-started-at: 2024-11-25T00:00:00Z
 			Workshop:    "nav2",
 			Channel:     "latest/stable",
 			SdkVolume: sdkstate.SdkVolume{
-				Name:      "openvino",
-				Version:   "2.1-084c8c8",
-				Revision:  "85",
-				BuildTime: &d20,
-				Size:      112 * 1024 * 1024,
+				Name:     "openvino",
+				Version:  "2.1-084c8c8",
+				Revision: "85",
+				BuiltAt:  &d20,
+				Size:     112 * 1024 * 1024,
 			},
 		},
 		{
@@ -260,11 +260,11 @@ sdkcraft-started-at: 2024-11-25T00:00:00Z
 			Workshop:    "lerobot",
 			Channel:     "latest/edge",
 			SdkVolume: sdkstate.SdkVolume{
-				Name:      "openvino",
-				Version:   "2.0",
-				Revision:  "82",
-				BuildTime: &d25,
-				Size:      101 * 1024 * 1024,
+				Name:     "openvino",
+				Version:  "2.0",
+				Revision: "82",
+				BuiltAt:  &d25,
+				Size:     101 * 1024 * 1024,
 			},
 		},
 	})

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -43,7 +43,7 @@ type apiSuite struct {
 	d          *Daemon
 	b          *fakebackend.FakeWorkshopBackend
 	secBackend *ifacetest.TestSecurityBackend
-	store      *sdk.FakeStore
+	gcsStore   *sdk.FakeGcsStore
 
 	workshopDir string
 	user        *user.User
@@ -80,9 +80,9 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 		ProjectId: "b8639dea",
 	}
 
-	s.store = &sdk.FakeStore{}
+	s.gcsStore = &sdk.FakeGcsStore{}
 	retrieveSystemSdk := func(setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error) {
-		return s.store.DownloadSdk(context.TODO(), setup, report)
+		return s.gcsStore.DownloadSdk(context.TODO(), setup, report)
 	}
 	s.restoreRetrieve = system.FakeRetrieveSystemSdk(retrieveSystemSdk)
 
@@ -151,7 +151,7 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	d.addRoutes()
 	s.d = d
 
-	sdk.ReplaceStore(s.d.state, s.store)
+	sdk.ReplaceGcsStore(s.d.state, s.gcsStore)
 	return d
 }
 

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -47,7 +47,7 @@ type apiSuite struct {
 
 	workshopDir string
 	user        *user.User
-	installTime time.Time
+	installedAt time.Time
 	project     workshop.Project
 	ctx         context.Context
 
@@ -89,8 +89,8 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	s.b, err = fakebackend.New(c.MkDir())
 	c.Check(err, check.IsNil)
 
-	s.installTime = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
-	s.restoreTime = testutil.FakeFunc(func() time.Time { return s.installTime }, &workshop.InstallTimeNow)
+	s.installedAt = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
+	s.restoreTime = testutil.FakeFunc(func() time.Time { return s.installedAt }, &workshop.InstallTimeNow)
 
 	// will be called when project is created
 	s.restoreProjectId = testutil.FakeFunc(func() (string, error) { return s.project.ProjectId, nil }, &workshop.NewProjectId)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -52,8 +52,8 @@ type SdkInfo struct {
 	Channel     string           `json:"channel,omitempty"`
 	Source      string           `json:"source,omitempty"`
 	Revision    string           `json:"revision"`
-	BuildTime   *time.Time       `json:"build-time,omitempty"`
-	InstallTime time.Time        `json:"install-time,omitempty"`
+	BuiltAt     *time.Time       `json:"built-at,omitempty"`
+	InstalledAt time.Time        `json:"installed-at,omitzero"`
 	Health      *HealthCheckInfo `json:"health-check,omitempty"`
 	Mounts      []*Mount         `json:"mounts,omitempty"`
 	Tunnels     []*Tunnel        `json:"tunnels,omitempty"`
@@ -151,7 +151,7 @@ func workshopToInfo(username string, w *workshop.Workshop, health healthstate.He
 			Channel:     sk.Channel,
 			Source:      source,
 			Revision:    sk.Revision.String(),
-			InstallTime: sk.InstallTime,
+			InstalledAt: sk.InstalledAt,
 			Health:      healthInfo,
 		})
 	}
@@ -212,8 +212,8 @@ func workshopToInfoFull(ctx context.Context, username string, w *workshop.Worksh
 			Channel:     sk.Channel,
 			Source:      source,
 			Revision:    sk.Revision.String(),
-			BuildTime:   sk.BuildTime,
-			InstallTime: w.Sdks[sk.Name].InstallTime,
+			BuiltAt:     sk.BuiltAt,
+			InstalledAt: w.Sdks[sk.Name].InstalledAt,
 			Health:      healthInfo,
 			Mounts:      mntInfos,
 			Tunnels:     tunnelInfos,

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -374,7 +374,7 @@ title: title
 version: '0.1.2'
 summary: summary
 description: SDK
-sdkcraft-started-at: '2020-04-22T19:12:07.903032Z'
+sdkcraft-started-at: '2020-04-22T19:12:07.903032+00:00'
 plugs:
   data:
     interface: mount
@@ -389,7 +389,7 @@ title: title
 version: '0.1.3'
 summary: summary
 description: SDK
-sdkcraft-started-at: '2020-04-22T19:12:07.903032Z'
+sdkcraft-started-at: '2020-04-22T19:12:07.903032+00:00'
 plugs:
   ssh-agent:
     interface: ssh-agent
@@ -403,7 +403,7 @@ title: title
 version: '20200401.3f3a63f'
 summary: summary
 description: SDK
-sdkcraft-started-at: '2020-05-03T22:05:35.811829Z'
+sdkcraft-started-at: '2020-05-03T22:05:35.811829+00:00'
 plugs:
   photos:
     interface: mount
@@ -426,7 +426,7 @@ base: ubuntu@22.04
 version: '20200401.3f3a63f'
 summary: summary
 description: SDK
-sdkcraft-started-at: '2020-05-03T22:05:35.811829Z'
+sdkcraft-started-at: '2020-05-03T22:05:35.811829+00:00'
 plugs:
   photos:
     interface: mount
@@ -446,7 +446,7 @@ base: ubuntu@22.04
 version: '20200401.3f3a63f'
 summary: summary
 description: SDK
-sdkcraft-started-at: '2020-05-03T22:05:35.811829Z'
+sdkcraft-started-at: '2020-05-03T22:05:35.811829+00:00'
 `
 )
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -545,13 +545,13 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 			{
 				Name:        "system",
 				Revision:    system.SystemSdkRevision.String(),
-				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+				InstalledAt: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 			},
 			{
 				Name:        "test-sdk",
 				Channel:     "latest/stable",
 				Revision:    "1",
-				InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+				InstalledAt: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 			},
 		},
 	}, {
@@ -562,7 +562,7 @@ func (s *apiSuite) TestGetWorkshops(c *check.C) {
 		Sdks: []*SdkInfo{{
 			Name:        "system",
 			Revision:    system.SystemSdkRevision.String(),
-			InstallTime: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
+			InstalledAt: time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC),
 		}},
 	}})
 
@@ -667,7 +667,7 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 				{
 					Name:        "system",
 					Revision:    system.SystemSdkRevision.String(),
-					InstallTime: s.installTime,
+					InstalledAt: s.installedAt,
 					Tunnels: []*Tunnel{
 						{
 							Plug: sdk.PlugRef{
@@ -693,8 +693,8 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 					Version:     "0.1.2",
 					Channel:     "latest/stable",
 					Revision:    "1",
-					BuildTime:   &build1,
-					InstallTime: s.installTime,
+					BuiltAt:     &build1,
+					InstalledAt: s.installedAt,
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource,
@@ -733,8 +733,8 @@ func (s *apiSuite) TestGetWorkshopInfo(c *check.C) {
 					Version:     "20200401.3f3a63f",
 					Channel:     "latest/stable",
 					Revision:    "1",
-					BuildTime:   &build2,
-					InstallTime: s.installTime,
+					BuiltAt:     &build2,
+					InstalledAt: s.installedAt,
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource2,
@@ -821,8 +821,8 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 					Version:     "20200401.3f3a63f",
 					Channel:     "latest/stable",
 					Revision:    "1",
-					BuildTime:   &build2,
-					InstallTime: s.installTime,
+					BuiltAt:     &build2,
+					InstalledAt: s.installedAt,
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource,
@@ -839,15 +839,15 @@ func (s *apiSuite) TestGetWorkshopInfoSomePlugsBound(c *check.C) {
 				{
 					Name:        "system",
 					Revision:    system.SystemSdkRevision.String(),
-					InstallTime: s.installTime,
+					InstalledAt: s.installedAt,
 				},
 				{
 					Name:        "test-sdk",
 					Version:     "0.1.2",
 					Channel:     "latest/stable",
 					Revision:    "1",
-					BuildTime:   &build1,
-					InstallTime: s.installTime,
+					BuiltAt:     &build1,
+					InstalledAt: s.installedAt,
 					Mounts: []*Mount{
 						{
 							HostSource:     testSDKSource,
@@ -1160,7 +1160,7 @@ line 1: cannot unmarshal !!seq into string`,
 	c.Assert(sdkInfo.Name, check.Equals, sdk.System.String())
 	c.Assert(sdkInfo.Version, check.Equals, "")
 	c.Assert(sdkInfo.Type, check.Equals, sdk.System)
-	c.Assert(sdkInfo.BuildTime, check.IsNil)
+	c.Assert(sdkInfo.BuiltAt, check.IsNil)
 }
 
 func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {
@@ -1835,7 +1835,7 @@ func (s *apiSuite) ensureWorkshops(c *check.C, want []expectedWorkshop) {
 			sk.Sha3_384 = w.Sdks[sk.Name].Sha3_384
 			c.Check(sk.Sha3_384, check.Not(check.Equals), "")
 			c.Assert(w.Sdks[sk.Name].Setup, check.DeepEquals, sk)
-			c.Check(w.Sdks[sk.Name].InstallTime, check.Equals, s.installTime)
+			c.Check(w.Sdks[sk.Name].InstalledAt, check.Equals, s.installedAt)
 		}
 
 		repo := s.d.overlord.InterfaceManager().Repository()

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -488,8 +488,8 @@ var apiSuiteSdks = map[string]sdk.Meta{
 func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string) {
 	s.createWFile(c, name, yaml)
 
-	defer s.store.SetActionCallback(storeAction)()
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetActionCallback(storeAction)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	reqbuf := bytes.NewBufferString(fmt.Sprintf(`{"names":["%s"],"action":"launch"}`, name))
 	s.vars = map[string]string{"id": s.project.ProjectId}
@@ -905,7 +905,7 @@ type expectedResp struct {
 }
 
 func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected []*expectedResp) {
-	defer s.store.SetActionCallback(storeAction)()
+	defer s.gcsStore.SetActionCallback(storeAction)()
 
 	s.vars = map[string]string{"id": s.project.ProjectId}
 	requests := []*http.Request{}
@@ -1096,7 +1096,7 @@ func (s *apiSuite) TestLaunchWorkshopBasic(c *check.C) {
 	// Setup
 	s.createWFile(c, "basic", basic)
 	s.createWFile(c, "basic-invalid", basic_invalid)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic", "basic", "basic"],"action":"launch"}`),
@@ -1169,7 +1169,7 @@ func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopslot", workshopslot)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopslot"],"action":"launch"}`),
@@ -1199,7 +1199,7 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 		return fmt.Errorf(`cannot assign profile to "manysdks"`)
@@ -1252,7 +1252,7 @@ func (s *apiSuite) TestSnapshotFormat(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 	s.createWFile(c, "manysdks", manysdks_diverse)
 
 	s.mockTrySdk(c, "test-sdk-2", "test-sdk-2_all.sdk", testsdk2)
@@ -1504,7 +1504,7 @@ func (s *apiSuite) TestLaunchWorkshopPlugBindsSuccess(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "somebound", somebound)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["somebound"],"action":"launch"}`),
@@ -1540,7 +1540,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoMasterPlug(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "masterunknown", masterunknown)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["masterunknown"],"action":"launch"}`),
@@ -1565,7 +1565,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugNoSlavePlug(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "slaveunknown", slaveunknown)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["slaveunknown"],"action":"launch"}`),
@@ -1590,7 +1590,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "bindincompatible", bindincompatible)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["bindincompatible"],"action":"launch"}`),
@@ -1616,7 +1616,7 @@ func (s *apiSuite) TestLaunchWorkshopWithPlugOK(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "workshopplug", workshopplug)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopplug"],"action":"launch"}`),
@@ -1650,7 +1650,7 @@ func (s *apiSuite) TestLaunchWorkshopPlugAddedAndBound(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "workshopplugbound", workshopplugbound)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopplugbound"],"action":"launch"}`),
@@ -1686,7 +1686,7 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
@@ -1741,7 +1741,7 @@ func (s *apiSuite) TestWorkshopConnectionsUnknownPlug(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "workshopbrokenconn", workshopbrokenconn)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopbrokenconn"],"action":"launch"}`),
@@ -1774,7 +1774,7 @@ func (s *apiSuite) TestWorkshopConnectionsPlugIsBoundTo(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "connsplugbound", connsplugbound)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["connsplugbound"],"action":"launch"}`),
@@ -1993,7 +1993,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 	s.createWFile(c, "basic", basic)
 	s.createWFile(c, "manysdks", manysdks)
 	s.createWFile(c, "somebound", somebound)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic", "manysdks", "somebound"],"action":"launch"}`),
@@ -2117,7 +2117,7 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -2199,7 +2199,7 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -2285,7 +2285,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -2360,7 +2360,7 @@ func (s *apiSuite) TestRefreshNewSdkChannel(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -2453,7 +2453,7 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -2539,7 +2539,7 @@ func (s *apiSuite) TestRefreshSaveAndRestoreState(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownloadWithSaveRestore)()
+	defer s.gcsStore.SetDownloadCallback(storeDownloadWithSaveRestore)()
 
 	// Launch
 	requests := []*bytes.Buffer{
@@ -2678,7 +2678,7 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 	s.mockTrySdk(c, "test-sdk", "test-sdk_all.sdk", testsdk)
 	s.mockTrySdk(c, "test-sdk-2", "test-sdk-2_all_ubuntu@22.04.sdk", testsdk2)
 	s.createWFile(c, "manysdks", manysdks_try)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -2791,7 +2791,7 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 	s.mockProjectSdk(c, "test-sdk", testsdk)
 	s.mockProjectSdk(c, "test-sdk-2", testsdk2)
 	s.createWFile(c, "manysdks", manysdks_project)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -2901,7 +2901,7 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -2980,7 +2980,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -3061,7 +3061,7 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -3135,7 +3135,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks_plugadded)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -3214,7 +3214,7 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 	defer func() { _ = s.d.Overlord().Stop() }()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -3292,7 +3292,7 @@ func (s *apiSuite) TestRefreshRestore(c *check.C) {
 	defer func() { _ = s.d.Overlord().Stop() }()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -3371,7 +3371,7 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 	defer func() { _ = s.d.Overlord().Stop() }()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -3453,7 +3453,7 @@ func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
 	defer func() { _ = s.d.Overlord().Stop() }()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	oldGetBase := s.b.GetBaseCallback
 	s.b.GetBaseCallback = func(ctx context.Context, base string) (workshop.BaseImage, error) {
@@ -3551,7 +3551,7 @@ func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
 	defer func() { _ = s.d.Overlord().Stop() }()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks_system)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -3626,7 +3626,7 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 	// Setup
 	s.mockProjectSdk(c, "test-sdk-2", testsdk2)
 	s.createWFile(c, "basic", basic_refreshed)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -3692,7 +3692,7 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -3772,7 +3772,7 @@ func (s *apiSuite) TestRefreshNoRefreshInProgress(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -3807,7 +3807,7 @@ func (s *apiSuite) TestRefreshContinue(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 	s.createWFile(c, "basic", basic)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
 	s.secBackend.RemoveCallback = func(sdkName string) error {
@@ -3872,7 +3872,7 @@ func (s *apiSuite) TestRefreshAbort(c *check.C) {
 	s.d.Overlord().Loop()
 	defer s.d.Overlord().Stop()
 	s.createWFile(c, "basic", basic)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
 	s.secBackend.RemoveCallback = func(sdkName string) error {
@@ -4140,7 +4140,7 @@ func (s *apiSuite) TestValidateSdkInfo(c *check.C) {
 	s.mockTrySdk(c, "test-sdk-2", "test-sdk-2_all.sdk", testsdk2_invalid)
 	s.createWFile(c, "manysdks", manysdks_try)
 	s.createWFile(c, "wrongbase", wrongbase)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -4209,7 +4209,7 @@ func (s *apiSuite) TestLaunchWorkshopRefreshLaunchInProgress(c *check.C) {
 	defer s.d.Overlord().Stop()
 
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
 	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
@@ -4254,7 +4254,7 @@ func (s *apiSuite) TestLaunchWorkshopContinueSuccess(c *check.C) {
 	defer s.d.Overlord().Stop()
 
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
 	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
@@ -4299,7 +4299,7 @@ func (s *apiSuite) TestLaunchWorkshopNoRefreshInProgress(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -4335,7 +4335,7 @@ func (s *apiSuite) TestLaunchWorkshopChangeAbort(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
 	s.secBackend.SetupCallback = func(context context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
@@ -4381,7 +4381,7 @@ func (s *apiSuite) TestRefreshPartialOK(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "manysdks", manysdks)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -4499,7 +4499,7 @@ func (s *apiSuite) TestRefreshConflictChange(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	var errOnce sync.Once
 	s.secBackend.RemoveCallback = func(sdkName string) error {
@@ -4563,7 +4563,7 @@ func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Install test-sdk-2 first.
 	s.createWFile(c, "manysdks", manysdks_reversed)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
@@ -4625,7 +4625,7 @@ func (s *apiSuite) TestStartWorkshop(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -4676,7 +4676,7 @@ func (s *apiSuite) TestStopWorkshop(c *check.C) {
 	defer s.d.Overlord().Stop()
 	// Setup
 	s.createWFile(c, "basic", basic)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
@@ -4713,7 +4713,7 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"launch"}`),
@@ -4745,7 +4745,7 @@ func (s *apiSuite) TestRemoveWorkshopNotFound(c *check.C) {
 
 	// Setup
 	s.createWFile(c, "workshopconns", workshopconns)
-	defer s.store.SetDownloadCallback(storeDownload)()
+	defer s.gcsStore.SetDownloadCallback(storeDownload)()
 
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["workshopconns"],"action":"remove"}`),

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1190,7 +1190,7 @@ func (s *apiSuite) TestLaunchWorkshopWithSlotOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slot(s.project.ProjectId, "workshopslot", "test-sdk", "training"), check.Not(check.IsNil))
+	c.Assert(repo.Slot(s.project.ProjectId, "workshopslot", "test-sdk", "training"), check.NotNil)
 }
 
 func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
@@ -1707,7 +1707,7 @@ func (s *apiSuite) TestWorkshopConnectionsOK(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slot(s.project.ProjectId, "workshopconns", "test-sdk-2", "training"), check.Not(check.IsNil))
+	c.Assert(repo.Slot(s.project.ProjectId, "workshopconns", "test-sdk-2", "training"), check.NotNil)
 
 	conns, err := repo.Connections(s.project.ProjectId, "workshopconns", "test-sdk")
 	c.Assert(err, check.IsNil)

--- a/internal/daemon/snapshot-ingredients.yaml
+++ b/internal/daemon/snapshot-ingredients.yaml
@@ -31,7 +31,7 @@ BaseImage:
 SdkInstallation:
   Setup: sdk.Setup
   InstallOrder: int
-  InstallTime: time.Time
+  InstalledAt: time.Time
 Setup:
   Name: string
   Channel: string

--- a/internal/gcsstore/export_test.go
+++ b/internal/gcsstore/export_test.go
@@ -1,4 +1,4 @@
-package store
+package gcsstore
 
 import (
 	"context"

--- a/internal/gcsstore/integration_test.go
+++ b/internal/gcsstore/integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package store_test
+package gcsstore_test
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
-	store "github.com/canonical/workshop/internal/fakestore"
+	"github.com/canonical/workshop/internal/gcsstore"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
@@ -26,7 +26,7 @@ type storeIntegration struct {
 var _ = check.Suite(&storeIntegration{})
 
 func (f *storeIntegration) SetUpTest(c *check.C) {
-	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8080/storage/v1/"), check.IsNil)
+	c.Assert(os.Setenv("GCS_STORE_URL", "http://localhost:8080/storage/v1/"), check.IsNil)
 	f.oldRoot = dirs.BaseDir
 	f.oldCache = dirs.CacheDir
 	dirs.SetRootDir(c.MkDir())
@@ -35,13 +35,13 @@ func (f *storeIntegration) SetUpTest(c *check.C) {
 }
 
 func (f *storeIntegration) TearDownTest(c *check.C) {
-	c.Assert(os.Unsetenv("SDK_STORE_URL"), check.IsNil)
+	c.Assert(os.Unsetenv("GCS_STORE_URL"), check.IsNil)
 	dirs.SetCacheDir(f.oldCache)
 	dirs.SetRootDir(f.oldRoot)
 }
 
 func (f *storeIntegration) TestStoreDownloadOK(c *check.C) {
-	s := store.New()
+	s := gcsstore.New()
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.R(1)}
 	result, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.IsNil)
@@ -55,7 +55,7 @@ func (f *storeIntegration) TestStoreDownloadOK(c *check.C) {
 }
 
 func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
-	s := store.New()
+	s := gcsstore.New()
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.R(1)}
 	done, total := 0, 0
 	r := &progress.Reporter{Name: "1", Report: func(label string, d, t int) {
@@ -71,7 +71,7 @@ func (f *storeIntegration) TestStoreDownloadProgressReport(c *check.C) {
 }
 
 func (f *storeIntegration) TestStoreDownloadCleanupPrevious(c *check.C) {
-	s := store.New()
+	s := gcsstore.New()
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.R(1)}
 	prev := setup
 	prev.Revision = sdk.R(5)
@@ -92,7 +92,7 @@ func (f *storeIntegration) TestStoreDownloadCleanupPrevious(c *check.C) {
 }
 
 func (f *storeIntegration) TestStoreDownloadNotfound(c *check.C) {
-	s := store.New()
+	s := gcsstore.New()
 	setup := sdk.Setup{Name: "test-sdk-unknown", Channel: "latest/stable", Revision: sdk.R(1)}
 	_, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.ErrorMatches, `SDK not found in "latest/stable"`)
@@ -106,7 +106,7 @@ func (f *storeIntegration) TestStoreDownloadLocksSDKForExclusiveAccess(c *check.
 	m, r := logger.MockLogger()
 	defer r()
 
-	s := store.New()
+	s := gcsstore.New()
 	setup := sdk.Setup{
 		Name:     "test-sdk-basic",
 		Channel:  "latest/stable",
@@ -145,12 +145,12 @@ func (*failingReader) Read(p []byte) (n int, err error) {
 func (*failingReader) Close() error { return nil }
 
 func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
-	r := store.FakeSdkStoreSdkReader(func(ctx context.Context, setup sdk.Setup) (*store.SdkReader, error) {
-		return &store.SdkReader{ReadCloser: &failingReader{}, Revision: setup.Revision}, nil
+	r := gcsstore.FakeSdkStoreSdkReader(func(ctx context.Context, setup sdk.Setup) (*gcsstore.SdkReader, error) {
+		return &gcsstore.SdkReader{ReadCloser: &failingReader{}, Revision: setup.Revision}, nil
 	})
 	defer r()
 
-	s := store.New()
+	s := gcsstore.New()
 	setup := sdk.Setup{Name: "test-sdk-basic", Channel: "latest/stable", Revision: sdk.Revision{N: 55}}
 	_, err := s.DownloadSdk(context.Background(), setup, nil)
 	c.Assert(err, check.NotNil)
@@ -160,7 +160,7 @@ func (f *storeIntegration) TestStoreDownloadRemoveUnfinished(c *check.C) {
 func (s *storeIntegration) TestSdkActionInstallStoreError(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
-	store := store.New()
+	store := gcsstore.New()
 	acts := []sdk.SdkAction{{
 		ProjectId: "24242424",
 		Workshop:  "test-workshop",
@@ -178,8 +178,8 @@ func (f *storeIntegration) TestSdkActionTimeout(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
 	// Deliberately set to malformed address
-	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8181/storage/v1/"), check.IsNil)
-	s := store.New()
+	c.Assert(os.Setenv("GCS_STORE_URL", "http://localhost:8181/storage/v1/"), check.IsNil)
+	s := gcsstore.New()
 	acts := []sdk.SdkAction{{
 		ProjectId: "24242424",
 		Workshop:  "test-workshop",
@@ -191,7 +191,7 @@ func (f *storeIntegration) TestSdkActionTimeout(c *check.C) {
 	_, err := s.SdkAction(context.Background(), acts)
 
 	// Restore address for remaining tests
-	c.Assert(os.Setenv("SDK_STORE_URL", "http://localhost:8080/storage/v1/"), check.IsNil)
+	c.Assert(os.Setenv("GCS_STORE_URL", "http://localhost:8080/storage/v1/"), check.IsNil)
 
 	c.Assert(err, check.ErrorMatches, `(?s).*cannot connect to store.*`)
 }

--- a/internal/gcsstore/store.go
+++ b/internal/gcsstore/store.go
@@ -1,4 +1,4 @@
-package store
+package gcsstore
 
 import (
 	"bufio"
@@ -286,7 +286,7 @@ func extractSdkYAML(ctx context.Context, setup sdk.Setup) (string, error) {
 func storeConnect(ctx context.Context) (*ClientWrapper, error) {
 	opt := option.WithoutAuthentication()
 	testing := false
-	if url := os.Getenv("SDK_STORE_URL"); url != "" { // Set STORAGE_EMULATOR_HOST environment variable for GSC.
+	if url := os.Getenv("GCS_STORE_URL"); url != "" { // Set STORAGE_EMULATOR_HOST environment variable for GSC.
 		err := os.Setenv("STORAGE_EMULATOR_HOST", "localhost:8080")
 		if err != nil {
 			return nil, err

--- a/internal/gcsstore/store_test.go
+++ b/internal/gcsstore/store_test.go
@@ -1,4 +1,4 @@
-package store_test
+package gcsstore_test
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 
 	"gopkg.in/check.v1"
 
-	store "github.com/canonical/workshop/internal/fakestore"
+	"github.com/canonical/workshop/internal/gcsstore"
 	"github.com/canonical/workshop/internal/sdk"
 )
 
@@ -38,8 +38,8 @@ var testSdkNoBase = `name: test-sdk
 `
 
 func (s *storeSuite) TestSdkActionInstallOK(c *check.C) {
-	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
-		var s = store.StoreSdk{
+	r := gcsstore.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (gcsstore.StoreSdk, error) {
+		var s = gcsstore.StoreSdk{
 			Name:     "test-sdk",
 			Channel:  channel,
 			Revision: sdk.Revision{N: 123},
@@ -50,7 +50,7 @@ func (s *storeSuite) TestSdkActionInstallOK(c *check.C) {
 	defer r()
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
-	store := store.New()
+	store := gcsstore.New()
 	acts := []sdk.SdkAction{{
 		ProjectId: "24242424",
 		Workshop:  "test-workshop",
@@ -66,8 +66,8 @@ func (s *storeSuite) TestSdkActionInstallOK(c *check.C) {
 }
 
 func (s *storeSuite) TestSdkActionInstallNoBase(c *check.C) {
-	r := store.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (store.StoreSdk, error) {
-		var s = store.StoreSdk{
+	r := gcsstore.FakeSdkStoreInfo(func(ctx context.Context, name, channel string) (gcsstore.StoreSdk, error) {
+		var s = gcsstore.StoreSdk{
 			Name:     "test-sdk",
 			Channel:  channel,
 			Revision: sdk.Revision{N: 123},
@@ -78,7 +78,7 @@ func (s *storeSuite) TestSdkActionInstallNoBase(c *check.C) {
 	defer r()
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 
-	store := store.New()
+	store := gcsstore.New()
 	acts := []sdk.SdkAction{{
 		ProjectId: "24242424",
 		Workshop:  "test-workshop",

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -330,15 +330,15 @@ plugs:
 `},
 	})
 	// Plug() correctly finds plugs
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "a"), Not(IsNil))
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "b"), Not(IsNil))
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "c"), Not(IsNil))
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "a"), Not(IsNil))
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "b"), Not(IsNil))
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "c"), Not(IsNil))
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "a"), Not(IsNil))
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "b"), Not(IsNil))
-	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "c"), Not(IsNil))
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "a"), NotNil)
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "b"), NotNil)
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-xx", "xx", "c"), NotNil)
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "a"), NotNil)
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "b"), NotNil)
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-yy", "yy", "c"), NotNil)
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "a"), NotNil)
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "b"), NotNil)
+	c.Assert(s.testRepo.Plug(s.projectId, "ws-zz_instance", "zz", "c"), NotNil)
 }
 
 // Tests for Repository.RemovePlug()
@@ -369,7 +369,7 @@ func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
 	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from sdk "consumer", it is still connected`)
 	// The plug is still there
 	slot := s.testRepo.Plug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
-	c.Assert(slot, Not(IsNil))
+	c.Assert(slot, NotNil)
 }
 
 // Tests for Repository.AllPlugs()
@@ -663,7 +663,7 @@ func (s *RepositorySuite) TestRemoveSlotSuccedsWhenSlotExistsAndDisconnected(c *
 func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotDoesntExist(c *C) {
 	// Removing a slot that doesn't exist returns an appropriate error
 	err := s.testRepo.RemoveSlot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, Not(IsNil))
+	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from sdk "producer", no such slot`)
 }
 
@@ -680,7 +680,7 @@ func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotIsConnected(c *C) {
 	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from sdk "producer", it is still connected`)
 	// The slot is still there
 	slot := s.testRepo.Slot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(slot, Not(IsNil))
+	c.Assert(slot, NotNil)
 }
 
 // Tests for Repository.Connect()

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -109,7 +109,7 @@ type HealthState struct {
 // operations in progress for the workshop. The state must be locked.
 func WorkshopHealth(st *state.State, ws *workshop.Workshop) HealthState {
 	var healthState = HealthState{
-		Timestamp: time.Now(),
+		Timestamp: time.Now().UTC(),
 	}
 
 	// Check the project directory exists.
@@ -207,7 +207,7 @@ func (h *healthHandler) Before() error {
 	// (the health is set already if it is a retry)
 	if errors.Is(err, state.ErrNoState) {
 		h.context.Set("health", HealthCheck{
-			Timestamp:   time.Now(),
+			Timestamp:   time.Now().UTC(),
 			Sdk:         h.context.Sdk(),
 			CheckResult: CheckUnknown,
 		})

--- a/internal/overlord/hookstate/ctlcmd/health.go
+++ b/internal/overlord/hookstate/ctlcmd/health.go
@@ -114,7 +114,7 @@ func (c *healthCommand) Execute([]string) error {
 
 	health := &healthstate.HealthCheck{
 		Sdk:         ctx.Sdk(),
-		Timestamp:   time.Now(),
+		Timestamp:   time.Now().UTC(),
 		CheckResult: status,
 		Message:     c.Message,
 		Code:        c.Code,

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -28,7 +28,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/dirs"
-	store "github.com/canonical/workshop/internal/fakestore"
+	"github.com/canonical/workshop/internal/gcsstore"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/cmdstate"
@@ -125,8 +125,8 @@ func New(dir string, restartHandler restart.Handler) (*Overlord, error) {
 	o.stateEng = NewStateEngine(s)
 	o.runner = state.NewTaskRunner(s)
 
-	sto := store.New()
-	sdk.ReplaceStore(s, sto)
+	gcs := gcsstore.New()
+	sdk.ReplaceGcsStore(s, gcs)
 
 	if workshopBackendOverride != nil {
 		workshop.ReplaceBackend(s, workshopBackendOverride)

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -115,7 +115,7 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		meta, err = system.RetrieveSystemSdk(rec, reporter)
 	} else {
 		st.Lock()
-		store := sdk.StoreService(st)
+		store := sdk.GcsStoreService(st)
 		st.Unlock()
 
 		meta, err = store.DownloadSdk(ctx, rec, reporter)

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -406,7 +406,7 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 }
 
 func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
-	sdk.ReplaceStore(s.state, sdk.NewFakeStore())
+	sdk.ReplaceGcsStore(s.state, sdk.NewFakeGcsStore())
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -468,8 +468,8 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 // after SdkAction but before DownloadSdk. Should be able to remove when we
 // switch over to the real Store.
 func (s *sdkStateSuite) TestRetrieveUpdatedSdk(c *check.C) {
-	store := sdk.NewFakeStore()
-	sdk.ReplaceStore(s.state, store)
+	store := sdk.NewFakeGcsStore()
+	sdk.ReplaceGcsStore(s.state, store)
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -42,7 +42,7 @@ type sdkStateSuite struct {
 	ctx         context.Context
 	user        *user.User
 	project     workshop.Project
-	installTime time.Time
+	installedAt time.Time
 
 	restoreUserLookup  func()
 	restoreUserEnv     func()
@@ -158,8 +158,8 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	s.se.AddManager(s.sdkmgr)
 	s.se.AddManager(s.runner)
 
-	s.installTime = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
-	s.restoreInstallTime = testutil.FakeFunc(func() time.Time { return s.installTime }, &workshop.InstallTimeNow)
+	s.installedAt = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
+	s.restoreInstallTime = testutil.FakeFunc(func() time.Time { return s.installedAt }, &workshop.InstallTimeNow)
 
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{
 		{Name: "test", Channel: "latest/stable"},
@@ -247,7 +247,7 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	props, err := s.backend.Workshop(s.ctx, "ws")
 	c.Assert(err, check.IsNil)
 	c.Check(props.Sdks["test"].Setup, check.DeepEquals, newSdk.Setup)
-	c.Check(props.Sdks["test"].InstallTime, check.Equals, s.installTime)
+	c.Check(props.Sdks["test"].InstalledAt, check.Equals, s.installedAt)
 
 	sdkInfo, err := props.SdkInfo(s.ctx, "test")
 	c.Assert(err, check.IsNil)

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -13,11 +13,11 @@ import (
 )
 
 type SdkVolume struct {
-	Name      string     `json:"name"`
-	Version   string     `json:"version,omitempty"`
-	Revision  string     `json:"revision"`
-	BuildTime *time.Time `json:"build-time,omitempty"`
-	Size      uint64     `json:"size,omitempty"`
+	Name     string     `json:"name"`
+	Version  string     `json:"version,omitempty"`
+	Revision string     `json:"revision"`
+	BuiltAt  *time.Time `json:"built-at,omitempty"`
+	Size     uint64     `json:"size,omitempty"`
 }
 
 type SdkInstalled struct {
@@ -79,11 +79,11 @@ func (w *SdkManager) SdkVolumes(ctx context.Context) ([]SdkVolume, error) {
 		}
 
 		entries = append(entries, SdkVolume{
-			Name:      info.Name,
-			Version:   info.Version,
-			Revision:  s.Revision.String(),
-			BuildTime: info.BuildTime,
-			Size:      s.Size,
+			Name:     info.Name,
+			Version:  info.Version,
+			Revision: s.Revision.String(),
+			BuiltAt:  info.BuiltAt,
+			Size:     s.Size,
 		})
 	}
 	return entries, nil
@@ -135,11 +135,11 @@ func (w *SdkManager) Sdk(ctx context.Context, name string) (*SdkFullInfo, error)
 
 				full.Installed = append(full.Installed, SdkInstalled{
 					SdkVolume: SdkVolume{
-						Name:      info.Name,
-						Version:   info.Version,
-						Revision:  s.Revision.String(),
-						BuildTime: info.BuildTime,
-						Size:      s.Size,
+						Name:     info.Name,
+						Version:  info.Version,
+						Revision: s.Revision.String(),
+						BuiltAt:  info.BuiltAt,
+						Size:     s.Size,
 					},
 					Workshop:    winfo.Name,
 					ProjectPath: winfo.Project.Path,

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -127,7 +127,7 @@ func (a *artifactFinder) launchOrRefreshManifests(ctx context.Context, names []s
 		action = "refresh"
 	}
 
-	sto := sdk.StoreService(a.state)
+	sto := sdk.GcsStoreService(a.state)
 
 	rev := revert.New()
 	defer rev.Fail()
@@ -233,7 +233,7 @@ func (w *WorkshopManager) workshopManifest(ctx context.Context, projectId, name 
 	return &Manifest{File: wp.File, Image: wp.Image, Sdks: installed}, nil
 }
 
-func (a *artifactFinder) findStoreSdks(sto sdk.Store, ctx context.Context, file *workshop.File) ([]sdk.Setup, error) {
+func (a *artifactFinder) findStoreSdks(sto sdk.GcsStore, ctx context.Context, file *workshop.File) ([]sdk.Setup, error) {
 	acts := make([]sdk.SdkAction, 0, len(file.Sdks))
 	for _, sd := range file.Sdks {
 		if sd.Source != sdk.StoreSource {

--- a/internal/overlord/workshopstate/manifest_test.go
+++ b/internal/overlord/workshopstate/manifest_test.go
@@ -68,9 +68,9 @@ func (s *manifestSuite) SetUpTest(c *check.C) {
 	s.project = *project
 	s.ctx = context.WithValue(ctx, workshop.ContextProjectId, s.project.ProjectId)
 
-	store := sdk.NewFakeStore()
+	store := sdk.NewFakeGcsStore()
 	store.SetActionCallback(s.storeAction)
-	sdk.ReplaceStore(s.state, store)
+	sdk.ReplaceGcsStore(s.state, store)
 }
 
 func (s *manifestSuite) TearDownTest(c *check.C) {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/metautil"
+	"github.com/canonical/workshop/internal/timeutil"
 )
 
 type Meta struct {
@@ -106,16 +107,16 @@ func SetupId(setup Setup) Id {
 }
 
 type sdkYaml struct {
-	Name        string         `yaml:"name"`
-	Base        string         `yaml:"base"`
-	Arch        string         `yaml:"architecture"`
-	Version     string         `yaml:"version,omitempty"`
-	Summary     string         `yaml:"summary"`
-	Description string         `yaml:"description"`
-	Type        string         `yaml:"type"`
-	BuiltAt     *time.Time     `yaml:"sdkcraft-started-at,omitempty"`
-	Plugs       map[string]any `yaml:"plugs,omitempty"`
-	Slots       map[string]any `yaml:"slots,omitempty"`
+	Name        string            `yaml:"name"`
+	Base        string            `yaml:"base"`
+	Arch        string            `yaml:"architecture"`
+	Version     string            `yaml:"version,omitempty"`
+	Summary     string            `yaml:"summary"`
+	Description string            `yaml:"description"`
+	Type        string            `yaml:"type"`
+	BuiltAt     *timeutil.TimeUTC `yaml:"sdkcraft-started-at,omitempty"`
+	Plugs       map[string]any    `yaml:"plugs,omitempty"`
+	Slots       map[string]any    `yaml:"slots,omitempty"`
 }
 
 type Type string
@@ -269,7 +270,7 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 		Arch:          sdkYaml.Arch,
 		Version:       sdkYaml.Version,
 		Type:          Type(sdkYaml.Type),
-		BuiltAt:       sdkYaml.BuiltAt,
+		BuiltAt:       (*time.Time)(sdkYaml.BuiltAt),
 		Summary:       sdkYaml.Summary,
 		Description:   sdkYaml.Description,
 		Plugs:         make(map[string]*PlugInfo),

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -113,7 +113,7 @@ type sdkYaml struct {
 	Summary     string         `yaml:"summary"`
 	Description string         `yaml:"description"`
 	Type        string         `yaml:"type"`
-	BuildTime   *time.Time     `yaml:"sdkcraft-started-at,omitempty"`
+	BuiltAt     *time.Time     `yaml:"sdkcraft-started-at,omitempty"`
 	Plugs       map[string]any `yaml:"plugs,omitempty"`
 	Slots       map[string]any `yaml:"slots,omitempty"`
 }
@@ -150,7 +150,7 @@ type Info struct {
 	Revision    Revision
 	Channel     string
 	Source      Source
-	BuildTime   *time.Time
+	BuiltAt     *time.Time
 	Summary     string
 	Description string
 
@@ -269,7 +269,7 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 		Arch:          sdkYaml.Arch,
 		Version:       sdkYaml.Version,
 		Type:          Type(sdkYaml.Type),
-		BuildTime:     sdkYaml.BuildTime,
+		BuiltAt:       sdkYaml.BuiltAt,
 		Summary:       sdkYaml.Summary,
 		Description:   sdkYaml.Description,
 		Plugs:         make(map[string]*PlugInfo),

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -28,40 +28,40 @@ type SdkAction struct {
 	Channel   string
 }
 
-type cachedStoreKey struct{}
+type cachedGcsStoreKey struct{}
 
-// ReplaceStore replaces the store used by the manager.
-func ReplaceStore(state *state.State, store Store) {
+// ReplaceGcsStore replaces the GCS store used by the manager.
+func ReplaceGcsStore(state *state.State, store GcsStore) {
 	state.Lock()
-	state.Cache(cachedStoreKey{}, store)
+	state.Cache(cachedGcsStoreKey{}, store)
 	state.Unlock()
 }
 
-func cachedStore(st *state.State) Store {
-	sdkStore := st.Cached(cachedStoreKey{})
+func cachedGcsStore(st *state.State) GcsStore {
+	sdkStore := st.Cached(cachedGcsStoreKey{})
 	if sdkStore == nil {
 		return nil
 	}
-	return sdkStore.(Store)
+	return sdkStore.(GcsStore)
 }
 
-// Store returns the store service provided by the optional device context or
-// the one used by the snapstate package if the former has no
+// GcsStoreService returns the store service provided by the optional device
+// context or the one used by the snapstate package if the former has no
 // override.
-func StoreService(st *state.State) Store {
-	if cachedStore := cachedStore(st); cachedStore != nil {
-		return cachedStore
+func GcsStoreService(st *state.State) GcsStore {
+	if store := cachedGcsStore(st); store != nil {
+		return store
 	}
 	panic("internal error: needing the store before managers have initialized it")
 }
 
-type Store interface {
+type GcsStore interface {
 	SdkAction(ctx context.Context, actions []SdkAction) ([]Meta, error)
 	DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error)
 }
 
-func NewFakeStore() *FakeStore {
-	return &FakeStore{
+func NewFakeGcsStore() *FakeGcsStore {
+	return &FakeGcsStore{
 		ActionCalls: make([]TestActionCall, 0),
 	}
 }
@@ -74,7 +74,7 @@ type TestDownloadCall struct {
 	Setup Setup
 }
 
-type FakeStore struct {
+type FakeGcsStore struct {
 	ActionCalls []TestActionCall
 
 	downloadLock  sync.Mutex
@@ -84,7 +84,7 @@ type FakeStore struct {
 	DownloadCallback func(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error)
 }
 
-func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, actions []SdkAction) ([]Meta, error)) func() {
+func (f *FakeGcsStore) SetActionCallback(fa func(ctx context.Context, actions []SdkAction) ([]Meta, error)) func() {
 	old := f.ActionCallback
 	f.ActionCallback = fa
 	return func() {
@@ -92,7 +92,7 @@ func (f *FakeStore) SetActionCallback(fa func(ctx context.Context, actions []Sdk
 	}
 }
 
-func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error)) func() {
+func (f *FakeGcsStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error)) func() {
 	old := f.DownloadCallback
 	f.DownloadCallback = fa
 	return func() {
@@ -100,7 +100,7 @@ func (f *FakeStore) SetDownloadCallback(fa func(ctx context.Context, setup Setup
 	}
 }
 
-func (f *FakeStore) SdkAction(ctx context.Context, actions []SdkAction) ([]Meta, error) {
+func (f *FakeGcsStore) SdkAction(ctx context.Context, actions []SdkAction) ([]Meta, error) {
 	f.ActionCalls = append(f.ActionCalls, TestActionCall{
 		Actions: actions,
 	})
@@ -110,7 +110,7 @@ func (f *FakeStore) SdkAction(ctx context.Context, actions []SdkAction) ([]Meta,
 	return nil, nil
 }
 
-func (f *FakeStore) DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error) {
+func (f *FakeGcsStore) DownloadSdk(ctx context.Context, setup Setup, report *progress.Reporter) (*Meta, error) {
 	f.downloadLock.Lock()
 	defer f.downloadLock.Unlock()
 	f.DownloadCalls = append(f.DownloadCalls, TestDownloadCall{

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/canonical/workshop/internal/arch"
 )
@@ -30,10 +29,6 @@ func Validate(sdk *Info) error {
 	if !slices.Contains([]string{"", "all"}, sdk.Arch) && !slices.Contains(arch.AllowedArchitectures, sdk.Arch) {
 		arches := strings.Join(arch.AllowedArchitectures, ", ")
 		return fmt.Errorf("invalid SDK architecture %q; supported architectures: %s", sdk.Arch, arches)
-	}
-
-	if sdk.BuiltAt != nil && sdk.BuiltAt.Location() != time.UTC {
-		return fmt.Errorf("invalid SDK build time %q: must be UTC", sdk.BuiltAt.Format(time.RFC3339))
 	}
 
 	for plugName, plug := range sdk.Plugs {

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -32,8 +32,8 @@ func Validate(sdk *Info) error {
 		return fmt.Errorf("invalid SDK architecture %q; supported architectures: %s", sdk.Arch, arches)
 	}
 
-	if sdk.BuildTime != nil && sdk.BuildTime.Location() != time.UTC {
-		return fmt.Errorf("invalid SDK build time %q: must be UTC", sdk.BuildTime.Format(time.RFC3339))
+	if sdk.BuiltAt != nil && sdk.BuiltAt.Location() != time.UTC {
+		return fmt.Errorf("invalid SDK build time %q: must be UTC", sdk.BuiltAt.Format(time.RFC3339))
 	}
 
 	for plugName, plug := range sdk.Plugs {

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -117,18 +117,3 @@ architecture: '8086'
 	err = sdk.Validate(info)
 	c.Check(err, check.ErrorMatches, `invalid SDK architecture "8086"; supported architectures: amd64, arm64, armhf, i386, powerpc, ppc64, ppc64el, riscv64, s390x`)
 }
-
-func (s *ValidateSuite) TestSdkBuiltAtNotUTC(c *check.C) {
-	info, err := sdk.ReadSdkInfo([]byte(`name: foo
-base: ubuntu@24.04
-sdkcraft-started-at: '2025-01-09T15:26:13.702403+13:00'
-`), s.projectId, "ws")
-	c.Assert(err, check.IsNil)
-
-	err = sdk.Validate(info)
-	c.Check(err, check.ErrorMatches, `invalid SDK build time "2025-01-09T15:26:13\+13:00": must be UTC`)
-}
-
-func (s *ValidateSuite) TestAcceptableSdkBases(c *check.C) {
-	c.Assert(sdk.AllowedBases, check.DeepEquals, []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"})
-}

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -118,7 +118,7 @@ architecture: '8086'
 	c.Check(err, check.ErrorMatches, `invalid SDK architecture "8086"; supported architectures: amd64, arm64, armhf, i386, powerpc, ppc64, ppc64el, riscv64, s390x`)
 }
 
-func (s *ValidateSuite) TestSdkBuildTimeNotUTC(c *check.C) {
+func (s *ValidateSuite) TestSdkBuiltAtNotUTC(c *check.C) {
 	info, err := sdk.ReadSdkInfo([]byte(`name: foo
 base: ubuntu@24.04
 sdkcraft-started-at: '2025-01-09T15:26:13.702403+13:00'

--- a/internal/timeutil/utc.go
+++ b/internal/timeutil/utc.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timeutil
+
+import (
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TimeUTC is like time.Time but converts to UTC when (un)marshalled.
+type TimeUTC time.Time
+
+func (t TimeUTC) MarshalText() ([]byte, error) {
+	return time.Time(t).UTC().MarshalText()
+}
+
+func (t *TimeUTC) UnmarshalText(data []byte) error {
+	var temp time.Time
+	if err := temp.UnmarshalText(data); err != nil {
+		return err
+	}
+	*t = TimeUTC(temp.UTC())
+	return nil
+}
+
+func (t TimeUTC) MarshalYAML() (any, error) {
+	return time.Time(t).UTC(), nil
+}
+
+func (t *TimeUTC) UnmarshalYAML(value *yaml.Node) error {
+	var temp time.Time
+	if err := value.Decode(&temp); err != nil {
+		return err
+	}
+	*t = TimeUTC(temp.UTC())
+	return nil
+}

--- a/internal/timeutil/utc_test.go
+++ b/internal/timeutil/utc_test.go
@@ -1,0 +1,127 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package timeutil_test
+
+import (
+	"encoding/json"
+	"time"
+
+	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/workshop/internal/timeutil"
+)
+
+type utcSuite struct{}
+
+var _ = check.Suite(&utcSuite{})
+
+func (utcSuite) TestMarshalText(c *check.C) {
+	t0 := "2025-04-03T02:01:00.123456Z"
+
+	t1, err := timeutil.TimeUTC(time.Date(2025, 4, 3, 2, 1, 0, 123456000, time.UTC)).MarshalText()
+	c.Assert(err, check.IsNil)
+	c.Check(string(t1), check.Equals, t0)
+
+	t2, err := timeutil.TimeUTC(time.Date(2025, 4, 3, 3, 1, 0, 123456000, time.FixedZone("test", 3600))).MarshalText()
+	c.Assert(err, check.IsNil)
+	c.Check(string(t2), check.Equals, t0)
+}
+
+func (utcSuite) TestUnmarshalText(c *check.C) {
+	t0 := timeutil.TimeUTC(time.Date(2025, 4, 3, 2, 1, 0, 123456000, time.UTC))
+
+	var t1 timeutil.TimeUTC
+	err := t1.UnmarshalText([]byte("2025-04-03T02:01:00.123456Z"))
+	c.Assert(err, check.IsNil)
+	c.Check(t1, check.Equals, t0)
+
+	var t2 timeutil.TimeUTC
+	err = t2.UnmarshalText([]byte("2025-04-03T02:01:00.123456+00:00"))
+	c.Assert(err, check.IsNil)
+	c.Check(t2, check.Equals, t0)
+
+	var t3 timeutil.TimeUTC
+	err = t3.UnmarshalText([]byte("2025-04-03T03:01:00.123456+01:00"))
+	c.Assert(err, check.IsNil)
+	c.Check(t3, check.Equals, t0)
+}
+
+func (utcSuite) TestMarshalJSON(c *check.C) {
+	t0 := `"2025-04-03T02:01:00.123456Z"`
+
+	t1, err := json.Marshal(timeutil.TimeUTC(time.Date(2025, 4, 3, 2, 1, 0, 123456000, time.UTC)))
+	c.Assert(err, check.IsNil)
+	c.Check(string(t1), check.Equals, t0)
+
+	t2, err := json.Marshal(timeutil.TimeUTC(time.Date(2025, 4, 3, 3, 1, 0, 123456000, time.FixedZone("test", 3600))))
+	c.Assert(err, check.IsNil)
+	c.Check(string(t2), check.Equals, t0)
+}
+
+func (utcSuite) TestUnmarshalJSON(c *check.C) {
+	t0 := timeutil.TimeUTC(time.Date(2025, 4, 3, 2, 1, 0, 123456000, time.UTC))
+
+	var t1 timeutil.TimeUTC
+	err := json.Unmarshal([]byte(`"2025-04-03T02:01:00.123456Z"`), &t1)
+	c.Assert(err, check.IsNil)
+	c.Check(t1, check.Equals, t0)
+
+	var t2 timeutil.TimeUTC
+	err = json.Unmarshal([]byte(`"2025-04-03T02:01:00.123456+00:00"`), &t2)
+	c.Assert(err, check.IsNil)
+	c.Check(t2, check.Equals, t0)
+
+	var t3 timeutil.TimeUTC
+	err = json.Unmarshal([]byte(`"2025-04-03T03:01:00.123456+01:00"`), &t3)
+	c.Assert(err, check.IsNil)
+	c.Check(t3, check.Equals, t0)
+}
+
+func (utcSuite) TestMarshalYAML(c *check.C) {
+	t0 := "2025-04-03T02:01:00.123456Z\n"
+
+	t1, err := yaml.Marshal(timeutil.TimeUTC(time.Date(2025, 4, 3, 2, 1, 0, 123456000, time.UTC)))
+	c.Assert(err, check.IsNil)
+	c.Check(string(t1), check.Equals, t0)
+
+	t2, err := yaml.Marshal(timeutil.TimeUTC(time.Date(2025, 4, 3, 3, 1, 0, 123456000, time.FixedZone("test", 3600))))
+	c.Assert(err, check.IsNil)
+	c.Check(string(t2), check.Equals, t0)
+}
+
+func (utcSuite) TestUnmarshalYAML(c *check.C) {
+	t0 := timeutil.TimeUTC(time.Date(2025, 4, 3, 2, 1, 0, 123456000, time.UTC))
+
+	var t1 timeutil.TimeUTC
+	err := yaml.Unmarshal([]byte("2025-04-03T02:01:00.123456Z"), &t1)
+	c.Assert(err, check.IsNil)
+	c.Check(t1, check.Equals, t0)
+
+	var t2 timeutil.TimeUTC
+	err = yaml.Unmarshal([]byte("2025-04-03T02:01:00.123456+00:00"), &t2)
+	c.Assert(err, check.IsNil)
+	c.Check(t2, check.Equals, t0)
+
+	var t3 timeutil.TimeUTC
+	err = yaml.Unmarshal([]byte("2025-04-03T03:01:00.123456+01:00"), &t3)
+	c.Assert(err, check.IsNil)
+	c.Check(t3, check.Equals, t0)
+}

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -257,8 +257,8 @@ func cachedBackend(st *state.State) Backend {
 // the one used by the snapstate package if the former has no
 // override.
 func WorkshopBackend(st *state.State) Backend {
-	if cachedStore := cachedBackend(st); cachedStore != nil {
-		return cachedStore
+	if backend := cachedBackend(st); backend != nil {
+		return backend
 	}
 	panic("internal error: needing the store before managers have initialized it")
 }

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -648,7 +648,7 @@ func (b *FakeWorkshopBackend) InstallSdk(ctx context.Context, name string, setup
 	wp.Sdks[setup.Name] = workshop.SdkInstallation{
 		Setup:        setup,
 		InstallOrder: len(wp.Sdks) + 1,
-		InstalledAt:  workshop.InstallTimeNow(),
+		InstalledAt:  workshop.InstallTimeNow().UTC(),
 	}
 
 	usr, env, err := osutil.UserAndEnv(user)

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -648,7 +648,7 @@ func (b *FakeWorkshopBackend) InstallSdk(ctx context.Context, name string, setup
 	wp.Sdks[setup.Name] = workshop.SdkInstallation{
 		Setup:        setup,
 		InstallOrder: len(wp.Sdks) + 1,
-		InstallTime:  workshop.InstallTimeNow(),
+		InstalledAt:  workshop.InstallTimeNow(),
 	}
 
 	usr, env, err := osutil.UserAndEnv(user)

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -417,7 +417,7 @@ func (s *Backend) InstallSdk(ctx context.Context, name string, setup sdk.Setup) 
 	installation := workshop.SdkInstallation{
 		Setup:        setup,
 		InstallOrder: maxInstallOrder + 1,
-		InstallTime:  workshop.InstallTimeNow(),
+		InstalledAt:  workshop.InstallTimeNow(),
 	}
 	device, err := sdkToLxdDisk(installation, mount)
 	if err != nil {
@@ -456,11 +456,11 @@ func sdkToLxdDisk(sk workshop.SdkInstallation, mount workshop.Mount) (map[string
 	}
 	device["user.sdk.source"] = string(source)
 
-	installTime, err := sk.InstallTime.MarshalText()
+	installedAt, err := sk.InstalledAt.MarshalText()
 	if err != nil {
 		return nil, err
 	}
-	device["user.sdk.install-time"] = string(installTime)
+	device["user.sdk.installed-at"] = string(installedAt)
 
 	return device, nil
 }
@@ -489,7 +489,12 @@ func maybeSdkInstallation(key string, device map[string]string) (*workshop.SdkIn
 	if err := s.Revision.UnmarshalText([]byte(device["user.sdk.revision"])); err != nil {
 		return nil, err
 	}
-	if err := s.InstallTime.UnmarshalText([]byte(device["user.sdk.install-time"])); err != nil {
+	installedAt := device["user.sdk.installed-at"]
+	if installedAt == "" {
+		// TODO: remove this after a short transition period.
+		installedAt = device["user.sdk.install-time"]
+	}
+	if err := s.InstalledAt.UnmarshalText([]byte(installedAt)); err != nil {
 		return nil, err
 	}
 

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -19,6 +19,7 @@ import (
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/timeutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -417,7 +418,7 @@ func (s *Backend) InstallSdk(ctx context.Context, name string, setup sdk.Setup) 
 	installation := workshop.SdkInstallation{
 		Setup:        setup,
 		InstallOrder: maxInstallOrder + 1,
-		InstalledAt:  workshop.InstallTimeNow(),
+		InstalledAt:  workshop.InstallTimeNow().UTC(),
 	}
 	device, err := sdkToLxdDisk(installation, mount)
 	if err != nil {
@@ -456,7 +457,7 @@ func sdkToLxdDisk(sk workshop.SdkInstallation, mount workshop.Mount) (map[string
 	}
 	device["user.sdk.source"] = string(source)
 
-	installedAt, err := sk.InstalledAt.MarshalText()
+	installedAt, err := timeutil.TimeUTC(sk.InstalledAt).MarshalText()
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +495,8 @@ func maybeSdkInstallation(key string, device map[string]string) (*workshop.SdkIn
 		// TODO: remove this after a short transition period.
 		installedAt = device["user.sdk.install-time"]
 	}
-	if err := s.InstalledAt.UnmarshalText([]byte(installedAt)); err != nil {
+	installedUTC := (*timeutil.TimeUTC)(&s.InstalledAt)
+	if err := installedUTC.UnmarshalText([]byte(installedAt)); err != nil {
 		return nil, err
 	}
 

--- a/internal/workshop/lxd/tests/integration/snapshot_test.go
+++ b/internal/workshop/lxd/tests/integration/snapshot_test.go
@@ -250,10 +250,10 @@ func (s *snapshotSuite) workshopFormat(c *check.C, file *workshop.File, snapshot
 
 	for _, sk := range snapshot.Sdks {
 		device := inst.Devices[workshop.SdkDeviceName(sk.Name)]
-		var installTime time.Time
-		c.Assert(installTime.UnmarshalText([]byte(device["user.sdk.install-time"])), check.IsNil)
-		c.Check(installTime.IsZero(), check.Equals, false)
-		delete(device, "user.sdk.install-time")
+		var installedAt time.Time
+		c.Assert(installedAt.UnmarshalText([]byte(device["user.sdk.installed-at"])), check.IsNil)
+		c.Check(installedAt.IsZero(), check.Equals, false)
+		delete(device, "user.sdk.installed-at")
 
 		if _, ok := device["pool"]; !ok {
 			delete(device, "source")

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -367,7 +367,7 @@ base: ubuntu@20.04
 version: '0.1.2'
 summary: summary
 description: SDK
-sdkcraft-started-at: '2020-04-22T19:12:07.903032Z'
+sdkcraft-started-at: '2020-04-22T19:12:07.903032+00:00'
 `
 
 func (f *wsOps) TestLxdBackendImportSdkOK(c *check.C) {

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -50,7 +50,7 @@ type SdkInstallation struct {
 	sdk.Setup
 	// 1-based index of SDK installation (0 is reserved for the base).
 	InstallOrder int       `json:"install-order"`
-	InstallTime  time.Time `json:"install-time"`
+	InstalledAt  time.Time `json:"installed-at"`
 }
 
 func SdkDeviceName(sk string) string {

--- a/snap/local/commands/run_daemon
+++ b/snap/local/commands/run_daemon
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-SDK_STORE_URL=$(snapctl get store.url)
-export SDK_STORE_URL
+GCS_STORE_URL=$(snapctl get gcs.url)
+export GCS_STORE_URL
 
 WORKSHOP_IMAGE_SERVER=$(snapctl get workshop.image.server.url)
 export WORKSHOP_IMAGE_SERVER

--- a/tests/docs-how-to/connect-vscode/task.yaml
+++ b/tests/docs-how-to/connect-vscode/task.yaml
@@ -5,7 +5,7 @@ execute: |
   # Switch to real store for vscode-remote SDK
 
   stop_sdk_store
-  snap set workshop store.url=""
+  snap set workshop gcs.url=""
   snap restart workshop
   sleep 5  # Wait for daemon to restart
 
@@ -28,7 +28,7 @@ execute: |
 
   # Restore fake store
 
-  snap set workshop store.url=http://localhost:8080/storage/v1/
+  snap set workshop gcs.url=http://localhost:8080/storage/v1/
   snap restart workshop
   sleep 5
   start_sdk_store

--- a/tests/integration/gcs-store/task.yaml
+++ b/tests/integration/gcs-store/task.yaml
@@ -11,7 +11,7 @@ execute: |
   rm -rf cover
   mkdir cover
 
-  go test -cover "$SPREAD_PATH"/internal/fakestore/ -timeout=30m -tags=integration -check.v -check.f storeIntegration -coverpkg=github.com/canonical/workshop/internal/fakestore -args -test.gocoverdir="$PWD"/cover
+  go test -cover "$SPREAD_PATH"/internal/gcsstore/ -timeout=30m -tags=integration -check.v -check.f storeIntegration -coverpkg=github.com/canonical/workshop/internal/gcsstore -args -test.gocoverdir="$PWD"/cover
 
 artifacts:
   - cover

--- a/tests/lib/sdk/test-sdk-basic/latest/edge/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-basic/latest/edge/meta/sdk.yaml
@@ -7,4 +7,4 @@ summary: test-sdk-basic SDK
 description: |
   test-sdk-basic SDK
 
-sdkcraft-started-at: "2025-07-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-07-03T02:01:00.123456+00:00"

--- a/tests/lib/sdk/test-sdk-basic/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-basic/latest/stable/meta/sdk.yaml
@@ -7,4 +7,4 @@ summary: test-sdk-basic SDK
 description: |
   test-sdk-basic SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"

--- a/tests/lib/sdk/test-sdk-camera/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-camera/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-camera SDK
 description: |
   test-sdk-camera SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"
 plugs:
   camera:
     interface: camera

--- a/tests/lib/sdk/test-sdk-desktop/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-desktop/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-desktop SDK
 description: |
   test-sdk-desktop SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'
 plugs:
   desktop:
     interface: desktop

--- a/tests/lib/sdk/test-sdk-environment/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-environment/latest/stable/meta/sdk.yaml
@@ -7,4 +7,4 @@ summary: test-sdk-environment SDK
 description: |
   test-sdk-environment SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"

--- a/tests/lib/sdk/test-sdk-go/foxy/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-go/foxy/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-go SDK
 description: |
   test-sdk-go SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"
 plugs:
   mod-cache:
     interface: mount

--- a/tests/lib/sdk/test-sdk-go/jammy/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-go/jammy/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-go SDK
 description: |
   test-sdk-go SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'
 plugs:
   mod-cache:
     interface: mount

--- a/tests/lib/sdk/test-sdk-go/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-go/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-go SDK
 description: |
   test-sdk-go SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'
 plugs:
   mod-cache:
     interface: mount

--- a/tests/lib/sdk/test-sdk-go/noble/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-go/noble/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-go SDK
 description: |
   test-sdk-go SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"
 plugs:
   mod-cache:
     interface: mount

--- a/tests/lib/sdk/test-sdk-gpu/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-gpu/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-gpu SDK
 description: |
   test-sdk-gpu SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"
 plugs:
   gpu:
     interface: gpu

--- a/tests/lib/sdk/test-sdk-health-error/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-error/latest/stable/meta/sdk.yaml
@@ -6,4 +6,4 @@ summary: test-sdk-health-error SDK
 description: |
   test-sdk-health-error SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'

--- a/tests/lib/sdk/test-sdk-health-ok/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-ok/latest/stable/meta/sdk.yaml
@@ -6,4 +6,4 @@ summary: test-sdk-health-ok SDK
 description: |
   test-sdk-health-ok SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'

--- a/tests/lib/sdk/test-sdk-health-waiting/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-health-waiting/latest/stable/meta/sdk.yaml
@@ -6,4 +6,4 @@ summary: test-sdk-health-waiting SDK
 description: |
   test-sdk-health-waiting SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'

--- a/tests/lib/sdk/test-sdk-info/latest/edge/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-info/latest/edge/meta/sdk.yaml
@@ -7,4 +7,4 @@ summary: test-sdk-info summary
 description: |
   test-sdk-info description
 
-sdkcraft-started-at: "2025-07-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-07-03T02:01:00.123456+00:00"

--- a/tests/lib/sdk/test-sdk-info/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-info/latest/stable/meta/sdk.yaml
@@ -7,4 +7,4 @@ summary: test-sdk-info summary
 description: |
   test-sdk-info description
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"

--- a/tests/lib/sdk/test-sdk-mount-broken/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-mount-broken/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-mount-broken SDK
 description: |
   test-sdk-mount-broken SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"
 slots:
   one:
     interface: mount

--- a/tests/lib/sdk/test-sdk-mount/24.04/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-mount/24.04/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-mount SDK
 description: |
   test-sdk-mount SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"
 plugs:
   one:
     interface: mount

--- a/tests/lib/sdk/test-sdk-mount/latest/edge/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-mount/latest/edge/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-mount SDK
 description: |
   test-sdk-mount SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'
 plugs:
   one:
     interface: mount

--- a/tests/lib/sdk/test-sdk-mount/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-mount/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-mount SDK
 description: |
   test-sdk-mount SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'
 plugs:
   one:
     interface: mount

--- a/tests/lib/sdk/test-sdk-multiple-plugs/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-multiple-plugs/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-multiple-plugs SDK
 description: |
   test-sdk-multiple-plugs SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"
 plugs:
   one:
     interface: mount

--- a/tests/lib/sdk/test-sdk-setup-fail/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-setup-fail/latest/stable/meta/sdk.yaml
@@ -6,4 +6,4 @@ summary: test-sdk-setup-fail SDK
 description: |
   test-sdk-setup-fail SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"

--- a/tests/lib/sdk/test-sdk-ssh-agent/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-ssh-agent/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-ssh-agent SDK
 description: |
   test-sdk-ssh-agent SDK
 
-sdkcraft-started-at: "2025-04-03T02:01:00.123456Z"
+sdkcraft-started-at: "2025-04-03T02:01:00.123456+00:00"
 plugs:
   ssh-agent:
     interface: ssh-agent

--- a/tests/lib/sdk/test-sdk-tunnel/latest/stable/meta/sdk.yaml
+++ b/tests/lib/sdk/test-sdk-tunnel/latest/stable/meta/sdk.yaml
@@ -6,7 +6,7 @@ summary: test-sdk-tunnel SDK
 description: |
   test-sdk-tunnel SDK
 
-sdkcraft-started-at: '2025-04-03T02:01:00.123456Z'
+sdkcraft-started-at: '2025-04-03T02:01:00.123456+00:00'
 plugs:
   alias:
     interface: tunnel

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -88,7 +88,7 @@ function setup_workshop() {
     snap install --dangerous --classic /workshop/tests/*.snap
 
     if [ "$use_real_store" != "true" ]; then
-        snap set workshop store.url=http://localhost:8080/storage/v1/
+        snap set workshop gcs.url=http://localhost:8080/storage/v1/
         start_sdk_store
     fi
 


### PR DESCRIPTION
# Description

- Rename the old store to `gcsstore`, `GcsStore`, etc. The real store will soon be `sdkstore` or just `Store`.
- Rename timestamps from `*-time` to `*-at`. This is for consistency with SDKcraft, the Store API and `snapd`. I think the only thing this breaks is `install-time` in running workshops, I added some back compat logic for that case.
- Ensures the timestamps we get from SDKcraft are converted to UTC even if they aren't originally. The Store will have similar timestamps, which get a similar treatment. This allows us to remove a workaround from SDKcraft.
- Ensures the install and check-health time for SDKs are in UTC as well. These are generated by Workshop but were previously local. The warning timestamp is still local, but I left it as-is because it comes from `snapd`.
- Replaces `check.Not(check.IsNil)` with `check.NotNil`. Copilot liked the former a lot so hopefully this will teach it to use the shorter version.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
