### PR TITLE
Support LXD GPU CDI extension for gpu interface

### DIFF
--- a/.workshop/dev.yaml
+++ b/.workshop/dev.yaml
@@ -2,13 +2,10 @@ name: dev
 base: ubuntu@24.04
 sdks:
   - name: go
-    channel: all/edge
+    channel: 1.26/stable
   - name: project-tools
   - name: system
     plugs:
-      fake-store:
-        interface: tunnel
-        endpoint: 8080
       sphinx-build:
         interface: tunnel
         endpoint: 8000

--- a/.workshop/tools/sdk.yaml
+++ b/.workshop/tools/sdk.yaml
@@ -1,8 +1,5 @@
 name: tools
 slots:
-  fake-store:
-    interface: tunnel
-    endpoint: 8080
   sphinx-build:
     interface: tunnel
     endpoint: 8000

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -7,7 +7,7 @@ Workshop
    All code, documentation, and materials in this repository
    are company-private and must not be shared outside Canonical
    without prior authorization.
-   
+
    Do not redistribute or discuss this content or the project externally
    (at public forums, in social media, with customers)
    until an official public release is announced.

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -262,7 +262,7 @@ and add two plugs and a slot to the appropriate sections:
    version: "0.9.6"
    summary: Get up and running with large language models
    description: |
-     Get up and running with Llama 3.3, DeepSeek-R1, Phi-4, 
+     Get up and running with Llama 3.3, DeepSeek-R1, Phi-4,
      Gemma 3, Mistral Small 3.1 and other large language models.
    license: MIT
    platforms:

--- a/internal/interfaces/builtin/camera_test.go
+++ b/internal/interfaces/builtin/camera_test.go
@@ -1,8 +1,10 @@
 package builtin_test
 
 import (
+	"context"
 	"os/user"
 
+	"github.com/canonical/lxd/shared/api"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -18,6 +20,7 @@ type cameraSuite struct {
 	projectId         string
 	restoreUserLookup func()
 	restoreUserEnv    func()
+	restoreLxdInfo    func()
 }
 
 var _ = check.Suite(&cameraSuite{
@@ -32,9 +35,13 @@ func (s *cameraSuite) SetUpSuite(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil
 	})
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{}, false, nil
+	})
 }
 
 func (s *cameraSuite) TearDownSuite(c *check.C) {
+	s.restoreLxdInfo()
 	s.restoreUserEnv()
 	s.restoreUserLookup()
 }

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -1,9 +1,11 @@
 package builtin_test
 
 import (
+	"context"
 	"os/user"
 	"path/filepath"
 
+	"github.com/canonical/lxd/shared/api"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/dirs"
@@ -20,6 +22,7 @@ type desktopSuite struct {
 	projectId string
 
 	restoreUserLookup func()
+	restoreLxdInfo    func()
 }
 
 var _ = check.Suite(&desktopSuite{
@@ -33,9 +36,13 @@ func (s *desktopSuite) SetUpSuite(c *check.C) {
 	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
 		return &testuser, nil
 	})
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{}, false, nil
+	})
 }
 
 func (s *desktopSuite) TearDownSuite(c *check.C) {
+	s.restoreLxdInfo()
 	s.restoreUserLookup()
 }
 

--- a/internal/interfaces/builtin/gpu_test.go
+++ b/internal/interfaces/builtin/gpu_test.go
@@ -1,8 +1,10 @@
 package builtin_test
 
 import (
+	"context"
 	"os/user"
 
+	"github.com/canonical/lxd/shared/api"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -19,6 +21,7 @@ type gpuSuite struct {
 
 	restoreUserLookup func()
 	restoreUserEnv    func()
+	restoreLxdInfo    func()
 }
 
 var _ = check.Suite(&gpuSuite{
@@ -33,9 +36,13 @@ func (s *gpuSuite) SetUpSuite(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil
 	})
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{}, false, nil
+	})
 }
 
 func (s *gpuSuite) TearDownSuite(c *check.C) {
+	s.restoreLxdInfo()
 	s.restoreUserEnv()
 	s.restoreUserLookup()
 }

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -20,10 +20,12 @@
 package builtin_test
 
 import (
+	"context"
 	"os/user"
 	"path/filepath"
 	"testing"
 
+	"github.com/canonical/lxd/shared/api"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/asserts"
@@ -44,6 +46,7 @@ type mountSuite struct {
 
 	restoreUserLookup func()
 	restoreUserEnv    func()
+	restoreLxdInfo    func()
 }
 
 func Test(t *testing.T) {
@@ -64,9 +67,13 @@ func (s *mountSuite) SetUpSuite(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return s.env, nil
 	})
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{}, false, nil
+	})
 }
 
 func (s *mountSuite) TearDownSuite(c *check.C) {
+	s.restoreLxdInfo()
 	s.restoreUserEnv()
 	s.restoreUserLookup()
 }

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -1,8 +1,10 @@
 package builtin_test
 
 import (
+	"context"
 	"os/user"
 
+	"github.com/canonical/lxd/shared/api"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/interfaces"
@@ -19,6 +21,7 @@ type sshAgentSuite struct {
 
 	restoreUserLookup func()
 	restoreUserEnv    func()
+	restoreLxdInfo    func()
 }
 
 var _ = check.Suite(&sshAgentSuite{
@@ -34,9 +37,13 @@ func (s *sshAgentSuite) SetUpTest(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return map[string]string{"SSH_AUTH_SOCK": "/tmp/dir/ssh"}, nil
 	})
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{}, false, nil
+	})
 }
 
 func (s *sshAgentSuite) TearDownTest(c *check.C) {
+	s.restoreLxdInfo()
 	s.restoreUserEnv()
 	s.restoreUserLookup()
 }

--- a/internal/interfaces/builtin/tunnel_test.go
+++ b/internal/interfaces/builtin/tunnel_test.go
@@ -20,11 +20,13 @@
 package builtin_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
 
+	"github.com/canonical/lxd/shared/api"
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/asserts"
@@ -44,6 +46,7 @@ type tunnelSuite struct {
 
 	restoreUserLookup func()
 	restoreUserEnv    func()
+	restoreLxdInfo    func()
 }
 
 var _ = check.Suite(&tunnelSuite{
@@ -59,9 +62,13 @@ func (s *tunnelSuite) SetUpSuite(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil
 	})
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{}, false, nil
+	})
 }
 
 func (s *tunnelSuite) TearDownSuite(c *check.C) {
+	s.restoreLxdInfo()
 	s.restoreUserEnv()
 	s.restoreUserLookup()
 }

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -894,7 +894,7 @@ func (b *Backend) Remove(ctx context.Context, sdkRef sdk.Ref) error {
 	return cmp.Or(err, err2)
 }
 
-// NewSpecification returns a new mount specification.
+// NewSpecification returns a new SDK specification.
 func (b *Backend) NewSpecification(user string, sdk string) (interfaces.Specification, error) {
 	return NewSpecification(user, sdk)
 }

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -1,18 +1,48 @@
 package lxd_device
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/user"
 	"strconv"
 	"strings"
 
+	"github.com/canonical/lxd/shared/api"
+
 	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
+
+// lxdServerInfo retrieves GPU resources and CDI support from LXD.
+var lxdServerInfo = func(ctx context.Context) (*api.Resources, bool, error) {
+	conn, err := lxdbackend.ConnectLxd(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	defer conn.Disconnect()
+
+	resources, err := conn.GetServerResources()
+	if err != nil {
+		return nil, false, err
+	}
+
+	cdiSupported := conn.HasExtension("gpu_cdi") && conn.HasExtension("gpu_cdi_amd") && conn.HasExtension("gpu_cdi_hotplug")
+
+	return resources, cdiSupported, nil
+}
+
+// MockLxdServerInfo replaces the LXD server info function used by
+// NewSpecification and returns a restore function.
+func MockLxdServerInfo(f func(ctx context.Context) (*api.Resources, bool, error)) func() {
+	old := lxdServerInfo
+	lxdServerInfo = f
+	return func() { lxdServerInfo = old }
+}
 
 func NewSpecification(user string, sdk string) (*Specification, error) {
 	usr, env, err := osutil.UserAndEnv(user)
@@ -20,23 +50,35 @@ func NewSpecification(user string, sdk string) (*Specification, error) {
 		return nil, err
 	}
 
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, workshop.ContextUser, user)
+
+	resources, cdiSupported, err := lxdServerInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Specification{
-		devices:     make(map[string]map[string]string),
-		config:      make(map[string]string),
-		Profile:     workshop.NewSdkProfile(sdk),
-		User:        usr,
-		Environment: env,
+		devices:      make(map[string]map[string]string),
+		config:       make(map[string]string),
+		Profile:      workshop.NewSdkProfile(sdk),
+		User:         usr,
+		Environment:  env,
+		resources:    resources,
+		cdiSupported: cdiSupported,
 	}, nil
 }
 
 type Specification struct {
 	Profile workshop.SdkProfile
 
-	devices map[string]map[string]string
-	config  map[string]string
+	devices   map[string]map[string]string
+	config    map[string]string
+	resources *api.Resources
 
-	User        *user.User
-	Environment map[string]string
+	User         *user.User
+	Environment  map[string]string
+	cdiSupported bool
 }
 
 // AddPermanentSlot records side-effects of having a slot.
@@ -136,28 +178,73 @@ func (s *Specification) SetDesktop(desktop workshop.Desktop) error {
 	return nil
 }
 
+func detectGpuVendor(vendorID string) string {
+	switch vendorID {
+	case "8086":
+		return "intel"
+	case "10de":
+		return "nvidia"
+	case "1002":
+		return "amd"
+	default:
+		return "unknown"
+	}
+}
+
 func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 	s.Profile.Gpu = &gpu
 
-	// The default workshop user must be able to access the GPU device.
-	// Workshop assigns the GPU devices to workshop.workshop. A more
-	// traditional way here would be to add dri devices to the video/render
-	// groups, but it requires an additional workshop exec to find out the
-	// groups' ids at the LXD profile generation time. Given that we are
-	// solving the problem of access in a confined environment and workshop
-	// is a passwordless sudo user anyway, it was decided that it is OK if
-	// the workshop user owns GPU devices.
+	if s.cdiSupported {
+		gpus := s.resources.GPU
+		if gpus.Total == 0 {
+			logger.Debugf("GPU interface requested, but no GPU detected on the host system")
+			return nil
+		}
 
-	// On another note, the render and video groups are not assigned to the
-	// card*/render* dri devices by LXD properly. Both will be assigned to
-	// the group provided in "gid"; there is no way to assign video to card*
-	// and render to render* devices.
-	name := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name)
-	s.devices[name] = map[string]string{
-		"type":    "gpu",
-		"gputype": "physical",
-		"uid":     workshop.User.Uid,
-		"gid":     workshop.User.Gid,
+		for _, c := range gpus.Cards {
+			vendor := detectGpuVendor(c.VendorID)
+			switch vendor {
+			case "nvidia", "amd":
+				device := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name, vendor)
+				// Add "all" devices per vendor. Indexes would be rather accurate but
+				// the problem with indexes is that the AMD CDI start indexes from 0
+				// regardless what index the card has in the system whilst NVIDIA CDI
+				// indexes match the system indexes. LXD should include UUIDs
+				// in the GPU resources which we can use in the spec instead of IDs.
+				if _, ok := s.devices[device]; !ok {
+					s.devices[device] = map[string]string{
+						"type":    "gpu",
+						"gputype": "physical",
+						"id":      vendor + ".com/gpu=all",
+					}
+				}
+			case "intel":
+				// Intel GPUs are not yet supported by the GPU CDI spec, so we
+				// fall back to exposing them as 'physical' GPUs with a specific
+				// ID.
+				cardId := strconv.FormatUint(c.DRM.ID, 10)
+				device := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name, vendor, cardId)
+				s.devices[device] = map[string]string{
+					"type":    "gpu",
+					"gputype": "physical",
+					"uid":     workshop.User.Uid,
+					"gid":     workshop.User.Gid,
+					"id":      cardId,
+				}
+			default:
+				logger.Debugf("Unknown GPU vendor ID '%s' for GPU card with ID %d", c.VendorID, c.DRM.ID)
+			}
+
+		}
+	} else {
+		// TODO: Remove when switched to LXD 6.8
+		name := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name)
+		s.devices[name] = map[string]string{
+			"type":    "gpu",
+			"gputype": "physical",
+			"uid":     workshop.User.Uid,
+			"gid":     workshop.User.Gid,
+		}
 	}
 
 	return nil

--- a/internal/interfaces/lxd_device/spec_test.go
+++ b/internal/interfaces/lxd_device/spec_test.go
@@ -1,0 +1,193 @@
+package lxd_device
+
+import (
+	"context"
+	"os/user"
+	"testing"
+
+	"github.com/canonical/lxd/shared/api"
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type lxdSpecSuite struct {
+	restoreUserLookup func()
+	restoreUserEnv    func()
+	restoreLxdInfo    func()
+}
+
+var _ = check.Suite(&lxdSpecSuite{})
+
+func (s *lxdSpecSuite) SetUpTest(c *check.C) {
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &user.User{Username: "testuser", Uid: "1000", Gid: "1000", HomeDir: "/home/testuser"}, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(u *user.User) (map[string]string, error) {
+		return nil, nil
+	})
+}
+
+func (s *lxdSpecSuite) TearDownTest(c *check.C) {
+	if s.restoreLxdInfo != nil {
+		s.restoreLxdInfo()
+	}
+	s.restoreUserEnv()
+	s.restoreUserLookup()
+}
+
+func (s *lxdSpecSuite) TestSetGpuLegacyNoCDI(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{}, false, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+
+	// Legacy path creates a single device with uid/gid.
+	c.Assert(spec.devices, check.HasLen, 1)
+	dev, ok := spec.devices["test-sdk_gpu"]
+	c.Assert(ok, check.Equals, true)
+	c.Check(dev["type"], check.Equals, "gpu")
+	c.Check(dev["gputype"], check.Equals, "physical")
+	c.Check(dev["uid"], check.Equals, workshop.User.Uid)
+	c.Check(dev["gid"], check.Equals, workshop.User.Gid)
+}
+
+func (s *lxdSpecSuite) TestSetGpuCDINoGpuDetected(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{Total: 0}}, true, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+
+	// CDI with no GPUs: no devices created.
+	c.Assert(spec.devices, check.HasLen, 0)
+}
+
+func (s *lxdSpecSuite) TestSetGpuCDINvidia(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{
+			Total: 1,
+			Cards: []api.ResourcesGPUCard{
+				{VendorID: "10de", DRM: &api.ResourcesGPUCardDRM{ID: 0}},
+			},
+		}}, true, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(spec.devices, check.HasLen, 1)
+	dev, ok := spec.devices["test-sdk_gpu_nvidia"]
+	c.Assert(ok, check.Equals, true)
+	c.Check(dev["type"], check.Equals, "gpu")
+	c.Check(dev["gputype"], check.Equals, "physical")
+	c.Check(dev["id"], check.Equals, "nvidia.com/gpu=all")
+}
+
+func (s *lxdSpecSuite) TestSetGpuCDIAmd(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{
+			Total: 1,
+			Cards: []api.ResourcesGPUCard{
+				{VendorID: "1002", DRM: &api.ResourcesGPUCardDRM{ID: 1}},
+			},
+		}}, true, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(spec.devices, check.HasLen, 1)
+	dev, ok := spec.devices["test-sdk_gpu_amd"]
+	c.Assert(ok, check.Equals, true)
+	c.Check(dev["id"], check.Equals, "amd.com/gpu=all")
+}
+
+func (s *lxdSpecSuite) TestSetGpuCDIIntel(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{
+			Total: 1,
+			Cards: []api.ResourcesGPUCard{
+				{VendorID: "8086", DRM: &api.ResourcesGPUCardDRM{ID: 3}},
+			},
+		}}, true, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+
+	// Intel falls back to physical GPU with specific ID.
+	c.Assert(spec.devices, check.HasLen, 1)
+	dev, ok := spec.devices["test-sdk_gpu_intel_3"]
+	c.Assert(ok, check.Equals, true)
+	c.Check(dev["type"], check.Equals, "gpu")
+	c.Check(dev["gputype"], check.Equals, "physical")
+	c.Check(dev["id"], check.Equals, "3")
+	c.Check(dev["uid"], check.Equals, workshop.User.Uid)
+	c.Check(dev["gid"], check.Equals, workshop.User.Gid)
+}
+
+func (s *lxdSpecSuite) TestSetGpuCDIMultipleVendors(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{
+			Total: 3,
+			Cards: []api.ResourcesGPUCard{
+				{VendorID: "10de", DRM: &api.ResourcesGPUCardDRM{ID: 0}},
+				{VendorID: "10de", DRM: &api.ResourcesGPUCardDRM{ID: 1}},
+				{VendorID: "8086", DRM: &api.ResourcesGPUCardDRM{ID: 2}},
+			},
+		}}, true, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+
+	// nvidia deduplicates to one "all" entry, intel gets its own per-card entry.
+	c.Assert(spec.devices, check.HasLen, 2)
+	_, hasNvidia := spec.devices["test-sdk_gpu_nvidia"]
+	c.Check(hasNvidia, check.Equals, true)
+	_, hasIntel := spec.devices["test-sdk_gpu_intel_2"]
+	c.Check(hasIntel, check.Equals, true)
+}
+
+func (s *lxdSpecSuite) TestSetGpuCDIUnknownVendor(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{
+			Total: 1,
+			Cards: []api.ResourcesGPUCard{
+				{VendorID: "ffff", DRM: &api.ResourcesGPUCardDRM{ID: 0}},
+			},
+		}}, true, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+	c.Assert(spec.devices, check.HasLen, 0)
+}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	checkNvidiaRuntime  = checkNvidia
+	checkNvidiaRuntime  = checkUseLegacyNvidia
 	startCommandTimeout = 1 * time.Minute
 	storagePoolDriver   = "zfs"
 )
@@ -988,12 +988,16 @@ func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
 	return device
 }
 
-func checkNvidia() (bool, error) {
+func checkUseLegacyNvidia() (bool, error) {
 	conn, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {
 		return false, ErrorLxdBackend(err)
 	}
 	defer conn.Disconnect()
+
+	if conn.HasExtension("gpu_cdi") && conn.HasExtension("gpu_cdi_amd") && conn.HasExtension("gpu_cdi_hotplug") {
+		return false, nil
+	}
 
 	resources, err := conn.GetServerResources()
 	if err != nil {
@@ -1002,14 +1006,14 @@ func checkNvidia() (bool, error) {
 
 	// Check if nvidia card(s) are present as this requires additional
 	// configuration for the GPU interfaces runtime passthrough.
-	nvidiaRuntime := false
+	legacyNvidia := false
 	for _, card := range resources.GPU.Cards {
 		if card.Nvidia != nil {
-			nvidiaRuntime = true
+			legacyNvidia = true
 			break
 		}
 	}
-	return nvidiaRuntime, nil
+	return legacyNvidia, nil
 }
 
 func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File, baseFingerprint string) (map[string]string, error) {
@@ -1075,20 +1079,6 @@ runcmd:
 		return map[string]string{}, err
 	}
 
-	nvidiaRuntime, err := checkNvidiaRuntime()
-	if err != nil {
-		return nil, err
-	}
-
-	// nvidia.* properties must be set at launch as otherwise it requires a
-	// container restart to take effect.
-	cfgNvidiaDriverCapabilities := ""
-	cfgNvidiaRuntime := ""
-	if nvidiaRuntime {
-		cfgNvidiaDriverCapabilities = "all"
-		cfgNvidiaRuntime = "true"
-	}
-
 	// Include all options we might change, even those with default values,
 	// so that workshops can be rebuilt.
 	cfg := map[string]string{
@@ -1102,14 +1092,25 @@ runcmd:
 		"user.workshop.name":             file.Name,
 		"user.workshop.file":             string(f),
 		"user.workshop.base-fingerprint": baseFingerprint,
-		"nvidia.driver.capabilities":     cfgNvidiaDriverCapabilities,
-		"nvidia.runtime":                 cfgNvidiaRuntime,
 		// LXC appears to have a race condition wherein a proxy device mounted in
 		// a dynamically created directory has the potential to be 'masked' by this
 		// directory. We create an explicit mount for /tmp here (one such dymanic
 		// directory) to allow us to mount X11 sockets reliably.
 		// See: https://github.com/lxc/lxc/issues/434
 		"raw.lxc": "lxc.mount.entry = tmpfs tmp tmpfs defaults",
+	}
+
+	// TODO: Remove when switched to LXD 6.8
+	legacyNvidia, err := checkNvidiaRuntime()
+	if err != nil {
+		return nil, err
+	}
+
+	// nvidia.* properties must be set at launch as otherwise it requires a
+	// container restart to take effect.
+	if legacyNvidia {
+		cfg["nvidia.driver.capabilities"] = "all"
+		cfg["nvidia.runtime"] = "true"
 	}
 	return cfg, nil
 }

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -1,7 +1,7 @@
 summary: Test workshopd checks LXD compatibility
 priority: -101
 execute: |
-  . "$TESTSLIB"/utils.sh  
+  . "$TESTSLIB"/utils.sh
 
   workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"
 

--- a/tests/main/interface-gpu/task.yaml
+++ b/tests/main/interface-gpu/task.yaml
@@ -12,22 +12,26 @@ execute: |
   workshop_exec connections ws-gpu | MATCH "^gpu.+ws-gpu/test-sdk-gpu:gpu.+:gpu.+\-$"
 
   echo "Check the GPU interface plug can be connected and disconnected manually"
-  workshop_exec disconnect ws-gpu/test-sdk-gpu:gpu  
+  workshop_exec disconnect ws-gpu/test-sdk-gpu:gpu
   workshop_exec connect ws-gpu/test-sdk-gpu:gpu
   workshop_exec connections ws-gpu | MATCH "^gpu.+ws-gpu/test-sdk-gpu:gpu.+:gpu.+manual$"
 
   echo "Ensure a GPU device is created when connected"
 
-  # Ideally, check that a GPU device exists in the workshop (as a side effect of
-  # the interface being connected). However, given the VM env without a card0,
-  # ensure that the LXD profile contains a gpu device with a proper
-  # configuration.  
+  # The GPU device configuration depends on whether LXD supports the CDI
+  # extension and whether physical GPUs are present. In CI VMs without a GPU:
+  # - Without CDI: a legacy 'physical' device with uid/gid is created.
+  # - With CDI: no device is created (CDI cannot enumerate absent hardware).
   project_id=$(cat .workshop.lock)
-  lxc profile show --project workshop.ubuntu ws-gpu-"$project_id"-test-sdk-gpu | yq '.devices.test-sdk-gpu_gpu' > output.log
-  MATCH "type: gpu" < output.log
-  MATCH "gputype: physical" < output.log
-  MATCH 'uid: "1000"' < output.log
-  MATCH 'gid: "1000"' < output.log
+  profile="ws-gpu-${project_id}-test-sdk-gpu"
+
+  if ! lxc query /1.0 | grep -q gpu_cdi_hotplug; then
+    lxc profile show --project workshop.ubuntu "$profile" | yq '.devices.test-sdk-gpu_gpu' > output.log
+    MATCH "type: gpu" < output.log
+    MATCH "gputype: physical" < output.log
+    MATCH 'uid: "1000"' < output.log
+    MATCH 'gid: "1000"' < output.log
+  fi
 
   echo "Check a user cannot install a GPU slot (violates slot declaration)"
   workshop_exec launch ws-gpu-fail > launch.log || true


### PR DESCRIPTION
# Description

Adds CDI (Container Device Interface) support to the GPU interface. When LXD supports the `gpu_cdi`, `gpu_cdi_amd`, and `gpu_cdi_hotplug` extensions, GPU devices are enumerated by vendor (nvidia/amd use CDI specs like nvidia.com/gpu=all; Intel falls back to physical GPU by DRM ID due to the lack of CDI for intel). 

I tested this on the real hardware for all 3 vendors manually by launching `comfy-ui` and `openvino-toolkit` refence workshops. The intention with this kind of functionality is to use Testflinger queues as it was implemented for the CDI support in LXD.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
