### PR TITLE
Remove backward compatibility with workshops that still use install-time

### DIFF
--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -480,13 +480,8 @@ func maybeSdkInstallation(key string, device map[string]string) (*workshop.SdkIn
 	if err := s.Revision.UnmarshalText([]byte(device["user.sdk.revision"])); err != nil {
 		return nil, err
 	}
-	installedAt := device["user.sdk.installed-at"]
-	if installedAt == "" {
-		// TODO: remove this after a short transition period.
-		installedAt = device["user.sdk.install-time"]
-	}
-	installedUTC := (*timeutil.TimeUTC)(&s.InstalledAt)
-	if err := installedUTC.UnmarshalText([]byte(installedAt)); err != nil {
+	installedAt := (*timeutil.TimeUTC)(&s.InstalledAt)
+	if err := installedAt.UnmarshalText([]byte(device["user.sdk.installed-at"])); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description

Let's merge this once we're confident no one is using workshops which follow the old convention.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
