### PR TITLE
Doc: Fix typos

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -455,7 +455,7 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 	xdgRuntimeDir := filepath.Join(dirs.XdgRuntimeDirBase, strconv.Itoa(flags.UserId))
 	env["XDG_RUNTIME_DIR"] = xdgRuntimeDir
 
-	// The session bus address is often determined programatically, however some
+	// The session bus address is often determined programmatically, however some
 	// programs rely on an explicit environment variable. We set that here. Like
 	// the runtime dir above, we only guarantee that the bus exists for the
 	// workshop user.

--- a/docs/how-to/fix-workshops/debug-issues.rst
+++ b/docs/how-to/fix-workshops/debug-issues.rst
@@ -191,7 +191,7 @@ comment out SDKs one by one in the workshop definition
 and refresh the workshop after each change.
 
 When the issue reappears,
-the cause is likely the SDK you just reenabled,
+the cause is likely the SDK you just re-enabled,
 or its interaction with other SDKs.
 Investigate it using the :command:`workshop tasks` command
 to view detailed error information.

--- a/internal/asserts/constraint.go
+++ b/internal/asserts/constraint.go
@@ -102,7 +102,7 @@ func compileAttrMatcher(cc compileContext, constraints any) (attrMatcher, error)
 		return compileAltAttrMatcher(cc, x)
 	case string:
 		if !cc.hadMap {
-			return nil, fmt.Errorf("first level of non alternative constraints must be a set of key-value contraints")
+			return nil, fmt.Errorf("first level of non alternative constraints must be a set of key-value constraints")
 		}
 		if strings.HasPrefix(x, "$") {
 			if x == "$MISSING" {

--- a/internal/asserts/constraint_test.go
+++ b/internal/asserts/constraint_test.go
@@ -393,10 +393,10 @@ func (s *attrMatcherSuite) TestCompileErrors(c *C) {
 	c.Check(err, ErrorMatches, `cannot nest alternative constraints directly at "foo/alt#2/"`)
 
 	_, err = asserts.CompileAttrMatcher("FOO", nil)
-	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value constraints`)
 
 	_, err = asserts.CompileAttrMatcher([]any{"FOO"}, nil)
-	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+	c.Check(err, ErrorMatches, `first level of non alternative constraints must be a set of key-value constraints`)
 
 	_, err = asserts.CompileAttrMatcher(map[string]any{
 		"foo": "$FOO()",

--- a/internal/asserts/ifacedecls.go
+++ b/internal/asserts/ifacedecls.go
@@ -129,7 +129,7 @@ func (ac SideArityConstraint) Any() bool {
 	return ac.N == -1
 }
 
-// SlotConnectionConstraints specfies a set of constraints on an
+// SlotConnectionConstraints specifies a set of constraints on an
 // interface slot for a sdk relevant to its connection or
 // auto-connection.
 type SlotConnectionConstraints struct {
@@ -608,7 +608,7 @@ func compilePlugInstallationConstraints(context *subruleContext, cDef constraint
 	return plugInstCstrs, nil
 }
 
-// PlugConnectionConstraints specfies a set of constraints on an
+// PlugConnectionConstraints specifies a set of constraints on an
 // interface plug for a snap relevant to its connection or
 // auto-connection.
 type PlugConnectionConstraints struct {
@@ -693,7 +693,7 @@ func compilePlugConnectionConstraints(context *subruleContext, cDef constraintsD
 	return plugConnCstrs, nil
 }
 
-// PlugRule holds the rule of what is allowed, wrt instalation and
+// PlugRule holds the rule of what is allowed, wrt installation and
 // connection, for a plug of a specific interface for a sdk.
 type PlugRule struct {
 	Interface string

--- a/internal/asserts/ifacedecls_test.go
+++ b/internal/asserts/ifacedecls_test.go
@@ -290,10 +290,10 @@ func (s *attrConstraintsSuite) TestCompileErrors(c *check.C) {
 	c.Check(err, check.ErrorMatches, `cannot compile "foo" constraint "\[": error parsing regexp:.*`)
 
 	_, err = asserts.CompileAttributeConstraints("FOO")
-	c.Check(err, check.ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+	c.Check(err, check.ErrorMatches, `first level of non alternative constraints must be a set of key-value constraints`)
 
 	_, err = asserts.CompileAttributeConstraints([]any{"FOO"})
-	c.Check(err, check.ErrorMatches, `first level of non alternative constraints must be a set of key-value contraints`)
+	c.Check(err, check.ErrorMatches, `first level of non alternative constraints must be a set of key-value constraints`)
 
 	wrongDollarConstraints := []string{
 		"$",
@@ -597,7 +597,7 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleDefaults(c *check.C) {
 	checkBoolPlugConnConstraints(c, "deny-auto-connection", rule.DenyAutoConnection, true)
 }
 
-func (s *plugSlotRulesSuite) TestCompilePlugRuleInstalationConstraintsIDConstraints(c *check.C) {
+func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsIDConstraints(c *check.C) {
 	rule, err := asserts.CompilePlugRule("iface", map[string]any{
 		"allow-installation": map[string]any{
 			"plug-sdk-type": []any{sdk.System.String(), sdk.Regular.String()},

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -3798,7 +3798,7 @@ func (s *apiSuite) TestRefreshContinue(c *check.C) {
 	s.runActionTest(c, requests, expected)
 
 	// This will be called twice: first, on the refresh attempt, second, on the
-	// refresh --continue, which will be successfull and allow the refresh to
+	// refresh --continue, which will be successful and allow the refresh to
 	// finish.
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 2)
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -831,7 +831,7 @@ func (s *daemonSuite) TestRestartShutdown(c *check.C) {
 	st.Unlock()
 
 	sigCh := make(chan os.Signal, 2)
-	// stop (this will timeout but thats not relevant for this test)
+	// stop (this will timeout but that's not relevant for this test)
 	d.Stop(sigCh)
 
 	// ensure that the sigCh got closed as part of the stop
@@ -882,7 +882,7 @@ func (s *daemonSuite) TestRestartExpectedRebootIsMissing(c *check.C) {
 	}
 
 	sigCh := make(chan os.Signal, 2)
-	// stop (this will timeout but thats not relevant for this test)
+	// stop (this will timeout but that's not relevant for this test)
 	d.Stop(sigCh)
 
 	// an immediate shutdown was scheduled again

--- a/internal/daemon/snapshot-ingredients.yaml
+++ b/internal/daemon/snapshot-ingredients.yaml
@@ -1,7 +1,7 @@
 # When updating this file, please carefully consider whether the snapshot
 # format revision number needs to be bumped. This file is used by the
 # apiSuite.TestSnapshotIngredients test. It records the types Workshop uses
-# interally to define or describe workshops. Field types may be omitted if
+# internally to define or describe workshops. Field types may be omitted if
 # they're irrelevant to the snapshot format. Changes to this file may indicate
 # a need to expand the other snapshot format tests.
 File:

--- a/internal/https/http.go
+++ b/internal/https/http.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BasicAuthHeader creates a header that contains just the "Authorization"
-// entry.  The implementation was originally taked from net/http but this is
+// entry.  The implementation was originally taken from net/http but this is
 // needed externally from the http request object in order to use this with
 // our websockets. See 2 (end of page 4) http://www.ietf.org/rfc/rfc2617.txt
 // "To receive authorization, the client sends the userid and password,

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -370,7 +370,7 @@ func unmount(conn lxd.InstanceServer, pid, w string, where string) error {
 // 'systemd-fstab-generator' is responsible for creating mount entries from
 // fstab. Because of this, we need to first ensure it runs (generating the
 // on-demand unit files) by calling daemon-reload, and then activate the
-// newly-creaed units by restarting a downstream target (ie. local-fs) see:
+// newly-created units by restarting a downstream target (ie. local-fs) see:
 // https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html
 func reloadMounts(conn lxd.InstanceServer, pid, w string) error {
 	if err := runCommand(conn, pid, w, []string{"systemctl", "daemon-reload"}); err != nil {

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -202,7 +202,7 @@ revision: 0
 
 func (s *baseDeclSuite) TestDoesNotPanic(c *check.C) {
 	// In case there are any issues in the actual interfaces we'd get a panic
-	// on startup. This test prevents this from happing unnoticed.
+	// on startup. This test prevents this from happening unnoticed.
 	_, err := policy.ComposeBaseDeclaration(builtin.Interfaces())
 	c.Assert(err, check.IsNil)
 }

--- a/internal/interfaces/repo_test.go
+++ b/internal/interfaces/repo_test.go
@@ -649,7 +649,7 @@ func (s *RepositorySuite) TestAddSlotParallelInstance(c *C) {
 
 // Tests for Repository.RemoveSlot()
 
-func (s *RepositorySuite) TestRemoveSlotSuccedsWhenSlotExistsAndDisconnected(c *C) {
+func (s *RepositorySuite) TestRemoveSlotSucceedsWhenSlotExistsAndDisconnected(c *C) {
 	err := s.testRepo.AddSlot(s.slot)
 	c.Assert(err, IsNil)
 	// Removing a vacant slot simply works

--- a/internal/osutil/stat.go
+++ b/internal/osutil/stat.go
@@ -42,7 +42,7 @@ func IsDir(path string) bool {
 	return fileInfo.IsDir()
 }
 
-// IsDevice returns true if mode coresponds to a device (char/block).
+// IsDevice returns true if mode corresponds to a device (char/block).
 func IsDevice(mode os.FileMode) bool {
 	return (mode & (os.ModeDevice | os.ModeCharDevice)) != 0
 }

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -32,7 +32,7 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-// OnUndo helps to skip the undo handler if the change is an abort-backgroud refresh
+// OnUndo helps to skip the undo handler if the change is an abort-background refresh
 func OnUndo(handler state.HandlerFunc) state.HandlerFunc {
 	return func(task *state.Task, tomb *tomb.Tomb) error {
 		st := task.State()
@@ -54,8 +54,8 @@ func OnUndo(handler state.HandlerFunc) state.HandlerFunc {
 // OnDo helps to decide whether:
 // 1. The task needs to be put on Wait (wait-on-error for refresh).
 //
-// 2. The error needs to be reported but safely ingored (ContextCancelled can
-// happen if a user cancells or something gets interrupted during the execution
+// 2. The error needs to be reported but safely ignored (ContextCancelled can
+// happen if a user cancels or something gets interrupted during the execution
 // due to abortion, e.g. a running hook is called off because their change was
 // aborted.
 //

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -282,7 +282,7 @@ func (h *healthHandler) Done() (err error) {
 		// if reached the maximum possible retries, reset the counter. This is
 		// required for scenarios when a user provided --wait-on-error to
 		// workshop refresh. If provided and check-health failed after multiple
-		// attemps, refresh will wait on this error allowing to repeat the task
+		// attempts, refresh will wait on this error allowing to repeat the task
 		// with --continue. In this case, we must to re-run the health check
 		// from scratch.
 		h.context.Lock()

--- a/internal/overlord/hookstate/context.go
+++ b/internal/overlord/hookstate/context.go
@@ -279,7 +279,7 @@ func (c *Context) Logf(fmt string, args ...any) {
 func (c *Context) Errorf(format string, args ...any) {
 	c.writing()
 	if c.IsEphemeral() {
-		// XXX: loger has no Errorf() :/
+		// XXX: logger has no Errorf() :/
 		logger.Noticef(format, args...)
 	} else {
 		c.task.Errorf(format, args...)

--- a/internal/overlord/hookstate/manager.go
+++ b/internal/overlord/hookstate/manager.go
@@ -25,7 +25,7 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-// Handler is the interface a client must satify to handle hooks.
+// Handler is the interface a client must satisfy to handle hooks.
 type Handler interface {
 	// Before is called right before the hook is to be run.
 	Before() error

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -949,7 +949,7 @@ func (m *InterfaceManager) doRemoveProfiles(task *state.Task, tomb *tomb.Tomb) e
 
 	for _, backend := range m.repo.Backends() {
 		// If there are not plugs or slots declared by the SDK the profile does
-		// not neccessarily exist for the SDK.
+		// not necessarily exist for the SDK.
 		ref := sdk.Ref{ProjectId: p.ProjectId, Workshop: w, Sdk: s}
 		if err := backend.Remove(ctx, ref); err != nil && !errors.Is(err, workshop.ErrSdkProfileNotFound) {
 			return err

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -39,13 +39,13 @@ import (
 
 type interfaceHandlersSuite struct {
 	interfaceManagerSuite
-	mgr                      *ifacestate.InterfaceManager
-	user                     *user.User
-	restoreSimple            func()
-	restoreDeny              func()
-	restoreSecurtityBackends func()
-	restoreUserLookup        func()
-	restoreUserEnv           func()
+	mgr                     *ifacestate.InterfaceManager
+	user                    *user.User
+	restoreSimple           func()
+	restoreDeny             func()
+	restoreSecurityBackends func()
+	restoreUserLookup       func()
+	restoreUserEnv          func()
 }
 
 var _ = check.Suite(&interfaceHandlersSuite{})
@@ -215,7 +215,7 @@ func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 		return errors.New("error-trigger task")
 	}
 	s.runner.AddHandler("error-trigger", erroringHandler, nil)
-	s.restoreSecurtityBackends = ifacestate.MockSecurityBackends([]interfaces.SecurityBackend{s.secBackend})
+	s.restoreSecurityBackends = ifacestate.MockSecurityBackends([]interfaces.SecurityBackend{s.secBackend})
 
 	s.o.AddManager(s.mgr)
 	s.o.AddManager(s.runner)
@@ -226,7 +226,7 @@ func (s *interfaceHandlersSuite) SetUpTest(c *check.C) {
 func (s *interfaceHandlersSuite) TearDownTest(c *check.C) {
 	s.restoreSimple()
 	s.restoreDeny()
-	s.restoreSecurtityBackends()
+	s.restoreSecurityBackends()
 	s.restoreUserEnv()
 	s.restoreUserLookup()
 }

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -78,7 +78,7 @@ func (m *InterfaceManager) Repository() *interfaces.Repository {
 type ConnectionState struct {
 	// Auto indicates whether the connection was established automatically
 	Auto bool
-	// ByGadget indicates whether the connection was trigged by the gadget
+	// ByGadget indicates whether the connection was triggered by the gadget
 	ByGadget bool
 	// Interface name of the connection
 	Interface string

--- a/internal/overlord/state/state_test.go
+++ b/internal/overlord/state/state_test.go
@@ -984,7 +984,7 @@ func (ss *stateSuite) TestPruneMaxChangesHonored(c *C) {
 	// 10 changes, none ready
 	for i := 0; i < 10; i++ {
 		chg := st.NewChange(fmt.Sprintf("chg%d", i), "not-ready")
-		t := st.NewTask("foo", "not-readly")
+		t := st.NewTask("foo", "not-ready")
 		chg.AddTask(t)
 	}
 	c.Assert(st.Changes(), HasLen, 10)

--- a/internal/overlord/state/task.go
+++ b/internal/overlord/state/task.go
@@ -229,7 +229,7 @@ func (t *Task) Summary() string {
 //	Error                  V    V
 //	                     Undone Error
 //
-// Do -> Doing -> Done is the direct succcess scenario.
+// Do -> Doing -> Done is the direct success scenario.
 //
 // Wait can transition to its waited status,
 // usually Done|Undone or back to Doing.

--- a/internal/overlord/state/taskrunner_test.go
+++ b/internal/overlord/state/taskrunner_test.go
@@ -453,7 +453,7 @@ func (ts *taskRunnerSuite) TestAbortAcrossLanesDescendantTask(c *C) {
 	})
 }
 
-func (ts *taskRunnerSuite) TestAbortAcrossLanesStriclyOrderedTasks(c *C) {
+func (ts *taskRunnerSuite) TestAbortAcrossLanesStrictlyOrderedTasks(c *C) {
 
 	// <task>(<lane>)
 	//  t11(1) -> t12(1)

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -370,7 +370,7 @@ func (m *WorkshopManager) doStop(task *state.Task, tomb *tomb.Tomb) error {
 	defer cancel()
 	go func() {
 		// LXD has an internal timeout (30 seconds) for the operation,
-		// if exceeded, the dealine error will be returned
+		// if exceeded, the deadline error will be returned
 		stopped <- StopWorkshop(m.backend, stopctx, w, force)
 	}()
 

--- a/internal/sdkstore/client.go
+++ b/internal/sdkstore/client.go
@@ -19,7 +19,7 @@ const (
 	// field in the Config struct.
 	DefaultServerURL = "https://api.pkg.store"
 
-	// RefreshTimeout is the timout callers should use for Refresh calls.
+	// RefreshTimeout is the timeout callers should use for Refresh calls.
 	RefreshTimeout = 10 * time.Second
 )
 

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -458,7 +458,7 @@ func (s *systemd) Status(unitNames ...string) ([]*UnitStatus, error) {
 	return sts, nil
 }
 
-// IsEnabled checkes whether the given service is enabled
+// IsEnabled checks whether the given service is enabled
 func (s *systemd) IsEnabled(serviceName string) (bool, error) {
 	if s.mode == GlobalUserMode {
 		panic("cannot call is-enabled with GlobalUserMode")
@@ -476,7 +476,7 @@ func (s *systemd) IsEnabled(serviceName string) (bool, error) {
 	return false, err
 }
 
-// IsActive checkes whether the given service is Active
+// IsActive checks whether the given service is Active
 func (s *systemd) IsActive(serviceName string) (bool, error) {
 	if s.mode == GlobalUserMode {
 		panic("cannot call is-active with GlobalUserMode")

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1082,7 +1082,7 @@ runcmd:
 		"user.workshop.base-fingerprint": baseFingerprint,
 		// LXC appears to have a race condition wherein a proxy device mounted in
 		// a dynamically created directory has the potential to be 'masked' by this
-		// directory. We create an explicit mount for /tmp here (one such dymanic
+		// directory. We create an explicit mount for /tmp here (one such dynamic
 		// directory) to allow us to mount X11 sockets reliably.
 		// See: https://github.com/lxc/lxc/issues/434
 		"raw.lxc": "lxc.mount.entry = tmpfs tmp tmpfs defaults",

--- a/internal/workshop/lxd/lxd_base_manager.go
+++ b/internal/workshop/lxd/lxd_base_manager.go
@@ -346,7 +346,7 @@ func handleImageUpdate(opmeta map[string]any, imsize int64) *downloadUpdate {
 		}
 		// now, "done" is the percentage value. The state.Task progress
 		// reporting expects to have bytes all the way up to the client
-		// to calculate the download speed. Thus, covert percentages to
+		// to calculate the download speed. Thus, convert percentages to
 		// bytes.
 		donebytes := imsize * done / 100
 		return &downloadUpdate{Label: "download", Done: donebytes, Total: imsize}

--- a/internal/workshop/project.go
+++ b/internal/workshop/project.go
@@ -104,7 +104,7 @@ func (w *Project) ReadWorkshops() (map[string]string, error) {
 
 	// *.yaml is the only supported extension for workshop files as the only
 	// recommended "official" extension: https://yaml.org/faq.html. Also, having a
-	// single way of naming workshop files avoids unneccesary inconsistencies.
+	// single way of naming workshop files avoids unnecessary inconsistencies.
 	files, err := filepath.Glob(filepath.Join(w.Path, Directory, "*.yaml"))
 	if err != nil {
 		return nil, err

--- a/internal/wsutil/wsutil_linux.go
+++ b/internal/wsutil/wsutil_linux.go
@@ -54,7 +54,7 @@ func MirrorToWebsocket(conn MessageWriter, r io.ReadCloser, exited chan struct{}
 }
 
 // Extensively commented directly in the code. Please leave the comments!
-// Looking at this in a couple of months noone will know why and how this works
+// Looking at this in a couple of months no one will know why and how this works
 // anymore.
 func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd int) <-chan []byte {
 	if bufferSize <= (128 * 1024) {
@@ -77,7 +77,7 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 	// following function call. Here's why: Assume the above case, now the
 	// attached child (the shell in this example) exits. This will not
 	// generate any poll() event: We won't get POLLHUP because the
-	// background process is holding stdin/stdout open and noone is writing
+	// background process is holding stdin/stdout open and no one is writing
 	// to it. So we effectively block on GetPollRevents() in the function
 	// below. Hence, we use another go routine here who's only job is to
 	// handle that case: When we detect that the child has exited we check


### PR DESCRIPTION
# Description

Found via `codespell -L allws,generall,fo,te,childs,optio,ot,nknown,connectts,wee,egister,elease` 
and `typos --hidden --format brief`

# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
