### PR TITLE
Avoid Store query when workshop has no Store SDKs

### DIFF
--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -308,6 +308,9 @@ func (a *artifactFinder) findStoreSdks(sto sdk.Store, ctx context.Context, file 
 	if err != nil {
 		return nil, err
 	}
+	if len(req.Packages) == 0 {
+		return nil, nil
+	}
 
 	// We have to request each SDK 4 times because the Store requires SDK
 	// platforms to exactly match the request.

--- a/internal/overlord/workshopstate/manifest_test.go
+++ b/internal/overlord/workshopstate/manifest_test.go
@@ -258,6 +258,10 @@ func (s *manifestSuite) TestLaunchOK(c *check.C) {
 	testSdk.Channel = "latest/edge"
 	c.Check(manifests[0].Sdks, check.DeepEquals, []sdk.Setup{systemSdk.Setup})
 	c.Check(manifests[1].Sdks, check.DeepEquals, []sdk.Setup{systemSdk.Setup, testSdk.Setup})
+
+	c.Assert(s.store.ResolveCalls, check.HasLen, 1)
+	c.Assert(s.store.ResolveCalls[0].Packages, check.HasLen, 4)
+	c.Check(s.store.ResolveCalls[0].Packages[0].Name, check.Equals, "test")
 }
 
 func (s *manifestSuite) TestRefreshOK(c *check.C) {


### PR DESCRIPTION
# Description

Somehow I missed this obvious optimisation on the first pass.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
