### PR TITLE
Doc: Revert to canonical URLs, pull back llms.txt claims

### DIFF
--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -108,7 +108,7 @@ type SketchFile struct {
 	Hooks map[string]string `yaml:"hooks,omitempty"`
 }
 
-var sketchTemplate = `# For details: https://documentation.ubuntu.com/canonical-workshop/latest/explanation/sdks/concepts/#sketch-sdk
+var sketchTemplate = `# For details: https://ubuntu.com/workshop/docs/explanation/sdks/concepts/#sketch-sdk
 name: sketch
 hooks:
   # Use 'setup-base' to customize the base image
@@ -130,7 +130,7 @@ plugs:
 
 slots:
   # Use this configuration to expose a port, then add a corresponding system SDK plug
-  # More details: https://documentation.ubuntu.com/canonical-workshop/latest/how-to/customize-workshops/forward-ports/
+  # More details: https://ubuntu.com/workshop/docs/how-to/customize-workshops/forward-ports/
   # my-web-server:
   #   interface: tunnel
   #   endpoint: 8080

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,11 +1,7 @@
 Workshop
 ========
 
-.. image:: https://app.readthedocs.com/projects/canonical-workshop/badge/?version=latest
-   :target: https://documentation.ubuntu.com/canonical-workshop/
-   :alt: Documentation status
-
-**A tool for defining and handling ephemeral development environments**.
+**Workshops are secure, fast, and composable development environments that come agent-ready**.
 
 List your dependencies and components in YAML to define an environment. The key
 pieces of a definition are SDKs, independent but connectable units of
@@ -86,14 +82,14 @@ Documentation
 
 Refer to the
 `Tutorial
-<https://documentation.ubuntu.com/canonical-workshop/latest/tutorial/>`_
+<https://ubuntu.com/workshop/docs/tutorial/>`_
 in our docs for a detailed introduction to Workshop.
 
 To know more about `SDKcraft <https://github.com/canonical/sdkcraft/>`_,
 the SDK authoring tool for Workshop,
 jump straight to the
 `SDK crafting guide
-<https://documentation.ubuntu.com/canonical-workshop/latest/tutorial/part-4-craft-sdks/>`_
+<https://ubuntu.com/workshop/docs/tutorial/part-4-craft-sdks/>`_
 in our docs.
 
 For reference examples of SDK implementation, see the

--- a/docs/reference/ai-agents.rst
+++ b/docs/reference/ai-agents.rst
@@ -22,12 +22,13 @@ so agents don't have to rediscover the CLIs every session.
 LLM-readable docs
 -----------------
 
-|ws_markup| publishes two files that follow the
-`llms.txt convention <https://llmstxt.org/>`_:
-`llms.txt <https://ubuntu.com/workshop/docs/llms.txt>`_
-indexes every page with a one-line summary,
-and `llms-full.txt <https://ubuntu.com/workshop/docs/llms-full.txt>`_
-concatenates every page as Markdown.
+..
+   |ws_markup| publishes two files that follow the
+.. `llms.txt convention <https://llmstxt.org/>`_:
+.. `llms.txt <https://ubuntu.com/workshop/docs/llms.txt>`_
+.. indexes every page with a one-line summary,
+.. and `llms-full.txt <https://ubuntu.com/workshop/docs/llms-full.txt>`_
+.. concatenates every page as Markdown.
 
 To fetch a single page as Markdown,
 append :file:`.md` to its URL.


### PR DESCRIPTION
The `llms.txt` bit is due to the fact that [RTD doesn't serve these files](https://docs.readthedocs.com/platform/stable/reference/llms-txt.html) with our current publishing scheme; the investigation is ongoing, so I'm not entirely dropping this.