### PR TITLE
Ensure auto-connect does not create duplicate connections

### DIFF
--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	"strings"
 	"syscall"
 
 	"gopkg.in/tomb.v2"
@@ -283,10 +284,19 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 				// this is a normal and common condition.
 				continue
 			}
-
 			connectRefs = append(connectRefs, connRef)
 		}
 	}
+
+	// Sort connections by their ID to ensure deterministic order of connection tasks creation.
+	slices.SortFunc(connectRefs, func(a, b *interfaces.ConnRef) int {
+		return strings.Compare(a.ID(), b.ID())
+	})
+
+	// Remove duplicates: keep only first occurrence of each ID
+	connectRefs = slices.CompactFunc(connectRefs, func(a, b *interfaces.ConnRef) bool {
+		return a.ID() == b.ID()
+	})
 
 	ts := m.batchAutoConnectTasks(wp, info, connectRefs, plugDynamic, slotDynamic)
 	handlersetup.InjectTasks(task, ts)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -81,6 +81,20 @@ plugs:
 `,
 }
 
+var consumerSelfConnect = sdk.Meta{
+	Setup: consumer.Setup,
+	SdkYAML: `name: consumer
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: mock-network
+    attribute: one
+slots:
+  slot:
+    interface: mock-network
+`,
+}
+
 var consumerManyPlugs = sdk.Meta{
 	Setup: consumer.Setup,
 	SdkYAML: `name: consumer
@@ -343,6 +357,57 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 
 	// ensure that backend profiles were set for both SDKs
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectPlugAndSlotInSameSdk(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerSelfConnect})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerSelfConnect.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange()
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate task count (one connection - one task)
+	connectTasks := 0
+	for _, task := range chg.Tasks() {
+		if task.Kind() == "connect" {
+			connectTasks++
+		}
+	}
+	c.Assert(connectTasks, check.Equals, 1)
+
+	// Validate
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	ref, err = repo.Connected(s.prj.ProjectId, "ws", "consumer", "slot")
+	c.Assert(ref, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+
+	var conns map[string]any
+	err = s.state.Get("conns", &conns)
+	c.Check(err, check.IsNil)
+	c.Assert(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/consumer:slot": map[string]any{
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]any{"attribute": "one"},
+		},
+	})
+
+	// ensure that backend profiles were set for the updated SDK
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 


### PR DESCRIPTION
# Description

- Fix duplicating connections if plug and slot come from the same SDK (mount).
- Enable deterministic order of the 'connect' tasks creation.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
