### PR TITLE
Return full channel from find and info

### DIFF
--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -379,7 +379,9 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 			},
 			ChannelMap: []transport.InfoChannelMap{{
 				Channel: transport.Channel{
-					Name: "latest/stable",
+					Name:  "latest/stable",
+					Track: "latest",
+					Risk:  "stable",
 					Platform: transport.Platform{
 						Name:         "ubuntu",
 						Channel:      "20.04",
@@ -396,7 +398,9 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 				},
 			}, {
 				Channel: transport.Channel{
-					Name: "latest/edge",
+					Name:  "latest/edge",
+					Track: "latest",
+					Risk:  "edge",
 					Platform: transport.Platform{
 						Name:         "ubuntu",
 						Channel:      "20.04",
@@ -495,6 +499,8 @@ sdkcraft-started-at: 2024-11-25T00:00:00+00:00
 
 	c.Check(full.Channels, testutil.DeepUnsortedMatches, []sdkstate.SdkRevision{{
 		Channel:      "latest/stable",
+		Track:        "latest",
+		Risk:         "stable",
 		Revision:     "85",
 		BuiltAt:      &d20,
 		UploadedAt:   &stableUploaded,
@@ -505,6 +511,8 @@ sdkcraft-started-at: 2024-11-25T00:00:00+00:00
 		DownloadSize: 1234,
 	}, {
 		Channel:      "latest/edge",
+		Track:        "latest",
+		Risk:         "edge",
 		Revision:     "82",
 		BuiltAt:      &d25,
 		UploadedAt:   &edgeUploaded,
@@ -571,7 +579,9 @@ func (s *apiSuite) TestSdkInfoStoreOnly(c *check.C) {
 			},
 			ChannelMap: []transport.InfoChannelMap{{
 				Channel: transport.Channel{
-					Name: "latest/stable",
+					Name:  "latest/stable",
+					Track: "latest",
+					Risk:  "stable",
 					Platform: transport.Platform{
 						Name:         "ubuntu",
 						Channel:      "20.04",
@@ -620,6 +630,8 @@ func (s *apiSuite) TestSdkInfoStoreOnly(c *check.C) {
 
 	c.Check(full.Channels, check.DeepEquals, []sdkstate.SdkRevision{{
 		Channel:      "latest/stable",
+		Track:        "latest",
+		Risk:         "stable",
 		Revision:     "85",
 		BuiltAt:      &d20,
 		UploadedAt:   &stableUploaded,

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -175,7 +175,7 @@ func (w *SdkManager) FindSdks(ctx context.Context, query string) ([]SdkSummary, 
 			Description: entry.Metadata.Description,
 			License:     entry.Metadata.License,
 			Publisher:   publisher,
-			Channel:     entry.DefaultRelease.Channel.Name,
+			Channel:     entry.DefaultRelease.Channel.Track + "/" + entry.DefaultRelease.Channel.Risk,
 			Track:       entry.DefaultRelease.Channel.Track,
 			Risk:        entry.DefaultRelease.Channel.Risk,
 			Revision:    sdk.Revision{N: entry.DefaultRelease.Revision}.String(),
@@ -242,7 +242,7 @@ func (w *SdkManager) fillChannels(ctx context.Context, name string, full *SdkFul
 		}
 
 		channel := SdkRevision{
-			Channel:      entry.Channel.Name,
+			Channel:      entry.Channel.Track + "/" + entry.Channel.Risk,
 			Track:        entry.Channel.Track,
 			Risk:         entry.Channel.Risk,
 			Revision:     sdk.Revision{N: entry.Revision.Revision}.String(),


### PR DESCRIPTION
# Description

This fixes test failures but is intended as a temporary fix, proper channel parsing will come when we fully switch to the Store.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
