### PR TITLE
Suggest a command if not found instead of showing full CLI help

### DIFF
--- a/cmd/sdk/root.go
+++ b/cmd/sdk/root.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -18,13 +20,15 @@ type CmdRoot struct {
 
 func (c *CmdRoot) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "sdk",
-		Short:             "Inspect SDK volumes installed on the system",
-		SilenceErrors:     true,
-		SilenceUsage:      true,
-		TraverseChildren:  true,
-		Version:           version.Version,
-		PersistentPostRun: c.postRun,
+		Use:                        "sdk",
+		Short:                      "Inspect SDK volumes installed on the system",
+		SilenceErrors:              true,
+		SilenceUsage:               true,
+		TraverseChildren:           true,
+		Version:                    version.Version,
+		RunE:                       c.run,
+		PersistentPostRun:          c.postRun,
+		SuggestionsMinimumDistance: 2,
 	}
 	cmd.SetVersionTemplate("{{.Version}}\n")
 	cmd.DisableAutoGenTag = true
@@ -37,6 +41,17 @@ func (c *CmdRoot) Command() *cobra.Command {
 	cmd.PersistentFlags().BoolP("version", "v", false, "Print SDK CLI version.")
 
 	return cmd
+}
+
+func (c *CmdRoot) run(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+	msg := fmt.Sprintf("unknown command %q", args[0])
+	if suggestions := cmd.SuggestionsFor(args[0]); len(suggestions) > 0 {
+		msg += "\n\nDid you mean this?\n\t" + strings.Join(suggestions, "\n\t")
+	}
+	return errors.New(msg)
 }
 
 func (c *CmdRoot) client() (*client.Client, error) {

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -29,7 +31,9 @@ func (c *CmdRoot) Command() *cobra.Command {
 		SilenceUsage:     true,
 		TraverseChildren: true,
 
-		PersistentPostRun: c.postRun,
+		RunE:                       c.run,
+		PersistentPostRun:          c.postRun,
+		SuggestionsMinimumDistance: 2,
 	}
 	cmd.SetVersionTemplate("{{.Version}}\n")
 
@@ -164,6 +168,17 @@ func (c *CmdRoot) Command() *cobra.Command {
 	cmd.DisableAutoGenTag = true
 
 	return cmd
+}
+
+func (c *CmdRoot) run(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+	msg := fmt.Sprintf("unknown command %q", args[0])
+	if suggestions := cmd.SuggestionsFor(args[0]); len(suggestions) > 0 {
+		msg += "\n\nDid you mean this?\n\t" + strings.Join(suggestions, "\n\t")
+	}
+	return errors.New(msg)
 }
 
 func (c *CmdRoot) client() (*client.Client, error) {


### PR DESCRIPTION
# Description

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
