### PR TITLE
tests: install Workshop from the store in the build-an-sdk test

### DIFF
--- a/tests/docs-how-to/build-an-sdk/task.yaml
+++ b/tests/docs-how-to/build-an-sdk/task.yaml
@@ -44,8 +44,6 @@ execute: |
   run_sdkcraft clean
   run_sdkcraft try
 
-  # The Test the SDK section in the doc invokes sdkcraft test, which installs
-  # Workshop from the store, so no local snap copy is needed.
   run_sdkcraft test --list | MATCH "main/launch"
 
   # Consume the try SDK from a fresh workshop project.

--- a/tests/docs-how-to/build-an-sdk/task.yaml
+++ b/tests/docs-how-to/build-an-sdk/task.yaml
@@ -44,11 +44,8 @@ execute: |
   run_sdkcraft clean
   run_sdkcraft try
 
-  # The Test the SDK section in the doc invokes sdkcraft test. It needs
-  # a local workshop snap next to the SDK tests/ directory because the
-  # Workshop snap is still private; copy the one snapcraft built for spread.
-  cp /workshop/tests/workshop_*.snap tests/
-  chown -R ubuntu:ubuntu tests
+  # The Test the SDK section in the doc invokes sdkcraft test, which installs
+  # Workshop from the store, so no local snap copy is needed.
   run_sdkcraft test --list | MATCH "main/launch"
 
   # Consume the try SDK from a fresh workshop project.


### PR DESCRIPTION
# Description

The `tests/docs-how-to/build-an-sdk` spread test still copied a local `workshop_*.snap` into the SDK's `tests/` directory and described Workshop as "still private", which is no longer accurate.

This drops the obsolete `cp` (and its now-redundant `chown`) and the stale comment. `sdkcraft test --list` no longer requires a local snap, so `run_sdkcraft test --list | MATCH "main/launch"` continues to pass.

Documentation tests are updated (`how-to/develop-sdks/build-an-sdk`).
