### PR TITLE
Workaround issue with freezing udisks2 on suspend

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -325,6 +325,17 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 		return err
 	}
 
+	fs, err := s.instanceFs(conn, req.Name)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+
+	// Workaround https://github.com/canonical/lxd/issues/17983.
+	if err := fs.RemoveIfExists("/etc/systemd/system/graphical.target.wants/udisks2.service"); err != nil {
+		return err
+	}
+
 	// Ubuntu 20.04 was released before cloud-init added support for LXD. The
 	// current images contain a more recent version of cloud-init, but the
 	// image metadata.yaml contains templated seed data files. See
@@ -339,12 +350,6 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 	// snapshot. There's no way to remove the seed files before starting the
 	// instance for the first time, but we can force cloud-init to use the LXD
 	// data source by adding a config file.
-	fs, err := s.instanceFs(conn, req.Name)
-	if err != nil {
-		return err
-	}
-	defer fs.Close()
-
 	forceLXD := []byte("datasource_list: [LXD]\n")
 	return fs.WriteFile("/etc/cloud/cloud.cfg.d/90_workshop.cfg", forceLXD, 0644)
 }


### PR DESCRIPTION
# Description

See https://github.com/canonical/lxd/issues/17983. Tested with 20.04 and 24.04 workshops so far. The 22.04 image doesn't have udisks2, and suspend works there.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
