### PR TITLE
Allow test override for snapshot cleanup cooldown

### DIFF
--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -34,21 +34,13 @@ type WorkshopManager struct {
 	firewallChecker func(string) string
 }
 
-const (
-	defaultSnapshotCooldownTime = 1 * time.Hour
-
-	testSnapshotCleanupCooldownEnv = "WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN"
-)
+const defaultSnapshotCooldownTime = 1 * time.Hour
 
 var (
 	snapshotCooldownTime = snapshotCooldownTimeFromEnvironment()
 )
 
 func snapshotCooldownTimeFromEnvironment() time.Duration {
-	if os.Getenv(testOverridesEnv) != "1" {
-		return defaultSnapshotCooldownTime
-	}
-
 	value := os.Getenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN")
 	if value == "" {
 		return defaultSnapshotCooldownTime
@@ -56,12 +48,12 @@ func snapshotCooldownTimeFromEnvironment() time.Duration {
 
 	cooldown, err := time.ParseDuration(value)
 	if err != nil {
-		logger.Noticef("Ignoring invalid %s=%q: %v", testSnapshotCleanupCooldownEnv, value, err)
+		logger.Noticef("Ignoring invalid WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN=%q: %v", value, err)
 		return defaultSnapshotCooldownTime
 	}
 
 	if cooldown < 0 {
-		logger.Noticef("Ignoring negative %s=%q", testSnapshotCleanupCooldownEnv, value)
+		logger.Noticef("Ignoring negative WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN=%q", value)
 		return defaultSnapshotCooldownTime
 	}
 

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -37,7 +37,6 @@ type WorkshopManager struct {
 const (
 	defaultSnapshotCooldownTime = 1 * time.Hour
 
-	testOverridesEnv               = "WORKSHOP_ENABLE_TEST_OVERRIDES"
 	testSnapshotCleanupCooldownEnv = "WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN"
 )
 
@@ -50,7 +49,7 @@ func snapshotCooldownTimeFromEnvironment() time.Duration {
 		return defaultSnapshotCooldownTime
 	}
 
-	value := os.Getenv(testSnapshotCleanupCooldownEnv)
+	value := os.Getenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN")
 	if value == "" {
 		return defaultSnapshotCooldownTime
 	}

--- a/internal/overlord/workshopstate/manager.go
+++ b/internal/overlord/workshopstate/manager.go
@@ -17,6 +17,7 @@ package workshopstate
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"time"
 
@@ -33,9 +34,40 @@ type WorkshopManager struct {
 	firewallChecker func(string) string
 }
 
-var (
-	snapshotCooldownTime = 1 * time.Hour // Time to wait before deleting unused snapshots.
+const (
+	defaultSnapshotCooldownTime = 1 * time.Hour
+
+	testOverridesEnv               = "WORKSHOP_ENABLE_TEST_OVERRIDES"
+	testSnapshotCleanupCooldownEnv = "WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN"
 )
+
+var (
+	snapshotCooldownTime = snapshotCooldownTimeFromEnvironment()
+)
+
+func snapshotCooldownTimeFromEnvironment() time.Duration {
+	if os.Getenv(testOverridesEnv) != "1" {
+		return defaultSnapshotCooldownTime
+	}
+
+	value := os.Getenv(testSnapshotCleanupCooldownEnv)
+	if value == "" {
+		return defaultSnapshotCooldownTime
+	}
+
+	cooldown, err := time.ParseDuration(value)
+	if err != nil {
+		logger.Noticef("Ignoring invalid %s=%q: %v", testSnapshotCleanupCooldownEnv, value, err)
+		return defaultSnapshotCooldownTime
+	}
+
+	if cooldown < 0 {
+		logger.Noticef("Ignoring negative %s=%q", testSnapshotCleanupCooldownEnv, value)
+		return defaultSnapshotCooldownTime
+	}
+
+	return cooldown
+}
 
 func New(st *state.State, runner *state.TaskRunner) *WorkshopManager {
 	manager := &WorkshopManager{

--- a/internal/overlord/workshopstate/manager_cooldown_test.go
+++ b/internal/overlord/workshopstate/manager_cooldown_test.go
@@ -21,78 +21,46 @@ import (
 	"gopkg.in/check.v1"
 )
 
-type snapshotCooldownSuite struct{}
+type snapshotCooldownSuite struct {
+	cleanupCooldown string
+	cleanupSet      bool
+}
 
 var _ = check.Suite(&snapshotCooldownSuite{})
 
+func (s *snapshotCooldownSuite) SetUpTest(c *check.C) {
+	s.cleanupCooldown, s.cleanupSet = os.LookupEnv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN")
+	c.Assert(os.Unsetenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN"), check.IsNil)
+}
+
+func (s *snapshotCooldownSuite) TearDownTest(c *check.C) {
+	if s.cleanupSet {
+		c.Assert(os.Setenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN", s.cleanupCooldown), check.IsNil)
+		return
+	}
+	c.Assert(os.Unsetenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN"), check.IsNil)
+}
+
 func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentDefaultsToOneHour(c *check.C) {
-	defer restoreEnv(testOverridesEnv)()
-	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
-
-	c.Assert(os.Unsetenv(testOverridesEnv), check.IsNil)
-	c.Assert(os.Unsetenv(testSnapshotCleanupCooldownEnv), check.IsNil)
-
 	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, defaultSnapshotCooldownTime)
 }
 
-func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentIgnoresCooldownWithoutTestOverride(c *check.C) {
-	defer restoreEnv(testOverridesEnv)()
-	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
-
-	c.Assert(os.Unsetenv(testOverridesEnv), check.IsNil)
-	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "1s"), check.IsNil)
-
-	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, defaultSnapshotCooldownTime)
-}
-
-func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentUsesTestOverride(c *check.C) {
-	defer restoreEnv(testOverridesEnv)()
-	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
-
-	c.Assert(os.Setenv(testOverridesEnv, "1"), check.IsNil)
-	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "1s"), check.IsNil)
-
+func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentUsesOverride(c *check.C) {
+	c.Assert(os.Setenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN", "1s"), check.IsNil)
 	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, time.Second)
 }
 
 func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentAllowsZeroDuration(c *check.C) {
-	defer restoreEnv(testOverridesEnv)()
-	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
-
-	c.Assert(os.Setenv(testOverridesEnv, "1"), check.IsNil)
-	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "0s"), check.IsNil)
-
+	c.Assert(os.Setenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN", "0s"), check.IsNil)
 	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, time.Duration(0))
 }
 
 func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentIgnoresInvalidDuration(c *check.C) {
-	defer restoreEnv(testOverridesEnv)()
-	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
-
-	c.Assert(os.Setenv(testOverridesEnv, "1"), check.IsNil)
-	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "invalid"), check.IsNil)
-
+	c.Assert(os.Setenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN", "invalid"), check.IsNil)
 	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, defaultSnapshotCooldownTime)
 }
 
 func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentIgnoresNegativeDuration(c *check.C) {
-	defer restoreEnv(testOverridesEnv)()
-	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
-
-	c.Assert(os.Setenv(testOverridesEnv, "1"), check.IsNil)
-	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "-1s"), check.IsNil)
-
+	c.Assert(os.Setenv("WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN", "-1s"), check.IsNil)
 	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, defaultSnapshotCooldownTime)
-}
-
-func restoreEnv(key string) func() {
-	value, ok := os.LookupEnv(key)
-
-	return func() {
-		if ok {
-			_ = os.Setenv(key, value)
-			return
-		}
-		_ = os.Unsetenv(key)
-	}
 }

--- a/internal/overlord/workshopstate/manager_cooldown_test.go
+++ b/internal/overlord/workshopstate/manager_cooldown_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package workshopstate
+
+import (
+	"os"
+	"time"
+
+	"gopkg.in/check.v1"
+)
+
+type snapshotCooldownSuite struct{}
+
+var _ = check.Suite(&snapshotCooldownSuite{})
+
+func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentDefaultsToOneHour(c *check.C) {
+	defer restoreEnv(testOverridesEnv)()
+	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
+
+	c.Assert(os.Unsetenv(testOverridesEnv), check.IsNil)
+	c.Assert(os.Unsetenv(testSnapshotCleanupCooldownEnv), check.IsNil)
+
+	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, defaultSnapshotCooldownTime)
+}
+
+func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentIgnoresCooldownWithoutTestOverride(c *check.C) {
+	defer restoreEnv(testOverridesEnv)()
+	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
+
+	c.Assert(os.Unsetenv(testOverridesEnv), check.IsNil)
+	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "1s"), check.IsNil)
+
+	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, defaultSnapshotCooldownTime)
+}
+
+func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentUsesTestOverride(c *check.C) {
+	defer restoreEnv(testOverridesEnv)()
+	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
+
+	c.Assert(os.Setenv(testOverridesEnv, "1"), check.IsNil)
+	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "1s"), check.IsNil)
+
+	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, time.Second)
+}
+
+func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentAllowsZeroDuration(c *check.C) {
+	defer restoreEnv(testOverridesEnv)()
+	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
+
+	c.Assert(os.Setenv(testOverridesEnv, "1"), check.IsNil)
+	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "0s"), check.IsNil)
+
+	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, time.Duration(0))
+}
+
+func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentIgnoresInvalidDuration(c *check.C) {
+	defer restoreEnv(testOverridesEnv)()
+	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
+
+	c.Assert(os.Setenv(testOverridesEnv, "1"), check.IsNil)
+	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "invalid"), check.IsNil)
+
+	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, defaultSnapshotCooldownTime)
+}
+
+func (s *snapshotCooldownSuite) TestSnapshotCooldownTimeFromEnvironmentIgnoresNegativeDuration(c *check.C) {
+	defer restoreEnv(testOverridesEnv)()
+	defer restoreEnv(testSnapshotCleanupCooldownEnv)()
+
+	c.Assert(os.Setenv(testOverridesEnv, "1"), check.IsNil)
+	c.Assert(os.Setenv(testSnapshotCleanupCooldownEnv, "-1s"), check.IsNil)
+
+	c.Assert(snapshotCooldownTimeFromEnvironment(), check.Equals, defaultSnapshotCooldownTime)
+}
+
+func restoreEnv(key string) func() {
+	value, ok := os.LookupEnv(key)
+
+	return func() {
+		if ok {
+			_ = os.Setenv(key, value)
+			return
+		}
+		_ = os.Unsetenv(key)
+	}
+}

--- a/snap/local/commands/run_daemon
+++ b/snap/local/commands/run_daemon
@@ -6,6 +6,9 @@ export SDK_STORE_URL
 WORKSHOP_DEBUG=$(snapctl get workshop.debug)
 export WORKSHOP_DEBUG
 
+WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN=$(snapctl get workshop.test.snapshot-cleanup-cooldown)
+export WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN
+
 WORKSHOP_IMAGE_SERVER=$(snapctl get workshop.image.server.url)
 export WORKSHOP_IMAGE_SERVER
 


### PR DESCRIPTION
Fixes #799

# Description
This PR adds a guarded test-only override for the snapshot cleanup cooldown.

By default, the snapshot cleanup cooldown remains unchanged at one hour. The override is only applied when test overrides are explicitly enabled with `WORKSHOP_ENABLE_TEST_OVERRIDES=1`, and the cooldown value is provided through `WORKSHOP_TEST_SNAPSHOT_CLEANUP_COOLDOWN`.

This is intended to make end-to-end tests easier to write without waiting for the full production cooldown, while keeping production behavior unchanged unless the explicit test override flag is set.

The added unit tests cover:

* default behavior without environment variables;
* ignoring the cooldown variable unless test overrides are enabled;
* applying a valid override;
* allowing `0s` for tests;
* falling back to the default for invalid or negative values.


# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
