### PR TITLE
Doc: remove internal-only setup steps from tutorial

### DIFF
--- a/docs/tutorial/part-1-get-started.rst
+++ b/docs/tutorial/part-1-get-started.rst
@@ -93,17 +93,11 @@ using the `--classic <https://snapcraft.io/docs/install-modes/>`_ option:
 
 .. code-block:: console
 
-   $ sudo snap login
    $ sudo snap install --classic workshop
 
 
 To get the newest features, install from the edge channel:
 :command:`sudo snap install --classic --edge workshop`.
-
-.. warning::
-
-   If this command fails, you may need an invitation;
-   contact Dmitry Lyfar (dmitry.lyfar@canonical.com, @dlyfar on Mattermost).
 
 
 .. _tut_define_launch:


### PR DESCRIPTION
Drop the unnecessary `snap login` step and remove the internal invitation warning from the getting started tutorial.

These instructions are no longer required and are not relevant for public users ahead of the upcoming release.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] ~I have checked and added or updated relevant release notes.~
* [x] I have included the technical author in the review.

Content:

* [x] Headings and titles accurately describe the content.
* [x] New and updated pages include correct metadata.
* [ ] ~Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).~
* [x] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] ~If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).~


