### PR TITLE
Add firewall check on the startup

### DIFF
--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -5,19 +5,23 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/canonical/workshop/internal/logger"
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/workshop"
+	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
 )
 
 type WorkshopManager struct {
-	backend workshop.Backend
-	state   *state.State
+	backend         workshop.Backend
+	state           *state.State
+	firewallChecker func(string) string
 }
 
 func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	manager := &WorkshopManager{
-		state: st,
+		state:           st,
+		firewallChecker: lxdbackend.CheckBridgeFirewall,
 	}
 
 	st.Lock()
@@ -43,6 +47,12 @@ func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 }
 
 func (m *WorkshopManager) StartUp() error {
+	if msg := m.firewallChecker(lxdbackend.NetworkBridgeName); msg != "" {
+		logger.Noticef("WARNING: %s", msg)
+		m.state.Lock()
+		m.state.Warnf("%s", msg)
+		m.state.Unlock()
+	}
 	return nil
 }
 

--- a/internal/workshop/lxd/export_test.go
+++ b/internal/workshop/lxd/export_test.go
@@ -8,6 +8,23 @@ var (
 	CheckServerVersion = checkVersion
 )
 
+func MockFirewallChecker(f func(string) string) func() {
+	old := firewallChecker
+	firewallChecker = f
+	return func() {
+		firewallChecker = old
+	}
+}
+
+// Exported for testing.
+var (
+	AnalyzeNftJSON       = analyzeNftJSON
+	BridgeBlockedWarning = bridgeBlockedWarning
+	CauseUnknown         = causeUnknown
+	CauseDocker          = causeDocker
+	CauseUFW             = causeUFW
+)
+
 func MockNvidiaRuntime(f func() (bool, error)) func() {
 	old := checkNvidiaRuntime
 	checkNvidiaRuntime = f

--- a/internal/workshop/lxd/firewall.go
+++ b/internal/workshop/lxd/firewall.go
@@ -1,0 +1,200 @@
+package lxdbackend
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+
+	"github.com/canonical/workshop/internal/logger"
+)
+
+const firewallDocLink = "https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/"
+
+// CheckBridgeFirewall detects whether firewall rules block forwarding on the
+// workshop bridge. It returns a non-empty warning message with a proposed
+// resolution if an issue is detected, or an empty string if everything looks
+// fine.
+//
+// Detection is cause-agnostic: it checks whether the FORWARD chain policy is
+// DROP/REJECT and whether any rules ACCEPT traffic for the bridge. The
+// remediation advice is cause-aware: it suggests Docker-specific, UFW-specific,
+// or generic commands depending on what is found.
+//
+// Uses `nft -j` (JSON output) for structured, robust parsing.
+//
+// See: https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/
+func CheckBridgeFirewall(bridgeName string) string {
+	return firewallChecker(bridgeName)
+}
+
+var firewallChecker = checkBridgeFirewall
+
+func checkBridgeFirewall(bridgeName string) string {
+	nft, err := exec.LookPath("nft")
+	if err != nil {
+		return ""
+	}
+
+	out, err := exec.Command(nft, "-j", "list", "table", "ip", "filter").CombinedOutput()
+	if err != nil {
+		logger.Noticef("%s", out)
+		return "" // no filter table
+	}
+
+	return analyzeNftJSON(out, bridgeName)
+}
+
+// nftRuleset represents the top-level nft JSON output.
+type nftRuleset struct {
+	Nftables []nftObject `json:"nftables"`
+}
+
+// nftObject is a single entry in the nftables array. Each entry contains
+// exactly one of the possible object types.
+type nftObject struct {
+	Chain *nftChain `json:"chain,omitempty"`
+	Rule  *nftRule  `json:"rule,omitempty"`
+}
+
+// nftChain represents a chain object from nft JSON output.
+type nftChain struct {
+	Family string `json:"family"`
+	Table  string `json:"table"`
+	Name   string `json:"name"`
+	Policy string `json:"policy"`
+}
+
+// nftRule represents a rule object from nft JSON output. We only need the
+// raw expression array to scan for interface references and accept verdicts.
+type nftRule struct {
+	Family string            `json:"family"`
+	Table  string            `json:"table"`
+	Chain  string            `json:"chain"`
+	Expr   []json.RawMessage `json:"expr"`
+}
+
+// analyzeNftJSON parses nft JSON output and returns a warning if forwarding
+// is blocked for the bridge.
+func analyzeNftJSON(data []byte, bridgeName string) string {
+	var ruleset nftRuleset
+	if err := json.Unmarshal(data, &ruleset); err != nil {
+		return ""
+	}
+
+	if !forwardPolicyIsDrop(ruleset) {
+		return ""
+	}
+
+	if bridgeHasAcceptRule(ruleset, bridgeName) {
+		return ""
+	}
+
+	return bridgeBlockedWarning(bridgeName, detectFirewallCause(ruleset))
+}
+
+// forwardPolicyIsDrop returns true if the FORWARD chain has a "drop" policy.
+func forwardPolicyIsDrop(ruleset nftRuleset) bool {
+	for _, obj := range ruleset.Nftables {
+		if obj.Chain != nil && obj.Chain.Name == "FORWARD" {
+			return obj.Chain.Policy == "drop"
+		}
+	}
+	return false
+}
+
+// bridgeHasAcceptRule checks whether any rule in the filter table references
+// the bridge interface and has an accept verdict.
+func bridgeHasAcceptRule(ruleset nftRuleset, bridgeName string) bool {
+	for _, obj := range ruleset.Nftables {
+		if obj.Rule == nil {
+			continue
+		}
+		if ruleMatchesBridge(obj.Rule.Expr, bridgeName) && ruleHasAccept(obj.Rule.Expr) {
+			return true
+		}
+	}
+	return false
+}
+
+// ruleMatchesBridge returns true if any expression in the rule references the
+// bridge interface name. In nft JSON, interface matches look like:
+//
+//	{"match": {"left": {"meta": {"key": "iifname"}}, "right": "workshopbr0", ...}}
+//
+// We check for the bridge name appearing as a string value anywhere in the
+// expression tree.
+func ruleMatchesBridge(exprs []json.RawMessage, bridgeName string) bool {
+	for _, expr := range exprs {
+		if strings.Contains(string(expr), bridgeName) {
+			return true
+		}
+	}
+	return false
+}
+
+// ruleHasAccept returns true if any expression in the rule is an accept
+// verdict: {"accept": null}.
+func ruleHasAccept(exprs []json.RawMessage) bool {
+	for _, expr := range exprs {
+		if strings.Contains(string(expr), `"accept"`) {
+			return true
+		}
+	}
+	return false
+}
+
+// firewallCause identifies the likely source of the FORWARD DROP policy to
+// tailor the remediation advice.
+type firewallCause int
+
+const (
+	causeUnknown firewallCause = iota
+	causeDocker
+	causeUFW
+)
+
+// detectFirewallCause inspects chain and rule names for markers of known
+// firewall software.
+func detectFirewallCause(ruleset nftRuleset) firewallCause {
+	for _, obj := range ruleset.Nftables {
+		if obj.Chain != nil && strings.Contains(obj.Chain.Name, "DOCKER") {
+			return causeDocker
+		}
+		if obj.Rule != nil && strings.Contains(obj.Rule.Chain, "ufw") {
+			return causeUFW
+		}
+	}
+	for _, obj := range ruleset.Nftables {
+		if obj.Chain != nil && strings.Contains(obj.Chain.Name, "ufw") {
+			return causeUFW
+		}
+	}
+	return causeUnknown
+}
+
+func bridgeBlockedWarning(bridgeName string, cause firewallCause) string {
+	base := "firewall rules may be blocking network traffic on the " + bridgeName +
+		" bridge: the FORWARD chain policy is set to DROP with no rules " +
+		"allowing traffic through the bridge"
+
+	switch cause {
+	case causeDocker:
+		return base + ". " +
+			"This is likely caused by Docker. To resolve, run: " +
+			"sudo nft insert rule ip filter DOCKER-USER iifname " + bridgeName + " accept \\; " +
+			"sudo nft insert rule ip filter DOCKER-USER oifname " + bridgeName +
+			" ct state related,established accept" +
+			" (see " + firewallDocLink + ")"
+	case causeUFW:
+		return base + ". " +
+			"This is likely caused by UFW. To resolve, run: " +
+			"sudo ufw allow in on " + bridgeName + " && " +
+			"sudo ufw route allow in on " + bridgeName + " && " +
+			"sudo ufw route allow out on " + bridgeName +
+			" (see " + firewallDocLink + ")"
+	default:
+		return base + ". " +
+			"To resolve, add firewall rules allowing forwarding through " + bridgeName +
+			" (see " + firewallDocLink + ")"
+	}
+}

--- a/internal/workshop/lxd/firewall_test.go
+++ b/internal/workshop/lxd/firewall_test.go
@@ -1,0 +1,142 @@
+package lxdbackend
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+type FirewallTests struct{}
+
+var _ = check.Suite(&FirewallTests{})
+
+func TestFirewallSuite(t *testing.T) { check.TestingT(t) }
+
+// nft -j output samples for testing. These mirror real `nft -j list table ip
+// filter` output with the metainfo object omitted for brevity.
+
+const nftJSONDockerDrop = `{"nftables": [
+	{"chain": {"family": "ip", "table": "filter", "name": "INPUT", "handle": 1, "type": "filter", "hook": "input", "prio": 0, "policy": "accept"}},
+	{"chain": {"family": "ip", "table": "filter", "name": "FORWARD", "handle": 2, "type": "filter", "hook": "forward", "prio": 0, "policy": "drop"}},
+	{"chain": {"family": "ip", "table": "filter", "name": "OUTPUT", "handle": 3, "type": "filter", "hook": "output", "prio": 0, "policy": "accept"}},
+	{"chain": {"family": "ip", "table": "filter", "name": "DOCKER-USER", "handle": 4}},
+	{"chain": {"family": "ip", "table": "filter", "name": "DOCKER-ISOLATION-STAGE-1", "handle": 5}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "FORWARD", "expr": [{"jump": {"target": "DOCKER-USER"}}]}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "FORWARD", "expr": [{"jump": {"target": "DOCKER-ISOLATION-STAGE-1"}}]}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "FORWARD", "expr": [{"match": {"left": {"meta": {"key": "oifname"}}, "op": "==", "right": "docker0"}}, {"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": ["established", "related"]}}, {"accept": null}]}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "DOCKER-USER", "expr": [{"return": null}]}}
+]}`
+
+const nftJSONDockerDropWithBridge = `{"nftables": [
+	{"chain": {"family": "ip", "table": "filter", "name": "FORWARD", "handle": 2, "type": "filter", "hook": "forward", "prio": 0, "policy": "drop"}},
+	{"chain": {"family": "ip", "table": "filter", "name": "DOCKER-USER", "handle": 4}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "FORWARD", "expr": [{"jump": {"target": "DOCKER-USER"}}]}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "DOCKER-USER", "expr": [{"match": {"left": {"meta": {"key": "iifname"}}, "op": "==", "right": "workshopbr0"}}, {"accept": null}]}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "DOCKER-USER", "expr": [{"match": {"left": {"meta": {"key": "oifname"}}, "op": "==", "right": "workshopbr0"}}, {"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": ["established", "related"]}}, {"accept": null}]}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "DOCKER-USER", "expr": [{"return": null}]}}
+]}`
+
+const nftJSONAcceptPolicy = `{"nftables": [
+	{"chain": {"family": "ip", "table": "filter", "name": "FORWARD", "handle": 1, "type": "filter", "hook": "forward", "prio": 0, "policy": "accept"}}
+]}`
+
+const nftJSONUFWDrop = `{"nftables": [
+	{"chain": {"family": "ip", "table": "filter", "name": "FORWARD", "handle": 1, "type": "filter", "hook": "forward", "prio": 0, "policy": "drop"}},
+	{"chain": {"family": "ip", "table": "filter", "name": "ufw-before-forward", "handle": 2}},
+	{"chain": {"family": "ip", "table": "filter", "name": "ufw-after-forward", "handle": 3}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "FORWARD", "expr": [{"jump": {"target": "ufw-before-forward"}}]}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "ufw-before-forward", "expr": [{"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": ["established", "related"]}}, {"accept": null}]}}
+]}`
+
+const nftJSONUFWDropWithBridge = `{"nftables": [
+	{"chain": {"family": "ip", "table": "filter", "name": "FORWARD", "handle": 1, "type": "filter", "hook": "forward", "prio": 0, "policy": "drop"}},
+	{"chain": {"family": "ip", "table": "filter", "name": "ufw-before-forward", "handle": 2}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "FORWARD", "expr": [{"jump": {"target": "ufw-before-forward"}}]}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "ufw-before-forward", "expr": [{"match": {"left": {"meta": {"key": "iifname"}}, "op": "==", "right": "workshopbr0"}}, {"accept": null}]}}
+]}`
+
+const nftJSONGenericDrop = `{"nftables": [
+	{"chain": {"family": "ip", "table": "filter", "name": "FORWARD", "handle": 1, "type": "filter", "hook": "forward", "prio": 0, "policy": "drop"}},
+	{"rule": {"family": "ip", "table": "filter", "chain": "FORWARD", "expr": [{"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": ["established", "related"]}}, {"accept": null}]}}
+]}`
+
+const nftJSONEmpty = `{"nftables": [
+	{"chain": {"family": "ip", "table": "filter", "name": "FORWARD", "handle": 1, "type": "filter", "hook": "forward", "prio": 0, "policy": "accept"}}
+]}`
+
+// --- analyzeNftJSON tests ---
+
+func (s *FirewallTests) TestAnalyzeNftJSONDockerDropBlocked(c *check.C) {
+	msg := analyzeNftJSON([]byte(nftJSONDockerDrop), "workshopbr0")
+	c.Assert(msg, check.Not(check.Equals), "")
+	c.Check(msg, check.Matches, ".*Docker.*")
+	c.Check(msg, check.Matches, ".*DOCKER-USER.*")
+	c.Check(msg, check.Matches, ".*workshopbr0.*")
+}
+
+func (s *FirewallTests) TestAnalyzeNftJSONDockerDropCompensated(c *check.C) {
+	msg := analyzeNftJSON([]byte(nftJSONDockerDropWithBridge), "workshopbr0")
+	c.Assert(msg, check.Equals, "")
+}
+
+func (s *FirewallTests) TestAnalyzeNftJSONAcceptPolicy(c *check.C) {
+	msg := analyzeNftJSON([]byte(nftJSONAcceptPolicy), "workshopbr0")
+	c.Assert(msg, check.Equals, "")
+}
+
+func (s *FirewallTests) TestAnalyzeNftJSONUFWBlocked(c *check.C) {
+	msg := analyzeNftJSON([]byte(nftJSONUFWDrop), "workshopbr0")
+	c.Assert(msg, check.Not(check.Equals), "")
+	c.Check(msg, check.Matches, ".*UFW.*")
+	c.Check(msg, check.Matches, ".*ufw allow.*")
+}
+
+func (s *FirewallTests) TestAnalyzeNftJSONUFWCompensated(c *check.C) {
+	msg := analyzeNftJSON([]byte(nftJSONUFWDropWithBridge), "workshopbr0")
+	c.Assert(msg, check.Equals, "")
+}
+
+func (s *FirewallTests) TestAnalyzeNftJSONGenericDrop(c *check.C) {
+	msg := analyzeNftJSON([]byte(nftJSONGenericDrop), "workshopbr0")
+	c.Assert(msg, check.Not(check.Equals), "")
+	c.Check(msg, check.Not(check.Matches), ".*Docker.*")
+	c.Check(msg, check.Not(check.Matches), ".*UFW.*")
+	c.Check(msg, check.Matches, ".*workshopbr0.*")
+}
+
+func (s *FirewallTests) TestAnalyzeNftJSONEmpty(c *check.C) {
+	msg := analyzeNftJSON([]byte(nftJSONEmpty), "workshopbr0")
+	c.Assert(msg, check.Equals, "")
+}
+
+func (s *FirewallTests) TestAnalyzeNftJSONInvalidJSON(c *check.C) {
+	msg := analyzeNftJSON([]byte("not json"), "workshopbr0")
+	c.Assert(msg, check.Equals, "")
+}
+
+func (s *FirewallTests) TestAnalyzeNftJSONNoForwardChain(c *check.C) {
+	msg := analyzeNftJSON([]byte(`{"nftables": []}`), "workshopbr0")
+	c.Assert(msg, check.Equals, "")
+}
+
+// --- bridgeBlockedWarning tests ---
+
+func (s *FirewallTests) TestBridgeBlockedWarningDocker(c *check.C) {
+	msg := bridgeBlockedWarning("workshopbr0", causeDocker)
+	c.Check(msg, check.Matches, ".*Docker.*nft.*DOCKER-USER.*workshopbr0.*")
+	c.Check(msg, check.Matches, ".*documentation.ubuntu.com.*")
+}
+
+func (s *FirewallTests) TestBridgeBlockedWarningUFW(c *check.C) {
+	msg := bridgeBlockedWarning("workshopbr0", causeUFW)
+	c.Check(msg, check.Matches, ".*UFW.*ufw allow.*workshopbr0.*")
+	c.Check(msg, check.Matches, ".*documentation.ubuntu.com.*")
+}
+
+func (s *FirewallTests) TestBridgeBlockedWarningUnknown(c *check.C) {
+	msg := bridgeBlockedWarning("workshopbr0", causeUnknown)
+	c.Check(msg, check.Not(check.Matches), ".*Docker.*")
+	c.Check(msg, check.Not(check.Matches), ".*UFW.*")
+	c.Check(msg, check.Matches, ".*workshopbr0.*")
+	c.Check(msg, check.Matches, ".*documentation.ubuntu.com.*")
+}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -34,6 +34,10 @@ const (
 
 	networkName = "workshopbr0"
 	networkType = "bridge"
+
+	// NetworkBridgeName is the name of the LXD bridge network used by
+	// workshops, exported for use by other packages (e.g. firewall checks).
+	NetworkBridgeName = networkName
 )
 
 var (

--- a/tests/main/firewall-docker/task.yaml
+++ b/tests/main/firewall-docker/task.yaml
@@ -1,0 +1,64 @@
+summary: Check firewall warning when Docker blocks the bridge
+prepare: |
+  . "$TESTSLIB"/utils.sh
+
+  # Remove LXD so Docker is the first to enable ip_forward and sets FORWARD
+  # policy to DROP.
+  snap remove lxd --purge
+  sysctl -w net.ipv4.ip_forward=0
+
+  # Install Docker CE.
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+
+  ARCH=$(dpkg --print-architecture)
+  CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
+  echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${CODENAME} stable" \
+    > /etc/apt/sources.list.d/docker.list
+
+  apt-get update
+  apt-get install -y docker-ce
+
+  # Bring LXD back and reinstall workshop with clean state.
+  setup_lxd
+  snap restart workshop
+restore: |
+  . "$TESTSLIB"/utils.sh
+
+  apt-get remove -y --purge docker-ce
+  rm -f /etc/apt/sources.list.d/docker.list /etc/apt/keyrings/docker.asc
+
+  # Flush leftover Docker nft rules, then restore LXD and workshop
+  # to clean state. LXD recreates its own rules on setup.
+  nft flush ruleset
+  snap remove lxd --purge
+  setup_lxd
+  rm -f /home/ubuntu/.cache/workshop/warnings.json
+  setup_workshop
+debug: |
+  nft list table ip filter
+
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check that Docker FORWARD DROP triggers a firewall warning"
+  workshop_exec list | MATCH "^WARNING: There is 1 new warning"
+  workshop_exec warnings |
+    tr -d '\n' |
+    sed -e 's,\s\+, ,g' |
+    MATCH 'firewall rules may be blocking network traffic on the workshopbr0 bridge.*Docker.*nft.*DOCKER-USER'
+
+  echo "Check that warning is consumed after reading"
+  workshop_exec list | NOMATCH "new warning"
+
+  echo "Check that applying the fix and restarting clears the warning"
+  nft insert rule ip filter DOCKER-USER iifname workshopbr0 accept
+  nft insert rule ip filter DOCKER-USER oifname workshopbr0 ct state related,established accept
+  snap restart workshop
+  workshop_exec list | NOMATCH "new warning"
+  workshop_exec okay
+  workshop_exec warnings | MATCH "^No further warnings.$"
+
+  echo "Clean up nft rules"
+  nft flush chain ip filter DOCKER-USER

--- a/tests/main/firewall-docker/task.yaml
+++ b/tests/main/firewall-docker/task.yaml
@@ -27,8 +27,8 @@ restore: |
   . "$TESTSLIB"/utils.sh
 
   apt-get remove -y --purge docker-ce
+  apt-get autoremove -y --purge
   rm -f /etc/apt/sources.list.d/docker.list /etc/apt/keyrings/docker.asc
-
   # Flush leftover Docker nft rules, then restore LXD and workshop
   # to clean state. LXD recreates its own rules on setup.
   nft flush ruleset


### PR DESCRIPTION
# Description

The choice to use json output of `nft` and not parse older `iptables` format is intentional. The check is run on a startup which should be sufficient enough for the socket-activated daemon. The check accounts for the forward policy and for whether an exception is made for `workshopbr0` in the user-defined chains (we do not evaluate FORWARD chain rules only for simplicity and to avoid tracing all user defined chains from the FORWARD; it may result in some false positives, e.g. accept added to the INPUT chain but not to FORWARD, but that's unlikely as these rules would come from our warning recommendation). 

I decided not to add the check to the API layer to minimize the overhead even though the check itself is seemingly light. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
