### PR TITLE
Remember connections across refreshes

### DIFF
--- a/docs/explanation/workshops/concepts.rst
+++ b/docs/explanation/workshops/concepts.rst
@@ -425,7 +425,7 @@ Connections across refresh and restore
 Interface connections fall into three observable categories,
 each treated differently when a workshop is refreshed or restored:
 
-- *Auto-connections* are established at launch
+- *Auto-connections* are established at launch and refresh
   from the SDK's auto-connect rules
   and from the :samp:`connections` section of the workshop definition.
 
@@ -449,32 +449,17 @@ by :command:`workshop refresh` and :command:`workshop restore`:
      - After :command:`workshop refresh`
      - After :command:`workshop restore`
 
-   * - Auto-connection still valid in the new definition
+   * - Connection still valid in the new definition
      - Re-established
      - Re-established
 
-   * - Auto-connection whose plug or slot is removed in the new definition
+   * - Connection whose plug or slot is removed in the new definition
      - Dropped
      - Not applicable; definition doesn't change
-
-   * - Manual runtime connection added with :command:`workshop connect`
-     - Dropped
-     - Dropped
 
    * - Manually disconnected auto-connection
      - Stays disconnected
      - Stays disconnected
-
-
-The practical consequence is that
-runtime use of :command:`workshop connect`
-should be reserved for short-lived experimentation:
-to make a connection that survives a refresh,
-add it to the :samp:`connections` section of the workshop definition.
-Conversely, a deliberate :command:`workshop disconnect`
-is preserved across refreshes and restores,
-so once a default auto-connection has been turned off,
-it stays off until explicitly reconnected.
 
 
 .. _exp_workshop_definition_actions:

--- a/docs/explanation/workshops/concepts.rst
+++ b/docs/explanation/workshops/concepts.rst
@@ -449,9 +449,13 @@ by :command:`workshop refresh` and :command:`workshop restore`:
      - After :command:`workshop refresh`
      - After :command:`workshop restore`
 
-   * - Connection still valid in the new definition
+   * - Auto-connection still valid in the new definition
      - Re-established
      - Re-established
+
+   * - Manual runtime connection still valid in the new definition
+     - Re-established
+     - Dropped
 
    * - Connection whose plug or slot is removed in the new definition
      - Dropped
@@ -459,7 +463,7 @@ by :command:`workshop refresh` and :command:`workshop restore`:
 
    * - Manually disconnected auto-connection
      - Stays disconnected
-     - Stays disconnected
+     - Re-established
 
 
 .. _exp_workshop_definition_actions:

--- a/docs/tutorial/part-2-work-with-interfaces.rst
+++ b/docs/tutorial/part-2-work-with-interfaces.rst
@@ -152,13 +152,6 @@ to run Jupyter notebooks with the Ollama models:
      - name: jupyter
 
 
-.. code-block:: console
-
-   $ workshop refresh
-
-     "dev" refreshed
-
-
 .. @artefact tunnel interface
 
 Next, add the tunnel interface plug under the :samp:`system` SDK
@@ -185,27 +178,15 @@ to the host system at a port of your choice (here, :samp:`8989`):
 
 The slot we're going to connect this plug to comes from the SDK itself
 and is named :samp:`jupyter`,
-so you don't have to add it manually:
-
-.. code-block:: console
-   :emphasize-lines: 8
-
-   $ workshop connections --all
-
-     INTERFACE  PLUG                SLOT                      NOTES
-     gpu        dev/ollama:gpu      dev/system:gpu            -
-     mount      dev/jupyter:venv    dev/system:mount          -
-     mount      dev/ollama:models   dev/system:mount          -
-     tunnel     -                   dev/ollama:ollama-server  -
-     tunnel     dev/system:jupyter  dev/jupyter:jupyter       -
-
+so you don't have to add it manually.
 
 Refresh the workshop to enable the tunnel;
 |ws_markup| will auto-connect the plug to the slot by matching their names
 (the plug's name is also :samp:`jupyter`).
-Check the result using :command:`workshop info`:
+Check the result using :command:`workshop connections` or :command:`workshop info`:
 
 .. code-block:: console
+   :emphasize-lines: 24
 
    $ workshop refresh
 
@@ -222,6 +203,15 @@ Check the result using :command:`workshop info`:
              from:  127.0.0.1:8989/tcp
              to:    127.0.0.1:8888/tcp
      ...
+
+   $ workshop connections --all
+
+     INTERFACE  PLUG                SLOT                      NOTES
+     gpu        dev/ollama:gpu      dev/system:gpu            -
+     mount      dev/jupyter:venv    dev/system:mount          -
+     mount      dev/ollama:models   dev/system:mount          manual
+     tunnel     -                   dev/ollama:ollama-server  -
+     tunnel     dev/system:jupyter  dev/jupyter:jupyter       -
 
 
 Now, JupyterLab is available at the plug address:
@@ -298,7 +288,7 @@ instead of falling back to :samp:`dev/system:mount`:
      INTERFACE  PLUG                SLOT                      NOTES
      gpu        dev/ollama:gpu      dev/system:gpu            -
      mount      dev/jupyter:venv    dev/uv:venv               -
-     mount      dev/ollama:models   dev/system:mount          -
+     mount      dev/ollama:models   dev/system:mount          manual
      mount      dev/uv:cache        dev/system:mount          -
      tunnel     -                   dev/ollama:ollama-server  -
      tunnel     dev/system:jupyter  dev/jupyter:jupyter       -

--- a/docs/tutorial/part-2-work-with-interfaces.rst
+++ b/docs/tutorial/part-2-work-with-interfaces.rst
@@ -281,7 +281,7 @@ Apply the new definition by refreshing the workshop:
 instead of falling back to :samp:`dev/system:mount`:
 
 .. code-block:: console
-   :emphasize-lines: 6
+   :emphasize-lines: 5
 
    $ workshop connections --all
 

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1593,8 +1593,13 @@ func (s *apiSuite) TestDisconnectPlugSuccess(c *check.C) {
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", &disconnectOpts{})
 	s.d.state.Lock()
 	var conns map[string]any
-	s.d.state.Get("conns", &conns)
-	c.Assert(conns, check.HasLen, 0)
+	c.Assert(s.d.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
+			"interface": "test",
+			"undesired": true,
+		},
+	})
 	s.d.state.Unlock()
 }
 
@@ -1634,8 +1639,17 @@ func (s *apiSuite) TestDisconnectBoundPlugMasterSuccess(c *check.C) {
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
 	var conns map[string]any
-	s.d.state.Get("conns", &conns)
-	c.Assert(conns, check.HasLen, 0)
+	c.Assert(s.d.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
+			"interface": "test",
+			"undesired": true,
+		},
+		"b8639dea/consumer-ws/consumer:plug2 b8639dea/producer-ws/producer:slot": map[string]any{
+			"interface": "test",
+			"undesired": true,
+		},
+	})
 	s.d.state.Unlock()
 }
 
@@ -1648,8 +1662,17 @@ func (s *apiSuite) TestDisconnectBoundWithEmptyPlug(c *check.C) {
 	s.testDisconnect(c, "", "", "", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
 	var conns map[string]any
-	s.d.state.Get("conns", &conns)
-	c.Assert(conns, check.HasLen, 0)
+	c.Assert(s.d.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
+			"interface": "test",
+			"undesired": true,
+		},
+		"b8639dea/consumer-ws/consumer:plug2 b8639dea/producer-ws/producer:slot": map[string]any{
+			"interface": "test",
+			"undesired": true,
+		},
+	})
 	s.d.state.Unlock()
 }
 
@@ -1662,8 +1685,17 @@ func (s *apiSuite) TestDisconnectBoundPlugSlaveSuccess(c *check.C) {
 	s.testDisconnect(c, "consumer-ws", "consumer", "plug2", "producer-ws", "producer", "slot", opts)
 	s.d.state.Lock()
 	var conns map[string]any
-	s.d.state.Get("conns", &conns)
-	c.Assert(conns, check.HasLen, 0)
+	c.Assert(s.d.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"b8639dea/consumer-ws/consumer:plug b8639dea/producer-ws/producer:slot": map[string]any{
+			"interface": "test",
+			"undesired": true,
+		},
+		"b8639dea/consumer-ws/consumer:plug2 b8639dea/producer-ws/producer:slot": map[string]any{
+			"interface": "test",
+			"undesired": true,
+		},
+	})
 	s.d.state.Unlock()
 }
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -2473,7 +2473,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 	s.ensureSnapshotsAfterCooldown(c, []string{"system", "test-sdk"}, []string{"test-sdk-2"})
 }
 
-func updateSdkStoreRev(name string, rev int, meta, digest string) func() {
+func updateSdkStoreRev(name string, rev int, meta, digest string) func() { //nolint:unparam // Call sites happen to use the same args currently.
 	oldrev := apiSuiteSdks[name]
 
 	newrev := oldrev
@@ -3562,6 +3562,140 @@ func (s *apiSuite) TestRefreshRestore(c *check.C) {
 	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume, "test-sdk-1", "test-sdk-2-1"})
+}
+
+func (s *apiSuite) TestRefreshRestoreForgetsConnections(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer func() { _ = s.d.Overlord().Stop() }()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks)
+	defer s.store.SetDownloadCallback(storeDownload(c))()
+	defer updateSdkStoreRev("test-sdk", 2, testsdk_r2, "fa5db9e2bc81f9d102707caef2a53b3c99b2b84dbad64cfe5a4d1a95971614d7294ba7b9c6f0477408c541a07ef0b567")()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", PackageID: "t5tqUClfNeHiiOpvPvT29O0HkxeaXBOq", Channel: "latest/stable", Revision: sdk.R(2)},
+			{Name: "test-sdk-2", PackageID: "iCJybjjWd2n48hKoMdjGEIWwA3i2TmX7", Channel: "latest/stable", Revision: sdk.R(1)},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+		},
+		plugs: []string{
+			"test-sdk:desktop",
+			"test-sdk:ssh-agent",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
+		},
+		slots: []string{
+			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:custom-device",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+	s.ensureWorkshops(c, want)
+
+	cmd := apiCmd("/v1/connections")
+	body := strings.NewReader(`{
+		"action":"connect",
+		"plugs":[{"project-id":"b8639dea","workshop":"manysdks","sdk":"test-sdk","plug":"ssh-agent"}],
+		"slots":[{"project-id":"b8639dea","workshop":"manysdks","sdk":"system","slot":"ssh-agent"}]
+	}`)
+	req, err := s.createProjectsRequest("POST", cmd.Path, body)
+	c.Assert(err, check.IsNil)
+	rsp := v1PostConnections(cmd, req, nil).(*resp)
+	st := s.d.state
+	st.Lock()
+	chg := st.Change(rsp.Change)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+	<-chg.Ready()
+
+	body = strings.NewReader(`{
+		"action":"disconnect",
+		"plugs":[{"project-id":"b8639dea","workshop":"manysdks","sdk":"test-sdk-2","plug":"gpu"}],
+		"slots":[{"project-id":"b8639dea","workshop":"manysdks","sdk":"system","slot":"gpu"}]
+	}`)
+	req, err = s.createProjectsRequest("POST", cmd.Path, body)
+	c.Assert(err, check.IsNil)
+	rsp = v1PostConnections(cmd, req, nil).(*resp)
+	st.Lock()
+	chg = st.Change(rsp.Change)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+	<-chg.Ready()
+
+	cmd = apiCmd("/v1/projects/{id}/workshops/{name}/mounts")
+	s.vars = map[string]string{"id": "b8639dea", "name": "manysdks"}
+	body = strings.NewReader(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk-2","plug":"photos"},"host-source":%q}`, c.MkDir()))
+	req, err = s.createProjectsRequest("POST", "/v1/projects/b8639dea/workshops/manysdks/mounts", body)
+	c.Assert(err, check.IsNil)
+	rsp = v1PostWorkshopMount(cmd, req, nil).(*resp)
+	st.Lock()
+	chg = st.Change(rsp.Change)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+	<-chg.Ready()
+
+	want[0].connections = []string{
+		"b8639dea/manysdks/test-sdk:ssh-agent b8639dea/manysdks/system:ssh-agent",
+		"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+	}
+	s.ensureWorkshops(c, want)
+
+	connRef, err := interfaces.ParseConnRef("b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount")
+	c.Assert(err, check.IsNil)
+	repo := s.d.overlord.InterfaceManager().Repository()
+	conn, err := repo.Connection(connRef)
+	c.Assert(err, check.IsNil)
+	_, ok := conn.Slot.Lookup("host-source")
+	c.Check(ok, check.Equals, true)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh","options":{"mode":"transactional","refresh-option":"restore"}}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	want[0].connections = []string{
+		"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+		"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+	}
+	s.ensureWorkshops(c, want)
+
+	conn, err = repo.Connection(connRef)
+	c.Assert(err, check.IsNil)
+	_, ok = conn.Slot.Lookup("host-source")
+	c.Check(ok, check.Equals, false)
 }
 
 func (s *apiSuite) TestRefreshBaseChange(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -3257,6 +3257,154 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 	})
 }
 
+func (s *apiSuite) TestRefreshPreservesConnections(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer func() { _ = s.d.Overlord().Stop() }()
+	// Setup
+	s.createWFile(c, "manysdks", manysdks_plugadded)
+	defer s.store.SetDownloadCallback(storeDownload(c))()
+	defer updateSdkStoreRev("test-sdk", 2, testsdk_r2, "fa5db9e2bc81f9d102707caef2a53b3c99b2b84dbad64cfe5a4d1a95971614d7294ba7b9c6f0477408c541a07ef0b567")()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	want := []expectedWorkshop{{
+		name: "manysdks",
+		base: "ubuntu@22.04",
+		sdks: []sdk.Setup{
+			{Name: sdk.System.String(), Source: sdk.SystemSource, Revision: system.SystemSdkRevision},
+			{Name: "test-sdk", PackageID: "t5tqUClfNeHiiOpvPvT29O0HkxeaXBOq", Channel: "latest/stable", Revision: sdk.R(2)},
+			{Name: "test-sdk-2", PackageID: "iCJybjjWd2n48hKoMdjGEIWwA3i2TmX7", Channel: "latest/stable", Revision: sdk.R(1)},
+		},
+		connections: []string{
+			"b8639dea/manysdks/test-sdk:new-plug b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+			"b8639dea/manysdks/test-sdk-2:gpu b8639dea/manysdks/system:gpu",
+		},
+		plugs: []string{
+			"test-sdk:desktop",
+			"test-sdk:new-plug",
+			"test-sdk:ssh-agent",
+			"test-sdk-2:photos",
+			"test-sdk-2:gpu",
+		},
+		slots: []string{
+			"test-sdk-2:data-slot",
+			"system:camera",
+			"system:custom-device",
+			"system:desktop",
+			"system:gpu",
+			"system:mount",
+			"system:ssh-agent",
+		},
+	}}
+	s.ensureWorkshops(c, want)
+
+	cmd := apiCmd("/v1/connections")
+	body := strings.NewReader(`{
+		"action":"connect",
+		"plugs":[{"project-id":"b8639dea","workshop":"manysdks","sdk":"test-sdk","plug":"ssh-agent"}],
+		"slots":[{"project-id":"b8639dea","workshop":"manysdks","sdk":"system","slot":"ssh-agent"}]
+	}`)
+	req, err := s.createProjectsRequest("POST", cmd.Path, body)
+	c.Assert(err, check.IsNil)
+	rsp := v1PostConnections(cmd, req, nil).(*resp)
+	st := s.d.state
+	st.Lock()
+	chg := st.Change(rsp.Change)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+	<-chg.Ready()
+
+	body = strings.NewReader(`{
+		"action":"disconnect",
+		"plugs":[{"project-id":"b8639dea","workshop":"manysdks","sdk":"test-sdk-2","plug":"gpu"}],
+		"slots":[{"project-id":"b8639dea","workshop":"manysdks","sdk":"system","slot":"gpu"}]
+	}`)
+	req, err = s.createProjectsRequest("POST", cmd.Path, body)
+	c.Assert(err, check.IsNil)
+	rsp = v1PostConnections(cmd, req, nil).(*resp)
+	st.Lock()
+	chg = st.Change(rsp.Change)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+	<-chg.Ready()
+
+	cmd = apiCmd("/v1/projects/{id}/workshops/{name}/mounts")
+	s.vars = map[string]string{"id": "b8639dea", "name": "manysdks"}
+	body = strings.NewReader(fmt.Sprintf(`{"action":"remount","plug":{"sdk":"test-sdk-2","plug":"photos"},"host-source":%q}`, c.MkDir()))
+	req, err = s.createProjectsRequest("POST", "/v1/projects/b8639dea/workshops/manysdks/mounts", body)
+	c.Assert(err, check.IsNil)
+	rsp = v1PostWorkshopMount(cmd, req, nil).(*resp)
+	st.Lock()
+	chg = st.Change(rsp.Change)
+	st.Unlock()
+	c.Assert(chg, check.NotNil)
+	<-chg.Ready()
+
+	want[0].connections = []string{
+		"b8639dea/manysdks/test-sdk:new-plug b8639dea/manysdks/system:mount",
+		"b8639dea/manysdks/test-sdk:ssh-agent b8639dea/manysdks/system:ssh-agent",
+		"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+	}
+	s.ensureWorkshops(c, want)
+
+	connRef, err := interfaces.ParseConnRef("b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount")
+	c.Assert(err, check.IsNil)
+	repo := s.d.overlord.InterfaceManager().Repository()
+	conn, err := repo.Connection(connRef)
+	c.Assert(err, check.IsNil)
+	var oldSource string
+	err = conn.Slot.Attr("host-source", &oldSource)
+	c.Assert(err, check.IsNil)
+
+	s.createWFile(c, "manysdks", manysdks)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"refresh"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "refresh",
+			Summary: `Refresh "manysdks" workshop`,
+		},
+	}
+
+	s.runActionTest(c, requests, expected)
+
+	want[0].connections = []string{
+		"b8639dea/manysdks/test-sdk:ssh-agent b8639dea/manysdks/system:ssh-agent",
+		"b8639dea/manysdks/test-sdk-2:photos b8639dea/manysdks/system:mount",
+	}
+	want[0].plugs = []string{
+		"test-sdk:desktop",
+		"test-sdk:ssh-agent",
+		"test-sdk-2:photos",
+		"test-sdk-2:gpu",
+	}
+	s.ensureWorkshops(c, want)
+
+	conn, err = repo.Connection(connRef)
+	c.Assert(err, check.IsNil)
+	var newSource string
+	err = conn.Slot.Attr("host-source", &newSource)
+	c.Assert(err, check.IsNil)
+	c.Check(newSource, check.Equals, oldSource)
+}
+
 func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()

--- a/internal/overlord/handlersetup/handler_setup.go
+++ b/internal/overlord/handlersetup/handler_setup.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/internal/overlord/conflict"
+	"github.com/canonical/workshop/internal/overlord/ifacestate/schema"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
@@ -299,6 +300,20 @@ func workshopBaseOnly(change *state.Change, w string, age Age) (*workshop.Snapsh
 
 	snapshot := workshop.SdkSnapshot(format, image, nil)
 	return &snapshot, nil
+}
+
+func WorkshopPreservedConns(change *state.Change, w string) (map[string]schema.PreservedConn, error) {
+	var prev map[string]schema.PreservedConn
+	if err := change.Get(WorkshopPreservedConnsKey(w), &prev); errors.Is(err, state.ErrNoState) {
+		prev = nil
+	} else if err != nil {
+		return nil, fmt.Errorf("internal error: %q workshop previous connections not found (change ID: %s)", w, change.ID())
+	}
+	return prev, nil
+}
+
+func WorkshopPreservedConnsKey(w string) string {
+	return w + "_conns"
 }
 
 // SdkVolumeLastUsed returns the most recent Task of the given Change that

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -101,62 +101,87 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, tomb *tomb.Tomb) (err
 	chg := task.Change()
 	// If auto-connect is executed during refresh, chances are, that there are
 	// SDKs that are going to be reinstalled without any changes to their
-	// mount interface plugs. In this case, their 'source' directories must be
-	// set to how it was in the previous workshop instance as some of those
-	// plugs may have been remounted with `workshop remount`. To preserve that,
-	// we store the mount interface connection's 'source' directories when the
-	// old workshop/SDK is removed (see the 'disconnect' task handler) and check
-	// if any of those are still relevant for the new workshop.
-	var remounts map[string]string
-	if err := chg.Get("remounts", &remounts); err != nil && !errors.Is(err, state.ErrNoState) {
+	// plugs. In this case, we should reconnect the manual connections that
+	// existed before the refresh, and preserve attributes for existing auto
+	// connections. In particular, the 'host-source' for mount slots must be
+	// preserved as some may have been remounted with `workshop remount`. The
+	// old connections are stored in the refresh Change when the old SDK's
+	// plugs and slots are disconnected.
+	preserved, err := handlersetup.WorkshopPreservedConns(chg, w)
+	if err != nil {
 		return err
 	}
 
-	return m.connectAuto(task, wp, info, remounts)
+	return m.connectAuto(task, wp, info, preserved)
 }
 
-// Returns mount interface connection IDs of the SDK and their corresponding
-// plug's dynamic attributes.
-func (m *InterfaceManager) remountSources(projectId, w, s string) map[string]string {
-	// [ref.ID]source
-	var candidates = make(map[string]string)
+func (m *InterfaceManager) preserveConns(st *state.State, chg *state.Change, projectId, w, s string) error {
 	refs, err := m.repo.Connections(projectId, w, s)
 	if err != nil {
+		return err
+	}
+	if len(refs) == 0 {
 		return nil
 	}
 
+	conns, err := getConns(st)
+	if err != nil {
+		return err
+	}
+
+	preserved, err := handlersetup.WorkshopPreservedConns(chg, w)
+	if err != nil {
+		return err
+	}
+	if preserved == nil {
+		preserved = make(map[string]schema.PreservedConn, len(refs))
+	}
+
+	changed := false
 	for _, cref := range refs {
-		conn, err := m.repo.Connection(cref)
-		if err != nil {
+		if _, ok := preserved[cref.ID()]; ok {
+			// Another SDK already preserved it.
 			continue
 		}
-		if conn.Interface() == "mount" {
-			attrs := conn.Slot.DynamicAttrs()
-			if attrs["host-source"] != nil {
-				candidates[cref.ID()] = attrs["host-source"].(string)
-			}
+		state := conns[cref.ID()]
+		if state == nil {
+			continue
 		}
+		preserved[cref.ID()] = schema.PreservedConn{
+			Auto:             state.Auto,
+			Interface:        state.Interface,
+			DynamicPlugAttrs: state.DynamicPlugAttrs,
+			DynamicSlotAttrs: state.DynamicSlotAttrs,
+		}
+		changed = true
 	}
-	return candidates
+
+	if changed {
+		chg.Set(handlersetup.WorkshopPreservedConnsKey(w), preserved)
+	}
+	return nil
 }
 
-func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, plugDynamic, slotDynamic map[string]map[string]any) *state.TaskSet {
-
+func (m *InterfaceManager) batchAutoConnectTasks(wp *workshop.Workshop, info *sdk.Info, refs []*interfaces.ConnRef, attrs map[string]schema.PreservedConn) *state.TaskSet {
 	connectTs := state.NewTaskSet()
 	var affected = map[sdk.Ref]bool{}
 	for _, ref := range refs {
-		connect := m.state.NewTask("connect", fmt.Sprintf("Connect %q to %q", ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
+		action := "Reconnect"
+		if attrs[ref.ID()].Auto {
+			action = "Connect"
+		}
+		connect := m.state.NewTask("connect", fmt.Sprintf("%s %q to %q", action, ref.PlugRef.ShortRef(), ref.SlotRef.ShortRef()))
 
 		connect.Set("plug", ref.PlugRef)
 		connect.Set("slot", ref.SlotRef)
-		connect.Set("auto", true)
+		connect.Set("auto", attrs[ref.ID()].Auto)
 		connect.Set("delayed-setup-profile", true)
 
-		if plugDynamic != nil {
-			connect.Set("plug-dynamic", plugDynamic[ref.ID()])
+		if attrs[ref.ID()].DynamicPlugAttrs != nil {
+			connect.Set("plug-dynamic", attrs[ref.ID()].DynamicPlugAttrs)
 		}
-		if slotDynamic != nil {
-			connect.Set("slot-dynamic", slotDynamic[ref.ID()])
+		if attrs[ref.ID()].DynamicSlotAttrs != nil {
+			connect.Set("slot-dynamic", attrs[ref.ID()].DynamicSlotAttrs)
 		}
 		connectTs.AddTask(connect)
 
@@ -195,18 +220,61 @@ func workshopConns(wp *workshop.Workshop) []interfaces.ConnRef {
 	return conns
 }
 
-func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, info *sdk.Info, remounts map[string]string) error {
+func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, info *sdk.Info, preserved map[string]schema.PreservedConn) error {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return err
 	}
+	wconns := workshopConns(wp)
 
-	var connectRefs = []*interfaces.ConnRef{}
-	var wconns = workshopConns(wp)
-	var plugDynamic = make(map[string]map[string]any)
-	var slotDynamic = make(map[string]map[string]any)
+	connectRefs := []*interfaces.ConnRef{}
+	connectAttrs := map[string]schema.PreservedConn{}
+
+	planConnect := func(iface string, connRef *interfaces.ConnRef, slaves []sdk.PlugRef) {
+		attrs := preserved[connRef.ID()]
+		if attrs.Interface == iface {
+			mconn, bound := attrs.DynamicPlugAttrs["bind"].(string)
+			if bound {
+				mattrs, ok := preserved[mconn]
+				if ok {
+					attrs = mattrs
+				} else {
+					logger.Noticef("On connectAuto: plug %q was bound but connection %q not preserved", connRef.PlugRef, mconn)
+					attrs = schema.PreservedConn{Auto: attrs.Auto}
+				}
+			}
+		} else {
+			attrs = schema.PreservedConn{Auto: true}
+		}
+
+		slotRef := connRef.SlotRef
+		for _, slave := range slaves {
+			slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
+			if _, ok := conns[slref.ID()]; ok {
+				continue
+			}
+			connectRefs = append(connectRefs, slref)
+			// save associated binds as a dynamic attribute.
+			connectAttrs[slref.ID()] = schema.PreservedConn{
+				Auto:             attrs.Auto,
+				DynamicPlugAttrs: map[string]any{"bind": connRef.ID()},
+			}
+		}
+
+		if _, ok := conns[connRef.ID()]; ok {
+			// Suggested connection already exist (or has Undesired flag
+			// set) so don't clobber it. NOTE: we don't log anything here as
+			// this is a normal and common condition.
+			return
+		}
+		connectRefs = append(connectRefs, connRef)
+		connectAttrs[connRef.ID()] = attrs
+	}
 
 	for _, plug := range info.Plugs {
+		candidates := m.repo.AutoConnectCandidateSlots(info.ProjectId, info.Workshop,
+			info.Name, plug.Name, autoConnectChecker(wconns))
+
 		ref := plug.Ref()
 		master, slaves := MaybeBound(wp, ref)
 		if master != ref {
@@ -215,42 +283,9 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 			continue
 		}
 
-		candidates := m.repo.AutoConnectCandidateSlots(info.ProjectId, info.Workshop,
-			info.Name, plug.Name, autoConnectChecker(wconns))
-
 		for _, slot := range candidates {
 			connRef := interfaces.NewConnRef(plug, slot)
-			if slotDynamic[connRef.ID()] == nil {
-				slotDynamic[connRef.ID()] = make(map[string]any)
-			}
-
-			// remounts may be not nil when a previously existing mount
-			// interface connection (e.g. pre-refresh) needs to be recreated
-			// without changes to its 'source' attribute in the new workshop
-			// (given the new workshop also has an SDK with exactly the same
-			// plug; the target directory may change in the new workshop).
-			if src, ok := remounts[connRef.ID()]; ok {
-				slotDynamic[connRef.ID()]["host-source"] = src
-			}
-
-			slotRef := slot.Ref()
-			// save associated binds as a dynamic attribute
-			for _, slave := range slaves {
-				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
-				if _, ok := conns[slref.ID()]; !ok {
-					connectRefs = append(connectRefs, slref)
-					plugDynamic[slref.ID()] = make(map[string]any)
-					plugDynamic[slref.ID()]["bind"] = connRef.ID()
-				}
-			}
-
-			if _, ok := conns[connRef.ID()]; ok {
-				// Suggested connection already exist (or has Undesired flag
-				// set) so don't clobber it. NOTE: we don't log anything here as
-				// this is a normal and common condition.
-				continue
-			}
-			connectRefs = append(connectRefs, connRef)
+			planConnect(plug.Interface, connRef, slaves)
 		}
 	}
 
@@ -268,38 +303,46 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 			}
 
 			connRef := interfaces.NewConnRef(plug, slot)
-			if slotDynamic[connRef.ID()] == nil {
-				slotDynamic[connRef.ID()] = make(map[string]any)
-			}
-
-			// remounts may be not nil when a previously existing mount
-			// interface connection (e.g. pre-refresh) needs to be recreated
-			// without changes to its 'source' attribute in the new workshop
-			// (given the new workshop also has an SDK with exactly the same
-			// plug; the target directory may change in the new workshop).
-			if src, ok := remounts[connRef.ID()]; ok {
-				slotDynamic[connRef.ID()]["host-source"] = src
-			}
-
-			slotRef := slot.Ref()
-			// save associated binds as a dynamic attribute
-			for _, slave := range slaves {
-				slref := &interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
-				if _, ok := conns[slref.ID()]; !ok {
-					connectRefs = append(connectRefs, slref)
-					plugDynamic[slref.ID()] = make(map[string]any)
-					plugDynamic[slref.ID()]["bind"] = connRef.ID()
-				}
-			}
-
-			if _, ok := conns[connRef.ID()]; ok {
-				// Suggested connection already exist (or has Undesired flag
-				// set) so don't clobber it. NOTE: we don't log anything here as
-				// this is a normal and common condition.
+			if _, ok := connectAttrs[connRef.ID()]; ok {
+				// Already handled above.
 				continue
 			}
-			connectRefs = append(connectRefs, connRef)
+			planConnect(plug.Interface, connRef, slaves)
 		}
+	}
+
+	for id, attrs := range preserved {
+		if _, ok := connectAttrs[id]; ok || attrs.Auto {
+			// Either already handled above, or the new policy prevents it.
+			continue
+		}
+
+		connRef, err := interfaces.ParseConnRef(id)
+		if err != nil {
+			return err
+		}
+		plugRef, slotRef := connRef.PlugRef, connRef.SlotRef
+		if plugRef.Sdk != info.Name && slotRef.Sdk != info.Name {
+			continue
+		}
+
+		plug := m.repo.Plug(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name)
+		slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
+		if plug == nil || slot == nil || plug.Interface != attrs.Interface || slot.Interface != attrs.Interface {
+			continue
+		}
+
+		master, slaves := MaybeBound(wp, plugRef)
+		if master != plugRef {
+			// the plug is bound to, the decision to reconnect (and attributes)
+			// are taken from its master. If the master was manually connected,
+			// its connection will be setup together with all bound plugs.
+			// Otherwise, the bound plugs remain disconnected. In both cases we
+			// discard the old attributes of the bound plug (except "bind").
+			continue
+		}
+
+		planConnect(attrs.Interface, connRef, slaves)
 	}
 
 	// Sort connections by their ID to ensure deterministic order of connection tasks creation.
@@ -307,12 +350,7 @@ func (m *InterfaceManager) connectAuto(task *state.Task, wp *workshop.Workshop, 
 		return strings.Compare(a.ID(), b.ID())
 	})
 
-	// Remove duplicates: keep only first occurrence of each ID
-	connectRefs = slices.CompactFunc(connectRefs, func(a, b *interfaces.ConnRef) bool {
-		return a.ID() == b.ID()
-	})
-
-	ts := m.batchAutoConnectTasks(wp, info, connectRefs, plugDynamic, slotDynamic)
+	ts := m.batchAutoConnectTasks(wp, info, connectRefs, connectAttrs)
 	handlersetup.InjectTasks(task, ts)
 	m.state.EnsureBefore(0)
 	task.SetStatus(state.DoneStatus)
@@ -369,21 +407,9 @@ func (m *InterfaceManager) doDisconnectInterfaces(task *state.Task, tomb *tomb.T
 		return err
 	}
 
-	// Save 'source' attributes for the mount interface connections as some of
-	// them may have been remounted to a non-default locations, so these can be
-	// set after refresh for this SDK.
-	cattrs := m.remountSources(project.ProjectId, w, s)
-
-	if len(cattrs) > 0 {
-		chg := task.Change()
-		var remounts map[string]string
-		if err = chg.Get("remounts", &remounts); errors.Is(err, state.ErrNoState) {
-			remounts = make(map[string]string)
-		} else if err != nil {
-			return err
-		}
-		maps.Copy(remounts, cattrs)
-		chg.Set("remounts", remounts)
+	// Preserve connection state so it can be reconnected after refresh.
+	if err := m.preserveConns(st, task.Change(), project.ProjectId, w, s); err != nil {
+		return err
 	}
 
 	connections, err := m.repo.Connections(project.ProjectId, w, s)

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -407,9 +407,17 @@ func (m *InterfaceManager) doDisconnectInterfaces(task *state.Task, tomb *tomb.T
 		return err
 	}
 
-	// Preserve connection state so it can be reconnected after refresh.
-	if err := m.preserveConns(st, task.Change(), project.ProjectId, w, s); err != nil {
+	// Preserve connection state for refresh (but not restore or remove).
+	var forget bool
+	if err := task.Get("forget", &forget); errors.Is(err, state.ErrNoState) {
+		forget = false
+	} else if err != nil {
 		return err
+	}
+	if !forget {
+		if err := m.preserveConns(st, task.Change(), project.ProjectId, w, s); err != nil {
+			return err
+		}
 	}
 
 	connections, err := m.repo.Connections(project.ProjectId, w, s)
@@ -853,8 +861,10 @@ func (m *InterfaceManager) doDiscard(task *state.Task, tomb *tomb.Tomb) error {
 			delete(conns, id)
 		}
 	}
-	task.Set("removed", removed)
-	setConns(st, conns)
+	if len(removed) > 0 {
+		task.Set("removed", removed)
+		setConns(st, conns)
+	}
 
 	return nil
 }
@@ -865,9 +875,11 @@ func (m *InterfaceManager) undoDiscard(task *state.Task, tomb *tomb.Tomb) error 
 	defer st.Unlock()
 
 	var removed map[string]*schema.ConnState
-	err := task.Get("removed", &removed)
-	if err != nil && !errors.Is(err, state.ErrNoState) {
+	if err := task.Get("removed", &removed); err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
+	}
+	if len(removed) == 0 {
+		return nil
 	}
 
 	conns, err := getConns(st)
@@ -880,6 +892,83 @@ func (m *InterfaceManager) undoDiscard(task *state.Task, tomb *tomb.Tomb) error 
 	}
 	setConns(st, conns)
 	task.Set("removed", nil)
+	return nil
+}
+
+// doRestoreConns restores previously discarded connections to the state,
+// provided that the plugs and slots still exist.
+func (m *InterfaceManager) doRestoreConns(task *state.Task, tomb *tomb.Tomb) error {
+	user, project, w, err := handlersetup.UserProjectWorkshop(task)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := handlersetup.BackendContext(tomb, user, project.ProjectId)
+	defer cancel()
+
+	wp, err := m.backend.Workshop(ctx, w)
+	if err != nil {
+		return err
+	}
+
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var discardId string
+	if err := task.Get("discard-conns-task", &discardId); err != nil {
+		return err
+	}
+	discard := st.Task(discardId)
+	if discard == nil {
+		return errors.New("internal error: no corresponding discard-conns task found")
+	}
+
+	var removed map[string]*schema.ConnState
+	if err := discard.Get("removed", &removed); err != nil && !errors.Is(err, state.ErrNoState) {
+		return err
+	}
+
+	conns, err := getConns(st)
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	for id, connState := range removed {
+		if !connState.Undesired {
+			continue
+		}
+
+		connRef, err := interfaces.ParseConnRef(id)
+		if err != nil {
+			continue
+		}
+		plugRef, slotRef := connRef.PlugRef, connRef.SlotRef
+
+		plug := m.repo.Plug(plugRef.ProjectId, plugRef.Workshop, plugRef.Sdk, plugRef.Name)
+		slot := m.repo.Slot(slotRef.ProjectId, slotRef.Workshop, slotRef.Sdk, slotRef.Name)
+		if plug == nil || slot == nil || plug.Interface != connState.Interface || slot.Interface != connState.Interface {
+			continue
+		}
+
+		master, slaves := MaybeBound(wp, plugRef)
+		if master != plugRef {
+			// the plug is bound to, the decision to remain disconnected is
+			// taken from its master.
+			continue
+		}
+
+		conns[id] = connState
+		for _, slave := range slaves {
+			slref := interfaces.ConnRef{PlugRef: slave, SlotRef: slotRef}
+			conns[slref.ID()] = connState
+		}
+		changed = true
+	}
+	if changed {
+		setConns(st, conns)
+	}
 	return nil
 }
 

--- a/internal/overlord/ifacestate/handlers.go
+++ b/internal/overlord/ifacestate/handlers.go
@@ -724,18 +724,15 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, tomb *tomb.Tomb) (err 
 		}
 	})
 
-	switch {
-	case forget:
+	if forget {
 		delete(conns, cref.ID())
-	case conn.Auto:
+	} else {
 		conn.Undesired = true
 		conn.DynamicPlugAttrs = nil
 		conn.DynamicSlotAttrs = nil
 		conn.StaticPlugAttrs = nil
 		conn.StaticSlotAttrs = nil
 		conns[cref.ID()] = conn
-	default:
-		delete(conns, cref.ID())
 	}
 	setConns(st, conns)
 

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -97,6 +97,17 @@ plugs:
 `,
 }
 
+var consumerSSH = sdk.Meta{
+	Setup: consumer.Setup,
+	SdkYAML: `name: consumer
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: mock-ssh-agent
+    attribute: one
+`,
+}
+
 var consumerSelfConnect = sdk.Meta{
 	Setup: consumer.Setup,
 	SdkYAML: `name: consumer
@@ -130,6 +141,20 @@ plugs:
     attribute: four
   bound:
     interface: mock-network
+    attribute: one
+`,
+}
+
+var consumerBoundSSH = sdk.Meta{
+	Setup: consumer.Setup,
+	SdkYAML: `name: consumer
+base: ubuntu@22.04
+plugs:
+  plug:
+    interface: mock-ssh-agent
+    attribute: one
+  bound:
+    interface: mock-ssh-agent
     attribute: one
 `,
 }
@@ -257,11 +282,11 @@ type denyAutoIface struct {
 func (di denyAutoIface) Name() string                                            { return di.name }
 func (di denyAutoIface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool { return false }
 
-func (s *interfaceHandlersSuite) newAutoconnectChange() *state.Change {
+func (s *interfaceHandlersSuite) newAutoconnectChange(sk string) *state.Change {
 	chg := s.state.NewChange("sample", "...")
 	t1 := s.state.NewTask("resolve-interfaces", "...")
 	t2 := s.state.NewTask("auto-connect", "...")
-	t2.Set("sdk", "consumer")
+	t2.Set("sdk", sk)
 	t2.WaitFor(t1)
 	setWorkshopProject("ws", s.prj, t1, t2)
 	chg.Set("user", "testuser")
@@ -283,7 +308,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugSlotPairSuccess(c *check.C) 
 
 	// Execute
 	s.state.Lock()
-	chg := s.newAutoconnectChange()
+	chg := s.newAutoconnectChange("consumer")
 	s.state.Unlock()
 
 	s.settle(c)
@@ -330,7 +355,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindPlugSuccess(c *check.C) {
 
 	// Execute
 	s.state.Lock()
-	chg := s.newAutoconnectChange()
+	chg := s.newAutoconnectChange("consumer")
 	s.state.Unlock()
 
 	s.settle(c)
@@ -387,7 +412,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectPlugAndSlotInSameSdk(c *check.C)
 
 	// Execute
 	s.state.Lock()
-	chg := s.newAutoconnectChange()
+	chg := s.newAutoconnectChange("consumer")
 	s.state.Unlock()
 
 	s.settle(c)
@@ -444,7 +469,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBindMasterPlugNotFound(c *check.
 
 	// Execute
 	s.state.Lock()
-	chg := s.newAutoconnectChange()
+	chg := s.newAutoconnectChange("consumer")
 	s.state.Unlock()
 
 	s.settle(c)
@@ -489,7 +514,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectBackendSetupFail(c *check.C) {
 
 	// Execute
 	s.state.Lock()
-	chg := s.newAutoconnectChange()
+	chg := s.newAutoconnectChange("consumer")
 	s.state.Unlock()
 
 	s.settle(c)
@@ -614,7 +639,7 @@ func (s *interfaceHandlersSuite) TestAutoconnectNoConnectionCandidates(c *check.
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 }
 
-func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoconnectPreservesAttributesOnRefresh(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
 	repo := s.mgr.Repository()
@@ -627,19 +652,15 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 
 	// Execute
 	s.state.Lock()
-	chg := s.state.NewChange("refresh", "...")
+	chg := s.newAutoconnectChange("consumer")
 	// existing remounts that should be preserved after refresh
-	chg.Set("remounts", map[string]string{
-		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": "/old/source",
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"slot-dynamic": map[string]any{"host-source": "/old/source"},
+		},
 	})
-	t1 := s.state.NewTask("resolve-interfaces", "...")
-	t2 := s.state.NewTask("auto-connect", "...")
-	t2.Set("sdk", "consumer")
-	t2.WaitFor(t1)
-	setWorkshopProject("ws", s.prj, t1, t2)
-	chg.Set("user", "testuser")
-	chg.AddTask(t1)
-	chg.AddTask(t2)
 	s.state.Unlock()
 
 	s.settle(c)
@@ -649,7 +670,6 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(t1.Status(), check.Equals, state.DoneStatus)
 	var conns map[string]any
 	s.state.Get("conns", &conns)
 	c.Assert(conns, check.DeepEquals, map[string]any{
@@ -666,6 +686,471 @@ func (s *interfaceHandlersSuite) TestAutoconnectRemountedPlugsOnRefresh(c *check
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
 }
 
+func (s *interfaceHandlersSuite) TestAutoconnectPreservesManualConnectionsOnRefresh(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producerSSH.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerSSH.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"interface":    "mock-ssh-agent",
+			"plug-dynamic": map[string]any{"test-dynamic-attr": "new-dynamic-value"},
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+	c.Assert(err, check.IsNil)
+	c.Assert(refs, check.HasLen, 1)
+	c.Check(refs[0].ID(), check.Equals, "42424242/ws/consumer:plug 42424242/ws-producer/producer:slot")
+
+	refs, err = repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Assert(err, check.IsNil)
+	c.Assert(refs, check.HasLen, 1)
+	c.Check(refs[0].ID(), check.Equals, "42424242/ws/consumer:plug 42424242/ws-producer/producer:slot")
+
+	var conns map[string]any
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"interface":    "mock-ssh-agent",
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"test-dynamic-attr": "new-dynamic-value"},
+		},
+	})
+
+	// ensure that backend profiles were set for both SDKs
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectForgetsConnectionWithoutPlugOnRefresh(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", nil)
+
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	// Preserved connection but different plug interface.
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"interface": "mock-ssh-agent",
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	var conns map[string]any
+	c.Check(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectForgetsConnectionWithoutSlotOnRefresh(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	s.launchWorkshop(c, "ws-consumer", nil)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange("producer")
+	// Preserved connection but different plug interface.
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws-consumer/consumer:plug 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-ssh-agent",
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "producer", "slot")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	var conns map[string]any
+	c.Check(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectForgetsRepurposedPlugOnRefresh(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producerSSH.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	// Preserved connection but different plug interface.
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"interface": "mock-ssh-agent",
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	refs, err = repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	var conns map[string]any
+	c.Check(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectForgetsRepurposedSlotOnRefresh(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerSSH.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	// Preserved connection but different slot interface.
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"interface": "mock-ssh-agent",
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	refs, err = repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	var conns map[string]any
+	c.Check(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectForgetsDeniedAutoconnection(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producerSSH.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerSSH.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":      true,
+			"interface": "mock-ssh-agent",
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	refs, err = repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	var conns map[string]any
+	c.Check(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectForgetsNewlyBoundPlug(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producerSSH})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producerSSH.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	wp := s.launchWorkshop(c, "ws", []sdk.Meta{consumerBoundSSH})
+	wp.File.Sdks[0].Plugs = map[string]workshop.PlugOrBind{
+		"bound": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
+	}
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerBoundSSH.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Before the refresh, "bound" was manually connected but unbound.
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]any{
+			"interface":    "mock-ssh-agent",
+			"plug-dynamic": map[string]any{"custom": "value"},
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	refs, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	refs, err = repo.Connected(s.prj.ProjectId, "ws-producer", "producer", "slot")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
+	var conns map[string]any
+	c.Check(s.state.Get("conns", &conns), testutil.ErrorIs, state.ErrNoState)
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectPreservesReversedBinding(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	wp := s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs})
+	wp.File.Sdks[0].Plugs = map[string]workshop.PlugOrBind{
+		"bound": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
+	}
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Before the refresh, "plug" was bound to "bound".
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-dynamic": map[string]any{"bind": "42424242/ws/consumer:bound 42424242/ws-producer/producer:slot"},
+		},
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-dynamic": map[string]any{"custom": "value"},
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	var conns map[string]any
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"custom": "value"},
+		},
+		"42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":        true,
+			"interface":   "mock-network",
+			"plug-static": map[string]any{"attribute": "two"},
+		},
+		"42424242/ws/consumer:plug3 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":        true,
+			"interface":   "mock-network",
+			"plug-static": map[string]any{"attribute": "three"},
+		},
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"bind": "42424242/ws/consumer:plug 42424242/ws-producer/producer:slot"},
+		},
+	})
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectBindsIndependentPlugs(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	wp := s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs})
+	wp.File.Sdks[0].Plugs = map[string]workshop.PlugOrBind{
+		"bound": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
+	}
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Before the refresh both plugs were independent with their own attributes.
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"slot-dynamic": map[string]any{"host-source": "/data/plug"},
+		},
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"slot-dynamic": map[string]any{"host-source": "/data/bound"},
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	var conns map[string]any
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-static":  map[string]any{"attribute": "one"},
+			"slot-dynamic": map[string]any{"host-source": "/data/plug"},
+		},
+		"42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":        true,
+			"interface":   "mock-network",
+			"plug-static": map[string]any{"attribute": "two"},
+		},
+		"42424242/ws/consumer:plug3 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":        true,
+			"interface":   "mock-network",
+			"plug-static": map[string]any{"attribute": "three"},
+		},
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"bind": "42424242/ws/consumer:plug 42424242/ws-producer/producer:slot"},
+		},
+	})
+}
+
+func (s *interfaceHandlersSuite) TestAutoconnectClonesNewlyUnboundPlugs(c *check.C) {
+	// Setup
+	repo := s.mgr.Repository()
+	s.launchWorkshop(c, "ws-producer", []sdk.Meta{producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-producer")), check.IsNil)
+
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+
+	// Before the refresh, "bound" was bound to "plug".
+	s.state.Lock()
+	chg := s.newAutoconnectChange("consumer")
+	chg.Set("ws_conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-dynamic": map[string]any{"custom": "value"},
+		},
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-dynamic": map[string]any{"bind": "42424242/ws/consumer:plug 42424242/ws-producer/producer:slot"},
+		},
+	})
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	var conns map[string]any
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"custom": "value"},
+		},
+		"42424242/ws/consumer:plug2 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":        true,
+			"interface":   "mock-network",
+			"plug-static": map[string]any{"attribute": "two"},
+		},
+		"42424242/ws/consumer:plug3 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":        true,
+			"interface":   "mock-network",
+			"plug-static": map[string]any{"attribute": "three"},
+		},
+		"42424242/ws/consumer:bound 42424242/ws-producer/producer:slot": map[string]any{
+			"auto":         true,
+			"interface":    "mock-network",
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"custom": "value"},
+		},
+	})
+}
+
 func (s *interfaceHandlersSuite) TestUndoAutoConnect(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a candidate SDK/slot
@@ -679,7 +1164,7 @@ func (s *interfaceHandlersSuite) TestUndoAutoConnect(c *check.C) {
 
 	// Execute
 	s.state.Lock()
-	chg := s.newAutoconnectChange()
+	chg := s.newAutoconnectChange("consumer")
 	terr := s.state.NewTask("error-trigger", "...")
 	terr.WaitAll(state.NewTaskSet(chg.Tasks()...))
 	chg.AddTask(terr)
@@ -711,8 +1196,8 @@ func (s *interfaceHandlersSuite) newRemountChange(newSource string) *state.Chang
 
 	t1 := s.state.NewTask("remount", "remount")
 	t1.Set("host-source", newSource)
-	t1.Set("plug", sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
-	setWorkshopProject("ws-consumer", s.prj, t1)
+	t1.Set("plug", sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"})
+	setWorkshopProject("ws", s.prj, t1)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
@@ -740,10 +1225,10 @@ slots:
     mount:
         interface: mount
 `
-	wm := s.launchWorkshop(c, "ws-consumer", []sdk.Meta{{Setup: consumer.Setup, SdkYAML: sdkYaml}})
+	wm := s.launchWorkshop(c, "ws", []sdk.Meta{{Setup: consumer.Setup, SdkYAML: sdkYaml}})
 	wm.Running = true
-	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
-	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, systemYaml, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, sdkYaml, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(s.mgr.Repository().AddSdk(sdk.MockInfo(c, systemYaml, s.prj.ProjectId, "ws")), check.IsNil)
 
 	dynamic := map[string]any{}
 	if source != "" {
@@ -751,14 +1236,14 @@ slots:
 	}
 	s.state.Lock()
 	s.state.Set("conns", map[string]any{
-		"42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount": map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/system:mount": map[string]any{
 			"interface":    "mount",
 			"auto":         true,
 			"plug-static":  map[string]any{"workshop-target": "/opt"},
 			"slot-dynamic": dynamic,
 		},
 	})
-	_, err := ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws-consumer", "consumer")
+	_, err := ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws", "consumer")
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 }
@@ -783,7 +1268,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessDestExistsAndEmpty(c *check.C
 	c.Assert(change.Status(), check.Equals, state.DoneStatus)
 
 	repo := s.mgr.Repository()
-	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
@@ -827,7 +1312,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	c.Assert(change.Status(), check.Equals, state.DoneStatus)
 
 	repo := s.mgr.Repository()
-	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
@@ -840,7 +1325,7 @@ func (s *interfaceHandlersSuite) TestRemountSuccessIfNewSourceDoesNotExist(c *ch
 	c.Assert(oldSource, testutil.FileAbsent)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 1)
 	c.Assert(s.secBackend.SetupCalls[0].SdkRef.Sdk, check.Equals, "consumer")
-	c.Assert(s.secBackend.SetupCalls[0].SdkRef.Workshop, check.Equals, "ws-consumer")
+	c.Assert(s.secBackend.SetupCalls[0].SdkRef.Workshop, check.Equals, "ws")
 
 	// ensure the global conns state was updated correctly
 	conns, err := ifacestate.GetConns(s.state)
@@ -875,7 +1360,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptyFails(c *chec
 	c.Assert(change.Status(), check.Equals, state.ErrorStatus)
 
 	repo := s.mgr.Repository()
-	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
@@ -899,7 +1384,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 	s.launchRemountWorkshop(c, oldSource)
 
 	// the remount will be performed if the workshop is not running
-	err = s.wsbackend.StopWorkshop(s.ctx, "ws-consumer", true)
+	err = s.wsbackend.StopWorkshop(s.ctx, "ws", true)
 	c.Check(err, check.IsNil)
 	change := s.newRemountChange(newSource)
 
@@ -913,7 +1398,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameNewSourceNotEmptySucceeds(c *c
 	c.Assert(change.Status(), check.Equals, state.DoneStatus)
 
 	repo := s.mgr.Repository()
-	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
@@ -947,7 +1432,7 @@ func (s *interfaceHandlersSuite) TestRemountRenameUnexpectedError(c *check.C) {
 	c.Assert(change.Status(), check.Equals, state.ErrorStatus)
 
 	repo := s.mgr.Repository()
-	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
@@ -984,7 +1469,7 @@ func (s *interfaceHandlersSuite) TestRemountInterfaceBackendSetupFails(c *check.
 	c.Assert(change.Status(), check.Equals, state.ErrorStatus)
 
 	repo := s.mgr.Repository()
-	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
@@ -1016,10 +1501,10 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfOldSourceNotExist(c *check.C)
 
 	warnings := s.state.AllWarnings()
 	c.Check(warnings, check.HasLen, 1)
-	c.Check(warnings[0].String(), check.Matches, `cannot find source ".*/id/42424242/ws-consumer/mount/consumer/plug" for "ws-consumer/consumer:plug"; using existing directory ".*"`)
+	c.Check(warnings[0].String(), check.Matches, `cannot find source ".*/id/42424242/ws/mount/consumer/plug" for "ws/consumer:plug"; using existing directory ".*"`)
 
 	repo := s.mgr.Repository()
-	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
@@ -1049,10 +1534,10 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfNeitherSourceExists(c *check.
 
 	warnings := s.state.AllWarnings()
 	c.Check(warnings, check.HasLen, 1)
-	c.Check(warnings[0].String(), check.Matches, `cannot find source ".*/id/42424242/ws-consumer/mount/consumer/plug" for "ws-consumer/consumer:plug"; created directory ".*"`)
+	c.Check(warnings[0].String(), check.Matches, `cannot find source ".*/id/42424242/ws/mount/consumer/plug" for "ws/consumer:plug"; created directory ".*"`)
 
 	repo := s.mgr.Repository()
-	ref, err := repo.Connected(s.prj.ProjectId, "ws-consumer", "consumer", "plug")
+	ref, err := repo.Connected(s.prj.ProjectId, "ws", "consumer", "plug")
 	c.Assert(ref, check.HasLen, 1)
 	c.Assert(err, check.IsNil)
 
@@ -1068,12 +1553,8 @@ func (s *interfaceHandlersSuite) TestRemountWorksIfNeitherSourceExists(c *check.
 
 func (s *interfaceHandlersSuite) newDisconnectInterfacesChange(sdkName string) *state.Change {
 	t1 := s.state.NewTask("auto-disconnect", "...")
-	t1.Set("plug", sdk.PlugRef{
-		ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"})
-	t1.Set("slot", sdk.PlugRef{
-		ProjectId: s.prj.ProjectId, Workshop: "ws-consumer", Sdk: "producer", Name: "slot"})
 	t1.Set("sdk", sdkName)
-	setWorkshopProject("ws-consumer", s.prj, t1)
+	setWorkshopProject("ws", s.prj, t1)
 
 	chg := s.state.NewChange("sample", "...")
 	chg.Set("user", "testuser")
@@ -1085,11 +1566,11 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a connected plug
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-consumer", []sdk.Meta{consumer, producer})
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
 
 	connRef := &interfaces.ConnRef{
-		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
-		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "producer", Name: "slot"},
 	}
 
 	s.state.Lock()
@@ -1117,8 +1598,8 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
-	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 0)
+	c.Assert(repo.Slots(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 0)
 
 	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
@@ -1128,7 +1609,7 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
-func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoDisconnectPreservesRemounts(c *check.C) {
 	// Setup
 	// Create an already installed workshop with a connected mount plug
 	source := c.MkDir()
@@ -1150,23 +1631,31 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSavesRemounts(c *check.C) {
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 0)
 
-	var attrs map[string]any
-	c.Assert(chg.Get("remounts", &attrs), check.IsNil)
-	c.Assert(attrs, check.HasLen, 1)
-	c.Assert(attrs["42424242/ws-consumer/consumer:plug 42424242/ws-consumer/system:mount"],
-		check.DeepEquals, source)
+	var preserved map[string]any
+	c.Assert(chg.Get("ws_conns", &preserved), check.IsNil)
+	c.Assert(preserved, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/system:mount": map[string]any{
+			"auto":         true,
+			"interface":    "mount",
+			"slot-dynamic": map[string]any{"host-source": source},
+		},
+	})
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
-func (s *interfaceHandlersSuite) TestAutoDisconnectIgnoresAutoConnections(c *check.C) {
+func (s *interfaceHandlersSuite) TestAutoDisconnectPreservesBinding(c *check.C) {
 	// Setup
-	// Create an already installed workshop with an auto-connected mount plug
-	s.launchRemountWorkshop(c, "")
+	repo := s.mgr.Repository()
+	wp := s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs, producer})
+	wp.File.Sdks[0].Plugs = map[string]workshop.PlugOrBind{
+		"bound": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
+	}
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
-	// Execute
 	s.state.Lock()
-	chg := s.newDisconnectInterfacesChange("consumer")
+	chg := s.newAutoconnectChange("consumer")
 	s.state.Unlock()
 
 	s.settle(c)
@@ -1175,14 +1664,79 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectIgnoresAutoConnections(c *che
 	defer s.state.Unlock()
 	c.Check(chg.Err(), check.IsNil)
 
+	refs, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Check(refs, check.HasLen, 4)
+	c.Assert(err, check.IsNil)
+
+	var conns map[string]any
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]any{"attribute": "one"},
+		},
+		"42424242/ws/consumer:plug2 42424242/ws/producer:slot": map[string]any{
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]any{"attribute": "two"},
+		},
+		"42424242/ws/consumer:plug3 42424242/ws/producer:slot": map[string]any{
+			"interface":   "mock-network",
+			"auto":        true,
+			"plug-static": map[string]any{"attribute": "three"},
+		},
+		"42424242/ws/consumer:bound 42424242/ws/producer:slot": map[string]any{
+			"interface":    "mock-network",
+			"auto":         true,
+			"plug-static":  map[string]any{"attribute": "one"},
+			"plug-dynamic": map[string]any{"bind": "42424242/ws/consumer:plug 42424242/ws/producer:slot"},
+		},
+	})
+
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)
+
+	// Execute
+	chg = s.newDisconnectInterfacesChange("consumer")
+
+	s.state.Unlock()
+	s.settle(c)
+	s.state.Lock()
+
+	c.Assert(chg.Err(), check.IsNil)
+
 	// Validate
+	refs, err = repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
+
 	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 0)
 
-	var attrs map[string]any
-	c.Assert(chg.Get("remounts", &attrs), check.NotNil)
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
+	var preserved map[string]any
+	c.Assert(chg.Get("ws_conns", &preserved), check.IsNil)
+	c.Assert(preserved, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"auto":      true,
+		},
+		"42424242/ws/consumer:plug2 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"auto":      true,
+		},
+		"42424242/ws/consumer:plug3 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"auto":      true,
+		},
+		"42424242/ws/consumer:bound 42424242/ws/producer:slot": map[string]any{
+			"interface":    "mock-network",
+			"auto":         true,
+			"plug-dynamic": map[string]any{"bind": "42424242/ws/consumer:plug 42424242/ws/producer:slot"},
+		},
+	})
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 10)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
@@ -1205,8 +1759,9 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectDisconnected(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
-	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+	refs, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
@@ -1233,8 +1788,9 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectNoSdkProfile(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
-	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+	refs, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
@@ -1252,12 +1808,12 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
 	s.launchWorkshop(c, "ws-consumer", []sdk.Meta{consumer, producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws-consumer")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	connRef := &interfaces.ConnRef{
-		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
-		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "producer", Name: "slot"},
 	}
 
 	s.state.Lock()
@@ -1285,8 +1841,8 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 	c.Check(chg.Err(), check.NotNil)
 
 	// Validate
-	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 1)
-	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 1)
+	c.Assert(repo.Slots(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 0)
 
 	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
@@ -1299,13 +1855,13 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 func (s *interfaceHandlersSuite) TestUndoAutoDisconnectManualRestored(c *check.C) {
 	// Setup
 	repo := s.mgr.Repository()
-	s.launchWorkshop(c, "ws-consumer", []sdk.Meta{consumer, producer})
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws-consumer")), check.IsNil)
-	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws-consumer")), check.IsNil)
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	connRef := &interfaces.ConnRef{
-		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "consumer", Name: "plug"},
-		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws-consumer", Sdk: "producer", Name: "slot"},
+		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: "42424242", Workshop: "ws", Sdk: "producer", Name: "slot"},
 	}
 
 	s.state.Lock()
@@ -1332,8 +1888,8 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnectManualRestored(c *check.C
 	c.Check(chg.Err(), check.NotNil)
 
 	// Validate
-	c.Assert(repo.Plugs(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 1)
-	c.Assert(repo.Slots(s.prj.ProjectId, "ws-consumer", "consumer"), check.HasLen, 0)
+	c.Assert(repo.Plugs(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 1)
+	c.Assert(repo.Slots(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 0)
 
 	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -2250,9 +2250,13 @@ func (s *interfaceHandlersSuite) TestUndoDisconnectSetupFailure(c *check.C) {
 	c.Assert(prods, check.HasLen, 0)
 
 	var conns map[string]any
-	err = s.state.Get("conns", &conns)
-	c.Assert(err, check.IsNil)
-	c.Assert(conns, check.HasLen, 0)
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Check(conns, check.DeepEquals, map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+	})
 
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 3)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 0)

--- a/internal/overlord/ifacestate/handlers_test.go
+++ b/internal/overlord/ifacestate/handlers_test.go
@@ -80,6 +80,18 @@ slots:
 `,
 }
 
+var producerManySlots = sdk.Meta{
+	Setup: producer.Setup,
+	SdkYAML: `name: producer
+base: ubuntu@22.04
+slots:
+  slot:
+    interface: mock-network
+  slot-ssh:
+    interface: mock-ssh-agent
+`,
+}
+
 var consumer = sdk.Meta{
 	Setup: sdk.Setup{
 		Name:      "consumer",
@@ -1243,7 +1255,8 @@ slots:
 			"slot-dynamic": dynamic,
 		},
 	})
-	_, err := ifacestate.ReloadConnections(s.mgr, s.prj.ProjectId, "ws", "consumer")
+	workshopNames := map[string][]string{"42424242": {"ws"}}
+	_, err := ifacestate.ReloadConnections(s.mgr, workshopNames, s.prj.ProjectId, "ws", "consumer")
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 }
@@ -1567,6 +1580,8 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	// Create an already installed workshop with a connected plug
 	repo := s.mgr.Repository()
 	s.launchWorkshop(c, "ws", []sdk.Meta{consumer, producer})
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
 
 	connRef := &interfaces.ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: "42424242", Workshop: "ws", Sdk: "consumer", Name: "plug"},
@@ -1582,7 +1597,8 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 			"plug-dynamic": map[string]any{"test-dynamic-attr": "new-dynamic-value"},
 		},
 	})
-	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
+	workshopNames := map[string][]string{"42424242": {"ws"}}
+	_, err := ifacestate.ReloadConnections(s.mgr, workshopNames, "", "", "")
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 
@@ -1598,14 +1614,15 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectSuccess(c *check.C) {
 	c.Check(chg.Err(), check.IsNil)
 
 	// Validate
-	c.Assert(repo.Plugs(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 0)
-	c.Assert(repo.Slots(s.prj.ProjectId, "ws", "consumer"), check.HasLen, 0)
+	refs, err := repo.Connections(s.prj.ProjectId, "ws", "consumer")
+	c.Assert(err, check.IsNil)
+	c.Check(refs, check.HasLen, 0)
 
 	var stateConns map[string]any
 	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
 	c.Assert(stateConns, check.HasLen, 0)
 
-	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
+	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
@@ -1642,6 +1659,32 @@ func (s *interfaceHandlersSuite) TestAutoDisconnectPreservesRemounts(c *check.C)
 	})
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
+}
+
+func (s *interfaceHandlersSuite) TestAutoDisconnectCanForgetRemounts(c *check.C) {
+	// Setup
+	// Create an already installed workshop with a connected mount plug
+	source := c.MkDir()
+	s.launchRemountWorkshop(c, source)
+
+	// Execute
+	s.state.Lock()
+	chg := s.newDisconnectInterfacesChange("consumer")
+	chg.Tasks()[0].Set("forget", true)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	var stateConns map[string]any
+	c.Assert(s.state.Get("conns", &stateConns), check.IsNil)
+	c.Assert(stateConns, check.HasLen, 0)
+
+	c.Check(chg.Has("ws_conns"), check.Equals, false)
 }
 
 func (s *interfaceHandlersSuite) TestAutoDisconnectPreservesBinding(c *check.C) {
@@ -1825,7 +1868,8 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnect(c *check.C) {
 			"plug-dynamic": map[string]any{"test-dynamic-attr": "new-dynamic-value"},
 		},
 	})
-	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
+	workshopNames := map[string][]string{"42424242": {"ws"}}
+	_, err := ifacestate.ReloadConnections(s.mgr, workshopNames, "", "", "")
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 
@@ -1872,7 +1916,8 @@ func (s *interfaceHandlersSuite) TestUndoAutoDisconnectManualRestored(c *check.C
 			"plug-dynamic": map[string]any{"test-dynamic-attr": "new-dynamic-value"},
 		},
 	})
-	_, err := ifacestate.ReloadConnections(s.mgr, "", "", "")
+	workshopNames := map[string][]string{"42424242": {"ws"}}
+	_, err := ifacestate.ReloadConnections(s.mgr, workshopNames, "", "", "")
 	c.Assert(err, check.IsNil)
 	s.state.Unlock()
 
@@ -2604,6 +2649,226 @@ func (s *interfaceHandlersSuite) TestUndoDiscardConnsSuccess(c *check.C) {
 			Auto:      true,
 			Interface: "mock-network",
 			Undesired: true,
+		},
+	})
+}
+
+func (s *interfaceHandlersSuite) TestRestoreConnsSuccess(c *check.C) {
+	// Setup
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs, producerManySlots})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producerManySlots.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	s.state.Lock()
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:missing 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:plug 42424242/ws/producer:missing": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:plug-ssh 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:plug2 42424242/ws/producer:slot-ssh": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:plug3 42424242/ws/producer:slot": map[string]any{
+			"auto":      true,
+			"interface": "mock-network",
+		},
+		"42424242/ws/consumer:bound 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+		},
+	})
+	s.state.Unlock()
+
+	// Execute
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("discard-conns", "...")
+	t1.Set("sdk", "consumer")
+	t2 := s.state.NewTask("restore-conns", "...")
+	t2.Set("discard-conns-task", t1.ID())
+	t2.WaitFor(t1)
+	setWorkshopProject("ws", s.prj, t1, t2)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	var conns map[string]*schema.ConnState
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Assert(conns, check.DeepEquals, map[string]*schema.ConnState{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": {
+			Interface: "mock-network",
+			Undesired: true,
+		},
+	})
+}
+
+func (s *interfaceHandlersSuite) TestRestoreConnsNewBinding(c *check.C) {
+	// Setup
+	wp := s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs, producer})
+	wp.File.Sdks[0].Plugs = map[string]workshop.PlugOrBind{
+		"bound": {Bind: &workshop.PlugRef{Sdk: "consumer", Name: "plug"}},
+	}
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producer.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	s.state.Lock()
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:bound 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+		},
+	})
+	s.state.Unlock()
+
+	// Execute
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("discard-conns", "...")
+	t1.Set("sdk", "consumer")
+	t2 := s.state.NewTask("restore-conns", "...")
+	t2.Set("discard-conns-task", t1.ID())
+	t2.WaitFor(t1)
+	setWorkshopProject("ws", s.prj, t1, t2)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.IsNil)
+
+	// Validate
+	var conns map[string]*schema.ConnState
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Assert(conns, check.DeepEquals, map[string]*schema.ConnState{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": {
+			Interface: "mock-network",
+			Undesired: true,
+		},
+		"42424242/ws/consumer:bound 42424242/ws/producer:slot": {
+			Interface: "mock-network",
+			Undesired: true,
+		},
+	})
+}
+
+func (s *interfaceHandlersSuite) TestUndoRestoreConnsSuccess(c *check.C) {
+	// Setup
+	s.launchWorkshop(c, "ws", []sdk.Meta{consumerManyPlugs, producerManySlots})
+	repo := s.mgr.Repository()
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, consumerManyPlugs.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	c.Assert(repo.AddSdk(sdk.MockInfo(c, producerManySlots.SdkYAML, s.prj.ProjectId, "ws")), check.IsNil)
+	s.state.Lock()
+	s.state.Set("conns", map[string]any{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:missing 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:plug 42424242/ws/producer:missing": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:plug-ssh 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:plug2 42424242/ws/producer:slot-ssh": map[string]any{
+			"interface": "mock-network",
+			"undesired": true,
+		},
+		"42424242/ws/consumer:plug3 42424242/ws/producer:slot": map[string]any{
+			"auto":      true,
+			"interface": "mock-network",
+		},
+		"42424242/ws/consumer:bound 42424242/ws/producer:slot": map[string]any{
+			"interface": "mock-network",
+		},
+	})
+	s.state.Unlock()
+
+	// Execute
+	s.state.Lock()
+	chg := s.state.NewChange("sample", "...")
+	t1 := s.state.NewTask("discard-conns", "...")
+	t1.Set("sdk", "consumer")
+	t2 := s.state.NewTask("restore-conns", "...")
+	t2.Set("discard-conns-task", t1.ID())
+	t2.WaitFor(t1)
+	terr := s.state.NewTask("error-trigger", "...")
+	terr.WaitFor(t2)
+	setWorkshopProject("ws", s.prj, t1, t2, terr)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	chg.AddTask(terr)
+	s.state.Unlock()
+
+	s.settle(c)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	c.Check(chg.Err(), check.ErrorMatches, "(?s).*error-trigger task.*")
+
+	// Validate
+	var conns map[string]*schema.ConnState
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	c.Assert(conns, check.DeepEquals, map[string]*schema.ConnState{
+		"42424242/ws/consumer:plug 42424242/ws/producer:slot": {
+			Interface: "mock-network",
+			Undesired: true,
+		},
+		"42424242/ws/consumer:missing 42424242/ws/producer:slot": {
+			Interface: "mock-network",
+			Undesired: true,
+		},
+		"42424242/ws/consumer:plug 42424242/ws/producer:missing": {
+			Interface: "mock-network",
+			Undesired: true,
+		},
+		"42424242/ws/consumer:plug-ssh 42424242/ws/producer:slot": {
+			Interface: "mock-network",
+			Undesired: true,
+		},
+		"42424242/ws/consumer:plug2 42424242/ws/producer:slot-ssh": {
+			Interface: "mock-network",
+			Undesired: true,
+		},
+		"42424242/ws/consumer:plug3 42424242/ws/producer:slot": {
+			Auto:      true,
+			Interface: "mock-network",
+		},
+		"42424242/ws/consumer:bound 42424242/ws/producer:slot": {
+			Interface: "mock-network",
 		},
 	})
 }

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -60,6 +60,7 @@ func New(s *state.State, r *state.TaskRunner) *InterfaceManager {
 	r.AddHandler("disconnect", OnDo(m.doDisconnect), OnUndo(m.undoDisconnect))
 
 	r.AddHandler("discard-conns", m.doDiscard, OnUndo(m.undoDiscard))
+	r.AddHandler("restore-conns", OnDo(m.doRestoreConns), OnUndo(m.doDiscard))
 
 	r.AddHandler("setup-profiles", OnDo(m.doSetupProfiles), OnUndo(m.undoSetupProfiles))
 	r.AddHandler("remove-profiles", OnDo(m.doRemoveProfiles), nil)
@@ -188,6 +189,7 @@ func (m *InterfaceManager) ensureBackendInit() error {
 		return fmt.Errorf("interface manager not ready: %w", err)
 	}
 
+	workshopNames := make(map[string][]string)
 	for user, projects := range allprojects {
 
 		ctx := context.WithValue(context.Background(), workshop.ContextUser, user)
@@ -198,6 +200,8 @@ func (m *InterfaceManager) ensureBackendInit() error {
 				return fmt.Errorf("cannot load workshops from %q: %v", project.Path, err)
 			}
 			for _, workshop := range workshops {
+				workshopNames[project.ProjectId] = append(workshopNames[project.ProjectId], workshop.Name)
+
 				// Recreate the workshopctl mount for every workshop.
 				if err := m.recreateInternalMounts(pctx, workshop.Name); err != nil {
 					return fmt.Errorf("cannot create internal mounts for %q workshop: %v", workshop.Name, err)
@@ -225,7 +229,7 @@ func (m *InterfaceManager) ensureBackendInit() error {
 			logger.Noticef("cannot copy Xauthority file for user %q, X11 applications may not work: %v", user, err)
 		}
 	}
-	_, err = m.reloadConnections("", "", "")
+	_, err = m.reloadConnections(workshopNames, "", "", "")
 	if err != nil {
 		return err
 	}
@@ -380,7 +384,7 @@ func (m *InterfaceManager) Ensure() error {
 // affecting a given sdk.
 //
 // The return value is the list of affected sdk names.
-func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string) (map[sdk.Ref]bool, error) {
+func (m *InterfaceManager) reloadConnections(workshopNames map[string][]string, projectId, workshop, sdkName string) (map[sdk.Ref]bool, error) {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return nil, err
@@ -388,11 +392,6 @@ func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string
 	connStateChanged := false
 	affected := make(map[sdk.Ref]bool)
 	for connId, connState := range conns {
-		// Skip entries that just mark a connection as undesired. Those don't
-		// carry attributes that can go stale.
-		if connState.Undesired {
-			continue
-		}
 		connRef, err := interfaces.ParseConnRef(connId)
 		if err != nil {
 			return nil, err
@@ -412,20 +411,23 @@ func (m *InterfaceManager) reloadConnections(projectId, workshop, sdkName string
 			}
 		}
 
+		// Remove connections involving nonexistent workshops.
+		if !slices.Contains(workshopNames[connRef.PlugRef.ProjectId], connRef.PlugRef.Workshop) || !slices.Contains(workshopNames[connRef.SlotRef.ProjectId], connRef.SlotRef.Workshop) {
+			delete(conns, connId)
+			connStateChanged = true
+			continue
+		}
+
+		// No need to restore anything.
+		if connState.Undesired {
+			continue
+		}
+
 		plugInfo := m.repo.Plug(connRef.PlugRef.ProjectId, connRef.PlugRef.Workshop, connRef.PlugRef.Sdk, connRef.PlugRef.Name)
 		slotInfo := m.repo.Slot(connRef.SlotRef.ProjectId, connRef.SlotRef.Workshop, connRef.SlotRef.Sdk, connRef.SlotRef.Name)
-
-		// The connection refers to a plug or slot that doesn't exist anymore, e.g. because of a refresh
-		// to a new sdk revision that doesn't have the given plug/slot.
+		// The connection refers to a plug or slot that doesn't exist anymore.
+		// Keep it in the state in case we're in the middle of a Change.
 		if plugInfo == nil || slotInfo == nil {
-			// automatic connection can simply be removed (it will be re-created automatically if needed)
-			// as long as it wasn't disconnected manually; note that undesired flag is taken care of at
-			// the beginning of the loop.
-			if connState.Auto {
-				delete(conns, connId)
-				connStateChanged = true
-			}
-			// otherwise keep it and silently ignore, e.g. in case of a revert.
 			continue
 		}
 

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -80,8 +80,6 @@ func (m *InterfaceManager) Repository() *interfaces.Repository {
 type ConnectionState struct {
 	// Auto indicates whether the connection was established automatically
 	Auto bool
-	// ByGadget indicates whether the connection was triggered by the gadget
-	ByGadget bool
 	// Interface name of the connection
 	Interface string
 	// Undesired indicates whether the connection, otherwise established

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -195,27 +195,22 @@ func (m *InterfaceManager) ensureBackendInit() error {
 			pctx := context.WithValue(ctx, workshop.ContextProjectId, project.ProjectId)
 			workshops, err := m.backend.ProjectWorkshops(pctx)
 			if err != nil {
-				logger.Noticef("Cannot load workshops from %q: %v", project.Path, err)
-				continue
+				return fmt.Errorf("cannot load workshops from %q: %v", project.Path, err)
 			}
 			for _, workshop := range workshops {
-				// recreate the socket device for every workshop to ensure
-				// workshopctl can function (if the daemon was stopped the
-				// socket will render /deleted)
+				// Recreate the workshopctl mount for every workshop.
 				if err := m.recreateInternalMounts(pctx, workshop.Name); err != nil {
-					logger.Noticef("Cannot create internal mounts for %q workshop: %v", workshop.Name, err)
+					return fmt.Errorf("cannot create internal mounts for %q workshop: %v", workshop.Name, err)
 				}
 
 				infos, err := workshop.SdkInfosByInstallOrder(pctx)
 				if err != nil {
-					logger.Noticef("Cannot obtain the installed SDKs for %q workshop: %v", workshop.Name, err)
-					continue
+					return fmt.Errorf("cannot obtain the installed SDKs for %q workshop: %v", workshop.Name, err)
 				}
 
 				for _, info := range infos {
 					if err = m.repo.AddSdk(info); err != nil {
-						logger.Noticef("Cannot register %q SDK interfaces: %v", info.Name, err)
-						continue
+						return fmt.Errorf("cannot register %q SDK interfaces: %v", info.Name, err)
 					}
 				}
 			}

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -279,7 +279,7 @@ slots:
 	c.Assert(mgr.Repository().Interfaces().Connections, check.HasLen, 0)
 }
 
-func (s *interfaceManagerSuite) TestManagerRemovesNonexistingAutoConnectionss(c *check.C) {
+func (s *interfaceManagerSuite) TestManagerRemovesNonexistingWorkshopConnections(c *check.C) {
 	var consumerYaml = `
 name: consumer
 base: ubuntu@22.04
@@ -305,13 +305,14 @@ slots:
 	})
 
 	s.state.Lock()
-	key := fmt.Sprintf("%s/ws/consumer:plug-1 %s/core/producer:slot-1", s.prj.ProjectId, s.prj.ProjectId)
+	missingPlug := fmt.Sprintf("%s/ws-missing/consumer:plug %s/ws/producer:slot", s.prj.ProjectId, s.prj.ProjectId)
+	missingSlot := fmt.Sprintf("%s/ws/consumer:plug %s/ws-missing/producer:slot", s.prj.ProjectId, s.prj.ProjectId)
+	stalePlugSlot := fmt.Sprintf("%s/ws/consumer:plug-1 %s/ws/producer:slot-1", s.prj.ProjectId, s.prj.ProjectId)
 
 	s.state.Set("conns", map[string]any{
-		key: map[string]any{
-			"interface": "test",
-			"auto":      true,
-		},
+		missingPlug:   map[string]any{"interface": "test", "auto": true},
+		missingSlot:   map[string]any{"interface": "test"},
+		stalePlugSlot: map[string]any{"interface": "test", "auto": true},
 	})
 	s.state.Unlock()
 
@@ -320,6 +321,17 @@ slots:
 	c.Assert(err, check.IsNil)
 
 	c.Assert(mgr.Repository().Interfaces().Connections, check.HasLen, 0)
+
+	s.state.Lock()
+	var conns map[string]any
+	c.Assert(s.state.Get("conns", &conns), check.IsNil)
+	s.state.Unlock()
+	_, ok := conns[missingPlug]
+	c.Check(ok, check.Equals, false)
+	_, ok = conns[missingSlot]
+	c.Check(ok, check.Equals, false)
+	_, ok = conns[stalePlugSlot]
+	c.Check(ok, check.Equals, true)
 }
 
 func (s *interfaceManagerSuite) TestConnectionStatesAutoManual(c *check.C) {

--- a/internal/overlord/ifacestate/schema/schema.go
+++ b/internal/overlord/ifacestate/schema/schema.go
@@ -32,3 +32,11 @@ type ConnState struct {
 	StaticSlotAttrs  map[string]any `json:"slot-static,omitempty" yaml:"slot-static,omitempty"`
 	DynamicSlotAttrs map[string]any `json:"slot-dynamic,omitempty" yaml:"slot-dynamic,omitempty"`
 }
+
+// PreservedConn holds properties of a connection that are preserved by refreshes.
+type PreservedConn struct {
+	Auto             bool           `json:"auto,omitempty" yaml:"auto"`
+	Interface        string         `json:"interface,omitempty" yaml:"interface"`
+	DynamicPlugAttrs map[string]any `json:"plug-dynamic,omitempty" yaml:"plug-dynamic,omitempty"`
+	DynamicSlotAttrs map[string]any `json:"slot-dynamic,omitempty" yaml:"slot-dynamic,omitempty"`
+}

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -248,7 +248,7 @@ func (w *WorkshopManager) RefreshMany(ctx context.Context, project workshop.Proj
 		}
 
 		if option == conflict.RefreshRestore || hasUpdates(current[i], latest[i]) {
-			tasks := refresh(w.state, project, current[i], latest[i], len(snapshot.Sdks))
+			tasks := refresh(w.state, project, current[i], latest[i], len(snapshot.Sdks), option)
 			tasksets = append(tasksets, tasks)
 		}
 	}
@@ -348,7 +348,7 @@ func sdkAdditions(sdks []workshop.SdkRecord, name string) workshop.SdkRecord {
 	return sk
 }
 
-func refresh(st *state.State, project workshop.Project, current, latest Manifest, intact int) *state.TaskSet {
+func refresh(st *state.State, project workshop.Project, current, latest Manifest, intact int, option conflict.RefreshOption) *state.TaskSet {
 	refresh := state.NewTaskSet()
 	prev := (*state.TaskSet)(nil)
 	addTaskSet := func(ts *state.TaskSet) {
@@ -393,8 +393,11 @@ func refresh(st *state.State, project workshop.Project, current, latest Manifest
 	saveState := runHooks(st, saveSdks, 0, hookstate.SaveState)
 	addTaskSet(saveState)
 
-	disconnect := disconnectSdks(st, currentSdks)
+	disconnect := disconnectSdks(st, currentSdks, option == conflict.RefreshRestore)
 	addTaskSet(disconnect)
+
+	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", latest.File.Name))
+	addTaskSet(state.NewTaskSet(discard))
 
 	stop := st.NewTask("stop-workshop", fmt.Sprintf("Stop %q workshop", latest.File.Name))
 	stop.Set("force", true)
@@ -425,6 +428,12 @@ func refresh(st *state.State, project workshop.Project, current, latest Manifest
 	// Install updated SDKs to the rebuilt workshop.
 	install := installSdks(st, newSdks)
 	addTaskSet(install)
+
+	if option == conflict.RefreshUpdate {
+		restoreConns := st.NewTask("restore-conns", fmt.Sprintf("Restore %q undesired connections", latest.File.Name))
+		restoreConns.Set("discard-conns-task", discard.ID())
+		addTaskSet(state.NewTaskSet(restoreConns))
+	}
 
 	configureTimezone := st.NewTask("configure-timezone", fmt.Sprintf("Configure %q workshop timezone", latest.File.Name))
 	addTaskSet(state.NewTaskSet(configureTimezone))
@@ -537,12 +546,13 @@ func uninstallSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
 	return uninstallSet
 }
 
-func disconnectSdks(st *state.State, sdks []sdk.Setup) *state.TaskSet {
+func disconnectSdks(st *state.State, sdks []sdk.Setup, forget bool) *state.TaskSet {
 	prev := (*state.Task)(nil)
 	disconnSet := state.NewTaskSet()
 	for _, s := range sdks {
 		disconn := st.NewTask("auto-disconnect", fmt.Sprintf("Disconnect interfaces of %q SDK", s.Name))
 		disconn.Set("sdk", s.Name)
+		disconn.Set("forget", forget)
 		disconnSet.AddTask(disconn)
 
 		if prev != nil {
@@ -733,7 +743,7 @@ func remove(st *state.State, manifest Manifest, hasStash, running bool, project 
 	sdks := slices.Clone(manifest.Sdks)
 	slices.Reverse(sdks)
 
-	disconnectSet := disconnectSdks(st, sdks)
+	disconnectSet := disconnectSdks(st, sdks, true)
 	addTaskSet(disconnectSet)
 
 	discard := st.NewTask("discard-conns", fmt.Sprintf("Discard %q undesired connections", manifest.File.Name))

--- a/tests/docs-how-to/add-mounts/task.yaml
+++ b/tests/docs-how-to/add-mounts/task.yaml
@@ -59,11 +59,12 @@ execute: |
 
   echo "Manual connection state survives refresh and start/stop"
   workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+manual$"
+  cat workshop.yaml | yq '.sdks[-1] as $jupyter | del(.sdks[-1]) | .sdks = [$jupyter] + .sdks' | sponge workshop.yaml
   workshop_exec refresh
-  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+manual$"
+  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+-$"
   workshop_exec stop dev
   workshop_exec start dev
-  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+manual$"
+  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+-$"
 
   echo "'workshop restore' resets connections and mounts to defaults"
   workshop_exec restore dev

--- a/tests/docs-how-to/add-mounts/task.yaml
+++ b/tests/docs-how-to/add-mounts/task.yaml
@@ -61,11 +61,11 @@ execute: |
   workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+manual$"
   cat workshop.yaml | yq '.sdks[-1] as $jupyter | del(.sdks[-1]) | .sdks = [$jupyter] + .sdks' | sponge workshop.yaml
   workshop_exec refresh
-  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+-$"
+  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+manual$"
   workshop_exec stop dev
   workshop_exec start dev
-  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+-$"
+  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+manual$"
 
   echo "'workshop restore' resets connections and mounts to defaults"
   workshop_exec restore dev
-  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+-$"
+  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+manual$"

--- a/tests/docs-how-to/add-mounts/task.yaml
+++ b/tests/docs-how-to/add-mounts/task.yaml
@@ -68,4 +68,4 @@ execute: |
 
   echo "'workshop restore' resets connections and mounts to defaults"
   workshop_exec restore dev
-  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+manual$"
+  workshop_exec connections dev | MATCH "^mount.+dev/uv:shared.+:mount.+-$"

--- a/tests/docs-how-to/manage-python-environments/task.yaml
+++ b/tests/docs-how-to/manage-python-environments/task.yaml
@@ -1,6 +1,6 @@
 summary: Test 'How to manage Python environments with the uv SDK' to ensure it's operational
 restore: |
-  rm -rf ~/pyproj
+  rm -rf pyproj
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/docs-tutorial/part-1/task.yaml
+++ b/tests/docs-tutorial/part-1/task.yaml
@@ -1,6 +1,8 @@
 summary: Run tutorial part 1 commands to ensure it's operational
 restore: |
-  rm -rf ~/ollama-python-project
+  . "$TESTSLIB"/utils.sh
+  (cd ollama-python-project && workshop_exec remove) || true
+  rm -rf ollama-python-project
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/docs-tutorial/part-2/task.yaml
+++ b/tests/docs-tutorial/part-2/task.yaml
@@ -1,6 +1,8 @@
 summary: Run tutorial part 2 commands to ensure it's operational
 restore: |
-  rm -rf ~/ollama-python-project ~/.ollama
+  . "$TESTSLIB"/utils.sh
+  (cd ollama-python-project && workshop_exec remove) || true
+  rm -rf ollama-python-project ~/.ollama
 execute: |
   . "$TESTSLIB"/utils.sh
 
@@ -19,12 +21,18 @@ execute: |
 
   ## Manage connections
 
-  workshop_exec connections
+  workshop_exec connections > conns.log
+  MATCH '^gpu[[:space:]]+dev/ollama:gpu[[:space:]]+dev/system:gpu[[:space:]]+-$' < conns.log
+  MATCH '^mount[[:space:]]+dev/ollama:models[[:space:]]+dev/system:mount[[:space:]]+-$' < conns.log
 
   workshop_exec disconnect dev/ollama:models
-  workshop_exec connections
+  workshop_exec connections > conns.log
+  MATCH '^gpu[[:space:]]+dev/ollama:gpu[[:space:]]+dev/system:gpu[[:space:]]+-$' < conns.log
+  NOMATCH 'dev/ollama:models' < conns.log
+
   workshop_exec connect dev/ollama:models :mount
-  workshop_exec connections
+  workshop_exec connections > conns.log
+  MATCH '^mount[[:space:]]+dev/ollama:models[[:space:]]+dev/system:mount[[:space:]]+manual$' < conns.log
 
   mkdir -p ~/.ollama/models
   workshop_exec remount dev/ollama:models ~/.ollama/models
@@ -41,9 +49,15 @@ execute: |
           interface: tunnel
           endpoint: 127.0.0.1:8989
   EOF
-  workshop_exec connections --all
   workshop_exec refresh
   workshop_exec info
+
+  # The manual connection made above has to survive the refresh.
+  workshop_exec connections --all > conns.log
+  MATCH '^mount[[:space:]]+dev/jupyter:venv[[:space:]]+dev/system:mount[[:space:]]+-$' < conns.log
+  MATCH '^mount[[:space:]]+dev/ollama:models[[:space:]]+dev/system:mount[[:space:]]+manual$' < conns.log
+  MATCH '^tunnel[[:space:]]+dev/system:jupyter[[:space:]]+dev/jupyter:jupyter[[:space:]]+-$' < conns.log
+
   retry 5 curl -w '\n' http://127.0.0.1:8989/api
 
 
@@ -69,7 +83,9 @@ execute: |
 
   # Apply the new definition.
   workshop_exec refresh
-  workshop_exec connections --all | MATCH 'dev/jupyter:venv\s+dev/uv:venv'
+  workshop_exec connections --all > conns.log
+  MATCH '^mount[[:space:]]+dev/jupyter:venv[[:space:]]+dev/uv:venv[[:space:]]+-$' < conns.log
+  MATCH '^mount[[:space:]]+dev/ollama:models[[:space:]]+dev/system:mount[[:space:]]+manual$' < conns.log
 
   # Smoke-test uv from inside the workshop.
   workshop_exec exec dev -- uv --version

--- a/tests/docs-tutorial/part-3/task.yaml
+++ b/tests/docs-tutorial/part-3/task.yaml
@@ -1,6 +1,6 @@
 summary: Run tutorial part 3 commands to ensure it's operational
 restore: |
-  rm -rf ~/ollama-python-project ~/.ollama
+  rm -rf ollama-python-project ~/.ollama
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/docs-tutorial/part-4/task.yaml
+++ b/tests/docs-tutorial/part-4/task.yaml
@@ -1,6 +1,6 @@
 summary: Run tutorial part 4 commands to ensure it's operational
 restore: |
-  rm -rf ~/ollama
+  rm -rf ollama
 execute: |
   . "$TESTSLIB"/utils.sh
   lxc storage set default size=32GB

--- a/tests/main/interface-plug-binding/task.yaml
+++ b/tests/main/interface-plug-binding/task.yaml
@@ -5,19 +5,15 @@ prepare: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
-  function check_original_binding() {
-    MATCH "mount      -                                          ws-bind/test-sdk-mount:jobs  -" < conns.log
-    MATCH "mount      ws-bind/test-sdk-mount:one                 ws-bind/system:mount         bind.2" < conns.log
-    MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         bind.5" < conns.log
-    MATCH "mount      ws-bind/test-sdk-multiple-plugs:one        ws-bind/system:mount         bind.2" < conns.log
-    MATCH "mount      ws-bind/test-sdk-multiple-plugs:two        ws-bind/system:mount         bind.5" < conns.log
-    MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -                            bind.6" < conns.log
-    MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -                            bind.6" < conns.log
-  }
-
   echo "Check binding on launch"
   workshop_exec connections ws-bind > conns.log
-  check_original_binding
+  MATCH "mount      -                                          ws-bind/test-sdk-mount:jobs  -" < conns.log
+  MATCH "mount      ws-bind/test-sdk-mount:one                 ws-bind/system:mount         bind.2" < conns.log
+  MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         bind.5" < conns.log
+  MATCH "mount      ws-bind/test-sdk-multiple-plugs:one        ws-bind/system:mount         bind.2" < conns.log
+  MATCH "mount      ws-bind/test-sdk-multiple-plugs:two        ws-bind/system:mount         bind.5" < conns.log
+  MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -                            bind.6" < conns.log
+  MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -                            bind.6" < conns.log
 
   echo "Check bound mount plugs use host directories of the plug they are bound to"
   workshop_exec info > mounts.log
@@ -47,7 +43,13 @@ execute: |
   sed -i -e "0,/stable/s/stable/edge/" workshop.yaml
   workshop_exec refresh
   workshop_exec connections ws-bind > conns.log
-  check_original_binding
+  MATCH "mount      -                                          ws-bind/test-sdk-mount:jobs  -" < conns.log
+  MATCH "mount      ws-bind/test-sdk-mount:one                 ws-bind/system:mount         bind.2" < conns.log
+  MATCH "mount      ws-bind/test-sdk-mount:two                 ws-bind/system:mount         manual,bind.5" < conns.log
+  MATCH "mount      ws-bind/test-sdk-multiple-plugs:one        ws-bind/system:mount         bind.2" < conns.log
+  MATCH "mount      ws-bind/test-sdk-multiple-plugs:two        ws-bind/system:mount         manual,bind.5" < conns.log
+  MATCH "ssh-agent  ws-bind/test-sdk-multiple-plugs:ssh-agent  -                            bind.6" < conns.log
+  MATCH "ssh-agent  ws-bind/test-sdk-ssh-agent:ssh-agent       -                            bind.6" < conns.log
 
   echo "Check a plug can be unbound"
   cat workshop.yaml | yq 'del(.sdks[2].plugs)' | sponge workshop.yaml

--- a/tests/main/try-sdks/task.yaml
+++ b/tests/main/try-sdks/task.yaml
@@ -6,7 +6,7 @@ restore: |
   lxc storage volume delete workshop custom/test-sdk-basic-2-x2 || true
   (cd "$TESTSLIB/sdk/test-sdk-basic-2/latest/stable" && run_sdkcraft clean) || true
   (cd "$TESTSLIB/sdk/test-sdk-basic-2/latest/edge" && run_sdkcraft clean) || true
-  rm -rf /home/ubuntu/.local/share/workshop/try/test-sdk-basic-2
+  rm -rf work /home/ubuntu/.local/share/workshop/try/test-sdk-basic-2
 execute: |
   . "$TESTSLIB"/utils.sh
 


### PR DESCRIPTION
# Description

Previously, refresh would remember `host-source` for remounted mount connections. Now, it remembers all dynamic attributes (which should have the same effect). It also remembers manual connections and disconnections.

Bound plugs are reconnected (or kept disconnected) alongside the plug they are bound to, regardless of the previous state of the plug itself. Plugs that used to be bound, but are now independent, are handled transparently, i.e. dynamic attributes come from the main connection rather than one of the bound copies.

Unlike refresh, restore resets manual connections, disconnections and remounts, as if the user removed and re-launched the workshop.

I also fixed a usability issue that isn't really a bug, but I think makes sense to do given the other changes. Previously, manually disconnecting a manual connection would not store anything in the state. I assume the reasoning was that connections are only created manually if they aren't auto-connectable. Now that manual connections are preserved by refresh, policies can change, and a manual disconnection might be undone on the next refresh. So we should always mark manual disconnections as undesired. Temporary disconnections can still be done with `disconnect --forget`.

Finally, I changed some error handling from logging into daemon degradation, otherwise the interface manager might prune some connections that we want to keep.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.