### PR TITLE
Handle GPU cards without DRM information

### DIFF
--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -231,6 +231,10 @@ func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 			// Intel GPUs are not yet supported by the GPU CDI spec, so we
 			// fall back to exposing them as 'physical' GPUs with a specific
 			// ID.
+			if c.DRM == nil {
+				logger.Debugf("Intel GPU detected without DRM info")
+				continue
+			}
 			cardId := strconv.FormatUint(c.DRM.ID, 10)
 			device := lxdbackend.DeviceName(s.Profile.Sdk, gpu.Name, vendor, cardId)
 			s.devices[device] = map[string]string{
@@ -241,6 +245,10 @@ func (s *Specification) SetGpu(gpu workshop.Gpu) error {
 				"id":      cardId,
 			}
 		default:
+			if c.DRM == nil {
+				logger.Debugf("Unknown GPU vendor ID '%s' for GPU card without DRM info", c.VendorID)
+				continue
+			}
 			logger.Debugf("Unknown GPU vendor ID '%s' for GPU card with ID %d", c.VendorID, c.DRM.ID)
 		}
 	}

--- a/internal/interfaces/lxd_device/spec_test.go
+++ b/internal/interfaces/lxd_device/spec_test.go
@@ -184,3 +184,39 @@ func (s *lxdSpecSuite) TestSetGpuCDIUnknownVendor(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(spec.devices, check.HasLen, 0)
 }
+
+func (s *lxdSpecSuite) TestSetGpuCDIIntelWithoutDRM(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{
+			Total: 1,
+			Cards: []api.ResourcesGPUCard{
+				{VendorID: "8086"},
+			},
+		}}, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+	c.Assert(spec.devices, check.HasLen, 0)
+}
+
+func (s *lxdSpecSuite) TestSetGpuCDIUnknownVendorWithoutDRM(c *check.C) {
+	s.restoreLxdInfo = MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{GPU: api.ResourcesGPU{
+			Total: 1,
+			Cards: []api.ResourcesGPUCard{
+				{VendorID: "ffff"},
+			},
+		}}, nil
+	})
+
+	spec, err := NewSpecification("testuser", "test-sdk")
+	c.Assert(err, check.IsNil)
+
+	err = spec.SetGpu(workshop.Gpu{Name: "gpu"})
+	c.Assert(err, check.IsNil)
+	c.Assert(spec.devices, check.HasLen, 0)
+}


### PR DESCRIPTION
# Description

Handle GPU cards reported by LXD without DRM information.

When LXD reports an unknown GPU card with `drm: null`, `SetGpu` currently dereferences `c.DRM.ID` while logging the unknown vendor. This causes `workshopd` to panic during GPU interface setup.

This change skips Intel or unknown GPU cards without DRM metadata instead of dereferencing `c.DRM.ID`.

I verified this locally on a host where LXD reports Microsoft GPU devices with vendor ID `1414`, including one card with `drm: null`.

Before this change, `workshop launch` caused `workshopd` to panic in `lxd_device.(*Specification).SetGpu`.

After this change, `workshopd` logs the unsupported GPU card and continues launching the workshop.

Fixes #789

Tests:

```text
gofmt -w internal/interfaces/lxd_device/spec.go internal/interfaces/lxd_device/spec_test.go
go test ./internal/interfaces/lxd_device
go test ./...
golangci-lint run
```

# Self-review quick check

* [x] Make decisions that cost a lot to reverse explicit in the PR description.
* [x] Avoid nested conditions.
* [x] Delete dead code and redundant comments.
* [x] Normalise symmetries by sticking to doing identical things identically.

```
// one way to handle errors
if err := f(); err != nil {
   ...
}

// one way to handle multiple returns
val, err := f()
if err != nil {
   ...
}
...
```

* [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
* [x] Put variable declaration and initialisation together.
* [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
* [x] Put a blank line between two logically different chunks of code.
* [x] Follow the [[style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages)](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [[style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md)](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.