### PR TITLE
Migrate to LXD import_custom_volume_tar API

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -67,7 +67,7 @@ Prerequisites
 ~~~~~~~~~~~~~
 
 Workshop requires
-`LXD 6.3+ <https://canonical.com/lxd>`_
+`LXD 6.6+ <https://canonical.com/lxd>`_
 for low-level operation.
 
 If the ``snap install`` command reports an issue with LXD,

--- a/docs/tutorial/part-1-get-started.rst
+++ b/docs/tutorial/part-1-get-started.rst
@@ -44,7 +44,7 @@ Prerequisites
 ~~~~~~~~~~~~~
 
 |ws_markup| relies on
-`LXD 6.3+ <https://canonical.com/lxd>`_
+`LXD 6.6+ <https://canonical.com/lxd>`_
 for low-level operation
 and uses its
 `REST API <https://documentation.ubuntu.com/lxd/latest/restapi_landing/>`_

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -46,7 +46,7 @@ Prerequisites
 ~~~~~~~~~~~~~
 
 |sdk_markup| relies on
-`LXD 6.3+ <https://canonical.com/lxd>`_
+`LXD 6.6+ <https://canonical.com/lxd>`_
 for low-level operation,
 using its
 `REST API <https://documentation.ubuntu.com/lxd/latest/restapi_landing/>`_

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -94,11 +94,6 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	ctx, cancel := BackendContext(tomb, user, project.ProjectId)
 	defer cancel()
 
-	if _, err = m.backend.Sdk(ctx, rec); err == nil {
-		logger.Debugf("On doRetrieveSdk: reuse existing SDK volume %q", sdk.VolumeName(rec.Name, rec.Revision))
-		return nil
-	}
-
 	fl, err := sdk.OpenLock(rec.Name)
 	if err != nil {
 		return err
@@ -106,6 +101,11 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 	defer fl.Close()
 	if err := fl.Lock(); err != nil {
 		return err
+	}
+
+	if _, err = m.backend.Sdk(ctx, rec); err == nil {
+		logger.Debugf("On doRetrieveSdk: reuse existing SDK volume %q", sdk.VolumeName(rec.Name, rec.Revision))
+		return nil
 	}
 
 	if err := m.retrieveSdk(ctx, task, rec); err != nil {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -145,7 +145,7 @@ To restart the workshop daemon: 'sudo snap restart workshop'`, err)
 
 func checkVersion(version string) error {
 	const minimalLXDMajor = 6
-	const minimalLXDMinor = 3
+	const minimalLXDMinor = 6
 
 	comps := strings.Split(version, ".")
 

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -3,6 +3,7 @@ package lxdbackend
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -92,34 +93,61 @@ func (s *Backend) ImportSdk(ctx context.Context, meta sdk.Meta, tarball *os.File
 	}
 	defer unlockVolume(name)
 
-	conn, err := s.LxdClient(ctx)
+	// Disable cancellation, because the LXD operation will plow on regardless,
+	// and the lock is supposed to prevent concurrent import operations.
+	lockedCtx := context.WithoutCancel(ctx)
+	conn, err := s.LxdClient(lockedCtx)
 	if err != nil {
 		return err
 	}
 	defer conn.Disconnect()
 
-	_, _, err = conn.GetStoragePoolVolume(storagePool, "custom", name)
-	if err == nil {
-		return workshop.ErrVolumeAlreadyExists
-	}
-	if !api.StatusErrorCheck(err, http.StatusNotFound) {
+	volume, _, err := conn.GetStoragePoolVolume(storagePool, "custom", name)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return err
+	}
+	if err == nil {
+		if volume.Config["user.kind"] == "sdk" {
+			return workshop.ErrVolumeAlreadyExists
+		}
+		if err := s.cleanupPartialImportSdk(conn, name, ""); err != nil {
+			return err
+		}
 	}
 
 	vol := lxd.StoragePoolVolumeBackupArgs{
-		BackupFile: tarball,
+		BackupFile: io.NopCloser(tarball),
 		Name:       name,
 	}
 
-	op, err := conn.CreateStoragePoolVolumeFromTarball(storagePool, vol)
-	if err != nil {
-		return err
-	}
-	if err = op.WaitContext(ctx); err != nil {
-		return err
+	for i := range 2 {
+		op, err := conn.CreateStoragePoolVolumeFromTarball(storagePool, vol)
+		if err != nil {
+			return err
+		}
+		if err := op.Wait(); i == 0 && IsImportSdkConflict(err) {
+			// It's very unlikely, but if workshopd dies right after uploading
+			// the tarball, then restarts and retries the import before LXD
+			// creates the import operation, but the original operation updates
+			// the database before the current one, then this operation results
+			// in a conflict, and we should retry. It's also possible that the
+			// current operation wins the race, and we can safely let the other
+			// one fail in the background.
+			if err := s.cleanupPartialImportSdk(conn, name, op.Get().ID); err != nil {
+				return err
+			}
+			if _, err := tarball.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+			continue
+		} else if err != nil {
+			return err
+		}
+		break
 	}
 
-	volume, etag, err := conn.GetStoragePoolVolume(storagePool, "custom", name)
+	var etag string
+	volume, etag, err = conn.GetStoragePoolVolume(storagePool, "custom", name)
 	if err != nil {
 		return err
 	}
@@ -129,11 +157,51 @@ func (s *Backend) ImportSdk(ctx context.Context, meta sdk.Meta, tarball *os.File
 	volume.Config["user.sdk.revision"] = meta.Revision.String()
 	volume.Config["user.sha3-384"] = meta.Sha3_384
 	volume.Config["user.sdk.meta"] = meta.SdkYAML
-	op, err = conn.UpdateStoragePoolVolume(storagePool, "custom", name, volume.Writable(), etag)
+	op, err := conn.UpdateStoragePoolVolume(storagePool, "custom", name, volume.Writable(), etag)
 	if err != nil {
 		return err
 	}
 	return op.Wait()
+}
+
+// If workshopd dies, an import operation can be in progress despite holding
+// the volume lock. Since we can't currently detect which operation it is
+// (since https://github.com/canonical/lxd/pull/18033 isn't in stable yet), we
+// wait for all import operations to complete before proceeding. We can't
+// assume the volume has the right contents, because LXD creates the volume's
+// database entry before extracting the tarball. However, once we're able to
+// identify the specific operation, it should be safe to reuse the volume
+// after the operation succeeds.
+func (s *Backend) cleanupPartialImportSdk(conn lxd.InstanceServer, name string, ignoreID string) error {
+	ops, err := conn.GetOperations()
+	if err != nil {
+		return err
+	}
+
+	for _, op := range ops {
+		if op.ID == ignoreID || !IsImportSdkOperation(op) {
+			continue
+		}
+		if _, _, err := conn.GetOperationWait(op.ID, -1); err != nil && !api.StatusErrorCheck(err) {
+			return err
+		}
+	}
+
+	return s.deleteVolume(conn, name)
+}
+
+// Export this so the LXD candidate tests pick up description changes.
+func IsImportSdkOperation(op api.Operation) bool {
+	return op.Description == "Creating storage volume"
+}
+
+// Export this so the LXD candidate tests pick up error message changes.
+func IsImportSdkConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "'storage_volumes_unique_storage_pool_id_node_id_project_id_name_type'") ||
+		strings.Contains(err.Error(), "volume already exists on storage pool")
 }
 
 func (s *Backend) DeleteSdk(ctx context.Context, setup sdk.Setup) error {
@@ -143,7 +211,10 @@ func (s *Backend) DeleteSdk(ctx context.Context, setup sdk.Setup) error {
 	}
 	defer conn.Disconnect()
 
-	name := sdk.VolumeName(setup.Name, setup.Revision)
+	return s.deleteVolume(conn, sdk.VolumeName(setup.Name, setup.Revision))
+}
+
+func (s *Backend) deleteVolume(conn lxd.InstanceServer, name string) error {
 	op, err := conn.DeleteStoragePoolVolume(storagePool, "custom", name)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
@@ -206,6 +277,10 @@ func (s *Backend) Sdk(ctx context.Context, setup sdk.Setup) (workshop.SdkVolume,
 	}
 	if err != nil {
 		return workshop.SdkVolume{}, err
+	}
+	if vol.Config["user.kind"] != "sdk" {
+		// This can happen when ImportSdk is aborted abruptly.
+		return workshop.SdkVolume{}, workshop.ErrVolumeNotFound
 	}
 
 	size := volumeSize(conn, vol.Name)

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -2,13 +2,10 @@ package lxdbackend
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -22,21 +19,6 @@ import (
 	"github.com/canonical/workshop/internal/timeutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
-
-var volumeIndex = `name: %s
-backend: %s
-type: custom
-config:
-  volume:
-    name: %s
-    description: "SDK Volume"
-    type: custom
-    content_type: filesystem
-`
-
-func volumeIndexContent(name string) string {
-	return fmt.Sprintf(volumeIndex, name, storagePool, name)
-}
 
 // LockVolume ensures exclusive access to the specified volume. If there is an
 // ongoing operation on the volume, the calling goroutine will block until the
@@ -124,89 +106,12 @@ func (s *Backend) ImportSdk(ctx context.Context, meta sdk.Meta, tarball *os.File
 		return err
 	}
 
-	// The tarballs will be transformed into a LXD-compatible backup format to
-	// create them directly as a custom volume. The LXD's tar archive has the
-	// following format:
-	//
-	// backup/
-	//  volume/
-	//  index.yaml
-
-	dir, err := os.MkdirTemp("", name)
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(dir)
-
-	// umask 0 with --no-same-permissions preserves normal permissions,
-	// just not setuid, setgid, etc. The parent directory should be empty
-	// with 700 permissions. For more details see
-	// https://www.gnu.org/software/tar/manual/html_section/Security.html
-	unpack := exec.CommandContext(ctx, "bash",
-		"-c",
-		`umask 0 && exec -- "$0" "$@"`,
-		"tar",
-		"--extract",
-		"--no-same-owner",
-		"--no-same-permissions",
-		"--keep-old-files",
-		"--file=/dev/stdin",
-		"--transform",
-		"s,^,volume/,",
-		"--directory="+dir,
-	)
-	unpack.Stdin = tarball
-
-	if _, err := unpack.Output(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			logger.Debugf("Failed to unpack volume tarball: %s", exitErr.Stderr)
-		}
-		return err
-	}
-
-	// Generate index.yaml for the volume.
-	if err = os.WriteFile(filepath.Join(dir, "index.yaml"), []byte(volumeIndexContent(name)), 0644); err != nil {
-		return err
-	}
-
-	newtar := filepath.Join(dir, filepath.Base(tarball.Name()))
-	repack := exec.CommandContext(ctx, "tar",
-		"--create",
-		"--format=posix",
-		"--force-local",
-		"--remove-files",
-		"--file",
-		newtar,
-		"--transform",
-		"s,^,backup/,",
-		"--directory="+dir,
-		"--no-same-owner",
-		"volume/",
-		"index.yaml",
-	)
-
-	if _, err := repack.Output(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			logger.Debugf("Failed to repack volume tarball: %s", exitErr.Stderr)
-			return exitErr
-		}
-		return err
-	}
-
-	f, err := os.Open(newtar)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
 	vol := lxd.StoragePoolVolumeBackupArgs{
-		BackupFile: f,
+		BackupFile: tarball,
 		Name:       name,
 	}
 
-	op, err := conn.CreateStoragePoolVolumeFromBackup(storagePool, vol)
+	op, err := conn.CreateStoragePoolVolumeFromTarball(storagePool, vol)
 	if err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -114,13 +114,13 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 }
 
 func (f *LxdBeTests) TestCheckLxdVersion(c *check.C) {
-	err := lxdbackend.CheckServerVersion("6.3")
+	err := lxdbackend.CheckServerVersion("6.6")
 	c.Assert(err, check.IsNil)
 
-	err = lxdbackend.CheckServerVersion("6.4")
+	err = lxdbackend.CheckServerVersion("6.7")
 	c.Assert(err, check.IsNil)
 
-	err = lxdbackend.CheckServerVersion("6.2")
+	err = lxdbackend.CheckServerVersion("6.5")
 	c.Assert(err, check.ErrorMatches, ".*LXD server version.*is not supported.*")
 
 	err = lxdbackend.CheckServerVersion("5.9")
@@ -135,9 +135,9 @@ func (f *LxdBeTests) TestCheckLxdVersion(c *check.C) {
 	err = lxdbackend.CheckServerVersion("6.x")
 	c.Assert(err, check.ErrorMatches, ".*cannot parse LXD server version.*")
 
-	err = lxdbackend.CheckServerVersion("6.3.1")
+	err = lxdbackend.CheckServerVersion("6.6.1")
 	c.Assert(err, check.IsNil)
 
-	err = lxdbackend.CheckServerVersion("6.2.9")
+	err = lxdbackend.CheckServerVersion("6.5.9")
 	c.Assert(err, check.ErrorMatches, ".*LXD server version.*is not supported.*")
 }

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -384,8 +384,6 @@ func (f *wsOps) TestLxdBackendImportSdkOK(c *check.C) {
 	}
 	tarball := helper.MockSdkTarball(c, meta.Name, testsdk)
 
-	cmd := testutil.FakeCommand(c, "tar", `/usr/bin/tar "$@"`)
-
 	var wg sync.WaitGroup
 
 	var successCnt, existCnt int32
@@ -408,8 +406,6 @@ func (f *wsOps) TestLxdBackendImportSdkOK(c *check.C) {
 	c.Check(atomic.LoadInt32(&successCnt), check.Equals, int32(1))
 	c.Check(atomic.LoadInt32(&existCnt), check.Equals, int32(4))
 
-	c.Check(cmd.Calls(), check.HasLen, 2)
-
 	vinfo, err := f.bd.Sdk(f.ctx, meta.Setup)
 	c.Check(err, check.IsNil)
 	meta.Channel = ""
@@ -421,6 +417,65 @@ func (f *wsOps) TestLxdBackendImportSdkOK(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(vinfo.Meta, check.Equals, meta)
 	c.Check(vinfo.Workshops, check.HasLen, 0)
+
+	err = f.bd.DeleteSdk(f.ctx, meta.Setup)
+	c.Assert(err, check.IsNil)
+}
+
+// This test detects changes to the import operation type and conflict error
+// message. See IsImportSdkOperation and IsImportSdkConflict.
+func (f *wsOps) TestLxdBackendImportSdkConflict(c *check.C) {
+	// Execute
+	meta := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:      "test",
+			PackageID: "a9J51jhjzpckN8VxhqoZ8dNKcZ7pOrBb",
+			Channel:   "latest/stable",
+			Revision:  sdk.R(1),
+			Sha3_384:  "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: testsdk,
+	}
+	tarball := helper.MockSdkTarball(c, meta.Name, testsdk)
+
+	// Create test project without racing for it.
+	conn, err := f.bd.LxdClient(f.ctx)
+	c.Assert(err, check.IsNil)
+	conn.Disconnect()
+
+	var wg sync.WaitGroup
+
+	var successCnt, existCnt int32
+	for range 2 {
+		wg.Go(func() {
+			conn, err := f.bd.LxdClient(f.ctx)
+			c.Assert(err, check.IsNil)
+			defer conn.Disconnect()
+
+			file, err := os.Open(tarball)
+			c.Assert(err, check.IsNil)
+			defer file.Close()
+
+			vol := lxd.StoragePoolVolumeBackupArgs{
+				BackupFile: file,
+				Name:       sdk.VolumeName(meta.Name, meta.Revision),
+			}
+			op, err := conn.CreateStoragePoolVolumeFromTarball("workshop", vol)
+			if err == nil {
+				c.Check(lxdbackend.IsImportSdkOperation(op.Get()), check.Equals, true)
+				err = op.Wait()
+			}
+			if lxdbackend.IsImportSdkConflict(err) {
+				atomic.AddInt32(&existCnt, 1)
+			} else if c.Check(err, check.IsNil) {
+				atomic.AddInt32(&successCnt, 1)
+			}
+		})
+	}
+	wg.Wait()
+
+	c.Check(atomic.LoadInt32(&successCnt), check.Equals, int32(1))
+	c.Check(atomic.LoadInt32(&existCnt), check.Equals, int32(1))
 
 	err = f.bd.DeleteSdk(f.ctx, meta.Setup)
 	c.Assert(err, check.IsNil)
@@ -440,51 +495,47 @@ func (f *wsOps) TestLxdBackendImportSdkInterrupted(c *check.C) {
 	}
 	tarball := helper.MockSdkTarball(c, meta.Name, testsdk)
 
-	cmd := testutil.FakeCommand(c, "tar", `/usr/bin/tar "$@"`)
+	conn, err := f.bd.LxdClient(f.ctx)
+	c.Assert(err, check.IsNil)
+	defer conn.Disconnect()
 
-	var wg sync.WaitGroup
+	// Simulate operation started by previous workshopd run.
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
 
-	var successCnt, existCnt, canceled int32
-	for i := range 5 {
-		newctx, cancel := context.WithCancel(f.ctx)
+		file, err := os.Open(tarball)
+		c.Assert(err, check.IsNil)
+		defer file.Close()
 
-		if i%2 == 0 {
-			cancel()
-		} else {
-			defer cancel()
+		vol := lxd.StoragePoolVolumeBackupArgs{
+			BackupFile: file,
+			Name:       sdk.VolumeName(meta.Name, meta.Revision),
+		}
+		op, err := conn.CreateStoragePoolVolumeFromTarball("workshop", vol)
+		c.Assert(err, check.IsNil)
+		close(started)
+		_ = op.Wait()
+	}()
+
+	file, err := os.Open(tarball)
+	if c.Check(err, check.IsNil) {
+		defer file.Close()
+
+		err = f.bd.ImportSdk(f.ctx, meta, file)
+		c.Check(err, check.IsNil)
+
+		select {
+		case <-started:
+		case <-done:
 		}
 
-		wg.Go(func() {
-			file, err := os.Open(tarball)
-			c.Assert(err, check.IsNil)
-			defer file.Close()
-			if err := f.bd.ImportSdk(newctx, meta, file); err == nil {
-				atomic.AddInt32(&successCnt, 1)
-			} else if errors.Is(err, workshop.ErrVolumeAlreadyExists) {
-				atomic.AddInt32(&existCnt, 1)
-			} else if errors.Is(err, context.Canceled) {
-				atomic.AddInt32(&canceled, 1)
-			} else {
-				c.Assert(err, check.IsNil)
-			}
-		})
+		err = f.bd.DeleteSdk(f.ctx, meta.Setup)
+		c.Check(err, check.IsNil)
 	}
-	wg.Wait()
 
-	c.Check(atomic.LoadInt32(&successCnt), check.Equals, int32(1))
-	c.Check(atomic.LoadInt32(&existCnt), check.Equals, int32(1))
-	c.Check(atomic.LoadInt32(&canceled), check.Equals, int32(3))
-
-	c.Check(cmd.Calls(), check.HasLen, 2)
-
-	vinfo, err := f.bd.Sdk(f.ctx, meta.Setup)
-	c.Check(err, check.IsNil)
-	meta.Channel = ""
-	c.Check(vinfo.Meta, check.Equals, meta)
-	c.Check(vinfo.Workshops, check.HasLen, 0)
-
-	err = f.bd.DeleteSdk(f.ctx, meta.Setup)
-	c.Assert(err, check.IsNil)
+	<-done
 }
 
 func (f *wsOps) TestLxdBackendDeleteWorkshop(c *check.C) {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,6 +49,7 @@ parts:
     source: .
     source-type: local
     build-packages:
+      - build-essential
       - git
     build-snaps:
       - go/1.26/stable
@@ -61,7 +62,7 @@ parts:
         export CGO_LDFLAGS="-Wl,-rpath=/snap/core24/current/lib/aarch64-linux-gnu -Wl,--disable-new-dtags -Wl,-dynamic-linker=/snap/core24/current/lib/ld-linux-aarch64.so.1"
       fi
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshop" ./cmd/workshop
-      go build -o "${CRAFT_PART_INSTALL}/bin/workshopd" ./cmd/workshopd
+      CGO_ENABLED=1 go build -o "${CRAFT_PART_INSTALL}/bin/workshopd" ./cmd/workshopd
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshopctl" ./cmd/workshopctl
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/sdk" ./cmd/sdk
 

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -10,7 +10,7 @@ execute: |
   lxd waitready
   snap restart workshop
   ! workshop_exec list > error.log 2>&1 || false
-  MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.3.\*$" < error.log
+  MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.6.\*$" < error.log
 
   snap remove lxd --purge
   setup_lxd


### PR DESCRIPTION
# Description

Fixes https://github.com/canonical/workshop/issues/645. To use the new import tarball API, the minimum LXD version is now 6.6.

The API itself doesn't change much from before, it's still difficult to use correctly if the import is cancelled. We disable cancellation so that normal usage never leads to partial imports. If `workshopd` (or LXD) is killed unexpectedly, partial imports can still occur, so we try to clean them up. I've covered all the scenarios I can think of, but wouldn't be surprised if it isn't 100% correct (e.g. due to imprecise error handling).

I also moved the existence check in doRetrieveSdk; it's likely that several `retrieve-sdk` tasks start at the same time, one of which proceeds while the others wait to grab the lock. After locking, the volume now exists so we can skip the other steps. I think there's no reason to use file-based locking here, but kept it in for now.

Finally, I edited the snap build to ensure `workshopd` uses `libc` to lookup users instead of just parsing `/etc/passwd`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
