### PR TITLE
Fix sdk-info test after updating the Store

### DIFF
--- a/tests/main/sdk-info/header.txt
+++ b/tests/main/sdk-info/header.txt
@@ -1,5 +1,5 @@
 name:       test-sdk-info
-publisher:  Jonathan Conder (usso-jeconder)
+publisher:  Dmitry Lyfar (usso-dlyfar)
 license:    GPL-3.0
 
 This is test-sdk-info's description. You have a paragraph or two to tell the
@@ -8,7 +8,3 @@ we live in tweetspace.
 
 CHANNELS  (SDK Store preview: Workshop won't see these revisions yet)
   CHANNEL           VERSION  BUILD       BASE  REV  SIZE
-  latest/stable     -                               
-  latest/candidate  -                               
-  latest/beta       -                               
-  latest/edge       0.1      2026-03-10  all     1  677B

--- a/tests/main/sdk-info/task.yaml
+++ b/tests/main/sdk-info/task.yaml
@@ -16,7 +16,12 @@ execute: |
 
   echo "Test SDK info without any volumes"
   sdk_exec info test-sdk-info > info.log
-  diff -u header.txt info.log
+  diff -u header.txt <(head --lines="$lines" info.log)
+
+  MATCH '[[:space:]]+latest/stable[[:space:]]+1\.0[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+all[[:space:]]+[0-9]+[[:space:]]+[0-9]+B' < info.log
+  MATCH '[[:space:]]+latest/candidate[[:space:]]+\^[[:space:]]*' < info.log
+  MATCH '[[:space:]]+latest/beta[[:space:]]+\^[[:space:]]*' < info.log
+  MATCH '[[:space:]]+latest/edge[[:space:]]+2\.0[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+all[[:space:]]+[0-9]+[[:space:]]+[0-9]+B' < info.log
 
   echo "Test SDK info with one volume"
   workshop_exec launch edge
@@ -24,6 +29,7 @@ execute: |
 
   sdk_exec info test-sdk-info > info.log
   diff -u header.txt <(head --lines="$lines" info.log)
+  MATCH '[[:space:]]+latest/stable[[:space:]]+1\.0[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+all[[:space:]]+[0-9]+[[:space:]]+[0-9]+B' < info.log
   MATCH "$PWD[[:space:]]+edge[[:space:]]+latest/edge[[:space:]]+2\\.0[[:space:]]+ubuntu@22.04[[:space:]]+[[:digit:]]+$" < info.log
 
   echo "Test SDK info with two volumes"
@@ -33,6 +39,7 @@ execute: |
 
   sdk_exec info test-sdk-info > info.log
   diff -u header.txt <(head --lines="$lines" info.log)
+  MATCH '[[:space:]]+latest/edge[[:space:]]+2\.0[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+all[[:space:]]+[0-9]+[[:space:]]+[0-9]+B' < info.log
   MATCH "$PWD[[:space:]]+edge[[:space:]]+latest/edge[[:space:]]+2\\.0[[:space:]]+ubuntu@22.04[[:space:]]+[[:digit:]]+$" < info.log
   MATCH "[[:space:]]+stable[[:space:]]+latest/stable[[:space:]]+1\\.0[[:space:]]+ubuntu@22.04[[:space:]]+[[:digit:]]+$" < info.log
 


### PR DESCRIPTION
# Description

Works for me locally and should be more robust to future changes

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
