### PR TITLE
Clean up unused snapshots

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -55,7 +55,7 @@ Prerequisites
 ~~~~~~~~~~~~~
 
 Workshop requires
-`LXD 6.6+ <https://canonical.com/lxd>`_
+`LXD 6.8+ <https://canonical.com/lxd>`_
 for low-level operation.
 
 If the ``snap install`` command reports an issue with LXD,

--- a/docs/tutorial/part-1-get-started.rst
+++ b/docs/tutorial/part-1-get-started.rst
@@ -51,7 +51,7 @@ it is also compatible with Windows Subsystem for Linux (WSL2),
 where it uses Btrfs instead of ZFS for storage.
 
 |ws_markup| relies on
-`LXD 6.6+ <https://canonical.com/lxd>`_
+`LXD 6.8+ <https://canonical.com/lxd>`_
 for low-level operation
 and uses its
 `REST API <https://documentation.ubuntu.com/lxd/latest/restapi_landing/>`_

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -43,7 +43,7 @@ Prerequisites
 ~~~~~~~~~~~~~
 
 |sdk_markup| relies on
-`LXD 6.6+ <https://canonical.com/lxd>`_
+`LXD 6.8+ <https://canonical.com/lxd>`_
 for low-level operation,
 using its
 `REST API <https://documentation.ubuntu.com/lxd/latest/restapi_landing/>`_

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -91,7 +91,7 @@ func (s *apiSuite) workshopFile(ws string, sdks []*sdk.Info) *workshop.File {
 func (s *apiSuite) mockInstalledSDK(c *check.C, yaml string, w string) *workshop.Workshop {
 	info := sdk.MockInfo(c, yaml, s.project.ProjectId, w)
 	wf := s.workshopFile(w, []*sdk.Info{info})
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	wp, err := s.b.Workshop(s.ctx, w)
@@ -128,7 +128,7 @@ func (s *apiSuite) mockInstalledSDKBoundPlug(c *check.C, yaml string, w string, 
 		Name:      to}
 	c.Assert(s.d.overlord.InterfaceManager().Repository().AddSdk(info), check.IsNil)
 	wf := s.workshopFile(w, []*sdk.Info{info})
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 	wp, err := s.b.Workshop(s.ctx, w)
 	c.Check(err, check.IsNil)

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -40,7 +41,7 @@ func (s *apiSuite) setupExec(c *check.C) *Command {
 	s.createWFile(c, "ws", wsYaml)
 
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Actions: map[string]workshop.Action{"lint": "\n\n\ngolangci-lint run\n"}}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 
 	err := s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)

--- a/internal/daemon/api_sdks_test.go
+++ b/internal/daemon/api_sdks_test.go
@@ -439,11 +439,11 @@ func (s *apiSuite) TestSdkInfoGetOk(c *check.C) {
 	s.createWFile(c, "lerobot", "name: lerobot\nbase: ubuntu@20.04\n")
 
 	wf := &workshop.File{Name: "nav2", Base: "ubuntu@20.04"}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	wf = &workshop.File{Name: "lerobot", Base: "ubuntu@20.04"}
-	snapshot = workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot = workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	// Add SDK setups with channels so the endpoint can report channels.
@@ -664,7 +664,7 @@ func (s *apiSuite) TestSdkInfoLocalOnly(c *check.C) {
 
 	s.createWFile(c, "nav2", "name: nav2\nbase: ubuntu@20.04\n")
 	wf := &workshop.File{Name: "nav2", Base: "ubuntu@20.04"}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	// Add SDK setup with channels so the endpoint can report channels.
@@ -795,7 +795,7 @@ func (s *apiSuite) TestSdkInfoGetInvalidLocalMetadata(c *check.C) {
 
 	s.createWFile(c, "ws", "name: ws\nbase: ubuntu@20.04\n")
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	c.Assert(s.b.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot), check.IsNil)
 
 	meta := sdk.Meta{

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -472,23 +472,23 @@ func refresh(ctx context.Context, mgr *workshopstate.WorkshopManager, reqData *w
 	return current, latest, tasksets, nil
 }
 
-func remove(ctx context.Context, mgr *workshopstate.WorkshopManager, reqData *workshopReq, pid string) ([]workshopstate.Manifest, []*state.TaskSet, error) {
+func remove(ctx context.Context, mgr *workshopstate.WorkshopManager, reqData *workshopReq, pid string) (stashed, current []workshopstate.Manifest, tasksets []*state.TaskSet, err error) {
 	project, err := mgr.Project(ctx, pid)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	current, running, err := mgr.RemoveManifests(ctx, pid, reqData.Names)
+	stashed, current, running, err := mgr.RemoveManifests(ctx, pid, reqData.Names)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	tasksets, err := mgr.RemoveMany(ctx, project, current, running)
+	tasksets, err = mgr.RemoveMany(ctx, project, current, running)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return current, tasksets, nil
+	return stashed, current, tasksets, nil
 }
 
 var validActions = []string{
@@ -541,7 +541,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	defer st.Unlock()
 
 	var change *state.Change
-	var current, latest []workshopstate.Manifest
+	var current, latest, stashed []workshopstate.Manifest
 	var tasksets []*state.TaskSet
 
 	if mode.Resume() {
@@ -567,7 +567,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 			tasksets, err = wsmgr.StopMany(r.Context(), reqData.Names, projectId)
 		case "remove":
 			change = newWorkshopChange(st, "remove", user, projectId, reqData.Action, reqData.Names)
-			current, tasksets, err = remove(r.Context(), wsmgr, &reqData, projectId)
+			stashed, current, tasksets, err = remove(r.Context(), wsmgr, &reqData, projectId)
 		default:
 			return statusBadRequest("internal error: action passed validation but was not matched during dispatch")
 		}
@@ -580,16 +580,19 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("%w", err)
 	}
 
-	for _, m := range current {
-		change.Set(handlersetup.WorkshopFormatKey(m.File.Name, handlersetup.OldWorkshop), m.Format)
-		change.Set(handlersetup.WorkshopBaseKey(m.File.Name, handlersetup.OldWorkshop), m.Image)
-		change.Set(handlersetup.WorkshopSdksKey(m.File.Name, handlersetup.OldWorkshop), m.Sdks)
+	manifestsByAge := map[handlersetup.Age][]workshopstate.Manifest{
+		handlersetup.OldWorkshop: current,
+		handlersetup.NewWorkshop: latest,
+		handlersetup.OldStash:    stashed,
 	}
-	for _, m := range latest {
-		change.Set(handlersetup.WorkshopFormatKey(m.File.Name, handlersetup.NewWorkshop), m.Format)
-		change.Set(handlersetup.WorkshopBaseKey(m.File.Name, handlersetup.NewWorkshop), m.Image)
-		change.Set(handlersetup.WorkshopSdksKey(m.File.Name, handlersetup.NewWorkshop), m.Sdks)
+	for age, manifests := range manifestsByAge {
+		for _, m := range manifests {
+			change.Set(handlersetup.WorkshopFormatKey(m.File.Name, age), m.Format)
+			change.Set(handlersetup.WorkshopBaseKey(m.File.Name, age), m.Image)
+			change.Set(handlersetup.WorkshopSdksKey(m.File.Name, age), m.Sdks)
+		}
 	}
+
 	for _, taskset := range tasksets {
 		change.AddAll(taskset)
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -436,8 +436,8 @@ func launch(ctx context.Context, mgr *workshopstate.WorkshopManager, reqData *wo
 		return nil, nil, err
 	}
 
-	taskset, err := mgr.LaunchMany(ctx, project, manifests)
-	return manifests, taskset, err
+	tasksets, err := mgr.LaunchMany(ctx, project, manifests)
+	return manifests, tasksets, err
 }
 
 func refreshOption(reqData *workshopReq) (conflict.RefreshOption, error) {
@@ -448,28 +448,47 @@ func refreshOption(reqData *workshopReq) (conflict.RefreshOption, error) {
 	return conflict.ParseRefreshSetting(reqData.Options.RefreshOption)
 }
 
-func refresh(ctx context.Context, mgr *workshopstate.WorkshopManager, reqData *workshopReq, pid string) ([]workshopstate.Manifest, []*state.TaskSet, error) {
+func refresh(ctx context.Context, mgr *workshopstate.WorkshopManager, reqData *workshopReq, pid string) (current, latest []workshopstate.Manifest, tasksets []*state.TaskSet, err error) {
 	refreshOption, err := refreshOption(reqData)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
+	project, err := mgr.Project(ctx, pid)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	current, latest, err = mgr.RefreshManifests(ctx, project, reqData.Names, refreshOption)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	tasksets, err = mgr.RefreshMany(ctx, project, current, latest, refreshOption)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return current, latest, tasksets, nil
+}
+
+func remove(ctx context.Context, mgr *workshopstate.WorkshopManager, reqData *workshopReq, pid string) ([]workshopstate.Manifest, []*state.TaskSet, error) {
 	project, err := mgr.Project(ctx, pid)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	current, latest, err := mgr.RefreshManifests(ctx, project, reqData.Names, refreshOption)
+	current, running, err := mgr.RemoveManifests(ctx, pid, reqData.Names)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	taskset, err := mgr.RefreshMany(ctx, project, current, latest, refreshOption)
+	tasksets, err := mgr.RemoveMany(ctx, project, current, running)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return latest, taskset, nil
+	return current, tasksets, nil
 }
 
 var validActions = []string{
@@ -522,8 +541,8 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	defer st.Unlock()
 
 	var change *state.Change
-	var manifests []workshopstate.Manifest
-	var taskset []*state.TaskSet
+	var current, latest []workshopstate.Manifest
+	var tasksets []*state.TaskSet
 
 	if mode.Resume() {
 		change, err = conflict.ResumeAfterWait(st, reqData.Names[0], projectId, mode, reqData.Action)
@@ -534,21 +553,21 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 			change = newWorkshopChange(st, "launch", user, projectId, reqData.Action, reqData.Names)
 			change.Set("wait-setup", conflict.ChangeSetup{Mode: mode.String()})
 			change.Set("verbose", reqData.Options.Verbose)
-			manifests, taskset, err = launch(r.Context(), wsmgr, &reqData, projectId)
+			latest, tasksets, err = launch(r.Context(), wsmgr, &reqData, projectId)
 		case "refresh":
 			change = newWorkshopChange(st, "refresh", user, projectId, reqData.Action, reqData.Names)
 			change.Set("wait-setup", conflict.ChangeSetup{Mode: mode.String()})
 			change.Set("verbose", reqData.Options.Verbose)
-			manifests, taskset, err = refresh(r.Context(), wsmgr, &reqData, projectId)
+			current, latest, tasksets, err = refresh(r.Context(), wsmgr, &reqData, projectId)
 		case "start":
 			change = newWorkshopChange(st, "start", user, projectId, reqData.Action, reqData.Names)
-			taskset, err = wsmgr.StartMany(r.Context(), reqData.Names, projectId)
+			tasksets, err = wsmgr.StartMany(r.Context(), reqData.Names, projectId)
 		case "stop":
 			change = newWorkshopChange(st, "stop", user, projectId, reqData.Action, reqData.Names)
-			taskset, err = wsmgr.StopMany(r.Context(), reqData.Names, projectId)
+			tasksets, err = wsmgr.StopMany(r.Context(), reqData.Names, projectId)
 		case "remove":
 			change = newWorkshopChange(st, "remove", user, projectId, reqData.Action, reqData.Names)
-			taskset, err = wsmgr.RemoveMany(r.Context(), reqData.Names, projectId)
+			current, tasksets, err = remove(r.Context(), wsmgr, &reqData, projectId)
 		default:
 			return statusBadRequest("internal error: action passed validation but was not matched during dispatch")
 		}
@@ -561,12 +580,16 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("%w", err)
 	}
 
-	for _, m := range manifests {
-		change.Set(handlersetup.WorkshopBaseKey(m.File.Name), m.Image)
-		change.Set(handlersetup.WorkshopSdksKey(m.File.Name), m.Sdks)
+	for _, m := range current {
+		change.Set(handlersetup.WorkshopBaseKey(m.File.Name, handlersetup.OldWorkshop), m.Image)
+		change.Set(handlersetup.WorkshopSdksKey(m.File.Name, handlersetup.OldWorkshop), m.Sdks)
 	}
-	for _, tset := range taskset {
-		change.AddAll(tset)
+	for _, m := range latest {
+		change.Set(handlersetup.WorkshopBaseKey(m.File.Name, handlersetup.NewWorkshop), m.Image)
+		change.Set(handlersetup.WorkshopSdksKey(m.File.Name, handlersetup.NewWorkshop), m.Sdks)
+	}
+	for _, taskset := range tasksets {
+		change.AddAll(taskset)
 	}
 	if len(change.Tasks()) == 0 {
 		change.SetStatus(state.DoneStatus)

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -581,10 +581,12 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	for _, m := range current {
+		change.Set(handlersetup.WorkshopFormatKey(m.File.Name, handlersetup.OldWorkshop), m.Format)
 		change.Set(handlersetup.WorkshopBaseKey(m.File.Name, handlersetup.OldWorkshop), m.Image)
 		change.Set(handlersetup.WorkshopSdksKey(m.File.Name, handlersetup.OldWorkshop), m.Sdks)
 	}
 	for _, m := range latest {
+		change.Set(handlersetup.WorkshopFormatKey(m.File.Name, handlersetup.NewWorkshop), m.Format)
 		change.Set(handlersetup.WorkshopBaseKey(m.File.Name, handlersetup.NewWorkshop), m.Image)
 		change.Set(handlersetup.WorkshopSdksKey(m.File.Name, handlersetup.NewWorkshop), m.Sdks)
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1913,7 +1913,9 @@ func (s *apiSuite) ensureWorkshops(c *check.C, want []expectedWorkshop) {
 func (s *apiSuite) ensureSdkVolumesAfterCooldown(c *check.C, want []string) {
 	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
 
-	for i := 0; i < 6; i = i + 1 {
+	// More Ensure calls than usual to prevent FakeSdkVolumeCooldownTime
+	// from racing with the outstanding cleanup handlers.
+	for range 12 {
 		c.Check(s.d.overlord.StateEngine().Ensure(), check.IsNil)
 		s.d.overlord.StateEngine().Wait()
 	}

--- a/internal/daemon/snapshot-ingredients.yaml
+++ b/internal/daemon/snapshot-ingredients.yaml
@@ -63,3 +63,4 @@ FakeWorkshop:
   Workshop: '*workshop.Workshop'
   Devices: map[string]map[string]string
   WorkshopFilesystem:
+  CurrentSnapshot: workshop.Snapshot

--- a/internal/daemon/snapshot-ingredients.yaml
+++ b/internal/daemon/snapshot-ingredients.yaml
@@ -57,6 +57,7 @@ FakeWorkshopBackend:
   SnapshotCalls:
   SnapshotCallback:
   Snapshots:
+  RemovedSnapshots:
   BaseDir:
   SnapshotDir:
 FakeWorkshop:

--- a/internal/daemon/snapshot-ingredients.yaml
+++ b/internal/daemon/snapshot-ingredients.yaml
@@ -21,6 +21,7 @@ Workshop:
   Project: workshop.Project
   File: '*workshop.File'
   Name: string
+  Format: sdk.Revision
   Image: workshop.BaseImage
   Running: bool
   Sdks: map[string]workshop.SdkInstallation

--- a/internal/interfaces/builtin/camera_test.go
+++ b/internal/interfaces/builtin/camera_test.go
@@ -49,8 +49,8 @@ func (s *cameraSuite) SetUpSuite(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil
 	})
-	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
-		return &api.Resources{}, false, nil
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{}, nil
 	})
 }
 

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -50,8 +50,8 @@ func (s *desktopSuite) SetUpSuite(c *check.C) {
 	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
 		return &testuser, nil
 	})
-	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
-		return &api.Resources{}, false, nil
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{}, nil
 	})
 }
 

--- a/internal/interfaces/builtin/gpu_test.go
+++ b/internal/interfaces/builtin/gpu_test.go
@@ -50,8 +50,8 @@ func (s *gpuSuite) SetUpSuite(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil
 	})
-	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
-		return &api.Resources{}, false, nil
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{}, nil
 	})
 }
 

--- a/internal/interfaces/builtin/mount_test.go
+++ b/internal/interfaces/builtin/mount_test.go
@@ -67,8 +67,8 @@ func (s *mountSuite) SetUpSuite(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return s.env, nil
 	})
-	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
-		return &api.Resources{}, false, nil
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{}, nil
 	})
 }
 

--- a/internal/interfaces/builtin/ssh_agent_test.go
+++ b/internal/interfaces/builtin/ssh_agent_test.go
@@ -51,8 +51,8 @@ func (s *sshAgentSuite) SetUpTest(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return map[string]string{"SSH_AUTH_SOCK": "/tmp/dir/ssh"}, nil
 	})
-	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
-		return &api.Resources{}, false, nil
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{}, nil
 	})
 }
 

--- a/internal/interfaces/builtin/tunnel_test.go
+++ b/internal/interfaces/builtin/tunnel_test.go
@@ -62,8 +62,8 @@ func (s *tunnelSuite) SetUpSuite(c *check.C) {
 	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
 		return nil, nil
 	})
-	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
-		return &api.Resources{}, false, nil
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{}, nil
 	})
 }
 

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -32,27 +32,25 @@ import (
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
 
-// lxdServerInfo retrieves GPU resources and CDI support from LXD.
-var lxdServerInfo = func(ctx context.Context) (*api.Resources, bool, error) {
+// lxdServerInfo retrieves GPU resources from LXD.
+var lxdServerInfo = func(ctx context.Context) (*api.Resources, error) {
 	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	defer conn.Disconnect()
 
 	resources, err := conn.GetServerResources()
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	cdiSupported := conn.HasExtension("gpu_cdi") && conn.HasExtension("gpu_cdi_amd") && conn.HasExtension("gpu_cdi_hotplug")
-
-	return resources, cdiSupported, nil
+	return resources, nil
 }
 
 // MockLxdServerInfo replaces the LXD server info function used by
 // NewSpecification and returns a restore function.
-func MockLxdServerInfo(f func(ctx context.Context) (*api.Resources, bool, error)) func() {
+func MockLxdServerInfo(f func(ctx context.Context) (*api.Resources, error)) func() {
 	old := lxdServerInfo
 	lxdServerInfo = f
 	return func() { lxdServerInfo = old }
@@ -67,19 +65,18 @@ func NewSpecification(user string, sdk string) (*Specification, error) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, workshop.ContextUser, user)
 
-	resources, cdiSupported, err := lxdServerInfo(ctx)
+	resources, err := lxdServerInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Specification{
-		devices:      make(map[string]map[string]string),
-		config:       make(map[string]string),
-		Profile:      workshop.NewSdkProfile(sdk),
-		User:         usr,
-		Environment:  env,
-		resources:    resources,
-		cdiSupported: cdiSupported,
+		devices:     make(map[string]map[string]string),
+		config:      make(map[string]string),
+		Profile:     workshop.NewSdkProfile(sdk),
+		User:        usr,
+		Environment: env,
+		resources:   resources,
 	}, nil
 }
 
@@ -90,9 +87,8 @@ type Specification struct {
 	config    map[string]string
 	resources *api.Resources
 
-	User         *user.User
-	Environment  map[string]string
-	cdiSupported bool
+	User        *user.User
+	Environment map[string]string
 }
 
 // AddPermanentSlot records side-effects of having a slot.
@@ -208,56 +204,44 @@ func detectGpuVendor(vendorID string) string {
 func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 	s.Profile.Gpu = &gpu
 
-	if s.cdiSupported {
-		gpus := s.resources.GPU
-		if gpus.Total == 0 {
-			logger.Debugf("GPU interface requested, but no GPU detected on the host system")
-			return nil
-		}
+	gpus := s.resources.GPU
+	if gpus.Total == 0 {
+		logger.Debugf("GPU interface requested, but no GPU detected on the host system")
+		return nil
+	}
 
-		for _, c := range gpus.Cards {
-			vendor := detectGpuVendor(c.VendorID)
-			switch vendor {
-			case "nvidia", "amd":
-				device := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name, vendor)
-				// Add "all" devices per vendor. Indexes would be rather accurate but
-				// the problem with indexes is that the AMD CDI start indexes from 0
-				// regardless what index the card has in the system whilst NVIDIA CDI
-				// indexes match the system indexes. LXD should include UUIDs
-				// in the GPU resources which we can use in the spec instead of IDs.
-				if _, ok := s.devices[device]; !ok {
-					s.devices[device] = map[string]string{
-						"type":    "gpu",
-						"gputype": "physical",
-						"id":      vendor + ".com/gpu=all",
-					}
-				}
-			case "intel":
-				// Intel GPUs are not yet supported by the GPU CDI spec, so we
-				// fall back to exposing them as 'physical' GPUs with a specific
-				// ID.
-				cardId := strconv.FormatUint(c.DRM.ID, 10)
-				device := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name, vendor, cardId)
+	for _, c := range gpus.Cards {
+		vendor := detectGpuVendor(c.VendorID)
+		switch vendor {
+		case "nvidia", "amd":
+			device := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name, vendor)
+			// Add "all" devices per vendor. Indexes would be rather accurate but
+			// the problem with indexes is that the AMD CDI start indexes from 0
+			// regardless what index the card has in the system whilst NVIDIA CDI
+			// indexes match the system indexes. LXD should include UUIDs
+			// in the GPU resources which we can use in the spec instead of IDs.
+			if _, ok := s.devices[device]; !ok {
 				s.devices[device] = map[string]string{
 					"type":    "gpu",
 					"gputype": "physical",
-					"uid":     workshop.User.Uid,
-					"gid":     workshop.User.Gid,
-					"id":      cardId,
+					"id":      vendor + ".com/gpu=all",
 				}
-			default:
-				logger.Debugf("Unknown GPU vendor ID '%s' for GPU card with ID %d", c.VendorID, c.DRM.ID)
 			}
-
-		}
-	} else {
-		// TODO: Remove when switched to LXD 6.8
-		name := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name)
-		s.devices[name] = map[string]string{
-			"type":    "gpu",
-			"gputype": "physical",
-			"uid":     workshop.User.Uid,
-			"gid":     workshop.User.Gid,
+		case "intel":
+			// Intel GPUs are not yet supported by the GPU CDI spec, so we
+			// fall back to exposing them as 'physical' GPUs with a specific
+			// ID.
+			cardId := strconv.FormatUint(c.DRM.ID, 10)
+			device := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name, vendor, cardId)
+			s.devices[device] = map[string]string{
+				"type":    "gpu",
+				"gputype": "physical",
+				"uid":     workshop.User.Uid,
+				"gid":     workshop.User.Gid,
+				"id":      cardId,
+			}
+		default:
+			logger.Debugf("Unknown GPU vendor ID '%s' for GPU card with ID %d", c.VendorID, c.DRM.ID)
 		}
 	}
 

--- a/internal/interfaces/lxd_device/spec_test.go
+++ b/internal/interfaces/lxd_device/spec_test.go
@@ -53,30 +53,9 @@ func (s *lxdSpecSuite) TearDownTest(c *check.C) {
 	s.restoreUserLookup()
 }
 
-func (s *lxdSpecSuite) TestSetGpuLegacyNoCDI(c *check.C) {
-	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
-		return &api.Resources{}, false, nil
-	})
-
-	spec, err := NewSpecification("testuser", "test-sdk")
-	c.Assert(err, check.IsNil)
-
-	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
-	c.Assert(err, check.IsNil)
-
-	// Legacy path creates a single device with uid/gid.
-	c.Assert(spec.devices, check.HasLen, 1)
-	dev, ok := spec.devices["test-sdk_gpu"]
-	c.Assert(ok, check.Equals, true)
-	c.Check(dev["type"], check.Equals, "gpu")
-	c.Check(dev["gputype"], check.Equals, "physical")
-	c.Check(dev["uid"], check.Equals, workshop.User.Uid)
-	c.Check(dev["gid"], check.Equals, workshop.User.Gid)
-}
-
 func (s *lxdSpecSuite) TestSetGpuCDINoGpuDetected(c *check.C) {
-	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
-		return &api.Resources{GPU: api.ResourcesGPU{Total: 0}}, true, nil
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{Total: 0}}, nil
 	})
 
 	spec, err := NewSpecification("testuser", "test-sdk")
@@ -90,13 +69,13 @@ func (s *lxdSpecSuite) TestSetGpuCDINoGpuDetected(c *check.C) {
 }
 
 func (s *lxdSpecSuite) TestSetGpuCDINvidia(c *check.C) {
-	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
 		return &api.Resources{GPU: api.ResourcesGPU{
 			Total: 1,
 			Cards: []api.ResourcesGPUCard{
 				{VendorID: "10de", DRM: &api.ResourcesGPUCardDRM{ID: 0}},
 			},
-		}}, true, nil
+		}}, nil
 	})
 
 	spec, err := NewSpecification("testuser", "test-sdk")
@@ -114,13 +93,13 @@ func (s *lxdSpecSuite) TestSetGpuCDINvidia(c *check.C) {
 }
 
 func (s *lxdSpecSuite) TestSetGpuCDIAmd(c *check.C) {
-	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
 		return &api.Resources{GPU: api.ResourcesGPU{
 			Total: 1,
 			Cards: []api.ResourcesGPUCard{
 				{VendorID: "1002", DRM: &api.ResourcesGPUCardDRM{ID: 1}},
 			},
-		}}, true, nil
+		}}, nil
 	})
 
 	spec, err := NewSpecification("testuser", "test-sdk")
@@ -136,13 +115,13 @@ func (s *lxdSpecSuite) TestSetGpuCDIAmd(c *check.C) {
 }
 
 func (s *lxdSpecSuite) TestSetGpuCDIIntel(c *check.C) {
-	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
 		return &api.Resources{GPU: api.ResourcesGPU{
 			Total: 1,
 			Cards: []api.ResourcesGPUCard{
 				{VendorID: "8086", DRM: &api.ResourcesGPUCardDRM{ID: 3}},
 			},
-		}}, true, nil
+		}}, nil
 	})
 
 	spec, err := NewSpecification("testuser", "test-sdk")
@@ -163,7 +142,7 @@ func (s *lxdSpecSuite) TestSetGpuCDIIntel(c *check.C) {
 }
 
 func (s *lxdSpecSuite) TestSetGpuCDIMultipleVendors(c *check.C) {
-	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
 		return &api.Resources{GPU: api.ResourcesGPU{
 			Total: 3,
 			Cards: []api.ResourcesGPUCard{
@@ -171,7 +150,7 @@ func (s *lxdSpecSuite) TestSetGpuCDIMultipleVendors(c *check.C) {
 				{VendorID: "10de", DRM: &api.ResourcesGPUCardDRM{ID: 1}},
 				{VendorID: "8086", DRM: &api.ResourcesGPUCardDRM{ID: 2}},
 			},
-		}}, true, nil
+		}}, nil
 	})
 
 	spec, err := NewSpecification("testuser", "test-sdk")
@@ -189,13 +168,13 @@ func (s *lxdSpecSuite) TestSetGpuCDIMultipleVendors(c *check.C) {
 }
 
 func (s *lxdSpecSuite) TestSetGpuCDIUnknownVendor(c *check.C) {
-	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, bool, error) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
 		return &api.Resources{GPU: api.ResourcesGPU{
 			Total: 1,
 			Cards: []api.ResourcesGPUCard{
 				{VendorID: "ffff", DRM: &api.ResourcesGPUCardDRM{ID: 0}},
 			},
-		}}, true, nil
+		}}, nil
 	})
 
 	spec, err := NewSpecification("testuser", "test-sdk")

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -250,35 +250,54 @@ func WorkshopSdksKey(w string, age Age) string {
 	return strings.Join([]string{w, string(age), "sdks"}, "_")
 }
 
-func WorkshopSnapshot(change *state.Change, w, lastIntact string) (*workshop.Snapshot, error) {
-	format, err := WorkshopFormat(change, w, NewWorkshop)
-	if err != nil {
-		return nil, err
-	}
-
-	image, err := WorkshopBase(change, w, NewWorkshop)
-	if err != nil {
-		return nil, err
-	}
-
+func WorkshopSdkSnapshot(change *state.Change, w, lastIntact string) (*workshop.Snapshot, error) {
 	if lastIntact == "" {
-		snapshot := workshop.SdkSnapshot(format, image, nil)
-		return &snapshot, nil
+		return workshopBaseOnly(change, w, NewWorkshop)
 	}
 
-	sdks, err := WorkshopSdks(change, w, NewWorkshop)
+	snapshot, err := workshopSnapshot(change, w, NewWorkshop)
 	if err != nil {
 		return nil, err
 	}
 
-	idx := slices.IndexFunc(sdks, func(s sdk.Setup) bool {
+	idx := slices.IndexFunc(snapshot.Sdks, func(s sdk.ContentID) bool {
 		return s.Name == lastIntact
 	})
 	if idx < 0 {
 		return nil, fmt.Errorf("internal error: %q workshop has no %q SDK", w, lastIntact)
 	}
+	snapshot.Sdks = snapshot.Sdks[:idx+1]
 
-	snapshot := workshop.SdkSnapshot(format, image, sdks[:idx+1])
+	return snapshot, nil
+}
+
+func workshopSnapshot(change *state.Change, w string, age Age) (*workshop.Snapshot, error) {
+	base, err := workshopBaseOnly(change, w, age)
+	if err != nil {
+		return nil, err
+	}
+
+	sdks, err := WorkshopSdks(change, w, age)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot := workshop.SdkSnapshot(base.Format, base.Image, sdks)
+	return &snapshot, nil
+}
+
+func workshopBaseOnly(change *state.Change, w string, age Age) (*workshop.Snapshot, error) {
+	format, err := WorkshopFormat(change, w, age)
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := WorkshopBase(change, w, age)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot := workshop.SdkSnapshot(format, image, nil)
 	return &snapshot, nil
 }
 
@@ -307,6 +326,89 @@ func SdkVolumeLastUsedKey(sk string, revision sdk.Revision) string {
 type taskTime struct {
 	Task string    `json:"task"`
 	Time time.Time `json:"time"`
+}
+
+// SnapshotLastUsed returns the most recent Task of the given Change that
+// stopped using the given snapshot or a descendant thereof.
+func SnapshotLastUsed(change *state.Change, snapshot workshop.Snapshot) (string, time.Time, error) {
+	var tasks []taskTimeWorkshop
+	if err := change.Get("snapshots-last-used", &tasks); err != nil {
+		return "", time.Time{}, err
+	}
+
+	var task string
+	var latest time.Time
+	for _, t := range tasks {
+		s, err := workshopSnapshot(change, t.Workshop, t.Age)
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		if !s.IsBasedOn(snapshot) {
+			continue
+		}
+
+		if task == "" || t.Time.After(latest) || (t.Time.Equal(latest) && t.Task > task) {
+			task = t.Task
+			latest = t.Time
+		}
+	}
+
+	if task == "" {
+		return "", time.Time{}, state.ErrNoState
+	}
+	return task, latest, nil
+}
+
+// SnapshotLastUsedByTask returns the snapshot that the given Task stopped
+// using, if any.
+func SnapshotLastUsedByTask(task *state.Task) (*workshop.Snapshot, time.Time, error) {
+	change := task.Change()
+
+	var workshops []taskTimeWorkshop
+	if err := change.Get("snapshots-last-used", &workshops); err != nil {
+		return nil, time.Time{}, err
+	}
+
+	for _, w := range workshops {
+		if w.Task != task.ID() {
+			continue
+		}
+
+		snapshot, err := workshopSnapshot(change, w.Workshop, w.Age)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+
+		// Each Task deals with at most one snapshot, so we return early.
+		return snapshot, w.Time, nil
+	}
+	return nil, time.Time{}, state.ErrNoState
+}
+
+// SetSnapshotLastUsed records the most recent Task of the given Change that
+// stopped using a snapshot. The given workshop name and age are used to
+// identify the specific snapshot (which is already stored in the Change; see
+// e.g. WorkshopSdks).
+func SetSnapshotLastUsed(change *state.Change, w string, age Age, task string, time time.Time) error {
+	var tasks []taskTimeWorkshop
+	if err := change.Get("snapshots-last-used", &tasks); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
+	tasks = append(tasks, taskTimeWorkshop{
+		taskTime: taskTime{Time: time, Task: task},
+		Workshop: w,
+		Age:      age,
+	})
+
+	change.Set("snapshots-last-used", tasks)
+	return nil
+}
+
+type taskTimeWorkshop struct {
+	taskTime
+	Workshop string `json:"workshop"`
+	Age      Age    `json:"age"`
 }
 
 func BackendContext(tomb *tomb.Tomb, user string, projectId string) (context.Context, context.CancelFunc) {

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"gopkg.in/tomb.v2"
@@ -202,32 +203,41 @@ func UserProjectWorkshop(task *state.Task) (string, *workshop.Project, string, e
 	return user, &prj, name, nil
 }
 
-func WorkshopBase(change *state.Change, w string) (workshop.BaseImage, error) {
+type Age string
+
+const (
+	// OldWorkshop indicates the state of the workshop before a Change.
+	OldWorkshop = Age("old")
+	// NewWorkshop indicates the planned state of the workshop after a Change.
+	NewWorkshop = Age("new")
+)
+
+func WorkshopBase(change *state.Change, w string, age Age) (workshop.BaseImage, error) {
 	var image workshop.BaseImage
-	if err := change.Get(WorkshopBaseKey(w), &image); err != nil {
-		return workshop.BaseImage{}, fmt.Errorf("internal error: %q workshop base image not found (change ID: %s)", w, change.ID())
+	if err := change.Get(WorkshopBaseKey(w, age), &image); err != nil {
+		return workshop.BaseImage{}, fmt.Errorf("internal error: %q workshop %s base image not found (change ID: %s)", w, age, change.ID())
 	}
 	return image, nil
 }
 
-func WorkshopBaseKey(w string) string {
-	return w + "_base"
+func WorkshopBaseKey(w string, age Age) string {
+	return strings.Join([]string{w, string(age), "base"}, "_")
 }
 
-func WorkshopSdks(change *state.Change, w string) ([]sdk.Setup, error) {
+func WorkshopSdks(change *state.Change, w string, age Age) ([]sdk.Setup, error) {
 	var sdks []sdk.Setup
-	if err := change.Get(WorkshopSdksKey(w), &sdks); err != nil {
-		return nil, fmt.Errorf("internal error: %q workshop SDKs not found (change ID: %s)", w, change.ID())
+	if err := change.Get(WorkshopSdksKey(w, age), &sdks); err != nil {
+		return nil, fmt.Errorf("internal error: %q workshop %s SDKs not found (change ID: %s)", w, age, change.ID())
 	}
 	return sdks, nil
 }
 
-func WorkshopSdksKey(w string) string {
-	return w + "_sdks"
+func WorkshopSdksKey(w string, age Age) string {
+	return strings.Join([]string{w, string(age), "sdks"}, "_")
 }
 
 func WorkshopSnapshot(change *state.Change, w, lastIntact string) (*workshop.Snapshot, error) {
-	image, err := WorkshopBase(change, w)
+	image, err := WorkshopBase(change, w, NewWorkshop)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +247,7 @@ func WorkshopSnapshot(change *state.Change, w, lastIntact string) (*workshop.Sna
 		return &snapshot, nil
 	}
 
-	sdks, err := WorkshopSdks(change, w)
+	sdks, err := WorkshopSdks(change, w, NewWorkshop)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -212,6 +212,18 @@ const (
 	NewWorkshop = Age("new")
 )
 
+func WorkshopFormat(change *state.Change, w string, age Age) (sdk.Revision, error) {
+	var format sdk.Revision
+	if err := change.Get(WorkshopFormatKey(w, age), &format); err != nil {
+		return sdk.Revision{}, fmt.Errorf("internal error: %q workshop %s format not found (change ID: %s)", w, age, change.ID())
+	}
+	return format, nil
+}
+
+func WorkshopFormatKey(w string, age Age) string {
+	return strings.Join([]string{w, string(age), "format"}, "_")
+}
+
 func WorkshopBase(change *state.Change, w string, age Age) (workshop.BaseImage, error) {
 	var image workshop.BaseImage
 	if err := change.Get(WorkshopBaseKey(w, age), &image); err != nil {
@@ -237,13 +249,18 @@ func WorkshopSdksKey(w string, age Age) string {
 }
 
 func WorkshopSnapshot(change *state.Change, w, lastIntact string) (*workshop.Snapshot, error) {
+	format, err := WorkshopFormat(change, w, NewWorkshop)
+	if err != nil {
+		return nil, err
+	}
+
 	image, err := WorkshopBase(change, w, NewWorkshop)
 	if err != nil {
 		return nil, err
 	}
 
 	if lastIntact == "" {
-		snapshot := workshop.Snapshot{Image: image}
+		snapshot := workshop.SdkSnapshot(format, image, nil)
 		return &snapshot, nil
 	}
 
@@ -259,7 +276,7 @@ func WorkshopSnapshot(change *state.Change, w, lastIntact string) (*workshop.Sna
 		return nil, fmt.Errorf("internal error: %q workshop has no %q SDK", w, lastIntact)
 	}
 
-	snapshot := workshop.SdkSnapshot(image, sdks[:idx+1])
+	snapshot := workshop.SdkSnapshot(format, image, sdks[:idx+1])
 	return &snapshot, nil
 }
 

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -210,6 +210,8 @@ const (
 	OldWorkshop = Age("old")
 	// NewWorkshop indicates the planned state of the workshop after a Change.
 	NewWorkshop = Age("new")
+	// OldStash indicates the state of the stash before a Change.
+	OldStash = Age("old-stash")
 )
 
 func WorkshopFormat(change *state.Change, w string, age Age) (sdk.Revision, error) {

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v3"
@@ -250,6 +251,33 @@ func WorkshopSnapshot(change *state.Change, w, lastIntact string) (*workshop.Sna
 
 	snapshot := workshop.SdkSnapshot(image, sdks[:idx+1])
 	return &snapshot, nil
+}
+
+// SdkVolumeLastUsed returns the most recent Task of the given Change that
+// stopped using the given SDK volume.
+func SdkVolumeLastUsed(change *state.Change, setup sdk.Setup) (string, time.Time, error) {
+	var lastUsed taskTime
+	if err := change.Get(SdkVolumeLastUsedKey(setup.Name, setup.Revision), &lastUsed); err != nil {
+		return "", time.Time{}, err
+	}
+	return lastUsed.Task, lastUsed.Time, nil
+}
+
+// SetSdkVolumeLastUsed records the most recent Task of the given Change that
+// stopped using the given SDK volume, and a timestamp set to shortly before
+// that happened.
+func SetSdkVolumeLastUsed(change *state.Change, setup sdk.Setup, task string, time time.Time) {
+	lastUsed := taskTime{Task: task, Time: time}
+	change.Set(SdkVolumeLastUsedKey(setup.Name, setup.Revision), lastUsed)
+}
+
+func SdkVolumeLastUsedKey(sk string, revision sdk.Revision) string {
+	return sdk.VolumeName(sk, revision) + "_last-used"
+}
+
+type taskTime struct {
+	Task string    `json:"task"`
+	Time time.Time `json:"time"`
 }
 
 func BackendContext(tomb *tomb.Tomb, user string, projectId string) (context.Context, context.CancelFunc) {

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -202,8 +202,8 @@ func (s *healthSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 
 	chg := s.state.NewChange("launch", "test")
 	chg.Set("project-id", s.project.ProjectId)
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
-	chg.Set("ws_sdks", []sdk.Setup{})
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_new_sdks", []sdk.Setup{})
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
 	setWorkshopProject("ws", s.project, task)
@@ -224,8 +224,8 @@ func (s *healthSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
 
 	chg := s.state.NewChange("refresh", "test")
 	chg.Set("project-id", s.project.ProjectId)
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
-	chg.Set("ws_sdks", []sdk.Setup{})
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.SetStatus(state.WaitStatus)
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
@@ -288,8 +288,8 @@ func (s *healthSuite) TestCheckStatusPending(c *check.C) {
 
 	chg := s.state.NewChange("refresh", "test")
 	chg.Set("project-id", s.project.ProjectId)
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
-	chg.Set("ws_sdks", []sdk.Setup{})
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.SetStatus(state.DoingStatus)
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")
@@ -313,8 +313,8 @@ func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
 
 	chg := s.state.NewChange("refresh", "test")
 	chg.Set("project-id", s.project.ProjectId)
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
-	chg.Set("ws_sdks", []sdk.Setup{})
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.SetStatus(state.WaitStatus)
 	task := s.state.NewTask("create-workshop", "test task")
 	task.Set("workshop-file", "name: ws\nbase: ubuntu@20.04\n")

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -113,7 +113,7 @@ var (
 
 func (s *healthSuite) launchWorkshopWithSDKs(c *check.C, sdks []workshop.SdkRecord, hooks map[string]map[string]string) *workshop.Workshop {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: sdks}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
@@ -202,6 +202,7 @@ func (s *healthSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 
 	chg := s.state.NewChange("launch", "test")
 	chg.Set("project-id", s.project.ProjectId)
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("ws_new_sdks", []sdk.Setup{})
 	task := s.state.NewTask("create-workshop", "test task")
@@ -224,6 +225,7 @@ func (s *healthSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
 
 	chg := s.state.NewChange("refresh", "test")
 	chg.Set("project-id", s.project.ProjectId)
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.SetStatus(state.WaitStatus)
@@ -288,6 +290,7 @@ func (s *healthSuite) TestCheckStatusPending(c *check.C) {
 
 	chg := s.state.NewChange("refresh", "test")
 	chg.Set("project-id", s.project.ProjectId)
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.SetStatus(state.DoingStatus)
@@ -313,6 +316,7 @@ func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
 
 	chg := s.state.NewChange("refresh", "test")
 	chg.Set("project-id", s.project.ProjectId)
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.SetStatus(state.WaitStatus)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -138,7 +138,7 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 
 	// Launch a workshop provinding no hooks
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 
@@ -582,7 +582,7 @@ func (s *hookSuite) TestHookWithMultipleHandlersIsError(c *check.C) {
 
 func (s *hookSuite) launchWorkshop(c *check.C, newsdk string) {
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04", Sdks: []workshop.SdkRecord{{Name: "one", Channel: "latest/stable"}}}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 	ws, err := s.backend.WorkshopFs(s.ctx, "ws")

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -143,7 +143,7 @@ func (s *interfaceManagerSuite) launchWorkshop(c *check.C, ws string, sdks []sdk
 	err = yaml.Unmarshal(workshopFile.Bytes(), &wf)
 	c.Assert(err, check.IsNil)
 
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err = s.wsbackend.LaunchOrRebuildWorkshop(ctx, &wf, snapshot)
 	c.Assert(err, check.IsNil)
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -393,7 +393,7 @@ func (m *SdkManager) doSnapshotSdk(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	st.Lock()
-	snapshot, err := WorkshopSnapshot(change, w, sk)
+	snapshot, err := WorkshopSdkSnapshot(change, w, sk)
 	st.Unlock()
 	if err != nil {
 		return err

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -478,9 +478,7 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 	}
 
 	if time.Since(cooldownStart) < sdkVolumeCooldownTime {
-		remaining := sdkVolumeCooldownTime - time.Since(cooldownStart)
-		return fmt.Errorf("cooldown period for %q SDK volume has not elapsed yet, time remaining: %s",
-			sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), remaining.Round(time.Second))
+		return &state.Retry{}
 	}
 
 	// Check if there are any tasks in progress that use the same SDK volume.

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -477,7 +477,7 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		}
 	}
 
-	if time.Since(cooldownStart) < sdkVolumeCooldownTime {
+	if timeNow().Sub(cooldownStart) < sdkVolumeCooldownTime {
 		return &state.Retry{}
 	}
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -305,7 +305,7 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	sk, err := sdkName(task)
+	sdkSetup, err := SdkSetup(task, w)
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 	rev := revert.New()
 	defer rev.Fail()
 
-	if err := m.repo.RemoveSdk(project.ProjectId, w, sk); err != nil {
+	if err := m.repo.RemoveSdk(project.ProjectId, w, sdkSetup.Name); err != nil {
 		return err
 	}
 	cleanupCtx := context.WithoutCancel(ctx)
@@ -324,12 +324,21 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		cleanupCtx, cancel := context.WithTimeout(cleanupCtx, 30*time.Second)
 		defer cancel()
 
-		if reverr := m.registerSdk(cleanupCtx, w, sk); reverr != nil {
-			logger.Noticef("On doUninstallSdk: cannot re-register %q SDK on cleanup: %v", sk, reverr)
+		if reverr := m.registerSdk(cleanupCtx, w, sdkSetup.Name); reverr != nil {
+			logger.Noticef("On doUninstallSdk: cannot re-register %q SDK on cleanup: %v", sdkSetup.Name, reverr)
 		}
 	})
 
-	if err := m.backend.UninstallSdk(ctx, w, sk); err != nil {
+	if sdkSetup.IsVolume() && sdkSetup.Source != sdk.SystemSource {
+		// Record when the volume was last used in this change. The cleanup logic
+		// won't remove an SDK for a fixed window of time after this point.
+		st := task.State()
+		st.Lock()
+		SetSdkVolumeLastUsed(task.Change(), sdkSetup, task.ID(), timeNow())
+		st.Unlock()
+	}
+
+	if err := m.backend.UninstallSdk(ctx, w, sdkSetup.Name); err != nil {
 		return err
 	}
 
@@ -402,8 +411,6 @@ func (m *SdkManager) doSnapshotSdk(task *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
-type SdkVolumeCooldownTimeKey string
-
 // doDeleteUnusedSdkVolumes is a cleanup handler that deletes unused SDK volumes.
 // It is called periodically to ensure that SDK volumes that are no longer
 // needed are removed from the system. The cleanup is done only if there are no
@@ -420,13 +427,13 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 	user, prj, w, err := UserProjectWorkshop(task)
 	if err != nil {
 		// Log as an internal error, no need to retry again.
-		logger.Debugf("On SdkManager.Cleanup: internal error: %v", err)
+		logger.Noticef("On SdkManager.Cleanup: internal error: %v", err)
 		return nil
 	}
 
 	sdkSetup, err := SdkSetup(task, w)
 	if err != nil {
-		logger.Debugf("On SdkManager.Cleanup: the %q task is not associated with a SDK setup", task.ID())
+		logger.Noticef("On SdkManager.Cleanup: the %q task is not associated with a SDK setup", task.ID())
 		return nil
 	}
 
@@ -441,57 +448,50 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 	st.Lock()
 	defer st.Unlock()
 
-	if task.Kind() == "install-sdk" && task.Status() == state.DoneStatus {
-		// If the launch or refresh was successful, no need to clean up the SDK volume.
+	// Check the last Task in this Change to uninstall the SDK. If there isn't
+	// one, there's no need to clean up. If there's a later Task, we let it
+	// handle the cleanup instead.
+	taskID, lastUsed, err := SdkVolumeLastUsed(task.Change(), sdkSetup)
+	if err != nil || taskID != task.ID() {
+		if err != nil && !errors.Is(err, state.ErrNoState) {
+			logger.Noticef("On SdkManager.Cleanup: internal error: %v", err)
+		}
 		return nil
 	}
 
-	vk := SdkVolumeCooldownTimeKey(sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
-	cooldownStart, ok := st.Cached(vk).(time.Time)
-	if !ok {
-		// No cooldown start time cached means that clean up has just started or
-		// workshopd was restarted.
-		st.Cache(vk, task.ReadyTime())
-		// We need to return here to give other competing cleanup tasks a chance
-		// to find out who was the last one to initiate the cleanup.
-		return fmt.Errorf("new cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), task.ReadyTime())
-	} else {
-		// Imagine the situation when a change with multiple tasks that use this
-		// volume is in progress. Every uninstall-sdk task will initiate a
-		// cleanup after the change is ready. All cleanups are unarranged and
-		// can run concurrently. We need to ensure that only one of them will
-		// continue to track the volume cooldown time.
-		readyTime := task.ReadyTime()
-		if readyTime.Before(cooldownStart) {
-			// Another more recent task initiated cleanup for this SDK
-			// volume, no need to continue.
-			return nil
-		}
-		if readyTime.After(cooldownStart) {
-			// Update the cooldown start time to the current task ready time.
-			st.Cache(vk, readyTime)
-			// We need to return here to give other competing cleanup tasks
-			// a chance to find out who was the last one to initiate the
-			// cleanup.
-			return fmt.Errorf("new cooldown start time for %q SDK volume: %v", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision), readyTime)
-		}
-	}
-
-	if timeNow().Sub(cooldownStart) < sdkVolumeCooldownTime {
-		return &state.Retry{}
-	}
-
-	// Check if there are any tasks in progress that use the same SDK volume.
-	// Remember, cleanup tasks are attempted on every Ensure call, which can be
-	// either periodic or triggered by a new API request. If it's the latter,
-	// there could be a chance that the volume will be used again.
+	// Check for changes that might use the same SDK volume. If one is in
+	// progress and retrieve-sdk is done already, removing the SDK will break
+	// the install-sdk task. If another task uninstalled the SDK after us, we
+	// can let it handle the cleanup.
 	changes := st.Changes()
 	blocking := []string{"launch", "refresh", "remove"}
 	for _, change := range changes {
 		// Other changes like "exec" do not affect SDK volumes, so we can skip them.
-		if slices.Contains(blocking, change.Kind()) && !change.IsReady() {
+		if !slices.Contains(blocking, change.Kind()) {
+			continue
+		}
+		if !change.IsReady() {
 			return &state.Retry{}
 		}
+
+		taskID, time, err := SdkVolumeLastUsed(change, sdkSetup)
+		if errors.Is(err, state.ErrNoState) {
+			continue
+		}
+		if err != nil {
+			logger.Noticef("On SdkManager.Cleanup: internal error: %v", err)
+			return nil
+		}
+
+		// Just compare task IDs lexicographically; it doesn't really matter
+		// which one handles the cleanup as long as there's consensus.
+		if time.After(lastUsed) || (time.Equal(lastUsed) && taskID > task.ID()) {
+			return nil
+		}
+	}
+
+	if timeNow().Sub(lastUsed) < sdkVolumeCooldownTime {
+		return &state.Retry{}
 	}
 
 	// Delete volume ignores ErrVolumeNotFound.
@@ -502,7 +502,6 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		} else {
 			logger.Debugf("On SdkManager.Cleanup: the %q SDK volume was deleted", sdk.VolumeName(sdkSetup.Name, sdkSetup.Revision))
 		}
-		st.Cache(vk, nil)
 		return nil
 	}
 

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -41,27 +41,17 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-func SdkSetup(task *state.Task, w string) (sdk.Setup, error) {
+func SdkSetup(task *state.Task, w string, age Age) (sdk.Setup, error) {
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
 
-	// Some tasks, notably uninstall-sdk, store the sdk.Setup directly,
-	// since it isn't stored anywhere else. Note that the uninstall-sdk
-	// handler only needs the SDK name, but the cleanup handler needs more.
-	var setup sdk.Setup
-	if err := task.Get("sdk-setup", &setup); err == nil {
-		return setup, nil
-	}
-
-	// Tasks like install-sdk can reuse the sdk.Setup
-	// from the launch or refresh Change.
 	var sk string
 	if err := task.Get("sdk", &sk); err != nil {
 		return sdk.Setup{}, err
 	}
 
-	setups, err := WorkshopSdks(task.Change(), w)
+	setups, err := WorkshopSdks(task.Change(), w, age)
 	if err != nil {
 		return sdk.Setup{}, err
 	}
@@ -93,14 +83,14 @@ func (m *SdkManager) doRetrieveSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	rec, err := SdkSetup(task, w)
+	rec, err := SdkSetup(task, w, NewWorkshop)
 	if err != nil {
 		return err
 	}
 
 	st := task.State()
 	st.Lock()
-	base, err := WorkshopBase(task.Change(), w)
+	base, err := WorkshopBase(task.Change(), w, NewWorkshop)
 	st.Unlock()
 	if err != nil {
 		return err
@@ -266,7 +256,11 @@ func (m *SdkManager) doInstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	sdkSetup, err := SdkSetup(task, w)
+	age := NewWorkshop
+	if task.Kind() == "uninstall-sdk" {
+		age = OldWorkshop
+	}
+	sdkSetup, err := SdkSetup(task, w, age)
 	if err != nil {
 		return err
 	}
@@ -305,7 +299,11 @@ func (m *SdkManager) doUninstallSdk(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	sdkSetup, err := SdkSetup(task, w)
+	age := OldWorkshop
+	if task.Kind() == "install-sdk" {
+		age = NewWorkshop
+	}
+	sdkSetup, err := SdkSetup(task, w, age)
 	if err != nil {
 		return err
 	}
@@ -431,7 +429,11 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		return nil
 	}
 
-	sdkSetup, err := SdkSetup(task, w)
+	age := OldWorkshop
+	if task.Kind() == "install-sdk" {
+		age = NewWorkshop
+	}
+	sdkSetup, err := SdkSetup(task, w, age)
 	if err != nil {
 		logger.Noticef("On SdkManager.Cleanup: the %q task is not associated with a SDK setup", task.ID())
 		return nil

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -258,7 +258,7 @@ func (s *sdkStateSuite) TestDoInstallSdkSuccess(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t)
 	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	chg.AddTask(t)
 
 	s.state.Unlock()
@@ -315,7 +315,7 @@ func (s *sdkStateSuite) TestDoInstallSdkFailedPolicyCheck(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t)
 	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{testSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{testSdk.Setup})
 	chg.AddTask(t)
 
 	s.state.Unlock()
@@ -367,7 +367,7 @@ func (s *sdkStateSuite) TestDoInstallSdkBadInterfacesFound(c *check.C) {
 	setWorkshopProject("ws", s.project, t)
 
 	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	chg.AddTask(t)
 
 	s.state.Unlock()
@@ -411,7 +411,7 @@ func (s *sdkStateSuite) TestUndoInstallSdkSuccess(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("project-id", s.project.ProjectId)
 	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	chg.AddTask(t)
 	chg.AddTask(terr)
 
@@ -456,8 +456,8 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t)
 	chg.Set("user", "testuser")
-	chg.Set("ws_base", workshop.BaseOnly("ubuntu@22.04", "fakeimage123"))
-	chg.Set("ws_sdks", []sdk.Setup{newSdk})
+	chg.Set("ws_new_base", workshop.BaseOnly("ubuntu@22.04", "fakeimage123"))
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk})
 	chg.AddTask(t)
 
 	s.state.Unlock()
@@ -530,8 +530,8 @@ func (s *sdkStateSuite) TestSnapshotSdkTwice(c *check.C) {
 
 	chg := s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
-	chg.Set("ws_base", image)
-	chg.Set("ws_sdks", sdks)
+	chg.Set("ws_new_base", image)
+	chg.Set("ws_new_sdks", sdks)
 	chg.AddTask(t1)
 	chg.AddTask(t2)
 
@@ -556,8 +556,8 @@ func (s *sdkStateSuite) TestSnapshotSdkTwice(c *check.C) {
 
 	chg = s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
-	chg.Set("ws_base", image)
-	chg.Set("ws_sdks", sdks[:1])
+	chg.Set("ws_new_base", image)
+	chg.Set("ws_new_sdks", sdks[:1])
 	chg.AddTask(t)
 
 	s.state.Unlock()
@@ -598,8 +598,8 @@ func (s *sdkStateSuite) TestSnapshotSkippedPostResume(c *check.C) {
 	chg := s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
 	chg.Set("project-id", s.project.ProjectId)
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
-	chg.Set("ws_sdks", sdks)
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_new_sdks", sdks)
 	chg.Set("wait-setup", conflict.ChangeSetup{Mode: conflict.ChangeWaitOnError.String()})
 	chg.AddTask(t1)
 	chg.AddTask(t2)
@@ -649,13 +649,13 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterCooldownOK(c *check.C) {
 	s.mockSdk(c, oldSdk)
 	t := s.state.NewTask("uninstall-sdk", "...")
 	t.Set("sdk", oldSdk.Name)
-	t.Set("sdk-setup", oldSdk.Setup)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
 	newSdk := oldSdk
 	newSdk.Revision = sdk.R(2)
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_old_sdks", []sdk.Setup{oldSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t)
 	chg.AddTask(t)
 	s.state.Unlock()
@@ -698,7 +698,7 @@ func (s *sdkStateSuite) TestSDKVolumeRemovedAfterFailedLaunch(c *check.C) {
 
 	chg := s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t, t2)
 	chg.AddTask(t)
 	chg.AddTask(t2)
@@ -739,7 +739,7 @@ func (s *sdkStateSuite) TestSDKVolumeExitCleanupAfterSuccessfulLaunch(c *check.C
 
 	chg := s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t)
 	chg.AddTask(t)
 	s.state.Unlock()
@@ -772,13 +772,13 @@ func (s *sdkStateSuite) TestSDKVolumeNotRemovedBeforeCooldown(c *check.C) {
 	s.mockSdk(c, oldSdk)
 	t := s.state.NewTask("uninstall-sdk", "...")
 	t.Set("sdk", oldSdk.Name)
-	t.Set("sdk-setup", oldSdk.Setup)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
 	newSdk := oldSdk
 	newSdk.Revision = sdk.R(2)
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_old_sdks", []sdk.Setup{oldSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t)
 	chg.AddTask(t)
 	s.state.Unlock()
@@ -818,19 +818,19 @@ func (s *sdkStateSuite) TestTaskSDKVolumeExitCleanupIfUsedAgain(c *check.C) {
 	s.mockSdk(c, oldSdk)
 	t := s.state.NewTask("uninstall-sdk", "...")
 	t.Set("sdk", oldSdk.Name)
-	t.Set("sdk-setup", oldSdk.Setup)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
 	newSdk := oldSdk
 	newSdk.Revision = sdk.R(2)
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_old_sdks", []sdk.Setup{oldSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t)
 	chg.AddTask(t)
 
 	other := s.state.NewChange("launch", "...")
 	other.Set("user", "testuser")
-	other.Set("ws2_sdks", []sdk.Setup{oldSdk.Setup})
+	other.Set("ws2_new_sdks", []sdk.Setup{oldSdk.Setup})
 	t2 := s.state.NewTask("install-sdk", "t2")
 	t2.Set("sdk", oldSdk.Name)
 	setWorkshopProject("ws2", s.project, t2)
@@ -869,19 +869,19 @@ func (s *sdkStateSuite) TestTaskSDKVolumeRetriesCleanupIfBlockingChangesArePrese
 	s.mockSdk(c, oldSdk)
 	t := s.state.NewTask("uninstall-sdk", "...")
 	t.Set("sdk", oldSdk.Name)
-	t.Set("sdk-setup", oldSdk.Setup)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
 	newSdk := oldSdk
 	newSdk.Revision = sdk.R(2)
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg.Set("ws_old_sdks", []sdk.Setup{oldSdk.Setup})
+	chg.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t)
 	chg.AddTask(t)
 
 	other := s.state.NewChange("launch", "...")
 	other.Set("user", "testuser")
-	other.Set("ws2_sdks", []sdk.Setup{oldSdk.Setup})
+	other.Set("ws2_new_sdks", []sdk.Setup{oldSdk.Setup})
 	t2 := s.state.NewTask("install-sdk", "t2")
 	t2.Set("sdk", oldSdk.Name)
 	t2.SetToWait(state.DoStatus)
@@ -939,11 +939,9 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 
 	t1 := s.state.NewTask("uninstall-sdk", "t1")
 	t1.Set("sdk", oldSdk.Name)
-	t1.Set("sdk-setup", oldSdk.Setup)
 
 	t2 := s.state.NewTask("uninstall-sdk", "t2")
 	t2.Set("sdk", oldSdk.Name)
-	t2.Set("sdk-setup", oldSdk.Setup)
 	t2.WaitFor(t1)
 
 	// Add both tasks to their own changes
@@ -951,13 +949,15 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 	chg1.Set("user", "testuser")
 	newSdk := oldSdk
 	newSdk.Revision = sdk.R(2)
-	chg1.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg1.Set("ws_old_sdks", []sdk.Setup{oldSdk.Setup})
+	chg1.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t1)
 	chg1.AddTask(t1)
 
 	chg2 := s.state.NewChange("refresh", "chg2")
 	chg2.Set("user", "testuser")
-	chg2.Set("ws2_sdks", []sdk.Setup{newSdk.Setup})
+	chg2.Set("ws2_old_sdks", []sdk.Setup{oldSdk.Setup})
+	chg2.Set("ws2_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws2", s.project, t2)
 	chg2.AddTask(t2)
 
@@ -1003,7 +1003,7 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupBlockedBeforeUninstall(c *check.C) {
 	t.Set("sdk", oldSdk.Name)
 	chg := s.state.NewChange("launch", "chg")
 	chg.Set("user", "testuser")
-	chg.Set("ws2_sdks", []sdk.Setup{oldSdk.Setup})
+	chg.Set("ws2_new_sdks", []sdk.Setup{oldSdk.Setup})
 	setWorkshopProject("ws2", s.project, t)
 	chg.AddTask(t)
 
@@ -1022,12 +1022,12 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupBlockedBeforeUninstall(c *check.C) {
 
 	t1 := s.state.NewTask("uninstall-sdk", "t1")
 	t1.Set("sdk", oldSdk.Name)
-	t1.Set("sdk-setup", oldSdk.Setup)
 	chg1 := s.state.NewChange("refresh", "chg1")
 	chg1.Set("user", "testuser")
 	newSdk := oldSdk
 	newSdk.Revision = sdk.R(2)
-	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg1.Set("ws_old_sdks", []sdk.Setup{oldSdk.Setup})
+	chg1.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t1)
 	chg1.AddTask(t1)
 
@@ -1047,11 +1047,11 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupBlockedBeforeUninstall(c *check.C) {
 
 	t2 := s.state.NewTask("uninstall-sdk", "t2")
 	t2.Set("sdk", oldSdk.Name)
-	t2.Set("sdk-setup", oldSdk.Setup)
 	t2.WaitFor(t1)
 	chg2 := s.state.NewChange("refresh", "chg2")
 	chg2.Set("user", "testuser")
-	chg.Set("ws2_sdks", []sdk.Setup{newSdk.Setup})
+	chg2.Set("ws2_old_sdks", []sdk.Setup{oldSdk.Setup})
+	chg2.Set("ws2_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws2", s.project, t2)
 	chg2.AddTask(t2)
 
@@ -1098,12 +1098,12 @@ func (s *sdkStateSuite) TestSDKVolumeExitCleanupOnNonvolume(c *check.C) {
 
 	t1 := s.state.NewTask("uninstall-sdk", "t1")
 	t1.Set("sdk", sdkProject.Name)
-	t1.Set("sdk-setup", sdkProject.Setup)
 	chg1 := s.state.NewChange("refresh", "chg1")
 	chg1.Set("user", "testuser")
 	newSdk := sdkProject
 	newSdk.Revision = sdk.R(-2)
-	chg1.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	chg1.Set("ws_old_sdks", []sdk.Setup{sdkProject.Setup})
+	chg1.Set("ws_new_sdks", []sdk.Setup{newSdk.Setup})
 	setWorkshopProject("ws", s.project, t1)
 	chg1.AddTask(t1)
 

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -196,7 +196,7 @@ func (s *sdkStateSuite) SetUpTest(c *check.C) {
 		{Name: "test", Channel: "latest/stable"},
 		{Name: "test-broken", Channel: "latest/stable"},
 	}}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
@@ -456,7 +456,8 @@ func (s *sdkStateSuite) TestRetrieveSystemSdkSuccess(c *check.C) {
 	chg := s.state.NewChange("sample", "...")
 	setWorkshopProject("ws", s.project, t)
 	chg.Set("user", "testuser")
-	chg.Set("ws_new_base", workshop.BaseOnly("ubuntu@22.04", "fakeimage123"))
+	chg.Set("ws_new_format", sdk.R(1))
+	chg.Set("ws_new_base", workshop.BaseOnly(sdk.R(1), "ubuntu@22.04", "fakeimage123"))
 	chg.Set("ws_new_sdks", []sdk.Setup{newSdk})
 	chg.AddTask(t)
 
@@ -518,8 +519,8 @@ func (s *sdkStateSuite) TestSnapshotSdkTwice(c *check.C) {
 		Revision: sdk.R(2),
 		Sha3_384: "f77092aae283a4d8ffe7ae51017569d6c999afdbe7c4264ab82f44e79a82151994de9b90ae43216dee70aaec91b23647",
 	}}
-	snapshot1 := workshop.SdkSnapshot(image, sdks[:1])
-	snapshot2 := workshop.SdkSnapshot(image, sdks)
+	snapshot1 := workshop.SdkSnapshot(sdk.R(1), image, sdks[:1])
+	snapshot2 := workshop.SdkSnapshot(sdk.R(1), image, sdks)
 
 	t1 := s.state.NewTask("snapshot-sdk", "...")
 	t1.Set("sdk", "test")
@@ -530,6 +531,7 @@ func (s *sdkStateSuite) TestSnapshotSdkTwice(c *check.C) {
 
 	chg := s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", image)
 	chg.Set("ws_new_sdks", sdks)
 	chg.AddTask(t1)
@@ -556,6 +558,7 @@ func (s *sdkStateSuite) TestSnapshotSdkTwice(c *check.C) {
 
 	chg = s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", image)
 	chg.Set("ws_new_sdks", sdks[:1])
 	chg.AddTask(t)
@@ -598,6 +601,7 @@ func (s *sdkStateSuite) TestSnapshotSkippedPostResume(c *check.C) {
 	chg := s.state.NewChange("launch", "...")
 	chg.Set("user", "testuser")
 	chg.Set("project-id", s.project.ProjectId)
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 	chg.Set("ws_new_sdks", sdks)
 	chg.Set("wait-setup", conflict.ChangeSetup{Mode: conflict.ChangeWaitOnError.String()})

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -1018,7 +1018,6 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupBlockedBeforeUninstall(c *check.C) {
 
 	defer sdkstate.FakeSdkVolumeCooldownTime(time.Hour)()
 	t1time := time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)
-	defer state.MockTime(t1time)()
 	defer sdkstate.MockTime(t1time)()
 
 	t1 := s.state.NewTask("uninstall-sdk", "t1")
@@ -1041,11 +1040,9 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupBlockedBeforeUninstall(c *check.C) {
 	s.state.Lock()
 
 	c.Check(t1.Status(), check.Equals, state.DoneStatus)
-	c.Check(t1.ReadyTime().Equal(t1time), check.Equals, true)
 
 	// Advance time and set up final uninstall.
 	t2time := t1time.Add(time.Hour - time.Second)
-	defer state.MockTime(t2time)()
 	defer sdkstate.MockTime(t2time)()
 
 	t2 := s.state.NewTask("uninstall-sdk", "t2")
@@ -1065,10 +1062,8 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupBlockedBeforeUninstall(c *check.C) {
 	s.state.Lock()
 
 	c.Check(t2.Status(), check.Equals, state.DoneStatus)
-	c.Check(t2.ReadyTime().Equal(t2time), check.Equals, true)
 
 	// Advance time again..
-	defer state.MockTime(t2time.Add(2 * time.Second))()
 	defer sdkstate.MockTime(t2time.Add(2 * time.Second))()
 
 	// Run the first post-cooldown cleanup for ws, and the first cleanup for
@@ -1083,6 +1078,9 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupBlockedBeforeUninstall(c *check.C) {
 
 	c.Check(t1.IsClean(), check.Equals, true)
 	c.Check(t2.IsClean(), check.Equals, false)
+
+	_, err := s.backend.Sdk(s.ctx, oldSdk.Setup)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *sdkStateSuite) TestSDKVolumeExitCleanupOnNonvolume(c *check.C) {

--- a/internal/overlord/sdkstate/handlers_test.go
+++ b/internal/overlord/sdkstate/handlers_test.go
@@ -980,6 +980,111 @@ func (s *sdkStateSuite) TestSDKVolumeCleanupPerformedByLatestUser(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
+// Check that uninstall-sdk blocks cleanup for the cooldown period, even if
+// the clenanup handler for another Task runs immediately afterwards.
+func (s *sdkStateSuite) TestSDKVolumeCleanupBlockedBeforeUninstall(c *check.C) {
+	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
+
+	s.state.Lock()
+	oldSdk := sdk.Meta{
+		Setup: sdk.Setup{
+			Name:      "test",
+			PackageID: "a9J51jhjzpckN8VxhqoZ8dNKcZ7pOrBb",
+			Channel:   "latest/stable",
+			Revision:  sdk.R(1),
+			Sha3_384:  "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
+		},
+		SdkYAML: sdkYaml,
+	}
+	s.mockSdk(c, oldSdk)
+
+	// Ensure SDK is in use via ws2.
+	t := s.state.NewTask("install-sdk", "t")
+	t.Set("sdk", oldSdk.Name)
+	chg := s.state.NewChange("launch", "chg")
+	chg.Set("user", "testuser")
+	chg.Set("ws2_sdks", []sdk.Setup{oldSdk.Setup})
+	setWorkshopProject("ws2", s.project, t)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Check(t.Status(), check.Equals, state.DoneStatus)
+
+	defer sdkstate.FakeSdkVolumeCooldownTime(time.Hour)()
+	t1time := time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)
+	defer state.MockTime(t1time)()
+	defer sdkstate.MockTime(t1time)()
+
+	t1 := s.state.NewTask("uninstall-sdk", "t1")
+	t1.Set("sdk", oldSdk.Name)
+	t1.Set("sdk-setup", oldSdk.Setup)
+	chg1 := s.state.NewChange("refresh", "chg1")
+	chg1.Set("user", "testuser")
+	newSdk := oldSdk
+	newSdk.Revision = sdk.R(2)
+	chg.Set("ws_sdks", []sdk.Setup{newSdk.Setup})
+	setWorkshopProject("ws", s.project, t1)
+	chg1.AddTask(t1)
+
+	// Uninstall SDK but don't clean it up (no fake time passes).
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Check(t1.Status(), check.Equals, state.DoneStatus)
+	c.Check(t1.ReadyTime().Equal(t1time), check.Equals, true)
+
+	// Advance time and set up final uninstall.
+	t2time := t1time.Add(time.Hour - time.Second)
+	defer state.MockTime(t2time)()
+	defer sdkstate.MockTime(t2time)()
+
+	t2 := s.state.NewTask("uninstall-sdk", "t2")
+	t2.Set("sdk", oldSdk.Name)
+	t2.Set("sdk-setup", oldSdk.Setup)
+	t2.WaitFor(t1)
+	chg2 := s.state.NewChange("refresh", "chg2")
+	chg2.Set("user", "testuser")
+	chg.Set("ws2_sdks", []sdk.Setup{newSdk.Setup})
+	setWorkshopProject("ws2", s.project, t2)
+	chg2.AddTask(t2)
+
+	// Uninstall SDK from ws2 and attempt another cleanup.
+	s.state.Unlock()
+	c.Check(s.se.Ensure(), check.IsNil)
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(t2.Status(), check.Equals, state.DoneStatus)
+	c.Check(t2.ReadyTime().Equal(t2time), check.Equals, true)
+
+	// Advance time again..
+	defer state.MockTime(t2time.Add(2 * time.Second))()
+	defer sdkstate.MockTime(t2time.Add(2 * time.Second))()
+
+	// Run the first post-cooldown cleanup for ws, and the first cleanup for
+	// ws2. Even if ws wins the race, the SDK should not be deleted.
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(t1.IsClean(), check.Equals, true)
+	c.Check(t2.IsClean(), check.Equals, false)
+}
+
 func (s *sdkStateSuite) TestSDKVolumeExitCleanupOnNonvolume(c *check.C) {
 	s.state.Lock()
 	sdkProject := sdk.Meta{

--- a/internal/overlord/sdkstate/manager.go
+++ b/internal/overlord/sdkstate/manager.go
@@ -110,6 +110,8 @@ type SdkManager struct {
 
 var (
 	sdkVolumeCooldownTime = 1 * time.Hour // Time to wait before deleting unused SDK volumes.
+
+	timeNow = time.Now
 )
 
 func New(s *state.State, runner *state.TaskRunner, repo *interfaces.Repository) *SdkManager {
@@ -366,4 +368,10 @@ func FakeSdkVolumeCooldownTime(t time.Duration) (restore func()) {
 	return func() {
 		sdkVolumeCooldownTime = old
 	}
+}
+
+func MockTime(now time.Time) (restore func()) {
+	old := timeNow
+	timeNow = func() time.Time { return now }
+	return func() { timeNow = old }
 }

--- a/internal/overlord/sdkstate/request_test.go
+++ b/internal/overlord/sdkstate/request_test.go
@@ -17,6 +17,7 @@ package sdkstate_test
 import (
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
@@ -51,7 +52,7 @@ func (i *SdkStateTasks) TestRetrieve(c *check.C) {
 	}
 
 	change := i.state.NewChange("sample", "...")
-	change.Set("ws_sdks", []sdk.Setup{trySdk, storeSdk})
+	change.Set("ws_new_sdks", []sdk.Setup{trySdk, storeSdk})
 
 	t1 := sdkstate.Retrieve(i.state, trySdk)
 	t2 := sdkstate.Retrieve(i.state, storeSdk)
@@ -59,13 +60,13 @@ func (i *SdkStateTasks) TestRetrieve(c *check.C) {
 
 	i.state.Unlock()
 
-	s, err := sdkstate.SdkSetup(t1, "ws")
+	s, err := sdkstate.SdkSetup(t1, "ws", handlersetup.NewWorkshop)
 	c.Assert(err, check.IsNil)
 	c.Check(s, check.Equals, trySdk)
 	c.Check(t1.Kind(), check.Equals, "retrieve-sdk")
 	c.Check(t1.Summary(), check.Equals, `Retrieve "test-sdk" SDK`)
 
-	s, err = sdkstate.SdkSetup(t2, "ws")
+	s, err = sdkstate.SdkSetup(t2, "ws", handlersetup.NewWorkshop)
 	c.Assert(err, check.IsNil)
 	c.Check(s, check.Equals, storeSdk)
 	c.Check(t2.Kind(), check.Equals, "retrieve-sdk")

--- a/internal/overlord/state/taskrunner.go
+++ b/internal/overlord/state/taskrunner.go
@@ -318,6 +318,7 @@ func (r *TaskRunner) clean(t *Task) {
 		return
 	}
 
+	t.At(time.Time{}) // clear schedule
 	tomb := &tomb.Tomb{}
 	r.tombs[t.ID()] = tomb
 	tomb.Go(func() error {
@@ -332,8 +333,11 @@ func (r *TaskRunner) clean(t *Task) {
 		delete(r.tombs, t.ID())
 
 		if err := tomb.Err(); err != nil {
-			if _, ok := err.(*Retry); !ok {
+			x, ok := err.(*Retry)
+			if !ok {
 				logger.Debugf("Cleaning task %s: %s", t.ID(), err)
+			} else if x.After != 0 {
+				t.At(timeNow().Add(x.After))
 			}
 		} else {
 			t.SetClean()
@@ -427,7 +431,13 @@ ConsiderTasks:
 		status := t.Status()
 		if status.Ready() {
 			if !t.IsClean() {
-				r.clean(t)
+				// skip tasks scheduled for later and also track the earliest one
+				tWhen := t.AtTime()
+				if tWhen.IsZero() || !ensureTime.Before(tWhen) {
+					r.clean(t)
+				} else if nextTaskTime.IsZero() || nextTaskTime.After(tWhen) {
+					nextTaskTime = tWhen
+				}
 			}
 			continue
 		}

--- a/internal/overlord/state/taskrunner.go
+++ b/internal/overlord/state/taskrunner.go
@@ -331,8 +331,10 @@ func (r *TaskRunner) clean(t *Task) {
 
 		delete(r.tombs, t.ID())
 
-		if tomb.Err() != nil {
-			logger.Debugf("Cleaning task %s: %s", t.ID(), tomb.Err())
+		if err := tomb.Err(); err != nil {
+			if _, ok := err.(*Retry); !ok {
+				logger.Debugf("Cleaning task %s: %s", t.ID(), err)
+			}
 		} else {
 			t.SetClean()
 		}

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -46,7 +46,7 @@ func (m *WorkshopManager) doDownloadBase(task *state.Task, tomb *tomb.Tomb) erro
 
 	st := task.State()
 	st.Lock()
-	image, err := WorkshopBase(task.Change(), w)
+	image, err := WorkshopBase(task.Change(), w, NewWorkshop)
 	st.Unlock()
 	if err != nil {
 		return err

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"slices"
 	"syscall"
 	"time"
 
@@ -93,7 +94,7 @@ func (m *WorkshopManager) doConstructWorkshop(task *state.Task, tomb *tomb.Tomb)
 	}
 
 	st.Lock()
-	snapshot, err := WorkshopSnapshot(task.Change(), w, lastIntact)
+	snapshot, err := WorkshopSdkSnapshot(task.Change(), w, lastIntact)
 	st.Unlock()
 	if err != nil {
 		return err
@@ -394,6 +395,18 @@ func (m *WorkshopManager) doRemoveWorkshop(task *state.Task, tomb *tomb.Tomb) er
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
 
+	age := OldWorkshop
+	if task.Kind() == "create-workshop" {
+		age = NewWorkshop
+	}
+	st := task.State()
+	st.Lock()
+	err = SetSnapshotLastUsed(task.Change(), w, age, task.ID(), time.Now())
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
 	return m.backend.RemoveWorkshop(ctx, w)
 }
 
@@ -405,6 +418,18 @@ func (m *WorkshopManager) doRemoveWorkshopStash(task *state.Task, tomb *tomb.Tom
 
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
+
+	st := task.State()
+	st.Lock()
+	age := OldWorkshop
+	if task.Change().Kind() == "remove" {
+		age = OldStash
+	}
+	err = SetSnapshotLastUsed(task.Change(), w, age, task.ID(), time.Now())
+	st.Unlock()
+	if err != nil {
+		return err
+	}
 
 	if err := m.backend.RemoveWorkshopStash(ctx, w); err != nil {
 		task.State().Lock()
@@ -438,6 +463,14 @@ func (m *WorkshopManager) undoStashWorkshop(task *state.Task, tomb *tomb.Tomb) e
 
 	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
 	defer cancel()
+
+	st := task.State()
+	st.Lock()
+	err = SetSnapshotLastUsed(task.Change(), w, NewWorkshop, task.ID(), time.Now())
+	st.Unlock()
+	if err != nil {
+		return err
+	}
 
 	if err = m.backend.UnstashWorkshop(ctx, w); err != nil {
 		return err
@@ -490,4 +523,120 @@ func (m *WorkshopManager) doRemoveStateStorage(task *state.Task, tomb *tomb.Tomb
 	}
 
 	return nil
+}
+
+// doDeleteUnusedSnapshots is a cleanup handler that deletes unused snapshots.
+// It is called periodically to ensure that snapshots that are no longer
+// needed are removed from the system. The cleanup is done only if there are no
+// tasks in progress that might use the snapshot. The cleanup is also
+// throttled to avoid deleting snapshots too frequently. The cooldown time is
+// defined by the snapshotCooldownTime constant.
+//
+// There are multiple scenarios when this cleanup is triggered:
+//   - A workshop was removed (remove-workshop or, if launch failed, create-workshop task)
+//   - A stash was removed (after a successful refresh, or if a workshop is
+//     removed while a refresh is paused)
+//   - A workshop was replaced (undo stash-workshop task)
+func (m *WorkshopManager) doDeleteUnusedSnapshots(task *state.Task, tomb *tomb.Tomb) error {
+	user, prj, _, err := UserProjectWorkshop(task)
+	if err != nil {
+		// Log as an internal error, no need to retry again.
+		logger.Noticef("On WorkshopManager.doDeleteUnusedSnapshots: internal error: %v", err)
+		return nil
+	}
+
+	ctx, cancel := BackendContext(tomb, user, prj.ProjectId)
+	defer cancel()
+
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	snapshot, lastUsed, err := SnapshotLastUsedByTask(task)
+	if err != nil {
+		if !errors.Is(err, state.ErrNoState) {
+			logger.Noticef("On WorkshopManager.doDeleteUnusedSnapshots: internal error: %v", err)
+		}
+		return nil
+	}
+
+	for range snapshot.Sdks {
+		removed, err := m.deleteUnusedSnapshot(ctx, task, *snapshot, lastUsed)
+		if err != nil {
+			return err
+		}
+		if !removed {
+			return nil
+		}
+		snapshot.Sdks = snapshot.Sdks[:len(snapshot.Sdks)-1]
+	}
+	return nil
+}
+
+func (m *WorkshopManager) deleteUnusedSnapshot(ctx context.Context, task *state.Task, snapshot workshop.Snapshot, lastUsed time.Time) (bool, error) {
+	// Check for changes that might use the same snapshot. If one is in
+	// progress, removing the snapshot will break the launch or rebuild. If
+	// another task stopped using the snapshot after us, we can let it handle
+	// the cleanup.
+	st := task.State()
+	changes := st.Changes()
+	blocking := []string{"launch", "refresh", "remove"}
+	for _, change := range changes {
+		// Other changes like "exec" do not affect snapshots, so we can skip them.
+		if !slices.Contains(blocking, change.Kind()) {
+			continue
+		}
+		if !change.IsReady() {
+			return false, &state.Retry{}
+		}
+
+		taskID, time, err := SnapshotLastUsed(change, snapshot)
+		if errors.Is(err, state.ErrNoState) {
+			continue
+		}
+		if err != nil {
+			logger.Noticef("On WorkshopManager.doDeleteUnusedSnapshots: internal error: %v", err)
+			return false, nil
+		}
+
+		if taskID == task.ID() {
+			continue
+		}
+		// Just compare task IDs lexicographically; it doesn't really matter
+		// which one handles the cleanup as long as there's consensus.
+		if time.After(lastUsed) || (time.Equal(lastUsed) && taskID > task.ID()) {
+			return false, nil
+		}
+
+		// Earlier tasks may be responsible for cleaning up descendant
+		// snapshots. We wait for them to be clean to avoid deleting snapshots
+		// in the wrong order.
+		if t := st.Task(taskID); t == nil {
+			logger.Noticef("On WorkshopManager.doDeleteUnusedSnapshots: internal error: task %s not found", taskID)
+			return false, nil
+		} else if !t.IsClean() {
+			return false, &state.Retry{}
+		}
+	}
+
+	if time.Since(lastUsed) < snapshotCooldownTime {
+		return false, &state.Retry{}
+	}
+
+	info, err := m.backend.Snapshot(ctx, snapshot)
+	if errors.Is(err, workshop.ErrSnapshotNotFound) || (err != nil && info != nil) {
+		// Snapshot not found, or a hash collision.
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if len(info.Workshops) > 0 {
+		return false, nil
+	}
+
+	if err := m.backend.RemoveSnapshot(ctx, snapshot); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -317,8 +317,8 @@ func (s *workshopHandlers) TestCreateWorkshopNoWorkshopDefinitionFound(c *check.
 	t1 := s.state.NewTask("create-workshop", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
-	chg.Set("ws_sdks", []sdk.Setup{})
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.AddTask(t1)
 
 	s.state.Unlock()
@@ -342,8 +342,8 @@ func (s *workshopHandlers) TestCreateWorkshopWithSystemSdk(c *check.C) {
 	t1.Set("workshop-file", wsJammy)
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
-	chg.Set("ws_sdks", []sdk.Setup{})
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.AddTask(t1)
 
 	s.state.Unlock()
@@ -371,8 +371,8 @@ func (s *workshopHandlers) TestCreateWorkshopCleanup(c *check.C) {
 	t1.Set("workshop-file", wsJammy)
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
-	chg.Set("ws_sdks", []sdk.Setup{})
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
+	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.AddTask(t1)
 
 	s.state.Unlock()
@@ -404,8 +404,8 @@ func (s *workshopHandlers) TestRebuildWorkshopNoCleanup(c *check.C) {
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	image := workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"}
-	chg.Set("ws_base", image)
-	chg.Set("ws_sdks", []sdk.Setup{})
+	chg.Set("ws_new_base", image)
+	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.AddTask(t1)
 
 	s.state.Unlock()
@@ -442,7 +442,7 @@ func (s *workshopHandlers) TestDownloadBase(c *check.C) {
 	t1 := s.state.NewTask("download-base", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
-	chg.Set("ws_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage1234"})
+	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage1234"})
 	chg.AddTask(t1)
 
 	s.state.Unlock()

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -27,8 +27,12 @@ import (
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/fsutil"
+	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
+	"github.com/canonical/workshop/internal/overlord/conflict"
+	"github.com/canonical/workshop/internal/overlord/handlersetup"
+	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/progress"
@@ -51,6 +55,7 @@ type workshopHandlers struct {
 	state   *state.State
 	runner  *state.TaskRunner
 	se      *overlord.StateEngine
+	sdkmgr  *sdkstate.SdkManager
 	wrkmgr  *workshopstate.WorkshopManager
 	ctx     context.Context
 	project workshop.Project
@@ -118,6 +123,9 @@ func (s *workshopHandlers) SetUpTest(c *check.C) {
 	s.state = state.New(nil)
 	s.runner = state.NewTaskRunner(s.state)
 
+	sdk.ReplaceStore(s.state, sdk.NewFakeStore())
+	s.sdkmgr = sdkstate.New(s.state, s.runner, interfaces.NewRepository())
+
 	// empty task handler
 	workshop.ReplaceBackend(s.state, s.backend)
 	s.runner.AddHandler("fake-task", fakeHandler, nil)
@@ -127,9 +135,10 @@ func (s *workshopHandlers) SetUpTest(c *check.C) {
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
 		return ErrTrigger
 	}
-	s.runner.AddHandler("error-trigger", erroringHandler, nil)
+	s.runner.AddHandler("error-trigger", handlersetup.OnDo(erroringHandler), nil)
 
 	s.se = overlord.NewStateEngine(s.state)
+	s.se.AddManager(s.sdkmgr)
 	s.se.AddManager(s.wrkmgr)
 	s.se.AddManager(s.runner)
 	err = s.se.StartUp()
@@ -590,4 +599,816 @@ func (s *workshopHandlers) TestConfigureTimezoneMissingDpkg(c *check.C) {
 
 	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
 	c.Check(s.backend.ExecCalls, check.HasLen, 2)
+}
+
+func setWorkshopManifest(chg *state.Change, age handlersetup.Age, manifest workshopstate.Manifest) {
+	chg.Set(handlersetup.WorkshopFormatKey(manifest.File.Name, age), manifest.Format)
+	chg.Set(handlersetup.WorkshopBaseKey(manifest.File.Name, age), manifest.Image)
+	chg.Set(handlersetup.WorkshopSdksKey(manifest.File.Name, age), manifest.Sdks)
+}
+
+func (s *workshopHandlers) launchWorkshop(c *check.C, manifest workshopstate.Manifest) {
+	chg := s.state.NewChange("launch", "...")
+	chg.Set("user", "testuser")
+	setWorkshopManifest(chg, handlersetup.NewWorkshop, manifest)
+
+	create := s.state.NewTask("create-workshop", "...")
+	handlersetup.SetWorkshopFile(create, manifest.File)
+	setWorkshopProject(manifest.File.Name, s.project, create)
+	chg.AddTask(create)
+
+	prev := create
+	for _, setup := range manifest.Sdks {
+		t := s.state.NewTask("snapshot-sdk", "...")
+		t.Set("sdk", setup.Name)
+		setWorkshopProject(manifest.File.Name, s.project, t)
+		t.WaitFor(prev)
+		chg.AddTask(t)
+		prev = t
+	}
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.IsNil)
+	c.Assert(chg.IsReady(), check.Equals, true)
+}
+
+var (
+	testSdk = sdk.Setup{
+		Name:      "test-sdk",
+		PackageID: "0CT76RxrmdAGQwbVIAbBel0EBoIv8lP7",
+		Channel:   "latest/stable",
+		Revision:  sdk.R(1),
+		Sha3_384:  "d024fbe91c6b99d0064306d52006c17a5d0406822ff253fbbe6a934ca9be50d3ff9a6ec3bac3be8396006029a1ff453a",
+	}
+
+	testSdk2 = sdk.Setup{
+		Name:      "test-sdk-2",
+		PackageID: "1AiTeMJjEGJyaBU8qiFiQDEfKjGTx3jp",
+		Channel:   "latest/stable",
+		Revision:  sdk.R(1),
+		Sha3_384:  "d4089378c26310627268153caa216240311f2a3193c778e96ed6dd895dc10c82db50f4f39676b29d23d9813b21e14b9b",
+	}
+)
+
+func (s *workshopHandlers) TestSnapshotRemovedAfterRemove(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	manifest := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk, testSdk2},
+	}
+	snapshot1 := workshop.SdkSnapshot(manifest.Format, manifest.Image, manifest.Sdks[:1])
+	snapshot2 := workshop.SdkSnapshot(manifest.Format, manifest.Image, manifest.Sdks)
+
+	s.launchWorkshop(c, manifest)
+
+	s1, err := s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+
+	s2, err := s.backend.Snapshot(s.ctx, snapshot2)
+	c.Assert(err, check.IsNil)
+	c.Check(s2.Snapshot, check.DeepEquals, snapshot2)
+	c.Check(s2.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+
+	chg := s.state.NewChange("remove", "...")
+	chg.Set("user", "testuser")
+	setWorkshopManifest(chg, handlersetup.OldWorkshop, manifest)
+
+	t := s.state.NewTask("remove-workshop", "...")
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.IsNil)
+	c.Assert(chg.IsReady(), check.Equals, true)
+	c.Assert(t.IsClean(), check.Equals, true)
+
+	_, err = s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+	_, err = s.backend.Snapshot(s.ctx, snapshot2)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+}
+
+func (s *workshopHandlers) TestSnapshotRemovedAfterFailedLaunch(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	manifest := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk, testSdk2},
+	}
+	snapshot1 := workshop.SdkSnapshot(manifest.Format, manifest.Image, manifest.Sdks[:1])
+	snapshot2 := workshop.SdkSnapshot(manifest.Format, manifest.Image, manifest.Sdks)
+
+	chg := s.state.NewChange("launch", "...")
+	chg.Set("user", "testuser")
+	setWorkshopManifest(chg, handlersetup.NewWorkshop, manifest)
+
+	t := s.state.NewTask("create-workshop", "...")
+	handlersetup.SetWorkshopFile(t, manifest.File)
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+
+	t1 := s.state.NewTask("snapshot-sdk", "...")
+	t1.Set("sdk", "test-sdk")
+	setWorkshopProject("ws", s.project, t1)
+	t1.WaitFor(t)
+	chg.AddTask(t1)
+
+	t2 := s.state.NewTask("snapshot-sdk", "...")
+	t2.Set("sdk", "test-sdk-2")
+	setWorkshopProject("ws", s.project, t2)
+	t2.WaitFor(t1)
+	chg.AddTask(t2)
+
+	terr := s.state.NewTask("error-trigger", "...")
+	setWorkshopProject("ws", s.project, terr)
+	terr.WaitFor(t2)
+	chg.AddTask(terr)
+
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+
+	s.state.Unlock()
+	for range 12 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.NotNil)
+	c.Assert(chg.IsReady(), check.Equals, true)
+	c.Assert(t.Status(), check.Equals, state.UndoneStatus)
+	c.Assert(t.IsClean(), check.Equals, true)
+
+	_, err := s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+	_, err = s.backend.Snapshot(s.ctx, snapshot2)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+}
+
+func (s *workshopHandlers) TestSnapshotRemovedAfterRefresh(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	current := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot1 := workshop.SdkSnapshot(current.Format, current.Image, current.Sdks)
+
+	latest := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk2},
+	}
+	snapshot2 := workshop.SdkSnapshot(latest.Format, latest.Image, latest.Sdks)
+
+	s.launchWorkshop(c, current)
+
+	s1, err := s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+
+	chg := s.state.NewChange("refresh", "...")
+	chg.Set("user", "testuser")
+	setWorkshopManifest(chg, handlersetup.OldWorkshop, current)
+	setWorkshopManifest(chg, handlersetup.NewWorkshop, latest)
+
+	stash := s.state.NewTask("stash-workshop", "...")
+	setWorkshopProject("ws", s.project, stash)
+	chg.AddTask(stash)
+
+	rebuild := s.state.NewTask("rebuild-workshop", "...")
+	handlersetup.SetWorkshopFile(rebuild, latest.File)
+	setWorkshopProject("ws", s.project, rebuild)
+	rebuild.WaitFor(stash)
+	chg.AddTask(rebuild)
+
+	snapshot := s.state.NewTask("snapshot-sdk", "...")
+	snapshot.Set("sdk", "test-sdk-2")
+	setWorkshopProject("ws", s.project, snapshot)
+	snapshot.WaitFor(rebuild)
+	chg.AddTask(snapshot)
+
+	removeStash := s.state.NewTask("remove-workshop-stash", "...")
+	setWorkshopProject("ws", s.project, removeStash)
+	removeStash.WaitFor(snapshot)
+	chg.AddTask(removeStash)
+
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.IsNil)
+	c.Assert(chg.IsReady(), check.Equals, true)
+	c.Assert(removeStash.IsClean(), check.Equals, true)
+
+	_, err = s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+	s2, err := s.backend.Snapshot(s.ctx, snapshot2)
+	c.Assert(err, check.IsNil)
+	c.Check(s2.Snapshot, check.DeepEquals, snapshot2)
+	c.Check(s2.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+}
+
+func (s *workshopHandlers) TestSnapshotRemovedAfterFailedRefresh(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	current := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot1 := workshop.SdkSnapshot(current.Format, current.Image, current.Sdks)
+
+	latest := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk2},
+	}
+	snapshot2 := workshop.SdkSnapshot(latest.Format, latest.Image, latest.Sdks)
+
+	s.launchWorkshop(c, current)
+
+	s1, err := s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+
+	chg := s.state.NewChange("refresh", "...")
+	chg.Set("user", "testuser")
+	setWorkshopManifest(chg, handlersetup.OldWorkshop, current)
+	setWorkshopManifest(chg, handlersetup.NewWorkshop, latest)
+
+	stash := s.state.NewTask("stash-workshop", "...")
+	setWorkshopProject("ws", s.project, stash)
+	chg.AddTask(stash)
+
+	rebuild := s.state.NewTask("rebuild-workshop", "...")
+	handlersetup.SetWorkshopFile(rebuild, latest.File)
+	setWorkshopProject("ws", s.project, rebuild)
+	rebuild.WaitFor(stash)
+	chg.AddTask(rebuild)
+
+	snapshot := s.state.NewTask("snapshot-sdk", "...")
+	snapshot.Set("sdk", "test-sdk-2")
+	setWorkshopProject("ws", s.project, snapshot)
+	snapshot.WaitFor(rebuild)
+	chg.AddTask(snapshot)
+
+	terr := s.state.NewTask("error-trigger", "...")
+	setWorkshopProject("ws", s.project, terr)
+	terr.WaitFor(snapshot)
+	chg.AddTask(terr)
+
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+
+	s.state.Unlock()
+	for range 12 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.NotNil)
+	c.Assert(chg.IsReady(), check.Equals, true)
+	c.Assert(stash.Status(), check.Equals, state.UndoneStatus)
+	c.Assert(stash.IsClean(), check.Equals, true)
+
+	s1, err = s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+	_, err = s.backend.Snapshot(s.ctx, snapshot2)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+}
+
+func (s *workshopHandlers) TestSnapshotRemovedAfterRemoveMidRefresh(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	current := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot1 := workshop.SdkSnapshot(current.Format, current.Image, current.Sdks)
+
+	latest := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk2},
+	}
+	snapshot2 := workshop.SdkSnapshot(latest.Format, latest.Image, latest.Sdks)
+
+	s.launchWorkshop(c, current)
+
+	s1, err := s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+
+	// First, refresh and wait on error.
+	refresh := s.state.NewChange("refresh", "...")
+	refresh.Set("user", "testuser")
+	refresh.Set("project-id", s.project.ProjectId)
+	refresh.Set("wait-setup", conflict.ChangeSetup{Mode: conflict.ChangeWaitOnError.String()})
+	setWorkshopManifest(refresh, handlersetup.OldWorkshop, current)
+	setWorkshopManifest(refresh, handlersetup.NewWorkshop, latest)
+
+	stash := s.state.NewTask("stash-workshop", "...")
+	setWorkshopProject("ws", s.project, stash)
+	refresh.AddTask(stash)
+
+	rebuild := s.state.NewTask("rebuild-workshop", "...")
+	handlersetup.SetWorkshopFile(rebuild, latest.File)
+	setWorkshopProject("ws", s.project, rebuild)
+	rebuild.WaitFor(stash)
+	refresh.AddTask(rebuild)
+
+	snapshot := s.state.NewTask("snapshot-sdk", "...")
+	snapshot.Set("sdk", "test-sdk-2")
+	setWorkshopProject("ws", s.project, snapshot)
+	snapshot.WaitFor(rebuild)
+	refresh.AddTask(snapshot)
+
+	terr := s.state.NewTask("error-trigger", "...")
+	setWorkshopProject("ws", s.project, terr)
+	terr.WaitFor(snapshot)
+	refresh.AddTask(terr)
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(refresh.Err(), check.IsNil)
+	c.Assert(refresh.Status(), check.Equals, state.WaitStatus)
+	c.Assert(terr.Status(), check.Equals, state.WaitStatus)
+
+	s1, err = s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+
+	s2, err := s.backend.Snapshot(s.ctx, snapshot2)
+	c.Assert(err, check.IsNil)
+	c.Check(s2.Snapshot, check.DeepEquals, snapshot2)
+	c.Check(s2.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+
+	// Next, remove the partially-refreshed workshop.
+	err = conflict.BackgroundDiscardWaitingRefresh(s.state, "ws", s.project.ProjectId)
+	c.Assert(err, check.IsNil)
+
+	remove := s.state.NewChange("remove", "...")
+	remove.Set("user", "testuser")
+	setWorkshopManifest(remove, handlersetup.OldStash, current)
+	setWorkshopManifest(remove, handlersetup.OldWorkshop, latest)
+
+	removeWorkshop := s.state.NewTask("remove-workshop", "...")
+	setWorkshopProject("ws", s.project, removeWorkshop)
+	remove.AddTask(removeWorkshop)
+
+	removeStash := s.state.NewTask("remove-workshop-stash", "...")
+	setWorkshopProject("ws", s.project, removeStash)
+	removeStash.WaitFor(removeWorkshop)
+	remove.AddTask(removeStash)
+
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(refresh.Err(), check.IsNil)
+	c.Assert(refresh.IsReady(), check.Equals, true)
+	c.Assert(remove.Err(), check.IsNil)
+	c.Assert(remove.IsReady(), check.Equals, true)
+	c.Assert(removeWorkshop.IsClean(), check.Equals, true)
+	c.Assert(removeStash.IsClean(), check.Equals, true)
+
+	_, err = s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+	_, err = s.backend.Snapshot(s.ctx, snapshot2)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+}
+
+func (s *workshopHandlers) TestSnapshotExitCleanupAfterSuccessfulLaunch(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	manifest := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot := workshop.SdkSnapshot(manifest.Format, manifest.Image, manifest.Sdks)
+
+	chg := s.state.NewChange("launch", "...")
+	chg.Set("user", "testuser")
+	setWorkshopManifest(chg, handlersetup.NewWorkshop, manifest)
+
+	t := s.state.NewTask("create-workshop", "...")
+	handlersetup.SetWorkshopFile(t, manifest.File)
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+
+	t1 := s.state.NewTask("snapshot-sdk", "...")
+	t1.Set("sdk", "test-sdk")
+	setWorkshopProject("ws", s.project, t1)
+	t1.WaitFor(t)
+	chg.AddTask(t1)
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.IsNil)
+	c.Assert(chg.IsReady(), check.Equals, true)
+	c.Assert(t.IsClean(), check.Equals, true)
+
+	s1, err := s.backend.Snapshot(s.ctx, snapshot)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot)
+	c.Check(s1.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
+}
+
+func (s *workshopHandlers) TestSnapshotNotRemovedBeforeCooldown(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	manifest := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot := workshop.SdkSnapshot(manifest.Format, manifest.Image, manifest.Sdks)
+
+	s.launchWorkshop(c, manifest)
+
+	chg := s.state.NewChange("remove", "...")
+	chg.Set("user", "testuser")
+	setWorkshopManifest(chg, handlersetup.OldWorkshop, manifest)
+
+	t := s.state.NewTask("remove-workshop", "...")
+	setWorkshopProject("ws", s.project, t)
+	chg.AddTask(t)
+
+	// Set cooldown to a large value so it never passes.
+	defer workshopstate.FakeSnapshotCooldownTime(24 * time.Hour)()
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	// The task should not be clean (cleanup not performed).
+	c.Assert(chg.Err(), check.IsNil)
+	c.Assert(chg.IsReady(), check.Equals, true)
+	c.Assert(t.IsClean(), check.Equals, false)
+
+	// The snapshot should still exist.
+	s1, err := s.backend.Snapshot(s.ctx, snapshot)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot)
+	c.Check(s1.Workshops[s.project.ProjectId], check.HasLen, 0)
+}
+
+func (s *workshopHandlers) TestSnapshotExitCleanupIfUsedAgain(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	manifest1 := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot1 := workshop.SdkSnapshot(manifest1.Format, manifest1.Image, manifest1.Sdks)
+
+	manifest2 := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws2", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+
+	s.launchWorkshop(c, manifest1)
+
+	// Launch ws2.
+	launch := s.state.NewChange("launch", "...")
+	launch.Set("user", "testuser")
+	setWorkshopManifest(launch, handlersetup.NewWorkshop, manifest2)
+
+	create := s.state.NewTask("create-workshop", "...")
+	handlersetup.SetWorkshopFile(create, manifest2.File)
+	setWorkshopProject("ws2", s.project, create)
+	launch.AddTask(create)
+
+	snapshot := s.state.NewTask("snapshot-sdk", "...")
+	snapshot.Set("sdk", "test-sdk")
+	setWorkshopProject("ws2", s.project, snapshot)
+	snapshot.WaitFor(create)
+	launch.AddTask(snapshot)
+
+	// Remove ws.
+	remove := s.state.NewChange("remove", "...")
+	remove.Set("user", "testuser")
+	setWorkshopManifest(remove, handlersetup.OldWorkshop, manifest1)
+	removeWorkshop := s.state.NewTask("remove-workshop", "...")
+	setWorkshopProject("ws", s.project, removeWorkshop)
+	remove.AddTask(removeWorkshop)
+
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(launch.Err(), check.IsNil)
+	c.Assert(launch.IsReady(), check.Equals, true)
+	c.Assert(remove.Err(), check.IsNil)
+	c.Assert(remove.IsReady(), check.Equals, true)
+	c.Assert(removeWorkshop.IsClean(), check.Equals, true)
+
+	s1, err := s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws2"})
+}
+
+func (s *workshopHandlers) TestSnapshotRetriesCleanupIfBlockingChangesArePresent(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	manifest1 := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot1 := workshop.SdkSnapshot(manifest1.Format, manifest1.Image, manifest1.Sdks)
+
+	manifest2 := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws2", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+
+	s.launchWorkshop(c, manifest1)
+
+	// Remove ws.
+	remove := s.state.NewChange("remove", "...")
+	remove.Set("user", "testuser")
+	setWorkshopManifest(remove, handlersetup.OldWorkshop, manifest1)
+
+	removeWorkshop := s.state.NewTask("remove-workshop", "...")
+	setWorkshopProject("ws", s.project, removeWorkshop)
+	remove.AddTask(removeWorkshop)
+
+	// Launch ws2 that using the same snapshot.
+	launch := s.state.NewChange("launch", "...")
+	launch.Set("user", "testuser")
+	setWorkshopManifest(launch, handlersetup.NewWorkshop, manifest2)
+
+	create := s.state.NewTask("create-workshop", "...")
+	handlersetup.SetWorkshopFile(create, manifest2.File)
+	setWorkshopProject("ws2", s.project, create)
+	create.SetToWait(state.DoStatus)
+	launch.AddTask(create)
+
+	terr := s.state.NewTask("error-trigger", "...")
+	setWorkshopProject("ws2", s.project, terr)
+	terr.WaitFor(create)
+	launch.AddTask(terr)
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(launch.Err(), check.IsNil)
+	c.Assert(launch.IsReady(), check.Equals, false)
+	c.Assert(remove.Err(), check.IsNil)
+	c.Assert(remove.IsReady(), check.Equals, true)
+	c.Assert(removeWorkshop.IsClean(), check.Equals, false)
+
+	s1, err := s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.HasLen, 0)
+
+	// Finish the blocking launch change so cleanup can proceed.
+	waited := create.WaitedStatus()
+	create.SetStatus(waited)
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(launch.Err(), check.NotNil)
+	c.Assert(launch.IsReady(), check.Equals, true)
+	c.Assert(remove.Err(), check.IsNil)
+	c.Assert(remove.IsReady(), check.Equals, true)
+	c.Assert(removeWorkshop.IsClean(), check.Equals, true)
+
+	_, err = s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.Equals, workshop.ErrSnapshotNotFound)
+}
+
+func (s *workshopHandlers) TestSnapshotCleanupPerformedByLatestUser(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	manifest1 := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot1 := workshop.SdkSnapshot(manifest1.Format, manifest1.Image, manifest1.Sdks)
+
+	manifest2 := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws2", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+
+	s.launchWorkshop(c, manifest1)
+	s.launchWorkshop(c, manifest2)
+
+	chg1 := s.state.NewChange("remove", "...")
+	chg1.Set("user", "testuser")
+	setWorkshopManifest(chg1, handlersetup.OldWorkshop, manifest1)
+
+	t1 := s.state.NewTask("remove-workshop", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg1.AddTask(t1)
+
+	chg2 := s.state.NewChange("remove", "...")
+	chg2.Set("user", "testuser")
+	setWorkshopManifest(chg2, handlersetup.OldWorkshop, manifest2)
+
+	t2 := s.state.NewTask("remove-workshop", "...")
+	t2.WaitFor(t1)
+	setWorkshopProject("ws2", s.project, t2)
+	chg2.AddTask(t2)
+
+	// Use default cooldown (1h), so t2 will not be clean (cooldown not passed).
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg1.Err(), check.IsNil)
+	c.Assert(chg1.IsReady(), check.Equals, true)
+	c.Assert(chg2.Err(), check.IsNil)
+	c.Assert(chg2.IsReady(), check.Equals, true)
+	// The first task should be clean (cleanup skipped due to newer task)
+	c.Assert(t1.IsClean(), check.Equals, true)
+	// The second task should not be clean (cleanup not performed, cooldown not passed)
+	c.Assert(t2.IsClean(), check.Equals, false)
+
+	s1, err := s.backend.Snapshot(s.ctx, snapshot1)
+	c.Assert(err, check.IsNil)
+	c.Check(s1.Snapshot, check.DeepEquals, snapshot1)
+	c.Check(s1.Workshops[s.project.ProjectId], check.HasLen, 0)
+}
+
+func (s *workshopHandlers) TestSnapshotCleanupWaitsForDependentSnapshots(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	manifest1 := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk, testSdk2},
+	}
+	snapshot1 := workshop.SdkSnapshot(manifest1.Format, manifest1.Image, manifest1.Sdks)
+
+	manifest2 := workshopstate.Manifest{
+		File:   &workshop.File{Name: "ws2", Base: "ubuntu@22.04"},
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"},
+		Sdks:   []sdk.Setup{testSdk},
+	}
+	snapshot2 := workshop.SdkSnapshot(manifest2.Format, manifest2.Image, manifest2.Sdks)
+
+	s.launchWorkshop(c, manifest1)
+	s.launchWorkshop(c, manifest2)
+
+	chg1 := s.state.NewChange("remove", "...")
+	chg1.Set("user", "testuser")
+	setWorkshopManifest(chg1, handlersetup.OldWorkshop, manifest1)
+
+	t1 := s.state.NewTask("remove-workshop", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg1.AddTask(t1)
+
+	chg2 := s.state.NewChange("remove", "...")
+	chg2.Set("user", "testuser")
+	setWorkshopManifest(chg2, handlersetup.OldWorkshop, manifest2)
+
+	t2 := s.state.NewTask("remove-workshop", "...")
+	setWorkshopProject("ws2", s.project, t2)
+	// We remove ws2 after ws, so ws2 is responsible for cleaning up the
+	// test-sdk snapshot, but still has to wait for ws to clean up test-sdk-2.
+	t2.WaitFor(t1)
+	chg2.AddTask(t2)
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg1.Err(), check.IsNil)
+	c.Assert(chg1.IsReady(), check.Equals, true)
+	c.Assert(chg2.Err(), check.IsNil)
+	c.Assert(chg2.IsReady(), check.Equals, true)
+	c.Assert(t1.IsClean(), check.Equals, false)
+	c.Assert(t2.IsClean(), check.Equals, false)
+
+	c.Assert(s.backend.RemovedSnapshots, check.HasLen, 0)
+
+	// Drop the cooldown so both cleanup handlers run simultaneously.
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+
+	s.state.Unlock()
+	for range 6 {
+		c.Check(s.se.Ensure(), check.IsNil)
+		s.se.Wait()
+	}
+	s.state.Lock()
+
+	c.Assert(chg1.Err(), check.IsNil)
+	c.Assert(chg1.IsReady(), check.Equals, true)
+	c.Assert(chg2.Err(), check.IsNil)
+	c.Assert(chg2.IsReady(), check.Equals, true)
+	c.Assert(t1.IsClean(), check.Equals, true)
+	c.Assert(t2.IsClean(), check.Equals, true)
+
+	c.Assert(s.backend.RemovedSnapshots, check.DeepEquals, []workshop.Snapshot{snapshot1, snapshot2})
 }

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -146,7 +146,7 @@ func (s *workshopHandlers) TestStopPeriodicProgressUpdate(c *check.C) {
 	defer s.state.Unlock()
 	s.createWFile(c, "ws", wsFocal)
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 
@@ -189,7 +189,7 @@ func (s *workshopHandlers) TestUndoStash(c *check.C) {
 		{Name: "test2", Channel: "latest/stable"},
 	}}
 
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 
@@ -238,7 +238,7 @@ func (s *workshopHandlers) TestRemoveWorkshop(c *check.C) {
 	userDataDir := workshop.UserDataRootDir(s.user.HomeDir, nil)
 
 	for _, wf := range wFiles {
-		snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+		snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 		err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 		c.Check(err, check.IsNil)
 
@@ -317,6 +317,7 @@ func (s *workshopHandlers) TestCreateWorkshopNoWorkshopDefinitionFound(c *check.
 	t1 := s.state.NewTask("create-workshop", "...")
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.AddTask(t1)
@@ -342,6 +343,7 @@ func (s *workshopHandlers) TestCreateWorkshopWithSystemSdk(c *check.C) {
 	t1.Set("workshop-file", wsJammy)
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.AddTask(t1)
@@ -371,6 +373,7 @@ func (s *workshopHandlers) TestCreateWorkshopCleanup(c *check.C) {
 	t1.Set("workshop-file", wsJammy)
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.AddTask(t1)
@@ -404,6 +407,7 @@ func (s *workshopHandlers) TestRebuildWorkshopNoCleanup(c *check.C) {
 	setWorkshopProject("ws", s.project, t1)
 	chg.Set("user", "testuser")
 	image := workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"}
+	chg.Set("ws_new_format", sdk.R(1))
 	chg.Set("ws_new_base", image)
 	chg.Set("ws_new_sdks", []sdk.Setup{})
 	chg.AddTask(t1)

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/canonical/workshop/internal/logger"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
@@ -31,6 +32,10 @@ type WorkshopManager struct {
 	state           *state.State
 	firewallChecker func(string) string
 }
+
+var (
+	snapshotCooldownTime = 1 * time.Hour // Time to wait before deleting unused snapshots.
+)
 
 func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	manager := &WorkshopManager{
@@ -57,6 +62,11 @@ func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	runner.AddHandler("create-state-storage", OnDo(manager.doCreateStateStorage), OnUndo(manager.doRemoveStateStorage))
 	runner.AddHandler("remove-state-storage", OnDo(manager.doRemoveStateStorage), nil)
 
+	runner.AddCleanup("create-workshop", manager.doDeleteUnusedSnapshots)
+	runner.AddCleanup("remove-workshop", manager.doDeleteUnusedSnapshots)
+	runner.AddCleanup("stash-workshop", manager.doDeleteUnusedSnapshots)
+	runner.AddCleanup("remove-workshop-stash", manager.doDeleteUnusedSnapshots)
+
 	return manager
 }
 
@@ -72,6 +82,14 @@ func (m *WorkshopManager) StartUp() error {
 
 func (w *WorkshopManager) Ensure() error {
 	return nil
+}
+
+func FakeSnapshotCooldownTime(t time.Duration) (restore func()) {
+	old := snapshotCooldownTime
+	snapshotCooldownTime = t
+	return func() {
+		snapshotCooldownTime = old
+	}
 }
 
 // Project finds an existing project with the given ID.

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -125,6 +125,37 @@ func (w *WorkshopManager) RefreshManifests(ctx context.Context, project workshop
 	}
 }
 
+func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string, names []string) ([]Manifest, []bool, error) {
+	ctx = context.WithValue(ctx, workshop.ContextProjectId, projectId)
+
+	manifests := make([]Manifest, 0, len(names))
+	running := make([]bool, 0, len(names))
+	for _, name := range names {
+		wp, err := w.backend.Workshop(ctx, name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
+		}
+
+		if err := conflict.BackgroundDiscardWaitingRefresh(w.state, name, projectId); err != nil {
+			return nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
+		}
+		allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus}
+		if err := healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+			return nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
+		}
+
+		installed := make([]sdk.Setup, 0, len(wp.Sdks))
+		for _, sk := range wp.SdksByInstallOrder() {
+			installed = append(installed, sk.Setup)
+		}
+		manifests = append(manifests, Manifest{File: wp.File, Image: wp.Image, Sdks: installed})
+
+		running = append(running, wp.Running)
+	}
+
+	return manifests, running, nil
+}
+
 type artifactFinder struct {
 	*WorkshopManager
 	user        *user.User

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -126,35 +126,50 @@ func (w *WorkshopManager) RefreshManifests(ctx context.Context, project workshop
 	}
 }
 
-func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string, names []string) ([]Manifest, []bool, error) {
+func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string, names []string) (stashed, current []Manifest, running []bool, err error) {
 	ctx = context.WithValue(ctx, workshop.ContextProjectId, projectId)
 
-	manifests := make([]Manifest, 0, len(names))
-	running := make([]bool, 0, len(names))
+	stashed = make([]Manifest, 0, len(names))
+	current = make([]Manifest, 0, len(names))
+	running = make([]bool, 0, len(names))
 	for _, name := range names {
 		wp, err := w.backend.Workshop(ctx, name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
+			return nil, nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
 		}
 
 		if err := conflict.BackgroundDiscardWaitingRefresh(w.state, name, projectId); err != nil {
-			return nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
+			return nil, nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
 		}
 		allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus}
 		if err := healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
-			return nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
+			return nil, nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
 		}
 
 		installed := make([]sdk.Setup, 0, len(wp.Sdks))
 		for _, sk := range wp.SdksByInstallOrder() {
 			installed = append(installed, sk.Setup)
 		}
-		manifests = append(manifests, Manifest{File: wp.File, Format: wp.Format, Image: wp.Image, Sdks: installed})
+		current = append(current, Manifest{File: wp.File, Format: wp.Format, Image: wp.Image, Sdks: installed})
 
 		running = append(running, wp.Running)
+
+		stash, err := w.backend.StashedWorkshop(ctx, name)
+		if errors.Is(err, workshop.ErrWorkshopNotLaunched) {
+			continue
+		}
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		installed = make([]sdk.Setup, 0, len(stash.Sdks))
+		for _, sk := range stash.SdksByInstallOrder() {
+			installed = append(installed, sk.Setup)
+		}
+		stashed = append(stashed, Manifest{File: stash.File, Format: stash.Format, Image: stash.Image, Sdks: installed})
 	}
 
-	return manifests, running, nil
+	return stashed, current, running, nil
 }
 
 type artifactFinder struct {

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -41,9 +41,10 @@ import (
 // Manifest lists the components needed to construct a workshop. It augments
 // the workshop definition with specific versions of the base image and SDKs.
 type Manifest struct {
-	File  *workshop.File
-	Image workshop.BaseImage
-	Sdks  []sdk.Setup
+	File   *workshop.File
+	Format sdk.Revision
+	Image  workshop.BaseImage
+	Sdks   []sdk.Setup
 }
 
 func (m *Manifest) maybeRevision(sk string) sdk.Revision {
@@ -148,7 +149,7 @@ func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string,
 		for _, sk := range wp.SdksByInstallOrder() {
 			installed = append(installed, sk.Setup)
 		}
-		manifests = append(manifests, Manifest{File: wp.File, Image: wp.Image, Sdks: installed})
+		manifests = append(manifests, Manifest{File: wp.File, Format: wp.Format, Image: wp.Image, Sdks: installed})
 
 		running = append(running, wp.Running)
 	}
@@ -242,9 +243,10 @@ func (a *artifactFinder) launchOrRefreshManifests(ctx context.Context, names []s
 			return nil, nil, fmt.Errorf("cannot %s %q: %w", action, name, err)
 		}
 
+		format := a.backend.FormatRevision()
 		installOrder := sdkInstallOrder(files[i])
 		sdks := ordered(installOrder, storeSdks[i], localSdks)
-		latest = append(latest, Manifest{File: files[i], Image: images[i], Sdks: sdks})
+		latest = append(latest, Manifest{File: files[i], Format: format, Image: images[i], Sdks: sdks})
 	}
 
 	return current, latest, nil
@@ -278,7 +280,7 @@ func (w *WorkshopManager) workshopManifest(ctx context.Context, projectId, name 
 	for _, sk := range wp.SdksByInstallOrder() {
 		installed = append(installed, sk.Setup)
 	}
-	return &Manifest{File: wp.File, Image: wp.Image, Sdks: installed}, nil
+	return &Manifest{File: wp.File, Format: wp.Format, Image: wp.Image, Sdks: installed}, nil
 }
 
 func (a *artifactFinder) findStoreSdks(sto sdk.Store, ctx context.Context, file *workshop.File) ([]sdk.Setup, error) {

--- a/internal/overlord/workshopstate/manifest_test.go
+++ b/internal/overlord/workshopstate/manifest_test.go
@@ -216,7 +216,7 @@ func (s *manifestSuite) createWFile(c *check.C, ws, base string, sdks []workshop
 
 func (s *manifestSuite) launchWorkshopWithSDKs(c *check.C, ws, base string, sdks []workshop.SdkRecord) *workshop.Workshop {
 	wf := s.createWFile(c, ws, base, sdks)
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
@@ -284,6 +284,9 @@ func (s *manifestSuite) TestRefreshOK(c *check.C) {
 	err = os.WriteFile(workshop.Filepath(s.project.Path, "test-2"), []byte(fileText), 0644)
 	c.Assert(err, check.IsNil)
 
+	// Update format revision number
+	s.backend.SetFormatRevision(sdk.R(2))
+
 	// Retrieve manifests.
 	current, latest, err := s.manager.RefreshManifests(s.ctx, s.project, []string{"test-1", "test-2"}, conflict.RefreshUpdate)
 	c.Assert(err, check.IsNil)
@@ -298,6 +301,8 @@ func (s *manifestSuite) TestRefreshOK(c *check.C) {
 		Sdks: sdks,
 	})
 	c.Check(latest[0].File, check.DeepEquals, current[0].File)
+	c.Check(current[0].Format, check.Equals, sdk.R(1))
+	c.Check(latest[0].Format, check.Equals, sdk.R(2))
 	c.Check(current[0].Image, check.Equals, workshop.BaseImage{Name: "ubuntu@20.04", Fingerprint: "fakeimage123"})
 	c.Check(latest[0].Image, check.Equals, current[0].Image)
 
@@ -312,6 +317,8 @@ func (s *manifestSuite) TestRefreshOK(c *check.C) {
 		Base: "ubuntu@22.04",
 		Sdks: sdks,
 	})
+	c.Check(current[1].Format, check.Equals, sdk.R(1))
+	c.Check(latest[1].Format, check.Equals, sdk.R(2))
 	c.Check(current[1].Image, check.Equals, current[0].Image)
 	c.Check(latest[1].Image, check.Equals, workshop.BaseImage{Name: "ubuntu@22.04", Fingerprint: "fakeimage123"})
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -281,7 +281,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, project workshop.Proj
 }
 
 func (w *WorkshopManager) bestSnapshot(ctx context.Context, manifest Manifest) (*workshop.Snapshot, error) {
-	snapshot := workshop.SdkSnapshot(manifest.Image, manifest.Sdks)
+	snapshot := workshop.SdkSnapshot(manifest.Format, manifest.Image, manifest.Sdks)
 	for range manifest.Sdks {
 		found, err := w.backend.HasSnapshot(ctx, snapshot)
 		if err != nil {
@@ -296,8 +296,8 @@ func (w *WorkshopManager) bestSnapshot(ctx context.Context, manifest Manifest) (
 }
 
 func hasUpdates(current, latest Manifest) bool {
-	currentSnapshot := workshop.SdkSnapshot(current.Image, current.Sdks)
-	finalSnapshot := workshop.SdkSnapshot(latest.Image, latest.Sdks)
+	currentSnapshot := workshop.SdkSnapshot(current.Format, current.Image, current.Sdks)
+	finalSnapshot := workshop.SdkSnapshot(latest.Format, latest.Image, latest.Sdks)
 	if !currentSnapshot.Equal(finalSnapshot) {
 		return true
 	}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -694,40 +694,16 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 	return execSet, nil
 }
 
-func (w *WorkshopManager) RemoveMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
-	project, err := w.Project(ctx, projectId)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx = context.WithValue(ctx, workshop.ContextProjectId, project.ProjectId)
-
-	var workshops = make([]*workshop.Workshop, 0, len(names))
-	for _, name := range names {
-		wp, err := w.backend.Workshop(ctx, name)
-		if err != nil {
-			return nil, fmt.Errorf("cannot remove %q: %w", name, err)
-		}
-		workshops = append(workshops, wp)
-		if err = conflict.BackgroundDiscardWaitingRefresh(w.state, name, projectId); err != nil {
-			return nil, fmt.Errorf("cannot remove %q: %w", name, err)
-		}
-
-		allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus}
-		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
-			return nil, fmt.Errorf("cannot remove %q: %w", name, err)
-		}
-	}
-
+func (w *WorkshopManager) RemoveMany(ctx context.Context, project workshop.Project, manifests []Manifest, running []bool) ([]*state.TaskSet, error) {
 	taskset := []*state.TaskSet{}
-	for _, wp := range workshops {
-		remove := remove(w.state, wp, project)
+	for i, m := range manifests {
+		remove := remove(w.state, m, running[i], project)
 		taskset = append(taskset, remove)
 	}
 	return taskset, nil
 }
 
-func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *state.TaskSet {
+func remove(st *state.State, manifest Manifest, running bool, project workshop.Project) *state.TaskSet {
 	removeSet := state.NewTaskSet()
 	var prevRemove *state.TaskSet
 	addTaskSet := func(ts *state.TaskSet) {
@@ -741,21 +717,19 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 		removeSet.AddAll(ts)
 	}
 
-	sdks := make([]sdk.Setup, 0, len(w.Sdks))
-	for _, sk := range w.Sdks {
-		sdks = append(sdks, sk.Setup)
-	}
+	sdks := slices.Clone(manifest.Sdks)
+	slices.Reverse(sdks)
 
 	disconnectSet := disconnectSdks(st, sdks)
 	addTaskSet(disconnectSet)
 
-	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", w.Name))
+	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", manifest.File.Name))
 	addTaskSet(state.NewTaskSet(discard))
 
-	if w.Running {
+	if running {
 		// It's safe to stop if the workshop isn't running, but we
 		// don't want to start it if the Change is undone.
-		stop := st.NewTask("stop-workshop", fmt.Sprintf("Stop %q workshop", w.Name))
+		stop := st.NewTask("stop-workshop", fmt.Sprintf("Stop %q workshop", manifest.File.Name))
 		stop.Set("force", true)
 		addTaskSet(state.NewTaskSet(stop))
 	}
@@ -763,7 +737,7 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 	uninstall := uninstallSdks(st, sdks)
 	addTaskSet(uninstall)
 
-	remove := st.NewTask("remove-workshop", fmt.Sprintf("Remove %q workshop", w.Name))
+	remove := st.NewTask("remove-workshop", fmt.Sprintf("Remove %q workshop", manifest.File.Name))
 	addTaskSet(state.NewTaskSet(remove))
 
 	// The point of no return starts after the workshop is removed. If any of the tasks
@@ -771,10 +745,10 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 	removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
 	addTaskSet(state.NewTaskSet(removeStateStorage))
 
-	removeStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", w.Name))
+	removeStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", manifest.File.Name))
 	addTaskSet(state.NewTaskSet(removeStash))
 
-	removeDirs := st.NewTask("remove-workshop-storage", fmt.Sprintf("Remove %q storage directories", w.Name))
+	removeDirs := st.NewTask("remove-workshop-storage", fmt.Sprintf("Remove %q storage directories", manifest.File.Name))
 	addTaskSet(state.NewTaskSet(removeDirs))
 
 	// Directories should exist from before create-workshop until after remove-workshop.
@@ -786,7 +760,7 @@ func remove(st *state.State, w *workshop.Workshop, project workshop.Project) *st
 	removeStateStorage.JoinLane(cleanupLane)
 
 	for _, task := range removeSet.Tasks() {
-		task.Set("workshop", w.Name)
+		task.Set("workshop", manifest.File.Name)
 		task.Set("project", project)
 	}
 	return removeSet

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -16,6 +16,7 @@ package workshopstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -283,14 +284,13 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, project workshop.Proj
 func (w *WorkshopManager) bestSnapshot(ctx context.Context, manifest Manifest) (*workshop.Snapshot, error) {
 	snapshot := workshop.SdkSnapshot(manifest.Format, manifest.Image, manifest.Sdks)
 	for range manifest.Sdks {
-		found, err := w.backend.HasSnapshot(ctx, snapshot)
-		if err != nil {
+		if _, err := w.backend.Snapshot(ctx, snapshot); errors.Is(err, workshop.ErrSnapshotNotFound) {
+			snapshot.Sdks = snapshot.Sdks[:len(snapshot.Sdks)-1]
+		} else if err != nil {
 			return nil, err
-		}
-		if found {
+		} else {
 			break
 		}
-		snapshot.Sdks = snapshot.Sdks[:len(snapshot.Sdks)-1]
 	}
 	return &snapshot, nil
 }

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -131,7 +131,7 @@ func (s *requestSuite) launchWorkshopWithSDKs(c *check.C, ws string, sdks []work
 	c.Assert(err, check.IsNil)
 
 	wf := workshop.File{Name: ws, Base: "ubuntu@20.04", Sdks: sdks}
-	snapshot := workshop.BaseOnly(wf.Base, "fakeimage123")
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err = s.backend.LaunchOrRebuildWorkshop(s.ctx, &wf, snapshot)
 	c.Assert(err, check.IsNil)
 
@@ -194,8 +194,9 @@ connections:
 	c.Assert(err, check.IsNil)
 
 	current := []workshopstate.Manifest{{
-		File:  &oldf,
-		Image: workshop.BaseImage{Name: newf.Base, Fingerprint: "fakeimage123"},
+		File:   &oldf,
+		Format: sdk.R(1),
+		Image:  workshop.BaseImage{Name: newf.Base, Fingerprint: "fakeimage123"},
 		Sdks: []sdk.Setup{{
 			Name:     "system",
 			Source:   sdk.SystemSource,
@@ -221,9 +222,10 @@ connections:
 		}},
 	}}
 	latest := []workshopstate.Manifest{{
-		File:  &newf,
-		Image: current[0].Image,
-		Sdks:  slices.Clone(current[0].Sdks),
+		File:   &newf,
+		Format: current[0].Format,
+		Image:  current[0].Image,
+		Sdks:   slices.Clone(current[0].Sdks),
 	}}
 
 	// No updates.
@@ -235,6 +237,13 @@ connections:
 	ts, err = s.mgr.RefreshMany(s.ctx, s.project, current, latest, conflict.RefreshRestore)
 	c.Assert(err, check.IsNil)
 	c.Check(ts, check.Not(check.HasLen), 0)
+
+	// Updated format.
+	latest[0].Format = sdk.R(2)
+	ts, err = s.mgr.RefreshMany(s.ctx, s.project, current, latest, conflict.RefreshUpdate)
+	c.Assert(err, check.IsNil)
+	c.Check(ts, check.Not(check.HasLen), 0)
+	latest[0].Format = current[0].Format
 
 	// Updated SDK.
 	latest[0].Sdks[1].Revision = sdk.R(43)
@@ -389,15 +398,16 @@ sdks:
 
 	// Final snapshot already exists.
 	manifest := workshopstate.Manifest{
-		File:  &wf,
-		Image: image,
-		Sdks:  []sdk.Setup{uv, golang, rust, node},
+		File:   &wf,
+		Format: sdk.R(1),
+		Image:  image,
+		Sdks:   []sdk.Setup{uv, golang, rust, node},
 	}
 	s.backend.Snapshots = []fakebackend.FakeSnapshot{
-		{Snapshot: workshop.SdkSnapshot(image, manifest.Sdks[:1]), Id: 0},
-		{Snapshot: workshop.SdkSnapshot(image, manifest.Sdks[:2]), Id: 1},
-		{Snapshot: workshop.SdkSnapshot(image, manifest.Sdks[:3]), Id: 2},
-		{Snapshot: workshop.SdkSnapshot(image, manifest.Sdks[:4]), Id: 3},
+		{Snapshot: workshop.SdkSnapshot(manifest.Format, image, manifest.Sdks[:1]), Id: 0},
+		{Snapshot: workshop.SdkSnapshot(manifest.Format, image, manifest.Sdks[:2]), Id: 1},
+		{Snapshot: workshop.SdkSnapshot(manifest.Format, image, manifest.Sdks[:3]), Id: 2},
+		{Snapshot: workshop.SdkSnapshot(manifest.Format, image, manifest.Sdks[:4]), Id: 3},
 	}
 
 	tasksets, err := s.mgr.LaunchMany(s.ctx, s.project, []workshopstate.Manifest{manifest})
@@ -438,10 +448,10 @@ sdks:
 
 	// Snapshots only exist for outdated workshop.
 	s.backend.Snapshots = []fakebackend.FakeSnapshot{
-		{Snapshot: workshop.SdkSnapshot(image, manifest.Sdks[:1]), Id: 0},
-		{Snapshot: workshop.SdkSnapshot(image, manifest.Sdks[:2]), Id: 1},
-		{Snapshot: workshop.SdkSnapshot(image, manifest.Sdks[:3]), Id: 2},
-		{Snapshot: workshop.SdkSnapshot(image, manifest.Sdks[:4]), Id: 3},
+		{Snapshot: workshop.SdkSnapshot(manifest.Format, image, manifest.Sdks[:1]), Id: 0},
+		{Snapshot: workshop.SdkSnapshot(manifest.Format, image, manifest.Sdks[:2]), Id: 1},
+		{Snapshot: workshop.SdkSnapshot(manifest.Format, image, manifest.Sdks[:3]), Id: 2},
+		{Snapshot: workshop.SdkSnapshot(manifest.Format, image, manifest.Sdks[:4]), Id: 3},
 	}
 	manifest.Sdks[2] = rust_r2
 
@@ -558,20 +568,22 @@ sdks:
 
 	// Updated SDKs.
 	current := workshopstate.Manifest{
-		File:  &wf,
-		Image: image,
-		Sdks:  []sdk.Setup{uv, golang, rust, node},
+		File:   &wf,
+		Format: sdk.R(1),
+		Image:  image,
+		Sdks:   []sdk.Setup{uv, golang, rust, node},
 	}
 	latest := workshopstate.Manifest{
-		File:  &wf,
-		Image: image,
-		Sdks:  []sdk.Setup{uv, golang_r2, rust_r2, node},
+		File:   &wf,
+		Format: sdk.R(1),
+		Image:  image,
+		Sdks:   []sdk.Setup{uv, golang_r2, rust_r2, node},
 	}
 	s.backend.Snapshots = []fakebackend.FakeSnapshot{
-		{Snapshot: workshop.SdkSnapshot(image, current.Sdks[:1]), Id: 0},
-		{Snapshot: workshop.SdkSnapshot(image, current.Sdks[:2]), Id: 1},
-		{Snapshot: workshop.SdkSnapshot(image, current.Sdks[:3]), Id: 2},
-		{Snapshot: workshop.SdkSnapshot(image, current.Sdks[:4]), Id: 3},
+		{Snapshot: workshop.SdkSnapshot(current.Format, image, current.Sdks[:1]), Id: 0},
+		{Snapshot: workshop.SdkSnapshot(current.Format, image, current.Sdks[:2]), Id: 1},
+		{Snapshot: workshop.SdkSnapshot(current.Format, image, current.Sdks[:3]), Id: 2},
+		{Snapshot: workshop.SdkSnapshot(current.Format, image, current.Sdks[:4]), Id: 3},
 	}
 
 	tasksets, err := s.mgr.RefreshMany(s.ctx, s.project, []workshopstate.Manifest{current}, []workshopstate.Manifest{latest}, conflict.RefreshUpdate)
@@ -628,7 +640,7 @@ sdks:
 	current.Sdks = latest.Sdks
 	latest.File = &wf
 	latest.Sdks = []sdk.Setup{uv, golang, rust, node}
-	snapshot := fakebackend.FakeSnapshot{Snapshot: workshop.SdkSnapshot(image, current.Sdks), Id: 4}
+	snapshot := fakebackend.FakeSnapshot{Snapshot: workshop.SdkSnapshot(current.Format, image, current.Sdks), Id: 4}
 	s.backend.Snapshots = append(s.backend.Snapshots, snapshot)
 
 	tasksets, err = s.mgr.RefreshMany(s.ctx, s.project, []workshopstate.Manifest{current}, []workshopstate.Manifest{latest}, conflict.RefreshUpdate)

--- a/internal/testutil/base.go
+++ b/internal/testutil/base.go
@@ -65,7 +65,7 @@ func backupMockables(mockablesByPtr []any) (backup []*reflect.Value) {
 	for i, ptr := range mockablesByPtr {
 		mockedPtr := reflect.ValueOf(ptr)
 
-		if mockedPtr.Type().Kind() != reflect.Ptr {
+		if mockedPtr.Type().Kind() != reflect.Pointer {
 			panic("Backup: each mockable must be passed by pointer!")
 		}
 

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -51,6 +51,7 @@ var (
 	ErrVolumeNotFound        = errors.New("volume not found")
 	ErrVolumeAlreadyExists   = errors.New("volume already exists")
 	ErrVolumeInUse           = errors.New("volume is in use")
+	ErrSnapshotNotFound      = errors.New("snapshot not found")
 	ErrSnapshotAlreadyExists = errors.New("snapshot already exists")
 	ErrSdkProfileNotFound    = errors.New("sdk profile not found")
 	ErrIncompatibleBackend   = errors.New("incompatible backend")
@@ -122,6 +123,18 @@ func (s Snapshot) Equal(other Snapshot) bool {
 	return s.Format == other.Format && s.Image == other.Image && slices.Equal(s.Sdks, other.Sdks)
 }
 
+// IsBasedOn returns true if other is a prefix of s.
+func (s Snapshot) IsBasedOn(other Snapshot) bool {
+	if s.Format != other.Format || s.Image != other.Image {
+		return false
+	}
+	if len(s.Sdks) < len(other.Sdks) {
+		return false
+	}
+	s.Sdks = s.Sdks[:len(other.Sdks)]
+	return slices.Equal(s.Sdks, other.Sdks)
+}
+
 // BaseOnly identifies a "snapshot" which consists of a base image only.
 func BaseOnly(format sdk.Revision, name, fingerprint string) Snapshot {
 	return Snapshot{Format: format, Image: BaseImage{Name: name, Fingerprint: fingerprint}}
@@ -140,6 +153,12 @@ func SdkSnapshot(format sdk.Revision, image BaseImage, sdks []sdk.Setup) Snapsho
 // IsBase returns whether the snapshot is just a base image.
 func (s Snapshot) IsBase() bool {
 	return len(s.Sdks) == 0
+}
+
+type SnapshotInfo struct {
+	Snapshot
+	// Project ID / Workshop pairs that are based on the snapshot.
+	Workshops map[string][]string
 }
 
 type SdkManager interface {
@@ -216,8 +235,11 @@ type Backend interface {
 	// Number representing workshop and snapshot compatibility level.
 	FormatRevision() sdk.Revision
 
-	// Check if the given snapshot already exists.
-	HasSnapshot(ctx context.Context, snapshot Snapshot) (bool, error)
+	// Look up the given snapshot. On success, returns the given snapshot and
+	// the workshops that are based on it. On failure, returns an error. In the
+	// unlikely event the error is caused by a snapshot conflict (i.e. a name
+	// collision), also returns the conflicting snapshot.
+	Snapshot(ctx context.Context, snapshot Snapshot) (*SnapshotInfo, error)
 
 	// Launch a clean workshop instance. If the workshop exists, wipe out
 	// its rootfs and rebuild it from the given snapshot (which may be just

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -113,23 +113,24 @@ type BaseImageManager interface {
 // backend-specific details. For example snapshot names in LXD are subject to
 // length limits and a restricted character set.
 type Snapshot struct {
-	Image BaseImage
-	Sdks  []sdk.ContentID
+	Format sdk.Revision
+	Image  BaseImage
+	Sdks   []sdk.ContentID
 }
 
 func (s Snapshot) Equal(other Snapshot) bool {
-	return s.Image == other.Image && slices.Equal(s.Sdks, other.Sdks)
+	return s.Format == other.Format && s.Image == other.Image && slices.Equal(s.Sdks, other.Sdks)
 }
 
 // BaseOnly identifies a "snapshot" which consists of a base image only.
-func BaseOnly(name, fingerprint string) Snapshot {
-	return Snapshot{Image: BaseImage{Name: name, Fingerprint: fingerprint}}
+func BaseOnly(format sdk.Revision, name, fingerprint string) Snapshot {
+	return Snapshot{Format: format, Image: BaseImage{Name: name, Fingerprint: fingerprint}}
 }
 
 // SdkSnapshot identifies a snapshot consisting of a base image and a sequence
 // of installed SDKs.
-func SdkSnapshot(image BaseImage, sdks []sdk.Setup) Snapshot {
-	snapshot := Snapshot{Image: image, Sdks: make([]sdk.ContentID, 0, len(sdks))}
+func SdkSnapshot(format sdk.Revision, image BaseImage, sdks []sdk.Setup) Snapshot {
+	snapshot := Snapshot{Format: format, Image: image, Sdks: make([]sdk.ContentID, 0, len(sdks))}
 	for _, s := range sdks {
 		snapshot.Sdks = append(snapshot.Sdks, sdk.SetupContentID(s))
 	}
@@ -211,6 +212,9 @@ type Backend interface {
 
 	// Returns a list of workshops for the project in context.
 	ProjectWorkshops(ctx context.Context) ([]*Workshop, error)
+
+	// Number representing workshop and snapshot compatibility level.
+	FormatRevision() sdk.Revision
 
 	// Check if the given snapshot already exists.
 	HasSnapshot(ctx context.Context, snapshot Snapshot) (bool, error)

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -73,6 +73,9 @@ func (e *ErrExec) Error() string {
 }
 
 type Stash interface {
+	// Loads a stashed workshop instance.
+	StashedWorkshop(ctx context.Context, name string) (*Workshop, error)
+
 	// Make a stash of the workshop. The workshop will be stopped and will not
 	// be available to other workshop operations, e.g. list, stop, start and so
 	// on. A new workshop with the same name can be launched for the same

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -133,6 +133,7 @@ type FakeWorkshopBackend struct {
 	SnapshotCalls        []SnapshotCall
 	SnapshotCallback     func(ctx context.Context, name string, snapshot workshop.Snapshot) error
 	Snapshots            []FakeSnapshot
+	RemovedSnapshots     []workshop.Snapshot
 
 	BaseDir     string
 	SnapshotDir string
@@ -267,6 +268,7 @@ func (f *FakeWorkshopBackend) resetWorkshop(ctx context.Context, file *workshop.
 			Profiles: map[string]workshop.SdkProfile{},
 		}
 		ws.Devices = map[string]map[string]string{}
+		ws.CurrentSnapshot = snapshot
 		return nil
 	}
 
@@ -951,6 +953,8 @@ func (f *FakeWorkshopBackend) RemoveSnapshot(ctx context.Context, snapshot works
 	defer f.snapshotLock.Unlock()
 
 	if idx := f.snapshotIdx(snapshot); idx >= 0 {
+		f.RemovedSnapshots = append(f.RemovedSnapshots, snapshot)
+
 		snapId := f.Snapshots[idx].Id
 		f.Snapshots = slices.Delete(f.Snapshots, idx, idx+1)
 		return os.RemoveAll(filepath.Join(f.SnapshotDir, fmt.Sprint(snapId)))

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -46,6 +46,7 @@ type FakeWorkshop struct {
 	*workshop.Workshop
 	Devices            map[string]map[string]string
 	WorkshopFilesystem fsutil.Fs
+	CurrentSnapshot    workshop.Snapshot
 }
 
 type FakeVolume struct {
@@ -293,6 +294,7 @@ func (f *FakeWorkshopBackend) resetWorkshop(ctx context.Context, file *workshop.
 	ws.File = file
 	ws.Format = f.FormatRevision()
 	ws.Image = snapshot.Image
+	ws.CurrentSnapshot = snapshot
 	return nil
 }
 
@@ -841,11 +843,38 @@ func (f *FakeWorkshopBackend) SetFormatRevision(format sdk.Revision) func() {
 	return func() { f.formatRevision = old }
 }
 
-func (f *FakeWorkshopBackend) HasSnapshot(ctx context.Context, snapshot workshop.Snapshot) (bool, error) {
+func (f *FakeWorkshopBackend) Snapshot(ctx context.Context, snapshot workshop.Snapshot) (*workshop.SnapshotInfo, error) {
 	f.snapshotLock.Lock()
-	defer f.snapshotLock.Unlock()
+	idx := f.snapshotIdx(snapshot)
+	f.snapshotLock.Unlock()
+	if idx < 0 {
+		return nil, workshop.ErrSnapshotNotFound
+	}
 
-	return f.snapshotIdx(snapshot) >= 0, nil
+	f.workshopLock.Lock()
+	defer f.workshopLock.Unlock()
+
+	workshops := make(map[string][]string)
+	for pid, wps := range f.Workshops {
+		for name, wp := range wps {
+			if wp.CurrentSnapshot.IsBasedOn(snapshot) {
+				workshops[pid] = append(workshops[pid], name)
+			}
+		}
+	}
+	for pid, wps := range f.StashedWorkshops {
+		for name, wp := range wps {
+			name = strings.TrimPrefix(name, "stash-")
+			if slices.Contains(workshops[pid], name) {
+				continue
+			}
+
+			if wp.CurrentSnapshot.IsBasedOn(snapshot) {
+				workshops[pid] = append(workshops[pid], name)
+			}
+		}
+	}
+	return &workshop.SnapshotInfo{Snapshot: snapshot, Workshops: workshops}, nil
 }
 
 func (f *FakeWorkshopBackend) TakeSnapshot(ctx context.Context, name string, snapshot workshop.Snapshot) error {
@@ -858,6 +887,19 @@ func (f *FakeWorkshopBackend) TakeSnapshot(ctx context.Context, name string, sna
 	if err != nil {
 		return err
 	}
+
+	_, projectId, err := f.userProject(ctx)
+	if err != nil {
+		return err
+	}
+
+	f.workshopLock.Lock()
+	wp := f.Workshops[projectId][name]
+	f.workshopLock.Unlock()
+	if wp == nil {
+		return workshop.ErrWorkshopNotLaunched
+	}
+	wp.CurrentSnapshot = snapshot
 
 	f.snapshotLock.Lock()
 	defer f.snapshotLock.Unlock()

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -125,6 +125,8 @@ type FakeWorkshopBackend struct {
 
 	AttachVolumeCalls []AttachVolumeCall
 
+	formatRevision sdk.Revision
+
 	snapshotLock         sync.Mutex
 	LaunchOrRebuildCalls []LaunchOrRebuildCall
 	SnapshotCalls        []SnapshotCall
@@ -257,6 +259,7 @@ func (f *FakeWorkshopBackend) resetWorkshop(ctx context.Context, file *workshop.
 			Name:     file.Name,
 			Running:  false,
 			Project:  *prj,
+			Format:   f.FormatRevision(),
 			Image:    snapshot.Image,
 			File:     file,
 			Sdks:     map[string]workshop.SdkInstallation{},
@@ -288,6 +291,7 @@ func (f *FakeWorkshopBackend) resetWorkshop(ctx context.Context, file *workshop.
 	}
 
 	ws.File = file
+	ws.Format = f.FormatRevision()
 	ws.Image = snapshot.Image
 	return nil
 }
@@ -822,6 +826,19 @@ func (s *FakeWorkshopBackend) detachVolume(ctx context.Context, name, what, wher
 	volume.Mounts = slices.Delete(volume.Mounts, idx, idx+1)
 	s.Volumes[what] = volume
 	return err
+}
+
+func (f *FakeWorkshopBackend) FormatRevision() sdk.Revision {
+	if f.formatRevision.Unset() {
+		return sdk.R(1)
+	}
+	return f.formatRevision
+}
+
+func (f *FakeWorkshopBackend) SetFormatRevision(format sdk.Revision) func() {
+	old := f.formatRevision
+	f.formatRevision = format
+	return func() { f.formatRevision = old }
 }
 
 func (f *FakeWorkshopBackend) HasSnapshot(ctx context.Context, snapshot workshop.Snapshot) (bool, error) {

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -498,6 +498,27 @@ func DoExecDefault(ctx context.Context, name string, args *workshop.Execution) (
 	}, nil
 }
 
+func (s *FakeWorkshopBackend) StashedWorkshop(ctx context.Context, name string) (*workshop.Workshop, error) {
+	user, projectId, err := s.userProject(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	project := s.project(user, projectId)
+	if project == nil {
+		return nil, api.StatusErrorf(404, "project not found")
+	}
+
+	s.workshopLock.Lock()
+	defer s.workshopLock.Unlock()
+
+	wp := s.StashedWorkshops[projectId]["stash-"+name]
+	if wp == nil {
+		return nil, workshop.ErrWorkshopNotLaunched
+	}
+	return wp.Workshop, nil
+}
+
 func (s *FakeWorkshopBackend) RemoveWorkshopStash(ctx context.Context, name string) error {
 	_, projectId, err := s.userProject(ctx)
 	if err != nil {

--- a/internal/workshop/lxd/export_test.go
+++ b/internal/workshop/lxd/export_test.go
@@ -38,11 +38,3 @@ var (
 	CauseDocker          = causeDocker
 	CauseUFW             = causeUFW
 )
-
-func MockNvidiaRuntime(f func() (bool, error)) func() {
-	old := checkNvidiaRuntime
-	checkNvidiaRuntime = f
-	return func() {
-		checkNvidiaRuntime = old
-	}
-}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -38,6 +38,7 @@ import (
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/revert"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/syscheck"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -318,7 +319,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		return err
 	}
 
-	config, err := s.workshopConfig(projectId, usr.Uid, usr.Gid, file, snapshot.Image.Fingerprint)
+	config, err := s.workshopConfig(projectId, usr.Uid, usr.Gid, file, snapshot.Format, snapshot.Image.Fingerprint)
 	if err != nil {
 		return err
 	}
@@ -792,6 +793,11 @@ func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p wo
 		return nil, fmt.Errorf("cannot load workshop: %v", err)
 	}
 
+	format, err := sdk.ParseRevision(inst.Config[workshop.ConfigWorkshopSnapshotFormat])
+	if err != nil {
+		return nil, err
+	}
+
 	image := workshop.BaseImage{
 		Name:        f.Base,
 		Fingerprint: inst.Config[workshop.ConfigWorkshopBaseFingerprint],
@@ -825,6 +831,7 @@ func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p wo
 		Backend:  b,
 		Project:  p,
 		Name:     f.Name,
+		Format:   format,
 		Image:    image,
 		Running:  inst.StatusCode == api.Running || inst.StatusCode == api.Ready,
 		Sdks:     sdks,
@@ -1019,7 +1026,7 @@ func checkUseLegacyNvidia() (bool, error) {
 	return legacyNvidia, nil
 }
 
-func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File, baseFingerprint string) (map[string]string, error) {
+func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File, format sdk.Revision, baseFingerprint string) (map[string]string, error) {
 	cloudInitConfig := `#cloud-config
 users:
   - default
@@ -1086,7 +1093,7 @@ runcmd:
 		"security.nesting":               "true",
 		"user.user-data":                 cloudInitConfig,
 		"user.network-config":            cloudInitNetwork,
-		"user.workshop.format-revision":  SnapshotFormatRevision.String(),
+		"user.workshop.format-revision":  format.String(),
 		"user.workshop.project-id":       projectId,
 		"user.workshop.name":             file.Name,
 		"user.workshop.file":             string(f),

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -138,7 +138,7 @@ To restart the workshop daemon: 'sudo snap restart workshop'`, err)
 
 func checkVersion(version string) error {
 	const minimalLXDMajor = 6
-	const minimalLXDMinor = 6
+	const minimalLXDMinor = 8
 
 	comps := strings.Split(version, ".")
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -740,6 +740,10 @@ func (s *Backend) Workshop(ctx context.Context, name string) (*workshop.Workshop
 	}
 	defer conn.Disconnect()
 
+	return s.workshop(ctx, conn, name, false)
+}
+
+func (s *Backend) workshop(ctx context.Context, conn lxd.InstanceServer, name string, stash bool) (*workshop.Workshop, error) {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return nil, fmt.Errorf("context key project-id not found")
@@ -761,7 +765,14 @@ func (s *Backend) Workshop(ctx context.Context, name string) (*workshop.Workshop
 	}
 	p := projects[user][idx]
 
-	inst, _, err := conn.GetInstance(InstanceName(name, projectId))
+	var instName string
+	if stash {
+		instName = instanceStashName(name, projectId)
+	} else {
+		instName = InstanceName(name, projectId)
+	}
+
+	inst, _, err := conn.GetInstance(instName)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return nil, workshop.ErrWorkshopNotLaunched

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -56,7 +56,6 @@ const (
 )
 
 var (
-	checkNvidiaRuntime  = checkUseLegacyNvidia
 	startCommandTimeout = 1 * time.Minute
 	storagePoolDriver   = "zfs"
 )
@@ -1009,34 +1008,6 @@ func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
 	return device
 }
 
-func checkUseLegacyNvidia() (bool, error) {
-	conn, err := lxd.ConnectLXDUnix("", nil)
-	if err != nil {
-		return false, ErrorLxdBackend(err)
-	}
-	defer conn.Disconnect()
-
-	if conn.HasExtension("gpu_cdi") && conn.HasExtension("gpu_cdi_amd") && conn.HasExtension("gpu_cdi_hotplug") {
-		return false, nil
-	}
-
-	resources, err := conn.GetServerResources()
-	if err != nil {
-		return false, err
-	}
-
-	// Check if nvidia card(s) are present as this requires additional
-	// configuration for the GPU interfaces runtime passthrough.
-	legacyNvidia := false
-	for _, card := range resources.GPU.Cards {
-		if card.Nvidia != nil {
-			legacyNvidia = true
-			break
-		}
-	}
-	return legacyNvidia, nil
-}
-
 func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File, format sdk.Revision, baseFingerprint string) (map[string]string, error) {
 	cloudInitConfig := `#cloud-config
 users:
@@ -1117,18 +1088,6 @@ runcmd:
 		"raw.lxc": "lxc.mount.entry = tmpfs tmp tmpfs defaults",
 	}
 
-	// TODO: Remove when switched to LXD 6.8
-	legacyNvidia, err := checkNvidiaRuntime()
-	if err != nil {
-		return nil, err
-	}
-
-	// nvidia.* properties must be set at launch as otherwise it requires a
-	// container restart to take effect.
-	if legacyNvidia {
-		cfg["nvidia.driver.capabilities"] = "all"
-		cfg["nvidia.runtime"] = "true"
-	}
 	return cfg, nil
 }
 

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -729,6 +729,9 @@ func (s *Backend) RemoveSnapshot(ctx context.Context, snapshot workshop.Snapshot
 		return fmt.Errorf("internal error: hashing snapshot info: %w", err)
 	}
 
+	// For completeness we should probably check for collisions here. But if
+	// the given snapshot is being removed, it was recently part of a workshop
+	// and we already checked for collisions on launch.
 	return s.deleteSnapshot(snapshotConn, sdkSnapshotName(snapshot, digest))
 }
 

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -124,29 +124,29 @@ func optionDomain(key string) configDomain {
 	}
 }
 
-func (s *Backend) HasSnapshot(ctx context.Context, snapshot workshop.Snapshot) (bool, error) {
+func (s *Backend) Snapshot(ctx context.Context, snapshot workshop.Snapshot) (*workshop.SnapshotInfo, error) {
 	if snapshot.IsBase() {
-		return false, errors.New("internal error: snapshots require at least one SDK")
+		return nil, errors.New("internal error: snapshots require at least one SDK")
 	}
 
 	conn, snapshotConn, err := s.snapshotClients(ctx)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	defer conn.Disconnect()
 
 	digest, err := s.HashSnapshot(snapshot)
 	if err != nil {
-		return false, fmt.Errorf("internal error: hashing snapshot info: %w", err)
+		return nil, fmt.Errorf("internal error: hashing snapshot info: %w", err)
 	}
 
 	name := sdkSnapshotName(snapshot, digest)
 	inst, _, err := snapshotConn.GetInstance(name)
 	if api.StatusErrorCheck(err, http.StatusNotFound) {
-		return false, nil
+		return nil, workshop.ErrSnapshotNotFound
 	}
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	// Check for in-progress snapshots. In this case we could wait for it to
@@ -155,24 +155,60 @@ func (s *Backend) HasSnapshot(ctx context.Context, snapshot workshop.Snapshot) (
 	// should coordinate their snapshots, not just those which happen to call
 	// HasSnapshot and TakeSnapshot at the same time.
 	if inst.Config[workshop.ConfigWorkshopSnapshotType] != "sdk" {
-		return false, nil
+		return nil, workshop.ErrSnapshotNotFound
 	}
 
-	if err := detectHashCollision(inst, snapshot); err != nil {
-		return false, err
+	other, err := detectHashCollision(inst, snapshot)
+	if err != nil {
+		if other == nil {
+			return nil, err
+		}
+		return &workshop.SnapshotInfo{Snapshot: *other}, err
 	}
-	return true, nil
+
+	workshops := map[string][]string{}
+
+	usedBy, err := conn.GetInstances(lxd.GetInstancesArgs{
+		InstanceType: api.InstanceTypeContainer,
+		Filters:      []string{fmt.Sprintf("config.user.workshop.snapshot-%v=%s", len(snapshot.Sdks), name)},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, inst := range usedBy {
+		projectId := inst.Config[workshop.ConfigProjectId]
+		name := inst.Config[workshop.ConfigWorkshopName]
+		workshops[projectId] = append(workshops[projectId], name)
+	}
+
+	// Check for stashed workshops as well.
+	usedBy, err = snapshotConn.GetInstances(lxd.GetInstancesArgs{
+		InstanceType: api.InstanceTypeContainer,
+		Filters:      []string{fmt.Sprintf("config.user.workshop.snapshot-%v=%s", len(snapshot.Sdks), name)},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, inst := range usedBy {
+		projectId := inst.Config[workshop.ConfigProjectId]
+		name := inst.Config[workshop.ConfigWorkshopName]
+		if !slices.Contains(workshops[projectId], name) {
+			workshops[projectId] = append(workshops[projectId], name)
+		}
+	}
+
+	return &workshop.SnapshotInfo{Snapshot: snapshot, Workshops: workshops}, nil
 }
 
-func detectHashCollision(inst *api.Instance, snapshot workshop.Snapshot) error {
+func detectHashCollision(inst *api.Instance, snapshot workshop.Snapshot) (*workshop.Snapshot, error) {
 	saved, err := identifySnapshot(inst)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := compareSnapshots(inst.Name, *saved, snapshot); err != nil {
-		return fmt.Errorf("hash collision detected: %w", err)
+		return saved, fmt.Errorf("hash collision detected: %w", err)
 	}
-	return nil
+	return saved, nil
 }
 
 func identifySnapshot(inst *api.Instance) (*workshop.Snapshot, error) {
@@ -273,11 +309,23 @@ func (s *Backend) TakeSnapshot(ctx context.Context, name string, snapshot worksh
 	}
 	defer conn.Disconnect()
 
-	inst, _, err := conn.GetInstance(InstanceName(name, projectId))
+	inst, etag, err := conn.GetInstance(InstanceName(name, projectId))
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return workshop.ErrWorkshopNotLaunched
 		}
+		return err
+	}
+
+	// Mark the snapshot as "in use" by this workshop. This can be done when
+	// installing the SDK to avoid an extra UpdateInstance, but is easier to do
+	// here since we already know the snapshot name.
+	inst.Config[fmt.Sprintf("user.workshop.snapshot-%v", len(snapshot.Sdks))] = snapshotName
+	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
+	if err != nil {
+		return err
+	}
+	if err := op.Wait(); err != nil {
 		return err
 	}
 
@@ -453,7 +501,7 @@ func (s *Backend) checkPartialSnapshot(snapshotConn lxd.InstanceServer, snapshot
 		return err
 	}
 
-	if err := detectHashCollision(inst, snapshot); err != nil {
+	if _, err := detectHashCollision(inst, snapshot); err != nil {
 		return err
 	}
 	return workshop.ErrSnapshotAlreadyExists
@@ -516,6 +564,22 @@ func (s *Backend) launchOrRebuildFromSnapshot(conn, snapshotConn lxd.InstanceSer
 		inst = &api.Instance{}
 	} else if err != nil {
 		return err
+	}
+
+	if req.Config == nil {
+		req.Config = make(map[string]string, len(snapshot.Sdks))
+	} else {
+		req.Config = maps.Clone(req.Config)
+	}
+	for i := range snapshot.Sdks {
+		partial := snapshot
+		partial.Sdks = partial.Sdks[:i+1]
+
+		digest, err := s.HashSnapshot(partial)
+		if err != nil {
+			return err
+		}
+		req.Config[fmt.Sprintf("user.workshop.snapshot-%v", i+1)] = sdkSnapshotName(partial, digest)
 	}
 
 	newApi := conn.HasExtension("instance_refresh_config")

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -165,9 +165,6 @@ func (s *Backend) HasSnapshot(ctx context.Context, snapshot workshop.Snapshot) (
 }
 
 func detectHashCollision(inst *api.Instance, snapshot workshop.Snapshot) error {
-	if inst.Config[workshop.ConfigWorkshopSnapshotFormat] != SnapshotFormatRevision.String() {
-		return fmt.Errorf("hash collision detected: %q snapshot taken by incompatible Workshop version", inst.Name)
-	}
 	saved, err := identifySnapshot(inst)
 	if err != nil {
 		return err
@@ -179,6 +176,11 @@ func detectHashCollision(inst *api.Instance, snapshot workshop.Snapshot) error {
 }
 
 func identifySnapshot(inst *api.Instance) (*workshop.Snapshot, error) {
+	format, err := sdk.ParseRevision(inst.Config[workshop.ConfigWorkshopSnapshotFormat])
+	if err != nil {
+		return nil, err
+	}
+
 	sdks := make([]sdk.ContentID, len(inst.Devices))
 	length := 0
 	maxInstallOrder := 0
@@ -207,6 +209,7 @@ func identifySnapshot(inst *api.Instance) (*workshop.Snapshot, error) {
 	}
 
 	return &workshop.Snapshot{
+		Format: format,
 		Image: workshop.BaseImage{
 			Name:        inst.Config[workshop.ConfigWorkshopBase],
 			Fingerprint: inst.Config[workshop.ConfigWorkshopBaseFingerprint],
@@ -217,6 +220,9 @@ func identifySnapshot(inst *api.Instance) (*workshop.Snapshot, error) {
 
 // compareSnapshots is like reflect.DeepEqual with specific error messages.
 func compareSnapshots(name string, actual, expected workshop.Snapshot) error {
+	if actual.Format != expected.Format {
+		return fmt.Errorf("%q snapshot has format revision %s; required: %s", name, actual.Format, expected.Format)
+	}
 	if actual.Image.Name != expected.Image.Name {
 		return fmt.Errorf("%q snapshot has %q base; required: %q", name, actual.Image.Name, expected.Image.Name)
 	}
@@ -282,9 +288,9 @@ func (s *Backend) TakeSnapshot(ctx context.Context, name string, snapshot worksh
 	}
 	config := map[string]string{
 		"security.protection.start":            "true",
+		workshop.ConfigWorkshopSnapshotFormat:  snapshot.Format.String(),
 		workshop.ConfigWorkshopBase:            snapshot.Image.Name,
 		workshop.ConfigWorkshopBaseFingerprint: snapshot.Image.Fingerprint,
-		workshop.ConfigWorkshopSnapshotFormat:  SnapshotFormatRevision.String(),
 		workshop.ConfigWorkshopSha3_384:        digest,
 	}
 	mergeConfig(inst.Config, nil, config, newApi)
@@ -859,8 +865,22 @@ func (s *Backend) snapshotClients(ctx context.Context) (lxd.InstanceServer, lxd.
 // - SDK config and devices (e.g. volume mounts)
 // - Direct modifications (e.g. mkdir /var/lib/workshop/run)
 // If something like this changes, bump the revision number so that workshops
-// constructed using the next release of Workshop see the changes.
-var SnapshotFormatRevision = sdk.R(1)
+// constructed using the next release of Workshop are updated on refresh.
+//
+// Some care needs to be taken with workshops using the old format. If a launch
+// or refresh is in progress, it should either continue in a manner consistent
+// with the old format, or fail if that isn't possible for some reason. For
+// example, after changing the format of installed SDKs, the install-sdk task
+// should either use a format consistent with the target workshop, or fail for
+// workshops stuck on the old format.
+//
+// Another issue is the restore command. In most cases this simply rebuilds
+// from the last snapshot, but if that snapshot doesn't exist then it will
+// replay some of the install-sdk and setup-base tasks. These can be handled in
+// the same way as in-progress launches and refreshes.
+func (s *Backend) FormatRevision() sdk.Revision {
+	return sdk.R(1)
+}
 
 func (s *Backend) HashSnapshot(snapshot workshop.Snapshot) (string, error) {
 	digest, err := hex.DecodeString(snapshot.Image.Fingerprint)
@@ -869,7 +889,7 @@ func (s *Backend) HashSnapshot(snapshot workshop.Snapshot) (string, error) {
 	}
 
 	hash := sha3.New384()
-	if _, err := fmt.Fprintf(hash, "%s %s\x00%s", SnapshotFormatRevision, snapshot.Image.Name, digest); err != nil {
+	if _, err := fmt.Fprintf(hash, "%s %s\x00%s", snapshot.Format, snapshot.Image.Name, digest); err != nil {
 		return "", err
 	}
 

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -732,6 +732,16 @@ func (s *Backend) RemoveSnapshot(ctx context.Context, snapshot workshop.Snapshot
 	return s.deleteSnapshot(snapshotConn, sdkSnapshotName(snapshot, digest))
 }
 
+func (s *Backend) StashedWorkshop(ctx context.Context, name string) (*workshop.Workshop, error) {
+	conn, snapshotConn, err := s.snapshotClients(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Disconnect()
+
+	return s.workshop(ctx, snapshotConn, name, true)
+}
+
 func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -329,8 +329,6 @@ func (s *Backend) TakeSnapshot(ctx context.Context, name string, snapshot worksh
 		return err
 	}
 
-	newApi := snapshotConn.HasExtension("instance_refresh_config")
-
 	if inst.Config == nil {
 		inst.Config = map[string]string{}
 	}
@@ -341,13 +339,12 @@ func (s *Backend) TakeSnapshot(ctx context.Context, name string, snapshot worksh
 		workshop.ConfigWorkshopBaseFingerprint: snapshot.Image.Fingerprint,
 		workshop.ConfigWorkshopSha3_384:        digest,
 	}
-	mergeConfig(inst.Config, nil, config, newApi)
+	mergeConfig(inst.Config, nil, config)
 
-	promote := storagePoolDriver == "zfs" && snapshotConn.HasExtension("storage_zfs_promote")
 	if inst.Devices == nil {
 		inst.Devices = map[string]map[string]string{}
 	}
-	if err := mergeDevices(inst.Devices, snapshot.Sdks, name, newApi, promote); err != nil {
+	if err := mergeDevices(inst.Devices, snapshot.Sdks, name); err != nil {
 		return err
 	}
 
@@ -582,19 +579,10 @@ func (s *Backend) launchOrRebuildFromSnapshot(conn, snapshotConn lxd.InstanceSer
 		req.Config[fmt.Sprintf("user.workshop.snapshot-%v", i+1)] = sdkSnapshotName(partial, digest)
 	}
 
-	newApi := conn.HasExtension("instance_refresh_config")
-
 	if source.Config == nil {
 		source.Config = map[string]string{}
 	}
-	var sourceConfig, reqConfig map[string]string
-	if !newApi {
-		// The old API handles config options inconsistently. This
-		// computes the form required for UpdateInstance.
-		sourceConfig = maps.Clone(source.Config)
-		reqConfig = req.Config
-	}
-	mergeConfig(source.Config, inst.Config, req.Config, newApi)
+	mergeConfig(source.Config, inst.Config, req.Config)
 
 	req.Architecture = source.Architecture
 	req.Config = source.Config
@@ -617,28 +605,7 @@ func (s *Backend) launchOrRebuildFromSnapshot(conn, snapshotConn lxd.InstanceSer
 		return err
 	}
 
-	if newApi {
-		return nil
-	}
-
-	var etag string
-	if inst.Name == "" {
-		inst, etag, err = conn.GetInstance(req.Name)
-		if err != nil {
-			return err
-		}
-	}
-
-	// If the workshop already existed, it still has the old config options
-	// and devices. If it did not exist, the config and devices are mostly
-	// correct, but we still need to remove placeholder SDK devices.
-	mergeConfig(sourceConfig, inst.Config, reqConfig, true)
-	req.Config = sourceConfig
-	op, err := conn.UpdateInstance(req.Name, req.InstancePut, etag)
-	if err != nil {
-		return err
-	}
-	return op.Wait()
+	return nil
 }
 
 // Hash is truncated to 16 hex digits to remain within the 63 characters
@@ -648,21 +615,10 @@ func sdkSnapshotName(snapshot workshop.Snapshot, digest string) string {
 	return sk + "-" + digest[:16]
 }
 
-func mergeConfig(source, target, config map[string]string, newApi bool) {
-	if newApi {
-		maps.DeleteFunc(source, func(k, v string) bool {
-			return optionDomain(k) != sharedProperty
-		})
-	} else {
-		// Omit options managed by LXD, to let it decide what to do.
-		maps.DeleteFunc(source, func(k, v string) bool {
-			return optionDomain(k) != customOption
-		})
-		// Tell LXD to remove all custom options.
-		for k := range source {
-			source[k] = ""
-		}
-	}
+func mergeConfig(source, target, config map[string]string) {
+	maps.DeleteFunc(source, func(k, v string) bool {
+		return optionDomain(k) != sharedProperty
+	})
 
 	for k, v := range target {
 		if optionDomain(k) == uniqueProperty {
@@ -673,31 +629,12 @@ func mergeConfig(source, target, config map[string]string, newApi bool) {
 	maps.Copy(source, config)
 }
 
-func mergeDevices(source map[string]map[string]string, sdks []sdk.ContentID, w string, newApi, promote bool) error {
-	if newApi {
-		maps.DeleteFunc(source, func(k string, v map[string]string) bool {
-			return k != "root"
-		})
-	} else {
-		none := map[string]string{"type": "none"}
-		for key, device := range source {
-			s, err := maybeSdkInstallation(key, device)
-			if err != nil {
-				return err
-			}
-			if s != nil {
-				idx := s.InstallOrder - 1
-				if idx < 0 || len(sdks) <= idx || sdks[idx].Name != s.Name {
-					return fmt.Errorf("internal error: %q workshop has unexpected %q SDK", w, s.Name)
-				}
-				delete(source, key)
-			} else if key != "root" {
-				source[key] = none
-			}
-		}
-	}
+func mergeDevices(source map[string]map[string]string, sdks []sdk.ContentID, w string) error {
+	maps.DeleteFunc(source, func(k string, v map[string]string) bool {
+		return k != "root"
+	})
 
-	if promote {
+	if storagePoolDriver == "zfs" {
 		root := maps.Clone(source["root"])
 		if source == nil || root == nil {
 			return fmt.Errorf("internal error: %q workshop has no rootfs", w)
@@ -836,19 +773,9 @@ func (s *Backend) copyInstance(src, dst lxd.InstanceServer, srcName, dstName str
 		}
 	}
 
-	newApi := dst.HasExtension("instance_refresh_config")
-
 	req := *srcInst
-	if !newApi {
-		// Set the config and device overrides. LXD will copy most other
-		// options from the source instance, but it will omit options which are
-		// unique to the source instance, like MAC addresses and UUIDs.
-		req.Config = config
-		req.Devices = nil
-	}
 
-	promote := storagePoolDriver == "zfs" && dst.HasExtension("storage_zfs_promote")
-	if promote {
+	if storagePoolDriver == "zfs" {
 		req.Devices = maps.Clone(req.Devices)
 		root := maps.Clone(req.Devices["root"])
 		if req.Devices == nil || root == nil {
@@ -871,21 +798,7 @@ func (s *Backend) copyInstance(src, dst lxd.InstanceServer, srcName, dstName str
 		return err
 	}
 
-	if newApi || dstInst.Name == "" {
-		// LXD created a new instance with copied config and devices.
-		return nil
-	}
-
-	// Otherwise, LXD replaced an existing instance's root disk, and it's
-	// our job to copy the config and devices.
-	req.Config = srcInst.Config
-	req.Devices = srcInst.Devices
-
-	op, err := dst.UpdateInstance(dstName, req.Writable(), "")
-	if err != nil {
-		return err
-	}
-	return op.Wait()
+	return nil
 }
 
 func (s *Backend) RemoveWorkshopStash(ctx context.Context, name string) error {

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -98,7 +98,7 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 	})
 
 	// Execute
-	cfg, err := lxdbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file, "fakeimage12345")
+	cfg, err := lxdbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file, b.FormatRevision(), "fakeimage12345")
 	defer reset()
 
 	// Validate
@@ -110,6 +110,7 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 	c.Assert(cfg["nvidia.runtime"], check.Equals, "true")
 	c.Assert(cfg["nvidia.driver.capabilities"], check.Equals, "all")
 	c.Assert(cfg["user.workshop.file"], check.Equals, marshalledWorkshop)
+	c.Assert(cfg["user.workshop.format-revision"], check.Equals, b.FormatRevision().String())
 	c.Assert(cfg["user.workshop.base-fingerprint"], check.Equals, "fakeimage12345")
 
 	// Setup
@@ -119,7 +120,7 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 	defer reset()
 
 	// Execute
-	cfg, err = lxdbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file, "")
+	cfg, err = lxdbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file, b.FormatRevision(), "")
 
 	// Validate
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -129,13 +129,13 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 }
 
 func (f *LxdBeTests) TestCheckLxdVersion(c *check.C) {
-	err := lxdbackend.CheckServerVersion("6.6")
+	err := lxdbackend.CheckServerVersion("6.8")
+	c.Assert(err, check.IsNil)
+
+	err = lxdbackend.CheckServerVersion("6.9")
 	c.Assert(err, check.IsNil)
 
 	err = lxdbackend.CheckServerVersion("6.7")
-	c.Assert(err, check.IsNil)
-
-	err = lxdbackend.CheckServerVersion("6.5")
 	c.Assert(err, check.ErrorMatches, ".*LXD server version.*is not supported.*")
 
 	err = lxdbackend.CheckServerVersion("5.9")
@@ -150,9 +150,9 @@ func (f *LxdBeTests) TestCheckLxdVersion(c *check.C) {
 	err = lxdbackend.CheckServerVersion("6.x")
 	c.Assert(err, check.ErrorMatches, ".*cannot parse LXD server version.*")
 
-	err = lxdbackend.CheckServerVersion("6.6.1")
+	err = lxdbackend.CheckServerVersion("6.8.1")
 	c.Assert(err, check.IsNil)
 
-	err = lxdbackend.CheckServerVersion("6.5.9")
+	err = lxdbackend.CheckServerVersion("6.7.9")
 	c.Assert(err, check.ErrorMatches, ".*LXD server version.*is not supported.*")
 }

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -93,39 +93,17 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 		},
 	}
 
-	reset := lxdbackend.MockNvidiaRuntime(func() (bool, error) {
-		return true, nil
-	})
-
 	// Execute
 	cfg, err := lxdbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file, b.FormatRevision(), "fakeimage12345")
-	defer reset()
 
 	// Validate
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg["raw.idmap"], check.Equals, "uid 1001 1000\ngid 1001 1000")
 	c.Assert(cfg["security.nesting"], check.Equals, "true")
 	c.Assert(cfg["user.workshop.project-id"], check.Equals, f.project.ProjectId)
-
-	c.Assert(cfg["nvidia.runtime"], check.Equals, "true")
-	c.Assert(cfg["nvidia.driver.capabilities"], check.Equals, "all")
 	c.Assert(cfg["user.workshop.file"], check.Equals, marshalledWorkshop)
 	c.Assert(cfg["user.workshop.format-revision"], check.Equals, b.FormatRevision().String())
 	c.Assert(cfg["user.workshop.base-fingerprint"], check.Equals, "fakeimage12345")
-
-	// Setup
-	reset = lxdbackend.MockNvidiaRuntime(func() (bool, error) {
-		return false, nil
-	})
-	defer reset()
-
-	// Execute
-	cfg, err = lxdbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file, b.FormatRevision(), "")
-
-	// Validate
-	c.Assert(err, check.IsNil)
-	c.Assert(cfg["nvidia.runtime"], check.Equals, "")
-	c.Assert(cfg["nvidia.driver.capabilities"], check.Equals, "")
 }
 
 func (f *LxdBeTests) TestCheckLxdVersion(c *check.C) {

--- a/internal/workshop/lxd/tests/helper/helper.go
+++ b/internal/workshop/lxd/tests/helper/helper.go
@@ -121,7 +121,7 @@ printf '%s\n' "$@"
 	_, _, err = bd.CreateOrLoadProject(ctx, dir)
 	c.Assert(err, check.IsNil)
 
-	snapshot := workshop.Snapshot{Image: image}
+	snapshot := workshop.BaseOnly(bd.FormatRevision(), image.Name, image.Fingerprint)
 	err = bd.LaunchOrRebuildWorkshop(ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 

--- a/internal/workshop/lxd/tests/integration/snapshot_test.go
+++ b/internal/workshop/lxd/tests/integration/snapshot_test.go
@@ -232,17 +232,6 @@ func (s *snapshotSuite) TestLxdBackendSnapshotFormat(c *check.C) {
 	// Validate snapshot metadata.
 	sdkSnapshot := s.snapshotFormat(c, snapshot)
 
-	conn, err := s.bd.LxdClient(s.ctx)
-	c.Assert(err, check.IsNil)
-	defer conn.Disconnect()
-	newApi := conn.HasExtension("instance_refresh_config")
-	if !newApi {
-		for _, name := range []string{"cache.apt", "workshop.network", "workshop.socket", "workshop.workshopctl"} {
-			c.Check(sdkSnapshot.Devices[name], check.DeepEquals, map[string]string{"type": "none"})
-			delete(sdkSnapshot.Devices, name)
-		}
-	}
-
 	c.Check(sdkSnapshot, testutil.JsonEquals, format["snapshot"])
 }
 

--- a/internal/workshop/lxd/tests/integration/snapshot_test.go
+++ b/internal/workshop/lxd/tests/integration/snapshot_test.go
@@ -162,7 +162,7 @@ func (s *snapshotSuite) TestLxdBackendSnapshotFormat(c *check.C) {
 			{Name: "local-sdk", Source: sdk.ProjectSource},
 		},
 	}
-	snapshot := workshop.Snapshot{Image: image}
+	snapshot := workshop.BaseOnly(s.bd.FormatRevision(), image.Name, image.Fingerprint)
 	rev := s.launchWorkshop(c, wf, snapshot)
 	defer rev.Fail()
 
@@ -275,7 +275,7 @@ func (s *snapshotSuite) workshopFormat(c *check.C, file *workshop.File, snapshot
 	delete(inst.Config, "user.workshop.file")
 
 	// Avoid having to update the saved configs when bumping the revision.
-	c.Check(inst.Config["user.workshop.format-revision"], check.Equals, lxdbackend.SnapshotFormatRevision.String())
+	c.Check(inst.Config["user.workshop.format-revision"], check.Equals, snapshot.Format.String())
 	delete(inst.Config, "user.workshop.format-revision")
 
 	// Hardware-dependent, not much influence on snapshots.
@@ -337,7 +337,7 @@ func (s *snapshotSuite) snapshotFormat(c *check.C, snapshot workshop.Snapshot) a
 	delete(inst.Config, "user.workshop.base-fingerprint")
 
 	// Avoid having to update the saved configs when bumping the revision.
-	c.Check(inst.Config["user.workshop.format-revision"], check.Equals, lxdbackend.SnapshotFormatRevision.String())
+	c.Check(inst.Config["user.workshop.format-revision"], check.Equals, snapshot.Format.String())
 	delete(inst.Config, "user.workshop.format-revision")
 	c.Check(inst.Config["user.workshop.sha3-384"], check.Equals, digest)
 	delete(inst.Config, "user.workshop.sha3-384")
@@ -373,7 +373,7 @@ func (s *snapshotSuite) snapshotDiff(c *check.C, base string) {
 		Name: "test1",
 		Base: base,
 	}
-	baseOnly := workshop.Snapshot{Image: image}
+	baseOnly := workshop.BaseOnly(s.bd.FormatRevision(), image.Name, image.Fingerprint)
 	r := s.launchWorkshop(c, wf1, baseOnly)
 	revert.Copy(rev, r)
 

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -1048,6 +1048,7 @@ func (f *wsOps) TestLxdBackendSnapshotOK(c *check.C) {
 	for i := range 4 {
 		name := fmt.Sprint("test", i+2)
 		args := &lxd.InstanceCopyArgs{Name: lxdbackend.InstanceName(name, f.project.ProjectId)}
+		inst.Config[workshop.ConfigWorkshopName] = name
 		op, err := conn.CopyInstance(conn, *inst, args)
 		c.Assert(err, check.IsNil)
 		c.Assert(op.Wait(), check.IsNil)
@@ -1067,9 +1068,8 @@ func (f *wsOps) TestLxdBackendSnapshotOK(c *check.C) {
 		}},
 	}
 
-	exists, err := f.bd.HasSnapshot(f.ctx, snapshot)
-	c.Assert(err, check.IsNil)
-	c.Check(exists, check.Equals, false)
+	_, err = f.bd.Snapshot(f.ctx, snapshot)
+	c.Check(err, testutil.ErrorIs, workshop.ErrSnapshotNotFound)
 
 	defer func() { _ = f.bd.RemoveSnapshot(f.ctx, snapshot) }()
 	var wg sync.WaitGroup
@@ -1088,9 +1088,13 @@ func (f *wsOps) TestLxdBackendSnapshotOK(c *check.C) {
 				c.Errorf("unexpected error: %v", err)
 			}
 
-			exists, err := f.bd.HasSnapshot(f.ctx, snapshot)
+			info, err := f.bd.Snapshot(f.ctx, snapshot)
 			c.Assert(err, check.IsNil)
-			c.Check(exists, check.Equals, true)
+			c.Check(info.Snapshot, check.DeepEquals, snapshot)
+			workshops := map[string][]string{
+				f.project.ProjectId: {"test", "test2", "test3", "test4", "test5"},
+			}
+			c.Check(info.Workshops, testutil.DeepUnsortedMatches, workshops)
 		})
 	}
 	wg.Wait()
@@ -1266,7 +1270,7 @@ func (f *wsOps) TestLxdBackendSnapshotHashCollision(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(op.Wait(), check.IsNil)
 
-	_, err = f.bd.HasSnapshot(f.ctx, snapshot)
+	_, err = f.bd.Snapshot(f.ctx, snapshot)
 	c.Check(err, check.ErrorMatches, `hash collision detected: "system-.*" snapshot has "ubuntu@22.04" base; required: "ubuntu@24.04"`)
 
 	inst.Config[workshop.ConfigWorkshopBase] = "ubuntu@24.04"

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -157,7 +157,7 @@ func (f *wsOps) TestLxdBackendWorkshopStashUnstash(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
-	snapshot := workshop.Snapshot{Image: image}
+	snapshot := workshop.BaseOnly(f.bd.FormatRevision(), image.Name, image.Fingerprint)
 	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
@@ -829,7 +829,7 @@ func (f *wsOps) TestLxdBackendWorkshopLaunch(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	wf := &workshop.File{Name: "test", Base: "ubuntu@24.04"}
-	snapshot := workshop.Snapshot{Image: image}
+	snapshot := workshop.BaseOnly(f.bd.FormatRevision(), image.Name, image.Fingerprint)
 	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
@@ -862,7 +862,7 @@ func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = f.bd.DownloadBase(f.ctx, image, nil)
 	c.Assert(err, check.IsNil)
-	snapshot := workshop.Snapshot{Image: image}
+	snapshot := workshop.BaseOnly(f.bd.FormatRevision(), image.Name, image.Fingerprint)
 	err = f.bd.LaunchOrRebuildWorkshop(f.ctx, wf, snapshot)
 	c.Assert(err, check.IsNil)
 
@@ -940,7 +940,7 @@ func (f *wsOps) TestLxdBackendWorkshopRestoreResetsSdkConfiguration(c *check.C) 
 	c.Check(info.Meta, check.Equals, saved)
 	c.Check(info.Workshops, check.DeepEquals, map[string][]string{f.project.ProjectId: {"test"}})
 
-	snapshot := workshop.SdkSnapshot(w.Image, []sdk.Setup{meta.Setup})
+	snapshot := workshop.SdkSnapshot(w.Format, w.Image, []sdk.Setup{meta.Setup})
 	err = f.bd.TakeSnapshot(f.ctx, "test", snapshot)
 	c.Assert(err, check.IsNil)
 
@@ -1055,6 +1055,7 @@ func (f *wsOps) TestLxdBackendSnapshotOK(c *check.C) {
 	}
 
 	snapshot := workshop.Snapshot{
+		Format: f.bd.FormatRevision(),
 		Image: workshop.BaseImage{
 			Name:        "ubuntu@24.04",
 			Fingerprint: "0b9429c9855cb158b90159bb818e6f98eab9b5b1260ace11b30ddb936e4f78979abc7cdc5e4e9fad51e3e290a2190ac2",
@@ -1105,6 +1106,7 @@ func (f *wsOps) TestLxdBackendSnapshotConflict(c *check.C) {
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
 	snapshot := workshop.Snapshot{
+		Format: f.bd.FormatRevision(),
 		Image: workshop.BaseImage{
 			Name:        "ubuntu@24.04",
 			Fingerprint: "0b9429c9855cb158b90159bb818e6f98eab9b5b1260ace11b30ddb936e4f78979abc7cdc5e4e9fad51e3e290a2190ac2",
@@ -1186,6 +1188,7 @@ func (f *wsOps) TestLxdBackendSnapshotInterrupted(c *check.C) {
 	snapshotConn := conn.UseProject("workshop-snapshots." + f.usr.Username)
 
 	snapshot := workshop.Snapshot{
+		Format: f.bd.FormatRevision(),
 		Image: workshop.BaseImage{
 			Name:        "ubuntu@24.04",
 			Fingerprint: "0b9429c9855cb158b90159bb818e6f98eab9b5b1260ace11b30ddb936e4f78979abc7cdc5e4e9fad51e3e290a2190ac2",
@@ -1233,6 +1236,7 @@ func (f *wsOps) TestLxdBackendSnapshotHashCollision(c *check.C) {
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
 
 	snapshot := workshop.Snapshot{
+		Format: f.bd.FormatRevision(),
 		Image: workshop.BaseImage{
 			Name:        "ubuntu@24.04",
 			Fingerprint: "0b9429c9855cb158b90159bb818e6f98eab9b5b1260ace11b30ddb936e4f78979abc7cdc5e4e9fad51e3e290a2190ac2",

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	ConfigProjectId               = "user.workshop.project-id"
+	ConfigWorkshopName            = "user.workshop.name"
 	ConfigWorkshopFile            = "user.workshop.file"
 	ConfigWorkshopBase            = "user.workshop.base"
 	ConfigWorkshopBaseFingerprint = "user.workshop.base-fingerprint"

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -50,6 +50,7 @@ type Workshop struct {
 	// file in the project directory due to user's edits, etc.
 	File    *File
 	Name    string
+	Format  sdk.Revision
 	Image   BaseImage
 	Running bool
 	// Installed SDKs.

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -10,7 +10,7 @@ execute: |
   lxd waitready
   snap restart workshop
   ! workshop_exec list > error.log 2>&1 || false
-  MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.6.\*$" < error.log
+  MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.8.\*$" < error.log
 
   snap remove lxd --purge
   setup_lxd


### PR DESCRIPTION
# Description

- Modifies the `state` package to prevent excessive logging when a cleanup handler returns `Retry`.
- Modifies the `state` package to skip retrying cleanup handlers if `Retry.After` has yet to elapse. Currently unused so we can probably drop that commit, maybe revisit later.

- Adds a test to validate a race condition I found in the SDK volume cleanup handler.
- Fixes the race condition by storing a time from *before* uninstalling the SDK, to avoid a small window when the SDK volume is unused but the `Task` has no `ReadyTime`.

- Moves SDK metadata out of `uninstall-sdk` Tasks and into their parent Changes.
- Adds SDK metadata from the stash (if it exists) to `remove` Changes.
- Adds a `handlersetup.Age` type to differentiate the data for Changes with multiple `Manifest`s (`refresh` and `remove`).
- Moves the snapshot format revision into `Manifest`s and `Snapshot`s. Was previously hardcoded, which made it impossible to reference old snapshots.
- Enables tracking of which snapshots a workshop relies on. Implemented using custom LXD config values to make it easy to query.
- Adds a cleanup handler to remove unused snapshots.

- Fixes a minor issue with `Ptr` and recent `golangci-lint` versions.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
