### PR TITLE
Add support for ubuntu@26.04

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -17,6 +17,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -431,30 +432,6 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		return err
 	}
 
-	if args.action {
-		logger.Debugf("Running action %q", av)
-	} else {
-		// Obtain an exec session as close to a real login shell as possible.
-		// This is required as an lxd exec call is a simple namespace exec, and LXD
-		// ignores the instance configuration by design:
-		// https://documentation.ubuntu.com/lxd/en/latest/instance-exec/#user-groups-and-working-directory
-
-		command := []string{"sudo",
-			"-u",
-			"#" + strconv.Itoa(flags.UserId),
-			"-g",
-			"#" + strconv.Itoa(flags.GroupId),
-			"--preserve-env",
-			"--",
-			"bash",
-			"-l",
-			"-c",
-			`exec -- "$0" "$@"`,
-		}
-		av = append(command, av...)
-		logger.Debugf("Running %q", av)
-	}
-
 	// Set up environment variables.
 	env := make(map[string]string)
 
@@ -491,6 +468,34 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		}
 
 		env[key] = value
+	}
+
+	if args.action {
+		logger.Debugf("Running action %q", av)
+	} else {
+		// Obtain an exec session as close to a real login shell as possible.
+		// This is required as an lxd exec call is a simple namespace exec, and LXD
+		// ignores the instance configuration by design:
+		// https://documentation.ubuntu.com/lxd/en/latest/instance-exec/#user-groups-and-working-directory
+		keys := slices.Sorted(maps.Keys(env))
+		command := []string{"sudo",
+			"-u",
+			"#" + strconv.Itoa(flags.UserId),
+			"-g",
+			"#" + strconv.Itoa(flags.GroupId),
+		}
+		for _, k := range keys {
+			command = append(command, "--preserve-env="+k)
+		}
+		command = append(command,
+			"--",
+			"bash",
+			"-l",
+			"-c",
+			`exec -- "$0" "$@"`,
+		)
+		av = append(command, av...)
+		logger.Debugf("Running %q", av)
 	}
 
 	// Record terminal state (and restore it before we exit).

--- a/docs/explanation/architecture/components.rst
+++ b/docs/explanation/architecture/components.rst
@@ -272,7 +272,7 @@ Images
 
 |ws_markup| containers are created from base operating system images.
 By default, |ws_markup| fetches base images,
-such as Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, or Ubuntu 24.04 LTS,
+such as Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, or Ubuntu 26.04 LTS,
 from the official
 `Ubuntu cloud image repository <https://cloud-images.ubuntu.com/releases>`_.
 

--- a/docs/reference/definition-files/schema.json
+++ b/docs/reference/definition-files/schema.json
@@ -18,9 +18,10 @@
       "enum": [
         "ubuntu@20.04",
         "ubuntu@22.04",
-        "ubuntu@24.04"
+        "ubuntu@24.04",
+        "ubuntu@26.04"
       ],
-      "errorMessage": "The base must be one of the supported values: ubuntu@20.04, ubuntu@22.04, ubuntu@24.04."
+      "errorMessage": "The base must be one of the supported values: ubuntu@20.04, ubuntu@22.04, ubuntu@24.04, ubuntu@26.04."
     },
     "sdks": {
       "type": "array",

--- a/docs/reference/definition-files/sdk-definition.rst
+++ b/docs/reference/definition-files/sdk-definition.rst
@@ -73,7 +73,7 @@ Other fields are optional.
        that provides the underlying OS capabilities.
 
        It can be :samp:`ubuntu@20.04`, :samp:`ubuntu@22.04`,
-       or :samp:`ubuntu@24.04`.
+       :samp:`ubuntu@24.04`, or :samp:`ubuntu@26.04`.
 
        SDKs with a :samp:`base` can only be added to a workshop with the same :samp:`base`.
        SDKs without a :samp:`base` can be added to any workshop.

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -60,8 +60,8 @@ and includes a number of mandatory and optional keys:
      - Workshop's base image
        that provides the underlying OS capabilities.
 
-       It can be :samp:`ubuntu@20.04`, :samp:`ubuntu@22.04`
-       or :samp:`ubuntu@24.04`.
+       It can be :samp:`ubuntu@20.04`, :samp:`ubuntu@22.04`,
+       :samp:`ubuntu@24.04`, or :samp:`ubuntu@26.04`.
 
    * - :samp:`sdks`
      - array

--- a/internal/daemon/snapshot-format.yaml
+++ b/internal/daemon/snapshot-format.yaml
@@ -54,7 +54,7 @@ test-sdk-2:
     snapshot-sdk: 2
   fs-calls: 10
   exec-calls:
-    - ["sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
 test-sdk:
   files:
     - drwxr-xr-x var
@@ -74,8 +74,8 @@ test-sdk:
     snapshot-sdk: 3
   fs-calls: 13
   exec-calls:
-    - ["sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
-    - ["sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
 sketch:
   files:
     - drwxr-xr-x var

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -20,9 +20,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -383,18 +385,23 @@ func (m *CommandManager) doInstallAction(task *state.Task, tomb *tomb.Tomb) erro
 		return errors.New("action not found")
 	}
 
+	keys := slices.Sorted(maps.Keys(args.Environment))
 	path := filepath.Join(dirs.WorkshopActionsDir, name)
 	command := []string{"sudo",
 		"-u",
 		"#" + strconv.Itoa(args.UserId),
 		"-g", "#" + strconv.Itoa(args.GroupId),
-		"--preserve-env",
+	}
+	for _, k := range keys {
+		command = append(command, "--preserve-env="+k)
+	}
+	command = append(command,
 		"--",
 		"bash",
 		"-elo",
 		"pipefail",
 		path,
-	}
+	)
 	args.Command = append(command, args.Command[1:]...)
 
 	wfs, err := m.backend.WorkshopFs(ctx, w)

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 
 	"github.com/canonical/x-go/strutil"
@@ -60,27 +62,6 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	if verbose {
 		command = append(command, "-o", "xtrace")
 	}
-
-	uid := "0"
-	gid := "0"
-	if hook.HookType == SetupProject {
-		uid = workshop.User.Uid
-		gid = workshop.User.Gid
-	}
-
-	runAsUser := []string{
-		"sudo",
-		"--user=#" + uid,
-		"--group=#" + gid,
-		"--preserve-env",
-		"--",
-		"bash",
-		"-l",
-		"-c",
-		`exec -- "$0" "$@"`,
-	}
-	command = append(runAsUser, command...)
-
 	command = append(command, hookPath)
 
 	execArgs := &workshop.ExecArgs{
@@ -144,6 +125,34 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		execArgs.Environment["XDG_RUNTIME_DIR"] = xdgRuntimeDir
 		execArgs.Environment["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=" + filepath.Join(xdgRuntimeDir, "bus")
 	}
+
+	uid := "0"
+	gid := "0"
+	if hook.HookType == SetupProject {
+		uid = workshop.User.Uid
+		gid = workshop.User.Gid
+	}
+
+	keys := slices.Collect(maps.Keys(execArgs.Environment))
+	keys = append(keys, "WORKSHOP_COOKIE")
+	slices.Sort(keys)
+
+	runAsUser := []string{
+		"sudo",
+		"--user=#" + uid,
+		"--group=#" + gid,
+	}
+	for _, k := range keys {
+		runAsUser = append(runAsUser, "--preserve-env="+k)
+	}
+	runAsUser = append(runAsUser,
+		"--",
+		"bash",
+		"-l",
+		"-c",
+		`exec -- "$0" "$@"`,
+	)
+	execArgs.Command = append(runAsUser, execArgs.Command...)
 
 	return h.executeHook(ctx, task, w, &hook, execArgs)
 }

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -160,7 +160,11 @@ func (s *hookSuite) TestExecSetupProject(c *check.C) {
 		"sudo",
 		"--user=#1000",
 		"--group=#1000",
-		"--preserve-env",
+		"--preserve-env=DBUS_SESSION_BUS_ADDRESS",
+		"--preserve-env=HOME",
+		"--preserve-env=SDK",
+		"--preserve-env=WORKSHOP_COOKIE",
+		"--preserve-env=XDG_RUNTIME_DIR",
 		"--",
 		"bash",
 		"-l",
@@ -222,7 +226,7 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
@@ -257,7 +261,7 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "-o", "xtrace", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "-o", "xtrace", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
 	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
@@ -298,7 +302,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
@@ -338,7 +342,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)

--- a/internal/sdk/validate.go
+++ b/internal/sdk/validate.go
@@ -12,7 +12,7 @@ import (
 const MAX_SDK_NAME_LENGTH = 40
 
 var (
-	AllowedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
+	AllowedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04", "ubuntu@26.04"}
 	sdkName      = regexp.MustCompile(`^(?:[a-z0-9]-?)*[a-z](?:-?[a-z0-9])*$`)
 	// Regular expression describing correct plug, slot and interface names.
 	validPlugSlotIface = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")

--- a/internal/sdk/validate_test.go
+++ b/internal/sdk/validate_test.go
@@ -105,7 +105,7 @@ base: ubuntu@21.04
 	c.Assert(err, check.IsNil)
 
 	err = sdk.Validate(info)
-	c.Check(err, check.ErrorMatches, `invalid SDK base "ubuntu@21.04"; supported bases: ubuntu@20.04, ubuntu@22.04, ubuntu@24.04`)
+	c.Check(err, check.ErrorMatches, `invalid SDK base "ubuntu@21.04"; supported bases: ubuntu@20.04, ubuntu@22.04, ubuntu@24.04, ubuntu@26.04`)
 }
 
 func (s *ValidateSuite) TestIllegalSdkArch(c *check.C) {

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -19,7 +19,7 @@ import (
 const MAX_WORKSHOP_NAME_LENGTH = 40
 
 var (
-	SupportedBases = []string{"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"}
+	SupportedBases = sdk.AllowedBases
 
 	workshopName = regexp.MustCompile(`^[a-z](?:-?[a-z0-9])*$`)
 	actionName   = workshopName


### PR DESCRIPTION
# Description

Ubuntu 26.04 images use `sudo-rs`, so `--preserve-env` doesn't work anymore. Luckily we know which environment variables we want to preserve at each of the places where we use it. However, I think long term we should look for an approach which avoids `sudo` if possible.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
