### PR TITLE
Reinstall original version of LXD after downgrading

### DIFF
--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -5,8 +5,6 @@ execute: |
 
   workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"
 
-  oldchannel=$(snap info lxd | yq -r .tracking)
-
   snap remove lxd --purge
   retry 5 snap install lxd --channel=5.21/stable
   lxd waitready
@@ -15,7 +13,6 @@ execute: |
   MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.3.\*$" < error.log
 
   snap remove lxd --purge
-  retry 5 snap install lxd --channel="$oldchannel"
-  lxd waitready
+  setup_lxd
   snap restart workshop
   workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"


### PR DESCRIPTION
# Description

When testing a local build of the LXD snap, `tests/main/compatible-backend` can end up reinstalling the wrong version, possibly affecting subsequent tests. We might as well reuse the logic from `setup_lxd`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
