### PR TITLE
Ignore exit status when printing debug logs

### DIFF
--- a/.spread.yaml
+++ b/.spread.yaml
@@ -29,9 +29,9 @@ suites:
       . "$TESTSLIB"/utils.sh
       cleanup_workshop
     debug-each: |
-      lxc list --project workshop.ubuntu
-      sudo -u ubuntu 2>&1 -- workshop list --global
-      journalctl --since="$(</tmp/spread-job-start)" --unit=snap.workshop.workshopd.service
+      lxc list --project workshop.ubuntu || true
+      sudo -u ubuntu 2>&1 -- workshop list --global || true
+      journalctl --since="$(</tmp/spread-job-start)" --unit=snap.workshop.workshopd.service || true
     kill-timeout: 30m
   tests/integration/:
     summary: LXD integration tests
@@ -55,7 +55,7 @@ suites:
       . "$TESTSLIB"/utils.sh
       cleanup_workshop
     debug-each: |
-      journalctl --since="$(</tmp/spread-job-start)" --unit=snap.workshop.workshopd.service
+      journalctl --since="$(</tmp/spread-job-start)" --unit=snap.workshop.workshopd.service || true
     kill-timeout: 30m
   tests/docs-how-to/:
     summary: Documentation how-to tests
@@ -69,7 +69,7 @@ suites:
       . "$TESTSLIB"/utils.sh
       cleanup_workshop
     debug-each: |
-      journalctl --since="$(</tmp/spread-job-start)" --unit=snap.workshop.workshopd.service
+      journalctl --since="$(</tmp/spread-job-start)" --unit=snap.workshop.workshopd.service || true
     kill-timeout: 20m
 exclude:
   - .git


### PR DESCRIPTION
# Description

Sometimes we want to see the workshopd logs, but the earlier debug commands fail. This fixes that so we print all logs unconditionally.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
