### PR TITLE
Implement workshop init command

### DIFF
--- a/cmd/workshop/init.go
+++ b/cmd/workshop/init.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+var defaultBase = "ubuntu@24.04"
+
+type CmdInit struct {
+	root *CmdRoot
+	sdks []string
+	base string
+}
+
+func (c *CmdInit) Command() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "init <NAME> --sdks <SDKs> [--base <BASE>]",
+		Args:    cobra.ExactArgs(1),
+		Short:   "Create a new workshop definition in the project directory",
+		GroupID: GrpCRUD,
+		Long: `
+Create a new workshop definition file in the project's .workshop/ directory.
+
+The NAME argument sets the workshop name. The command creates a named
+workshop file at .workshop/<NAME>.yaml. This fails if a workshop with
+the same name already exists.
+
+SDKs are specified as a comma-separated list. Each SDK entry can optionally
+include a channel using the <name>/<channel> syntax (e.g., "go/1.26/stable").
+`,
+		Example: `
+Create a workshop called "dev" with the Go and UV SDKs:
+$ workshop init dev --sdks go,uv
+
+Create a workshop with a specific SDK channel:
+$ workshop init dev --sdks go/1.26/stable
+
+Create a workshop using a specific base:
+$ workshop init dev --sdks go --base ubuntu@22.04`,
+		RunE: c.Run,
+	}
+
+	cmd.Flags().StringSliceVar(&c.sdks, "sdks", nil, `Comma-separated list of SDKs (e.g., "go,uv/latest/stable").`)
+	cmd.Flags().StringVar(&c.base, "base", defaultBase, "Base image for the workshop.")
+
+	_ = cmd.MarkFlagRequired("sdks")
+
+	return cmd
+}
+
+func (c *CmdInit) Run(cmd *cobra.Command, args []string) error {
+	projectDir := c.root.project()
+	name := args[0]
+
+	sdks, err := parseSdkArgs(c.sdks)
+	if err != nil {
+		return err
+	}
+
+	wfile := &workshop.File{
+		Name: name,
+		Base: c.base,
+		Sdks: sdks,
+	}
+
+	if err := workshop.ValidateFile(wfile); err != nil {
+		return err
+	}
+
+	if err := ensureCanCreate(projectDir, name); err != nil {
+		return err
+	}
+
+	path, err := writeWorkshopFile(projectDir, wfile)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(Stdout, "%q workshop created at %s\n", name, path)
+	return nil
+}
+
+// parseSdkArgs converts a list of strings like ["go/1.26/stable", "python"]
+// into SdkRecord entries.
+func parseSdkArgs(args []string) ([]workshop.SdkRecord, error) {
+	if len(args) == 0 {
+		return nil, errors.New("at least one SDK must be specified")
+	}
+
+	var sdks []workshop.SdkRecord
+	seen := make(map[string]bool)
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+		if arg == "" {
+			continue
+		}
+
+		name, channel, _ := strings.Cut(arg, "/")
+
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate SDK %q", name)
+		}
+		seen[name] = true
+
+		sdks = append(sdks, workshop.SdkRecord{
+			Name:    name,
+			Channel: channel,
+		})
+	}
+
+	if len(sdks) == 0 {
+		return nil, errors.New("at least one SDK must be specified")
+	}
+
+	return sdks, nil
+}
+
+// ensureCanCreate checks that no single-file workshop definition exists in the
+// project root and that no named workshop with the same name already exists.
+func ensureCanCreate(projectDir, name string) error {
+	for _, fname := range workshop.Filenames {
+		path := filepath.Join(projectDir, fname)
+		if _, err := os.Stat(path); err == nil {
+			dest := workshop.Directory + "/"
+			if wname := workshopNameFromFile(path); wname != "" {
+				dest = filepath.Join(workshop.Directory, wname+".yaml")
+			}
+			return fmt.Errorf("cannot init: %q already exists, move it to %s first to manage multiple workshops",
+				fname, dest)
+		}
+	}
+
+	path := workshop.Filepath(projectDir, name)
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("cannot init: %q workshop already exists at %q", name, path)
+	}
+	return nil
+}
+
+// workshopNameFromFile reads a workshop YAML file and returns its name field.
+func workshopNameFromFile(path string) string {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var partial struct {
+		Name string `yaml:"name"`
+	}
+	if err := yaml.Unmarshal(buf, &partial); err != nil {
+		return ""
+	}
+	return partial.Name
+}
+
+// writeWorkshopFile creates the .workshop/ directory and writes the YAML file.
+func writeWorkshopFile(projectDir string, wfile *workshop.File) (string, error) {
+	dir := filepath.Join(projectDir, workshop.Directory)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("cannot create %q: %w", dir, err)
+	}
+
+	path := workshop.Filepath(projectDir, wfile.Name)
+
+	out, err := yaml.Marshal(wfile)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(path, out, 0644); err != nil {
+		return "", fmt.Errorf("cannot write %q: %w", path, err)
+	}
+
+	return path, nil
+}

--- a/cmd/workshop/init_test.go
+++ b/cmd/workshop/init_test.go
@@ -1,0 +1,425 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+type workshopInit struct {
+	BaseWorkshopSuite
+}
+
+var _ = check.Suite(&workshopInit{})
+
+func (s *workshopInit) SetUpTest(c *check.C) {
+	s.BaseWorkshopSuite.SetUpTest(c)
+}
+
+func (s *workshopInit) makeCmd(projectDir string) *CmdInit {
+	return &CmdInit{
+		root: &CmdRoot{cwd: projectDir},
+		base: defaultBase,
+	}
+}
+
+func (s *workshopInit) run(cmd *CmdInit, name string) error {
+	return cmd.Run(nil, []string{name})
+}
+
+// --- Success cases ---
+
+func (s *workshopInit) TestInitBasic(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go", "python"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	path := workshop.Filepath(projectDir, "dev")
+	_, err = os.Stat(path)
+	c.Assert(err, check.IsNil)
+
+	content, err := os.ReadFile(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(string(content), "name: dev"), check.Equals, true)
+	c.Assert(strings.Contains(string(content), "base: ubuntu@24.04"), check.Equals, true)
+	c.Assert(strings.Contains(string(content), "go"), check.Equals, true)
+	c.Assert(strings.Contains(string(content), "python"), check.Equals, true)
+
+	c.Assert(s.stdout.String(), check.Matches, `"dev" workshop created at .*\n`)
+}
+
+func (s *workshopInit) TestInitWithSdkChannel(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go/1.26/stable", "python"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	path := workshop.Filepath(projectDir, "dev")
+	content, err := os.ReadFile(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(string(content), "channel: 1.26/stable"), check.Equals, true)
+}
+
+func (s *workshopInit) TestInitWithCustomBase(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+	cmd.base = "ubuntu@22.04"
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	path := workshop.Filepath(projectDir, "dev")
+	content, err := os.ReadFile(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(string(content), "base: ubuntu@22.04"), check.Equals, true)
+}
+
+func (s *workshopInit) TestInitMultipleNamedWorkshops(c *check.C) {
+	projectDir := c.MkDir()
+
+	// Create first workshop.
+	cmd1 := s.makeCmd(projectDir)
+	cmd1.sdks = []string{"go"}
+	err := s.run(cmd1, "dev")
+	c.Assert(err, check.IsNil)
+
+	s.ResetStdStreams()
+
+	// Create second workshop.
+	cmd2 := s.makeCmd(projectDir)
+	cmd2.sdks = []string{"python"}
+	err = s.run(cmd2, "test")
+	c.Assert(err, check.IsNil)
+
+	// Both should exist.
+	_, err = os.Stat(workshop.Filepath(projectDir, "dev"))
+	c.Assert(err, check.IsNil)
+	_, err = os.Stat(workshop.Filepath(projectDir, "test"))
+	c.Assert(err, check.IsNil)
+}
+
+func (s *workshopInit) TestInitSystemSdk(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"system", "go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	path := workshop.Filepath(projectDir, "dev")
+	content, err := os.ReadFile(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(string(content), "system"), check.Equals, true)
+}
+
+// --- Failure: same name already exists ---
+
+func (s *workshopInit) TestInitNameAlreadyExists(c *check.C) {
+	projectDir := c.MkDir()
+
+	// Pre-create a workshop with the same name.
+	wsDir := filepath.Join(projectDir, workshop.Directory)
+	c.Assert(os.MkdirAll(wsDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(wsDir, "dev.yaml"), []byte("name: dev\nbase: ubuntu@24.04\n"), 0644), check.IsNil)
+
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `cannot init: "dev" workshop already exists at ".*dev.yaml"`)
+}
+
+// --- Different name exists is OK ---
+
+func (s *workshopInit) TestInitDifferentNameExists(c *check.C) {
+	projectDir := c.MkDir()
+
+	// Pre-create a different workshop.
+	wsDir := filepath.Join(projectDir, workshop.Directory)
+	c.Assert(os.MkdirAll(wsDir, 0755), check.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(wsDir, "other.yaml"), []byte("name: other\nbase: ubuntu@24.04\n"), 0644), check.IsNil)
+
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	// Both should exist.
+	_, err = os.Stat(workshop.Filepath(projectDir, "other"))
+	c.Assert(err, check.IsNil)
+	_, err = os.Stat(workshop.Filepath(projectDir, "dev"))
+	c.Assert(err, check.IsNil)
+}
+
+// --- Validation failures ---
+
+func (s *workshopInit) TestInitInvalidBase(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+	cmd.base = "foo@1.0"
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `base "foo@1.0" not supported`)
+}
+
+func (s *workshopInit) TestInitInvalidWorkshopName(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err := s.run(cmd, "99-bad")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "a workshop's name must.*")
+}
+
+func (s *workshopInit) TestInitWorkshopNameTooLong(c *check.C) {
+	projectDir := c.MkDir()
+	long := strings.Repeat("a", workshop.MAX_WORKSHOP_NAME_LENGTH+1)
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err := s.run(cmd, long)
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `workshop name ".*" too long`)
+}
+
+func (s *workshopInit) TestInitInvalidSdkName(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"INVALID_SDK"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `invalid SDK name "INVALID_SDK"`)
+}
+
+func (s *workshopInit) TestInitDuplicateSdk(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go", "go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `duplicate SDK "go"`)
+}
+
+func (s *workshopInit) TestInitEmptySdks(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "at least one SDK must be specified")
+}
+
+func (s *workshopInit) TestInitInvalidChannel(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go/latest/foo"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `"go" SDK: invalid risk "foo" in channel "latest/foo"`)
+}
+
+func (s *workshopInit) TestInitReservedSdkName(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"agent"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
+}
+
+func (s *workshopInit) TestInitWorkshopYamlExists(c *check.C) {
+	projectDir := c.MkDir()
+	err := os.WriteFile(filepath.Join(projectDir, "workshop.yaml"), []byte("name: old\n"), 0644)
+	c.Assert(err, check.IsNil)
+
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err = s.run(cmd, "dev")
+	c.Assert(err, check.ErrorMatches, `cannot init: "workshop.yaml" already exists, move it to .workshop/old.yaml first to manage multiple workshops`)
+}
+
+func (s *workshopInit) TestInitDotWorkshopYamlExists(c *check.C) {
+	projectDir := c.MkDir()
+	err := os.WriteFile(filepath.Join(projectDir, ".workshop.yaml"), []byte("name: old\n"), 0644)
+	c.Assert(err, check.IsNil)
+
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err = s.run(cmd, "dev")
+	c.Assert(err, check.ErrorMatches, `cannot init: ".workshop.yaml" already exists, move it to .workshop/old.yaml first to manage multiple workshops`)
+}
+
+func (s *workshopInit) TestInitWorkshopYamlExistsNoName(c *check.C) {
+	projectDir := c.MkDir()
+	err := os.WriteFile(filepath.Join(projectDir, "workshop.yaml"), []byte("base: ubuntu@24.04\n"), 0644)
+	c.Assert(err, check.IsNil)
+
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err = s.run(cmd, "dev")
+	c.Assert(err, check.ErrorMatches, `cannot init: "workshop.yaml" already exists, move it to .workshop/ first to manage multiple workshops`)
+}
+
+// --- Corner cases ---
+
+func (s *workshopInit) TestInitCreatesWorkshopDirectory(c *check.C) {
+	projectDir := c.MkDir()
+	wsDir := filepath.Join(projectDir, workshop.Directory)
+
+	// Ensure .workshop/ doesn't exist yet.
+	_, err := os.Stat(wsDir)
+	c.Assert(os.IsNotExist(err), check.Equals, true)
+
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err = s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	// .workshop/ directory should have been created.
+	info, err := os.Stat(wsDir)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.IsDir(), check.Equals, true)
+}
+
+func (s *workshopInit) TestInitDoesNotOverwriteExistingDirContents(c *check.C) {
+	projectDir := c.MkDir()
+	wsDir := filepath.Join(projectDir, workshop.Directory)
+	c.Assert(os.MkdirAll(wsDir, 0755), check.IsNil)
+
+	// Create an unrelated directory in .workshop/.
+	otherFile := filepath.Join(wsDir, "tools")
+	c.Assert(os.MkdirAll(otherFile, 0755), check.IsNil)
+
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	// Other directory still exists.
+	_, err = os.Stat(otherFile)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *workshopInit) TestInitOutputFormat(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	expectedPath := workshop.Filepath(projectDir, "dev")
+	c.Assert(s.stdout.String(), check.Equals, "\"dev\" workshop created at "+expectedPath+"\n")
+}
+
+func (s *workshopInit) TestInitProjectFlagOverride(c *check.C) {
+	projectDir := c.MkDir()
+	otherDir := c.MkDir()
+
+	// Use --project flag (simulated via root.prj).
+	cmd := &CmdInit{
+		root: &CmdRoot{cwd: otherDir, prj: projectDir},
+		sdks: []string{"go"},
+		base: defaultBase,
+	}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	// File should be in projectDir, not otherDir.
+	_, err = os.Stat(workshop.Filepath(projectDir, "dev"))
+	c.Assert(err, check.IsNil)
+	_, err = os.Stat(workshop.Filepath(otherDir, "dev"))
+	c.Assert(os.IsNotExist(err), check.Equals, true)
+}
+
+func (s *workshopInit) TestInitYamlRoundTrip(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go/1.26/stable", "system", "python"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	// The generated file should be parseable by the existing readWorkshop.
+	project := workshop.Project{Path: projectDir, ProjectId: "test"}
+	file, err := project.Workshop("dev")
+	c.Assert(err, check.IsNil)
+	c.Assert(file.Name, check.Equals, "dev")
+	c.Assert(file.Base, check.Equals, "ubuntu@24.04")
+	c.Assert(file.Sdks, check.HasLen, 3)
+	c.Assert(file.Sdks[0].Name, check.Equals, "go")
+	c.Assert(file.Sdks[0].Channel, check.Equals, "1.26/stable")
+	c.Assert(file.Sdks[1].Name, check.Equals, "system")
+	c.Assert(file.Sdks[2].Name, check.Equals, "python")
+}
+
+// --- parseSdkArgs unit tests ---
+
+func (s *workshopInit) TestParseSdkArgsSimple(c *check.C) {
+	sdks, err := parseSdkArgs([]string{"go", "python"})
+	c.Assert(err, check.IsNil)
+	c.Assert(sdks, check.HasLen, 2)
+	c.Assert(sdks[0].Name, check.Equals, "go")
+	c.Assert(sdks[0].Channel, check.Equals, "")
+	c.Assert(sdks[1].Name, check.Equals, "python")
+}
+
+func (s *workshopInit) TestParseSdkArgsWithChannel(c *check.C) {
+	sdks, err := parseSdkArgs([]string{"go/1.26/stable"})
+	c.Assert(err, check.IsNil)
+	c.Assert(sdks, check.HasLen, 1)
+	c.Assert(sdks[0].Name, check.Equals, "go")
+	c.Assert(sdks[0].Channel, check.Equals, "1.26/stable")
+}
+
+func (s *workshopInit) TestParseSdkArgsDuplicate(c *check.C) {
+	_, err := parseSdkArgs([]string{"go", "go"})
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `duplicate SDK "go"`)
+}
+
+func (s *workshopInit) TestParseSdkArgsEmpty(c *check.C) {
+	_, err := parseSdkArgs([]string{})
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "at least one SDK must be specified")
+}
+
+func (s *workshopInit) TestParseSdkArgsWhitespace(c *check.C) {
+	sdks, err := parseSdkArgs([]string{" go ", " python "})
+	c.Assert(err, check.IsNil)
+	c.Assert(sdks, check.HasLen, 2)
+	c.Assert(sdks[0].Name, check.Equals, "go")
+	c.Assert(sdks[1].Name, check.Equals, "python")
+}
+
+func (s *workshopInit) TestParseSdkArgsOnlyWhitespace(c *check.C) {
+	_, err := parseSdkArgs([]string{" ", "  "})
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "at least one SDK must be specified")
+}

--- a/cmd/workshop/root.go
+++ b/cmd/workshop/root.go
@@ -83,6 +83,7 @@ func (c *CmdRoot) Command() *cobra.Command {
 	cmd.SetHelpCommandGroupID(GrpMisc)
 	cmd.SetCompletionCommandGroupID(GrpMisc)
 
+	cmd.AddCommand((&CmdInit{root: c}).Command())
 	cmd.AddCommand((&CmdLaunch{root: c}).Command())
 	cmd.AddCommand((&CmdList{root: c}).Command())
 	cmd.AddCommand((&CmdChanges{root: c}).Command())

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -232,6 +232,38 @@ func (a *Action) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// ValidateFile validates a workshop File struct.
+func ValidateFile(file *File) error {
+	if !workshopName.MatchString(file.Name) {
+		return fmt.Errorf("a workshop's name must: (1) start with a letter, (2) only include digits, lowercase letters, and hyphens joining them")
+	}
+	if len(file.Name) > MAX_WORKSHOP_NAME_LENGTH {
+		return fmt.Errorf("workshop name %q too long", file.Name)
+	}
+
+	if !slices.Contains(SupportedBases, file.Base) {
+		return fmt.Errorf("base %q not supported", file.Base)
+	}
+
+	if err := validateSdks(file.Sdks); err != nil {
+		return err
+	}
+
+	if err := validateBinding(file.Sdks); err != nil {
+		return err
+	}
+
+	if err := validateConnections(file); err != nil {
+		return err
+	}
+
+	if err := validateActions(file); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func readWorkshop(path string) (*File, error) {
 	var err error
 	var file File
@@ -252,30 +284,7 @@ func readWorkshop(path string) (*File, error) {
 		return nil, err
 	}
 
-	if !workshopName.MatchString(file.Name) {
-		return nil, fmt.Errorf("a workshop's name must: (1) start with a letter, (2) only include digits, lowercase letters, and hyphens joining them")
-	}
-	if len(file.Name) > MAX_WORKSHOP_NAME_LENGTH {
-		return nil, fmt.Errorf("workshop name %q too long", file.Name)
-	}
-
-	if !slices.Contains(SupportedBases, file.Base) {
-		return nil, fmt.Errorf("base %q not supported", file.Base)
-	}
-
-	if err = validateSdks(file.Sdks); err != nil {
-		return nil, err
-	}
-
-	if err = validateBinding(file.Sdks); err != nil {
-		return nil, err
-	}
-
-	if err = validateConnections(&file); err != nil {
-		return nil, err
-	}
-
-	if err = validateActions(&file); err != nil {
+	if err := ValidateFile(&file); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description

```
workshop init <name> --sdks <sdks> [--base <base>]
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
