### PR TITLE
Workshop and SDK CLI redesign

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -103,6 +103,13 @@ type Config struct {
 
 	// UserAgent is the User-Agent header sent to the Workshop daemon.
 	UserAgent string
+
+	// RetryInterval is the time to wait between GET retries. Negative
+	// values disable retries.
+	RetryInterval time.Duration
+
+	// Timeout is the time to spend retrying the request.
+	Timeout time.Duration
 }
 
 // A Client knows how to talk to the Workshop daemon.
@@ -110,6 +117,9 @@ type Client struct {
 	baseURL   url.URL
 	doer      doer
 	userAgent string
+
+	retryInterval time.Duration
+	timeout       time.Duration
 
 	maintenance error
 
@@ -164,6 +174,17 @@ func New(config *Config) (*Client, error) {
 	client.userAgent = config.UserAgent
 	client.getWebsocket = func(url string) (clientWebsocket, error) {
 		return getWebsocket(transport, url)
+	}
+
+	if config.RetryInterval > 0 {
+		client.retryInterval = config.RetryInterval
+	} else if config.RetryInterval == 0 {
+		client.retryInterval = 250 * time.Millisecond
+	}
+	if config.Timeout > 0 {
+		client.timeout = config.Timeout
+	} else {
+		client.timeout = 5 * time.Second
 	}
 
 	return client, nil
@@ -261,24 +282,6 @@ func (client *Client) raw(ctx context.Context, method, urlpath string, query url
 	return rsp, nil
 }
 
-var (
-	doRetry   = 250 * time.Millisecond
-	doTimeout = 5 * time.Second
-)
-
-// FakeDoRetry fakes the delays used by the do retry loop (intended for
-// testing). Calling restore will revert the changes.
-func FakeDoRetry(retry, timeout time.Duration) (restore func()) {
-	oldRetry := doRetry
-	oldTimeout := doTimeout
-	doRetry = retry
-	doTimeout = timeout
-	return func() {
-		doRetry = oldRetry
-		doTimeout = oldTimeout
-	}
-}
-
 type hijacked struct {
 	do func(*http.Request) (*http.Response, error)
 }
@@ -296,18 +299,23 @@ func (client *Client) Hijack(f func(*http.Request) (*http.Response, error)) {
 // value. It's low-level, for testing/experimenting only; you should
 // usually use a higher level interface that builds on this.
 func (client *Client) do(method, path string, query url.Values, headers map[string]string, body io.Reader, v any) error {
-	retry := time.NewTicker(doRetry)
-	defer retry.Stop()
-	timeout := time.After(doTimeout)
+	var retry, timeout <-chan time.Time
+	if client.retryInterval > 0 {
+		ticker := time.NewTicker(client.retryInterval)
+		defer ticker.Stop()
+		retry = ticker.C
+		timeout = time.After(client.timeout)
+	}
+
 	var rsp *http.Response
 	var err error
 	for {
 		rsp, err = client.raw(context.Background(), method, path, query, headers, body)
-		if err == nil || method != "GET" {
+		if err == nil || method != "GET" || client.retryInterval <= 0 {
 			break
 		}
 		select {
-		case <-retry.C:
+		case <-retry:
 			continue
 		case <-timeout:
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -47,14 +47,16 @@ type clientSuite struct {
 	status     int
 	tmpDir     string
 	socketPath string
-	restore    func()
 }
 
 var _ = Suite(&clientSuite{})
 
 func (cs *clientSuite) SetUpTest(c *C) {
 	var err error
-	cs.cli, err = client.New(nil)
+	cs.cli, err = client.New(&client.Config{
+		RetryInterval: time.Millisecond,
+		Timeout:       10 * time.Millisecond,
+	})
 	c.Assert(err, IsNil)
 	cs.cli.SetDoer(cs)
 	cs.err = nil
@@ -69,12 +71,6 @@ func (cs *clientSuite) SetUpTest(c *C) {
 
 	cs.tmpDir = c.MkDir()
 	cs.socketPath = filepath.Join(cs.tmpDir, "workshop.socket")
-
-	cs.restore = client.FakeDoRetry(time.Millisecond, 10*time.Millisecond)
-}
-
-func (cs *clientSuite) TearDownTest(c *C) {
-	cs.restore()
 }
 
 func (cs *clientSuite) Do(req *http.Request) (*http.Response, error) {

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -90,10 +90,6 @@ func (cs *execSuite) Do(req *http.Request) (*http.Response, error) {
 	return cs.clientSuite.Do(req)
 }
 
-func (s *execSuite) TearDownTest(c *C) {
-	s.clientSuite.TearDownTest(c)
-}
-
 func (s *execSuite) TestExitZero(c *C) {
 	opts := &client.ExecOptions{
 		Command: []string{"true"},

--- a/cmd/internal/cmdutil/completion.go
+++ b/cmd/internal/cmdutil/completion.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmdutil
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func CompleteChoices(choices ...string) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return choices, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/cmd/internal/cmdutil"
 	"github.com/canonical/workshop/internal/arch"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 type CmdInfo struct {
@@ -47,6 +48,10 @@ Notes:
 		`Show SDKs compatible with a specific base.`)
 	cmd.PersistentFlags().StringVar(&c.Arch, "arch", "",
 		`Show SDKs compatible with a different architecture (or "all").`)
+
+	_ = cmd.RegisterFlagCompletionFunc("base", cmdutil.CompleteChoices(workshop.SupportedBases...))
+	arches := append([]string{"all"}, arch.AllowedArchitectures...)
+	_ = cmd.RegisterFlagCompletionFunc("arch", cmdutil.CompleteChoices(arches...))
 
 	return cmd
 }

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -147,14 +147,8 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 		fmt.Fprintf(w, "%s%s%s\n", esc.Bold, "INSTALLED", esc.End)
 		fmt.Fprintf(w, tpl, "PROJECT", "WORKSHOP", "CHANNEL", "VERSION", "BASE", "ARCH", maxRev, "REV")
 	}
-	var prev *client.SdkInstalled
 	for _, it := range installed {
-		var project string
-		if prev == nil || prev.ProjectPath != it.ProjectPath {
-			project = cmdutil.ContractHome(it.ProjectPath)
-		}
-		prev = &it
-
+		project := cmdutil.ContractHome(it.ProjectPath)
 		channel := cmdutil.EmptyDash(it.Channel)
 		base := it.Base
 		if base == "" {

--- a/cmd/sdk/info_test.go
+++ b/cmd/sdk/info_test.go
@@ -207,7 +207,7 @@ INSTALLED
   %-*s  dev       latest/edge    2.0          all           all     82
   %-*s  ci        latest/stable  2.1-084c8c8  ubuntu@20.04  amd64   85
   %-*s  dev       latest/stable  2.1-084c8c8  ubuntu@20.04  amd64   85
-`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, "")
+`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, nav)
 
 	c.Check(s.Stdout(), check.Equals, want)
 	s.ResetStdStreams()
@@ -236,7 +236,7 @@ INSTALLED
   %-*s  dev       latest/edge    2.0          all            82
   %-*s  ci        latest/stable  2.1-084c8c8  ubuntu@20.04   85
   %-*s  dev       latest/stable  2.1-084c8c8  ubuntu@20.04   85
-`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, "")
+`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, nav)
 
 	c.Check(s.Stdout(), check.Equals, want)
 	s.ResetStdStreams()
@@ -321,7 +321,7 @@ INSTALLED
   %-*s  dev       latest/edge    2.0           82
   %-*s  ci        latest/stable  2.1-084c8c8   85
   %-*s  dev       latest/stable  2.1-084c8c8   85
-`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, "")
+`, maxProject, "PROJECT", maxProject, lerobot, maxProject, nav, maxProject, nav)
 
 	c.Check(s.Stdout(), check.Equals, want)
 	s.ResetStdStreams()

--- a/cmd/sdk/list.go
+++ b/cmd/sdk/list.go
@@ -59,22 +59,21 @@ func (c *CmdList) Run(cmd *cobra.Command, _ []string) error {
 	})
 
 	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
-	maxSize := 0
+	maxRev := len("REV")
+	maxSize := len("SIZE")
 	for _, sdk := range sdks {
-		szl := len(units.GetByteSizeString(int64(sdk.Size), 2))
-		if szl > maxSize {
-			maxSize = szl
-		}
+		maxRev = max(maxRev, len(sdk.Revision))
+		maxSize = max(maxSize, len(units.GetByteSizeString(sdk.Size, 2)))
 	}
-
-	fmt.Fprintf(w, "Name\tVersion\tRev\t%*s\n", maxSize, "Size")
+	fmt.Fprintf(w, "NAME\tVERSION\t%*s\t%*s\n", maxRev, "REV", maxSize, "SIZE")
 	for _, sdk := range sdks {
 		version := sdk.Version
 		if version == "" {
 			version = "-"
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%*s\n", sdk.Name, version, sdk.Revision, maxSize, units.GetByteSizeString(int64(sdk.Size), 2))
+		size := units.GetByteSizeString(sdk.Size, 2)
+		fmt.Fprintf(w, "%s\t%s\t%*s\t%*s\n", sdk.Name, version, maxRev, sdk.Revision, maxSize, size)
 	}
 
 	return w.Flush()

--- a/cmd/sdk/list.go
+++ b/cmd/sdk/list.go
@@ -13,7 +13,8 @@ import (
 )
 
 type CmdList struct {
-	root *CmdRoot
+	root      *CmdRoot
+	noHeaders bool
 }
 
 func (c *CmdList) Command() *cobra.Command {
@@ -35,6 +36,8 @@ Notes:
 		Args: cobra.NoArgs,
 		RunE: c.Run,
 	}
+
+	cmd.PersistentFlags().BoolVar(&c.noHeaders, "no-headers", false, "Hide table headers.")
 
 	return cmd
 }
@@ -59,13 +62,18 @@ func (c *CmdList) Run(cmd *cobra.Command, _ []string) error {
 	})
 
 	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
-	maxRev := len("REV")
-	maxSize := len("SIZE")
+	var maxRev, maxSize int
+	if !c.noHeaders {
+		maxRev = len("REV")
+		maxSize = len("SIZE")
+	}
 	for _, sdk := range sdks {
 		maxRev = max(maxRev, len(sdk.Revision))
 		maxSize = max(maxSize, len(units.GetByteSizeString(sdk.Size, 2)))
 	}
-	fmt.Fprintf(w, "NAME\tVERSION\t%*s\t%*s\n", maxRev, "REV", maxSize, "SIZE")
+	if !c.noHeaders {
+		fmt.Fprintf(w, "NAME\tVERSION\t%*s\t%*s\n", maxRev, "REV", maxSize, "SIZE")
+	}
 	for _, sdk := range sdks {
 		version := sdk.Version
 		if version == "" {

--- a/cmd/sdk/list.go
+++ b/cmd/sdk/list.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/cmd/internal/cmdutil"
+	"github.com/canonical/workshop/internal/sdk"
 )
 
 type CmdList struct {
@@ -58,7 +60,17 @@ func (c *CmdList) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	slices.SortFunc(sdks, func(a, b client.SdkVolume) int {
-		return cmp.Compare(a.Name, b.Name)
+		if a.Name != b.Name {
+			return cmp.Compare(a.Name, b.Name)
+		}
+		rev1, err1 := sdk.ParseRevision(a.Revision)
+		rev2, err2 := sdk.ParseRevision(b.Revision)
+		if err1 == nil && err2 == nil {
+			// Newest first.
+			return cmp.Compare(rev2.N, rev1.N)
+		}
+		// Should be unreachable.
+		return cmp.Compare(b.Revision, a.Revision)
 	})
 
 	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
@@ -75,11 +87,7 @@ func (c *CmdList) Run(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintf(w, "NAME\tVERSION\t%*s\t%*s\n", maxRev, "REV", maxSize, "SIZE")
 	}
 	for _, sdk := range sdks {
-		version := sdk.Version
-		if version == "" {
-			version = "-"
-		}
-
+		version := cmdutil.EmptyDash(sdk.Version)
 		size := units.GetByteSizeString(sdk.Size, 2)
 		fmt.Fprintf(w, "%s\t%s\t%*s\t%*s\n", sdk.Name, version, maxRev, sdk.Revision, maxSize, size)
 	}

--- a/cmd/sdk/list_test.go
+++ b/cmd/sdk/list_test.go
@@ -74,8 +74,8 @@ func (s *sdkSuite) TestList(c *check.C) {
 	cmd.SetArgs([]string{"list"})
 	c.Assert(cmd.Execute(), check.IsNil)
 
-	c.Check(s.Stdout(), check.Equals, `Name    Version  Rev    Size
-ollama  1.0-053  82       0B
-ros2    -        5    1.05MB
+	c.Check(s.Stdout(), check.Equals, `NAME    VERSION  REV    SIZE
+ollama  1.0-053   82      0B
+ros2    -          5  1.05MB
 `)
 }

--- a/cmd/sdk/list_test.go
+++ b/cmd/sdk/list_test.go
@@ -78,4 +78,14 @@ func (s *sdkSuite) TestList(c *check.C) {
 ollama  1.0-053   82      0B
 ros2    -          5  1.05MB
 `)
+	s.ResetStdStreams()
+
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"list", "--no-headers"})
+	c.Assert(cmd.Execute(), check.IsNil)
+
+	c.Check(s.Stdout(), check.Equals, `ollama  1.0-053  82      0B
+ros2    -         5  1.05MB
+`)
+	s.ResetStdStreams()
 }

--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -11,7 +11,8 @@ import (
 )
 
 type CmdChanges struct {
-	root *CmdRoot
+	root      *CmdRoot
+	noHeaders bool
 }
 
 func (c *CmdChanges) Command() *cobra.Command {
@@ -51,6 +52,8 @@ $ workshop changes`,
 		RunE: c.Run,
 	}
 
+	cmd.PersistentFlags().BoolVar(&c.noHeaders, "no-headers", false, "Hide table headers.")
+
 	return cmd
 }
 
@@ -70,7 +73,9 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	w := tabWriter()
-	fmt.Fprintf(w, "ID\tSTATUS\tSPAWN\tREADY\tSUMMARY\n")
+	if !c.noHeaders {
+		fmt.Fprintf(w, "ID\tSTATUS\tSPAWN\tREADY\tSUMMARY\n")
+	}
 	for _, chg := range chngs {
 		spawnTime := timeutil.Human(chg.SpawnTime)
 		readyTime := timeutil.Human(chg.ReadyTime)

--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -65,26 +65,27 @@ func (c *CmdChanges) Run(cmd *cobra.Command, av []string) error {
 		return err
 	}
 
-	if len(chngs) > 0 {
-		w := tabWriter()
-		fmt.Fprintf(w, "ID\tStatus\tSpawn\tReady\tSummary\n")
-
-		for _, chg := range chngs {
-			spawnTime := timeutil.Human(chg.SpawnTime)
-			readyTime := timeutil.Human(chg.ReadyTime)
-			if chg.ReadyTime.IsZero() {
-				readyTime = "-"
-			}
-
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-				chg.ID,
-				chg.Status,
-				spawnTime,
-				readyTime,
-				chg.Summary)
-		}
-		w.Flush()
+	if len(chngs) == 0 {
+		return nil
 	}
+
+	w := tabWriter()
+	fmt.Fprintf(w, "ID\tSTATUS\tSPAWN\tREADY\tSUMMARY\n")
+	for _, chg := range chngs {
+		spawnTime := timeutil.Human(chg.SpawnTime)
+		readyTime := timeutil.Human(chg.ReadyTime)
+		if chg.ReadyTime.IsZero() {
+			readyTime = "-"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			chg.ID,
+			chg.Status,
+			spawnTime,
+			readyTime,
+			chg.Summary)
+	}
+	w.Flush()
 
 	return nil
 }

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -139,19 +139,19 @@ func (c *CmdConnect) complete(cmd *cobra.Command, args []string, toComplete stri
 	cli, err := c.root.client()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// Create map of endpoint string and associated plugs

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -136,7 +136,7 @@ func (c *CmdConnect) Run(cmd *cobra.Command, av []string) error {
 }
 
 func (c *CmdConnect) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	cli, err := c.root.client()
+	cli, err := c.root.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -15,8 +15,9 @@ import (
 )
 
 type CmdConnections struct {
-	root *CmdRoot
-	all  bool
+	root      *CmdRoot
+	all       bool
+	noHeaders bool
 }
 
 func (c *CmdConnections) Command() *cobra.Command {
@@ -49,6 +50,7 @@ $ workshop connections`,
 	}
 
 	cmd.Flags().BoolVar(&c.all, "all", false, "Include disconnected plugs in the output.")
+	cmd.Flags().BoolVar(&c.noHeaders, "no-headers", false, "Hide table headers.")
 
 	return cmd
 }
@@ -202,7 +204,9 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 	sort.Sort(byConnectionData(annotatedConns))
 
 	w := tabWriter()
-	fmt.Fprintln(w, i18n.G("INTERFACE\tPLUG\tSLOT\tNOTES"))
+	if !c.noHeaders {
+		fmt.Fprintln(w, i18n.G("INTERFACE\tPLUG\tSLOT\tNOTES"))
+	}
 	for _, note := range annotatedConns {
 		// find the plug that the current connection is bound to
 		idx := slices.IndexFunc(annotatedConns, func(c connection) bool { return c.plug != "" && note.bind != "" && c.plug == note.bind })

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -169,9 +169,6 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 		})
 	}
 
-	w := tabWriter()
-	fmt.Fprintln(w, i18n.G("Interface\tPlug\tSlot\tNotes"))
-
 	for _, plug := range connections.Plugs {
 		if len(plug.Connections) == 0 && c.all {
 			var bind = maybeBound(plug.Ref(), connections.Plugs)
@@ -198,18 +195,21 @@ func (c *CmdConnections) Run(cmd *cobra.Command, av []string) error {
 		}
 	}
 
+	if len(annotatedConns) == 0 {
+		return nil
+	}
+
 	sort.Sort(byConnectionData(annotatedConns))
 
+	w := tabWriter()
+	fmt.Fprintln(w, i18n.G("INTERFACE\tPLUG\tSLOT\tNOTES"))
 	for _, note := range annotatedConns {
 		// find the plug that the current connection is bound to
 		idx := slices.IndexFunc(annotatedConns, func(c connection) bool { return c.plug != "" && note.bind != "" && c.plug == note.bind })
 		note.bindIdx = idx + 1
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", note.interfaceName, note.plug, note.slot, note)
 	}
-
-	if len(annotatedConns) > 0 {
-		w.Flush()
-	}
+	w.Flush()
 
 	return nil
 }

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -198,12 +198,12 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1, 3:
+		case 1, 3, 5:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, s.prjId, s.prjDir)
 			fmt.Fprintln(w, r)
-		case 2, 4:
+		case 2, 4, 6:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v1/connections")
 			c.Check(r.URL.Query(), check.DeepEquals, query)
@@ -216,9 +216,10 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *check.C) {
 			})
 		}
 	})
-	cmd := &CmdConnections{root: &CmdRoot{}}
-	err := cmd.Run(cmd.Command(), []string{"foo"})
-	c.Check(err, check.IsNil)
+	cmd := (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"connections", "foo"})
+	err := cmd.Execute()
+	c.Assert(err, check.IsNil)
 	c.Assert(s.Stdout(), check.Equals, "")
 	c.Assert(s.Stderr(), check.Equals, "")
 
@@ -235,13 +236,25 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *check.C) {
 			},
 		},
 	}
-	err = cmd.Run(cmd.Command(), []string{"foo"})
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"connections", "foo"})
+	err = cmd.Execute()
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
 		"INTERFACE  PLUG  SLOT                                 NOTES\n" +
 		"leds       -     leds-provider/provider:capslock-led  -\n"
 	c.Assert(s.Stdout(), check.Equals, expectedStdout)
 	c.Assert(s.Stderr(), check.Equals, "")
+	s.ResetStdStreams()
+
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"connections", "--no-headers", "foo"})
+	err = cmd.Execute()
+	c.Assert(err, check.IsNil)
+	expectedStdout = "leds  -   leds-provider/provider:capslock-led  -\n"
+	c.Assert(s.Stdout(), check.Equals, expectedStdout)
+	c.Assert(s.Stderr(), check.Equals, "")
+	s.ResetStdStreams()
 }
 
 func (s *connectionsSuite) TestConnectionsSomeConnected(c *check.C) {

--- a/cmd/workshop/connections_test.go
+++ b/cmd/workshop/connections_test.go
@@ -169,7 +169,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *check.C) {
 	err := cmd.Run(command, []string{})
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
-		"Interface  Plug                                 Slot  Notes\n" +
+		"INTERFACE  PLUG                                 SLOT  NOTES\n" +
 		"leds       keyboard-lights/lights:capslock-led  -     -\n"
 	c.Assert(s.Stdout(), check.Equals, expectedStdout)
 	c.Assert(s.Stderr(), check.Equals, "")
@@ -185,7 +185,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedPlugs(c *check.C) {
 	err = cmd.Run(cmd.Command(), []string{"keyboard-lights"})
 	c.Assert(err, check.IsNil)
 	expectedStdout = "" +
-		"Interface  Plug                                 Slot  Notes\n" +
+		"INTERFACE  PLUG                                 SLOT  NOTES\n" +
 		"leds       keyboard-lights/lights:capslock-led  -     -\n"
 	c.Assert(s.Stdout(), check.Equals, expectedStdout)
 	c.Assert(s.Stderr(), check.Equals, "")
@@ -238,7 +238,7 @@ func (s *connectionsSuite) TestConnectionsNoneConnectedSlots(c *check.C) {
 	err = cmd.Run(cmd.Command(), []string{"foo"})
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
-		"Interface  Plug  Slot                                 Notes\n" +
+		"INTERFACE  PLUG  SLOT                                 NOTES\n" +
 		"leds       -     leds-provider/provider:capslock-led  -\n"
 	c.Assert(s.Stdout(), check.Equals, expectedStdout)
 	c.Assert(s.Stderr(), check.Equals, "")
@@ -368,7 +368,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnected(c *check.C) {
 	err := cmd.Run(cmd.Command(), []string{})
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
-		"Interface  Plug                              Slot                                  Notes\n" +
+		"INTERFACE  PLUG                              SLOT                                  NOTES\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led   -\n" +
 		"leds       keyboard-lights/lights:numlock    keyboard-lights/system:numlock-led    manual\n" +
 		"leds       keyboard-lights/lights:scrollock  keyboard-lights/system:scrollock-led  -\n"
@@ -507,7 +507,7 @@ func (s *connectionsSuite) TestConnectionsSomeConnectedBound(c *check.C) {
 	err := cmd.Run(cmd.Command(), []string{})
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
-		"Interface  Plug                              Slot                                  Notes\n" +
+		"INTERFACE  PLUG                              SLOT                                  NOTES\n" +
 		"leds       keyboard-lights/lights:capslock   leds-provider/provider:capslock-led   -\n" +
 		"leds       keyboard-lights/lights:numlock    keyboard-lights/system:numlock-led    manual,bind.3\n" +
 		"leds       keyboard-lights/lights:scrollock  keyboard-lights/system:scrollock-led  manual,bind.3\n"
@@ -645,7 +645,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnected(c *check.C) {
 	err := cmd.Run(cmdAll, []string{})
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
-		"Interface  Plug                              Slot                                          Notes\n" +
+		"INTERFACE  PLUG                              SLOT                                          NOTES\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
 		"leds       -                                 keyboard-lights/system:numlock-led            -\n" +
 		"leds       -                                 leds-provider/system:capslock-led             -\n" +
@@ -776,7 +776,7 @@ func (s *connectionsSuite) TestConnectionsSomeDisconnectedBound(c *check.C) {
 	err := cmd.Run(cmdAll, []string{})
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
-		"Interface  Plug                              Slot                                          Notes\n" +
+		"INTERFACE  PLUG                              SLOT                                          NOTES\n" +
 		"leds       -                                 keyboard-lights/numlock-provider:numlock-led  -\n" +
 		"leds       -                                 keyboard-lights/system:numlock-led            -\n" +
 		"leds       -                                 keyboard-lights/system:scrollock-led          -\n" +
@@ -845,7 +845,7 @@ func (s *connectionsSuite) TestConnectionsOnlyDisconnected(c *check.C) {
 	err := cmd.Run(cmd.Command(), []string{"leds-provider"})
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
-		"Interface  Plug  Slot                                        Notes\n" +
+		"INTERFACE  PLUG  SLOT                                        NOTES\n" +
 		"leds       -     leds-provider/numlock-provider:numlock-led  -\n" +
 		"leds       -     leds-provider/provider:capslock-led         -\n"
 	c.Assert(s.Stdout(), check.Equals, expectedStdout)
@@ -1124,7 +1124,7 @@ func (s *connectionsSuite) TestConnectionsSorting(c *check.C) {
 	err := cmd.Run(cmdAll, []string{})
 	c.Assert(err, check.IsNil)
 	expectedStdout := "" +
-		"Interface  Plug                         Slot                           Notes\n" +
+		"INTERFACE  PLUG                         SLOT                           NOTES\n" +
 		"desktop    abc/foo:desktop-plug         abc/system:desktop             -\n" +
 		"leds       -                            abc/leds-provider:numlock-led  -\n" +
 		"leds       abc/keyboard-lights:numlock  -                              -\n" +

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -119,7 +119,7 @@ func (c *CmdDisconnect) Run(cmd *cobra.Command, av []string) error {
 }
 
 func (c *CmdDisconnect) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	cli, err := c.root.client()
+	cli, err := c.root.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -122,19 +122,19 @@ func (c *CmdDisconnect) complete(cmd *cobra.Command, args []string, toComplete s
 	cli, err := c.root.client()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, All: true})
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// Create map of endpoint strings and associated plugs

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -194,7 +194,7 @@ and the shell is interactive,
 the separator is also optional:
 $ workshop exec sh`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Waiting"}),
+		ValidArgsFunction: c.complete,
 	}
 
 	cmd.Flags().SortFlags = false
@@ -202,6 +202,14 @@ $ workshop exec sh`,
 	commonVars(cmd.Flags(), &c.flags)
 
 	return cmd
+}
+
+func (c *CmdExec) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+
+	return c.root.doCompleteWorkshopNames(args, []string{"Ready", "Waiting"})
 }
 
 func (c *CmdExec) Run(cmd *cobra.Command, av []string) error {
@@ -310,19 +318,19 @@ func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([
 	// must be an argument to the action. The case len(args.av) == 1 and
 	// args.argsLenAtDash < 0 is ambiguous, we check later on.
 	if len(args.av) > 1 || (args.argsLenAtDash == 0 && len(args.av) > 0) {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return nil, cobra.ShellCompDirectiveDefault
 	}
 
 	cli, err := c.root.client()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// Argument after a separator must be an action.
@@ -336,7 +344,7 @@ func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([
 		// the workshop name, it must be an action and we don't know
 		// how to complete the second argument.
 		if err == nil && args.av[0] != workshop {
-			return nil, cobra.ShellCompDirectiveNoFileComp
+			return nil, cobra.ShellCompDirectiveDefault
 		}
 		// Otherwise the second argument is an action.
 		return completeActions(cli, project, args.av)
@@ -348,9 +356,6 @@ func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([
 
 	// With a single workshop, complete actions first.
 	actions, directive := completeActions(cli, project, []string{workshop})
-	if directive == cobra.ShellCompDirectiveError {
-		return actions, directive
-	}
 	// If no actions match, but the workshop name does, complete it instead.
 	partialMatch := func(name string) bool { return strings.HasPrefix(name, toComplete) }
 	if !slices.ContainsFunc(actions, partialMatch) && strings.HasPrefix(workshop, toComplete) {
@@ -363,7 +368,7 @@ func completeActions(cli *client.Client, p *client.Project, args []string) ([]st
 	actions, err := listActions(cli, p, args)
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	names := make([]string, 0, len(actions))
 	for name := range actions {

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -321,7 +321,7 @@ func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 
-	cli, err := c.root.client()
+	cli, err := c.root.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -273,7 +273,7 @@ func (m *workshopExec) TestSingleWorkshopRunCompletion(c *check.C) {
 
 	os.Args = []string{"workshop", "__complete", "run", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"foo"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveDefault)
 	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", ""}
@@ -283,7 +283,7 @@ func (m *workshopExec) TestSingleWorkshopRunCompletion(c *check.C) {
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "foo"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveDefault)
 	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "--", ""}
@@ -293,7 +293,7 @@ func (m *workshopExec) TestSingleWorkshopRunCompletion(c *check.C) {
 
 	os.Args = []string{"workshop", "__complete", "run", "--", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"foo"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveDefault)
 	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", "--", ""}
@@ -303,7 +303,7 @@ func (m *workshopExec) TestSingleWorkshopRunCompletion(c *check.C) {
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", "--", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "--", "foo"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveDefault)
 	c.Check(result, check.HasLen, 0)
 }
 
@@ -346,7 +346,7 @@ func (m *workshopExec) TestMultipleWorkshopRunCompletion(c *check.C) {
 
 	os.Args = []string{"workshop", "__complete", "run", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"foo"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveError)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", ""}
@@ -356,17 +356,17 @@ func (m *workshopExec) TestMultipleWorkshopRunCompletion(c *check.C) {
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "foo"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveDefault)
 	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "--", ""}
 	result, compDirective = run.ValidArgsFunction(run, nil, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveError)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
 	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "--", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"foo"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveDefault)
 	c.Check(result, check.HasLen, 0)
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", "--", ""}
@@ -376,6 +376,6 @@ func (m *workshopExec) TestMultipleWorkshopRunCompletion(c *check.C) {
 
 	os.Args = []string{"workshop", "__complete", "run", "ws", "--", "foo", ""}
 	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "--", "foo"}, "")
-	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveDefault)
 	c.Check(result, check.HasLen, 0)
 }

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -78,7 +78,7 @@ func (m *workshopExec) TestWorkshopActions(c *check.C) {
 	err := cmd.Run(cmd.Command(), nil)
 	c.Assert(err, check.IsNil)
 	c.Check(m.stdout.String(), check.Equals, "")
-	m.stdout.Reset()
+	m.ResetStdStreams()
 	c.Check(n, check.Equals, 3)
 
 	err = cmd.Run(cmd.Command(), []string{"ws"})

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -153,78 +153,77 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 
 	if len(workshop.Sdks) > 0 {
 		fmt.Fprintf(w, "sdks:\n")
-		for _, sk := range workshop.Sdks {
-			fmt.Fprintf(w, "  %s:\n", sk.Name)
+	}
+	for _, sk := range workshop.Sdks {
+		fmt.Fprintf(w, "  %s:\n", sk.Name)
 
-			tracking := sk.Channel
-			revision, err := sdk.ParseRevision(sk.Revision)
-			if err == nil && revision.Local() {
-				tracking = cmdutil.ContractHome(sk.Source)
-				if sk.BuiltAt.IsZero() {
-					sk.BuiltAt = sk.InstalledAt
-				}
+		tracking := sk.Channel
+		revision, err := sdk.ParseRevision(sk.Revision)
+		if err == nil && revision.Local() {
+			tracking = cmdutil.ContractHome(sk.Source)
+			if sk.BuiltAt.IsZero() {
+				sk.BuiltAt = sk.InstalledAt
 			}
+		}
 
-			// Tracking info is always the same for the system SDK. Omit it to
-			// highlight the difference between it and a regular type SDK.
-			if !sdk.IsSystem(sk.Name) {
-				fmt.Fprintf(w, "    tracking:\t%s\n", escape(tracking))
-			}
+		// Tracking info is always the same for the system SDK. Omit it to
+		// highlight the difference between it and a regular type SDK.
+		if !sdk.IsSystem(sk.Name) {
+			fmt.Fprintf(w, "    tracking:\t%s\n", escape(tracking))
+		}
 
-			var builtAt string
-			if !sk.BuiltAt.IsZero() {
-				builtAt = "\t" + sk.BuiltAt.Format(time.DateOnly)
-			}
-			var version string
-			if sk.Version != "" {
-				version = "\t" + sk.Version
-			}
-			fmt.Fprintf(w, "    installed:%s%s\t(%s)\n", version, builtAt, sk.Revision)
-			if sk.Health != nil {
-				fmt.Fprintf(w, "    message:\t%s\n", escape(sk.Health.Message))
-			}
+		var builtAt string
+		if !sk.BuiltAt.IsZero() {
+			builtAt = "\t" + sk.BuiltAt.Format(time.DateOnly)
+		}
+		var version string
+		if sk.Version != "" {
+			version = "\t" + sk.Version
+		}
+		fmt.Fprintf(w, "    installed:%s%s\t(%s)\n", version, builtAt, sk.Revision)
+		if sk.Health != nil {
+			fmt.Fprintf(w, "    message:\t%s\n", escape(sk.Health.Message))
+		}
 
-			if len(sk.Mounts) > 0 {
-				fmt.Fprintf(w, "    mounts:\n")
-				slices.SortFunc(sk.Mounts, func(a, b *client.Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
-				for _, mount := range sk.Mounts {
-					hostSource := string(escape(cmdutil.ContractHome(mount.HostSource)))
-					shortened := shortenDefaultPath(mount.HostSource, xdg, esc)
-					if shortened != mount.HostSource {
-						link := &url.URL{Scheme: "file", Host: hostname, Path: mount.HostSource}
-						hostSource = esc.MakeLink(shortened, link, hostSource)
-					}
-					if mount.HostSource != "" {
-						fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
-						fmt.Fprintf(w, "        host-source:\t%s\n", hostSource)
-						fmt.Fprintf(w, "        workshop-target:\t%s\n", escape(mount.WorkshopTarget))
-						continue
-					}
-					if mount.WorkshopSource != "" {
-						fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
-						fmt.Fprintf(w, "        workshop-source:\t%s\n", escape(mount.WorkshopSource))
-						fmt.Fprintf(w, "        workshop-target:\t%s\n", escape(mount.WorkshopTarget))
-						continue
-					}
-				}
+		if len(sk.Mounts) > 0 {
+			fmt.Fprintf(w, "    mounts:\n")
+		}
+		slices.SortFunc(sk.Mounts, func(a, b *client.Mount) int { return cmp.Compare(a.Plug.Name, b.Plug.Name) })
+		for _, mount := range sk.Mounts {
+			hostSource := string(escape(cmdutil.ContractHome(mount.HostSource)))
+			shortened := shortenDefaultPath(mount.HostSource, xdg, esc)
+			if shortened != mount.HostSource {
+				link := &url.URL{Scheme: "file", Host: hostname, Path: mount.HostSource}
+				hostSource = esc.MakeLink(shortened, link, hostSource)
 			}
+			if mount.HostSource != "" {
+				fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
+				fmt.Fprintf(w, "        host-source:\t%s\n", hostSource)
+				fmt.Fprintf(w, "        workshop-target:\t%s\n", escape(mount.WorkshopTarget))
+				continue
+			}
+			if mount.WorkshopSource != "" {
+				fmt.Fprintf(w, "      %s:\n", mount.Plug.Name)
+				fmt.Fprintf(w, "        workshop-source:\t%s\n", escape(mount.WorkshopSource))
+				fmt.Fprintf(w, "        workshop-target:\t%s\n", escape(mount.WorkshopTarget))
+				continue
+			}
+		}
 
-			if len(sk.Tunnels) > 0 {
-				fmt.Fprintf(w, "    tunnels:\n")
-				slices.SortFunc(sk.Tunnels, func(a, b *client.Tunnel) int {
-					return cmp.Compare(a.Plug.Name, b.Plug.Name)
-				})
-				for _, tunnel := range sk.Tunnels {
-					fmt.Fprintf(w, "      %s:\n", tunnel.Plug.Name)
-					fmt.Fprintf(w, "        from:\t%s\n", escape(formatEndpoint(tunnel.From)))
-					fmt.Fprintf(w, "        to:\t%s\n", escape(formatEndpoint(tunnel.To)))
-				}
-			}
+		if len(sk.Tunnels) > 0 {
+			fmt.Fprintf(w, "    tunnels:\n")
+		}
+		slices.SortFunc(sk.Tunnels, func(a, b *client.Tunnel) int {
+			return cmp.Compare(a.Plug.Name, b.Plug.Name)
+		})
+		for _, tunnel := range sk.Tunnels {
+			fmt.Fprintf(w, "      %s:\n", tunnel.Plug.Name)
+			fmt.Fprintf(w, "        from:\t%s\n", escape(formatEndpoint(tunnel.From)))
+			fmt.Fprintf(w, "        to:\t%s\n", escape(formatEndpoint(tunnel.To)))
 		}
 	}
 
 	w.Flush()
-
 	return nil
 }
 

--- a/cmd/workshop/info_test.go
+++ b/cmd/workshop/info_test.go
@@ -275,7 +275,7 @@ func (m *workshopInfo) TestWorkshopInfoWithSdkMountsXdgSet(c *check.C) {
 
 	cmd.Color = "always"
 	cmd.Unicode = "always"
-	m.stdout.Reset()
+	m.ResetStdStreams()
 
 	err = cmd.Run(cmd.Command(), []string{workshop})
 	c.Assert(err, check.IsNil)

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -147,19 +147,19 @@ func (c *CmdLaunch) complete(cmd *cobra.Command, args []string, toComplete strin
 	cli, err := c.root.client()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	instances, files, err := cli.List(&client.ListOptions{ProjectId: project.Id})
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var workshops []string

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -144,7 +144,7 @@ To view more information: "workshop tasks %s"`, w, w, w, changeId)
 }
 
 func (c *CmdLaunch) complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	cli, err := c.root.client()
+	cli, err := c.root.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -12,7 +12,6 @@ import (
 
 type workshopLaunch struct {
 	BaseWorkshopSuite
-	client *client.Client
 	prjDir string
 	prjId  string
 }
@@ -23,7 +22,6 @@ func (m *workshopLaunch) SetUpTest(c *check.C) {
 	m.prjDir = c.MkDir()
 	m.prjId = "42424242"
 	m.BaseWorkshopSuite.SetUpTest(c)
-	m.client = &client.Client{}
 }
 
 func (m *workshopLaunch) TestLaunchSuccess(c *check.C) {

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -15,8 +15,9 @@ import (
 )
 
 type CmdList struct {
-	root   *CmdRoot
-	global bool
+	root      *CmdRoot
+	global    bool
+	noHeaders bool
 }
 
 func (c *CmdList) Command() *cobra.Command {
@@ -54,6 +55,7 @@ $ workshop list --global`,
 	}
 
 	cmd.Flags().BoolVar(&c.global, "global", false, "List workshops from all projects in the system.")
+	cmd.Flags().BoolVar(&c.noHeaders, "no-headers", false, "Hide table headers.")
 
 	return cmd
 }
@@ -75,7 +77,9 @@ func (c *CmdList) runList() error {
 	w := tabWriter()
 	var header sync.Once
 	printHeader := func() {
-		fmt.Fprintf(w, "PROJECT\tWORKSHOP\tSTATUS\tNOTES\n")
+		if !c.noHeaders {
+			fmt.Fprintf(w, "PROJECT\tWORKSHOP\tSTATUS\tNOTES\n")
+		}
 	}
 
 	if !c.global {

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -69,62 +68,91 @@ func (c *CmdList) Run(cmd *cobra.Command, _ []string) error {
 }
 
 func (c *CmdList) runList() error {
+	if c.global {
+		return c.listGlobal()
+	}
+	return c.listProject()
+}
+
+func (c *CmdList) listProject() error {
 	cli, err := c.root.client()
 	if err != nil {
 		return err
 	}
 
+	project, err := cli.Project(c.root.project())
+	if err != nil {
+		return err
+	}
+
+	workshops, files, err := cli.List(&client.ListOptions{ProjectId: project.Id})
+	if err != nil {
+		return err
+	}
+
+	merged := sortWorkshops(workshops, files)
+	if len(merged) == 0 {
+		return nil
+	}
+
 	w := tabWriter()
-	var header sync.Once
-	printHeader := func() {
-		if !c.noHeaders {
-			fmt.Fprintf(w, "PROJECT\tWORKSHOP\tSTATUS\tNOTES\n")
-		}
+	if !c.noHeaders {
+		fmt.Fprintf(w, "WORKSHOP\tSTATUS\tNOTES\n")
 	}
-
-	if !c.global {
-		project, err := cli.Project(c.root.project())
-		if err != nil {
-			return err
-		}
-
-		workshops, files, err := cli.List(&client.ListOptions{ProjectId: project.Id})
-		if err != nil {
-			return err
-		}
-
-		/* List all workshops for the current project */
-		if len(workshops) != 0 || len(files) != 0 {
-			header.Do(printHeader)
-			print(w, workshops, files, *project)
-		}
-	} else {
-		projects, err := cli.Projects()
-		if err != nil {
-			return err
-		}
-
-		for _, p := range projects {
-			workshops, _, err := cli.List(&client.ListOptions{ProjectId: p.Id})
-			if err != nil {
-				return err
-			}
-			if len(workshops) == 0 {
-				continue
-			}
-			header.Do(printHeader)
-			// --global flag does not list files for consistency. We may not be
-			// aware of all the project directories on the system and, thus,
-			// will not know all the available "Off" workshops (contrary to the
-			// workshops that are in any known state, i.e. running instances,
-			// which we always know about from the workshop backend).
-			print(w, workshops, nil, p)
-		}
+	for _, wp := range merged {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", wp.name, wp.status, wp.notes)
 	}
-
 	w.Flush()
 
 	return nil
+}
+
+func (c *CmdList) listGlobal() error {
+	cli, err := c.root.client()
+	if err != nil {
+		return err
+	}
+
+	projects, err := cli.Projects()
+	if err != nil {
+		return err
+	}
+
+	w := tabWriter()
+	printHeaders := !c.noHeaders
+	for _, p := range projects {
+		workshops, _, err := cli.List(&client.ListOptions{ProjectId: p.Id})
+		if err != nil {
+			return err
+		}
+		// --global flag does not list files for consistency. We may not be
+		// aware of all the project directories on the system and, thus,
+		// will not know all the available "Off" workshops (contrary to the
+		// workshops that are in any known state, i.e. running instances,
+		// which we always know about from the workshop backend).
+		merged := sortWorkshops(workshops, nil)
+		if len(merged) == 0 {
+			continue
+		}
+
+		if printHeaders {
+			fmt.Fprintf(w, "PROJECT\tWORKSHOP\tSTATUS\tNOTES\n")
+			printHeaders = false
+		}
+		project := cmdutil.ContractHome(p.Path)
+		for _, wp := range merged {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", project, wp.name, wp.status, wp.notes)
+		}
+	}
+	w.Flush()
+
+	return nil
+}
+
+type workshopSummary struct {
+	name   string
+	status string
+	notes  string
 }
 
 func sorter[T *client.WorkshopInfo | *client.WorkshopFile](extract func(T) string) func(a, b T) int {
@@ -133,11 +161,13 @@ func sorter[T *client.WorkshopInfo | *client.WorkshopFile](extract func(T) strin
 	}
 }
 
-func print(w *tabwriter.Writer, workshops []*client.WorkshopInfo, files []*client.WorkshopFile, prj client.Project) {
+func sortWorkshops(workshops []*client.WorkshopInfo, files []*client.WorkshopFile) []workshopSummary {
+	result := make([]workshopSummary, 0, len(workshops)+len(files))
+
 	slices.SortFunc(workshops, sorter(func(w *client.WorkshopInfo) string { return w.Name }))
 	for _, wp := range workshops {
-		line := workshopEntry(wp, prj)
-		fmt.Fprintln(w, strings.Join(line, "\t"))
+		notes := cmdutil.EmptyDash(strings.Join(wp.Notes, ","))
+		result = append(result, workshopSummary{wp.Name, wp.Status, notes})
 	}
 
 	slices.SortFunc(files, sorter(func(f *client.WorkshopFile) string { return f.Name }))
@@ -146,31 +176,11 @@ func print(w *tabwriter.Writer, workshops []*client.WorkshopInfo, files []*clien
 			return cmp.Compare(w.Name, wf.Name)
 		})
 		if !found {
-			line := fileEntry(wf, prj)
-			fmt.Fprintln(w, strings.Join(line, "\t"))
+			result = append(result, workshopSummary{wf.Name, "Off", "-"})
 		}
 	}
-}
 
-func fileEntry(w *client.WorkshopFile, p client.Project) []string {
-	line := []string{
-		cmdutil.ContractHome(p.Path),
-		w.Name,
-		"Off",
-		"-",
-	}
-	return line
-}
-
-func workshopEntry(w *client.WorkshopInfo, p client.Project) []string {
-	comment := cmdutil.EmptyDash(strings.Join(w.Notes, ","))
-	line := []string{
-		cmdutil.ContractHome(p.Path),
-		w.Name,
-		w.Status,
-		comment,
-	}
-	return line
+	return result
 }
 
 func tabWriter() *tabwriter.Writer {

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -75,7 +75,7 @@ func (c *CmdList) runList() error {
 	w := tabWriter()
 	var header sync.Once
 	printHeader := func() {
-		fmt.Fprintf(w, "Project\tWorkshop\tStatus\tNotes\n")
+		fmt.Fprintf(w, "PROJECT\tWORKSHOP\tSTATUS\tNOTES\n")
 	}
 
 	if !c.global {

--- a/cmd/workshop/list_test.go
+++ b/cmd/workshop/list_test.go
@@ -101,9 +101,9 @@ func (m *workshopInfo) TestWorkshopListFilesOnly(c *check.C) {
 
 	err := cmd.runList()
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, `PROJECT        WORKSHOP  STATUS  NOTES
-/home/project  as-1      Off     -
-/home/project  ws        Off     -
+	c.Assert(m.stdout.String(), check.Equals, `WORKSHOP  STATUS  NOTES
+as-1      Off     -
+ws        Off     -
 `)
 	c.Check(n, check.Equals, 2)
 }
@@ -132,11 +132,11 @@ func (m *workshopInfo) TestWorkshopList(c *check.C) {
 	cmd.SetArgs([]string{"list"})
 	err := cmd.Execute()
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, `PROJECT        WORKSHOP  STATUS  NOTES
-/home/project  as-1      Ready   -
-/home/project  ws        Error   missing-project
-/home/project  ds-1      Off     -
-/home/project  zs-1      Off     -
+	c.Assert(m.stdout.String(), check.Matches, `WORKSHOP  STATUS  NOTES
+as-1      Ready   -
+ws        Error   missing-project
+ds-1      Off     -
+zs-1      Off     -
 `)
 	m.ResetStdStreams()
 	c.Check(n, check.Equals, 2)
@@ -145,10 +145,10 @@ func (m *workshopInfo) TestWorkshopList(c *check.C) {
 	cmd.SetArgs([]string{"list", "--no-headers"})
 	err = cmd.Execute()
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, `/home/project  as-1  Ready  -
-/home/project  ws    Error  missing-project
-/home/project  ds-1  Off    -
-/home/project  zs-1  Off    -
+	c.Assert(m.stdout.String(), check.Matches, `as-1  Ready  -
+ws    Error  missing-project
+ds-1  Off    -
+zs-1  Off    -
 `)
 	m.ResetStdStreams()
 	c.Check(n, check.Equals, 4)

--- a/cmd/workshop/list_test.go
+++ b/cmd/workshop/list_test.go
@@ -101,7 +101,7 @@ func (m *workshopInfo) TestWorkshopListFilesOnly(c *check.C) {
 
 	err := cmd.runList()
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, `Project        Workshop  Status  Notes
+	c.Assert(m.stdout.String(), check.Matches, `PROJECT        WORKSHOP  STATUS  NOTES
 /home/project  as-1      Off     -
 /home/project  ws        Off     -
 `)
@@ -131,7 +131,7 @@ func (m *workshopInfo) TestWorkshopList(c *check.C) {
 
 	err := cmd.runList()
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, `Project        Workshop  Status  Notes
+	c.Assert(m.stdout.String(), check.Matches, `PROJECT        WORKSHOP  STATUS  NOTES
 /home/project  as-1      Ready   -
 /home/project  ws        Error   missing-project
 /home/project  ds-1      Off     -
@@ -169,7 +169,7 @@ func (m *workshopInfo) TestWorkshopListGlobal(c *check.C) {
 	cmd.global = true
 	err := cmd.runList()
 	c.Assert(err, check.IsNil)
-	c.Assert(m.stdout.String(), check.Matches, `Project          Workshop  Status  Notes
+	c.Assert(m.stdout.String(), check.Matches, `PROJECT          WORKSHOP  STATUS  NOTES
 /home/project-1  as-1      Ready   -
 /home/project-1  ws        Error   missing-project
 /home/project-2  ws        Ready   -

--- a/cmd/workshop/list_test.go
+++ b/cmd/workshop/list_test.go
@@ -109,27 +109,28 @@ func (m *workshopInfo) TestWorkshopListFilesOnly(c *check.C) {
 }
 
 func (m *workshopInfo) TestWorkshopList(c *check.C) {
-	cmd := &CmdList{root: &CmdRoot{}}
 	n := 0
 	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		n++
 		switch n {
-		case 1:
+		case 1, 3:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
 			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, "/home/project")
 			fmt.Fprintln(w, r)
-		case 2:
+		case 2, 4:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
 			w.WriteHeader(200)
 			fmt.Fprintln(w, mockWorkshopList)
 		default:
-			c.Errorf("expected 2 calls, now on %d", n)
+			c.Errorf("expected 4 calls, now on %d", n)
 		}
 	})
 
-	err := cmd.runList()
+	cmd := (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"list"})
+	err := cmd.Execute()
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, `PROJECT        WORKSHOP  STATUS  NOTES
 /home/project  as-1      Ready   -
@@ -137,7 +138,20 @@ func (m *workshopInfo) TestWorkshopList(c *check.C) {
 /home/project  ds-1      Off     -
 /home/project  zs-1      Off     -
 `)
+	m.ResetStdStreams()
 	c.Check(n, check.Equals, 2)
+
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"list", "--no-headers"})
+	err = cmd.Execute()
+	c.Assert(err, check.IsNil)
+	c.Assert(m.stdout.String(), check.Matches, `/home/project  as-1  Ready  -
+/home/project  ws    Error  missing-project
+/home/project  ds-1  Off    -
+/home/project  zs-1  Off    -
+`)
+	m.ResetStdStreams()
+	c.Check(n, check.Equals, 4)
 }
 
 func (m *workshopInfo) TestWorkshopListGlobal(c *check.C) {

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -112,19 +112,19 @@ func (c *CmdRemount) complete(cmd *cobra.Command, args []string, toComplete stri
 	cli, err := c.root.client()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	project, err := cli.Project(c.root.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	connections, err := cli.Connections(&client.ConnectionOptions{ProjectId: project.Id, Interface: "mount"})
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// A mount must be connected for remount to work, only show currently

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -109,7 +109,7 @@ func (c *CmdRemount) complete(cmd *cobra.Command, args []string, toComplete stri
 		return completions, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	cli, err := c.root.client()
+	cli, err := c.root.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/workshop/remount_test.go
+++ b/cmd/workshop/remount_test.go
@@ -12,7 +12,6 @@ import (
 
 type remountSuite struct {
 	BaseWorkshopSuite
-	client *client.Client
 	prjDir string
 	prjId  string
 }
@@ -23,7 +22,6 @@ func (m *remountSuite) SetUpTest(c *check.C) {
 	m.prjDir = c.MkDir()
 	m.prjId = "42424242"
 	m.BaseWorkshopSuite.SetUpTest(c)
-	m.client = &client.Client{}
 }
 
 func (m *remountSuite) TestRemountSuccess(c *check.C) {

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -39,7 +39,7 @@ $ workshop remove nimble jazzy
 The name is optional if the project has only one workshop:
 $ workshop remove`,
 		RunE:              c.Run,
-		ValidArgsFunction: c.root.completeWorkshopName([]string{"Ready", "Stopped"}),
+		ValidArgsFunction: c.root.completeWorkshopNames([]string{"Ready", "Stopped"}),
 	}
 
 	return cmd

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -221,7 +221,7 @@ func (c *CmdRoot) postRun(cmd *cobra.Command, args []string) {
 func (c *CmdRoot) completeWorkshopName(status []string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {
-			return []string{}, cobra.ShellCompDirectiveNoFileComp
+			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
 		return c.doCompleteWorkshopNames(args, status)
@@ -238,13 +238,13 @@ func (c *CmdRoot) doCompleteWorkshopNames(args []string, status []string) ([]str
 	cli, err := c.client()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	project, err := cli.Project(c.project())
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	return completeWorkshopNames(cli, project, args, status)
@@ -254,7 +254,7 @@ func completeWorkshopNames(cli *client.Client, project *client.Project, args []s
 	workshopInfo, _, err := cli.List(&client.ListOptions{ProjectId: project.Id})
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	desiredStatus := func(s string) bool {

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -198,6 +199,12 @@ func (c *CmdRoot) client() (*client.Client, error) {
 	return cli, err
 }
 
+func (c *CmdRoot) noRetryClient() (*client.Client, error) {
+	config := ClientConfig
+	config.RetryInterval = -1 * time.Millisecond
+	return client.New(&config)
+}
+
 func (c *CmdRoot) project() string {
 	if c.cwd == "" {
 		return c.prj
@@ -249,7 +256,7 @@ func (c *CmdRoot) doCompleteProjectPaths(cmd *cobra.Command, toComplete string) 
 		return nil, cobra.ShellCompDirectiveFilterDirs
 	}
 
-	cli, err := c.client()
+	cli, err := c.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveFilterDirs
@@ -332,7 +339,7 @@ func (c *CmdRoot) completeWorkshopNames(status []string) cobra.CompletionFunc {
 }
 
 func (c *CmdRoot) doCompleteWorkshopNames(args []string, status []string) ([]string, cobra.ShellCompDirective) {
-	cli, err := c.client()
+	cli, err := c.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -165,6 +165,8 @@ func (c *CmdRoot) Command() *cobra.Command {
 	cmd.PersistentFlags().BoolP("help", "h", false, "Print the help message for the command.")
 	cmd.PersistentFlags().BoolP("version", "v", false, "Print Workshop version.")
 
+	_ = cmd.RegisterFlagCompletionFunc("project", c.completeProjectPaths())
+
 	cmd.DisableAutoGenTag = true
 
 	return cmd
@@ -216,6 +218,101 @@ func (c *CmdRoot) postRun(cmd *cobra.Command, args []string) {
 		maybePresentWarnings(c.cli.WarningsSummary())
 		c.cli.CloseIdleConnections()
 	}
+}
+
+func (c *CmdRoot) completeProjectPaths() cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return c.doCompleteProjectPaths(cmd, toComplete)
+	}
+}
+
+func (c *CmdRoot) doCompleteProjectPaths(cmd *cobra.Command, toComplete string) ([]string, cobra.ShellCompDirective) {
+	requireProject := []string{
+		"refresh",
+		"start",
+		"stop",
+		"info",
+		"exec",
+		"shell",
+		"run",
+		"remove",
+		"remount",
+		"connections",
+		"connect",
+		"disconnect",
+		"sketch-sdk",
+		"sketches",
+	}
+	if !slices.Contains(requireProject, cmd.Name()) {
+		// Project might be unknown (e.g. for `workshop launch`); any
+		// directory is potentially a new project.
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	}
+
+	cli, err := c.client()
+	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	}
+
+	projects, err := cli.Projects()
+	if err != nil {
+		cobra.CompDebugln(err.Error(), false)
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	}
+
+	// We can complete absolute or relative paths. Unfortunately, paths
+	// starting with ~/ aren't supported. If we return a path starting with
+	// ~, cobra will incorrectly escape it to \~ for both bash and zsh.
+	var completions []string
+	if filepath.IsAbs(toComplete) {
+		completions = completeAbsProjectPaths(projects)
+	} else {
+		completions, err = completeRelProjectPaths(projects)
+		if err != nil {
+			cobra.CompDebugln(err.Error(), false)
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		}
+	}
+
+	// Filter completions by prefix. Cobra usually does this for us, but
+	// if there aren't any matches we'd like to fall back to completing
+	// directories only. This doesn't work when toComplete was expanded
+	// from shell syntax (e.g. ~/...), but there's no way to distinguish
+	// that from the absolute path case.
+	completions = slices.DeleteFunc(completions, func(path string) bool {
+		return !strings.HasPrefix(path, toComplete)
+	})
+	if len(completions) == 0 {
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	}
+
+	return completions, cobra.ShellCompDirectiveDefault
+}
+
+func completeAbsProjectPaths(projects []client.Project) []string {
+	completions := make([]string, 0, len(projects))
+	for _, p := range projects {
+		completions = append(completions, p.Path)
+	}
+	return completions
+}
+
+func completeRelProjectPaths(projects []client.Project) ([]string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	completions := make([]string, 0, len(projects))
+	for _, p := range projects {
+		path, err := filepath.Rel(cwd, p.Path)
+		if err != nil {
+			return nil, err
+		}
+		completions = append(completions, path)
+	}
+	return completions, nil
 }
 
 func (c *CmdRoot) completeWorkshopName(status []string) cobra.CompletionFunc {

--- a/cmd/workshop/root_test.go
+++ b/cmd/workshop/root_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -84,6 +85,40 @@ func (s *rootSuite) SetUpTest(c *check.C) {
 	s.prjDir = c.MkDir()
 	s.prjId = "42424242"
 	s.BaseWorkshopSuite.SetUpTest(c)
+}
+
+func (s *rootSuite) TestProjectNameCompletion(c *check.C) {
+	otherPrj := c.MkDir()
+	otherId := "24242424"
+
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+		fmt.Fprintf(w, `{"type": "sync", "result": [{"id":"%s","path":"%s"},{"id":"%s","path":"%s"}]}`, s.prjId, s.prjDir, otherId, otherPrj)
+	})
+
+	cmd := (&CmdRoot{}).Command()
+	complete, ok := cmd.GetFlagCompletionFunc("project")
+	c.Assert(ok, check.Equals, true)
+
+	subcmds := cmd.Commands()
+	idx := slices.IndexFunc(subcmds, func(c *cobra.Command) bool {
+		return c.Name() == "launch"
+	})
+	c.Assert(idx, testutil.IntGreaterEqual, 0)
+
+	completions, directive := complete(subcmds[idx], nil, "")
+	c.Check(completions, check.HasLen, 0)
+	c.Check(directive, check.Equals, cobra.ShellCompDirectiveFilterDirs)
+
+	idx = slices.IndexFunc(subcmds, func(c *cobra.Command) bool {
+		return c.Name() == "refresh"
+	})
+	c.Assert(idx, testutil.IntGreaterEqual, 0)
+
+	completions, directive = complete(subcmds[idx], nil, "/")
+	c.Check(completions, testutil.DeepUnsortedMatches, []string{s.prjDir, otherPrj})
+	c.Check(directive, check.Equals, cobra.ShellCompDirectiveDefault)
 }
 
 func (s *rootSuite) TestWorkshopNameCompletion(c *check.C) {

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -603,7 +603,8 @@ func writeHooks(sdkdir string, file SketchFile) error {
 }
 
 type CmdSketches struct {
-	root *CmdRoot
+	root      *CmdRoot
+	noHeaders bool
 }
 
 func (c *CmdSketches) Command() *cobra.Command {
@@ -627,6 +628,8 @@ List the sketches in the current project directory:
 $ workshop sketches`,
 		RunE: c.Run,
 	}
+
+	cmd.PersistentFlags().BoolVar(&c.noHeaders, "no-headers", false, "Hide table headers.")
 
 	return cmd
 }
@@ -663,11 +666,14 @@ func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
 			entries = append(entries, entry)
 		}
 	}
-	maxRev := len("REV")
+	var maxRev int
+	if !c.noHeaders {
+		maxRev = len("REV")
+	}
 	for _, entry := range entries {
 		maxRev = max(maxRev, len(entry.rev))
 	}
-	if len(entries) > 0 {
+	if !c.noHeaders && len(entries) > 0 {
 		fmt.Fprintf(w, "PROJECT\tWORKSHOP\t%*s\tNOTES\n", maxRev, "REV")
 	}
 	for _, entry := range entries {

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/client"
-	"github.com/canonical/workshop/cmd/internal/cmdutil"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
@@ -674,10 +673,10 @@ func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
 		maxRev = max(maxRev, len(entry.rev))
 	}
 	if !c.noHeaders && len(entries) > 0 {
-		fmt.Fprintf(w, "PROJECT\tWORKSHOP\t%*s\tNOTES\n", maxRev, "REV")
+		fmt.Fprintf(w, "WORKSHOP\t%*s\tNOTES\n", maxRev, "REV")
 	}
 	for _, entry := range entries {
-		fmt.Fprintf(w, "%s\t%s\t%*s\t%s\n", entry.project, entry.workshop, maxRev, entry.rev, entry.notes)
+		fmt.Fprintf(w, "%s\t%*s\t%s\n", entry.workshop, maxRev, entry.rev, entry.notes)
 	}
 
 	w.Flush()
@@ -686,7 +685,6 @@ func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
 }
 
 type stashInfo struct {
-	project  string
 	workshop string
 	rev      string
 	notes    string
@@ -718,5 +716,5 @@ func stashEntry(userDataDir string, w *client.WorkshopInfo, p *client.Project) *
 		return nil
 	}
 
-	return &stashInfo{cmdutil.ContractHome(p.Path), w.Name, rev, notes}
+	return &stashInfo{w.Name, rev, notes}
 }

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -656,17 +656,22 @@ func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
 
 	userDataDir := workshop.UserDataRootDir(user.HomeDir, env)
 
-	var entries []string
+	var entries []*stashInfo
 	for _, wp := range wps {
 		entry := stashEntry(userDataDir, wp, p)
 		if entry != nil {
-			entries = append(entries, strings.Join(entry, "\t"))
+			entries = append(entries, entry)
 		}
 	}
-
-	if entries != nil {
-		fmt.Fprintln(w, "Project\tWorkshop\tRev\tNotes")
-		fmt.Fprintln(w, strings.Join(entries, "\n"))
+	maxRev := len("REV")
+	for _, entry := range entries {
+		maxRev = max(maxRev, len(entry.rev))
+	}
+	if len(entries) > 0 {
+		fmt.Fprintf(w, "PROJECT\tWORKSHOP\t%*s\tNOTES\n", maxRev, "REV")
+	}
+	for _, entry := range entries {
+		fmt.Fprintf(w, "%s\t%s\t%*s\t%s\n", entry.project, entry.workshop, maxRev, entry.rev, entry.notes)
 	}
 
 	w.Flush()
@@ -674,7 +679,14 @@ func (c *CmdSketches) Run(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func stashEntry(userDataDir string, w *client.WorkshopInfo, p *client.Project) []string {
+type stashInfo struct {
+	project  string
+	workshop string
+	rev      string
+	notes    string
+}
+
+func stashEntry(userDataDir string, w *client.WorkshopInfo, p *client.Project) *stashInfo {
 	rev := "-"
 	notes := ""
 	exists := false
@@ -700,5 +712,5 @@ func stashEntry(userDataDir string, w *client.WorkshopInfo, p *client.Project) [
 		return nil
 	}
 
-	return []string{cmdutil.ContractHome(p.Path), w.Name, rev, notes}
+	return &stashInfo{cmdutil.ContractHome(p.Path), w.Name, rev, notes}
 }

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/cmd/internal/cmdutil"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
@@ -76,6 +77,8 @@ $ workshop sketch-sdk nimble --stash`,
 	cmd.Flags().StringVar(&c.name, "name", "", "Name for the ejected SDK.")
 	cmd.Flags().BoolVar(&c.remove, "remove", false, "Remove the sketch SDK from the workshop.")
 	cmd.Flags().BoolVar(&c.verbose, "verbose", false, "Combine stdout and stderr output from hooks.")
+
+	_ = cmd.RegisterFlagCompletionFunc("name", cmdutil.CompleteChoices())
 
 	cmd.MarkFlagsMutuallyExclusive("stash", "restore", "eject", "remove")
 

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -831,12 +831,11 @@ func (m *workshopSketch) TestSketchesOK(c *check.C) {
 	err := cmd.Execute()
 	c.Assert(err, check.IsNil)
 
-	maxProject := max(len("PROJECT"), len(m.prjDir))
-	want := fmt.Sprintf(`%-*s  WORKSHOP  REV  NOTES
-%-*s  ws         x1  current
-%-*s  nosketch    -  stashed
-%-*s  both       x3  current,stashed
-`, maxProject, "PROJECT", maxProject, m.prjDir, maxProject, m.prjDir, maxProject, m.prjDir)
+	want := `WORKSHOP  REV  NOTES
+ws         x1  current
+nosketch    -  stashed
+both       x3  current,stashed
+`
 	c.Assert(m.stdout.String(), check.Equals, want)
 	m.ResetStdStreams()
 
@@ -847,10 +846,10 @@ func (m *workshopSketch) TestSketchesOK(c *check.C) {
 	err = cmd.Execute()
 	c.Assert(err, check.IsNil)
 
-	want = fmt.Sprintf(`%s  ws        x1  current
-%s  nosketch   -  stashed
-%s  both      x3  current,stashed
-`, m.prjDir, m.prjDir, m.prjDir)
+	want = `ws        x1  current
+nosketch   -  stashed
+both      x3  current,stashed
+`
 	c.Assert(m.stdout.String(), check.Equals, want)
 	m.ResetStdStreams()
 }

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -821,14 +821,14 @@ func (m *workshopSketch) TestSketchSdkRemoveRevertOnFail(c *check.C) {
 }
 
 func (m *workshopSketch) TestSketchesOK(c *check.C) {
-	cmd := &CmdSketches{root: &CmdRoot{}}
-
 	m.mockSketchesHappyPath(c, mockWorkshopsListWithSketch)
 	m.mockMinimalSketchSdk(c, "ws", true, []byte(simpleSketchMeta))
 	m.mockMinimalSketchSdk(c, "nosketch", false, []byte(simpleSketchMeta))
 	m.mockMinimalSketchSdk(c, "both", false, []byte(simpleSketchMeta))
 
-	err := cmd.Run(nil, nil)
+	cmd := (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"sketches"})
+	err := cmd.Execute()
 	c.Assert(err, check.IsNil)
 
 	maxProject := max(len("PROJECT"), len(m.prjDir))
@@ -838,6 +838,21 @@ func (m *workshopSketch) TestSketchesOK(c *check.C) {
 %-*s  both       x3  current,stashed
 `, maxProject, "PROJECT", maxProject, m.prjDir, maxProject, m.prjDir, maxProject, m.prjDir)
 	c.Assert(m.stdout.String(), check.Equals, want)
+	m.ResetStdStreams()
+
+	m.mockSketchesHappyPath(c, mockWorkshopsListWithSketch)
+
+	cmd = (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"sketches", "--no-headers"})
+	err = cmd.Execute()
+	c.Assert(err, check.IsNil)
+
+	want = fmt.Sprintf(`%s  ws        x1  current
+%s  nosketch   -  stashed
+%s  both      x3  current,stashed
+`, m.prjDir, m.prjDir, m.prjDir)
+	c.Assert(m.stdout.String(), check.Equals, want)
+	m.ResetStdStreams()
 }
 
 func (m *workshopSketch) TestSketchesEmpty(c *check.C) {

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -831,11 +831,13 @@ func (m *workshopSketch) TestSketchesOK(c *check.C) {
 	err := cmd.Run(nil, nil)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(m.stdout.String(), check.Matches, fmt.Sprintf(`Project +Workshop  Rev  Notes
-%s  ws        x1   current
-%s  nosketch  -    stashed
-%s  both      x3   current,stashed
-`, m.prjDir, m.prjDir, m.prjDir))
+	maxProject := max(len("PROJECT"), len(m.prjDir))
+	want := fmt.Sprintf(`%-*s  WORKSHOP  REV  NOTES
+%-*s  ws         x1  current
+%-*s  nosketch    -  stashed
+%-*s  both       x3  current,stashed
+`, maxProject, "PROJECT", maxProject, m.prjDir, maxProject, m.prjDir, maxProject, m.prjDir)
+	c.Assert(m.stdout.String(), check.Equals, want)
 }
 
 func (m *workshopSketch) TestSketchesEmpty(c *check.C) {

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -64,6 +64,9 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 		if err != nil {
 			return err
 		}
+		if change == nil {
+			return fmt.Errorf("change with id %q not found", av[0])
+		}
 	} else {
 		changesCmd := CmdChanges{
 			root: c.root,
@@ -76,11 +79,15 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 		if len(changes) == 0 {
 			return errors.New("cannot find any changes")
 		}
-		change = changes[len(changes)-1]
-	}
-
-	if change == nil {
-		return fmt.Errorf("change with id %q not found", av[0])
+		for _, recent := range slices.Backward(changes) {
+			if len(recent.Tasks) > 0 {
+				change = recent
+				break
+			}
+		}
+		if change == nil {
+			return errors.New("cannot find any nonempty changes")
+		}
 	}
 
 	tasks := change.Tasks

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -53,7 +53,7 @@ $ workshop tasks`,
 	return cmd
 }
 
-const line = "......................................................................"
+const hrule = "......................................................................"
 
 func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 	cli, err := c.root.client()
@@ -132,7 +132,7 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 			continue
 		}
 		fmt.Fprintln(os.Stdout)
-		fmt.Fprintln(os.Stdout, line)
+		fmt.Fprintln(os.Stdout, hrule)
 		fmt.Fprintln(os.Stdout, tsk.Summary)
 		fmt.Fprintln(os.Stdout)
 		for _, line := range tsk.Log {

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -13,7 +13,8 @@ import (
 )
 
 type CmdTasks struct {
-	root *CmdRoot
+	root      *CmdRoot
+	noHeaders bool
 }
 
 func (c *CmdTasks) Command() *cobra.Command {
@@ -46,6 +47,8 @@ $ workshop tasks`,
 		RunE:              c.Run,
 		ValidArgsFunction: c.complete,
 	}
+
+	cmd.PersistentFlags().BoolVar(&c.noHeaders, "no-headers", false, "Hide table headers.")
 
 	return cmd
 }
@@ -99,12 +102,17 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 		return a.SpawnTime.Compare(b.SpawnTime)
 	})
 
-	maxDur := len("DURATION")
+	var maxDur int
+	if !c.noHeaders {
+		maxDur = len("DURATION")
+	}
 	for _, tsk := range tasks {
 		maxDur = max(maxDur, len(tsk.DoingTime.Round(time.Millisecond).String()))
 	}
 	w := tabWriter()
-	fmt.Fprintf(w, "STATUS\t%*s\tSUMMARY\n", maxDur, "DURATION")
+	if !c.noHeaders {
+		fmt.Fprintf(w, "STATUS\t%*s\tSUMMARY\n", maxDur, "DURATION")
+	}
 	for _, tsk := range tasks {
 		duration := tsk.DoingTime.Round(time.Millisecond).String()
 		if tsk.DoingTime == 0 {

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -79,60 +79,50 @@ func (c *CmdTasks) Run(cmd *cobra.Command, av []string) error {
 		change = changes[len(changes)-1]
 	}
 
-	if change != nil {
-		tasks := change.Tasks
-
-		slices.SortFunc(tasks, func(a, b *client.Task) int {
-			if a.SpawnTime.Before(b.SpawnTime) {
-				return -1
-			} else if a.SpawnTime.After(b.SpawnTime) {
-				return 1
-			}
-			return 0
-		})
-
-		if len(tasks) > 0 {
-			w := tabWriter()
-
-			maxDur := len("Duration")
-			for _, tsk := range tasks {
-				dur := len(tsk.DoingTime.Round(time.Millisecond).String())
-				if dur > maxDur {
-					maxDur = dur
-				}
-			}
-
-			fmt.Fprintf(w, "Status\t%*s\tSummary\n", maxDur, "Duration")
-
-			for _, tsk := range tasks {
-				duration := tsk.DoingTime.Round(time.Millisecond).String()
-				if tsk.DoingTime == 0 {
-					duration = "-"
-				}
-
-				fmt.Fprintf(w, "%s\t%*s\t%s\n",
-					tsk.Status,
-					maxDur,
-					duration,
-					tsk.Summary)
-			}
-			w.Flush()
-
-			for _, tsk := range tasks {
-				if len(tsk.Log) == 0 {
-					continue
-				}
-				fmt.Fprintln(os.Stdout)
-				fmt.Fprintln(os.Stdout, line)
-				fmt.Fprintln(os.Stdout, tsk.Summary)
-				fmt.Fprintln(os.Stdout)
-				for _, line := range tsk.Log {
-					fmt.Fprintln(os.Stdout, line)
-				}
-			}
-		}
-	} else {
+	if change == nil {
 		return fmt.Errorf("change with id %q not found", av[0])
+	}
+
+	tasks := change.Tasks
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	slices.SortFunc(tasks, func(a, b *client.Task) int {
+		return a.SpawnTime.Compare(b.SpawnTime)
+	})
+
+	maxDur := len("DURATION")
+	for _, tsk := range tasks {
+		maxDur = max(maxDur, len(tsk.DoingTime.Round(time.Millisecond).String()))
+	}
+	w := tabWriter()
+	fmt.Fprintf(w, "STATUS\t%*s\tSUMMARY\n", maxDur, "DURATION")
+	for _, tsk := range tasks {
+		duration := tsk.DoingTime.Round(time.Millisecond).String()
+		if tsk.DoingTime == 0 {
+			duration = "-"
+		}
+
+		fmt.Fprintf(w, "%s\t%*s\t%s\n",
+			tsk.Status,
+			maxDur,
+			duration,
+			tsk.Summary)
+	}
+	w.Flush()
+
+	for _, tsk := range tasks {
+		if len(tsk.Log) == 0 {
+			continue
+		}
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprintln(os.Stdout, line)
+		fmt.Fprintln(os.Stdout, tsk.Summary)
+		fmt.Fprintln(os.Stdout)
+		for _, line := range tsk.Log {
+			fmt.Fprintln(os.Stdout, line)
+		}
 	}
 
 	return nil

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -151,7 +151,7 @@ func (c *CmdTasks) complete(cmd *cobra.Command, args []string, toComplete string
 	cli, err := c.root.client()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	changesCmd := CmdChanges{
@@ -160,15 +160,16 @@ func (c *CmdTasks) complete(cmd *cobra.Command, args []string, toComplete string
 	changes, err := changesCmd.changes(cli)
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	l := len(changes)
 	num := min(l, 10)
-	completions := make([]string, l)
+	completions := make([]string, 0, num)
 
 	for _, chg := range changes[l-num : l] {
-		completions = append(completions, fmt.Sprintf("%s\t%-5s %s\n", chg.ID, chg.Status, chg.Summary))
+		description := fmt.Sprintf("%-5s %s", chg.Status, chg.Summary)
+		completions = append(completions, cobra.CompletionWithDesc(chg.ID, description))
 	}
 
 	return completions, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -148,7 +148,7 @@ func (c *CmdTasks) complete(cmd *cobra.Command, args []string, toComplete string
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	cli, err := c.root.client()
+	cli, err := c.root.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -93,6 +93,8 @@ By default, relative times are used up to 60 days, then YYYY-MM-DD.`)
 		`Use Unicode characters to improve legibility (auto|never|always).
 By default, Unicode is used only if the output supports it.`)
 
+	_ = cmd.RegisterFlagCompletionFunc("unicode", cmdutil.CompleteChoices("auto", "never", "always"))
+
 	return cmd
 }
 

--- a/cmd/workshop/warnings_test.go
+++ b/cmd/workshop/warnings_test.go
@@ -241,8 +241,8 @@ func (s *warningSuite) TestListWithWarnings(c *check.C) {
 	}
 
 	c.Check(s.Stdout(), check.Equals, `
-PROJECT        WORKSHOP  STATUS  NOTES
-/home/project  ws        Off     -
+WORKSHOP  STATUS  NOTES
+ws        Off     -
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "WARNING: There are 2 new warnings. See \"workshop warnings\".\n")
 

--- a/cmd/workshop/warnings_test.go
+++ b/cmd/workshop/warnings_test.go
@@ -241,7 +241,7 @@ func (s *warningSuite) TestListWithWarnings(c *check.C) {
 	}
 
 	c.Check(s.Stdout(), check.Equals, `
-Project        Workshop  Status  Notes
+PROJECT        WORKSHOP  STATUS  NOTES
 /home/project  ws        Off     -
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "WARNING: There are 2 new warnings. See \"workshop warnings\".\n")

--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/canonical/workshop/cmd/internal/cmdutil"
 	"github.com/canonical/workshop/internal/daemon"
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
@@ -65,6 +66,8 @@ func (c *cmdRun) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.CreateDirs, "create-dirs", false, sharedRunEnterOptsHelp["create-dirs"])
 	cmd.Flags().StringVar(&c.HTTP, "http", "", sharedRunEnterOptsHelp["http"])
 	cmd.Flags().BoolVar(&c.Verbose, "verbose", false, sharedRunEnterOptsHelp["verbose"])
+
+	_ = cmd.RegisterFlagCompletionFunc("http", cmdutil.CompleteChoices())
 
 	return cmd
 }

--- a/snap/local/hooks/configure
+++ b/snap/local/hooks/configure
@@ -4,9 +4,13 @@
 . "$SNAP/snap/lib/completion"
 
 if [ -d /var/lib/snapd/desktop ]; then
-    workshop_completion bash /var/lib/snapd/desktop/bash-completion/completions/workshop
-    workshop_completion fish /var/lib/snapd/desktop/fish/vendor_completions.d/workshop.fish
+    install_completion sdk bash /var/lib/snapd/desktop/bash-completion/completions/sdk
+    install_completion workshop bash /var/lib/snapd/desktop/bash-completion/completions/workshop
+
+    install_completion sdk fish /var/lib/snapd/desktop/fish/vendor_completions.d/sdk.fish
+    install_completion workshop fish /var/lib/snapd/desktop/fish/vendor_completions.d/workshop.fish
 fi
 if [ -d /usr/local/share ] && [ -w /usr/local/share ]; then
-    workshop_completion zsh /usr/local/share/zsh/site-functions/_workshop
+    install_completion sdk zsh /usr/local/share/zsh/site-functions/_sdk
+    install_completion workshop zsh /usr/local/share/zsh/site-functions/_workshop
 fi

--- a/snap/local/hooks/remove
+++ b/snap/local/hooks/remove
@@ -27,6 +27,11 @@ done
 remove_network
 remove_volumes
 
+remove_completion /var/lib/snapd/desktop/bash-completion/completions/sdk
 remove_completion /var/lib/snapd/desktop/bash-completion/completions/workshop
+
+remove_completion /var/lib/snapd/desktop/fish/vendor_completions.d/sdk.fish
 remove_completion /var/lib/snapd/desktop/fish/vendor_completions.d/workshop.fish
+
+remove_completion /usr/local/share/zsh/site-functions/_sdk
 remove_completion /usr/local/share/zsh/site-functions/_workshop

--- a/snap/local/lib/completion
+++ b/snap/local/lib/completion
@@ -1,14 +1,15 @@
-workshop_completion() {
-    local shell path dir tmp
-    shell="$1"
-    path="$2"
+install_completion() {
+    local bin shell path dir tmp
+    bin="$1"
+    shell="$2"
+    path="$3"
 
     dir="$(dirname -- "$path")"
     install --directory -- "$dir"
 
     tmp="$(mktemp -- "${path}.XXXXXXXXXX")"
     chmod 0644 -- "$tmp"
-    "$SNAP/bin/workshop" completion "$shell" >"$tmp"
+    "$SNAP/bin/$bin" completion "$shell" >"$tmp"
     mv -- "$tmp" "$path"
 }
 

--- a/tests/main/check-health/task.yaml
+++ b/tests/main/check-health/task.yaml
@@ -8,7 +8,7 @@ execute: |
   workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Launch \"ws-ok\" workshop$"
   workshop_exec refresh ws-ok  
   workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Refresh \"ws-ok\" workshop$"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-ok[[:space:]]+Ready[[:space:]]+-$" 
+  workshop_exec list | MATCH "^ws-ok[[:space:]]+Ready[[:space:]]+-$" 
   workshop_exec remove ws-ok
 
   echo "Check health reported waiting"  
@@ -20,4 +20,4 @@ execute: |
   echo "Check health reported error"
   workshop_exec launch ws-error || true
   workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Error[[:space:]]+[:, [:alnum:]]+[[:space:]]+Launch \"ws-error\" workshop$"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-error[[:space:]]+Off[[:space:]]+-$" 
+  workshop_exec list | MATCH "^ws-error[[:space:]]+Off[[:space:]]+-$" 

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -3,7 +3,7 @@ priority: -101
 execute: |
   . "$TESTSLIB"/utils.sh  
 
-  workshop_exec list | MATCH "^.+[[:space:]]+comp-check[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"
 
   oldchannel=$(snap info lxd | yq -r .tracking)
 
@@ -18,4 +18,4 @@ execute: |
   retry 5 snap install lxd --channel="$oldchannel"
   lxd waitready
   snap restart workshop
-  workshop_exec list | MATCH "^.+[[:space:]]+comp-check[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"

--- a/tests/main/completion/bash.sh
+++ b/tests/main/completion/bash.sh
@@ -24,7 +24,7 @@ set -x
 func='__start_workshop'
 complete -p workshop | grep -qw "$func"
 
-# The completion functionality is well covered in unit tests. We check four
+# The completion functionality is well covered in unit tests. We check some
 # small examples here that each use different code paths.
 
 echo "Test launch completion"
@@ -43,3 +43,18 @@ do_complete workshop remount ws-comp/test-sdk-mount:one "$HOME/tmp/t"
 echo "Test stop completion"
 do_complete workshop stop w
 [ "$COMPREPLY" = ws-comp ]
+
+echo "Test project completion"
+mkdir -p empty-dir-with-no-workshops
+do_complete workshop launch --project ''
+printf '%s\0' "${COMPREPLY[@]}" | grep -Fqxz empty-dir-with-no-workshops
+do_complete workshop refresh --project ''
+printf '%s\0' "${COMPREPLY[@]}" | grep -Fqxz .
+pushd .. >/dev/null
+do_complete workshop launch --project compl
+[ "$COMPREPLY" = completion ]
+do_complete workshop refresh --project compl
+[ "$COMPREPLY" = completion ]
+do_complete workshop refresh --project "$PWD/compl"
+[ "$COMPREPLY" = "$PWD/completion" ]
+popd >/dev/null

--- a/tests/main/completion/bash.sh
+++ b/tests/main/completion/bash.sh
@@ -17,6 +17,7 @@ do_complete() {
 }
 
 source /usr/share/bash-completion/bash_completion
+_completion_loader sdk || true
 _completion_loader workshop || true
 
 set -x
@@ -58,3 +59,14 @@ do_complete workshop refresh --project compl
 do_complete workshop refresh --project "$PWD/compl"
 [ "$COMPREPLY" = "$PWD/completion" ]
 popd >/dev/null
+
+func='__start_sdk'
+complete -p sdk | grep -qw "$func"
+
+echo "Test base completion"
+do_complete sdk info --base ubuntu@24.0
+[ "$COMPREPLY" = ubuntu@24.04 ]
+
+echo "Test arch completion"
+do_complete sdk info --arch s3
+[ "$COMPREPLY" = s390x ]

--- a/tests/main/integrity-checks/task.yaml
+++ b/tests/main/integrity-checks/task.yaml
@@ -28,7 +28,7 @@ execute: |
   mkdir -p ./new-project
   cp -r "$PROJECT"/.workshop ./new-project/
   workshop_exec launch --project $(pwd)/new-project/
-  workshop_exec list --project $(pwd)/new-project | MATCH "^$(pwd)/new-project[[:space:]]+ws[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list --project $(pwd)/new-project | MATCH "^ws[[:space:]]+Ready[[:space:]]+-$"
 
   echo "Check for warnings when workshop files conflict"
   cp new-project/.workshop/ws.yaml new-project/.workshop.yaml

--- a/tests/main/launch-abort/task.yaml
+++ b/tests/main/launch-abort/task.yaml
@@ -5,11 +5,11 @@ execute: |
   workshop_exec launch --wait-on-error || true
 
   echo "Check the workshop is in Waiting state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-abort[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+  workshop_exec list | MATCH "^ws-launch-abort[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
   echo "Check the \"workshop launch --abort\" command reverts to the previous state"
   workshop_exec launch --abort | MATCH "\"ws-launch-abort\" launch aborted"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-abort[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-launch-abort[[:space:]]+Off[[:space:]]+-$"
 
   echo "Validate the task output from the launch attempt"
   workshop_exec tasks | tail -1 | MATCH ".*Aborting \"launch\" for workshop \"ws-launch-abort\"..."

--- a/tests/main/launch-continue/task.yaml
+++ b/tests/main/launch-continue/task.yaml
@@ -8,7 +8,7 @@ execute: |
   workshop_exec launch --wait-on-error || true
 
   echo "Check the workshop is in Waiting state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-cont[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+  workshop_exec list | MATCH "^ws-launch-cont[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
   echo "\"Fix\" the SDK error by creating an expected file"
   workshop_exec exec -- touch /home/workshop/setup-base-pass
@@ -17,4 +17,4 @@ execute: |
   workshop_exec launch --continue | MATCH "\"ws-launch-cont\" launched"
 
   echo "Check the workshop is in Ready state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-launch-cont[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-launch-cont[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/launch-multiple/task.yaml
+++ b/tests/main/launch-multiple/task.yaml
@@ -4,8 +4,8 @@ execute: |
 
   echo "Check workshop can be launched with a basic SDK"
   workshop_exec launch ws-one ws-two ws-three
-  workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-one[[:space:]]*Ready[[:space:]]*-"
-  workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-two[[:space:]]*Ready[[:space:]]*-"
-  workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-three[[:space:]]*Ready[[:space:]]*-"
+  workshop_exec list | MATCH "ws-one[[:space:]]*Ready[[:space:]]*-"
+  workshop_exec list | MATCH "ws-two[[:space:]]*Ready[[:space:]]*-"
+  workshop_exec list | MATCH "ws-three[[:space:]]*Ready[[:space:]]*-"
 
   workshop_exec remove ws-one ws-two ws-three

--- a/tests/main/launch-sdk/task.yaml
+++ b/tests/main/launch-sdk/task.yaml
@@ -4,7 +4,7 @@ execute: |
 
   echo "Check workshop can be launched with a basic SDK"
   workshop_exec launch --verbose
-  workshop_exec list | MATCH "$(pwd)[[:space:]]*ws-basic[[:space:]]*Ready[[:space:]]*-"
+  workshop_exec list | MATCH "ws-basic[[:space:]]*Ready[[:space:]]*-"
 
   # Check setup-base is run using bash -x
   workshop_exec tasks | MATCH "\\+ echo 'setup-base ran successfully\!'\$"

--- a/tests/main/launch/task.yaml
+++ b/tests/main/launch/task.yaml
@@ -14,7 +14,7 @@ execute: |
 
   function launch_and_validate() {
     workshop_exec launch "$1"
-    workshop_exec list | MATCH "$(pwd)[[:space:]]*$1[[:space:]]*Ready[[:space:]]*-"
+    workshop_exec list | MATCH "$1[[:space:]]*Ready[[:space:]]*-"
     # ensure the workshop has a socket for workshopctl
     workshop_exec exec "$1" test -S /var/lib/workshop/run/workshop.socket.untrusted
     # ensure the apt cache is mounted

--- a/tests/main/list/task.yaml
+++ b/tests/main/list/task.yaml
@@ -4,7 +4,7 @@ summary: |
   - Project-specific list from a nested directory
   - List from a moved directory
   - List from a copied directory
-  - List turning into list --global if executed outside of a project directory
+  - List failing if executed outside of a project directory
 
 restore: |
   . "$TESTSLIB"/utils.sh
@@ -21,12 +21,12 @@ execute: |
 
   echo "workshop list from a nested directory must work similarly as if ran from a project directory"
   pushd ./; mkdir "$PROJECT"/nested; cd "$PROJECT"/nested
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-list[[:space:]]+Ready[[:space:]]+-$"
   popd; rmdir "$PROJECT"/nested
 
   echo "workshop --project should accept a relative directory"
   mkdir relative
-  workshop_exec list --project relative | MATCH "^.+[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list --project relative | MATCH "^ws-list[[:space:]]+Ready[[:space:]]+-$"
   rmdir relative
 
   echo "Listing outside of a project directory should trigger an error"
@@ -35,31 +35,31 @@ execute: |
   echo "The directory was moved, its instances must update configuration with a new path"
   sudo -u ubuntu mv "$PROJECT" "$PROJECT"-new
   project_id=$(cat "$PROJECT"-new/.workshop.lock)
-  workshop_exec --project "$PROJECT"-new list | MATCH "^${PROJECT}-new[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec --project "$PROJECT"-new list | MATCH "^ws-list[[:space:]]+Ready[[:space:]]+-$"
 
   echo "The directory was copied, its projects instances should still stay available at the old path"
   sudo -u ubuntu cp -R "$PROJECT"-new "$PROJECT"-copy
-  workshop_exec --project "$PROJECT"-copy list | MATCH "^$PROJECT-copy[[:space:]]+ws-list[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec --project "$PROJECT"-copy list | MATCH "^ws-list[[:space:]]+Off[[:space:]]+-$"
   project_id_copy=$(cat "$PROJECT"-copy/.workshop.lock)
   test "$project_id_copy" != "$project_id"
 
   mv "$PROJECT"-new "$PROJECT"
   # launch from a new directory successfully
   workshop_exec --project "$PROJECT"-copy launch
-  workshop_exec --project "$PROJECT"-copy list | MATCH "^${PROJECT}-copy[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec --project "$PROJECT"-copy list | MATCH "^ws-list[[:space:]]+Ready[[:space:]]+-$"
   workshop_exec --project "$PROJECT" remove
   workshop_exec --project "$PROJECT"-copy remove
 
   echo "List should respect project-level workshop definitions"
   mv "$PROJECT"-copy/.workshop/ws-list.yaml "$PROJECT"-copy/workshop.yaml
-  workshop_exec --project "$PROJECT"-copy list | MATCH "^$PROJECT-copy[[:space:]]+ws-list[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec --project "$PROJECT"-copy list | MATCH "^ws-list[[:space:]]+Off[[:space:]]+-$"
   workshop_exec --project "$PROJECT"-copy launch
-  workshop_exec --project "$PROJECT"-copy list | MATCH "^${PROJECT}-copy[[:space:]]+ws-list[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec --project "$PROJECT"-copy list | MATCH "^ws-list[[:space:]]+Ready[[:space:]]+-$"
 
   echo "List should create nested project even if parent is known"
   mkdir -p "$PROJECT"-copy/subprj/.workshop
   touch "$PROJECT"-copy/subprj/.workshop/nested.yaml
-  workshop_exec --project "$PROJECT"-copy/subprj list | MATCH "^$PROJECT-copy/subprj[[:space:]]+nested[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec --project "$PROJECT"-copy/subprj list | MATCH "^nested[[:space:]]+Off[[:space:]]+-$"
   workshop_exec --project "$PROJECT"-copy remove
 
   # TODO:

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -14,11 +14,11 @@ execute: |
   sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' workshop.yaml
 
   echo "Check the workshop is in Waiting state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-abort[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+  workshop_exec list | MATCH "^ws-refresh-abort[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
   echo "Check the \"workshop refresh --abort\" command reverts to the previous state"
   workshop_exec refresh --abort | MATCH "\"ws-refresh-abort\" refresh aborted"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-abort[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-refresh-abort[[:space:]]+Ready[[:space:]]+-$"
 
   echo "Validate the task output from the refresh attempt"
   workshop_exec tasks | tail -1 | MATCH ".*Aborting \"refresh\" for workshop \"ws-refresh-abort\"..."

--- a/tests/main/refresh-continue/task.yaml
+++ b/tests/main/refresh-continue/task.yaml
@@ -14,7 +14,7 @@ execute: |
   sed -i 's/test-sdk-setup-fail/test-sdk-basic/g' workshop.yaml
 
   echo "Check the workshop is in Waiting state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-cont[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+  workshop_exec list | MATCH "^ws-refresh-cont[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
   echo "\"Fix\" the SDK error by creating an expected file"
   workshop_exec exec -- touch /home/workshop/setup-base-pass
@@ -23,4 +23,4 @@ execute: |
   workshop_exec refresh --continue | MATCH "\"ws-refresh-cont\" refreshed"
 
   echo "Check the workshop is in Ready state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-cont[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-refresh-cont[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -41,7 +41,7 @@ execute: |
   workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Refresh \"ws-refresh\" workshop$"
 
   echo "Check the workshop is in Ready state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-refresh[[:space:]]+Ready[[:space:]]+-$"
 
   workshop_exec refresh ws-refresh-sdk
 
@@ -49,7 +49,7 @@ execute: |
   workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Refresh \"ws-refresh-sdk\" workshop$"
 
   echo "Check the workshop is in Ready state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-refresh-sdk[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-refresh-sdk[[:space:]]+Ready[[:space:]]+-$"
 
   echo "Check workshop refresh when no updates are available"
   workshop_exec refresh ws-refresh-sdk | MATCH "no updates available for \"ws-refresh-sdk\""

--- a/tests/main/remove/task.yaml
+++ b/tests/main/remove/task.yaml
@@ -15,7 +15,7 @@ execute: |
 
   echo "Check the workshop can be removed if in Ready"
   workshop_exec remove ws-remove
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-remove[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-remove[[:space:]]+Off[[:space:]]+-$"
 
   echo "Check the apt cache was removed"
   workshop_exec launch ws-remove
@@ -24,12 +24,12 @@ execute: |
   echo "Check the workshop can be removed if in Stopped"
   workshop_exec stop ws-remove
   workshop_exec remove ws-remove
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-remove[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-remove[[:space:]]+Off[[:space:]]+-$"
   
   echo "Check the workshop can be removed and SDKs disconnected"
   workshop_exec launch ws-remove-mount
   workshop_exec remove ws-remove-mount
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-remove-mount[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-remove-mount[[:space:]]+Off[[:space:]]+-$"
 
   echo "Check the workshop can be removed if in Waiting"
   workshop_exec launch ws-remove
@@ -41,10 +41,10 @@ execute: |
   ! workshop_exec refresh --wait-on-error ws-remove
   workshop_exec remove ws-remove
   sed -i '/^sdks:$/,/^    channel: latest\/stable$/d' .workshop/ws-remove.yaml
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-remove[[:space:]]+Off[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-remove[[:space:]]+Off[[:space:]]+-$"
 
   echo "Check the workshop can be removed if in Error"
   workshop_exec launch ws-remove
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-remove[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-remove[[:space:]]+Ready[[:space:]]+-$"
   rm -f .workshop/ws-remove.yaml
   workshop_exec remove ws-remove

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -18,12 +18,12 @@ execute: |
   workshop_exec stop
 
   echo "Check the workshop is in Stopped state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-start[[:space:]]+Stopped[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-start[[:space:]]+Stopped[[:space:]]+-$"
 
   echo "Start the workshop"
   workshop_exec start
 
   echo "Check the workshop is in Ready state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-start[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-start[[:space:]]+Ready[[:space:]]+-$"
 
   check_linger

--- a/tests/main/stop/task.yaml
+++ b/tests/main/stop/task.yaml
@@ -12,10 +12,10 @@ execute: |
   workshop_exec stop
 
   echo "Check the workshop is in Stopped state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-stop[[:space:]]+Stopped[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-stop[[:space:]]+Stopped[[:space:]]+-$"
 
   echo "Check stopping the Stopped workshop does not result in error"
   workshop_exec stop
 
   echo "Check the workshop is in Stopped state"
-  workshop_exec list | MATCH "^.+[[:space:]]+ws-stop[[:space:]]+Stopped[[:space:]]+-$"
+  workshop_exec list | MATCH "^ws-stop[[:space:]]+Stopped[[:space:]]+-$"


### PR DESCRIPTION
# Description

Brings formatting of other commands in line with `sdk info`:
- Capitalise table headers
- Right-align numeric columns
- Hide headers if `--no-headers` is passed in (except for `sdk info` itself, which has 2 tables)
- Hide columns if they aren't relevant (i.e. the project column for `workshop sketches` and `workshop list` without `--global`)

On the other hand, `sdk info` now repeats project paths if they appear mutliple times. We decided to continue printing repeated projects in other commands like `workshop info`.

Previously `sdk list` sorted SDKs only by name. Now SDKs with the same name are sorted by descending revision number.

Fixes a bug where `workshop tasks` can have empty output if a `Change` failed before any tasks were added (in that case we check the next most recent task).

Expands shell completion:
- Only fall back to built-in path completion if it makes sense to do so
- Complete non-boolean optional arguments: `sdk info --arch|--base`, `workshop --project` and `workshop warnings --unicode`.
- Disable built-in path completion for `sketch-sdk --eject --name` and `workshopd --http`

Completion for `workshop --project` doesn't work as well as I'd like. This is due to cobra's `bash` and `zsh` scripts expanding the `toComplete` string and escaping the returned completions (including `~`). Maybe we should just use `ShellCompDirectiveFilterDirs` and call it a day.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
