### PR TITLE
Handle stale old-stash snapshot records

### DIFF
--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -392,9 +392,12 @@ func SnapshotLastUsedByTask(task *state.Task) (*workshop.Snapshot, time.Time, er
 			continue
 		}
 
-		snapshot, err := workshopSnapshot(change, w.Workshop, w.Age)
+		snapshot, ok, err := snapshotFromLastUsedRecord(change, w)
 		if err != nil {
 			return nil, time.Time{}, err
+		}
+		if !ok {
+			continue
 		}
 
 		// Each Task deals with at most one snapshot, so we return early.

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -323,6 +323,21 @@ func SdkVolumeLastUsedKey(sk string, revision sdk.Revision) string {
 	return sdk.VolumeName(sk, revision) + "_last-used"
 }
 
+func snapshotFromLastUsedRecord(change *state.Change, t taskTimeWorkshop) (*workshop.Snapshot, bool, error) {
+	snapshot, err := workshopSnapshot(change, t.Workshop, t.Age)
+	if err != nil {
+		// Completed remove changes may still contain a last-used record for
+		// the old stash after the stash metadata itself has already been removed.
+		// Such stale records should not prevent unused snapshot cleanup
+		// from reaching the existing safety checks.
+		if t.Age == OldStash {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return snapshot, true, nil
+}
+
 type taskTime struct {
 	Task string    `json:"task"`
 	Time time.Time `json:"time"`
@@ -339,9 +354,12 @@ func SnapshotLastUsed(change *state.Change, snapshot workshop.Snapshot) (string,
 	var task string
 	var latest time.Time
 	for _, t := range tasks {
-		s, err := workshopSnapshot(change, t.Workshop, t.Age)
+		s, ok, err := snapshotFromLastUsedRecord(change, t)
 		if err != nil {
 			return "", time.Time{}, err
+		}
+		if !ok {
+			continue
 		}
 		if !s.IsBasedOn(snapshot) {
 			continue

--- a/internal/overlord/handlersetup/handler_setup_test.go
+++ b/internal/overlord/handlersetup/handler_setup_test.go
@@ -240,3 +240,26 @@ func (s *CommonStateFuncs) TestSnapshotLastUsedSkipsMissingOldStash(c *check.C) 
 	c.Assert(task, check.Equals, "1")
 	c.Assert(lastUsed.Equal(oldWorkshopTime), check.Equals, true)
 }
+
+func (s *CommonStateFuncs) TestSnapshotLastUsedByTaskSkipsMissingOldStash(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("remove", `Remove "snapshot-check" workshop`)
+	task := s.state.NewTask("remove-workshop-stash", "Remove workshop from stash")
+	chg.AddTask(task)
+
+	staleOldStashTime := time.Now()
+	c.Assert(handlersetup.SetSnapshotLastUsed(
+		chg,
+		"snapshot-check",
+		handlersetup.OldStash,
+		task.ID(),
+		staleOldStashTime,
+	), check.IsNil)
+
+	snapshot, lastUsed, err := handlersetup.SnapshotLastUsedByTask(task)
+	c.Assert(snapshot, check.IsNil)
+	c.Assert(lastUsed.IsZero(), check.Equals, true)
+	c.Assert(err, check.Equals, state.ErrNoState)
+}

--- a/internal/overlord/handlersetup/handler_setup_test.go
+++ b/internal/overlord/handlersetup/handler_setup_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"sort"
 	"testing"
+	"time"
 
 	"gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
@@ -25,6 +26,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -184,4 +186,57 @@ func (s *CommonStateFuncs) TestInjectTasksMainAborted(c *check.C) {
 	// verify that extra tasks are on hold
 	c.Assert(t01.Status(), check.Equals, state.HoldStatus)
 	c.Assert(t02.Status(), check.Equals, state.HoldStatus)
+}
+
+func (s *CommonStateFuncs) TestSnapshotLastUsedSkipsMissingOldStash(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("remove", `Remove "snapshot-check" workshop`)
+
+	base := workshop.BaseImage{
+		Name:        "ubuntu@24.04",
+		Fingerprint: "base-fingerprint",
+	}
+	format := sdk.R(1)
+	setup := sdk.Setup{
+		Name:     "snapshot-check-base",
+		Source:   sdk.ProjectSource,
+		Revision: sdk.R("x1"),
+		Sha3_384: "snapshot-check-base-sha3",
+	}
+
+	// A valid old workshop snapshot record. This simulates another last-used
+	// entry in the same change that can still be resolved.
+	chg.Set(handlersetup.WorkshopFormatKey("snapshot-check", handlersetup.OldWorkshop), format)
+	chg.Set(handlersetup.WorkshopBaseKey("snapshot-check", handlersetup.OldWorkshop), base)
+	chg.Set(handlersetup.WorkshopSdksKey("snapshot-check", handlersetup.OldWorkshop), []sdk.Setup{setup})
+
+	oldWorkshopTime := time.Now()
+	c.Assert(handlersetup.SetSnapshotLastUsed(
+		chg,
+		"snapshot-check",
+		handlersetup.OldWorkshop,
+		"1",
+		oldWorkshopTime,
+	), check.IsNil)
+
+	// A stale old-stash entry. The matching old-stash format/base/sdks keys
+	// are intentionally absent, reproducing the state seen by snapshot cleanup
+	// after a completed remove change has removed the stash metadata.
+	staleOldStashTime := oldWorkshopTime.Add(time.Second)
+	c.Assert(handlersetup.SetSnapshotLastUsed(
+		chg,
+		"snapshot-check",
+		handlersetup.OldStash,
+		"2",
+		staleOldStashTime,
+	), check.IsNil)
+
+	snapshot := workshop.SdkSnapshot(format, base, []sdk.Setup{setup})
+
+	task, lastUsed, err := handlersetup.SnapshotLastUsed(chg, snapshot)
+	c.Assert(err, check.IsNil)
+	c.Assert(task, check.Equals, "1")
+	c.Assert(lastUsed.Equal(oldWorkshopTime), check.Equals, true)
 }


### PR DESCRIPTION
Fix: #799

# Description

This PR makes unused SDK snapshot cleanup more defensive when it encounters stale `old-stash` last-used records.

Snapshot cleanup already has several safeguards before removing a snapshot, such as checking last-used records, waiting for the cleanup cooldown, and asking the backend whether any workshops still reference the snapshot.

However, cleanup can currently stop before reaching those safeguards if a completed remove change still has a last-used record for `old-stash`, but the corresponding old-stash metadata is no longer available. In that case, cleanup logs an internal error such as:

```text
"snapshot-check" workshop old-stash format not found
```

and the unused SDK snapshot containers can remain in the LXD snapshot project.

This change treats stale `old-stash` last-used records as absent state during snapshot cleanup. It does not make snapshot deletion more aggressive; the existing cooldown and backend reference checks remain unchanged.

A regression test is added for the stale `old-stash` case.

## Local verification

I will add the local runtime verification details in a follow-up PR comment.

# Self-review quick check

* [x] Make decisions that cost a lot to reverse explicit in the PR description.
* [x] Avoid nested conditions.
* [x] Delete dead code and redundant comments.
* [x] Normalise symmetries by sticking to doing identical things identically.

```
// one way to handle errors
if err := f(); err != nil {
   ...
}

// one way to handle multiple returns
val, err := f()
if err != nil {
   ...
}
...
```

* [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
* [x] Put variable declaration and initialisation together.
* [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
* [x] Put a blank line between two logically different chunks of code.
* [x] Follow the [[style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages)](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [[style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md)](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.