### PR TITLE
Make all hooks to run as login shell

### DIFF
--- a/internal/daemon/snapshot-format.yaml
+++ b/internal/daemon/snapshot-format.yaml
@@ -54,7 +54,7 @@ test-sdk-2:
     snapshot-sdk: 2
   fs-calls: 10
   exec-calls:
-    - ["bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
 test-sdk:
   files:
     - drwxr-xr-x var
@@ -74,8 +74,8 @@ test-sdk:
     snapshot-sdk: 3
   fs-calls: 13
   exec-calls:
-    - ["bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
-    - ["bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
 sketch:
   files:
     - drwxr-xr-x var

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -60,20 +60,27 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	if verbose {
 		command = append(command, "-o", "xtrace")
 	}
+
+	uid := "0"
+	gid := "0"
 	if hook.HookType == SetupProject {
-		runAsUser := []string{
-			"sudo",
-			"--user=#" + workshop.User.Uid,
-			"--group=#" + workshop.User.Gid,
-			"--preserve-env",
-			"--",
-			"bash",
-			"-l",
-			"-c",
-			`exec -- "$0" "$@"`,
-		}
-		command = append(runAsUser, command...)
+		uid = workshop.User.Uid
+		gid = workshop.User.Gid
 	}
+
+	runAsUser := []string{
+		"sudo",
+		"--user=#" + uid,
+		"--group=#" + gid,
+		"--preserve-env",
+		"--",
+		"bash",
+		"-l",
+		"-c",
+		`exec -- "$0" "$@"`,
+	}
+	command = append(runAsUser, command...)
+
 	command = append(command, hookPath)
 
 	execArgs := &workshop.ExecArgs{

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -222,7 +222,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
@@ -257,7 +257,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"bash", "-o", "errexit", "-o", "pipefail", "-o", "xtrace", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "-o", "xtrace", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
@@ -298,7 +298,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
@@ -338,7 +338,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)


### PR DESCRIPTION
# Description

Workshop hooks should run uniformly as a login shell. That removes implicit issues that requires the knowledge of the internals, e.g. a second SDK being installed does not see the effect of the environment variables in its `setup-base` the first SDK added in `setup-base`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
