### PR TITLE
Make test SDKs immutable

### DIFF
--- a/.github/workflows/build-deps.yaml
+++ b/.github/workflows/build-deps.yaml
@@ -109,11 +109,10 @@ jobs:
             if git diff --quiet "${base}..HEAD" -- "$path"; then
               continue
             fi
-            # TODO: enable this after merging https://github.com/canonical/workshop/pull/689
-            # if git cat-file -t "${base}:./${path}" &> /dev/null; then
-            #   printf '::error::%s SDK is immutable, create a new SDK instead.\n' "${path%/}"
-            #   exit 1
-            # fi
+            if git cat-file -t "${base}:./${path}" &> /dev/null; then
+              printf '::error::%s SDK is immutable, create a new SDK instead.\n' "${path%/}"
+              exit 1
+            fi
           done
           cd ..
 

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -201,8 +201,9 @@ func currentUserAndEnv() (*user.User, map[string]string, error) {
 	return usr, env, err
 }
 
-// Returns the environment for the user as set by systemd.
-// This is the equivalent of running 'systemctl --user show-environment'
+// Returns the environment for the user as set by systemd, or the system
+// environment if user is root. This is the equivalent of running
+// `systemctl [--user] show-environment`.
 func userEnvironment(user *user.User) (map[string]string, error) {
 	// When running as the target user, systemctl can connect to the user
 	// bus directly, but this requires XDG_RUNTIME_DIR to be set. Other
@@ -213,17 +214,22 @@ func userEnvironment(user *user.User) (map[string]string, error) {
 	// --machine is ignored in the first case (given that it matches the
 	// current user), and XDG_RUNTIME_DIR is incorrect in the second case.
 	// See https://github.com/systemd/systemd/issues/39838.
-	args := []string{"--user", "show-environment"}
-	var env []string
+	var args []string
+	env := syscall.Environ()
 	uid, err := strconv.ParseInt(user.Uid, 10, 64)
-	if err == nil && uid == int64(os.Geteuid()) {
+	if err == nil && uid == 0 {
+		args = []string{"show-environment"}
+	} else if err == nil && uid == int64(os.Geteuid()) {
+		args = []string{"--user", "show-environment"}
 		defaultXdg := filepath.Join(dirs.XdgRuntimeDirBase, user.Uid)
-		env = append(env, "XDG_RUNTIME_DIR="+defaultXdg)
+		defaultEnv := []string{"XDG_RUNTIME_DIR=" + defaultXdg}
+		env = append(defaultEnv, env...)
 	} else {
-		args = append(args, fmt.Sprintf("--machine=%s@.host", user.Uid))
+		machine := fmt.Sprintf("--machine=%s@.host", user.Uid)
+		args = []string{machine, "--user", "show-environment"}
 	}
 	cmd := exec.Command("systemctl", args...)
-	cmd.Env = append(cmd.Env, env...)
+	cmd.Env = env
 
 	out, errOut, err := RunCmd(cmd)
 	if err != nil {

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -145,7 +145,7 @@ function sdk_exec() {
 }
 
 function run_sdkcraft() {
-    sudo XDG_RUNTIME_DIR="/run/user/$(id -u ubuntu)" -u ubuntu -- sdkcraft "$@"
+    sudo -u ubuntu -- sdkcraft "$@"
 }
 
 function install_sdkcraft() {


### PR DESCRIPTION
# Description

Also removes an SDKcraft workaround, since the issue should be fixed by https://github.com/canonical/sdkcraft/pull/234.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
