### PR TITLE
Add sdk find command

### DIFF
--- a/client/sdks.go
+++ b/client/sdks.go
@@ -1,6 +1,9 @@
 package client
 
-import "time"
+import (
+	"net/url"
+	"time"
+)
 
 type StoreAccount struct {
 	ID          string `json:"id"`
@@ -51,6 +54,36 @@ type SdkFullInfo struct {
 	Publisher   *StoreAccount  `json:"publisher,omitempty"`
 	Channels    []*SdkRevision `json:"channels,omitempty"`
 	Installed   []SdkInstalled `json:"installed,omitempty"`
+}
+
+type SdkSummary struct {
+	Name        string        `json:"name"`
+	PackageID   string        `json:"package-id,omitempty"`
+	Summary     string        `json:"summary,omitempty"`
+	Description string        `json:"description,omitempty"`
+	License     string        `json:"license,omitempty"`
+	Publisher   *StoreAccount `json:"publisher,omitempty"`
+	Channel     string        `json:"channel"`
+	Track       string        `json:"track"`
+	Risk        string        `json:"risk"`
+	Revision    string        `json:"revision"`
+	ReleasedAt  time.Time     `json:"released-at"`
+	Version     string        `json:"version,omitempty"`
+	Base        string        `json:"base,omitempty"`
+	Arch        string        `json:"arch,omitempty"`
+}
+
+// FindSdks searches the SDK Store.
+func (client *Client) FindSdks(q string) ([]SdkSummary, error) {
+	var sdks []SdkSummary
+	query := url.Values{}
+	query.Set("q", q)
+
+	_, err := client.doSync("GET", "/v1/find", query, nil, nil, &sdks)
+	if err != nil {
+		return nil, err
+	}
+	return sdks, nil
 }
 
 // Sdks lists the SDK volumes known to the daemon.

--- a/cmd/sdk/find.go
+++ b/cmd/sdk/find.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/cmd/internal/cmdutil"
+)
+
+type CmdFind struct {
+	cmdutil.ColorMixin
+	root      *CmdRoot
+	noHeaders bool
+}
+
+func (c *CmdFind) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "find <QUERY>",
+		Short:   "Search the Store for SDKs",
+		GroupID: GrpExplore,
+		Long: `
+Search the Store for SDKs matching the given query.
+The query can match the SDK's name, title, summary, description, or publisher.
+
+Notes:
+
+- Only the latest release of the SDK is shown.
+- To view more details for one of the SDKs, use "sdk info".
+- To list SDKs on the local system, use "sdk list".
+`,
+		RunE: c.Run,
+	}
+
+	cmd.PersistentFlags().BoolVar(&c.noHeaders, "no-headers", false, "Hide table headers.")
+
+	return cmd
+}
+
+func (c *CmdFind) Run(cmd *cobra.Command, av []string) error {
+	cli, err := c.root.client()
+	if err != nil {
+		return err
+	}
+
+	query := strings.Join(av, " ")
+	if strings.TrimSpace(query) == "" {
+		query = ""
+	}
+
+	sdks, err := cli.FindSdks(query)
+	if err != nil {
+		return err
+	}
+
+	if len(sdks) == 0 {
+		return fmt.Errorf("no matching SDKs for %q", query)
+	}
+
+	slices.SortFunc(sdks, func(a, b client.SdkSummary) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	esc := c.GetEscapes()
+	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
+	if !c.noHeaders {
+		fmt.Fprintln(w, "NAME\tVERSION\tPUBLISHER\tSUMMARY")
+	}
+	for _, sdk := range sdks {
+		version := cmdutil.EmptyDash(sdk.Version)
+		publisher := "-"
+		if sdk.Publisher != nil {
+			publisher = shortPublisher(sdk.Publisher, esc)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", sdk.Name, version, publisher, sdk.Summary)
+	}
+
+	return w.Flush()
+}
+
+func shortPublisher(publisher *client.StoreAccount, esc *cmdutil.Escapes) string {
+	var badge string
+	switch publisher.Validation {
+	case "verified":
+		badge = esc.Green + esc.Tick + esc.End
+	case "starred":
+		badge = esc.BrightYellow + esc.Star + esc.End
+	}
+	return publisher.DisplayName + badge
+}

--- a/cmd/sdk/find_test.go
+++ b/cmd/sdk/find_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
+)
+
+func (s *sdkSuite) TestFind(c *check.C) {
+	d1 := time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC)
+	d2 := time.Date(2024, 11, 20, 0, 0, 0, 0, time.UTC)
+
+	resp := []client.SdkSummary{{
+		Name:        "openvino",
+		PackageID:   "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e",
+		Summary:     "Intel OpenVINO toolkit",
+		Description: "Longer description\ncan be multiline.",
+		License:     "Apache-2.0",
+		Publisher: &client.StoreAccount{
+			ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+			Username:    "intel",
+			DisplayName: "Intel",
+			Validation:  "verified",
+		},
+		Channel:    "latest/stable",
+		Track:      "latest",
+		Risk:       "stable",
+		Revision:   "85",
+		ReleasedAt: d1,
+		Version:    "2.1-084c8c8",
+		Base:       "ubuntu@20.04",
+		Arch:       "amd64",
+	}, {
+		Name:        "openvino-notebooks",
+		PackageID:   "geGY07WPXyvnQahmRP1oOegGUyjurXrY",
+		Summary:     "Jupyter notebook tutorials for OpenVINO",
+		Description: "A collection of ready-to-run Jupyter notebooks for learning and experimenting with the OpenVINO™ Toolkit.",
+		License:     "Apache-2.0",
+		Publisher: &client.StoreAccount{
+			ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+			Username:    "hunter2",
+			DisplayName: "Hunter Two",
+			Validation:  "unproven",
+		},
+		Channel:    "latest/beta",
+		Track:      "latest",
+		Risk:       "beta",
+		Revision:   "7",
+		ReleasedAt: d2,
+		Version:    "0.1",
+		Base:       "",
+		Arch:       "all",
+	}}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/find")
+		c.Assert(r.URL.Query().Get("q"), check.Equals, "openvino")
+		body := map[string]any{
+			"type":   "sync",
+			"result": resp,
+		}
+		encoder := json.NewEncoder(w)
+		c.Assert(encoder.Encode(body), check.IsNil)
+	}))
+	defer srv.Close()
+
+	ClientConfig.BaseURL = srv.URL
+
+	cmd := (&CmdRoot{}).Command()
+	cmd.SetArgs([]string{"find", "openvino"})
+	c.Assert(cmd.Execute(), check.IsNil)
+
+	want := `NAME                VERSION      PUBLISHER   SUMMARY
+openvino            2.1-084c8c8  Intel**     Intel OpenVINO toolkit
+openvino-notebooks  0.1          Hunter Two  Jupyter notebook tutorials for OpenVINO
+`
+	c.Check(s.Stdout(), check.Equals, want)
+}

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -27,8 +27,9 @@ type CmdInfo struct {
 
 func (c *CmdInfo) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "info <SDK>",
-		Short: "Show SDK info",
+		Use:     "info <SDK>",
+		Short:   "Show SDK info",
+		GroupID: GrpExplore,
 		Long: `
 Prints the SDK's metadata,
 shows the revisions currently available in the SDK Store,

--- a/cmd/sdk/info.go
+++ b/cmd/sdk/info.go
@@ -88,7 +88,7 @@ func (c *CmdInfo) Run(cmd *cobra.Command, av []string) error {
 	w := tabwriter.NewWriter(Stdout, 4, 3, 2, ' ', tabwriter.StripEscape)
 	fmt.Fprintf(w, "name:\t%s\n", info.Name)
 	if info.Publisher != nil {
-		fmt.Fprintf(w, "publisher:\t%s\n", formatPublisher(info.Publisher, esc))
+		fmt.Fprintf(w, "publisher:\t%s\n", longPublisher(info.Publisher, esc))
 	}
 	if info.License != "" {
 		fmt.Fprintf(w, "license:\t%s\n", info.License)
@@ -225,7 +225,7 @@ func filterInstalled(installed []client.SdkInstalled, base, arch string) []clien
 	})
 }
 
-func formatPublisher(publisher *client.StoreAccount, esc *cmdutil.Escapes) string {
+func longPublisher(publisher *client.StoreAccount, esc *cmdutil.Escapes) string {
 	var badge string
 	switch publisher.Validation {
 	case "verified":
@@ -240,7 +240,6 @@ func formatPublisher(publisher *client.StoreAccount, esc *cmdutil.Escapes) strin
 		return publisher.DisplayName + badge
 	}
 	return fmt.Sprintf("%s (%s%s)", publisher.DisplayName, publisher.Username, badge)
-
 }
 
 func optionalColumns(prev, rev *client.SdkRevision) (string, string, string, string) {

--- a/cmd/sdk/list.go
+++ b/cmd/sdk/list.go
@@ -21,8 +21,9 @@ type CmdList struct {
 
 func (c *CmdList) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List SDK volumes available on this machine",
+		Use:     "list",
+		Short:   "List SDK volumes available on this machine",
+		GroupID: GrpExplore,
 		Long: `
 This command lists all local SDK volumes.
 

--- a/cmd/sdk/root.go
+++ b/cmd/sdk/root.go
@@ -49,6 +49,7 @@ func (c *CmdRoot) Command() *cobra.Command {
 	cmd.SetHelpCommandGroupID(GrpMisc)
 	cmd.SetCompletionCommandGroupID(GrpMisc)
 
+	cmd.AddCommand((&CmdFind{root: c}).Command())
 	cmd.AddCommand((&CmdList{root: c}).Command())
 	cmd.AddCommand((&CmdInfo{root: c}).Command())
 	cmd.AddCommand((&CmdDocs{root: c}).Command())

--- a/cmd/sdk/root.go
+++ b/cmd/sdk/root.go
@@ -14,6 +14,11 @@ import (
 	"github.com/canonical/workshop/internal/version"
 )
 
+const (
+	GrpExplore = "explore-troubleshoot"
+	GrpMisc    = "misc"
+)
+
 type CmdRoot struct {
 	cli *client.Client
 }
@@ -21,7 +26,6 @@ type CmdRoot struct {
 func (c *CmdRoot) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "sdk",
-		Short:                      "Inspect SDK volumes installed on the system",
 		SilenceErrors:              true,
 		SilenceUsage:               true,
 		TraverseChildren:           true,
@@ -32,6 +36,18 @@ func (c *CmdRoot) Command() *cobra.Command {
 	}
 	cmd.SetVersionTemplate("{{.Version}}\n")
 	cmd.DisableAutoGenTag = true
+
+	groups := []*cobra.Group{{
+		ID:    GrpExplore,
+		Title: "Discover and inspect available SDKs:",
+	}, {
+		ID:    GrpMisc,
+		Title: "Additional commands:",
+	}}
+	cmd.AddGroup(groups...)
+
+	cmd.SetHelpCommandGroupID(GrpMisc)
+	cmd.SetCompletionCommandGroupID(GrpMisc)
 
 	cmd.AddCommand((&CmdList{root: c}).Command())
 	cmd.AddCommand((&CmdInfo{root: c}).Command())

--- a/cmd/workshop/changes.go
+++ b/cmd/workshop/changes.go
@@ -17,9 +17,10 @@ type CmdChanges struct {
 
 func (c *CmdChanges) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "changes",
-		Args:  cobra.ExactArgs(0),
-		Short: "List recent changes to the workshops in a project",
+		Use:     "changes",
+		Args:    cobra.ExactArgs(0),
+		Short:   "List recent changes to the workshops in a project",
+		GroupID: GrpChanges,
 		Long: `
 Any substantial operation on a workshop is a change that consists of tasks;
 the command lists details of recent changes for all workshops within a project.

--- a/cmd/workshop/connect.go
+++ b/cmd/workshop/connect.go
@@ -18,9 +18,10 @@ type CmdConnect struct {
 
 func (c *CmdConnect) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "connect <WORKSHOP>/<SDK>:<PLUG> [<WORKSHOP>/<SDK>][:<SLOT>]",
-		Args:  cobra.RangeArgs(1, 2),
-		Short: "Connect a plug to a slot",
+		Use:     "connect <WORKSHOP>/<SDK>:<PLUG> [<WORKSHOP>/<SDK>][:<SLOT>]",
+		Args:    cobra.RangeArgs(1, 2),
+		Short:   "Connect a plug to a slot",
+		GroupID: GrpConnect,
 		Long: `
 This command connects a plug to a target slot
 that is specified as the second argument or deduced from the context.

--- a/cmd/workshop/connections.go
+++ b/cmd/workshop/connections.go
@@ -22,9 +22,10 @@ type CmdConnections struct {
 
 func (c *CmdConnections) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "connections [<WORKSHOP>]",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "List interface connections",
+		Use:     "connections [<WORKSHOP>]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "List interface connections",
+		GroupID: GrpConnect,
 		Long: `
 This command lists the connections between interface plugs and slots
 for the entire project or a single workshop within it.

--- a/cmd/workshop/disconnect.go
+++ b/cmd/workshop/disconnect.go
@@ -18,9 +18,10 @@ type CmdDisconnect struct {
 
 func (c *CmdDisconnect) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "disconnect <WORKSHOP>/<SDK>:<PLUG OR SLOT> [<WORKSHOP>/<SDK>]:[<SLOT>]",
-		Args:  cobra.RangeArgs(1, 2),
-		Short: "Disconnect a plug or a slot",
+		Use:     "disconnect <WORKSHOP>/<SDK>:<PLUG OR SLOT> [<WORKSHOP>/<SDK>]:[<SLOT>]",
+		Args:    cobra.RangeArgs(1, 2),
+		Short:   "Disconnect a plug or a slot",
+		GroupID: GrpConnect,
 		Long: `
 This command disconnects a plug from its slot, or a slot from all its plugs.
 

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -168,10 +168,11 @@ This command enumerates all actions in the workshop, printing a YAML map.
 
 func (c *CmdExec) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "exec [flags] [<WORKSHOP>] [--] <COMMAND>...",
-		Args:  cobra.MinimumNArgs(1),
-		Short: shortExecHelp,
-		Long:  longExecHelp,
+		Use:     "exec [flags] [<WORKSHOP>] [--] <COMMAND>...",
+		Args:    cobra.MinimumNArgs(1),
+		Short:   shortExecHelp,
+		GroupID: GrpUtilise,
+		Long:    longExecHelp,
 		Example: `
 Run the "go build main.go" command under the "nimble" workshop
 in the current project directory:
@@ -233,10 +234,11 @@ func execArgs(av []string, argsLenAtDash int) *ExecArgs {
 
 func (c *CmdShell) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "shell [<WORKSHOP>]",
-		Args:  cobra.MaximumNArgs(1),
-		Short: shortShellHelp,
-		Long:  longShellHelp,
+		Use:     "shell [<WORKSHOP>]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   shortShellHelp,
+		GroupID: GrpUtilise,
+		Long:    longShellHelp,
 		Example: `
 Open the default login shell of the "workshop" user into the "nimble" workshop
 in the current project directory:
@@ -268,10 +270,11 @@ func (c *CmdShell) Run(cmd *cobra.Command, av []string) error {
 
 func (c *CmdRun) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "run [flags] [<WORKSHOP>] [--] <ACTION> <ARGUMENTS>...",
-		Args:  cobra.MinimumNArgs(1),
-		Short: shortRunHelp,
-		Long:  longRunHelp,
+		Use:     "run [flags] [<WORKSHOP>] [--] <ACTION> <ARGUMENTS>...",
+		Args:    cobra.MinimumNArgs(1),
+		Short:   shortRunHelp,
+		GroupID: GrpUtilise,
+		Long:    longRunHelp,
 		Example: `
 Run the "build" action under the "nimble" workshop
 in the current project directory:
@@ -679,10 +682,11 @@ type CmdActions struct {
 
 func (c *CmdActions) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "actions [<WORKSHOP>]",
-		Args:  cobra.MaximumNArgs(1),
-		Short: shortActionsHelp,
-		Long:  longActionsHelp,
+		Use:     "actions [<WORKSHOP>]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   shortActionsHelp,
+		GroupID: GrpExplore,
+		Long:    longActionsHelp,
 		Example: `
 List actions for the "nimble" workshop in the current project directory:
 $ workshop actions nimble

--- a/cmd/workshop/info.go
+++ b/cmd/workshop/info.go
@@ -28,9 +28,10 @@ type CmdInfo struct {
 
 func (c *CmdInfo) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "info [<WORKSHOP>]",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "Print the current status and details of a workshop as YAML",
+		Use:     "info [<WORKSHOP>]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Print the current status and details of a workshop as YAML",
+		GroupID: GrpExplore,
 		Long: `
 This command outputs the basic settings, current status and individual SDK
 details for a workshop, formatting them as YAML. Specifically, it prints:

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -21,8 +21,9 @@ type CmdLaunch struct {
 
 func (c *CmdLaunch) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "launch <WORKSHOP>...",
-		Short: "Construct one or many workshops using their definitions",
+		Use:     "launch <WORKSHOP>...",
+		Short:   "Construct one or many workshops using their definitions",
+		GroupID: GrpCRUD,
 		Long: `
 This command constructs the workshops listed as arguments by going over their
 definitions and installing their components. For each workshop, it:

--- a/cmd/workshop/list.go
+++ b/cmd/workshop/list.go
@@ -21,9 +21,10 @@ type CmdList struct {
 
 func (c *CmdList) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "list",
-		Args:  cobra.ExactArgs(0),
-		Short: "List project workshops",
+		Use:     "list",
+		Args:    cobra.ExactArgs(0),
+		Short:   "List project workshops",
+		GroupID: GrpExplore,
 		Long: `
 This command enumerates all workshops in the project, printing a compact list:
 

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -22,8 +22,9 @@ type CmdRefresh struct {
 
 func (c *CmdRefresh) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "refresh [--abort|--continue|--restore|--wait-on-error] <WORKSHOP>...",
-		Short: "Update workshops according to their definitions",
+		Use:     "refresh [--abort|--continue|--restore|--wait-on-error] <WORKSHOP>...",
+		Short:   "Update workshops according to their definitions",
+		GroupID: GrpCRUD,
 		Long: `
 This command updates the workshops listed as arguments. For each workshop, 
 it checks the workshop definition and applies any required updates 

--- a/cmd/workshop/remount.go
+++ b/cmd/workshop/remount.go
@@ -15,9 +15,10 @@ type CmdRemount struct {
 
 func (c *CmdRemount) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "remount <WORKSHOP>/<SDK>:<PLUG> <SOURCE>",
-		Args:  cobra.ExactArgs(2),
-		Short: "Mount a new source location to the mount interface plug's target",
+		Use:     "remount <WORKSHOP>/<SDK>:<PLUG> <SOURCE>",
+		Args:    cobra.ExactArgs(2),
+		Short:   "Mount a new source location to the mount interface plug's target",
+		GroupID: GrpConnect,
 		Long: `
 This command mounts a new source location on the host to the target directory
 of the specified mount interface plug, qualified by the SDK name.

--- a/cmd/workshop/remove.go
+++ b/cmd/workshop/remove.go
@@ -14,8 +14,9 @@ type CmdRemove struct {
 
 func (c *CmdRemove) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "remove <WORKSHOP>...",
-		Short: "Remove one or many workshops",
+		Use:     "remove <WORKSHOP>...",
+		Short:   "Remove one or many workshops",
+		GroupID: GrpCRUD,
 		Long: `
 This command removes the workshops listed as arguments. For each workshop, it:
 

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -17,6 +17,17 @@ import (
 	"github.com/canonical/workshop/internal/version"
 )
 
+const (
+	GrpCRUD     = "create-update-delete"
+	GrpSketch   = "sketch"
+	GrpExplore  = "explore-troubleshoot"
+	GrpChanges  = "changes-tasks"
+	GrpConnect  = "connect"
+	GrpUtilise  = "utilise"
+	GrpWarnings = "warnings"
+	GrpMisc     = "misc"
+)
+
 type CmdRoot struct {
 	cwd string
 	cli *client.Client
@@ -38,127 +49,57 @@ func (c *CmdRoot) Command() *cobra.Command {
 	}
 	cmd.SetVersionTemplate("{{.Version}}\n")
 
-	cmd.AddGroup(
-		&cobra.Group{
-			ID:    "create-update-delete",
-			Title: "Create new workshops; start, stop, update or delete existing ones:",
-		},
-		&cobra.Group{
-			ID:    "sketch",
-			Title: "Customize a workshop:",
-		},
-		&cobra.Group{
-			ID:    "explore-troubleshoot",
-			Title: "Enumerate workshops, list their details:",
-		},
-		&cobra.Group{
-			ID:    "changes-tasks",
-			Title: "List recent changes and individual activities:",
-		},
-		&cobra.Group{
-			ID:    "connect",
-			Title: "Create, manage, list and drop interface connections:",
-		},
-		&cobra.Group{
-			ID:    "utilise",
-			Title: "Run commands inside a workshop:",
-		},
-		&cobra.Group{
-			ID:    "warnings",
-			Title: "List and acknowledge warnings:",
-		},
-		&cobra.Group{
-			ID:    "misc",
-			Title: "Additional commands:",
-		},
-	)
+	groups := []*cobra.Group{{
+		ID:    GrpCRUD,
+		Title: "Create new workshops; start, stop, update, or delete existing ones:",
+	}, {
+		ID:    GrpSketch,
+		Title: "Customize a workshop:",
+	}, {
+		ID:    GrpExplore,
+		Title: "Enumerate workshops, list their details:",
+	}, {
+		ID:    GrpChanges,
+		Title: "List recent changes and individual activities:",
+	}, {
+		ID:    GrpConnect,
+		Title: "Create, manage, list, and drop interface connections:",
+	}, {
+		ID:    GrpUtilise,
+		Title: "Run commands inside a workshop:",
+	}, {
+		ID:    GrpWarnings,
+		Title: "List and acknowledge warnings:",
+	}, {
+		ID:    GrpMisc,
+		Title: "Additional commands:",
+	}}
+	cmd.AddGroup(groups...)
 
-	cmd.SetHelpCommandGroupID("misc")
-	cmd.SetCompletionCommandGroupID("misc")
+	cmd.SetHelpCommandGroupID(GrpMisc)
+	cmd.SetCompletionCommandGroupID(GrpMisc)
 
-	launchCmd := (&CmdLaunch{root: c}).Command()
-	launchCmd.GroupID = "create-update-delete"
-	cmd.AddCommand(launchCmd)
-
-	listCmd := (&CmdList{root: c}).Command()
-	listCmd.GroupID = "explore-troubleshoot"
-	cmd.AddCommand(listCmd)
-
-	changesCmd := (&CmdChanges{root: c}).Command()
-	changesCmd.GroupID = "changes-tasks"
-	cmd.AddCommand(changesCmd)
-
-	tasksCmd := (&CmdTasks{root: c}).Command()
-	tasksCmd.GroupID = "changes-tasks"
-	cmd.AddCommand(tasksCmd)
-
-	refreshCmd := (&CmdRefresh{root: c}).Command()
-	refreshCmd.GroupID = "create-update-delete"
-	cmd.AddCommand(refreshCmd)
-
-	startCmd := (&CmdStart{root: c}).Command()
-	startCmd.GroupID = "create-update-delete"
-	cmd.AddCommand(startCmd)
-
-	stopCmd := (&CmdStop{root: c}).Command()
-	stopCmd.GroupID = "create-update-delete"
-	cmd.AddCommand(stopCmd)
-
-	infoCmd := (&CmdInfo{root: c}).Command()
-	infoCmd.GroupID = "explore-troubleshoot"
-	cmd.AddCommand(infoCmd)
-
-	execCmd := (&CmdExec{root: c}).Command()
-	execCmd.GroupID = "utilise"
-	cmd.AddCommand(execCmd)
-
-	shellCmd := (&CmdShell{root: c}).Command()
-	shellCmd.GroupID = "utilise"
-	cmd.AddCommand(shellCmd)
-
-	runCmd := (&CmdRun{root: c}).Command()
-	runCmd.GroupID = "utilise"
-	cmd.AddCommand(runCmd)
-
-	actionsCmd := (&CmdActions{root: c}).Command()
-	actionsCmd.GroupID = "explore-troubleshoot"
-	cmd.AddCommand(actionsCmd)
-
-	removeCmd := (&CmdRemove{root: c}).Command()
-	removeCmd.GroupID = "create-update-delete"
-	cmd.AddCommand(removeCmd)
-
-	remountCmd := (&CmdRemount{root: c}).Command()
-	remountCmd.GroupID = "connect"
-	cmd.AddCommand(remountCmd)
-
-	connectionsCmd := (&CmdConnections{root: c}).Command()
-	connectionsCmd.GroupID = "connect"
-	cmd.AddCommand(connectionsCmd)
-
-	connectCmd := (&CmdConnect{root: c}).Command()
-	connectCmd.GroupID = "connect"
-	cmd.AddCommand(connectCmd)
-
-	disconnectCmd := (&CmdDisconnect{root: c}).Command()
-	disconnectCmd.GroupID = "connect"
-	cmd.AddCommand(disconnectCmd)
-
-	warningsCmd := (&CmdWarnings{root: c}).Command()
-	warningsCmd.GroupID = "warnings"
-	cmd.AddCommand(warningsCmd)
-
-	okayCmd := (&CmdOkay{root: c}).Command()
-	okayCmd.GroupID = "warnings"
-	cmd.AddCommand(okayCmd)
-
-	sketchCmd := (&CmdSketch{root: c}).Command()
-	sketchCmd.GroupID = "sketch"
-	cmd.AddCommand(sketchCmd)
-
-	sketchesCmd := (&CmdSketches{root: c}).Command()
-	sketchesCmd.GroupID = "sketch"
-	cmd.AddCommand(sketchesCmd)
+	cmd.AddCommand((&CmdLaunch{root: c}).Command())
+	cmd.AddCommand((&CmdList{root: c}).Command())
+	cmd.AddCommand((&CmdChanges{root: c}).Command())
+	cmd.AddCommand((&CmdTasks{root: c}).Command())
+	cmd.AddCommand((&CmdRefresh{root: c}).Command())
+	cmd.AddCommand((&CmdStart{root: c}).Command())
+	cmd.AddCommand((&CmdStop{root: c}).Command())
+	cmd.AddCommand((&CmdInfo{root: c}).Command())
+	cmd.AddCommand((&CmdExec{root: c}).Command())
+	cmd.AddCommand((&CmdShell{root: c}).Command())
+	cmd.AddCommand((&CmdRun{root: c}).Command())
+	cmd.AddCommand((&CmdActions{root: c}).Command())
+	cmd.AddCommand((&CmdRemove{root: c}).Command())
+	cmd.AddCommand((&CmdRemount{root: c}).Command())
+	cmd.AddCommand((&CmdConnections{root: c}).Command())
+	cmd.AddCommand((&CmdConnect{root: c}).Command())
+	cmd.AddCommand((&CmdDisconnect{root: c}).Command())
+	cmd.AddCommand((&CmdWarnings{root: c}).Command())
+	cmd.AddCommand((&CmdOkay{root: c}).Command())
+	cmd.AddCommand((&CmdSketch{root: c}).Command())
+	cmd.AddCommand((&CmdSketches{root: c}).Command())
 
 	cmd.AddCommand((&CmdDocs{root: c}).Command())
 

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -33,9 +33,10 @@ type CmdSketch struct {
 
 func (c *CmdSketch) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "sketch-sdk [--stash|--restore|--eject|--remove] [<WORKSHOP>]",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "Customize a workshop",
+		Use:     "sketch-sdk [--stash|--restore|--eject|--remove] [<WORKSHOP>]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Customize a workshop",
+		GroupID: GrpSketch,
 		Long: `The command opens the sketch SDK template in the default text editor.
 Add customizations by editing the template, then save and exit 
 the editor to apply the changes to the workshop.
@@ -611,9 +612,10 @@ type CmdSketches struct {
 
 func (c *CmdSketches) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "sketches",
-		Args:  cobra.ExactArgs(0),
-		Short: "List project sketch SDKs",
+		Use:     "sketches",
+		Args:    cobra.ExactArgs(0),
+		Short:   "List project sketch SDKs",
+		GroupID: GrpSketch,
 		Long: `
 This command enumerates all sketches in the project, printing a compact list:
 

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -14,8 +14,9 @@ type CmdStart struct {
 
 func (c *CmdStart) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "start <WORKSHOP>...",
-		Short: "Start one or many workshops",
+		Use:     "start <WORKSHOP>...",
+		Short:   "Start one or many workshops",
+		GroupID: GrpCRUD,
 		Long: `
 This command activates the workshops listed as arguments. For each one, it:
 

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -14,8 +14,9 @@ type CmdStop struct {
 
 func (c *CmdStop) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "stop <WORKSHOP>...",
-		Short: "Stop one or many workshops",
+		Use:     "stop <WORKSHOP>...",
+		Short:   "Stop one or many workshops",
+		GroupID: GrpCRUD,
 		Long: `
 This command deactivates the workshops listed as arguments. For each one, it:
 

--- a/cmd/workshop/tasks.go
+++ b/cmd/workshop/tasks.go
@@ -19,9 +19,10 @@ type CmdTasks struct {
 
 func (c *CmdTasks) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "tasks [<CHANGE ID>]",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "List tasks for a specific change",
+		Use:     "tasks [<CHANGE ID>]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "List tasks for a specific change",
+		GroupID: GrpChanges,
 		Long: `
 Any substantial operation on a workshop is a change that consists of tasks;
 the command lists individual tasks that comprise a specific change.

--- a/cmd/workshop/warnings.go
+++ b/cmd/workshop/warnings.go
@@ -55,9 +55,10 @@ type CmdOkay struct {
 
 func (c *CmdWarnings) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "warnings",
-		Args:  cobra.ExactArgs(0),
-		Short: "List warnings",
+		Use:     "warnings",
+		Args:    cobra.ExactArgs(0),
+		Short:   "List warnings",
+		GroupID: GrpWarnings,
 		Long: `
 This command lists the warnings that were reported to the system.
 
@@ -100,9 +101,10 @@ By default, Unicode is used only if the output supports it.`)
 
 func (c *CmdOkay) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "okay",
-		Args:  cobra.ExactArgs(0),
-		Short: "Acknowledge listed warnings",
+		Use:     "okay",
+		Args:    cobra.ExactArgs(0),
+		Short:   "Acknowledge listed warnings",
+		GroupID: GrpWarnings,
 		Long: `
 This command acknowledges all warnings
 listed previously by the "workshop warnings" command.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b
 	github.com/gorilla/websocket v1.5.1
 	github.com/juju/clock v1.1.1
-	github.com/juju/errors v1.0.0
 	github.com/juju/retry v1.0.1
 	github.com/pkg/term v1.1.0
 	github.com/spf13/afero v1.15.0
@@ -33,6 +32,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
+	github.com/juju/errors v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/muhlemmer/gu v0.3.1 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -38,6 +38,11 @@ var api = []*Command{{
 	UserOK:  true,
 	GET:     v1GetSdkInfo,
 }, {
+	Path:    "/v1/find",
+	GuestOK: false,
+	UserOK:  true,
+	GET:     v1FindSdks,
+}, {
 	Path:    "/v1/projects/{id}/workshops",
 	GuestOK: false,
 	UserOK:  true,

--- a/internal/daemon/api_sdks.go
+++ b/internal/daemon/api_sdks.go
@@ -18,6 +18,22 @@ func v1GetSdks(c *Command, r *http.Request, _ *userState) Response {
 	return SyncResponse(sdks, http.StatusOK)
 }
 
+func v1FindSdks(c *Command, r *http.Request, _ *userState) Response {
+	mgr := c.d.overlord.SdkManager()
+	query := r.URL.Query()
+	q := query.Get("q")
+
+	sdks, err := mgr.FindSdks(r.Context(), q)
+	if err != nil {
+		if q == "" {
+			return statusInternalError("cannot find SDKs: %w", err)
+		}
+		return statusInternalError("cannot find SDKs matching %q: %w", q, err)
+	}
+
+	return SyncResponse(sdks, http.StatusOK)
+}
+
 func v1GetSdkInfo(c *Command, r *http.Request, _ *userState) Response {
 	name := muxVars(r)["name"]
 	if name == "" {

--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -178,6 +178,167 @@ func (s *apiSuite) importSdkVolume(c *check.C, meta sdk.Meta, size uint64) {
 	s.b.Volumes[name] = info
 }
 
+func (s *apiSuite) TestFindSdksOk(c *check.C) {
+	s.daemon(c)
+
+	stableReleased := time.Date(2026, 3, 10, 23, 48, 34, 474879000, time.UTC)
+	betaReleased := time.Date(2026, 1, 10, 23, 48, 34, 474879000, time.UTC)
+
+	restore := s.store.SetFindCallback(func(ctx context.Context, query string, options ...sdkstore.FindOption) ([]transport.FindResponse, error) {
+		if query != "openvino" {
+			return nil, nil
+		}
+
+		return []transport.FindResponse{{
+			Name:      "openvino",
+			PackageID: "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e",
+			Metadata: transport.FindMetadata{
+				Description: "Accelerated toolkit",
+				License:     "Apache-2.0",
+				Publisher: transport.Publisher{
+					ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+					Username:    "hunter2",
+					DisplayName: "Hunter Two",
+					Validation:  "unproven",
+				},
+				Summary: "Intel OpenVINO toolkit",
+			},
+			DefaultRelease: transport.FindChannelMap{
+				Channel: transport.Channel{
+					Name:  "latest/stable",
+					Track: "latest",
+					Risk:  "stable",
+					Platform: transport.Platform{
+						Name:         "ubuntu",
+						Channel:      "20.04",
+						Architecture: "amd64",
+					},
+					ReleasedAt: timeutil.TimeUTC(stableReleased),
+				},
+				Revision: 85,
+				Version:  "2.1-084c8c8",
+			},
+		}, {
+			Name:      "openvino-notebooks",
+			PackageID: "geGY07WPXyvnQahmRP1oOegGUyjurXrY",
+			Metadata: transport.FindMetadata{
+				Description: "A collection of ready-to-run Jupyter notebooks for learning and experimenting with the OpenVINO™ Toolkit.",
+				License:     "Apache-2.0",
+				Publisher: transport.Publisher{
+					ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+					Username:    "hunter2",
+					DisplayName: "Hunter Two",
+					Validation:  "unproven",
+				},
+				Summary: "Jupyter notebook tutorials for OpenVINO",
+			},
+			DefaultRelease: transport.FindChannelMap{
+				Channel: transport.Channel{
+					Name:  "latest/beta",
+					Track: "latest",
+					Risk:  "beta",
+					Platform: transport.Platform{
+						Name:         "all",
+						Channel:      "all",
+						Architecture: "all",
+					},
+					ReleasedAt: timeutil.TimeUTC(betaReleased),
+				},
+				Revision: 7,
+				Version:  "0.1",
+			},
+		}}, nil
+	})
+	defer restore()
+
+	req, err := s.createSdksRequest("GET", "/v1/find?q=openvino")
+	c.Assert(err, check.IsNil)
+
+	rsp := v1FindSdks(apiCmd("/v1/find"), req, nil).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Assert(rsp.Status, check.Equals, http.StatusOK)
+
+	sdks, ok := rsp.Result.([]sdkstate.SdkSummary)
+	c.Assert(ok, check.Equals, true)
+
+	c.Check(sdks, testutil.DeepUnsortedMatches, []sdkstate.SdkSummary{{
+		Name:        "openvino",
+		PackageID:   "U9IBEcXiDkuaPLYjyUBpRZMETAr7g39e",
+		Summary:     "Intel OpenVINO toolkit",
+		Description: "Accelerated toolkit",
+		License:     "Apache-2.0",
+		Publisher: &sdkstate.StoreAccount{
+			ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+			Username:    "hunter2",
+			DisplayName: "Hunter Two",
+			Validation:  "unproven",
+		},
+		Channel:    "latest/stable",
+		Track:      "latest",
+		Risk:       "stable",
+		Revision:   "85",
+		ReleasedAt: stableReleased,
+		Version:    "2.1-084c8c8",
+		Base:       "ubuntu@20.04",
+		Arch:       "amd64",
+	}, {
+		Name:        "openvino-notebooks",
+		PackageID:   "geGY07WPXyvnQahmRP1oOegGUyjurXrY",
+		Summary:     "Jupyter notebook tutorials for OpenVINO",
+		Description: "A collection of ready-to-run Jupyter notebooks for learning and experimenting with the OpenVINO™ Toolkit.",
+		License:     "Apache-2.0",
+		Publisher: &sdkstate.StoreAccount{
+			ID:          "ZeW8fMKBPHZBsaSm6LBPbpDZDpVcIHy1",
+			Username:    "hunter2",
+			DisplayName: "Hunter Two",
+			Validation:  "unproven",
+		},
+		Channel:    "latest/beta",
+		Track:      "latest",
+		Risk:       "beta",
+		Revision:   "7",
+		ReleasedAt: betaReleased,
+		Version:    "0.1",
+		Base:       "",
+		Arch:       "all",
+	}})
+}
+
+func (s *apiSuite) TestFindSdksNoMatches(c *check.C) {
+	s.daemon(c)
+
+	req, err := s.createSdksRequest("GET", "/v1/find?q=openvino")
+	c.Assert(err, check.IsNil)
+
+	rsp := v1FindSdks(apiCmd("/v1/find"), req, nil).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Assert(rsp.Status, check.Equals, http.StatusOK)
+
+	sdks, ok := rsp.Result.([]sdkstate.SdkSummary)
+	c.Assert(ok, check.Equals, true)
+	c.Check(sdks, check.HasLen, 0)
+}
+
+func (s *apiSuite) TestFindSdksStoreDown(c *check.C) {
+	s.daemon(c)
+
+	restore := s.store.SetFindCallback(func(ctx context.Context, query string, options ...sdkstore.FindOption) ([]transport.FindResponse, error) {
+		return nil, errors.New("destination unreachable")
+	})
+	defer restore()
+
+	req, err := s.createSdksRequest("GET", "/v1/find?q=openvino")
+	c.Assert(err, check.IsNil)
+
+	rsp := v1FindSdks(apiCmd("/v1/find"), req, nil).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Status, check.Equals, http.StatusInternalServerError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `cannot find SDKs matching "openvino": destination unreachable`)
+}
+
 func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 	s.daemon(c)
 

--- a/internal/https/middleware.go
+++ b/internal/https/middleware.go
@@ -5,6 +5,8 @@ package https
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -12,7 +14,6 @@ import (
 	"time"
 
 	"github.com/juju/clock"
-	"github.com/juju/errors"
 	"github.com/juju/retry"
 	"golang.org/x/net/http/httpproxy"
 
@@ -53,7 +54,7 @@ func DialContextMiddleware(breaker DialBreaker) TransportMiddleware {
 		}
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			if !breaker.Allowed(addr) {
-				return nil, errors.Errorf("access to address %q not allowed", addr)
+				return nil, fmt.Errorf("access to address %q not allowed", addr)
 			}
 
 			return dialer.DialContext(ctx, network, addr)
@@ -297,7 +298,7 @@ func (m retryMiddleware) clampBackoff(duration time.Duration) (time.Duration, er
 	}
 	if m.policy.MaxDelay > 0 && duration > m.policy.MaxDelay {
 		future := m.clock.Now().Add(duration)
-		return duration, errors.Errorf("API request retry is not accepting further requests until %s", future.Format(time.RFC3339))
+		return duration, fmt.Errorf("API request retry is not accepting further requests until %s", future.Format(time.RFC3339))
 	}
 	return duration, nil
 }

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -70,6 +70,23 @@ type SdkFullInfo struct {
 	Installed   []SdkInstalled `json:"installed,omitempty"`
 }
 
+type SdkSummary struct {
+	Name        string        `json:"name"`
+	PackageID   string        `json:"package-id,omitempty"`
+	Summary     string        `json:"summary,omitempty"`
+	Description string        `json:"description,omitempty"`
+	License     string        `json:"license,omitempty"`
+	Publisher   *StoreAccount `json:"publisher,omitempty"`
+	Channel     string        `json:"channel"`
+	Track       string        `json:"track"`
+	Risk        string        `json:"risk"`
+	Revision    string        `json:"revision"`
+	ReleasedAt  time.Time     `json:"released-at"`
+	Version     string        `json:"version,omitempty"`
+	Base        string        `json:"base,omitempty"`
+	Arch        string        `json:"arch,omitempty"`
+}
+
 type SdkManager struct {
 	state   *state.State
 	store   sdk.Store
@@ -126,6 +143,50 @@ func (w *SdkManager) SdkVolumes(ctx context.Context) ([]SdkVolume, error) {
 		})
 	}
 	return entries, nil
+}
+
+func (w *SdkManager) FindSdks(ctx context.Context, query string) ([]SdkSummary, error) {
+	response, err := w.store.Find(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]SdkSummary, 0, len(response))
+	for _, entry := range response {
+		var publisher *StoreAccount
+		if entry.Metadata.Publisher.ID != "" {
+			publisher = &StoreAccount{
+				ID:          entry.Metadata.Publisher.ID,
+				Username:    entry.Metadata.Publisher.Username,
+				DisplayName: entry.Metadata.Publisher.DisplayName,
+				Validation:  entry.Metadata.Publisher.Validation,
+			}
+		}
+
+		base := entry.DefaultRelease.Channel.Platform.Name + "@" + entry.DefaultRelease.Channel.Platform.Channel
+		if base == "all@all" {
+			base = ""
+		}
+
+		summary := SdkSummary{
+			Name:        entry.Name,
+			PackageID:   entry.PackageID,
+			Summary:     entry.Metadata.Summary,
+			Description: entry.Metadata.Description,
+			License:     entry.Metadata.License,
+			Publisher:   publisher,
+			Channel:     entry.DefaultRelease.Channel.Name,
+			Track:       entry.DefaultRelease.Channel.Track,
+			Risk:        entry.DefaultRelease.Channel.Risk,
+			Revision:    sdk.Revision{N: entry.DefaultRelease.Revision}.String(),
+			ReleasedAt:  time.Time(entry.DefaultRelease.Channel.ReleasedAt),
+			Version:     entry.DefaultRelease.Version,
+			Base:        base,
+			Arch:        entry.DefaultRelease.Channel.Platform.Architecture,
+		}
+		result = append(result, summary)
+	}
+	return result, nil
 }
 
 func (w *SdkManager) Sdk(ctx context.Context, name string) (*SdkFullInfo, error) {

--- a/internal/sdk/store.go
+++ b/internal/sdk/store.go
@@ -56,6 +56,7 @@ func StoreService(st *state.State) Store {
 }
 
 type Store interface {
+	Find(ctx context.Context, query string, options ...sdkstore.FindOption) ([]transport.FindResponse, error)
 	Info(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error)
 }
 
@@ -66,8 +67,34 @@ func NewFakeStore() *FakeStore {
 type FakeStore struct {
 	lock sync.Mutex
 
+	FindCalls    []string
+	FindCallback func(ctx context.Context, query string, options ...sdkstore.FindOption) ([]transport.FindResponse, error)
+
 	InfoCalls    []string
 	InfoCallback func(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error)
+}
+
+func (f *FakeStore) SetFindCallback(find func(ctx context.Context, query string, options ...sdkstore.FindOption) ([]transport.FindResponse, error)) func() {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	old := f.FindCallback
+	f.FindCallback = find
+	return func() {
+		f.FindCallback = old
+	}
+}
+
+func (f *FakeStore) Find(ctx context.Context, query string, options ...sdkstore.FindOption) ([]transport.FindResponse, error) {
+	f.lock.Lock()
+	f.FindCalls = append(f.FindCalls, query)
+	find := f.FindCallback
+	f.lock.Unlock()
+
+	if find == nil {
+		return nil, nil
+	}
+	return find(ctx, query, options...)
 }
 
 func (f *FakeStore) SetInfoCallback(info func(ctx context.Context, name string, options ...sdkstore.InfoOption) (transport.InfoResponse, error)) func() {

--- a/internal/sdkstore/client.go
+++ b/internal/sdkstore/client.go
@@ -59,6 +59,7 @@ func basePath(base *url.URL) path.Path {
 
 // Client represents the client side of an SDK store.
 type Client struct {
+	*findClient
 	*infoClient
 }
 
@@ -75,12 +76,14 @@ func NewClient(config Config) *Client {
 	}
 
 	base := basePath(baseURL)
+	findPath := base.JoinPath("find")
 	infoPath := base.JoinPath("info")
 
 	apiRequester := newAPIRequester(httpClient)
 	restClient := newHTTPRESTClient(apiRequester)
 
 	return &Client{
+		findClient: newFindClient(findPath, restClient),
 		infoClient: newInfoClient(infoPath, restClient),
 	}
 }

--- a/internal/sdkstore/errors.go
+++ b/internal/sdkstore/errors.go
@@ -43,8 +43,6 @@ func handleBasicAPIErrors(list transport.APIErrors) error {
 		return errors.New("SDK name not found")
 	case transport.ErrorCodeAPIError:
 		return errors.New("unexpected SDK Store API error")
-	case transport.ErrorCodeBadArgument:
-		return errors.New("query argument")
 	}
 	// We haven't handled the errors, so just return them.
 	masked = false

--- a/internal/sdkstore/find.go
+++ b/internal/sdkstore/find.go
@@ -1,0 +1,123 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3.
+
+package sdkstore
+
+import (
+	"context"
+	"strings"
+
+	"github.com/canonical/workshop/internal/sdkstore/path"
+	"github.com/canonical/workshop/internal/sdkstore/transport"
+)
+
+// FindOption to be passed to Find to customize the resulting request.
+type FindOption func(*findOptions)
+
+type findOptions struct {
+	fields     []string
+	categories []string
+	platforms  []transport.Platform
+}
+
+var defaultFindFields = []string{
+	"default-release",
+	"description",
+	"license",
+	"publisher",
+	"summary",
+}
+
+// WithFindFields sets the fields to query (nil for default).
+func WithFindFields(fields []string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.fields = fields
+	}
+}
+
+// WithFindCategories configures categories to filter by.
+func WithFindCategories(categories []string) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.categories = categories
+	}
+}
+
+// WithFindPlatforms configures platforms to filter by.
+func WithFindPlatforms(platforms []transport.Platform) FindOption {
+	return func(findOptions *findOptions) {
+		findOptions.platforms = platforms
+	}
+}
+
+func newFindOptions() *findOptions {
+	return &findOptions{}
+}
+
+type findClient struct {
+	path   path.Path
+	client RESTClient
+}
+
+func newFindClient(path path.Path, client RESTClient) *findClient {
+	return &findClient{
+		path:   path,
+		client: client,
+	}
+}
+
+// Find searches the Store for SDKs matching the given query. The query matches
+// most text fields: name, title, summary, description and publisher.
+func (c *findClient) Find(ctx context.Context, query string, options ...FindOption) (result []transport.FindResponse, err error) {
+	var resp struct {
+		transport.FindResponses
+		transport.ErrorResponse
+	}
+	if err := c.find(ctx, &resp, query, options...); err != nil {
+		return resp.Results, err
+	}
+	if err := handleBasicAPIErrors(resp.ErrorList); err != nil {
+		return resp.Results, err
+	}
+
+	return resp.Results, nil
+}
+
+func (c *findClient) find(ctx context.Context, resp any, query string, options ...FindOption) error {
+	opts := newFindOptions()
+	for _, option := range options {
+		option(opts)
+	}
+
+	if opts.fields == nil {
+		opts.fields = defaultFindFields
+	}
+	path, err := c.path.Query("fields", strings.Join(opts.fields, ","))
+	if err != nil {
+		return err
+	}
+	if query != "" {
+		path, err = path.Query("q", query)
+		if err != nil {
+			return err
+		}
+	}
+	if opts.categories != nil {
+		path, err = path.Query("categories", strings.Join(opts.categories, ","))
+		if err != nil {
+			return err
+		}
+	}
+	if opts.platforms != nil {
+		platforms := make([]string, 0, len(opts.platforms))
+		for _, p := range opts.platforms {
+			platforms = append(platforms, p.String())
+		}
+		path, err = path.Query("platforms", strings.Join(platforms, ","))
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = c.client.Get(ctx, path, resp)
+	return err
+}

--- a/internal/sdkstore/find_integration_test.go
+++ b/internal/sdkstore/find_integration_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package sdkstore
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/sdkstore/transport"
+)
+
+type findIntegration struct{}
+
+var _ = check.Suite(&findIntegration{})
+
+func (f *findIntegration) TestSdkFind(c *check.C) {
+	client := NewClient(Config{})
+	var response any
+	err := client.find(context.Background(), &response, "test-sdk-find-1")
+	c.Assert(err, check.IsNil)
+
+	var expected any
+	err = json.Unmarshal(testSdkFindRaw, &expected)
+	c.Assert(err, check.IsNil)
+	c.Check(response, check.DeepEquals, expected)
+}
+
+func (f *findIntegration) TestSdkFindWithPlatform(c *check.C) {
+	platforms := []transport.Platform{{
+		Name:         "all",
+		Channel:      "all",
+		Architecture: "s390x",
+	}}
+
+	client := NewClient(Config{})
+	var response any
+	err := client.find(context.Background(), &response, "test-sdk-find-1", WithFindFields(allFindFields), WithFindPlatforms(platforms))
+	c.Assert(err, check.IsNil)
+
+	var expected any
+	err = json.Unmarshal(testSdkFindS390XRaw, &expected)
+	c.Assert(err, check.IsNil)
+	c.Check(response, check.DeepEquals, expected)
+}
+
+func (f *findIntegration) TestSdkFindByPublisher(c *check.C) {
+	// Use platform to narrow down the search results.
+	platforms := []transport.Platform{{
+		Name:         "all",
+		Channel:      "all",
+		Architecture: "s390x",
+	}}
+
+	client := NewClient(Config{})
+	var response any
+	err := client.find(context.Background(), &response, "jeconder", WithFindFields(allFindFields), WithFindPlatforms(platforms))
+	c.Assert(err, check.IsNil)
+
+	var expected any
+	err = json.Unmarshal(testSdkFindS390XRaw, &expected)
+	c.Assert(err, check.IsNil)
+	c.Check(response, check.DeepEquals, expected)
+}
+
+func (f *findIntegration) TestSdkFindByTitle(c *check.C) {
+	client := NewClient(Config{})
+	var response any
+	err := client.find(context.Background(), &response, "Test SDK s390x title", WithFindFields(allFindFields))
+	c.Assert(err, check.IsNil)
+
+	var expected any
+	err = json.Unmarshal(testSdkFindS390XRaw, &expected)
+	c.Assert(err, check.IsNil)
+	c.Check(response, check.DeepEquals, expected)
+}
+
+func (f *findIntegration) TestSdkFindBySummary(c *check.C) {
+	client := NewClient(Config{})
+	var response any
+	err := client.find(context.Background(), &response, "Test SDK s390x summary", WithFindFields(allFindFields))
+	c.Assert(err, check.IsNil)
+
+	var expected any
+	err = json.Unmarshal(testSdkFindS390XRaw, &expected)
+	c.Assert(err, check.IsNil)
+	c.Check(response, check.DeepEquals, expected)
+}
+
+func (f *findIntegration) TestSdkFindByDescription(c *check.C) {
+	client := NewClient(Config{})
+	var response any
+	err := client.find(context.Background(), &response, "Test SDK s390x description", WithFindFields(allFindFields))
+	c.Assert(err, check.IsNil)
+
+	var expected any
+	err = json.Unmarshal(testSdkFindS390XRaw, &expected)
+	c.Assert(err, check.IsNil)
+	c.Check(response, check.DeepEquals, expected)
+}

--- a/internal/sdkstore/find_test.go
+++ b/internal/sdkstore/find_test.go
@@ -1,0 +1,218 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3.
+
+package sdkstore
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"go.uber.org/mock/gomock"
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/sdkstore/path"
+	"github.com/canonical/workshop/internal/sdkstore/transport"
+	"github.com/canonical/workshop/internal/testutil"
+)
+
+//go:embed test-sdk-find.raw.json
+var testSdkFindRaw []byte
+
+//go:embed test-sdk-find.json
+var testSdkFindResponse []byte
+
+//go:embed test-sdk-find-s390x.raw.json
+var testSdkFindS390XRaw []byte
+
+//go:embed test-sdk-find-s390x.json
+var testSdkFindS390XResponse []byte
+
+type FindSuite struct{}
+
+var _ = check.Suite(&FindSuite{})
+
+func (s *FindSuite) TestFind(c *check.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	query := "test-sdk-find"
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGet(c, restClient, path, query)
+
+	client := newFindClient(path, restClient)
+	responses, err := client.Find(context.Background(), query)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(responses), check.Equals, 1)
+	c.Assert(responses[0].Name, check.Equals, query)
+}
+
+func (s *FindSuite) TestFindWithOptions(c *check.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	query := "test-sdk-find"
+
+	expect, err := path.Query("categories", "ide,language")
+	c.Assert(err, check.IsNil)
+	expect, err = expect.Query("platforms", "ubuntu#24.04#amd64,ubuntu#24.04#arm64")
+	c.Assert(err, check.IsNil)
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGet(c, restClient, expect, query)
+
+	client := newFindClient(path, restClient)
+	categories := []string{"ide", "language"}
+	platforms := []transport.Platform{
+		{Name: "ubuntu", Channel: "24.04", Architecture: "amd64"},
+		{Name: "ubuntu", Channel: "24.04", Architecture: "arm64"},
+	}
+	responses, err := client.Find(context.Background(), query, WithFindCategories(categories), WithFindPlatforms(platforms))
+	c.Assert(err, check.IsNil)
+	c.Assert(len(responses), check.Equals, 1)
+	c.Assert(responses[0].Name, check.Equals, query)
+}
+
+func (s *FindSuite) TestFindFailure(c *check.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	query := "test-sdk-find"
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGetFailure(restClient)
+
+	client := newFindClient(path, restClient)
+	_, err := client.Find(context.Background(), query)
+	c.Assert(err, check.NotNil)
+}
+
+func (s *FindSuite) expectGet(c *check.C, client *MockRESTClient, p path.Path, query string) {
+	namedPath, err := p.Query("q", query)
+	c.Assert(err, check.IsNil)
+	namedPath, err = namedPath.Query("fields", strings.Join(defaultFindFields, ","))
+	c.Assert(err, check.IsNil)
+
+	client.EXPECT().Get(gomock.Any(), namedPath, gomock.Any()).Do(func(_ context.Context, _ path.Path, r any) (restResponse, error) {
+		results := []transport.FindResponse{{Name: query}}
+		data, err := json.Marshal(transport.FindResponses{Results: results})
+		if err != nil {
+			return restResponse{}, err
+		}
+		err = json.Unmarshal(data, r)
+		return restResponse{}, err
+	})
+}
+
+func (s *FindSuite) expectGetFailure(client *MockRESTClient) {
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(restResponse{StatusCode: http.StatusInternalServerError}, errors.New("boom"))
+}
+
+func (s *FindSuite) TestFindRequestPayload(c *check.C) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/sdks/find")
+		c.Check(r.URL.Query()["q"], check.DeepEquals, []string{"test-sdk-find"})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(testSdkFindRaw)
+		c.Assert(err, check.IsNil)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	base := basePath(MustParseURL(c, server.URL))
+	findPath := base.JoinPath("find")
+
+	apiRequester := newAPIRequester(DefaultHTTPClient())
+	restClient := newHTTPRESTClient(apiRequester)
+
+	client := newFindClient(findPath, restClient)
+	responses, err := client.Find(context.Background(), "test-sdk-find")
+	c.Assert(err, check.IsNil)
+
+	var expected any
+	err = json.Unmarshal(testSdkFindResponse, &expected)
+	c.Assert(err, check.IsNil)
+	c.Check(responses, testutil.JsonEquals, expected)
+}
+
+var allFindFields = []string{
+	"contact",
+	"default-release",
+	"description",
+	"license",
+	"links",
+	"media",
+	"publisher",
+	"summary",
+}
+
+func (s *FindSuite) TestFindRequestPayloadS390X(c *check.C) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/sdks/find")
+		c.Check(r.URL.Query()["q"], check.DeepEquals, []string{"Test SDK s390x summary"})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(testSdkFindS390XRaw)
+		c.Assert(err, check.IsNil)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	base := basePath(MustParseURL(c, server.URL))
+	findPath := base.JoinPath("find")
+
+	apiRequester := newAPIRequester(DefaultHTTPClient())
+	restClient := newHTTPRESTClient(apiRequester)
+
+	client := newFindClient(findPath, restClient)
+	responses, err := client.Find(context.Background(), "Test SDK s390x summary")
+	c.Assert(err, check.IsNil)
+
+	var expected any
+	err = json.Unmarshal(testSdkFindS390XResponse, &expected)
+	c.Assert(err, check.IsNil)
+	c.Check(responses, testutil.JsonEquals, expected)
+}
+
+func (s *FindSuite) TestFindErrorPayload(c *check.C) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/sdks/find")
+		c.Check(r.URL.Query()["q"], check.DeepEquals, []string{"not-found"})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`
+{"error-list": [{"code": "some-error-code", "message": "not found message"}]}
+`))
+		c.Assert(err, check.IsNil)
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	base := basePath(MustParseURL(c, server.URL))
+	findPath := base.JoinPath("find")
+
+	apiRequester := newAPIRequester(DefaultHTTPClient())
+	restClient := newHTTPRESTClient(apiRequester)
+
+	client := newFindClient(findPath, restClient)
+	_, err := client.Find(context.Background(), "not-found")
+	c.Assert(err, check.ErrorMatches, "not found message")
+}

--- a/internal/sdkstore/http_test.go
+++ b/internal/sdkstore/http_test.go
@@ -6,6 +6,7 @@ package sdkstore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/errors"
 	"go.uber.org/mock/gomock"
 	"gopkg.in/check.v1"
 
@@ -47,7 +47,7 @@ func (s *APIRequesterSuite) TestDoWithFailure(c *check.C) {
 	req := MustNewRequest(c, "http://api.foo.bar")
 
 	mockHTTPClient := NewMockHTTPClient(ctrl)
-	mockHTTPClient.EXPECT().Do(req).Return(emptyResponse(), errors.Errorf("boom")) //nolint:bodyclose
+	mockHTTPClient.EXPECT().Do(req).Return(emptyResponse(), errors.New("boom")) //nolint:bodyclose
 
 	requester := newAPIRequester(mockHTTPClient)
 	_, err := requester.Do(req) //nolint:bodyclose
@@ -222,7 +222,7 @@ func (s *RESTSuite) TestGetWithFailure(c *check.C) {
 	defer ctrl.Finish()
 
 	mockHTTPClient := NewMockHTTPClient(ctrl)
-	mockHTTPClient.EXPECT().Do(gomock.Any()).Return(emptyResponse(), errors.Errorf("boom")) //nolint:bodyclose
+	mockHTTPClient.EXPECT().Do(gomock.Any()).Return(emptyResponse(), errors.New("boom")) //nolint:bodyclose
 
 	client := newHTTPRESTClient(mockHTTPClient)
 

--- a/internal/sdkstore/info.go
+++ b/internal/sdkstore/info.go
@@ -40,18 +40,15 @@ func WithInfoFields(fields []string) InfoOption {
 	}
 }
 
-// Create a infoOptions instance with default values.
 func newInfoOptions() *infoOptions {
 	return &infoOptions{}
 }
 
-// infoClient defines a client for info requests.
 type infoClient struct {
 	path   path.Path
 	client RESTClient
 }
 
-// newInfoClient creates a infoClient for requesting
 func newInfoClient(path path.Path, client RESTClient) *infoClient {
 	return &infoClient{
 		path:   path,

--- a/internal/sdkstore/info_test.go
+++ b/internal/sdkstore/info_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 
-	"github.com/juju/errors"
 	"go.uber.org/mock/gomock"
 	"gopkg.in/check.v1"
 
@@ -104,7 +104,7 @@ func (s *InfoSuite) expectGet(c *check.C, client *MockRESTClient, p path.Path, n
 }
 
 func (s *InfoSuite) expectGetFailure(client *MockRESTClient) {
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(restResponse{StatusCode: http.StatusInternalServerError}, errors.Errorf("boom"))
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(restResponse{StatusCode: http.StatusInternalServerError}, errors.New("boom"))
 }
 
 func (s *InfoSuite) expectGetError(c *check.C, client *MockRESTClient, p path.Path, name string) {

--- a/internal/sdkstore/test-sdk-find-s390x.json
+++ b/internal/sdkstore/test-sdk-find-s390x.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "test-sdk-find-1-s390x",
+    "package-id": "dP9SNAfRBf8IL0w1OD8tuGEViVSBKji6",
+    "metadata": {
+      "description": "Test SDK s390x description",
+      "license": "AGPL-3.0",
+      "publisher": {
+        "display-name": "Jonathan Conder",
+        "id": "YnyjkYo9nA6AlXsTKnpxrCGxNZgmSdmu",
+        "username":"usso-jeconder",
+        "validation":"unproven"
+      },
+      "summary": "Test SDK s390x summary"
+    },
+    "default-release": {
+      "channel": {
+        "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
+        "platform": {
+          "architecture": "s390x",
+          "channel": "all",
+          "name": "all"
+        },
+        "released-at": "2026-03-19T08:24:40.960058Z"
+      },
+      "revision": 1,
+      "version": "0.1+s390x"
+    }
+  }
+]

--- a/internal/sdkstore/test-sdk-find-s390x.raw.json
+++ b/internal/sdkstore/test-sdk-find-s390x.raw.json
@@ -1,0 +1,37 @@
+{
+  "results": [
+    {
+      "name": "test-sdk-find-1-s390x",
+      "package-id": "dP9SNAfRBf8IL0w1OD8tuGEViVSBKji6",
+      "metadata": {
+        "contact": "",
+        "description": "Test SDK s390x description",
+        "license": "AGPL-3.0",
+        "links": {},
+        "media": [],
+        "publisher": {
+          "display-name": "Jonathan Conder",
+          "id": "YnyjkYo9nA6AlXsTKnpxrCGxNZgmSdmu",
+          "username":"usso-jeconder",
+          "validation":"unproven"
+        },
+        "summary": "Test SDK s390x summary"
+      },
+      "default-release": {
+        "channel": {
+          "name": "latest/edge",
+          "track": "latest",
+          "risk": "edge",
+          "platform": {
+            "architecture": "s390x",
+            "channel": "all",
+            "name": "all"
+          },
+          "released-at": "2026-03-19T08:24:40.960058+00:00"
+        },
+        "revision": 1,
+        "version": "0.1+s390x"
+      }
+    }
+  ]
+}

--- a/internal/sdkstore/test-sdk-find.json
+++ b/internal/sdkstore/test-sdk-find.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "test-sdk-find-1",
+    "package-id": "geGY07WPXyvnQahmRP1oOegGUyjurXrY",
+    "metadata": {
+      "description": "Test SDK description",
+      "license": "AGPL-3.0",
+      "publisher": {
+        "display-name": "Jonathan Conder",
+        "id": "YnyjkYo9nA6AlXsTKnpxrCGxNZgmSdmu",
+        "username":"usso-jeconder",
+        "validation":"unproven"
+      },
+      "summary": "Test SDK summary"
+    },
+    "default-release": {
+      "channel": {
+        "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
+        "platform": {
+          "architecture": "amd64",
+          "channel": "22.04",
+          "name": "ubuntu"
+        },
+        "released-at": "2026-03-19T07:54:22.067952Z"
+      },
+      "revision": 1,
+      "version": "0.1.1"
+    }
+  },
+  {
+    "name": "test-sdk-find-1-s390x",
+    "package-id": "dP9SNAfRBf8IL0w1OD8tuGEViVSBKji6",
+    "metadata": {
+      "description": "Test SDK s390x description",
+      "license": "AGPL-3.0",
+      "publisher": {
+        "display-name": "Jonathan Conder",
+        "id": "YnyjkYo9nA6AlXsTKnpxrCGxNZgmSdmu",
+        "username":"usso-jeconder",
+        "validation":"unproven"
+      },
+      "summary": "Test SDK s390x summary"
+    },
+    "default-release": {
+      "channel": {
+        "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
+        "platform": {
+          "architecture": "s390x",
+          "channel": "all",
+          "name": "all"
+        },
+        "released-at": "2026-03-19T08:24:40.960058Z"
+      },
+      "revision": 1,
+      "version": "0.1+s390x"
+    }
+  }
+]

--- a/internal/sdkstore/test-sdk-find.raw.json
+++ b/internal/sdkstore/test-sdk-find.raw.json
@@ -1,0 +1,64 @@
+{
+  "results": [
+    {
+      "name": "test-sdk-find-1",
+      "package-id": "geGY07WPXyvnQahmRP1oOegGUyjurXrY",
+      "metadata": {
+        "description": "Test SDK description",
+        "license": "AGPL-3.0",
+        "publisher": {
+          "display-name": "Jonathan Conder",
+          "id": "YnyjkYo9nA6AlXsTKnpxrCGxNZgmSdmu",
+          "username":"usso-jeconder",
+          "validation":"unproven"
+        },
+        "summary": "Test SDK summary"
+      },
+      "default-release": {
+        "channel": {
+          "name": "latest/edge",
+          "track": "latest",
+          "risk": "edge",
+          "platform": {
+            "architecture": "amd64",
+            "channel": "22.04",
+            "name": "ubuntu"
+          },
+          "released-at": "2026-03-19T07:54:22.067952+00:00"
+        },
+        "revision": 1,
+        "version": "0.1.1"
+      }
+    },
+    {
+      "name": "test-sdk-find-1-s390x",
+      "package-id": "dP9SNAfRBf8IL0w1OD8tuGEViVSBKji6",
+      "metadata": {
+        "description": "Test SDK s390x description",
+        "license": "AGPL-3.0",
+        "publisher": {
+          "display-name": "Jonathan Conder",
+          "id": "YnyjkYo9nA6AlXsTKnpxrCGxNZgmSdmu",
+          "username":"usso-jeconder",
+          "validation":"unproven"
+        },
+        "summary": "Test SDK s390x summary"
+      },
+      "default-release": {
+        "channel": {
+          "name": "latest/edge",
+          "track": "latest",
+          "risk": "edge",
+          "platform": {
+            "architecture": "s390x",
+            "channel": "all",
+            "name": "all"
+          },
+          "released-at": "2026-03-19T08:24:40.960058+00:00"
+        },
+        "revision": 1,
+        "version": "0.1+s390x"
+      }
+    }
+  ]
+}

--- a/internal/sdkstore/test-sdk-info-multi-base.json
+++ b/internal/sdkstore/test-sdk-info-multi-base.json
@@ -17,14 +17,14 @@
     {
       "channel": {
         "name": "latest/stable",
+        "track": "latest",
+        "risk": "stable",
         "platform": {
           "architecture": "amd64",
           "channel": "20.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:48:34.474879Z",
-        "risk": "stable",
-        "track": "latest"
+        "released-at": "2026-03-10T23:48:34.474879Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:16:19.894258Z",
@@ -61,14 +61,14 @@
     {
       "channel": {
         "name": "latest/stable",
+        "track": "latest",
+        "risk": "stable",
         "platform": {
           "architecture": "amd64",
           "channel": "22.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:48:44.327082Z",
-        "risk": "stable",
-        "track": "latest"
+        "released-at": "2026-03-10T23:48:44.327082Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:16:31.917435Z",
@@ -105,14 +105,14 @@
     {
       "channel": {
         "name": "latest/stable",
+        "track": "latest",
+        "risk": "stable",
         "platform": {
           "architecture": "amd64",
           "channel": "24.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:48:51.554637Z",
-        "risk": "stable",
-        "track": "latest"
+        "released-at": "2026-03-10T23:48:51.554637Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:16:42.684241Z",
@@ -149,14 +149,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "amd64",
           "channel": "20.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:09.397396Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:09.397396Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:07.605786Z",
@@ -193,14 +193,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "arm64",
           "channel": "20.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:37.506334Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:37.506334Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:33.890123Z",
@@ -237,14 +237,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "riscv64",
           "channel": "20.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:50:09.178916Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:50:09.178916Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:50:05.426185Z",
@@ -281,14 +281,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "amd64",
           "channel": "22.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:18.751516Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:18.751516Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:14.930412Z",
@@ -325,14 +325,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "arm64",
           "channel": "22.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:48.030485Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:48.030485Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:43.827456Z",
@@ -369,14 +369,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "riscv64",
           "channel": "22.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:50:16.955362Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:50:16.955362Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:50:15.292817Z",
@@ -413,14 +413,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "amd64",
           "channel": "24.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:28.111011Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:28.111011Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:24.736009Z",
@@ -457,14 +457,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "arm64",
           "channel": "24.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:57.942362Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:57.942362Z"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:53.081669Z",
@@ -501,14 +501,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "riscv64",
           "channel": "24.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-11T00:13:19.621866Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-11T00:13:19.621866Z"
       },
       "revision": {
         "created-at": "2026-03-11T00:13:15.679272Z",

--- a/internal/sdkstore/test-sdk-info-multi-base.raw.json
+++ b/internal/sdkstore/test-sdk-info-multi-base.raw.json
@@ -23,14 +23,14 @@
     {
       "channel": {
         "name": "latest/stable",
+        "track": "latest",
+        "risk": "stable",
         "platform": {
           "architecture": "amd64",
           "channel": "20.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:48:34.474879+00:00",
-        "risk": "stable",
-        "track": "latest"
+        "released-at": "2026-03-10T23:48:34.474879+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:16:19.894258+00:00",
@@ -67,14 +67,14 @@
     {
       "channel": {
         "name": "latest/stable",
+        "track": "latest",
+        "risk": "stable",
         "platform": {
           "architecture": "amd64",
           "channel": "22.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:48:44.327082+00:00",
-        "risk": "stable",
-        "track": "latest"
+        "released-at": "2026-03-10T23:48:44.327082+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:16:31.917435+00:00",
@@ -111,14 +111,14 @@
     {
       "channel": {
         "name": "latest/stable",
+        "track": "latest",
+        "risk": "stable",
         "platform": {
           "architecture": "amd64",
           "channel": "24.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:48:51.554637+00:00",
-        "risk": "stable",
-        "track": "latest"
+        "released-at": "2026-03-10T23:48:51.554637+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:16:42.684241+00:00",
@@ -155,14 +155,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "amd64",
           "channel": "20.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:09.397396+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:09.397396+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:07.605786+00:00",
@@ -199,14 +199,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "arm64",
           "channel": "20.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:37.506334+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:37.506334+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:33.890123+00:00",
@@ -243,14 +243,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "riscv64",
           "channel": "20.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:50:09.178916+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:50:09.178916+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:50:05.426185+00:00",
@@ -287,14 +287,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "amd64",
           "channel": "22.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:18.751516+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:18.751516+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:14.930412+00:00",
@@ -331,14 +331,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "arm64",
           "channel": "22.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:48.030485+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:48.030485+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:43.827456+00:00",
@@ -375,14 +375,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "riscv64",
           "channel": "22.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:50:16.955362+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:50:16.955362+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:50:15.292817+00:00",
@@ -419,14 +419,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "amd64",
           "channel": "24.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:28.111011+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:28.111011+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:24.736009+00:00",
@@ -463,14 +463,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "arm64",
           "channel": "24.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-10T23:49:57.942362+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T23:49:57.942362+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T23:49:53.081669+00:00",
@@ -507,14 +507,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "riscv64",
           "channel": "24.04",
           "name": "ubuntu"
         },
-        "released-at": "2026-03-11T00:13:19.621866+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-11T00:13:19.621866+00:00"
       },
       "revision": {
         "created-at": "2026-03-11T00:13:15.679272+00:00",

--- a/internal/sdkstore/test-sdk-info.json
+++ b/internal/sdkstore/test-sdk-info.json
@@ -17,14 +17,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "all",
           "channel": "all",
           "name": "all"
         },
-        "released-at": "2026-03-10T06:23:47.372123Z",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T06:23:47.372123Z"
       },
       "revision": {
         "created-at": "2026-03-10T06:23:16.908418Z",

--- a/internal/sdkstore/test-sdk-info.raw.json
+++ b/internal/sdkstore/test-sdk-info.raw.json
@@ -17,14 +17,14 @@
     {
       "channel": {
         "name": "latest/edge",
+        "track": "latest",
+        "risk": "edge",
         "platform": {
           "architecture": "all",
           "channel": "all",
           "name": "all"
         },
-        "released-at": "2026-03-10T06:23:47.372123+00:00",
-        "risk": "edge",
-        "track": "latest"
+        "released-at": "2026-03-10T06:23:47.372123+00:00"
       },
       "revision": {
         "created-at": "2026-03-10T06:23:16.908418+00:00",

--- a/internal/sdkstore/transport/common.go
+++ b/internal/sdkstore/transport/common.go
@@ -4,6 +4,8 @@
 package transport
 
 import (
+	"strings"
+
 	"github.com/canonical/workshop/internal/timeutil"
 )
 
@@ -29,6 +31,10 @@ type Platform struct {
 	Architecture string `json:"architecture"`
 }
 
+func (p Platform) String() string {
+	return strings.Join([]string{p.Name, p.Channel, p.Architecture}, "#")
+}
+
 // Download represents the download structure from the SDK Store.
 type Download struct {
 	URL      string `json:"url"`
@@ -40,6 +46,17 @@ type Download struct {
 type Category struct {
 	Featured bool   `json:"featured"`
 	Name     string `json:"name"`
+}
+
+// Links contains URLs associated with the SDK.
+type Links struct {
+	Contact   []string `json:"contact,omitempty"`
+	Docs      []string `json:"docs,omitempty"`
+	Donations []string `json:"donations,omitempty"`
+	Issues    []string `json:"issues,omitempty"`
+	Source    []string `json:"source,omitempty"`
+	Website   []string `json:"website,omitempty"`
+	Upstream  string   `json:"upstream,omitempty"`
 }
 
 // Media defines media attached to an SDK.

--- a/internal/sdkstore/transport/common.go
+++ b/internal/sdkstore/transport/common.go
@@ -14,11 +14,11 @@ import (
 // and platform. There can be multiple channels of the same track and risk, but
 // with different platforms.
 type Channel struct {
+	Name       string           `json:"name,omitempty"`
 	Track      string           `json:"track,omitempty"`
 	Risk       string           `json:"risk,omitempty"`
-	Name       string           `json:"name,omitempty"`
 	Platform   Platform         `json:"platform,omitzero"`
-	ReleasedAt timeutil.TimeUTC `json:"released-at"`
+	ReleasedAt timeutil.TimeUTC `json:"released-at,omitzero"`
 }
 
 // Platform is a typed tuple for identifying SDKs with a matching architecture,

--- a/internal/sdkstore/transport/find.go
+++ b/internal/sdkstore/transport/find.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3.
+
+package transport
+
+type FindResponses struct {
+	Results []FindResponse `json:"results,omitempty"`
+}
+
+type FindResponse struct {
+	Name           string         `json:"name"`
+	PackageID      string         `json:"package-id"`
+	Metadata       FindMetadata   `json:"metadata,omitzero"`
+	DefaultRelease FindChannelMap `json:"default-release,omitzero"`
+}
+
+// FindMetadata contains SDK details that apply to all revisions.
+type FindMetadata struct {
+	Contact     string    `json:"contact,omitempty"`
+	Description string    `json:"description,omitempty"`
+	License     string    `json:"license,omitempty"`
+	Links       Links     `json:"links,omitzero"`
+	Media       []Media   `json:"media,omitempty"`
+	Publisher   Publisher `json:"publisher,omitzero"`
+	Summary     string    `json:"summary,omitempty"`
+}
+
+type FindChannelMap struct {
+	Channel  Channel `json:"channel"`
+	Revision int     `json:"revision"`
+	Version  string  `json:"version"`
+}

--- a/internal/sdkstore/transport/info.go
+++ b/internal/sdkstore/transport/info.go
@@ -24,24 +24,13 @@ type InfoMetadata struct {
 	Contact     string     `json:"contact,omitempty"`
 	Description string     `json:"description,omitempty"`
 	License     string     `json:"license,omitempty"`
-	Links       InfoLinks  `json:"links,omitzero"`
+	Links       Links      `json:"links,omitzero"`
 	Media       []Media    `json:"media,omitempty"`
 	Private     bool       `json:"private,omitempty"`
 	Publisher   Publisher  `json:"publisher,omitzero"`
 	Summary     string     `json:"summary,omitempty"`
 	Title       string     `json:"title,omitempty"`
 	Website     string     `json:"website,omitempty"`
-}
-
-// InfoLinks contains URLs associated with the SDK.
-type InfoLinks struct {
-	Contact   []string `json:"contact,omitempty"`
-	Docs      []string `json:"docs,omitempty"`
-	Donations []string `json:"donations,omitempty"`
-	Issues    []string `json:"issues,omitempty"`
-	Source    []string `json:"source,omitempty"`
-	Website   []string `json:"website,omitempty"`
-	Upstream  string   `json:"upstream,omitempty"`
 }
 
 // InfoChannelMap represents the information channel map. This defines a unique

--- a/tests/main/sdk-find/task.yaml
+++ b/tests/main/sdk-find/task.yaml
@@ -1,0 +1,8 @@
+summary: Test sdk find output
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Test SDK find"
+  sdk_exec find test-sdk-find-1 > find.log
+  MATCH 'test-sdk-find-1[[:space:]]+0\.1\.1[[:space:]]+Jonathan Conder[[:space:]]+Test SDK summary' < find.log
+  MATCH 'test-sdk-find-1-s390x[[:space:]]+0\.1\+s390x[[:space:]]+Jonathan Conder[[:space:]]+Test SDK s390x summary' < find.log


### PR DESCRIPTION
# Description

Add a basic version of `sdk find`. It doesn't support `--category` yet, since as far as I know the Store doesn't have categories yet. But the Store client will support it when available. Platform filtering doesn't work very well yet either. It also doesn't support empty queries, this should be on the Store side like it is for Charmhub.

Currently I'm reusing the `/v1/sdks` endpoint in `workshopd`. If `?q=...` is given it queries the Store. Otherwise it retains the current behaviour. Open to other options here. But we can't do `/v1/sdks/find` because `find` would look like an SDK name.

I also added categories for the `sdk` CLI subcommands, and refactored the `workshop CLI` to match.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
