### PR TITLE
Add custom device interface

### DIFF
--- a/docs/.coverage.yaml
+++ b/docs/.coverage.yaml
@@ -155,6 +155,17 @@
   specs:
     - SK042
 
+"custom-device interface":
+  category: interface
+  type: concept
+  specs:
+    - SK052
+
+"custom-device interface attributes":
+  category: interface
+  type: concept
+  specs: []
+
 "check-health":
   category: SDK
   type: action

--- a/docs/explanation/interfaces/concepts.rst
+++ b/docs/explanation/interfaces/concepts.rst
@@ -38,6 +38,7 @@ so you cannot create a custom interface type.
 Currently, |ws_markup| and |sdk_markup| support the following:
 
 - :ref:`Camera interface <exp_camera_interface>` (manually connected)
+- :ref:`Custom device interface <exp_custom_device_interface>` (manually connected)
 - :ref:`Desktop interface <exp_desktop_interface>` (manually connected)
 - :ref:`GPU interface <exp_gpu_interface>` (auto-connected)
 - :ref:`Mount interface <exp_mount_interface>` (auto-connected)
@@ -128,6 +129,7 @@ but the overall aim is to conduct reasonably in each case:
 the :ref:`mount <exp_mount_interface>`
 and the :ref:`GPU <exp_gpu_interface>` interfaces are auto-connected,
 whereas the :ref:`camera <exp_camera_interface>`,
+:ref:`custom device <exp_custom_device_interface>`,
 :ref:`desktop <exp_desktop_interface>`, and :ref:`SSH <exp_ssh_interface>`
 interfaces require manual connection.
 

--- a/docs/explanation/interfaces/custom-device-interface.rst
+++ b/docs/explanation/interfaces/custom-device-interface.rst
@@ -1,0 +1,144 @@
+.. _exp_custom_device_interface:
+
+.. meta::
+   :description: Documentation on the custom-device interface that enables
+                 workshops to access arbitrary host devices belonging to a
+                 given subsystem, for hardware testing, device development, and
+                 other applications that need access to non-standard devices.
+
+Custom device interface
+=======================
+
+.. @artefact custom-device interface
+
+The custom device interface
+enables access to arbitrary host devices inside the workshop,
+identified by the device *subsystem* they belong to
+(for example, :samp:`input`, :samp:`tty`, or :samp:`usb`).
+
+By using the interface,
+the SDK publisher allows the workshop to access devices
+that no dedicated interface covers,
+such as serial adapters, input devices, or other peripherals
+used for testing hardware or embedded devices.
+
+.. _exp_custom_device_plug:
+
+Custom device interface plug
+----------------------------
+
+An essential element here is the custom device interface plug,
+which is declared in the SDK definition.
+
+Its structure includes the name of the plug,
+the interface (:samp:`custom-device`),
+and a :samp:`subsystem` attribute.
+
+Defining the plug in an SDK
+allows the workshops using this SDK to connect to matching devices,
+which can unlock additional SDK functionality.
+
+
+.. _exp_determine_subsystem:
+
+Device subsystems
+-----------------
+
+.. @artefact custom-device interface attributes
+
+The :samp:`subsystem` attribute for a given device
+is defined by the Linux kernel.
+One way to query device properties is :command:`udevadm info`:
+
+.. code-block:: console
+
+   $ udevadm info --query=property --property=SUBSYSTEM /dev/input/event0
+
+     SUBSYSTEM=input
+
+
+.. _exp_custom_device_slot:
+
+Custom device interface slot
+----------------------------
+
+To let SDKs in a workshop access the host's devices,
+|ws_markup| provides a custom device interface slot
+that multiple custom device interface plugs can access.
+
+When the SDK is installed at runtime during launch and refresh operations,
+|ws_markup| checks that the plug targeting the slot
+passes :ref:`validation <exp_interfaces_validation>`;
+if it does,
+it can be connected.
+
+
+Connection
+----------
+
+The interface isn't connected automatically at launch and refresh
+for security reasons.
+The :command:`workshop connect` and :command:`workshop disconnect` commands
+can be invoked manually after the workshop has started:
+
+.. @artefact workshop connect
+.. @artefact workshop disconnect
+
+.. code-block:: console
+
+   $ workshop connect ws/input-sdk:input-device :custom-device
+   $ workshop disconnect ws/input-sdk:input-device
+
+
+Establishing a connection means
+that all existing host devices belonging to the plug's subsystem
+will be made available inside the workshop.
+While the connection is active,
+adding new devices on the host will also make them available inside the workshop,
+whereas unplugged devices will also be removed from the workshop.
+
+To check if the interface is connected:
+
+.. @artefact workshop connections
+
+.. code-block:: console
+
+   $ workshop connections --all
+
+     INTERFACE      PLUG                       SLOT                     NOTES
+     ...
+     custom-device  ws/input-sdk:input-device  ws/system:custom-device  manual
+
+
+This means the host's devices from the given subsystem
+are available inside the workshop:
+
+.. @artefact workshop shell
+
+.. code-block:: console
+
+   $ workshop shell ws
+   workshop@ws-8584e571$ ls /dev/input/
+
+     event0  event1  mice
+
+
+See also
+--------
+
+Explanation:
+
+- :ref:`exp_interface_concepts`
+- :ref:`exp_plugs_slots`
+- :ref:`exp_sdk_definition`
+- :ref:`exp_workshop_definition`
+
+
+Reference:
+
+- :ref:`ref_workshop_connect`
+- :ref:`ref_workshop_connections`
+- :ref:`ref_workshop_disconnect`
+- :ref:`ref_workshop_launch`
+- :ref:`ref_workshop_refresh`
+- :ref:`ref_workshop_shell`

--- a/docs/explanation/interfaces/custom-device-interface.rst
+++ b/docs/explanation/interfaces/custom-device-interface.rst
@@ -39,7 +39,7 @@ allows the workshops using this SDK to connect to matching devices,
 which can unlock additional SDK functionality.
 
 
-.. _exp_determine_subsystem:
+.. _exp_custom_device_subsystem:
 
 Device subsystems
 -----------------

--- a/docs/explanation/interfaces/index.rst
+++ b/docs/explanation/interfaces/index.rst
@@ -33,6 +33,7 @@ such as displays, GPUs, and cameras:
    :maxdepth: 1
 
    camera-interface
+   custom-device-interface
    desktop-interface
    gpu-interface
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,6 +95,7 @@ In this documentation
    * - **Interfaces**
      - :ref:`Concepts <exp_interface_concepts>` •
        :ref:`Camera <exp_camera_interface>` •
+       :ref:`Custom device <exp_custom_device_interface>` •
        :ref:`Desktop <exp_desktop_interface>` •
        :ref:`GPU <exp_gpu_interface>` •
        :ref:`Mounts <exp_mount_interface>` •

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -241,7 +241,7 @@ The only camera interface slot is :samp:`system:camera`.
 
 
 Custom device interface
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. @artefact custom-device interface
 

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -178,8 +178,8 @@ but this detail isn't exposed in the definition files.
 
 Several interfaces expose resources that are host-based and singular by nature;
 the system SDK has default eponymous slots for these interfaces:
-:samp:`system:camera`, :samp:`system:desktop`, :samp:`system:gpu`,
-:samp:`system:mount`, and :samp:`system:ssh-agent`.
+:samp:`system:camera`, :samp:`system:custom-device`, :samp:`system:desktop`,
+:samp:`system:gpu`, :samp:`system:mount`, and :samp:`system:ssh-agent`.
 No other SDKs can declare slots for these interfaces, except for :samp:`mount`.
 The :samp:`system:mount` slot is still unique
 because it's the only one that provides access to the *host* filesystem,
@@ -238,6 +238,34 @@ and can't belong to the :ref:`system SDK <ref_system_sdk>`.
 They have no attributes.
 
 The only camera interface slot is :samp:`system:camera`.
+
+
+Custom device interface
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. @artefact custom-device interface
+
+Custom device interface plugs can't belong to the :ref:`system SDK <ref_system_sdk>`.
+They are described by the following attributes:
+
+.. @artefact custom-device interface attributes
+
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 2 1 6
+
+   * - Key
+     - Value
+     - Description
+
+   * - :samp:`subsystem` (required)
+     - string
+     - The Linux kernel subsystem of the host devices to expose,
+       for example :samp:`input`, :samp:`tty`, or :samp:`usb`.
+
+
+The only custom device interface slot is :samp:`system:custom-device`.
 
 
 Desktop interface

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -146,6 +146,7 @@ SDK plugs and slots
 Currently, |ws_markup| and |sdk_markup| support the following interface plugs:
 
 - :ref:`Camera <ref_camera_interface>`
+- :ref:`Custom device <ref_custom_device_interface>`
 - :ref:`Desktop <ref_desktop_interface>`
 - :ref:`GPU <ref_gpu_interface>`
 - :ref:`Mount <ref_mount_interface>`
@@ -179,6 +180,32 @@ as video capture devices.
 .. note::
 
    See the :ref:`explanation <exp_camera_interface>` for more details.
+
+
+.. _ref_custom_device_interface:
+
+Custom device interface
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. @artefact custom-device interface
+
+A custom-device plug in the definition must specify the plug name, the interface, and a ``subsystem`` attribute:
+
+.. code-block:: yaml
+   :caption: sdk.yaml
+
+    # ...
+    plugs:
+      <NAME>:
+        interface: custom-device
+        subsystem: <SUBSYSTEM>
+
+
+This makes host devices from the given subsystem directly available inside the workshop.
+
+.. note::
+
+   See the :ref:`explanation <exp_custom_device_interface>` for more details.
 
 
 .. _ref_desktop_interface:

--- a/docs/reference/sdks.rst
+++ b/docs/reference/sdks.rst
@@ -189,7 +189,9 @@ Custom device interface
 
 .. @artefact custom-device interface
 
-A custom-device plug in the definition must specify the plug name, the interface, and a ``subsystem`` attribute:
+A custom-device plug in the definition
+must specify the plug name, the interface,
+and a :samp:`subsystem` attribute:
 
 .. code-block:: yaml
    :caption: sdk.yaml

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1160,7 +1160,7 @@ line 1: cannot unmarshal !!seq into string`,
 	c.Assert(err, check.IsNil)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slots(s.project.ProjectId, "basic", sdk.System.String()), check.HasLen, 5)
+	c.Assert(repo.Slots(s.project.ProjectId, "basic", sdk.System.String()), check.HasLen, 6)
 
 	c.Assert(s.b.DownloadBaseCalls, check.HasLen, 1)
 
@@ -2102,6 +2102,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		slots: []string{
 			"mount-conflict:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2115,6 +2116,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		},
 		slots: []string{
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2128,6 +2130,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		},
 		slots: []string{
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2229,6 +2232,7 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2309,6 +2313,7 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2388,6 +2393,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		},
 		slots: []string{
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2484,6 +2490,7 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2693,6 +2700,7 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2740,6 +2748,7 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2806,6 +2815,7 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2852,6 +2862,7 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -2932,6 +2943,7 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3013,6 +3025,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3086,6 +3099,7 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 		},
 		slots: []string{
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3166,6 +3180,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3243,6 +3258,7 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3321,6 +3337,7 @@ func (s *apiSuite) TestRefreshRestore(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3402,6 +3419,7 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3500,6 +3518,7 @@ func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3576,6 +3595,7 @@ func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
 		},
 		slots: []string{
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3644,6 +3664,7 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 		},
 		slots: []string{
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -3724,6 +3745,7 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 		slots: []string{
 			"test-sdk-2:data-slot",
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -4412,6 +4434,7 @@ base: ubuntu@22.04
 		},
 		slots: []string{
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",
@@ -4464,6 +4487,7 @@ plugs:
 		},
 		slots: []string{
 			"system:camera",
+			"system:custom-device",
 			"system:desktop",
 			"system:gpu",
 			"system:mount",

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -497,6 +497,8 @@ var apiSuiteSdks = map[string]sdk.Meta{
 	},
 }
 
+var systemVolume = "system-" + system.SystemSdkRevision.String()
+
 func (s *apiSuite) launchWorkshop(c *check.C, name, yaml string) {
 	s.createWFile(c, name, yaml)
 
@@ -1251,7 +1253,7 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	c.Assert(repo.Slots(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
 	c.Assert(repo.Plugs(s.project.ProjectId, "manysdks", "test-sdk-2"), check.HasLen, 0)
 
-	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume})
 	s.ensureSnapshotsAfterCooldown(c, nil, []string{"system", "test-sdk", "test-sdk-2"})
 }
 
@@ -1658,7 +1660,7 @@ func (s *apiSuite) TestLaunchWorkshopWithPlugOK(c *check.C) {
 	c.Assert(conns, check.HasLen, 1)
 	c.Assert(conns[0].ID(), check.Equals, fmt.Sprintf(`%s/workshopplug/test-sdk:training-plug %s/workshopplug/system:mount`, s.project.ProjectId, s.project.ProjectId))
 
-	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume, "test-sdk-1", "test-sdk-2-1"})
 }
 
 func (s *apiSuite) TestLaunchWorkshopPlugAddedAndBound(c *check.C) {
@@ -2065,7 +2067,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 	}
 	s.runActionTest(c, requests, expected)
 
-	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1", "mount-conflict-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume, "test-sdk-1", "test-sdk-2-1", "mount-conflict-1"})
 
 	s.createWFile(c, "manysdks", manysdks_allremoved)
 	requests = []*bytes.Buffer{
@@ -2168,7 +2170,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 		{manysdks_allremoved, []string{"system"}},
 	})
 
-	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "mount-conflict-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume, "test-sdk-1", "mount-conflict-1"})
 }
 
 func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
@@ -2337,7 +2339,7 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 		{manysdks_extended, []string{"system"}},
 	})
 
-	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1", "test-sdk-3-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume, "test-sdk-1", "test-sdk-2-1", "test-sdk-3-1"})
 }
 
 func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
@@ -2414,7 +2416,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 		{manysdks_minusone, []string{"system", "test-sdk"}},
 	})
 
-	s.ensureSdkVolumesAfterCooldown(c, []string{"test-sdk-1", "system-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{"test-sdk-1", systemVolume})
 	s.ensureSnapshotsAfterCooldown(c, []string{"system", "test-sdk"}, []string{"test-sdk-2"})
 }
 
@@ -2513,7 +2515,7 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 	})
 
 	s.ensureSdkVolumesAfterCooldown(c, []string{
-		"system-1",
+		systemVolume,
 		"test-sdk-2",
 		"test-sdk-2-1",
 	})
@@ -3278,7 +3280,7 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 		{manysdks, nil},
 	})
 
-	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume, "test-sdk-1", "test-sdk-2-1"})
 }
 
 func (s *apiSuite) TestRefreshRestore(c *check.C) {
@@ -3358,7 +3360,7 @@ func (s *apiSuite) TestRefreshRestore(c *check.C) {
 		{manysdks, []string{"system", "test-sdk", "test-sdk-2"}},
 	})
 
-	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1", "test-sdk-1", "test-sdk-2-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume, "test-sdk-1", "test-sdk-2-1"})
 }
 
 func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
@@ -4857,7 +4859,7 @@ func (s *apiSuite) TestRemoveWorkshopSuccess(c *check.C) {
 		},
 	}
 	s.runActionTest(c, requests, expected)
-	s.ensureSdkVolumesAfterCooldown(c, []string{"system-1"})
+	s.ensureSdkVolumesAfterCooldown(c, []string{systemVolume})
 	s.ensureSnapshotsAfterCooldown(c, nil, []string{"system", "test-sdk", "test-sdk-2"})
 }
 

--- a/internal/interfaces/builtin/custom_device.go
+++ b/internal/interfaces/builtin/custom_device.go
@@ -1,0 +1,104 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+const customDeviceSummary = `allows sharing custom devices with SDKs`
+
+const customDeviceBaseDeclarationSlots = `
+  custom-device:
+    allow-installation:
+      slot-sdk-type:
+        - system
+      slot-names:
+        - $INTERFACE
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+const customDeviceBaseDeclarationPlugs = `
+  custom-device:
+    allow-installation:
+      plug-sdk-type:
+        - regular
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+var knownCustomDeviceAttributes = []string{"subsystem"}
+
+type customDeviceInterface struct{}
+
+func (iface *customDeviceInterface) Name() string {
+	return "custom-device"
+}
+
+func (iface *customDeviceInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              customDeviceSummary,
+		BaseDeclarationPlugs: customDeviceBaseDeclarationPlugs,
+		BaseDeclarationSlots: customDeviceBaseDeclarationSlots,
+		AffectsPlugOnRefresh: true,
+	}
+}
+
+func (iface *customDeviceInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
+	for name := range plug.Attrs {
+		if !slices.Contains(knownCustomDeviceAttributes, name) {
+			return fmt.Errorf("unknown attribute for custom-device interface plug: %q", name)
+		}
+	}
+
+	var subsystem string
+	if err := plug.Attr("subsystem", &subsystem); err != nil {
+		return err
+	}
+	if subsystem == "" {
+		return fmt.Errorf(`custom-device plug "subsystem" is empty`)
+	}
+
+	return nil
+}
+
+func (iface *customDeviceInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+func (iface *customDeviceInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	var subsystem string
+	if err := plug.Attr("subsystem", &subsystem); err != nil {
+		return err
+	}
+	return spec.AddCustomDevice(workshop.CustomDevice{Name: plug.Name(), Subsystem: subsystem})
+}
+
+func init() {
+	registerIface(&customDeviceInterface{})
+}

--- a/internal/interfaces/builtin/custom_device_test.go
+++ b/internal/interfaces/builtin/custom_device_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package builtin_test
+
+import (
+	"context"
+	"os/user"
+
+	"github.com/canonical/lxd/shared/api"
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+type customDeviceSuite struct {
+	iface             interfaces.Interface
+	projectId         string
+	restoreUserLookup func()
+	restoreUserEnv    func()
+	restoreLxdInfo    func()
+}
+
+var _ = check.Suite(&customDeviceSuite{
+	iface: builtin.MustInterface("custom-device"),
+})
+
+func (s *customDeviceSuite) SetUpSuite(c *check.C) {
+	s.projectId = "42424242"
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &testuser, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{}, nil
+	})
+}
+
+func (s *customDeviceSuite) TearDownSuite(c *check.C) {
+	s.restoreLxdInfo()
+	s.restoreUserEnv()
+	s.restoreUserLookup()
+}
+
+func (s *customDeviceSuite) TestName(c *check.C) {
+	c.Assert(s.iface.Name(), check.Equals, "custom-device")
+}
+
+func (s *customDeviceSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *customDeviceSuite) TestCustomDeviceInterface(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: accel
+`, s.projectId, "ws", "consumer", "mydevice")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+  custom-device:
+`, s.projectId, "ws", "producer", "custom-device")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the device specification.
+	expectedDevices := []workshop.CustomDevice{{Name: "mydevice", Subsystem: "accel"}}
+	c.Assert(deviceSpec.Profile.CustomDevices, check.DeepEquals, expectedDevices)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugUnknownAttribute(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+  mydevice:
+    interface: custom-device
+    workshop-target: /mnt
+`, s.projectId, "ws", "consumer", "mydevice")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `unknown attribute for custom-device interface plug: "workshop-target"`)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugMissingSubsystem(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+  mydevice:
+    interface: custom-device
+`, s.projectId, "ws", "consumer", "mydevice")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `attribute "subsystem" not found for plug "ws/consumer:mydevice"`)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugEmptySubsystem(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: ""
+`, s.projectId, "ws", "consumer", "mydevice")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `custom-device plug "subsystem" is empty`)
+}

--- a/internal/interfaces/builtin/mount.go
+++ b/internal/interfaces/builtin/mount.go
@@ -89,7 +89,7 @@ func (iface *mountInterface) StaticInfo() interfaces.StaticInfo {
 func (iface *mountInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 	for name := range plug.Attrs {
 		if !slices.Contains(knownPlugAttributes, name) {
-			return fmt.Errorf(`unknown attribute for mount interface plug: %q`, name)
+			return fmt.Errorf("unknown attribute for mount interface plug: %q", name)
 		}
 	}
 
@@ -189,14 +189,14 @@ func parseInt(attrs map[string]any, key string, fallback int64) (int64, error) {
 func (iface *mountInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 	if slot.Sdk.Type == sdk.System {
 		for name := range slot.Attrs {
-			return fmt.Errorf(`unknown attribute for system mount interface slot: %q`, name)
+			return fmt.Errorf("unknown attribute for system mount interface slot: %q", name)
 		}
 		return nil
 	}
 
 	for name := range slot.Attrs {
 		if !slices.Contains(knownSlotAttributes, name) {
-			return fmt.Errorf(`unknown attribute for mount interface slot: %q`, name)
+			return fmt.Errorf("unknown attribute for mount interface slot: %q", name)
 		}
 	}
 

--- a/internal/interfaces/builtin/tunnel.go
+++ b/internal/interfaces/builtin/tunnel.go
@@ -88,7 +88,7 @@ func (iface *tunnelInterface) StaticInfo() interfaces.StaticInfo {
 func (iface *tunnelInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 	for name := range plug.Attrs {
 		if !slices.Contains(knownTunnelAttributes, name) {
-			return fmt.Errorf(`unknown attribute for tunnel interface plug: %q`, name)
+			return fmt.Errorf("unknown attribute for tunnel interface plug: %q", name)
 		}
 	}
 
@@ -107,7 +107,7 @@ func (iface *tunnelInterface) BeforePreparePlug(plug *sdk.PlugInfo) error {
 func (iface *tunnelInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 	for name := range slot.Attrs {
 		if !slices.Contains(knownTunnelAttributes, name) {
-			return fmt.Errorf(`unknown attribute for tunnel interface slot: %q`, name)
+			return fmt.Errorf("unknown attribute for tunnel interface slot: %q", name)
 		}
 	}
 
@@ -121,7 +121,6 @@ func (iface *tunnelInterface) BeforePrepareSlot(slot *sdk.SlotInfo) error {
 	slot.Attrs["endpoint"] = address
 
 	return nil
-
 }
 
 func normalizeEndpoint(attrs interfaces.Attrer) (string, error) {

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -38,7 +38,7 @@ func BeforePreparePlug(iface Interface, plugInfo *sdk.PlugInfo) error {
 
 	// Plugs which accept attributes should define BeforePreparePlug.
 	for name := range plugInfo.Attrs {
-		return fmt.Errorf(`unknown attribute for %s interface plug: %q`, iface.Name(), name)
+		return fmt.Errorf("unknown attribute for %s interface plug: %q", iface.Name(), name)
 	}
 	return nil
 }
@@ -73,7 +73,7 @@ func BeforePrepareSlot(iface Interface, slotInfo *sdk.SlotInfo) error {
 	}
 	// Slots which accept attributes should define BeforePrepareSlot.
 	for name := range slotInfo.Attrs {
-		return fmt.Errorf(`unknown attribute for %s interface slot: %q`, iface.Name(), name)
+		return fmt.Errorf("unknown attribute for %s interface slot: %q", iface.Name(), name)
 	}
 	return nil
 }

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -191,7 +191,7 @@ func prepareMount(fs fsutil.Fs, user *user.User, mnt workshop.Mount) error {
 	case workshop.WorkshopWorkshop:
 		return prepareWorkshopWorkshopMount(fs, mnt)
 	default:
-		return fmt.Errorf(`unknown device type: %v`, mnt.Type)
+		return fmt.Errorf("unknown device type: %v", mnt.Type)
 	}
 }
 

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -282,6 +282,21 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 	return nil
 }
 
+func (s *Specification) AddCustomDevice(device workshop.CustomDevice) error {
+	s.Profile.CustomDevices = append(s.Profile.CustomDevices, device)
+
+	name := lxdbackend.DeviceName(s.Profile.Sdk, device.Name)
+	s.devices[name] = map[string]string{
+		"type":              "unix-hotplug",
+		"subsystem":         device.Subsystem,
+		"required":          "false",
+		"ownership.inherit": "true",
+	}
+	s.config[lxdbackend.DeviceTypeConfigKey(name)] = "custom-device"
+
+	return nil
+}
+
 func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey string) {
 	name := lxdbackend.DeviceName(s.Profile.Sdk, entry.Name)
 	s.config[lxdbackend.DeviceTypeConfigKey(name)] = configKey

--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -494,7 +494,7 @@ func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, sl
 	}
 	// Ensure that plug and slot are compatible
 	if slot.Interface != plug.Interface {
-		return nil, fmt.Errorf(`cannot connect: %s plug %q incompatible with %s slot %q`,
+		return nil, fmt.Errorf("cannot connect: %s plug %q incompatible with %s slot %q",
 			plug.Interface, ref.PlugRef.ShortRef(), slot.Interface, ref.SlotRef.ShortRef())
 	}
 
@@ -1088,7 +1088,7 @@ func (r *Repository) ResolveConnect(plugProjectId, plugWorkshop, plugSdkName, pl
 		switch len(candidates) {
 		case 0:
 			sdkRef := sdk.Ref{ProjectId: slotProjectId, Workshop: slotWorkshop, Sdk: slotSdkName}
-			return nil, fmt.Errorf(`%q SDK has no %s interface slots`, sdkRef.ShortRef(), plug.Interface)
+			return nil, fmt.Errorf("%q SDK has no %s interface slots", sdkRef.ShortRef(), plug.Interface)
 		case 1:
 			slotName = candidates[0]
 		default:

--- a/internal/sdk/system/meta/sdk.yaml
+++ b/internal/sdk/system/meta/sdk.yaml
@@ -10,5 +10,7 @@ slots:
     interface: ssh-agent
   camera:
     interface: camera
+  custom-device:
+    interface: custom-device
   desktop:
     interface: desktop

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -32,13 +32,13 @@ var (
 	//go:embed meta/*
 	SystemSdkFs embed.FS
 
-	SystemSdkRevision = sdk.R(1)
+	SystemSdkRevision = sdk.R(2)
 
 	RetrieveSystemSdk = retrieveSystemSdk
 )
 
 // Update the system SDK revision number when this hash changes.
-const SystemSdkDigest = "5891a3a98ed62339c5c24ded56de52a18873bd73ba8e1e03725376e7fc89c7560944b5fb7260c288b17e115e538d7da6"
+const SystemSdkDigest = "9fe8becc4142397ed62404170155290b559afc08fef418211e8032c17b29a35dbad4946b7fee7fe8bd67ac8ee40ae5c4"
 
 func SystemSdkMeta() (*sdk.Meta, error) {
 	setup := sdk.Setup{

--- a/internal/sdk/system/system_test.go
+++ b/internal/sdk/system/system_test.go
@@ -85,7 +85,7 @@ func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 
 	digest := hex.EncodeToString(hash.Sum(nil))
 	c.Check(digest, check.Equals, system.SystemSdkDigest, check.Commentf("system SDK revision needs updating"))
-	c.Check(system.SystemSdkRevision, check.Equals, sdk.R(1))
+	c.Check(system.SystemSdkRevision, check.Equals, sdk.R(2))
 }
 
 func (s *systemSdk) TestRetrieveSystemSdkWrongRevision(c *check.C) {

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -63,6 +63,11 @@ type Camera struct {
 	Name string `json:"name"`
 }
 
+type CustomDevice struct {
+	Name      string `json:"name"`
+	Subsystem string `json:"subsystem"`
+}
+
 type Mount struct {
 	Name      string      `json:"name"`
 	Type      MountType   `json:"type"`
@@ -112,12 +117,13 @@ type Gpu struct {
 type SdkProfile struct {
 	Sdk string
 
-	Camera  *Camera
-	Mounts  map[string]Mount
-	Tunnels []Tunnel
-	Agent   *SshAgent
-	Gpu     *Gpu
-	Desktop *Desktop
+	Camera        *Camera
+	CustomDevices []CustomDevice
+	Mounts        map[string]Mount
+	Tunnels       []Tunnel
+	Agent         *SshAgent
+	Gpu           *Gpu
+	Desktop       *Desktop
 }
 
 func NewSdkProfile(sdkName string) SdkProfile {

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -157,11 +157,17 @@ func LxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			}
 		case "unix-hotplug":
 			devtype := config[DeviceTypeConfigKey(devname)]
-			if devtype == "camera" {
-				continue
+			switch devtype {
+			case "camera":
+				// Ignore the real camera devices, config is under type=none.
+			case "custom-device":
+				pr.CustomDevices = append(pr.CustomDevices, workshop.CustomDevice{
+					Name:      name,
+					Subsystem: dev["subsystem"],
+				})
+			default:
+				logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
 			}
-
-			logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
 		case "none":
 			cfg, exist := config[DeviceConfigKey(devname)]
 			if !exist {

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -100,6 +100,11 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 					What:  "/var",
 					Where: "/etc",
 					Type:  workshop.WorkshopWorkshop}}},
+		{
+			Sdk:           "sdk",
+			Mounts:        map[string]workshop.Mount{},
+			CustomDevices: []workshop.CustomDevice{{Name: "mydevice", Subsystem: "accel"}},
+		},
 	}
 
 	for i, t := range []struct {
@@ -197,6 +202,16 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
           "where": "/etc", 
           "type": 1}`,
 				"user.workshop.sdk_plug.type": "mount"},
+		}, {
+			"sdk",
+			map[string]map[string]string{
+				"sdk_mydevice": {
+					"type":              "unix-hotplug",
+					"subsystem":         "accel",
+					"required":          "false",
+					"ownership.inherit": "true"}},
+			map[string]string{
+				"user.workshop.sdk_mydevice.type": "custom-device"},
 		},
 	} {
 		res, err := lxdbackend.LxdToSdkProfile(t.name, t.devs, t.cfg)
@@ -204,6 +219,7 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		c.Assert(res.Agent, check.DeepEquals, expected[i].Agent)
 		c.Assert(res.Desktop, check.DeepEquals, expected[i].Desktop)
 		c.Assert(res.Camera, check.DeepEquals, expected[i].Camera)
+		c.Assert(res.CustomDevices, testutil.DeepUnsortedMatches, expected[i].CustomDevices)
 		c.Assert(res.Gpu, check.DeepEquals, expected[i].Gpu)
 		c.Assert(res.Mounts, testutil.DeepUnsortedMatches, expected[i].Mounts)
 		c.Assert(res.Tunnels, testutil.DeepUnsortedMatches, expected[i].Tunnels)

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -54,6 +54,8 @@ EOF
         jq
         "linux-modules-extra-$(uname -r)"
         moreutils
+        python3-sdnotify
+        python3-uinput
         zfsutils-linux
         zsh
     )

--- a/tests/main/interface-custom-device/.workshop/custom-dev/sdk.yaml
+++ b/tests/main/interface-custom-device/.workshop/custom-dev/sdk.yaml
@@ -1,0 +1,6 @@
+name: custom-dev
+
+plugs:
+  my-custom-device:
+    interface: custom-device
+    subsystem: input

--- a/tests/main/interface-custom-device/.workshop/ws-custom-device-fail.yaml
+++ b/tests/main/interface-custom-device/.workshop/ws-custom-device-fail.yaml
@@ -1,0 +1,7 @@
+name: ws-custom-device-fail
+base: ubuntu@22.04
+sdks:
+  - name: system
+    slots:
+      user-custom-device:
+        interface: custom-device

--- a/tests/main/interface-custom-device/.workshop/ws-custom-device.yaml
+++ b/tests/main/interface-custom-device/.workshop/ws-custom-device.yaml
@@ -1,0 +1,4 @@
+name: ws-custom-device
+base: ubuntu@22.04
+sdks:
+  - name: project-custom-dev

--- a/tests/main/interface-custom-device/fakeinput.py
+++ b/tests/main/interface-custom-device/fakeinput.py
@@ -1,0 +1,7 @@
+import sdnotify
+import signal
+import uinput
+
+with uinput.Device([uinput.KEY_SPACE], name="workshop-test-input"):
+    sdnotify.SystemdNotifier().notify("READY=1")
+    signal.pause()

--- a/tests/main/interface-custom-device/task.yaml
+++ b/tests/main/interface-custom-device/task.yaml
@@ -1,0 +1,53 @@
+summary: Check custom-device interface scenarios
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-custom-device
+restore: |
+  . "$TESTSLIB"/utils.sh
+  systemctl stop workshop-test-input.service 2>/dev/null || true
+  workshop_exec remove ws-custom-device
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check the custom-device interface plug cannot be auto-connected"
+  workshop_exec connections ws-custom-device | MATCH "^custom-device.+ws-custom-device/custom-dev:my-custom-device.+\-.+\-$"
+
+  echo "Check the custom-device interface plug can be connected and disconnected manually"
+  workshop_exec connect ws-custom-device/custom-dev:my-custom-device :custom-device
+  workshop_exec connections ws-custom-device | MATCH "^custom-device.+ws-custom-device/custom-dev:my-custom-device.+:custom-device.+manual$"
+  workshop_exec disconnect ws-custom-device/custom-dev:my-custom-device
+  workshop_exec connections ws-custom-device | MATCH "^custom-device.+ws-custom-device/custom-dev:my-custom-device.+\-.+\-$"
+
+  attach_device() {
+    systemd-run --collect --property=KillSignal=SIGINT --same-dir --service-type=notify --unit=workshop-test-input python3 fakeinput.py
+  }
+  detach_device() {
+    systemctl stop workshop-test-input.service
+  }
+  detect_device() {
+    device_name=$(grep -l '^workshop-test-input$' /sys/class/input/*/device/name)
+    device_basename=$(basename -- "$(dirname -- "$(dirname -- "$device_name")")")
+    device_node="/dev/input/$device_basename"
+  }
+
+  echo "Ensure input devices are passed through when connected"
+  attach_device
+  detect_device
+  workshop_exec exec ws-custom-device test ! -e "$device_node"
+  workshop_exec connect ws-custom-device/custom-dev:my-custom-device :custom-device
+  workshop_exec exec ws-custom-device test -e "$device_node"
+
+  echo "Ensure input devices can be hotplugged"
+  detach_device
+  workshop_exec exec ws-custom-device test ! -e "$device_node"
+
+  attach_device
+  detect_device
+  workshop_exec exec ws-custom-device test -e "$device_node"
+
+  workshop_exec disconnect ws-custom-device/custom-dev:my-custom-device
+  workshop_exec exec ws-custom-device test ! -e "$device_node"
+
+  echo "Check a user cannot install a custom-device slot (violates slot declaration)"
+  workshop_exec launch ws-custom-device-fail > launch.log || true
+  MATCH ".*installation not allowed by \"user-custom-device\" slot rule of interface \"custom-device\"" < launch.log


### PR DESCRIPTION
# Description

Adds the `custom-device` interface, which is like the `camera` interface but allows SDK authors and Workshop users to specify a class of devices to expose inside the workshop. Currently the class is decided by the `subsystem` property, but this may expand in future.

All `custom-device` plugs connect to the unique `custom-device` slot in the system SDK. Only manual connections are allowed, for security reasons. Shell completion works well but you typically do have to spell out the slot in `workshop connect`.

The spread tests use Python's `uinput` library to create a fake input device and add it to a workshop. Have to credit copilot for its creativity here.

Now that we have a global refresh cache, adding the `custom-device` slot requires a `system` revision bump. I tested refreshing `workshop` to `edge/818` and was able to `--continue` an existing launch and `restore` a workshop still using `system-1`. This won't be possible once the `system-1` volume is cleaned up, but at that point there should be no changes in progress and no workshops that can be restored to revision `1`.

I think if `launch --wait-on-error` fails very early on, before `retrieve-sdk`, and the user doesn't have a `system-1` volume yet, then `launch --continue` might fail after refreshing the snap. But I don't think it's a significant issue.

Also removes a few places which use backticks for no good reason, since copilot was being a bit overzealous about it.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [x] Headings and titles accurately describe the content.
* [x] New and updated pages include correct metadata.
* [x] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [x] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [x] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
