### PR TITLE
Ensure tasks which trigger snapshot cleanup have access to required metadata

### DIFF
--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -483,7 +483,7 @@ func remove(ctx context.Context, mgr *workshopstate.WorkshopManager, reqData *wo
 		return nil, nil, nil, err
 	}
 
-	tasksets, err = mgr.RemoveMany(ctx, project, current, running)
+	tasksets, err = mgr.RemoveMany(ctx, project, stashed, current, running)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1911,11 +1911,12 @@ func (s *apiSuite) ensureWorkshops(c *check.C, want []expectedWorkshop) {
 // setting the cooldown time to 0 and running the state engine multiple times to
 // trigger the garbage collection.
 func (s *apiSuite) ensureSdkVolumesAfterCooldown(c *check.C, want []string) {
+	st := s.d.state
+	st.Lock()
 	defer sdkstate.FakeSdkVolumeCooldownTime(0)()
+	st.Unlock()
 
-	// More Ensure calls than usual to prevent FakeSdkVolumeCooldownTime
-	// from racing with the outstanding cleanup handlers.
-	for range 12 {
+	for range 6 {
 		c.Check(s.d.overlord.StateEngine().Ensure(), check.IsNil)
 		s.d.overlord.StateEngine().Wait()
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
 	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/sdk/system"
@@ -1251,6 +1252,7 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1"})
+	s.ensureSnapshotsAfterCooldown(c, nil, []string{"system", "test-sdk", "test-sdk-2"})
 }
 
 //go:embed snapshot-format.yaml
@@ -1939,6 +1941,39 @@ func (s *apiSuite) ensureSdkVolumesAfterCooldown(c *check.C, want []string) {
 	}
 }
 
+// ensureSnapshotsAfterCooldown ensures that unused snapshots are removed if
+// unused by setting the snapshot cooldown time to 0 and running the state
+// engine multiple times to trigger the garbage collection.
+func (s *apiSuite) ensureSnapshotsAfterCooldown(c *check.C, want, remove []string) {
+	st := s.d.state
+	st.Lock()
+	defer workshopstate.FakeSnapshotCooldownTime(0)()
+	st.Unlock()
+
+	for range 6 {
+		c.Check(s.d.overlord.StateEngine().Ensure(), check.IsNil)
+		s.d.overlord.StateEngine().Wait()
+	}
+
+	var remaining, removed []string
+	for _, snapshot := range s.b.Snapshots {
+		remaining = append(remaining, snapshotSdk(snapshot.Snapshot))
+	}
+	for _, snapshot := range s.b.RemovedSnapshots {
+		removed = append(removed, snapshotSdk(snapshot))
+	}
+
+	c.Assert(remaining, testutil.DeepUnsortedMatches, want)
+	c.Assert(removed, testutil.DeepUnsortedMatches, remove)
+}
+
+func snapshotSdk(snapshot workshop.Snapshot) string {
+	if len(snapshot.Sdks) == 0 {
+		return ""
+	}
+	return snapshot.Sdks[len(snapshot.Sdks)-1].Name
+}
+
 type launchOrRebuild struct {
 	file string
 	sdks []string
@@ -2374,6 +2409,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{"test-sdk-1", "system-1"})
+	s.ensureSnapshotsAfterCooldown(c, []string{"system", "test-sdk"}, []string{"test-sdk-2"})
 }
 
 func updateSdkStoreRev(name string, rev int, meta, digest string) func() {
@@ -4502,6 +4538,123 @@ func (s *apiSuite) TestRefreshConflictChange(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
+func (s *apiSuite) TestSnapshotRemovedAfterFailedRefresh(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload(c))()
+
+	// Fail when snapshotting test-sdk-2.
+	s.b.SnapshotCallback = func(ctx context.Context, name string, snapshot workshop.Snapshot) error {
+		if len(snapshot.Sdks) > 2 {
+			return errors.New("cannot take snapshot")
+		}
+		return nil
+	}
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.mockProjectSdk(c, "test-sdk-2", testsdk2)
+	s.createWFile(c, "basic", basic_refreshed)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "refresh",
+			Summary:   `Refresh "basic" workshop`,
+			ChangeErr: `(?s).*cannot take snapshot.*`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.ensureSnapshotsAfterCooldown(c, []string{"system"}, []string{"test-sdk"})
+}
+
+func (s *apiSuite) TestSnapshotsRemovedAfterRemoveMidRefresh(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.createWFile(c, "manysdks", manysdks)
+	defer s.store.SetDownloadCallback(storeDownload(c))()
+
+	// Fail when snapshotting test-sdk-2 post-refresh.
+	s.b.SnapshotCallback = func(ctx context.Context, name string, snapshot workshop.Snapshot) error {
+		if snapshot.Image.Name == "ubuntu@24.04" && len(snapshot.Sdks) > 2 {
+			return errors.New("cannot take snapshot")
+		}
+		return nil
+	}
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.createWFile(c, "manysdks", manysdks_newbase)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options":{"mode":"wait-on-error"}}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "refresh",
+			Summary:   `Refresh "manysdks" workshop`,
+			ChangeErr: `(?s).*cannot take snapshot.*`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	c.Assert(s.b.Snapshots, check.HasLen, 5)
+	st := s.d.state
+	st.Lock()
+	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "manysdks", []string{"exec"})
+	st.Unlock()
+	c.Assert(err, check.NotNil)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"remove"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "remove",
+			Summary: `Remove "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.ensureSnapshotsAfterCooldown(c, nil, []string{"system", "system", "test-sdk", "test-sdk", "test-sdk-2"})
+}
+
 func (s *apiSuite) TestSDKInstallationOrder(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()
@@ -4681,6 +4834,7 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 	}
 	s.runActionTest(c, requests, expected)
 	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1"})
+	s.ensureSnapshotsAfterCooldown(c, nil, []string{"system", "test-sdk", "test-sdk-2"})
 }
 
 func (s *apiSuite) TestRemoveWorkshopNotFound(c *check.C) {

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -194,24 +194,11 @@ func CheckChangeConflict(st *state.State, projectId, workshop string, ignoreKind
 	}
 }
 
-func BackgroundDiscardWaitingRefresh(st *state.State, workshop, projectId string) error {
-	chg, err := findRunningChange(st, projectId, workshop, []string{"exec"})
-	if err != nil {
-		return err
-	}
-
-	if chg == nil || chg.Status() != state.WaitStatus {
-		return nil
-	}
-
-	if chg.Kind() != "refresh" && chg.Kind() != "launch" {
-		return fmt.Errorf("cannot discard %s: %s is in progress", workshop, chg.Kind())
-	}
-
+func BackgroundDiscard(chg *state.Change, workshop string) {
 	for _, tsk := range chg.Tasks() {
 		if tsk.Status() == state.WaitStatus {
 			tsk.SetStatus(state.DoStatus)
-			tsk.Logf("Discarding %q for workshop %q...", chg.Kind(), workshop)
+			tsk.Logf("Discarding %q for %q workshop...", chg.Kind(), workshop)
 		}
 	}
 
@@ -221,7 +208,6 @@ func BackgroundDiscardWaitingRefresh(st *state.State, workshop, projectId string
 	chg.Set("discard-background", true)
 
 	chg.Abort()
-	return nil
 }
 
 // Attempt to resume the change associated with the Resume/Launch operation

--- a/internal/overlord/workshopstate/handlers.go
+++ b/internal/overlord/workshopstate/handlers.go
@@ -638,5 +638,6 @@ func (m *WorkshopManager) deleteUnusedSnapshot(ctx context.Context, task *state.
 	if err := m.backend.RemoveSnapshot(ctx, snapshot); err != nil {
 		return false, err
 	}
+	logger.Debugf("On WorkshopManager.doDeleteUnusedSnapshots: snapshot %v for task %s was deleted", len(snapshot.Sdks), task.ID())
 	return true, nil
 }

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -994,8 +994,14 @@ func (s *workshopHandlers) TestSnapshotRemovedAfterRemoveMidRefresh(c *check.C) 
 	c.Check(s2.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
 
 	// Next, remove the partially-refreshed workshop.
-	err = conflict.BackgroundDiscardWaitingRefresh(s.state, "ws", s.project.ProjectId)
-	c.Assert(err, check.IsNil)
+	err = conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", []string{"exec"})
+	c.Assert(err, check.DeepEquals, &conflict.ChangeConflictError{
+		ProjectId:  s.project.ProjectId,
+		Workshop:   "ws",
+		ChangeKind: refresh.Kind(),
+		ChangeID:   refresh.ID(),
+	})
+	conflict.BackgroundDiscard(refresh, "ws")
 
 	remove := s.state.NewChange("remove", "...")
 	remove.Set("user", "testuser")

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -30,7 +30,9 @@ import (
 	"github.com/canonical/workshop/internal/arch"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
+	"github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/healthstate"
+	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/revert"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/sdk/system"
@@ -138,9 +140,14 @@ func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string,
 			return nil, nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
 		}
 
-		if err := conflict.BackgroundDiscardWaitingRefresh(w.state, name, projectId); err != nil {
+		manifest, err := w.maybeDiscardWaitingRefresh(projectId, wp.File)
+		if err != nil {
 			return nil, nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
 		}
+		if manifest != nil {
+			stashed = append(stashed, *manifest)
+		}
+
 		allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.ErrorStatus, healthstate.StoppedStatus}
 		if err := healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
 			return nil, nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
@@ -153,23 +160,43 @@ func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string,
 		current = append(current, Manifest{File: wp.File, Format: wp.Format, Image: wp.Image, Sdks: installed})
 
 		running[wp.File.Name] = wp.Running
-
-		stash, err := w.backend.StashedWorkshop(ctx, name)
-		if errors.Is(err, workshop.ErrWorkshopNotLaunched) {
-			continue
-		}
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		installed = make([]sdk.Setup, 0, len(stash.Sdks))
-		for _, sk := range stash.SdksByInstallOrder() {
-			installed = append(installed, sk.Setup)
-		}
-		stashed = append(stashed, Manifest{File: stash.File, Format: stash.Format, Image: stash.Image, Sdks: installed})
 	}
 
 	return stashed, current, running, nil
+}
+
+func (w *WorkshopManager) maybeDiscardWaitingRefresh(projectId string, file *workshop.File) (*Manifest, error) {
+	err := conflict.CheckChangeConflict(w.state, projectId, file.Name, []string{"exec"})
+	if err == nil {
+		return nil, nil
+	}
+	conflictErr, ok := errors.AsType[*conflict.ChangeConflictError](err)
+	if !ok {
+		return nil, err
+	}
+	chg := w.state.Change(conflictErr.ChangeID)
+	if chg.Status() != state.WaitStatus || (chg.Kind() != "launch" && chg.Kind() != "refresh") {
+		// Let CheckWorkshopHealth handle the error.
+		return nil, nil
+	}
+
+	format, err := handlersetup.WorkshopFormat(chg, file.Name, handlersetup.OldWorkshop)
+	if err != nil {
+		return nil, err
+	}
+	image, err := handlersetup.WorkshopBase(chg, file.Name, handlersetup.OldWorkshop)
+	if err != nil {
+		return nil, err
+	}
+	sdks, err := handlersetup.WorkshopSdks(chg, file.Name, handlersetup.OldWorkshop)
+	if err != nil {
+		return nil, err
+	}
+
+	conflict.BackgroundDiscard(chg, file.Name)
+	// The file here is not quite right, but we only use the name field. If
+	// that changes in future, we should reconstruct it from chg.
+	return &Manifest{File: file, Format: format, Image: image, Sdks: sdks}, nil
 }
 
 type artifactFinder struct {

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -126,12 +126,12 @@ func (w *WorkshopManager) RefreshManifests(ctx context.Context, project workshop
 	}
 }
 
-func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string, names []string) (stashed, current []Manifest, running []bool, err error) {
+func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string, names []string) (stashed, current []Manifest, running map[string]bool, err error) {
 	ctx = context.WithValue(ctx, workshop.ContextProjectId, projectId)
 
 	stashed = make([]Manifest, 0, len(names))
 	current = make([]Manifest, 0, len(names))
-	running = make([]bool, 0, len(names))
+	running = make(map[string]bool, len(names))
 	for _, name := range names {
 		wp, err := w.backend.Workshop(ctx, name)
 		if err != nil {
@@ -152,7 +152,7 @@ func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string,
 		}
 		current = append(current, Manifest{File: wp.File, Format: wp.Format, Image: wp.Image, Sdks: installed})
 
-		running = append(running, wp.Running)
+		running[wp.File.Name] = wp.Running
 
 		stash, err := w.backend.StashedWorkshop(ctx, name)
 		if errors.Is(err, workshop.ErrWorkshopNotLaunched) {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -694,10 +694,10 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 	return execSet, nil
 }
 
-func (w *WorkshopManager) RemoveMany(ctx context.Context, project workshop.Project, manifests []Manifest, running []bool) ([]*state.TaskSet, error) {
+func (w *WorkshopManager) RemoveMany(ctx context.Context, project workshop.Project, manifests []Manifest, running map[string]bool) ([]*state.TaskSet, error) {
 	taskset := []*state.TaskSet{}
-	for i, m := range manifests {
-		remove := remove(w.state, m, running[i], project)
+	for _, m := range manifests {
+		remove := remove(w.state, m, running[m.File.Name], project)
 		taskset = append(taskset, remove)
 	}
 	return taskset, nil

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -694,16 +694,21 @@ func (w *WorkshopManager) Exec(ctx context.Context, name, projectId string, args
 	return execSet, nil
 }
 
-func (w *WorkshopManager) RemoveMany(ctx context.Context, project workshop.Project, manifests []Manifest, running map[string]bool) ([]*state.TaskSet, error) {
+func (w *WorkshopManager) RemoveMany(ctx context.Context, project workshop.Project, stashed, current []Manifest, running map[string]bool) ([]*state.TaskSet, error) {
+	hasStash := make(map[string]bool, len(stashed))
+	for _, s := range stashed {
+		hasStash[s.File.Name] = true
+	}
+
 	taskset := []*state.TaskSet{}
-	for _, m := range manifests {
-		remove := remove(w.state, m, running[m.File.Name], project)
+	for _, m := range current {
+		remove := remove(w.state, m, hasStash[m.File.Name], running[m.File.Name], project)
 		taskset = append(taskset, remove)
 	}
 	return taskset, nil
 }
 
-func remove(st *state.State, manifest Manifest, running bool, project workshop.Project) *state.TaskSet {
+func remove(st *state.State, manifest Manifest, hasStash, running bool, project workshop.Project) *state.TaskSet {
 	removeSet := state.NewTaskSet()
 	var prevRemove *state.TaskSet
 	addTaskSet := func(ts *state.TaskSet) {
@@ -745,8 +750,11 @@ func remove(st *state.State, manifest Manifest, running bool, project workshop.P
 	removeStateStorage := st.NewTask("remove-state-storage", "Remove SDK state storage")
 	addTaskSet(state.NewTaskSet(removeStateStorage))
 
-	removeStash := st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", manifest.File.Name))
-	addTaskSet(state.NewTaskSet(removeStash))
+	var removeStash *state.Task
+	if hasStash {
+		removeStash = st.NewTask("remove-workshop-stash", fmt.Sprintf("Remove %q workshop from stash", manifest.File.Name))
+		addTaskSet(state.NewTaskSet(removeStash))
+	}
 
 	removeDirs := st.NewTask("remove-workshop-storage", fmt.Sprintf("Remove %q storage directories", manifest.File.Name))
 	addTaskSet(state.NewTaskSet(removeDirs))
@@ -756,7 +764,9 @@ func remove(st *state.State, manifest Manifest, running bool, project workshop.P
 	// If an error occurs when removing the directories, it will not affect the other tasks.
 	cleanupLane := st.NewLane()
 	removeDirs.JoinLane(cleanupLane)
-	removeStash.JoinLane(cleanupLane)
+	if removeStash != nil {
+		removeStash.JoinLane(cleanupLane)
+	}
 	removeStateStorage.JoinLane(cleanupLane)
 
 	for _, task := range removeSet.Tasks() {

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -73,9 +73,6 @@ func (e *ErrExec) Error() string {
 }
 
 type Stash interface {
-	// Loads a stashed workshop instance.
-	StashedWorkshop(ctx context.Context, name string) (*Workshop, error)
-
 	// Make a stash of the workshop. The workshop will be stopped and will not
 	// be available to other workshop operations, e.g. list, stop, start and so
 	// on. A new workshop with the same name can be launched for the same

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -500,27 +500,6 @@ func DoExecDefault(ctx context.Context, name string, args *workshop.Execution) (
 	}, nil
 }
 
-func (s *FakeWorkshopBackend) StashedWorkshop(ctx context.Context, name string) (*workshop.Workshop, error) {
-	user, projectId, err := s.userProject(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	project := s.project(user, projectId)
-	if project == nil {
-		return nil, api.StatusErrorf(404, "project not found")
-	}
-
-	s.workshopLock.Lock()
-	defer s.workshopLock.Unlock()
-
-	wp := s.StashedWorkshops[projectId]["stash-"+name]
-	if wp == nil {
-		return nil, workshop.ErrWorkshopNotLaunched
-	}
-	return wp.Workshop, nil
-}
-
 func (s *FakeWorkshopBackend) RemoveWorkshopStash(ctx context.Context, name string) error {
 	_, projectId, err := s.userProject(ctx)
 	if err != nil {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -739,10 +739,6 @@ func (s *Backend) Workshop(ctx context.Context, name string) (*workshop.Workshop
 	}
 	defer conn.Disconnect()
 
-	return s.workshop(ctx, conn, name, false)
-}
-
-func (s *Backend) workshop(ctx context.Context, conn lxd.InstanceServer, name string, stash bool) (*workshop.Workshop, error) {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {
 		return nil, fmt.Errorf("context key project-id not found")
@@ -764,14 +760,7 @@ func (s *Backend) workshop(ctx context.Context, conn lxd.InstanceServer, name st
 	}
 	p := projects[user][idx]
 
-	var instName string
-	if stash {
-		instName = instanceStashName(name, projectId)
-	} else {
-		instName = InstanceName(name, projectId)
-	}
-
-	inst, _, err := conn.GetInstance(instName)
+	inst, _, err := conn.GetInstance(InstanceName(name, projectId))
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return nil, workshop.ErrWorkshopNotLaunched

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -672,16 +672,6 @@ func (s *Backend) RemoveSnapshot(ctx context.Context, snapshot workshop.Snapshot
 	return s.deleteSnapshot(snapshotConn, sdkSnapshotName(snapshot, digest))
 }
 
-func (s *Backend) StashedWorkshop(ctx context.Context, name string) (*workshop.Workshop, error) {
-	conn, snapshotConn, err := s.snapshotClients(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Disconnect()
-
-	return s.workshop(ctx, snapshotConn, name, true)
-}
-
 func (s *Backend) StashWorkshop(ctx context.Context, name string) error {
 	projectId, ok := ctx.Value(workshop.ContextProjectId).(string)
 	if !ok {


### PR DESCRIPTION
# Description

Fixes #799. This time I've tested it manually, adjusting the cooldown period, and it works fine.

The API for RemoveMany is getting more complicated, I don't think using `running []bool` is a good idea anymore, so I changed it to a map indexed by the workshop name.

Also refactored `RemoveMany` to precompute a map of stashed workshop names before the loop, improving lookup from O(n×m) to O(n+m), and renamed the inner `stashed` bool variable to `isStashed` to avoid shadowing the `stashed []Manifest` parameter.

Also fixes a test-only data race that appears in CI sometimes. Previously I had assumed the issue was from 2 tests interfering, but it remains even when running a single test like `TestLaunchWorkshopFailed`. It happens because Tasks are already in flight before we call `FakeSdkVolumeCooldownTime(0)`. Not sure why it was only surfaced by my cleanup logic changes.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.