### PR TITLE
Snapshot-related improvements

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -938,8 +938,7 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *check.C) {
 
 func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *check.C) {
 	notifySocket := filepath.Join(c.MkDir(), "notify.socket")
-	os.Setenv("NOTIFY_SOCKET", notifySocket)
-	defer os.Setenv("NOTIFY_SOCKET", "")
+	defer systemd.FakeNotifySocket(notifySocket)()
 
 	restore := standby.FakeStandbyWait(5 * time.Millisecond)
 	defer restore()
@@ -973,8 +972,7 @@ func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *check.C) {
 }
 
 func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *check.C) {
-	os.Setenv("NOTIFY_SOCKET", c.MkDir())
-	defer os.Setenv("NOTIFY_SOCKET", "")
+	defer systemd.FakeNotifySocket(c.MkDir())()
 
 	restore := standby.FakeStandbyWait(5 * time.Millisecond)
 	defer restore()

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -215,7 +215,7 @@ func userEnvironment(user *user.User) (map[string]string, error) {
 	// current user), and XDG_RUNTIME_DIR is incorrect in the second case.
 	// See https://github.com/systemd/systemd/issues/39838.
 	var args []string
-	env := syscall.Environ()
+	env := os.Environ()
 	uid, err := strconv.ParseInt(user.Uid, 10, 64)
 	if err == nil && uid == 0 {
 		args = []string{"show-environment"}

--- a/internal/systemd/export_test.go
+++ b/internal/systemd/export_test.go
@@ -30,12 +30,6 @@ func FakeServicesDir(dir string) (restore func()) {
 	}
 }
 
-func FakeOsGetenv(f func(string) string) func() {
-	oldOsGetenv := osGetenv
-	osGetenv = f
-	return func() { osGetenv = oldOsGetenv }
-}
-
 func FakeOsutilStreamCommand(f func(string, ...string) (io.ReadCloser, error)) func() {
 	old := osutilStreamCommand
 	osutilStreamCommand = f

--- a/internal/systemd/sdnotify.go
+++ b/internal/systemd/sdnotify.go
@@ -23,10 +23,25 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 )
 
-var osGetenv = os.Getenv
+var notifySocket string
+
+func FakeNotifySocket(socket string) func() {
+	oldSocket := notifySocket
+	notifySocket = socket
+	return func() { notifySocket = oldSocket }
+}
+
+func init() {
+	notifySocket = os.Getenv("NOTIFY_SOCKET")
+	// Unset so that subprocesses don't try to notify systemd; this prevents
+	// systemctl show-environment from spamming the workshopd journal. See
+	// https://github.com/systemd/systemd/blob/v260/src/shared/main-func.c#L23.
+	if err := os.Unsetenv("NOTIFY_SOCKET"); err != nil {
+		panic(fmt.Errorf("cannot unset NOTIFY_SOCKET: %w", err))
+	}
+}
 
 func SocketAvailable() bool {
-	notifySocket := osGetenv("NOTIFY_SOCKET")
 	return notifySocket != "" && osutil.FileExists(notifySocket)
 }
 
@@ -38,7 +53,6 @@ func SdNotify(notifyState string) error {
 		return fmt.Errorf("cannot use empty notify state")
 	}
 
-	notifySocket := osGetenv("NOTIFY_SOCKET")
 	if notifySocket == "" {
 		return fmt.Errorf("$NOTIFY_SOCKET not defined")
 	}

--- a/internal/systemd/sdnotify_test.go
+++ b/internal/systemd/sdnotify_test.go
@@ -25,27 +25,23 @@ import (
 )
 
 type sdNotifyTestSuite struct {
-	env           map[string]string
-	restoreGetenv func()
+	restoreSocket func()
 }
 
 var _ = Suite(&sdNotifyTestSuite{})
 
 func (sd *sdNotifyTestSuite) SetUpTest(c *C) {
-	sd.env = map[string]string{}
-	sd.restoreGetenv = systemd.FakeOsGetenv(func(k string) string {
-		return sd.env[k]
-	})
+	sd.restoreSocket = systemd.FakeNotifySocket("")
 }
 
 func (sd *sdNotifyTestSuite) TearDownTest(c *C) {
-	sd.restoreGetenv()
+	sd.restoreSocket()
 }
 
 func (sd *sdNotifyTestSuite) TestSocketAvailable(c *C) {
 	socketPath := filepath.Join(c.MkDir(), "notify.socket")
 	c.Assert(systemd.SocketAvailable(), Equals, false)
-	sd.env["NOTIFY_SOCKET"] = socketPath
+	defer systemd.FakeNotifySocket(socketPath)()
 	c.Assert(systemd.SocketAvailable(), Equals, false)
 	f, _ := os.Create(socketPath)
 	f.Close()
@@ -58,13 +54,13 @@ func (sd *sdNotifyTestSuite) TestSdNotifyMissingNotifyState(c *C) {
 
 func (sd *sdNotifyTestSuite) TestSdNotifyWrongNotifySocket(c *C) {
 	for _, t := range []struct {
-		env    string
+		socket string
 		errStr string
 	}{
 		{"", `\$NOTIFY_SOCKET not defined`},
 		{"xxx", `cannot use \$NOTIFY_SOCKET value: "xxx"`},
 	} {
-		sd.env["NOTIFY_SOCKET"] = t.env
+		defer systemd.FakeNotifySocket(t.socket)()
 		c.Check(systemd.SdNotify("something"), ErrorMatches, t.errStr)
 	}
 }
@@ -74,7 +70,7 @@ func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		sd.env["NOTIFY_SOCKET"] = sockPath
+		defer systemd.FakeNotifySocket(sockPath)()
 
 		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
 			Name: sockPath,

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	lxd "github.com/canonical/lxd/client"
@@ -43,6 +42,9 @@ var (
 	storagePoolDriver   = "zfs"
 )
 
+//go:embed start_command.sh
+var startCommand string
+
 // isWSL checks if we're running on Windows Subsystem for Linux
 func isWSL() bool {
 	var utsname unix.Utsname
@@ -57,35 +59,7 @@ func isWSL() bool {
 	return strings.Contains(version, "microsoft") || strings.Contains(version, "wsl2")
 }
 
-type volumeGuard struct {
-	c       chan struct{}
-	counter int32
-}
-
-var (
-	// However many backend instances are created, downloads are always a single
-	// instance map with the LXD backend.
-	imageLock        sync.Mutex
-	currentDownloads map[string]*downloadOp
-
-	volumeGuardsLock sync.Mutex
-	volumeGuards     map[string]*volumeGuard
-)
-
-//go:embed start_command.sh
-var startCommand string
-
 func init() {
-	imageLock.Lock()
-	defer imageLock.Unlock()
-	if currentDownloads == nil {
-		currentDownloads = make(map[string]*downloadOp)
-	}
-
-	volumeGuardsLock.Lock()
-	defer volumeGuardsLock.Unlock()
-	volumeGuards = make(map[string]*volumeGuard)
-
 	if isWSL() {
 		storagePoolDriver = "btrfs"
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -919,7 +919,11 @@ func (s *Backend) WorkshopFs(ctx context.Context, name string) (fsutil.Fs, error
 		return fsutil.Fs{}, fmt.Errorf("context key project-id not found")
 	}
 
-	sftp, err := conn.GetInstanceFileSFTP(InstanceName(name, projectId))
+	return s.instanceFs(conn, InstanceName(name, projectId))
+}
+
+func (s *Backend) instanceFs(conn lxd.InstanceServer, name string) (fsutil.Fs, error) {
+	sftp, err := conn.GetInstanceFileSFTP(name)
 	if err != nil {
 		return fsutil.Fs{}, err
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -313,15 +313,40 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		Type: api.InstanceTypeContainer,
 	}
 
-	if snapshot.IsBase() {
-		req.Source = api.InstanceSource{
-			Type:        api.SourceTypeImage,
-			Fingerprint: snapshot.Image.Fingerprint,
-		}
-		return s.launchOrRebuildFromImage(conn, snapshotConn, req)
+	if !snapshot.IsBase() {
+		return s.launchOrRebuildFromSnapshot(conn, snapshotConn, req, snapshot.Sdks)
 	}
 
-	return s.launchOrRebuildFromSnapshot(conn, snapshotConn, req, snapshot.Sdks)
+	req.Source = api.InstanceSource{
+		Type:        api.SourceTypeImage,
+		Fingerprint: snapshot.Image.Fingerprint,
+	}
+	if err := s.launchOrRebuildFromImage(conn, snapshotConn, req); err != nil {
+		return err
+	}
+
+	// Ubuntu 20.04 was released before cloud-init added support for LXD. The
+	// current images contain a more recent version of cloud-init, but the
+	// image metadata.yaml contains templated seed data files. See
+	// https://docs.cloud-init.io/en/latest/development/dir_layout.html#seed.
+	// This forces cloud-init to use the NoCloud data source instead of LXD.
+	//
+	// The seed files contain a hostname and instance-id, both set to the
+	// container name. This is OK when launching a new workshop, or rebuilding
+	// a workshop from an image (although the instance-id is different for
+	// 22.04 and up), but when rebuilding a workshop from a snapshot, it
+	// results in both the hostname and instance-id being taken from the
+	// snapshot. There's no way to remove the seed files before starting the
+	// instance for the first time, but we can force cloud-init to use the LXD
+	// data source by adding a config file.
+	fs, err := s.instanceFs(conn, req.Name)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+
+	forceLXD := []byte("datasource_list: [LXD]\n")
+	return fs.WriteFile("/etc/cloud/cloud.cfg.d/90_workshop.cfg", forceLXD, 0644)
 }
 
 func (s *Backend) launchOrRebuildFromImage(conn, snapshotConn lxd.InstanceServer, req api.InstancesPost) error {
@@ -1012,12 +1037,10 @@ apt:
 
     # Bypass confirmation prompts
     APT::Get::Assume-Yes "1";
+grub_dpkg:
+  enabled: false
+ssh_genkeytypes: [ed25519]
 write_files:
-- content: |
-    # Workaround for https://bugs.launchpad.net/snapd/+bug/2104066
-    [Service]
-    Environment=SNAPD_STANDBY_WAIT=1m
-  path: /etc/systemd/system/snapd.service.d/override.conf
 - content: |
     [DHCPv4]
     SendRelease=false
@@ -1032,8 +1055,6 @@ runcmd:
   - install --directory --mode=700 --owner=workshop --group=workshop /home/workshop/.cache /home/workshop/.config /home/workshop/.local
   # Create ~/.local/bin so SDKs don't need to source ~/.profile to add it to the PATH.
   - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/.local/bin
-  - systemctl daemon-reload
-  - systemctl restart snapd.service
   # Required to load above DHCP config.
   - networkctl reload
 `

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -397,11 +397,12 @@ func (s *Backend) launchOrRebuildFromImage(conn, snapshotConn lxd.InstanceServer
 	// containers. Finally, it clears volatile.idmap.next and
 	// volatile.last_state.idmap. All other options are unchanged. We
 	// preserve the LXD-managed options and forget the other ones.
-	req.Config = maps.Clone(req.Config)
-	for k, v := range rebuilt.Config {
-		if _, ok := req.Config[k]; !ok && optionDomain(k) != customOption {
-			req.Config[k] = v
-		}
+	maps.DeleteFunc(rebuilt.Config, func(k, v string) bool {
+		return optionDomain(k) == customOption
+	})
+	if rebuilt.Config != nil {
+		maps.Copy(rebuilt.Config, req.Config)
+		req.Config = rebuilt.Config
 	}
 
 	req.Architecture = rebuilt.Architecture

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -371,17 +371,17 @@ func (s *Backend) InstallSdk(ctx context.Context, name string, setup sdk.Setup) 
 	userDataDir := workshop.UserDataRootDir(usr.HomeDir, env)
 	mount := workshop.SdkMount(userDataDir, projectId, name, setup)
 
-	if mount.MakeWhere {
-		if err := s.mkdir(ctx, name, mount.Where, mount.Mode); err != nil {
-			return err
-		}
-	}
-
 	conn, err := s.LxdClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer conn.Disconnect()
+
+	if mount.MakeWhere {
+		if err := s.mkdir(conn, InstanceName(name, projectId), mount.Where, mount.Mode); err != nil {
+			return err
+		}
+	}
 
 	inst, etag, err := conn.GetInstance(InstanceName(name, projectId))
 	if err != nil {
@@ -421,8 +421,8 @@ func (s *Backend) InstallSdk(ctx context.Context, name string, setup sdk.Setup) 
 	return op.WaitContext(ctx)
 }
 
-func (s *Backend) mkdir(ctx context.Context, name string, path string, perm os.FileMode) error {
-	fs, err := s.WorkshopFs(ctx, name)
+func (s *Backend) mkdir(conn lxd.InstanceServer, name string, path string, perm os.FileMode) error {
+	fs, err := s.instanceFs(conn, name)
 	if err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -20,6 +21,16 @@ import (
 	"github.com/canonical/workshop/internal/timeutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
+
+var (
+	volumeGuardsLock sync.Mutex
+	volumeGuards     = map[string]*volumeGuard{}
+)
+
+type volumeGuard struct {
+	c       chan struct{}
+	counter int32
+}
 
 // LockVolume ensures exclusive access to the specified volume. If there is an
 // ongoing operation on the volume, the calling goroutine will block until the

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -176,12 +176,12 @@ func (s *Backend) launchOrRebuildFromSnapshot(conn, snapshotConn lxd.InstanceSer
 	if snapshot.Config == nil {
 		snapshot.Config = map[string]string{}
 	}
-	var config map[string]string
+	var snapshotConfig, reqConfig map[string]string
 	if !newApi {
 		// The old API handles config options inconsistently. This
 		// computes the form required for UpdateInstance.
-		config = maps.Clone(snapshot.Config)
-		mergeConfig(config, inst.Config, req.Config, true)
+		snapshotConfig = maps.Clone(snapshot.Config)
+		reqConfig = req.Config
 	}
 	mergeConfig(snapshot.Config, inst.Config, req.Config, newApi)
 
@@ -210,11 +210,20 @@ func (s *Backend) launchOrRebuildFromSnapshot(conn, snapshotConn lxd.InstanceSer
 		return nil
 	}
 
+	var etag string
+	if inst.Name == "" {
+		inst, etag, err = conn.GetInstance(req.Name)
+		if err != nil {
+			return err
+		}
+	}
+
 	// If the workshop already existed, it still has the old config options
 	// and devices. If it did not exist, the config and devices are mostly
 	// correct, but we still need to remove placeholder SDK devices.
-	req.Config = config
-	op, err := conn.UpdateInstance(req.Name, req.InstancePut, "")
+	mergeConfig(snapshotConfig, inst.Config, reqConfig, true)
+	req.Config = snapshotConfig
+	op, err := conn.UpdateInstance(req.Name, req.InstancePut, etag)
 	if err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -25,6 +25,11 @@ import (
 var (
 	ConnectSimpleStreams = lxd.ConnectSimpleStreams
 	imageServer          = "simplestreams:https://cloud-images.ubuntu.com/releases"
+
+	// However many backend instances are created, downloads are always a single
+	// instance map with the LXD backend.
+	imageLock        sync.Mutex
+	currentDownloads = map[string]*downloadOp{}
 )
 
 func (b *Backend) GetBase(ctx context.Context, base string) (workshop.BaseImage, error) {

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -16,7 +16,7 @@ launched:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '2a997ae6f1d1f450e68ca94a5c4a0d2cd887f1e9e8e7713cf91c49dc3e94f906192af9a31ecf074d52e38f0ad5b4185b'
+    user.user-data: '59c339a3a3271e1ae41686809a3c1607cced545f64c625fb6219d6d5f3147b205cf96d3ffca74c94be7dabcdf309b9cd'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -55,7 +55,7 @@ started:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '2a997ae6f1d1f450e68ca94a5c4a0d2cd887f1e9e8e7713cf91c49dc3e94f906192af9a31ecf074d52e38f0ad5b4185b'
+    user.user-data: '59c339a3a3271e1ae41686809a3c1607cced545f64c625fb6219d6d5f3147b205cf96d3ffca74c94be7dabcdf309b9cd'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -94,7 +94,7 @@ sdk-attached:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '2a997ae6f1d1f450e68ca94a5c4a0d2cd887f1e9e8e7713cf91c49dc3e94f906192af9a31ecf074d52e38f0ad5b4185b'
+    user.user-data: '59c339a3a3271e1ae41686809a3c1607cced545f64c625fb6219d6d5f3147b205cf96d3ffca74c94be7dabcdf309b9cd'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -145,7 +145,7 @@ sdk-mounted:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '2a997ae6f1d1f450e68ca94a5c4a0d2cd887f1e9e8e7713cf91c49dc3e94f906192af9a31ecf074d52e38f0ad5b4185b'
+    user.user-data: '59c339a3a3271e1ae41686809a3c1607cced545f64c625fb6219d6d5f3147b205cf96d3ffca74c94be7dabcdf309b9cd'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -101,40 +101,6 @@ function cleanup_workshop() {
     loginctl disable-linger ubuntu
 }
 
-# Publish test SDKs in the fake SDK Store
-function publish_test_sdks() {
-    for i in "$1"/*; do
-        SDK_NAME=$(basename "$i")
-        SDK_FILE=$SDK_NAME.sdk
-        SDK_PATH=$(readlink -f "$i")
-        STORE_PATH="$2/$SDK_NAME"
-
-        echo "$SDK_NAME:"
-        find "$SDK_PATH/" -mindepth 2 -maxdepth 2 -type d -printf "%P\n" | while IFS= read -r track; do
-            printf "\t%s -> %s\n" "$track" "$STORE_PATH/$track"
-            mkdir -p "$STORE_PATH/$track"
-            rm -f "$STORE_PATH/$track/$SDK_FILE"
-
-            readarray -d '' -t SDK_FILES < <(ls --almost-all --zero "$SDK_PATH/$track")
-            tar \
-                --create \
-                --format=posix \
-                --use-compress-program='zstd -10 --threads=0' \
-                --mode='a-st,go-w' \
-                --owner='root:0' \
-                --group='root:0' \
-                --mtime="$(date --utc +'%Y-%m-%dT%H:%M:%S.%6NZ')" \
-                --sort=name \
-                --force-local \
-                --file="$STORE_PATH/$track/$SDK_FILE" \
-                --directory="$SDK_PATH/$track" \
-                "${SDK_FILES[@]}"
-
-            cp -f "$SDK_PATH/$track/meta/sdk.yaml" "$STORE_PATH/$track"
-        done
-    done
-}
-
 # Workshop sub-command wrappers
 function workshop_exec() {
     sudo -u ubuntu -- workshop "$@" 2>&1

--- a/tests/main/refresh/multi/.workshop/ws-refresh-sdk.yaml
+++ b/tests/main/refresh/multi/.workshop/ws-refresh-sdk.yaml
@@ -2,3 +2,4 @@ name: ws-refresh-sdk
 base: ubuntu@22.04
 sdks:
   - name: test-sdk-basic
+    channel: stable

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -17,12 +17,8 @@ execute: |
   cd single
   workshop_exec exec -- sudo touch /var/cache/apt/archives/sentinel
 
-  echo "Check refresh supports project-level workshop definitions"
-  workshop_exec refresh
-
-  echo "Check apt cache is preserved across refreshes"
-  workshop_exec exec -- mountpoint /var/cache/apt/archives
-  workshop_exec exec -- sudo test -f /var/cache/apt/archives/sentinel
+  echo "Check refresh succeeds without updates"
+  workshop_exec refresh | MATCH 'no updates available for "ws-refresh"'
 
   echo "Check workshop refresh --no-wait"
   echo -e "sdks:\n  - name: test-sdk-health-waiting" >> workshop.yaml
@@ -33,16 +29,16 @@ execute: |
   # Check tests/lib/sdk/test-sdk-health-waiting/latest/stable/sdk/hooks/check-health for details
   sudo -u ubuntu 2>&1 -- expect -f ./health.exp
 
+  echo "Check apt cache is preserved across refreshes"
+  workshop_exec exec -- mountpoint /var/cache/apt/archives
+  workshop_exec exec -- sudo test -f /var/cache/apt/archives/sentinel
+
   echo "Check refresh supports multi-workshop projects"
   cd ../multi
-  workshop_exec refresh ws-refresh
+  workshop_exec refresh ws-refresh | MATCH 'no updates available for "ws-refresh"'
 
-  echo "Check refresh change is Done"
-  workshop_exec changes | MATCH "^[0-9]*[[:space:]]+Done[[:space:]]+[:, [:alnum:]]+[[:space:]]+Refresh \"ws-refresh\" workshop$"
-
-  echo "Check the workshop is in Ready state"
-  workshop_exec list | MATCH "^ws-refresh[[:space:]]+Ready[[:space:]]+-$"
-
+  echo "Update SDK"
+  sed -i 's/stable/edge/' .workshop/ws-refresh-sdk.yaml
   workshop_exec refresh ws-refresh-sdk
 
   echo "Check refresh change is Done"
@@ -50,9 +46,6 @@ execute: |
 
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^ws-refresh-sdk[[:space:]]+Ready[[:space:]]+-$"
-
-  echo "Check workshop refresh when no updates are available"
-  workshop_exec refresh ws-refresh-sdk | MATCH "no updates available for \"ws-refresh-sdk\""
 
   list_snapshots() {
     local pid


### PR DESCRIPTION
# Description

Bug fix: when launching a workshop from a snapshot (not currently possible outside tests), and using the old `CopyInstance` API, the LXD backend neglected to query the new instance config before calling `UpdateInstance`. This fails because LXD thinks it's trying to delete all the volatile options. These are now merged with the other options as intended.

Optimisations for `cloud-init`:
- The LXD data source is always used, even in `ubuntu@20.04` images which currently use `NoCloud` instead. This means all workshops have randomly-generated instance IDs, and avoids an issue where the instance hostname is baked into snapshots.
- Removes the need to restart snapd. The issue this worked around has been fixed for a while, and it saves a few seconds.
- Disables GRUB probing (not relevant for containers and saves a few hundred ms)
- Limits SSH keys to ED25519, also saves a few hundred ms and I think these are widely compatible now

Minor improvements:
- Clarifies config merge strategy when rebuilding a workshop from an image
- Removes need to create separate LXD connection for WorkshopFs
- Moves LXD backend locks into files that use them
- Reduces the number of no-op refreshes in the spread tests
- Removes an old GCS-related helper function
- Removes annoying `Got notification message from PID` messages from the snap logs

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
