### PR TITLE
Improve interface-related error messages

### DIFF
--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -257,7 +257,7 @@ func v1GetConnections(c *Command, r *http.Request, _ *userState) Response {
 
 	if workshop != "" {
 		if err := checkWorkshopExists(r.Context(), c.d.overlord.WorkshopManager(), projectId, workshop); err != nil {
-			return statusNotFound("cannot access workshop %q: %w", workshop, err)
+			return statusNotFound("cannot access %q workshop: %w", workshop, err)
 		}
 	}
 
@@ -332,7 +332,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 			continue
 		}
 		if err := checkInstalled(a.Plugs[i].ProjectId, a.Plugs[i].Workshop); err != nil {
-			return statusNotFound("cannot access workshop %q: %w", a.Plugs[i].Workshop, err)
+			return statusNotFound("cannot access %q workshop: %w", a.Plugs[i].Workshop, err)
 		}
 	}
 	for i := range a.Slots {
@@ -340,7 +340,7 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 			continue
 		}
 		if err := checkInstalled(a.Slots[i].ProjectId, a.Slots[i].Workshop); err != nil {
-			return statusNotFound("cannot access workshop %q: %w", a.Slots[i].Workshop, err)
+			return statusNotFound("cannot access %q workshop: %w", a.Slots[i].Workshop, err)
 		}
 	}
 
@@ -350,7 +350,9 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		repo := c.d.overlord.InterfaceManager().Repository()
 		connRef, err = repo.ResolveConnect(a.Plugs[0].ProjectId, a.Plugs[0].Workshop, a.Plugs[0].Sdk, a.Plugs[0].Name,
 			a.Slots[0].ProjectId, a.Slots[0].Workshop, a.Slots[0].Sdk, a.Slots[0].Name)
-		if err == nil {
+		if err != nil {
+			err = fmt.Errorf("cannot resolve connection: %w", err)
+		} else {
 			wsmgr := c.d.overlord.WorkshopManager()
 			var plugW, slotW *workshop.Workshop
 			plugW, err = wsmgr.Workshop(r.Context(), connRef.PlugRef.Workshop, connRef.PlugRef.ProjectId)
@@ -374,10 +376,8 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		var conns []*interfaces.ConnRef
 		conns, err = c.d.overlord.InterfaceManager().ResolveDisconnect(a.Plugs[0].ProjectId, a.Plugs[0].Workshop, a.Plugs[0].Sdk, a.Plugs[0].Name,
 			a.Slots[0].ProjectId, a.Slots[0].Workshop, a.Slots[0].Sdk, a.Slots[0].Name, a.Forget)
-		if err == nil {
-			if len(conns) == 0 {
-				return statusBadRequest("nothing to do")
-			}
+		if err == nil && len(conns) == 0 {
+			return statusBadRequest("nothing to do")
 		}
 		repo := c.d.overlord.InterfaceManager().Repository()
 		seen := map[interfaces.ConnRef]bool{}

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -240,7 +240,7 @@ func (s *apiSuite) TestConnectionsNotFound(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `cannot access workshop "not-found": workshop not launched`,
+			"message": `cannot access "not-found" workshop: workshop not launched`,
 		},
 		"status":      "Not Found",
 		"status-code": 404.0,
@@ -1241,7 +1241,7 @@ slots:
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `cannot connect "consumer-ws/consumer:plug" ("test" interface) to "producer-ws/producer:slot" ("different" interface)`,
+			"message": `cannot resolve connection: test plug "consumer-ws/consumer:plug" incompatible with different slot "producer-ws/producer:slot"`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1280,7 +1280,7 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchPlug(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `SDK "consumer-ws/consumer" has no plug named "missingplug"`,
+			"message": `cannot resolve connection: "consumer-ws/consumer" SDK has no plug named "missingplug"`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1319,7 +1319,7 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `SDK "producer-ws/producer" has no slot named "missingslot"`,
+			"message": `cannot resolve connection: "producer-ws/producer" SDK has no slot named "missingslot"`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1710,7 +1710,7 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `SDK "consumer-ws/consumer" has no plug named "missingplug"`,
+			"message": `"consumer-ws/consumer" SDK has no plug named "missingplug"`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1757,7 +1757,7 @@ func (s *apiSuite) testDisconnectFailureNoWorkshop(c *check.C, installedWorkshop
 	if producer {
 		c.Check(body, check.DeepEquals, map[string]any{
 			"result": map[string]any{
-				"message": `cannot access workshop "consumer-ws": workshop not launched`,
+				"message": `cannot access "consumer-ws" workshop: workshop not launched`,
 			},
 			"status":      "Not Found",
 			"status-code": 404.0,
@@ -1766,7 +1766,7 @@ func (s *apiSuite) testDisconnectFailureNoWorkshop(c *check.C, installedWorkshop
 	} else {
 		c.Check(body, check.DeepEquals, map[string]any{
 			"result": map[string]any{
-				"message": `cannot access workshop "producer-ws": workshop not launched`,
+				"message": `cannot access "producer-ws" workshop: workshop not launched`,
 			},
 			"status":      "Not Found",
 			"status-code": 404.0,

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1602,7 +1602,7 @@ func (s *apiSuite) TestLaunchWorkshopBindPlugIncompatibleIface(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "launch",
 			Summary:   `Launch "bindincompatible" workshop`,
-			ChangeErr: `(?s).*cannot bind "bindincompatible/test-sdk:data" \("mount" interface\) to "bindincompatible/test-sdk-2:gpu" \("gpu" interface\).*`,
+			ChangeErr: `(?s).*invalid plug binding: mount plug "bindincompatible/test-sdk:data" incompatible with gpu plug "bindincompatible/test-sdk-2:gpu".*`,
 		},
 	}
 
@@ -1753,7 +1753,7 @@ func (s *apiSuite) TestWorkshopConnectionsUnknownPlug(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "launch",
 			Summary:   `Launch "workshopbrokenconn" workshop`,
-			ChangeErr: `(?s).*SDK "workshopbrokenconn/test-sdk" has no plug named "data-unknown-plug".*`,
+			ChangeErr: `(?s).*"workshopbrokenconn/test-sdk" SDK has no plug named "data-unknown-plug".*`,
 		},
 	}
 
@@ -3719,7 +3719,7 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 			Status:    http.StatusAccepted,
 			Kind:      "refresh",
 			Summary:   `Refresh "manysdks" workshop`,
-			ChangeErr: `(?s).*SDK "manysdks/test-sdk" has no plug named "data-non-existent".*`,
+			ChangeErr: `(?s).*"manysdks/test-sdk" SDK has no plug named "data-non-existent".*`,
 		},
 	}
 	s.runActionTest(c, requests, expected)

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -83,7 +83,7 @@ func (r *Repository) AddInterface(i Interface) error {
 		return err
 	}
 	if _, ok := r.ifaces[interfaceName]; ok {
-		return fmt.Errorf("cannot add interface: %q, interface name is in use", interfaceName)
+		return fmt.Errorf("cannot add %s interface: name in use", interfaceName)
 	}
 	r.ifaces[interfaceName] = i
 
@@ -220,7 +220,7 @@ func (r *Repository) AddBackend(backend SecurityBackend) error {
 	name := backend.Name()
 	for _, other := range r.backends {
 		if other.Name() == name {
-			return fmt.Errorf("cannot add backend %q, security system name is in use", name)
+			return fmt.Errorf("cannot add %s backend: name in use", name)
 		}
 	}
 	r.backends = append(r.backends, backend)
@@ -279,14 +279,14 @@ func (r *Repository) Connection(connRef *ConnRef) (*Connection, error) {
 	plug := r.plugs[plugkey][connRef.PlugRef.Name]
 	if plug == nil {
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("SDK %q has no plug named %q",
+			message: fmt.Sprintf("%q SDK has no plug named %q",
 				connRef.PlugRef.SdkRef().ShortRef(), connRef.PlugRef.Name)}
 	}
 	// Ensure that such slot exists
 	slot := r.slots[slotkey][connRef.SlotRef.Name]
 	if slot == nil {
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("SDK %q has no slot named %q",
+			message: fmt.Sprintf("%q SDK has no slot named %q",
 				connRef.SlotRef.SdkRef().ShortRef(), connRef.SlotRef.Name)}
 	}
 	// Ensure that slot and plug are connected
@@ -315,13 +315,13 @@ func (r *Repository) AddPlug(plug *sdk.PlugInfo) error {
 	}
 	i := r.ifaces[plug.Interface]
 	if i == nil {
-		return fmt.Errorf("cannot add plug, interface %q is not known", plug.Interface)
+		return fmt.Errorf("cannot add plug: %q interface unknown", plug.Interface)
 	}
 	if _, ok := r.plugs[key][plug.Name]; ok {
-		return fmt.Errorf("sdk %q has plugs conflicting on name %q", plug.Sdk.Name, plug.Name)
+		return fmt.Errorf("%q SDK has plugs conflicting on name %q", plug.Sdk.Name, plug.Name)
 	}
 	if _, ok := r.slots[key][plug.Name]; ok {
-		return fmt.Errorf("sdk %q has plug and slot conflicting on name %q", plug.Sdk.Name, plug.Name)
+		return fmt.Errorf("%q SDK has plug and slot conflicting on name %q", plug.Sdk.Name, plug.Name)
 	}
 	if r.plugs[key] == nil {
 		r.plugs[key] = make(map[string]*sdk.PlugInfo)
@@ -341,11 +341,11 @@ func (r *Repository) RemovePlug(projectId, workshop, sdkName, plugName string) e
 	// Ensure that such plug exists
 	plug := r.plugs[key][plugName]
 	if plug == nil {
-		return fmt.Errorf("cannot remove plug %q from sdk %q, no such plug", plugName, sdkName)
+		return fmt.Errorf("cannot remove plug %q from %q SDK: no such plug", plugName, sdkName)
 	}
 	// Ensure that the plug is not used by any slot
 	if len(r.plugSlots[plug]) > 0 {
-		return fmt.Errorf("cannot remove plug %q from sdk %q, it is still connected", plugName, sdkName)
+		return fmt.Errorf("cannot remove plug %q from %q SDK: still connected", plugName, sdkName)
 	}
 	delete(r.plugs[key], plugName)
 	if len(r.plugs[key]) == 0 {
@@ -413,13 +413,13 @@ func (r *Repository) AddSlot(slot *sdk.SlotInfo) error {
 	// TODO: ensure that apps are correct
 	i := r.ifaces[slot.Interface]
 	if i == nil {
-		return fmt.Errorf("cannot add slot, interface %q is not known", slot.Interface)
+		return fmt.Errorf("cannot add slot: %q interface unknown", slot.Interface)
 	}
 	if _, ok := r.slots[key][slot.Name]; ok {
-		return fmt.Errorf("sdk %q has slots conflicting on name %q", slot.Sdk.Name, slot.Name)
+		return fmt.Errorf("%q SDK has slots conflicting on name %q", slot.Sdk.Name, slot.Name)
 	}
 	if _, ok := r.plugs[key][slot.Name]; ok {
-		return fmt.Errorf("sdk %q has plug and slot conflicting on name %q", slot.Sdk.Name, slot.Name)
+		return fmt.Errorf("%q SDK has plug and slot conflicting on name %q", slot.Sdk.Name, slot.Name)
 	}
 	if r.slots[key] == nil {
 		r.slots[key] = make(map[string]*sdk.SlotInfo)
@@ -440,11 +440,11 @@ func (r *Repository) RemoveSlot(projectId, workshop, sdkName, slotName string) e
 	// Ensure that such slot exists
 	slot := r.slots[key][slotName]
 	if slot == nil {
-		return fmt.Errorf("cannot remove slot %q from sdk %q, no such slot", slotName, sdkName)
+		return fmt.Errorf("cannot remove slot %q from %q SDK: no such slot", slotName, sdkName)
 	}
 	// Ensure that the slot is not using any plugs
 	if len(r.slotPlugs[slot]) > 0 {
-		return fmt.Errorf("cannot remove slot %q from sdk %q, it is still connected", slotName, sdkName)
+		return fmt.Errorf("cannot remove slot %q from %q SDK: still connected", slotName, sdkName)
 	}
 	delete(r.slots[key], slotName)
 	if len(r.slots[key]) == 0 {
@@ -494,8 +494,8 @@ func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, sl
 	}
 	// Ensure that plug and slot are compatible
 	if slot.Interface != plug.Interface {
-		return nil, fmt.Errorf(`cannot connect plug %q (%q interface) to %q (%q interface)`,
-			ref.PlugRef.ShortRef(), plug.Interface, ref.SlotRef.ShortRef(), slot.Interface)
+		return nil, fmt.Errorf(`cannot connect: %s plug %q incompatible with %s slot %q`,
+			plug.Interface, ref.PlugRef.ShortRef(), slot.Interface, ref.SlotRef.ShortRef())
 	}
 
 	iface, ok := r.ifaces[plug.Interface]
@@ -591,7 +591,7 @@ func (r *Repository) Disconnect(plugProjectId, plugWorkshop, plugSdkName, plugNa
 	if plug == nil {
 		sdkRef := sdk.Ref{ProjectId: plugProjectId, Workshop: plugWorkshop, Sdk: plugSdkName}
 		return &NoPlugOrSlotError{
-			message: fmt.Sprintf("SDK %q has no plug named %q", sdkRef.ShortRef(), plugName),
+			message: fmt.Sprintf("%q SDK has no plug named %q", sdkRef.ShortRef(), plugName),
 		}
 	}
 	// Ensure that such slot exists
@@ -599,7 +599,7 @@ func (r *Repository) Disconnect(plugProjectId, plugWorkshop, plugSdkName, plugNa
 	if slot == nil {
 		sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
 		return &NoPlugOrSlotError{
-			message: fmt.Sprintf("SDK %q has no slot named %q", sdkRef.ShortRef(), slotName),
+			message: fmt.Sprintf("%q SDK has no slot named %q", sdkRef.ShortRef(), slotName),
 		}
 	}
 	// Ensure that slot and plug are connected
@@ -670,7 +670,7 @@ func (r *Repository) connected(projectId, workshop, sk, plugOrSlotName string) (
 	if r.plugs[key][plugOrSlotName] == nil && r.slots[key][plugOrSlotName] == nil {
 		sdkRef := sdk.Ref{ProjectId: projectId, Workshop: workshop, Sdk: sk}
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("SDK %q has no plug or slot named %q",
+			message: fmt.Sprintf("%q SDK has no plug or slot named %q",
 				sdkRef.ShortRef(), plugOrSlotName)}
 	}
 	// Collect all the relevant connections
@@ -1043,16 +1043,16 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 	defer r.m.Unlock()
 
 	if plugProjectId == "" {
-		return nil, fmt.Errorf("cannot resolve connection, plug project-id name is empty")
+		return nil, fmt.Errorf("plug project ID is empty")
 	}
 	if plugWorkshop == "" {
-		return nil, fmt.Errorf("cannot resolve connection, plug Workshop name is empty")
+		return nil, fmt.Errorf("plug workshop name is empty")
 	}
 	if plugSdkName == "" {
-		return nil, fmt.Errorf("cannot resolve connection, plug SDK name is empty")
+		return nil, fmt.Errorf("plug SDK name is empty")
 	}
 	if plugName == "" {
-		return nil, fmt.Errorf("cannot resolve connection, plug name is empty")
+		return nil, fmt.Errorf("plug name is empty")
 	}
 
 	plugKey := plugOrSlotKey(plugProjectId, plugWorkshop, plugSdkName)
@@ -1062,7 +1062,7 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 	if plug == nil {
 		sdkRef := sdk.Ref{ProjectId: plugProjectId, Workshop: plugWorkshop, Sdk: plugSdkName}
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf(`SDK %q has no plug named %q`,
+			message: fmt.Sprintf(`%q SDK has no plug named %q`,
 				sdkRef.ShortRef(), plugName),
 		}
 	}
@@ -1088,13 +1088,13 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 		switch len(candidates) {
 		case 0:
 			sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
-			return nil, fmt.Errorf(`SDK %q has no %q interface slots`, sdkRef.ShortRef(), plug.Interface)
+			return nil, fmt.Errorf(`%q SDK has no %s interface slots`, sdkRef.ShortRef(), plug.Interface)
 		case 1:
 			slotName = candidates[0]
 		default:
 			sort.Strings(candidates)
 			sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
-			return nil, fmt.Errorf("SDK %q has multiple %q interface slots: %s",
+			return nil, fmt.Errorf("%q SDK has multiple %s interface slots: %s",
 				sdkRef.ShortRef(), plug.Interface, strings.Join(candidates, ", "))
 		}
 	}
@@ -1104,13 +1104,13 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 	if slot == nil {
 		sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
 		return nil, &NoPlugOrSlotError{
-			message: fmt.Sprintf("SDK %q has no slot named %q", sdkRef.ShortRef(), slotName),
+			message: fmt.Sprintf("%q SDK has no slot named %q", sdkRef.ShortRef(), slotName),
 		}
 	}
 	// Ensure that plug and slot are compatible
 	if slot.Interface != plug.Interface {
-		return nil, fmt.Errorf("cannot connect %q (%q interface) to %q (%q interface)",
-			plug.Ref().ShortRef(), plug.Interface, slot.Ref().ShortRef(), slot.Interface)
+		return nil, fmt.Errorf("%s plug %q incompatible with %s slot %q",
+			plug.Interface, plug.Ref().ShortRef(), slot.Interface, slot.Ref().ShortRef())
 	}
 	return NewConnRef(plug, slot), nil
 }

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -146,7 +146,7 @@ func (s *RepositorySuite) TestAddInterfaceClash(c *C) {
 	c.Assert(err, IsNil)
 	// Adding an interface with the same name as another interface is not allowed
 	err = s.emptyRepo.AddInterface(iface2)
-	c.Assert(err, ErrorMatches, `cannot add interface: "iface", interface name is in use`)
+	c.Assert(err, ErrorMatches, `cannot add iface interface: name in use`)
 	c.Assert(s.emptyRepo.Interface(iface1.Name()), Equals, iface1)
 }
 
@@ -181,7 +181,7 @@ func (s *RepositorySuite) TestAddBackend(c *C) {
 	backend := &ifacetest.TestSecurityBackend{BackendName: "test"}
 	c.Assert(s.emptyRepo.AddBackend(backend), IsNil)
 	err := s.emptyRepo.AddBackend(backend)
-	c.Assert(err, ErrorMatches, `cannot add backend "test", security system name is in use`)
+	c.Assert(err, ErrorMatches, `cannot add test backend: name in use`)
 }
 
 func (s *RepositorySuite) TestBackends(c *C) {
@@ -236,7 +236,7 @@ func (s *RepositorySuite) TestAddPlugClashingPlug(c *C) {
 	err := s.testRepo.AddPlug(s.plug)
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddPlug(s.plug)
-	c.Assert(err, ErrorMatches, `sdk "consumer" has plugs conflicting on name "plug"`)
+	c.Assert(err, ErrorMatches, `"consumer" SDK has plugs conflicting on name "plug"`)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
 }
 
@@ -255,7 +255,7 @@ func (s *RepositorySuite) TestAddPlugClashingSlot(c *C) {
 	err := s.testRepo.AddSlot(slot)
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddPlug(plug)
-	c.Assert(err, ErrorMatches, `sdk "sdk" has plug and slot conflicting on name "clashing"`)
+	c.Assert(err, ErrorMatches, `"sdk" SDK has plug and slot conflicting on name "clashing"`)
 	c.Assert(s.testRepo.AllSlots(""), HasLen, 1)
 	c.Assert(s.testRepo.Slot(slot.Sdk.ProjectId, slot.Sdk.Workshop, slot.Sdk.Name, slot.Name), DeepEquals, slot)
 }
@@ -273,7 +273,7 @@ func (s *RepositorySuite) TestAddPlugFailsWithInvalidPlugName(c *C) {
 
 func (s *RepositorySuite) TestAddPlugFailsWithUnknownInterface(c *C) {
 	err := s.emptyRepo.AddPlug(s.plug)
-	c.Assert(err, ErrorMatches, `cannot add plug, interface "interface" is not known`)
+	c.Assert(err, ErrorMatches, `cannot add plug: "interface" interface unknown`)
 	c.Assert(s.emptyRepo.AllPlugs(""), HasLen, 0)
 }
 
@@ -353,7 +353,7 @@ func (s *RepositorySuite) TestRemovePlugSucceedsWhenPlugExistsAndDisconnected(c 
 
 func (s *RepositorySuite) TestRemovePlugFailsWhenPlugDoesntExist(c *C) {
 	err := s.emptyRepo.RemovePlug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
-	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from sdk "consumer", no such plug`)
+	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from "consumer" SDK: no such plug`)
 }
 
 func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
@@ -366,7 +366,7 @@ func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
 	c.Assert(err, IsNil)
 	// Removing a plug used by a slot returns an appropriate error
 	err = s.testRepo.RemovePlug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
-	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from sdk "consumer", it is still connected`)
+	c.Assert(err, ErrorMatches, `cannot remove plug "plug" from "consumer" SDK: still connected`)
 	// The plug is still there
 	slot := s.testRepo.Plug(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
 	c.Assert(slot, NotNil)
@@ -580,7 +580,7 @@ func (s *RepositorySuite) TestSlotFailsWhenSlotDoesntExist(c *C) {
 
 func (s *RepositorySuite) TestAddSlotFailsWhenInterfaceIsUnknown(c *C) {
 	err := s.emptyRepo.AddSlot(s.slot)
-	c.Assert(err, ErrorMatches, `cannot add slot, interface "interface" is not known`)
+	c.Assert(err, ErrorMatches, `cannot add slot: "interface" interface unknown`)
 }
 
 func (s *RepositorySuite) TestAddSlotFailsWhenSlotNameIsInvalid(c *C) {
@@ -600,7 +600,7 @@ func (s *RepositorySuite) TestAddSlotClashingSlot(c *C) {
 	c.Assert(err, IsNil)
 	// Adding the slot again fails with appropriate error
 	err = s.testRepo.AddSlot(s.slot)
-	c.Assert(err, ErrorMatches, `sdk "producer" has slots conflicting on name "slot"`)
+	c.Assert(err, ErrorMatches, `"producer" SDK has slots conflicting on name "slot"`)
 }
 
 func (s *RepositorySuite) TestAddSlotClashingPlug(c *C) {
@@ -618,7 +618,7 @@ func (s *RepositorySuite) TestAddSlotClashingPlug(c *C) {
 	err := s.testRepo.AddPlug(plug)
 	c.Assert(err, IsNil)
 	err = s.testRepo.AddSlot(slot)
-	c.Assert(err, ErrorMatches, `sdk "sdk" has plug and slot conflicting on name "clashing"`)
+	c.Assert(err, ErrorMatches, `"sdk" SDK has plug and slot conflicting on name "clashing"`)
 	c.Assert(s.testRepo.AllPlugs(""), HasLen, 1)
 	c.Assert(s.testRepo.Plug(plug.Sdk.ProjectId, plug.Sdk.Workshop, plug.Sdk.Name, plug.Name), DeepEquals, plug)
 }
@@ -664,7 +664,7 @@ func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotDoesntExist(c *C) {
 	// Removing a slot that doesn't exist returns an appropriate error
 	err := s.testRepo.RemoveSlot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from sdk "producer", no such slot`)
+	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from "producer" SDK: no such slot`)
 }
 
 func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotIsConnected(c *C) {
@@ -677,7 +677,7 @@ func (s *RepositorySuite) TestRemoveSlotFailsWhenSlotIsConnected(c *C) {
 	c.Assert(err, IsNil)
 	// Removing a slot occupied by a plug returns an appropriate error
 	err = s.testRepo.RemoveSlot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from sdk "producer", it is still connected`)
+	c.Assert(err, ErrorMatches, `cannot remove slot "slot" from "producer" SDK: still connected`)
 	// The slot is still there
 	slot := s.testRepo.Slot(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
 	c.Assert(slot, NotNil)
@@ -750,7 +750,7 @@ func (s *RepositorySuite) TestConnectFailsWhenSlotAndPlugAreIncompatible(c *C) {
 	// Connecting a plug to an incompatible slot fails with an appropriate error
 	connRef := NewConnRef(s.plug, s.slot)
 	_, err = s.testRepo.Connect(connRef, nil, nil, nil, nil, nil)
-	c.Assert(err, ErrorMatches, `cannot connect plug "ws/consumer:plug" \("other-interface" interface\) to "ws/producer:slot" \("interface" interface\)`)
+	c.Assert(err, ErrorMatches, `cannot connect: other-interface plug "ws/consumer:plug" incompatible with interface slot "ws/producer:slot"`)
 }
 
 func (s *RepositorySuite) TestConnectSucceeds(c *C) {
@@ -782,7 +782,7 @@ func (s *RepositorySuite) TestDisconnectFailsOnEmptyArgs(c *C) {
 func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
 	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `SDK "ws/consumer" has no plug named "plug"`)
+	c.Assert(err, ErrorMatches, `"ws/consumer" SDK has no plug named "plug"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -791,7 +791,7 @@ func (s *RepositorySuite) TestDisconnectFailsWithoutPlug(c *C) {
 func (s *RepositorySuite) TestDisconnectFailsWithutSlot(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	err := s.testRepo.Disconnect(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name, s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Assert(err, ErrorMatches, `SDK "ws/producer" has no slot named "slot"`)
+	c.Assert(err, ErrorMatches, `"ws/producer" SDK has no slot named "slot"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -845,10 +845,10 @@ func (s *RepositorySuite) TestConnectedFailsWithEmptyPlugSlotName(c *C) {
 func (s *RepositorySuite) TestConnectedFailsWithoutPlugOrSlot(c *C) {
 	_, err1 := s.testRepo.Connected(s.plug.Sdk.ProjectId, s.plug.Sdk.Workshop, s.plug.Sdk.Name, s.plug.Name)
 	_, err2 := s.testRepo.Connected(s.slot.Sdk.ProjectId, s.slot.Sdk.Workshop, s.slot.Sdk.Name, s.slot.Name)
-	c.Check(err1, ErrorMatches, `SDK "ws/consumer" has no plug or slot named "plug"`)
+	c.Check(err1, ErrorMatches, `"ws/consumer" SDK has no plug or slot named "plug"`)
 	e, _ := err1.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
-	c.Check(err2, ErrorMatches, `SDK "ws/producer" has no plug or slot named "slot"`)
+	c.Check(err2, ErrorMatches, `"ws/producer" SDK has no plug or slot named "slot"`)
 	e, _ = err1.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }
@@ -1599,14 +1599,14 @@ func (s *RepositorySuite) TestConnection(c *C) {
 	_, err = s.testRepo.Connection(&ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"},
 		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "producer", Name: "slot"}})
-	c.Assert(err, ErrorMatches, `SDK "ws/a" has no plug named "b"`)
+	c.Assert(err, ErrorMatches, `"ws/a" SDK has no plug named "b"`)
 	e, _ := err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 
 	_, err = s.testRepo.Connection(&ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
 		SlotRef: sdk.SlotRef{ProjectId: s.projectId, Workshop: "ws", Sdk: "a", Name: "b"}})
-	c.Assert(err, ErrorMatches, `SDK "ws/a" has no slot named "b"`)
+	c.Assert(err, ErrorMatches, `"ws/a" SDK has no slot named "b"`)
 	e, _ = err.(*NoPlugOrSlotError)
 	c.Check(e, NotNil)
 }

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -39,7 +39,7 @@ func (m *InterfaceManager) doResolveInterfaces(task *state.Task, tomb *tomb.Tomb
 
 	// Ensure all bound plugs exist in the repository.
 	if err = m.resolveWorkshopBindings(wp); err != nil {
-		return err
+		return fmt.Errorf("invalid plug binding: %w", err)
 	}
 
 	// Ensure that connections requested via the workshop file use existing and
@@ -459,12 +459,12 @@ func (m *InterfaceManager) doConnect(task *state.Task, tomb *tomb.Tomb) error {
 
 	plug := m.repo.Plug(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name)
 	if plug == nil {
-		return fmt.Errorf("SDK %q has no plug named %q", plugRef.SdkRef().ShortRef(), plugRef.Name)
+		return fmt.Errorf("%q SDK has no plug named %q", plugRef.SdkRef().ShortRef(), plugRef.Name)
 	}
 
 	slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
 	if slot == nil {
-		return fmt.Errorf("SDK %q has no slot named %q", slotRef.SdkRef().ShortRef(), slotRef.Name)
+		return fmt.Errorf("%q SDK has no slot named %q", slotRef.SdkRef().ShortRef(), slotRef.Name)
 	}
 
 	var plugDynamicAttrs, slotDynamicAttrs map[string]any
@@ -573,12 +573,12 @@ func (m *InterfaceManager) undoConnect(task *state.Task, tomb *tomb.Tomb) error 
 
 	plug := m.repo.Plug(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name)
 	if plug == nil {
-		return fmt.Errorf("SDK %q has no plug named %q", plugRef.SdkRef().ShortRef(), plugRef.Name)
+		return fmt.Errorf("%q SDK has no plug named %q", plugRef.SdkRef().ShortRef(), plugRef.Name)
 	}
 
 	slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
 	if slot == nil {
-		return fmt.Errorf("SDK %q has no slot named %q", slotRef.SdkRef().ShortRef(), slotRef.Name)
+		return fmt.Errorf("%q SDK has no slot named %q", slotRef.SdkRef().ShortRef(), slotRef.Name)
 	}
 
 	if err = m.repo.Disconnect(plugRef.ProjectId, plugRef.Workshop,
@@ -747,10 +747,10 @@ func (m *InterfaceManager) undoDisconnect(task *state.Task, tomb *tomb.Tomb) (er
 		return nil
 	}
 	if plug == nil {
-		return fmt.Errorf("SDK %q has no plug named %q", cref.PlugRef.SdkRef().ShortRef(), cref.PlugRef.Name)
+		return fmt.Errorf("%q SDK has no plug named %q", cref.PlugRef.SdkRef().ShortRef(), cref.PlugRef.Name)
 	}
 	if slot == nil {
-		return fmt.Errorf("SDK %q has no slot named %q", cref.SlotRef.SdkRef().ShortRef(), cref.SlotRef.Name)
+		return fmt.Errorf("%q SDK has no slot named %q", cref.SlotRef.SdkRef().ShortRef(), cref.SlotRef.Name)
 	}
 
 	c, err := m.repo.Connect(&cref, oldconn.StaticPlugAttrs, oldconn.DynamicPlugAttrs,
@@ -1035,7 +1035,7 @@ func (m *InterfaceManager) remount(ctx context.Context, task *state.Task, plug *
 	revert.Add(func() {
 		if _, err := m.repo.Connect(connRef, connection.Plug.StaticAttrs(),
 			connection.Plug.DynamicAttrs(), connection.Slot.StaticAttrs(), oldDynamicAttrs, nil); err != nil {
-			logger.Debugf("On doRemount: cannot reconnect %q plug on a failed remount", plug.ShortRef())
+			logger.Debugf("On doRemount: cannot reconnect plug %q on a failed remount", plug.ShortRef())
 		}
 	})
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -432,7 +432,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindMasterPlugNotFound(c *check.
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	c.Check(chg.Err(), check.ErrorMatches, `(?s).*SDK "ws/consumer" has no plug named "no-such-plug2".*`)
+	c.Check(chg.Err(), check.ErrorMatches, `(?s).*"ws/consumer" SDK has no plug named "no-such-plug2".*`)
 
 	// Validate
 	pconns, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
@@ -523,7 +523,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectFailsOnConflictingMountTargets(c
 	defer s.state.Unlock()
 
 	// Validate
-	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*cannot connect "ws/conflict-[12]:plug" without binding to "ws/conflict-[12]:plug": unbound plugs cannot share target "/opt".*`)
+	c.Assert(chg.Err(), check.ErrorMatches, `(?s).*conflicting target "/opt": plug "ws/conflict-[12]:plug" must bind to plug "ws/conflict-[12]:plug".*`)
 }
 
 func (s *interfaceHandlersSuite) TestAutoconnectBindResolvesMountConflicts(c *check.C) {

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -407,21 +407,21 @@ func (m *InterfaceManager) resolveWorkshopBindings(w *workshop.Workshop) error {
 			master := m.repo.Plug(w.Project.ProjectId, w.Name, plug.Bind.Sdk, plug.Bind.Name)
 			if master == nil {
 				sdkRef := sdk.Ref{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: plug.Bind.Sdk}
-				return fmt.Errorf("SDK %q has no plug named %q", sdkRef.ShortRef(), plug.Bind.Name)
+				return fmt.Errorf("%q SDK has no plug named %q", sdkRef.ShortRef(), plug.Bind.Name)
 			}
 
 			slave := m.repo.Plug(w.Project.ProjectId, w.Name, s.Name, name)
 			if slave == nil {
 				sdkRef := sdk.Ref{ProjectId: w.Project.ProjectId, Workshop: w.Name, Sdk: s.Name}
-				return fmt.Errorf("internal error: SDK %q has no plug named %q", sdkRef.ShortRef(), name)
+				return fmt.Errorf("internal error: %q SDK has no plug named %q", sdkRef.ShortRef(), name)
 			}
 
 			if slave.Interface != master.Interface {
-				return fmt.Errorf("cannot bind %q (%q interface) to %q (%q interface)", slave.Ref().ShortRef(), slave.Interface, master.Ref().ShortRef(), master.Interface)
+				return fmt.Errorf("%s plug %q incompatible with %s plug %q", slave.Interface, slave.Ref().ShortRef(), master.Interface, master.Ref().ShortRef())
 			}
 
 			if slave.Label != master.Label || !reflect.DeepEqual(slave.Attrs, master.Attrs) {
-				return fmt.Errorf("cannot bind %q to %q: incompatible attributes", slave.Ref().ShortRef(), master.Ref().ShortRef())
+				return fmt.Errorf("plugs %q and %q have different attributes", slave.Ref().ShortRef(), master.Ref().ShortRef())
 			}
 		}
 	}
@@ -430,10 +430,17 @@ func (m *InterfaceManager) resolveWorkshopBindings(w *workshop.Workshop) error {
 
 func (m *InterfaceManager) resolveWorkshopConnections(w *workshop.Workshop) error {
 	for _, conn := range w.File.Connections {
+		if _, ok := w.Sdks[conn.PlugRef.Sdk]; !ok {
+			return fmt.Errorf("invalid connection between %q and %q: %q SDK not found", conn.PlugRef, conn.SlotRef, conn.PlugRef.Sdk)
+		}
+		if _, ok := w.Sdks[conn.SlotRef.Sdk]; !ok {
+			return fmt.Errorf("invalid connection between %q and %q: %q SDK not found", conn.PlugRef, conn.SlotRef, conn.SlotRef.Sdk)
+		}
+
 		_, err := m.repo.ResolveConnect(w.Project.ProjectId, w.Name, conn.PlugRef.Sdk, conn.PlugRef.Name,
 			w.Project.ProjectId, w.Name, conn.SlotRef.Sdk, conn.SlotRef.Name)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid connection between %q and %q: %w", conn.PlugRef, conn.SlotRef, err)
 		}
 	}
 	return nil
@@ -473,9 +480,8 @@ func (m *InterfaceManager) checkConflictingMounts(w *workshop.Workshop) error {
 			return target == candidateTarget
 		})
 		if idx >= 0 {
-			return fmt.Errorf(`cannot connect %q without binding to %q: unbound plugs cannot share target %q`,
-				plug.Ref().ShortRef(), plugs[idx].Ref().ShortRef(),
-				candidateTarget)
+			return fmt.Errorf(`conflicting target %q: plug %q must bind to plug %q`,
+				candidateTarget, plug.Ref().ShortRef(), plugs[idx].Ref().ShortRef())
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description

Fixes #678.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
