### PR TITLE
Extend sdk info command to query SDK Store

### DIFF
--- a/client/sdks.go
+++ b/client/sdks.go
@@ -2,6 +2,27 @@ package client
 
 import "time"
 
+type StoreAccount struct {
+	ID          string `json:"id"`
+	Username    string `json:"username"`
+	DisplayName string `json:"display-name"`
+	Validation  string `json:"validation,omitempty"`
+}
+
+type SdkRevision struct {
+	Channel      string     `json:"channel"`
+	Track        string     `json:"track"`
+	Risk         string     `json:"risk"`
+	Revision     string     `json:"revision"`
+	BuiltAt      *time.Time `json:"built-at,omitempty"`
+	UploadedAt   *time.Time `json:"uploaded-at,omitempty"`
+	ReleasedAt   time.Time  `json:"released-at"`
+	Version      string     `json:"version,omitempty"`
+	Base         string     `json:"base,omitempty"`
+	Arch         string     `json:"arch,omitempty"`
+	DownloadSize uint64     `json:"download-size,omitzero"`
+}
+
 // SdkVolume represents SDK volume summary returned by the daemon.
 type SdkVolume struct {
 	Name     string     `json:"name"`
@@ -15,13 +36,20 @@ type SdkInstalled struct {
 	ProjectPath string `json:"project-path"`
 	Workshop    string `json:"workshop"`
 	Channel     string `json:"channel,omitempty"`
+	Base        string `json:"base,omitempty"`
+	Arch        string `json:"architecture,omitempty"`
 	SdkVolume
 }
 
 type SdkFullInfo struct {
 	Name        string         `json:"name"`
+	PackageID   string         `json:"package-id,omitempty"`
+	Title       string         `json:"title,omitempty"`
 	Summary     string         `json:"summary,omitempty"`
 	Description string         `json:"description,omitempty"`
+	License     string         `json:"license,omitempty"`
+	Publisher   *StoreAccount  `json:"publisher,omitempty"`
+	Channels    []*SdkRevision `json:"channels,omitempty"`
 	Installed   []SdkInstalled `json:"installed,omitempty"`
 }
 

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -40,6 +40,8 @@ Notes:
 	return cmd
 }
 
+var channelRisks = []string{"stable", "candidate", "beta", "edge"}
+
 func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	cli, err := c.root.client()
 	if err != nil {
@@ -51,51 +53,178 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
+	tracks, revsByChannel := sortChannels(info.Channels)
+
 	slices.SortFunc(info.Installed, func(a, b client.SdkInstalled) int {
-		if a.Workshop != b.Workshop {
-			return cmp.Compare(a.Workshop, b.Workshop)
+		if a.ProjectPath != b.ProjectPath {
+			return cmp.Compare(a.ProjectPath, b.ProjectPath)
 		}
-		return cmp.Compare(a.ProjectPath, b.ProjectPath)
+		return cmp.Compare(a.Workshop, b.Workshop)
 	})
 
 	esc := c.GetEscapes()
-	escape := func(s string) []byte {
-		if s == "" || s == "-" {
-			s = esc.Dash
-		}
-		s = cmdutil.EscapeYAMLScalar(s)
-		e := []byte{tabwriter.Escape}
-		return fmt.Appendf(nil, "%s%s%s", e, s, e)
-	}
-
 	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
 	fmt.Fprintf(w, "name:\t%s\n", info.Name)
-	fmt.Fprintf(w, "summary:\t%s\n", escape(info.Summary))
+	if info.Publisher != nil {
+		fmt.Fprintf(w, "publisher:\t%s\n", formatPublisher(info.Publisher, esc))
+	}
+	if info.License != "" {
+		fmt.Fprintf(w, "license:\t%s\n", info.License)
+	}
 
 	if info.Description != "" {
-		fmt.Fprintln(w, "description: |")
-		description := strings.TrimSuffix(info.Description, "\n")
-		lines := strings.Split(description, "\n")
-		for _, line := range lines {
-			fmt.Fprintf(w, "  %s\n", line)
-		}
-	} else {
-		fmt.Fprintf(w, "description:\t%s", esc.Dash)
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, strings.TrimSuffix(info.Description, "\n"))
 	}
 
-	if len(info.Installed) > 0 {
-		fmt.Fprintln(w, "installed:")
+	maxRev := len("REV")
+	maxSize := len("SIZE")
+	for _, revs := range revsByChannel {
+		for _, rev := range revs {
+			maxRev = max(maxRev, len(rev.Revision))
+			maxSize = max(maxSize, len(units.GetByteSizeString(rev.DownloadSize, 2)))
+		}
 	}
+	tpl := "  %s\t%s\t%s\t%s\t%s\t%*s\t%*s\n"
+	if len(tracks) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "%s%s%s  (%s%s%s: %s)\n", esc.Bold, "CHANNELS", esc.End, esc.BrightYellow, "SDK Store preview", esc.End, "Workshop won't see these revisions yet")
+		fmt.Fprintf(w, tpl, "CHANNEL", "VERSION", "BUILD", "BASE", "ARCH", maxRev, "REV", maxSize, "SIZE")
+	}
+	for _, track := range tracks {
+		closedSign := "-"
+		for _, risk := range channelRisks {
+			channel := track + "/" + risk
+			revs := revsByChannel[channel]
+			if len(revs) == 0 {
+				fmt.Fprintf(w, tpl, channel, closedSign, "", "", "", 0, "", 0, "")
+				continue
+			}
+			closedSign = esc.UpArrow
+
+			var prev *client.SdkRevision
+			for _, rev := range revs {
+				channel, version, build, base := optionalColumns(prev, rev)
+				prev = rev
+
+				size := units.GetByteSizeString(rev.DownloadSize, 2)
+				fmt.Fprintf(w, tpl, channel, version, build, base, rev.Arch, maxRev, rev.Revision, maxSize, size)
+			}
+		}
+	}
+
+	maxRev = len("REV")
 	for _, it := range info.Installed {
-		project := cmdutil.ContractHome(it.ProjectPath)
+		maxRev = max(maxRev, len(it.Revision))
+	}
+	if len(info.Installed) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "%s%s%s\n", esc.Bold, "INSTALLED", esc.End)
+		fmt.Fprintf(w, "  PROJECT\tWORKSHOP\tCHANNEL\tVERSION\tBASE\tARCH\t%*s\n", maxRev, "REV")
+	}
+	var prev *client.SdkInstalled
+	for _, it := range info.Installed {
+		var project string
+		if prev == nil || prev.ProjectPath != it.ProjectPath {
+			project = cmdutil.ContractHome(it.ProjectPath)
+		}
+		prev = &it
+
 		channel := cmdutil.EmptyDash(it.Channel)
-		date := formatDate(it.BuiltAt)
-		fmt.Fprintf(w, "  %s:\t%s\t%s\t%s\t(%s)\t%s\n",
-			project, it.Workshop, channel, date, it.Revision, units.GetByteSizeString(int64(it.Size), 2))
+		base := it.Base
+		if base == "" {
+			base = "all"
+		}
+		fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%s\t%*s\n",
+			project, it.Workshop, channel, it.Version, base, it.Arch, maxRev, it.Revision)
 	}
 	w.Flush()
 
 	return nil
+}
+
+// sortChannels lists tracks (e.g. "latest") in whatever order the Store
+// decides, and groups revisions by channel (e.g. "latest/stable"). Within a
+// channel, revisions are sorted first by base OS (e.g. "ubuntu"), then by
+// descending base series (e.g. "24.04"), and finally by architecture. In the
+// unlikely event there's more than one revision with the same channel, base
+// and architecture, they are sorted by descending revision number.
+func sortChannels(channels []*client.SdkRevision) ([]string, map[string][]*client.SdkRevision) {
+	tracks := make([]string, 0, len(channels))
+	seen := make(map[string]bool, len(channels))
+	revsByChannel := make(map[string][]*client.SdkRevision, len(channels))
+
+	for _, rev := range channels {
+		if !seen[rev.Track] {
+			tracks = append(tracks, rev.Track)
+			seen[rev.Track] = true
+		}
+
+		revsByChannel[rev.Channel] = append(revsByChannel[rev.Channel], rev)
+	}
+
+	for _, revisions := range revsByChannel {
+		slices.SortFunc(revisions, func(a, b *client.SdkRevision) int {
+			os1, series1, _ := strings.Cut(a.Base, "@")
+			os2, series2, _ := strings.Cut(b.Base, "@")
+			if os1 != os2 {
+				return cmp.Compare(os1, os2)
+			}
+			if series1 != series2 {
+				// Newest first.
+				return cmp.Compare(series2, series1)
+			}
+			if a.Arch != b.Arch {
+				return cmp.Compare(a.Arch, b.Arch)
+			}
+			// Should be unreachable.
+			return cmp.Compare(b.Revision, a.Revision)
+		})
+	}
+
+	return tracks, revsByChannel
+}
+
+func formatPublisher(publisher *client.StoreAccount, esc *cmdutil.Escapes) string {
+	var badge string
+	switch publisher.Validation {
+	case "verified":
+		badge = esc.Green + esc.Tick + esc.End
+	case "starred":
+		badge = esc.BrightYellow + esc.Star + esc.End
+	}
+	// Following snap, we only show the username if it significantly
+	// differs from the display name.
+	niceUsername := strings.ReplaceAll(publisher.Username, "-", " ")
+	if strings.EqualFold(niceUsername, publisher.DisplayName) {
+		return publisher.DisplayName + badge
+	}
+	return fmt.Sprintf("%s (%s%s)", publisher.DisplayName, publisher.Username, badge)
+
+}
+
+func optionalColumns(prev, rev *client.SdkRevision) (string, string, string, string) {
+	var channel, version, build, base string
+	if prev == nil {
+		channel = rev.Channel
+	}
+	if prev == nil || prev.Version != rev.Version {
+		version = cmdutil.EmptyDash(rev.Version)
+		// Print everything after this, to avoid holes in the middle.
+		prev = nil
+	}
+	if prev == nil || formatDate(prev.BuiltAt) != formatDate(rev.BuiltAt) {
+		build = formatDate(rev.BuiltAt)
+		prev = nil
+	}
+	if prev == nil || prev.Base != rev.Base {
+		base = rev.Base
+		if base == "" {
+			base = "all"
+		}
+		prev = nil
+	}
+	return channel, version, build, base
 }
 
 func formatDate(t *time.Time) string {

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -13,11 +13,15 @@ import (
 
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/cmd/internal/cmdutil"
+	"github.com/canonical/workshop/internal/arch"
 )
 
 type CmdInfo struct {
 	cmdutil.ColorMixin
 	root *CmdRoot
+
+	Base string
+	Arch string
 }
 
 func (c *CmdInfo) Command() *cobra.Command {
@@ -25,7 +29,8 @@ func (c *CmdInfo) Command() *cobra.Command {
 		Use:   "info <SDK>",
 		Short: "Show SDK info",
 		Long: `
-This command prints the SDK's metadata
+Prints the SDK's metadata,
+shows the revisions currently available in the SDK Store,
 and lists workshops where the SDK is installed.
 
 Notes:
@@ -37,12 +42,22 @@ Notes:
 		Args: cobra.ExactArgs(1),
 		RunE: c.Run,
 	}
+
+	cmd.PersistentFlags().StringVar(&c.Base, "base", "",
+		`Show SDKs compatible with a specific base.`)
+	cmd.PersistentFlags().StringVar(&c.Arch, "arch", "",
+		`Show SDKs compatible with a different architecture (or "all").`)
+
 	return cmd
 }
 
 var channelRisks = []string{"stable", "candidate", "beta", "edge"}
 
 func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
+	if c.Arch == "" {
+		c.Arch = arch.DpkgArchitecture()
+	}
+
 	cli, err := c.root.client()
 	if err != nil {
 		return err
@@ -53,9 +68,10 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	tracks, revsByChannel := sortChannels(info.Channels)
+	tracks, revsByChannel := sortChannels(filterChannels(info.Channels, c.Base, c.Arch))
 
-	slices.SortFunc(info.Installed, func(a, b client.SdkInstalled) int {
+	installed := filterInstalled(info.Installed, c.Base, c.Arch)
+	slices.SortFunc(installed, func(a, b client.SdkInstalled) int {
 		if a.ProjectPath != b.ProjectPath {
 			return cmp.Compare(a.ProjectPath, b.ProjectPath)
 		}
@@ -85,7 +101,15 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 			maxSize = max(maxSize, len(units.GetByteSizeString(rev.DownloadSize, 2)))
 		}
 	}
-	tpl := "  %s\t%s\t%s\t%s\t%s\t%*s\t%*s\n"
+	baseTpl := "%s\t"
+	if c.Base != "" {
+		baseTpl = "%.0s"
+	}
+	archTpl := "%s\t"
+	if c.Arch != "all" {
+		archTpl = "%.0s"
+	}
+	tpl := "  %s\t%s\t%s\t" + baseTpl + archTpl + "%*s\t%*s\n"
 	if len(tracks) > 0 {
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "%s%s%s  (%s%s%s: %s)\n", esc.Bold, "CHANNELS", esc.End, esc.BrightYellow, "SDK Store preview", esc.End, "Workshop won't see these revisions yet")
@@ -114,16 +138,17 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	maxRev = len("REV")
-	for _, it := range info.Installed {
+	for _, it := range installed {
 		maxRev = max(maxRev, len(it.Revision))
 	}
-	if len(info.Installed) > 0 {
+	tpl = "  %s\t%s\t%s\t%s\t" + baseTpl + archTpl + "%*s\n"
+	if len(installed) > 0 {
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "%s%s%s\n", esc.Bold, "INSTALLED", esc.End)
-		fmt.Fprintf(w, "  PROJECT\tWORKSHOP\tCHANNEL\tVERSION\tBASE\tARCH\t%*s\n", maxRev, "REV")
+		fmt.Fprintf(w, tpl, "PROJECT", "WORKSHOP", "CHANNEL", "VERSION", "BASE", "ARCH", maxRev, "REV")
 	}
 	var prev *client.SdkInstalled
-	for _, it := range info.Installed {
+	for _, it := range installed {
 		var project string
 		if prev == nil || prev.ProjectPath != it.ProjectPath {
 			project = cmdutil.ContractHome(it.ProjectPath)
@@ -135,12 +160,19 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		if base == "" {
 			base = "all"
 		}
-		fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%s\t%*s\n",
-			project, it.Workshop, channel, it.Version, base, it.Arch, maxRev, it.Revision)
+		fmt.Fprintf(w, tpl, project, it.Workshop, channel, it.Version, base, it.Arch, maxRev, it.Revision)
 	}
 	w.Flush()
 
 	return nil
+}
+
+func filterChannels(channels []*client.SdkRevision, base, arch string) []*client.SdkRevision {
+	result := slices.Clone(channels)
+	return slices.DeleteFunc(result, func(rev *client.SdkRevision) bool {
+		return ((base != "" && rev.Base != "" && base != rev.Base) ||
+			(arch != "all" && rev.Arch != "all" && arch != rev.Arch))
+	})
 }
 
 // sortChannels lists tracks (e.g. "latest") in whatever order the Store
@@ -183,6 +215,14 @@ func sortChannels(channels []*client.SdkRevision) ([]string, map[string][]*clien
 	}
 
 	return tracks, revsByChannel
+}
+
+func filterInstalled(installed []client.SdkInstalled, base, arch string) []client.SdkInstalled {
+	result := slices.Clone(installed)
+	return slices.DeleteFunc(result, func(it client.SdkInstalled) bool {
+		return ((base != "" && it.Base != "" && base != it.Base) ||
+			(arch != "all" && it.Arch != "all" && arch != it.Arch))
+	})
 }
 
 func formatPublisher(publisher *client.StoreAccount, esc *cmdutil.Escapes) string {

--- a/cmd/sdk/info_test.go
+++ b/cmd/sdk/info_test.go
@@ -179,7 +179,7 @@ func (s *sdkSuite) TestInfo(c *check.C) {
 	ClientConfig.BaseURL = srv.URL
 
 	cmd := (&CmdRoot{}).Command()
-	cmd.SetArgs([]string{"info", "openvino"})
+	cmd.SetArgs([]string{"info", "openvino", "--arch=all"})
 	c.Assert(cmd.Execute(), check.IsNil)
 
 	maxProject := max(len("PROJECT"), len(nav), len(lerobot))
@@ -210,6 +210,121 @@ INSTALLED
 `, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, "")
 
 	c.Check(s.Stdout(), check.Equals, want)
+	s.ResetStdStreams()
+
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"info", "openvino", "--arch=amd64"})
+	c.Assert(cmd.Execute(), check.IsNil)
+
+	want = fmt.Sprintf(`name:       openvino
+publisher:  Intel**
+license:    Apache-2.0
+
+Longer description
+can be multiline.
+
+CHANNELS  (SDK Store preview: Workshop won't see these revisions yet)
+  CHANNEL           VERSION      BUILD       BASE          REV      SIZE
+  latest/stable     2.1-084c8c8  2024-11-25  ubuntu@22.04   88  123.46kB
+                                             ubuntu@20.04   85      123B
+  latest/candidate  ^                                           
+  latest/beta       ^                                           
+  latest/edge       2.0          2024-11-20  all            91   12.35MB
+
+INSTALLED
+  %-*s  WORKSHOP  CHANNEL        VERSION      BASE          REV
+  %-*s  dev       latest/edge    2.0          all            82
+  %-*s  ci        latest/stable  2.1-084c8c8  ubuntu@20.04   85
+  %-*s  dev       latest/stable  2.1-084c8c8  ubuntu@20.04   85
+`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, "")
+
+	c.Check(s.Stdout(), check.Equals, want)
+	s.ResetStdStreams()
+
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"info", "openvino", "--arch=riscv64"})
+	c.Assert(cmd.Execute(), check.IsNil)
+
+	maxProject = max(len("PROJECT"), len(lerobot))
+	want = fmt.Sprintf(`name:       openvino
+publisher:  Intel**
+license:    Apache-2.0
+
+Longer description
+can be multiline.
+
+CHANNELS  (SDK Store preview: Workshop won't see these revisions yet)
+  CHANNEL           VERSION      BUILD       BASE          REV     SIZE
+  latest/stable     2.2-c8c8084  2024-11-27  ubuntu@22.04   90  12.35MB
+                    2.1-084c8c8  2024-11-25  ubuntu@20.04   87  12.35kB
+  latest/candidate  ^                                           
+  latest/beta       ^                                           
+  latest/edge       2.0          2024-11-20  all            91  12.35MB
+
+INSTALLED
+  %-*s  WORKSHOP  CHANNEL      VERSION  BASE  REV
+  %-*s  dev       latest/edge  2.0      all    82
+`, maxProject, "PROJECT", maxProject, lerobot)
+
+	c.Check(s.Stdout(), check.Equals, want)
+	s.ResetStdStreams()
+
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"info", "openvino", "--arch=all", "--base=ubuntu@22.04"})
+	c.Assert(cmd.Execute(), check.IsNil)
+
+	want = fmt.Sprintf(`name:       openvino
+publisher:  Intel**
+license:    Apache-2.0
+
+Longer description
+can be multiline.
+
+CHANNELS  (SDK Store preview: Workshop won't see these revisions yet)
+  CHANNEL           VERSION      BUILD       ARCH     REV      SIZE
+  latest/stable     2.1-084c8c8  2024-11-25  amd64     88  123.46kB
+                                             arm64     89    1.23MB
+                    2.2-c8c8084  2024-11-27  riscv64   90   12.35MB
+  latest/candidate  ^                                      
+  latest/beta       ^                                      
+  latest/edge       2.0          2024-11-20  all       91   12.35MB
+
+INSTALLED
+  %-*s  WORKSHOP  CHANNEL      VERSION  ARCH  REV
+  %-*s  dev       latest/edge  2.0      all    82
+`, maxProject, "PROJECT", maxProject, lerobot)
+
+	c.Check(s.Stdout(), check.Equals, want)
+	s.ResetStdStreams()
+
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"info", "openvino", "--arch=amd64", "--base=ubuntu@20.04"})
+	c.Assert(cmd.Execute(), check.IsNil)
+
+	maxProject = max(len("PROJECT"), len(nav), len(lerobot))
+	want = fmt.Sprintf(`name:       openvino
+publisher:  Intel**
+license:    Apache-2.0
+
+Longer description
+can be multiline.
+
+CHANNELS  (SDK Store preview: Workshop won't see these revisions yet)
+  CHANNEL           VERSION      BUILD       REV     SIZE
+  latest/stable     2.1-084c8c8  2024-11-25   85     123B
+  latest/candidate  ^                             
+  latest/beta       ^                             
+  latest/edge       2.0          2024-11-20   91  12.35MB
+
+INSTALLED
+  %-*s  WORKSHOP  CHANNEL        VERSION      REV
+  %-*s  dev       latest/edge    2.0           82
+  %-*s  ci        latest/stable  2.1-084c8c8   85
+  %-*s  dev       latest/stable  2.1-084c8c8   85
+`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, "")
+
+	c.Check(s.Stdout(), check.Equals, want)
+	s.ResetStdStreams()
 }
 
 func (s *sdkSuite) TestInfoUnverifiedPublisher(c *check.C) {

--- a/cmd/sdk/info_test.go
+++ b/cmd/sdk/info_test.go
@@ -15,6 +15,8 @@ import (
 
 func (s *sdkSuite) TestInfo(c *check.C) {
 	d1 := time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC)
+	u1 := d1.Add(24 * time.Hour)
+	r1 := u1.Add(24 * time.Hour)
 	d2 := time.Date(2024, 11, 20, 0, 0, 0, 0, time.UTC)
 
 	home := c.MkDir()
@@ -23,14 +25,124 @@ func (s *sdkSuite) TestInfo(c *check.C) {
 
 	resp := client.SdkFullInfo{
 		Name:        "openvino",
-		Summary:     "ROS2 development environment",
+		PackageID:   "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e",
+		Title:       "OpenVINO",
+		Summary:     "Intel OpenVINO toolkit",
 		Description: "Longer description\ncan be multiline.",
+		License:     "Apache-2.0",
+		Publisher: &client.StoreAccount{
+			ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+			Username:    "intel",
+			DisplayName: "Intel",
+			Validation:  "verified",
+		},
+		Channels: []*client.SdkRevision{{
+			Channel:      "latest/stable",
+			Track:        "latest",
+			Risk:         "stable",
+			Revision:     "85",
+			BuiltAt:      &d1,
+			UploadedAt:   &u1,
+			ReleasedAt:   r1,
+			Version:      "2.1-084c8c8",
+			Base:         "ubuntu@20.04",
+			Arch:         "amd64",
+			DownloadSize: 123,
+		}, {
+			Channel:      "latest/stable",
+			Track:        "latest",
+			Risk:         "stable",
+			Revision:     "86",
+			BuiltAt:      &d1,
+			UploadedAt:   &u1,
+			ReleasedAt:   r1,
+			Version:      "2.1-084c8c8",
+			Base:         "ubuntu@20.04",
+			Arch:         "arm64",
+			DownloadSize: 1234,
+		}, {
+			Channel:      "latest/stable",
+			Track:        "latest",
+			Risk:         "stable",
+			Revision:     "87",
+			BuiltAt:      &d1,
+			UploadedAt:   &u1,
+			ReleasedAt:   r1,
+			Version:      "2.1-084c8c8",
+			Base:         "ubuntu@20.04",
+			Arch:         "riscv64",
+			DownloadSize: 12345,
+		}, {
+			Channel:      "latest/stable",
+			Track:        "latest",
+			Risk:         "stable",
+			Revision:     "88",
+			BuiltAt:      &d1,
+			UploadedAt:   &u1,
+			ReleasedAt:   r1,
+			Version:      "2.1-084c8c8",
+			Base:         "ubuntu@22.04",
+			Arch:         "amd64",
+			DownloadSize: 123456,
+		}, {
+			Channel:      "latest/stable",
+			Track:        "latest",
+			Risk:         "stable",
+			Revision:     "89",
+			BuiltAt:      &d1,
+			UploadedAt:   &u1,
+			ReleasedAt:   r1,
+			Version:      "2.1-084c8c8",
+			Base:         "ubuntu@22.04",
+			Arch:         "arm64",
+			DownloadSize: 1234567,
+		}, {
+			Channel:      "latest/stable",
+			Track:        "latest",
+			Risk:         "stable",
+			Revision:     "90",
+			BuiltAt:      &r1,
+			UploadedAt:   &r1,
+			ReleasedAt:   r1,
+			Version:      "2.2-c8c8084",
+			Base:         "ubuntu@22.04",
+			Arch:         "riscv64",
+			DownloadSize: 12345678,
+		}, {
+			Channel:      "latest/edge",
+			Track:        "latest",
+			Risk:         "edge",
+			Revision:     "91",
+			BuiltAt:      &d2,
+			UploadedAt:   &d2,
+			ReleasedAt:   d2,
+			Version:      "2.0",
+			Base:         "",
+			Arch:         "all",
+			DownloadSize: 12345678,
+		}},
 		Installed: []client.SdkInstalled{
 			{
 				ProjectPath: nav,
 				Workshop:    "ci",
 				Channel:     "latest/stable",
+				Base:        "ubuntu@20.04",
+				Arch:        "amd64",
 				SdkVolume: client.SdkVolume{
+					Version:  "2.1-084c8c8",
+					Revision: "85",
+					BuiltAt:  &d1,
+					Size:     109 * 1024 * 1024,
+				},
+			},
+			{
+				ProjectPath: nav,
+				Workshop:    "dev",
+				Channel:     "latest/stable",
+				Base:        "ubuntu@20.04",
+				Arch:        "amd64",
+				SdkVolume: client.SdkVolume{
+					Version:  "2.1-084c8c8",
 					Revision: "85",
 					BuiltAt:  &d1,
 					Size:     109 * 1024 * 1024,
@@ -40,7 +152,10 @@ func (s *sdkSuite) TestInfo(c *check.C) {
 				ProjectPath: lerobot,
 				Workshop:    "dev",
 				Channel:     "latest/edge",
+				Base:        "",
+				Arch:        "all",
 				SdkVolume: client.SdkVolume{
+					Version:  "2.0",
 					Revision: "82",
 					BuiltAt:  &d2,
 					Size:     102 * 1024 * 1024,
@@ -67,15 +182,68 @@ func (s *sdkSuite) TestInfo(c *check.C) {
 	cmd.SetArgs([]string{"info", "openvino"})
 	c.Assert(cmd.Execute(), check.IsNil)
 
-	want := fmt.Sprintf(`name:     openvino
-summary:  ROS2 development environment
-description: |
-  Longer description
-  can be multiline.
-installed:
-  %s:     ci   latest/stable  2024-11-25  (85)  114.29MB
-  %s:  dev  latest/edge    2024-11-20  (82)  106.95MB
-`, nav, lerobot)
+	maxProject := max(len("PROJECT"), len(nav), len(lerobot))
+	want := fmt.Sprintf(`name:       openvino
+publisher:  Intel**
+license:    Apache-2.0
 
+Longer description
+can be multiline.
+
+CHANNELS  (SDK Store preview: Workshop won't see these revisions yet)
+  CHANNEL           VERSION      BUILD       BASE          ARCH     REV      SIZE
+  latest/stable     2.1-084c8c8  2024-11-25  ubuntu@22.04  amd64     88  123.46kB
+                                                           arm64     89    1.23MB
+                    2.2-c8c8084  2024-11-27  ubuntu@22.04  riscv64   90   12.35MB
+                    2.1-084c8c8  2024-11-25  ubuntu@20.04  amd64     85      123B
+                                                           arm64     86    1.23kB
+                                                           riscv64   87   12.35kB
+  latest/candidate  ^                                                    
+  latest/beta       ^                                                    
+  latest/edge       2.0          2024-11-20  all           all       91   12.35MB
+
+INSTALLED
+  %-*s  WORKSHOP  CHANNEL        VERSION      BASE          ARCH   REV
+  %-*s  dev       latest/edge    2.0          all           all     82
+  %-*s  ci        latest/stable  2.1-084c8c8  ubuntu@20.04  amd64   85
+  %-*s  dev       latest/stable  2.1-084c8c8  ubuntu@20.04  amd64   85
+`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, "")
+
+	c.Check(s.Stdout(), check.Equals, want)
+}
+
+func (s *sdkSuite) TestInfoUnverifiedPublisher(c *check.C) {
+	resp := client.SdkFullInfo{
+		Name:      "openvimo",
+		PackageID: "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+		Publisher: &client.StoreAccount{
+			ID:          "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e",
+			Username:    "hunter2",
+			DisplayName: "Hunter Two",
+			Validation:  "unproven",
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/sdks/openvimo")
+		body := map[string]any{
+			"type":   "sync",
+			"result": resp,
+		}
+		encoder := json.NewEncoder(w)
+		c.Assert(encoder.Encode(body), check.IsNil)
+	}))
+	defer srv.Close()
+
+	ClientConfig.BaseURL = srv.URL
+
+	cmd := (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"info", "openvimo"})
+	c.Assert(cmd.Execute(), check.IsNil)
+
+	want := `name:       openvimo
+publisher:  Hunter Two (hunter2)
+`
 	c.Check(s.Stdout(), check.Equals, want)
 }

--- a/cmd/sdk/list_test.go
+++ b/cmd/sdk/list_test.go
@@ -45,6 +45,11 @@ func (s *sdkSuite) Stdout() string {
 	return s.stdout.String()
 }
 
+func (s *sdkSuite) ResetStdStreams() {
+	s.stdout.Reset()
+	s.stderr.Reset()
+}
+
 func (s *sdkSuite) TestList(c *check.C) {
 	sdks := []client.SdkVolume{
 		{Name: "ollama", Version: "1.0-053", Revision: "82"},

--- a/internal/daemon/api_sdks.go
+++ b/internal/daemon/api_sdks.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/canonical/workshop/internal/workshop"
+	"github.com/canonical/workshop/internal/sdkstore"
 )
 
 func v1GetSdks(c *Command, r *http.Request, _ *userState) Response {
@@ -26,10 +26,11 @@ func v1GetSdkInfo(c *Command, r *http.Request, _ *userState) Response {
 	mgr := c.d.overlord.SdkManager()
 
 	sk, err := mgr.Sdk(r.Context(), name)
+	var sdkErr *sdkstore.SdkNotFoundError
+	if errors.As(err, &sdkErr) {
+		return statusNotFound("%w", sdkErr)
+	}
 	if err != nil {
-		if errors.Is(err, workshop.ErrVolumeNotFound) {
-			return statusNotFound("%q SDK volume not found", name)
-		}
 		return statusInternalError("%w", err)
 	}
 

--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -1,6 +1,9 @@
 package daemon
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -10,7 +13,10 @@ import (
 
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdkstore"
+	"github.com/canonical/workshop/internal/sdkstore/transport"
 	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/timeutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -175,6 +181,68 @@ func (s *apiSuite) importSdkVolume(c *check.C, meta sdk.Meta, size uint64) {
 func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 	s.daemon(c)
 
+	stableReleased := time.Date(2026, 3, 10, 23, 48, 34, 474879000, time.UTC)
+	stableUploaded := time.Date(2026, 3, 10, 23, 45, 32, 474879000, time.UTC)
+	edgeReleased := time.Date(2026, 1, 10, 23, 48, 34, 474879000, time.UTC)
+	edgeUploaded := time.Date(2026, 1, 10, 23, 45, 32, 474879000, time.UTC)
+
+	restore := s.store.SetInfoCallback(func(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error) {
+		if name != "openvino" {
+			return transport.InfoResponse{}, &sdkstore.SdkNotFoundError{Name: name}
+		}
+
+		return transport.InfoResponse{
+			Name:      "openvino",
+			PackageID: "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e",
+			Metadata: transport.InfoMetadata{
+				Description: "Accelerated toolkit",
+				License:     "Apache-2.0",
+				Publisher: transport.Publisher{
+					ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+					Username:    "hunter2",
+					DisplayName: "Hunter Two",
+					Validation:  "unproven",
+				},
+			},
+			ChannelMap: []transport.InfoChannelMap{{
+				Channel: transport.Channel{
+					Name: "latest/stable",
+					Platform: transport.Platform{
+						Name:         "ubuntu",
+						Channel:      "20.04",
+						Architecture: "amd64",
+					},
+					ReleasedAt: timeutil.TimeUTC(stableReleased),
+				},
+				Revision: transport.InfoRevision{
+					CreatedAt: (*timeutil.TimeUTC)(&stableUploaded),
+					Download:  transport.Download{Size: 1234},
+					Revision:  85,
+					Version:   "2.1-084c8c8",
+					SdkYAML:   json.RawMessage(`{"sdkcraft-started-at": "2024-11-20T00:00:00+00:00"}`),
+				},
+			}, {
+				Channel: transport.Channel{
+					Name: "latest/edge",
+					Platform: transport.Platform{
+						Name:         "ubuntu",
+						Channel:      "20.04",
+						Architecture: "amd64",
+					},
+					ReleasedAt: timeutil.TimeUTC(edgeReleased),
+				},
+				Revision: transport.InfoRevision{
+					CreatedAt: (*timeutil.TimeUTC)(&edgeUploaded),
+					Download:  transport.Download{Size: 4321},
+					Revision:  82,
+					Version:   "2.0",
+					SdkYAML:   json.RawMessage(`{"sdkcraft-started-at": "2024-11-25T00:00:00+00:00"}`),
+				},
+			}},
+		}, nil
+	})
+	defer restore()
+
 	// Create two workshops in the same project.
 	s.createWFile(c, "nav2", "name: nav2\nbase: ubuntu@20.04\n")
 	s.createWFile(c, "lerobot", "name: lerobot\nbase: ubuntu@20.04\n")
@@ -199,7 +267,7 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 		SdkYAML: `name: openvino
 version: 2.1-084c8c8
 summary: Intel OpenVINO toolkit
-description: Accelerated toolkit
+description: Latest release
 sdkcraft-started-at: 2024-11-20T00:00:00+00:00
 `,
 	}
@@ -236,17 +304,50 @@ sdkcraft-started-at: 2024-11-25T00:00:00+00:00
 	full, ok := rsp.Result.(*sdkstate.SdkFullInfo)
 	c.Assert(ok, check.Equals, true)
 
-	c.Assert(full.Name, check.Equals, "openvino")
-	c.Assert(full.Summary, check.Not(check.Equals), "")
-	c.Assert(full.Description, check.Not(check.Equals), "")
+	c.Check(full.Name, check.Equals, "openvino")
+	c.Check(full.PackageID, check.Equals, "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e")
+	c.Check(full.Title, check.Equals, "")
+	c.Check(full.Summary, check.Not(check.Equals), "")
+	c.Check(full.Description, check.Equals, "Accelerated toolkit")
+	c.Check(full.License, check.Equals, "Apache-2.0")
+	c.Check(full.Publisher, check.DeepEquals, &sdkstate.StoreAccount{
+		ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+		Username:    "hunter2",
+		DisplayName: "Hunter Two",
+		Validation:  "unproven",
+	})
 
-	d20 := time.Date(2024, 11, 20, 0, 0, 0, 0, time.UTC).UTC().Round(0)
-	d25 := time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC).UTC().Round(0)
-	c.Assert(full.Installed, testutil.DeepUnsortedMatches, []sdkstate.SdkInstalled{
+	d20 := time.Date(2024, 11, 20, 0, 0, 0, 0, time.UTC)
+	d25 := time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC)
+
+	c.Check(full.Channels, testutil.DeepUnsortedMatches, []sdkstate.SdkRevision{{
+		Channel:      "latest/stable",
+		Revision:     "85",
+		BuiltAt:      &d20,
+		UploadedAt:   &stableUploaded,
+		ReleasedAt:   stableReleased,
+		Version:      "2.1-084c8c8",
+		Base:         "ubuntu@20.04",
+		Arch:         "amd64",
+		DownloadSize: 1234,
+	}, {
+		Channel:      "latest/edge",
+		Revision:     "82",
+		BuiltAt:      &d25,
+		UploadedAt:   &edgeUploaded,
+		ReleasedAt:   edgeReleased,
+		Version:      "2.0",
+		Base:         "ubuntu@20.04",
+		Arch:         "amd64",
+		DownloadSize: 4321,
+	}})
+
+	c.Check(full.Installed, testutil.DeepUnsortedMatches, []sdkstate.SdkInstalled{
 		{
 			ProjectPath: s.project.Path,
 			Workshop:    "nav2",
 			Channel:     "latest/stable",
+			Arch:        "all",
 			SdkVolume: sdkstate.SdkVolume{
 				Name:     "openvino",
 				Version:  "2.1-084c8c8",
@@ -259,6 +360,7 @@ sdkcraft-started-at: 2024-11-25T00:00:00+00:00
 			ProjectPath: s.project.Path,
 			Workshop:    "lerobot",
 			Channel:     "latest/edge",
+			Arch:        "all",
 			SdkVolume: sdkstate.SdkVolume{
 				Name:     "openvino",
 				Version:  "2.0",
@@ -270,7 +372,224 @@ sdkcraft-started-at: 2024-11-25T00:00:00+00:00
 	})
 }
 
-func (s *apiSuite) TestSdkInfoGetInvalidMetadata(c *check.C) {
+func (s *apiSuite) TestSdkInfoStoreOnly(c *check.C) {
+	s.daemon(c)
+
+	stableReleased := time.Date(2026, 3, 10, 23, 48, 34, 474879000, time.UTC)
+	stableUploaded := time.Date(2026, 3, 10, 23, 45, 32, 474879000, time.UTC)
+
+	restore := s.store.SetInfoCallback(func(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error) {
+		if name != "openvino" {
+			return transport.InfoResponse{}, &sdkstore.SdkNotFoundError{Name: name}
+		}
+
+		return transport.InfoResponse{
+			Name:      "openvino",
+			PackageID: "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e",
+			Metadata: transport.InfoMetadata{
+				Description: "Accelerated toolkit",
+				License:     "Apache-2.0",
+				Publisher: transport.Publisher{
+					ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+					Username:    "hunter2",
+					DisplayName: "Hunter Two",
+					Validation:  "unproven",
+				},
+			},
+			ChannelMap: []transport.InfoChannelMap{{
+				Channel: transport.Channel{
+					Name: "latest/stable",
+					Platform: transport.Platform{
+						Name:         "ubuntu",
+						Channel:      "20.04",
+						Architecture: "amd64",
+					},
+					ReleasedAt: timeutil.TimeUTC(stableReleased),
+				},
+				Revision: transport.InfoRevision{
+					CreatedAt: (*timeutil.TimeUTC)(&stableUploaded),
+					Download:  transport.Download{Size: 1234},
+					Revision:  85,
+					Version:   "2.1-084c8c8",
+					SdkYAML:   json.RawMessage(`{"sdkcraft-started-at": "2024-11-20T00:00:00+00:00"}`),
+				},
+			}},
+		}, nil
+	})
+	defer restore()
+
+	s.vars = map[string]string{"name": "openvino"}
+	req, err := s.createSdksRequest("GET", "/v1/sdks/openvino")
+	c.Assert(err, check.IsNil)
+
+	rsp := v1GetSdkInfo(apiCmd("/v1/sdks/{name}"), req, nil).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Assert(rsp.Status, check.Equals, http.StatusOK)
+
+	full, ok := rsp.Result.(*sdkstate.SdkFullInfo)
+	c.Assert(ok, check.Equals, true)
+
+	c.Check(full.Name, check.Equals, "openvino")
+	c.Check(full.PackageID, check.Equals, "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e")
+	c.Check(full.Title, check.Equals, "")
+	c.Check(full.Summary, check.Equals, "")
+	c.Check(full.Description, check.Equals, "Accelerated toolkit")
+	c.Check(full.License, check.Equals, "Apache-2.0")
+	c.Check(full.Publisher, check.DeepEquals, &sdkstate.StoreAccount{
+		ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+		Username:    "hunter2",
+		DisplayName: "Hunter Two",
+		Validation:  "unproven",
+	})
+
+	d20 := time.Date(2024, 11, 20, 0, 0, 0, 0, time.UTC)
+
+	c.Check(full.Channels, check.DeepEquals, []sdkstate.SdkRevision{{
+		Channel:      "latest/stable",
+		Revision:     "85",
+		BuiltAt:      &d20,
+		UploadedAt:   &stableUploaded,
+		ReleasedAt:   stableReleased,
+		Version:      "2.1-084c8c8",
+		Base:         "ubuntu@20.04",
+		Arch:         "amd64",
+		DownloadSize: 1234,
+	}})
+
+	c.Check(full.Installed, check.HasLen, 0)
+}
+
+func (s *apiSuite) TestSdkInfoLocalOnly(c *check.C) {
+	s.daemon(c)
+
+	s.createWFile(c, "nav2", "name: nav2\nbase: ubuntu@20.04\n")
+	wf := &workshop.File{Name: "nav2", Base: "ubuntu@20.04"}
+	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
+
+	// Add SDK setup with channels so the endpoint can report channels.
+	meta := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:     "openvino",
+			Channel:  "latest/stable",
+			Source:   sdk.StoreSource,
+			Revision: sdk.R(85),
+			Sha3_384: "e7439cbefe3266aa299e09c99a6ce7b0163aceea20a67e178445f588d3433fd7a3cd55036be3f92ceb0cfae54934da73",
+		},
+		SdkYAML: `name: openvino
+version: 2.1-084c8c8
+summary: Intel OpenVINO toolkit
+description: Latest release
+sdkcraft-started-at: 2024-11-20T00:00:00+00:00
+`,
+	}
+	s.importSdkVolume(c, meta, 112*1024*1024)
+	c.Assert(s.b.InstallSdk(s.ctx, "nav2", meta.Setup), check.IsNil)
+
+	s.vars = map[string]string{"name": "openvino"}
+	req, err := s.createSdksRequest("GET", "/v1/sdks/openvino")
+	c.Assert(err, check.IsNil)
+
+	rsp := v1GetSdkInfo(apiCmd("/v1/sdks/{name}"), req, nil).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Assert(rsp.Status, check.Equals, http.StatusOK)
+
+	full, ok := rsp.Result.(*sdkstate.SdkFullInfo)
+	c.Assert(ok, check.Equals, true)
+
+	c.Check(full.Name, check.Equals, "openvino")
+	c.Check(full.PackageID, check.Equals, "")
+	c.Check(full.Title, check.Equals, "")
+	c.Check(full.Summary, check.Not(check.Equals), "")
+	c.Check(full.Description, check.Not(check.Equals), "")
+	c.Check(full.License, check.Equals, "")
+	c.Check(full.Publisher, check.IsNil)
+
+	c.Check(full.Channels, check.HasLen, 0)
+
+	d20 := time.Date(2024, 11, 20, 0, 0, 0, 0, time.UTC)
+
+	c.Check(full.Installed, check.DeepEquals, []sdkstate.SdkInstalled{
+		{
+			ProjectPath: s.project.Path,
+			Workshop:    "nav2",
+			Channel:     "latest/stable",
+			Arch:        "all",
+			SdkVolume: sdkstate.SdkVolume{
+				Name:     "openvino",
+				Version:  "2.1-084c8c8",
+				Revision: "85",
+				BuiltAt:  &d20,
+				Size:     112 * 1024 * 1024,
+			},
+		},
+	})
+}
+
+func (s *apiSuite) TestSdkInfoStoreDown(c *check.C) {
+	s.daemon(c)
+
+	restore := s.store.SetInfoCallback(func(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error) {
+		return transport.InfoResponse{}, errors.New("destination unreachable")
+	})
+	defer restore()
+
+	s.vars = map[string]string{"name": "openvino"}
+	req, err := s.createSdksRequest("GET", "/v1/sdks/openvino")
+	c.Assert(err, check.IsNil)
+
+	rsp := v1GetSdkInfo(apiCmd("/v1/sdks/{name}"), req, nil).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Status, check.Equals, http.StatusInternalServerError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, "destination unreachable")
+}
+
+func (s *apiSuite) TestSdkInfoInvalidStoreMetadata(c *check.C) {
+	s.daemon(c)
+
+	stableReleased := time.Date(2026, 3, 10, 23, 48, 34, 474879000, time.UTC)
+
+	restore := s.store.SetInfoCallback(func(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error) {
+		if name != "bad" {
+			return transport.InfoResponse{}, &sdkstore.SdkNotFoundError{Name: name}
+		}
+
+		return transport.InfoResponse{
+			Name: "bad",
+			ChannelMap: []transport.InfoChannelMap{{
+				Channel: transport.Channel{
+					Name: "latest/stable",
+					Platform: transport.Platform{
+						Name:         "ubuntu",
+						Channel:      "20.04",
+						Architecture: "amd64",
+					},
+					ReleasedAt: timeutil.TimeUTC(stableReleased),
+				},
+				Revision: transport.InfoRevision{
+					Revision: 42,
+					SdkYAML:  json.RawMessage(`[`),
+				},
+			}},
+		}, nil
+	})
+	defer restore()
+
+	s.vars = map[string]string{"name": "bad"}
+	req, err := s.createSdksRequest("GET", "/v1/sdks/bad")
+	c.Assert(err, check.IsNil)
+
+	rsp := v1GetSdkInfo(apiCmd("/v1/sdks/{name}"), req, nil).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Status, check.Equals, http.StatusInternalServerError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `invalid "bad" SDK (42) metadata: yaml: line 1: did not find expected node content`)
+}
+
+func (s *apiSuite) TestSdkInfoGetInvalidLocalMetadata(c *check.C) {
 	s.daemon(c)
 
 	s.createWFile(c, "ws", "name: ws\nbase: ubuntu@20.04\n")

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -43,6 +43,7 @@ type apiSuite struct {
 	d          *Daemon
 	b          *fakebackend.FakeWorkshopBackend
 	secBackend *ifacetest.TestSecurityBackend
+	store      *sdk.FakeStore
 	gcsStore   *sdk.FakeGcsStore
 
 	workshopDir string
@@ -80,6 +81,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 		ProjectId: "b8639dea",
 	}
 
+	s.store = sdk.NewFakeStore()
 	s.gcsStore = &sdk.FakeGcsStore{}
 	retrieveSystemSdk := func(setup sdk.Setup, report *progress.Reporter) (*sdk.Meta, error) {
 		return s.gcsStore.DownloadSdk(context.TODO(), setup, report)
@@ -147,11 +149,13 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	d, err := New(&Options{Dir: s.workshopDir})
 	c.Assert(err, check.IsNil)
 
+	sdk.ReplaceStore(d.state, s.store)
+	sdk.ReplaceGcsStore(d.state, s.gcsStore)
+
 	c.Assert(d.overlord.StartUp(), check.IsNil)
 	d.addRoutes()
 	s.d = d
 
-	sdk.ReplaceGcsStore(s.d.state, s.gcsStore)
 	return d
 }
 

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -41,6 +41,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdkstore"
 	"github.com/canonical/workshop/internal/systemd"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -124,6 +125,13 @@ func New(dir string, restartHandler restart.Handler) (*Overlord, error) {
 
 	o.stateEng = NewStateEngine(s)
 	o.runner = state.NewTaskRunner(s)
+
+	storeConfig, err := sdkstore.EnvConfig()
+	if err != nil {
+		return nil, err
+	}
+	sto := sdkstore.NewClient(storeConfig)
+	sdk.ReplaceStore(s, sto)
 
 	gcs := gcsstore.New()
 	sdk.ReplaceGcsStore(s, gcs)

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -135,6 +135,8 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 
 	workshop.ReplaceBackend(s.state, s.backend)
 
+	sdk.ReplaceStore(s.state, sdk.NewFakeStore())
+
 	/* empty task handler */
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
 
@@ -154,9 +156,10 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 	s.runner.AddHandler("retry-task", retryHandler, nil)
 
 	s.se = overlord.NewStateEngine(s.state)
-	s.se.StartUp()
 	s.se.AddManager(s.sdkmgr)
 	s.se.AddManager(s.runner)
+	err = s.se.StartUp()
+	c.Assert(err, check.IsNil)
 
 	s.installedAt = time.Date(2023, 04, 25, 1, 2, 3, 0, time.UTC)
 	s.restoreInstallTime = testutil.FakeFunc(func() time.Time { return s.installedAt }, &workshop.InstallTimeNow)

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -2,15 +2,42 @@ package sdkstate
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/sdkstore"
+	"github.com/canonical/workshop/internal/timeutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
+
+type StoreAccount struct {
+	ID          string `json:"id"`
+	Username    string `json:"username"`
+	DisplayName string `json:"display-name"`
+	Validation  string `json:"validation,omitempty"`
+}
+
+type SdkRevision struct {
+	Channel      string     `json:"channel"`
+	Track        string     `json:"track"`
+	Risk         string     `json:"risk"`
+	Revision     string     `json:"revision"`
+	BuiltAt      *time.Time `json:"built-at,omitempty"`
+	UploadedAt   *time.Time `json:"uploaded-at,omitempty"`
+	ReleasedAt   time.Time  `json:"released-at"`
+	Version      string     `json:"version,omitempty"`
+	Base         string     `json:"base,omitempty"`
+	Arch         string     `json:"arch,omitempty"`
+	DownloadSize uint64     `json:"download-size,omitzero"`
+}
 
 type SdkVolume struct {
 	Name     string     `json:"name"`
@@ -24,20 +51,28 @@ type SdkInstalled struct {
 	ProjectPath string `json:"project-path"`
 	Workshop    string `json:"workshop"`
 	Channel     string `json:"channel,omitempty"`
+	Base        string `json:"base,omitempty"`
+	Arch        string `json:"architecture,omitempty"`
 	SdkVolume
 }
 
 // This struct maintains information merged from
 // the local volumes infos and the store.
-// TODO: obtain Description and Summary from the store.
 type SdkFullInfo struct {
 	Name        string         `json:"name"`
+	PackageID   string         `json:"package-id,omitempty"`
+	Title       string         `json:"title,omitempty"`
 	Summary     string         `json:"summary,omitempty"`
 	Description string         `json:"description,omitempty"`
+	License     string         `json:"license,omitempty"`
+	Publisher   *StoreAccount  `json:"publisher,omitempty"`
+	Channels    []SdkRevision  `json:"channels,omitempty"`
 	Installed   []SdkInstalled `json:"installed,omitempty"`
 }
 
 type SdkManager struct {
+	state   *state.State
+	store   sdk.Store
 	backend workshop.Backend
 	repo    *interfaces.Repository
 }
@@ -47,11 +82,7 @@ var (
 )
 
 func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) *SdkManager {
-	manager := &SdkManager{repo: repo}
-
-	s.Lock()
-	manager.backend = workshop.WorkshopBackend(s)
-	s.Unlock()
+	manager := &SdkManager{state: s, repo: repo}
 
 	runner.AddHandler("retrieve-sdk", OnDo(manager.doRetrieveSdk), nil)
 	runner.AddHandler("install-sdk", OnDo(manager.doInstallSdk), OnUndo(manager.doUninstallSdk))
@@ -62,6 +93,14 @@ func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) 
 	runner.AddCleanup("uninstall-sdk", manager.doDeleteUnusedSdkVolumes)
 
 	return manager
+}
+
+func (w *SdkManager) StartUp() error {
+	w.state.Lock()
+	w.store = sdk.StoreService(w.state)
+	w.backend = workshop.WorkshopBackend(w.state)
+	w.state.Unlock()
+	return nil
 }
 
 func (w *SdkManager) SdkVolumes(ctx context.Context) ([]SdkVolume, error) {
@@ -90,33 +129,101 @@ func (w *SdkManager) SdkVolumes(ctx context.Context) ([]SdkVolume, error) {
 }
 
 func (w *SdkManager) Sdk(ctx context.Context, name string) (*SdkFullInfo, error) {
-	sdks, err := w.backend.Sdks(ctx)
-	if err != nil {
+	full := &SdkFullInfo{Name: name}
+
+	var sdkErr *sdkstore.SdkNotFoundError
+	if err := w.fillChannels(ctx, name, full); err != nil && !errors.As(err, &sdkErr) {
 		return nil, err
 	}
 
-	sdks = slices.DeleteFunc(sdks, func(s workshop.SdkVolume) bool { return s.Name != name })
-	if len(sdks) == 0 {
-		return nil, workshop.ErrVolumeNotFound
+	if err := w.fillInstalled(ctx, name, full); err != nil {
+		return nil, err
 	}
 
-	full := SdkFullInfo{
-		Name:      name,
-		Installed: make([]SdkInstalled, 0, len(sdks)),
+	if sdkErr != nil && len(full.Installed) == 0 {
+		return nil, sdkErr
 	}
+	return full, nil
+}
+
+func (w *SdkManager) fillChannels(ctx context.Context, name string, full *SdkFullInfo) error {
+	response, err := w.store.Info(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	full.PackageID = response.PackageID
+	full.Title = response.Metadata.Title
+	full.Summary = response.Metadata.Summary
+	full.Description = response.Metadata.Description
+	full.License = response.Metadata.License
+	if response.Metadata.Publisher.ID != "" {
+		full.Publisher = &StoreAccount{
+			ID:          response.Metadata.Publisher.ID,
+			Username:    response.Metadata.Publisher.Username,
+			DisplayName: response.Metadata.Publisher.DisplayName,
+			Validation:  response.Metadata.Publisher.Validation,
+		}
+	}
+
+	full.Channels = make([]SdkRevision, 0, len(response.ChannelMap))
+	for _, entry := range response.ChannelMap {
+		var sdkYaml struct {
+			BuiltAt *timeutil.TimeUTC `yaml:"sdkcraft-started-at,omitempty"`
+		}
+		if err := yaml.Unmarshal(entry.Revision.SdkYAML, &sdkYaml); err != nil {
+			return fmt.Errorf("invalid %q SDK (%v) metadata: %w", response.Name, entry.Revision.Revision, err)
+		}
+
+		base := entry.Channel.Platform.Name + "@" + entry.Channel.Platform.Channel
+		if base == "all@all" {
+			base = ""
+		}
+
+		channel := SdkRevision{
+			Channel:      entry.Channel.Name,
+			Track:        entry.Channel.Track,
+			Risk:         entry.Channel.Risk,
+			Revision:     sdk.Revision{N: entry.Revision.Revision}.String(),
+			BuiltAt:      (*time.Time)(sdkYaml.BuiltAt),
+			UploadedAt:   (*time.Time)(entry.Revision.CreatedAt),
+			ReleasedAt:   time.Time(entry.Channel.ReleasedAt),
+			Version:      entry.Revision.Version,
+			Base:         base,
+			Arch:         entry.Channel.Platform.Architecture,
+			DownloadSize: entry.Revision.Download.Size,
+		}
+		full.Channels = append(full.Channels, channel)
+	}
+	return nil
+}
+
+func (w *SdkManager) fillInstalled(ctx context.Context, name string, full *SdkFullInfo) error {
+	sdks, err := w.backend.Sdks(ctx)
+	if err != nil {
+		return err
+	}
+	sdks = slices.DeleteFunc(sdks, func(s workshop.SdkVolume) bool { return s.Name != name })
+
+	full.Installed = make([]SdkInstalled, 0, len(sdks))
 	for _, s := range sdks {
 		info, err := sdk.ReadSdkInfo([]byte(s.SdkYAML), "", "")
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		// TODO: obtain summary, description, license from the actual store
-		// when it becomes available.
+		// Needed if the SDK isn't in the Store (e.g. try SDKs).
+		if full.Title == "" {
+			full.Title = info.Title
+		}
 		if full.Summary == "" {
 			full.Summary = info.Summary
 		}
 		if full.Description == "" {
 			full.Description = info.Description
+		}
+		if full.License == "" {
+			full.License = info.License
 		}
 
 		for pid, wps := range s.Workshops {
@@ -124,13 +231,20 @@ func (w *SdkManager) Sdk(ctx context.Context, name string) (*SdkFullInfo, error)
 			for _, wp := range wps {
 				winfo, err := w.backend.Workshop(pctx, wp)
 				if err != nil {
-					return nil, err
+					return err
 				}
 
 				channel := ""
 				sk, ok := winfo.Sdks[name]
 				if ok {
 					channel = sk.Channel
+				}
+
+				arch := info.Arch
+				if arch == "" {
+					// SDKcraft always sets architecture,
+					// but we probably shouldn't rely on it.
+					arch = "all"
 				}
 
 				full.Installed = append(full.Installed, SdkInstalled{
@@ -144,12 +258,13 @@ func (w *SdkManager) Sdk(ctx context.Context, name string) (*SdkFullInfo, error)
 					Workshop:    winfo.Name,
 					ProjectPath: winfo.Project.Path,
 					Channel:     channel,
+					Base:        info.Base,
+					Arch:        arch,
 				})
 			}
 		}
 	}
-
-	return &full, nil
+	return nil
 }
 
 func (w *SdkManager) Ensure() error {

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -111,8 +111,10 @@ type sdkYaml struct {
 	Base        string            `yaml:"base"`
 	Arch        string            `yaml:"architecture"`
 	Version     string            `yaml:"version,omitempty"`
+	Title       string            `yaml:"title"`
 	Summary     string            `yaml:"summary"`
 	Description string            `yaml:"description"`
+	License     string            `yaml:"license"`
 	Type        string            `yaml:"type"`
 	BuiltAt     *timeutil.TimeUTC `yaml:"sdkcraft-started-at,omitempty"`
 	Plugs       map[string]any    `yaml:"plugs,omitempty"`
@@ -152,8 +154,10 @@ type Info struct {
 	Channel     string
 	Source      Source
 	BuiltAt     *time.Time
+	Title       string
 	Summary     string
 	Description string
+	License     string
 
 	Plugs     map[string]*PlugInfo
 	PlugBinds map[string]PlugRef
@@ -271,8 +275,10 @@ func ReadSdkInfo(yamlData []byte, projectId, workshop string) (*Info, error) {
 		Version:       sdkYaml.Version,
 		Type:          Type(sdkYaml.Type),
 		BuiltAt:       (*time.Time)(sdkYaml.BuiltAt),
+		Title:         sdkYaml.Title,
 		Summary:       sdkYaml.Summary,
 		Description:   sdkYaml.Description,
+		License:       sdkYaml.License,
 		Plugs:         make(map[string]*PlugInfo),
 		PlugBinds:     make(map[string]PlugRef),
 		Slots:         make(map[string]*SlotInfo),

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/progress"
+	"github.com/canonical/workshop/internal/sdkstore"
+	"github.com/canonical/workshop/internal/sdkstore/transport"
 )
 
 type StoreAction int
@@ -26,6 +28,69 @@ type SdkAction struct {
 	Name      string
 	Base      string
 	Channel   string
+}
+
+type cachedStoreKey struct{}
+
+// ReplaceStore replaces the SDK store used by the manager.
+func ReplaceStore(state *state.State, store Store) {
+	state.Lock()
+	state.Cache(cachedStoreKey{}, store)
+	state.Unlock()
+}
+
+func cachedStore(st *state.State) Store {
+	sdkStore := st.Cached(cachedStoreKey{})
+	if sdkStore == nil {
+		return nil
+	}
+	return sdkStore.(Store)
+}
+
+// StoreService returns the active store service.
+func StoreService(st *state.State) Store {
+	if store := cachedStore(st); store != nil {
+		return store
+	}
+	panic("internal error: needing the store before managers have initialized it")
+}
+
+type Store interface {
+	Info(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error)
+}
+
+func NewFakeStore() *FakeStore {
+	return &FakeStore{}
+}
+
+type FakeStore struct {
+	lock sync.Mutex
+
+	InfoCalls    []string
+	InfoCallback func(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error)
+}
+
+func (f *FakeStore) SetInfoCallback(info func(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error)) func() {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	old := f.InfoCallback
+	f.InfoCallback = info
+	return func() {
+		f.InfoCallback = old
+	}
+}
+
+func (f *FakeStore) Info(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error) {
+	f.lock.Lock()
+	f.InfoCalls = append(f.InfoCalls, name)
+	info := f.InfoCallback
+	f.lock.Unlock()
+
+	if info == nil {
+		return transport.InfoResponse{}, &sdkstore.SdkNotFoundError{Name: name}
+	}
+	return info(ctx, name, options...)
 }
 
 type cachedGcsStoreKey struct{}

--- a/internal/sdkstore/client.go
+++ b/internal/sdkstore/client.go
@@ -4,7 +4,9 @@
 package sdkstore
 
 import (
+	"fmt"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/canonical/workshop/internal/https"
@@ -36,6 +38,18 @@ type Config struct {
 	// HTTPClient represents the HTTP client to use for all API
 	// requests. If nil, use the default HTTP client.
 	HTTPClient https.HTTPClient
+}
+
+func EnvConfig() (Config, error) {
+	var storeURL *url.URL
+	if custom := os.Getenv("SDK_STORE_URL"); custom != "" {
+		var err error
+		storeURL, err = url.Parse(custom)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid SDK_STORE_URL: %w", err)
+		}
+	}
+	return Config{URL: storeURL}, nil
 }
 
 // basePath returns the base configuration path for speaking to the server API.

--- a/internal/sdkstore/errors.go
+++ b/internal/sdkstore/errors.go
@@ -16,7 +16,7 @@ type SdkNotFoundError struct {
 }
 
 func (e *SdkNotFoundError) Error() string {
-	return fmt.Sprintf("%q SDK not found", e.Name)
+	return fmt.Sprintf("no matching SDKs for %q", e.Name)
 }
 
 // Handle some of the basic error messages.

--- a/internal/sdkstore/info_test.go
+++ b/internal/sdkstore/info_test.go
@@ -85,7 +85,7 @@ func (s *InfoSuite) TestInfoError(c *check.C) {
 
 	client := newInfoClient(path, restClient)
 	_, err := client.Info(context.Background(), name)
-	c.Assert(err, check.ErrorMatches, `"test-sdk-info" SDK not found`)
+	c.Assert(err, check.ErrorMatches, `no matching SDKs for "test-sdk-info"`)
 }
 
 func (s *InfoSuite) expectGet(c *check.C, client *MockRESTClient, p path.Path, name string) {

--- a/snap/local/commands/run_daemon
+++ b/snap/local/commands/run_daemon
@@ -3,6 +3,9 @@
 GCS_STORE_URL=$(snapctl get gcs.url)
 export GCS_STORE_URL
 
+SDK_STORE_URL=$(snapctl get store.url)
+export SDK_STORE_URL
+
 WORKSHOP_IMAGE_SERVER=$(snapctl get workshop.image.server.url)
 export WORKSHOP_IMAGE_SERVER
 

--- a/tests/main/sdk-info/header.txt
+++ b/tests/main/sdk-info/header.txt
@@ -1,5 +1,14 @@
-name:     test-sdk-info
-summary:  test-sdk-info summary
-description: |
-  test-sdk-info description
-installed:
+name:       test-sdk-info
+publisher:  Jonathan Conder (usso-jeconder)
+license:    GPL-3.0
+
+This is test-sdk-info's description. You have a paragraph or two to tell the
+most important story about it. Keep it under 100 words though,
+we live in tweetspace.
+
+CHANNELS  (SDK Store preview: Workshop won't see these revisions yet)
+  CHANNEL           VERSION  BUILD       BASE  REV  SIZE
+  latest/stable     -                               
+  latest/candidate  -                               
+  latest/beta       -                               
+  latest/edge       0.1      2026-03-10  all     1  677B

--- a/tests/main/sdk-info/task.yaml
+++ b/tests/main/sdk-info/task.yaml
@@ -12,17 +12,19 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
+  lines=$(wc -l < header.txt)
+
   echo "Test SDK info without any volumes"
-  ! sdk_exec info test-sdk-info
+  sdk_exec info test-sdk-info > info.log
+  diff -u header.txt info.log
 
   echo "Test SDK info with one volume"
   workshop_exec launch edge
   sdk_exec list | MATCH '^test-sdk-info[[:space:]]+2\.0[[:space:]]+[[:digit:]]+[[:space:]]+.*kB$'
 
   sdk_exec info test-sdk-info > info.log
-  head --lines=-1 info.log > header.log
-  diff -u header.log header.txt
-  tail --lines=1 info.log | MATCH "$PWD:[[:space:]]+edge[[:space:]]+latest/edge[[:space:]]+2025-07-03[[:space:]]+\\([[:digit:]]+\\)[[:space:]]+.*kB$"
+  diff -u header.txt <(head --lines="$lines" info.log)
+  MATCH "$PWD[[:space:]]+edge[[:space:]]+latest/edge[[:space:]]+2\\.0[[:space:]]+ubuntu@22.04[[:space:]]+[[:digit:]]+$" < info.log
 
   echo "Test SDK info with two volumes"
   workshop_exec launch stable
@@ -30,10 +32,9 @@ execute: |
   sdk_exec list | MATCH '^test-sdk-info[[:space:]]+2\.0[[:space:]]+[[:digit:]]+[[:space:]]+.*kB$'
 
   sdk_exec info test-sdk-info > info.log
-  head --lines=-2 info.log > header.log
-  diff -u header.log header.txt
-  tail --lines=2 info.log | MATCH "$PWD:[[:space:]]+edge[[:space:]]+latest/edge[[:space:]]+2025-07-03[[:space:]]+\\([[:digit:]]+\\)[[:space:]]+.*kB$"
-  tail --lines=2 info.log | MATCH "$PWD:[[:space:]]+stable[[:space:]]+latest/stable[[:space:]]+2025-04-03[[:space:]]+\\([[:digit:]]+\\)[[:space:]]+.*kB$"
+  diff -u header.txt <(head --lines="$lines" info.log)
+  MATCH "$PWD[[:space:]]+edge[[:space:]]+latest/edge[[:space:]]+2\\.0[[:space:]]+ubuntu@22.04[[:space:]]+[[:digit:]]+$" < info.log
+  MATCH "[[:space:]]+stable[[:space:]]+latest/stable[[:space:]]+1\\.0[[:space:]]+ubuntu@22.04[[:space:]]+[[:digit:]]+$" < info.log
 
   echo "Test SDK info with two volumes but one workshop"
   workshop_exec remove edge
@@ -41,6 +42,5 @@ execute: |
   sdk_exec list | MATCH '^test-sdk-info[[:space:]]+2\.0[[:space:]]+[[:digit:]]+[[:space:]]+.*kB$'
 
   sdk_exec info test-sdk-info > info.log
-  head --lines=-1 info.log > header.log
-  diff -u header.log header.txt
-  tail --lines=1 info.log | MATCH "$PWD:[[:space:]]+stable[[:space:]]+latest/stable[[:space:]]+2025-04-03[[:space:]]+\\([[:digit:]]+\\)[[:space:]]+.*kB$"
+  diff -u header.txt <(head --lines="$lines" info.log)
+  MATCH "$PWD[[:space:]]+stable[[:space:]]+latest/stable[[:space:]]+1\\.0[[:space:]]+ubuntu@22.04[[:space:]]+[[:digit:]]+$" < info.log


### PR DESCRIPTION
# Description

Adds more information to the `/v1/sdks/{name}` response, namely:
- ID, title, license, publisher.
- A list of channels and their most recent revisions, for each platform.
- The base and architecture of each SDK volume.

If no SDK volumes exist, only the Store metadata is shown, and vice versa. If the SDK doesn't exist in the Store or locally, the endpoint returns 404. The error message looks slightly different from the spec (for consistency):
```console
$ sdk info foo
error: no matching SDKs for "foo"
```

The `sdk info` command presents this new information in a more readable way, using tabular output. SDKs can be filtered by architecture and base. By default only the host's architecture is shown.

I'll adjust the other tables for consistency in a follow up PR. Making the headings bold will probably take longer, since Go's `tabwriter` doesn't recognize ANSI escape sequences. YAML support is removed for now. It will take a bit of work to convert the API response into the format described in the spec.

The SDK CLI doesn't current have a generate-docs subcommand, I'll make another PR to fix that.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
