### PR TITLE
Fix exec summaries to show the requested command

### DIFF
--- a/client/exec.go
+++ b/client/exec.go
@@ -35,6 +35,9 @@ type ExecOptions struct {
 	Workshop string
 	// Required: command and arguments (first element is the executable).
 	Command []string
+	// Optional command prefix prepended by Workshop before execution. If empty,
+	// the command is executed without a prefix.
+	CommandPrefix []string
 	// True to treat command as a workshop action with arguments.
 	Action bool
 
@@ -80,14 +83,20 @@ type ExecOptions struct {
 }
 
 type execPayload struct {
-	Command     []string          `json:"command"`
-	Action      bool              `json:"action,omitempty"`
-	Environment map[string]string `json:"environment,omitempty"`
-	WorkingDir  string            `json:"working-dir,omitempty"`
-	UserId      *int              `json:"user-id,omitempty"`
-	GroupId     *int              `json:"group-id,omitempty"`
-	Terminal    bool              `json:"terminal,omitempty"`
-	Timeout     string            `json:"timeout,omitempty"`
+	// Command is the user-requested command. It is used for user-facing
+	// summaries and diagnostics.
+	Command []string `json:"command"`
+
+	// CommandPrefix is a Workshop-managed wrapper prepended to [Command] at the
+	// execution boundary. Older clients may omit this field.
+	CommandPrefix []string          `json:"command-prefix,omitempty"`
+	Action        bool              `json:"action,omitempty"`
+	Environment   map[string]string `json:"environment,omitempty"`
+	WorkingDir    string            `json:"working-dir,omitempty"`
+	UserId        *int              `json:"user-id,omitempty"`
+	GroupId       *int              `json:"group-id,omitempty"`
+	Terminal      bool              `json:"terminal,omitempty"`
+	Timeout       string            `json:"timeout,omitempty"`
 
 	Interactive bool `json:"interactive,omitempty"`
 	SplitStderr bool `json:"split-stderr,omitempty"`
@@ -132,18 +141,19 @@ func (client *Client) Exec(opts *ExecOptions, workshop, projectId string) (*Exec
 	}
 
 	payload := execPayload{
-		Command:     opts.Command,
-		Action:      opts.Action,
-		Environment: opts.Environment,
-		WorkingDir:  opts.WorkingDir,
-		UserId:      opts.UserId,
-		GroupId:     opts.GroupId,
-		Timeout:     timeoutStr,
-		Terminal:    opts.Terminal,
-		Interactive: opts.Interactive,
-		SplitStderr: false,
-		Width:       opts.Width,
-		Height:      opts.Height,
+		Command:       opts.Command,
+		CommandPrefix: opts.CommandPrefix,
+		Action:        opts.Action,
+		Environment:   opts.Environment,
+		WorkingDir:    opts.WorkingDir,
+		UserId:        opts.UserId,
+		GroupId:       opts.GroupId,
+		Timeout:       timeoutStr,
+		Terminal:      opts.Terminal,
+		Interactive:   opts.Interactive,
+		SplitStderr:   false,
+		Width:         opts.Width,
+		Height:        opts.Height,
 	}
 	var body bytes.Buffer
 	err := json.NewEncoder(&body).Encode(&payload)

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -102,6 +102,21 @@ func (s *execSuite) TestExitZero(c *C) {
 	c.Assert(err, IsNil)
 }
 
+// TestEmptyCommandPrefix verifies an explicitly empty command prefix is
+// treated as omitted and does not appear in the exec payload.
+func (s *execSuite) TestEmptyCommandPrefix(c *C) {
+	opts := &client.ExecOptions{
+		Command:       []string{"true"},
+		CommandPrefix: []string{},
+	}
+	process, reqBody := s.exec(c, opts, 0)
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"true"},
+	})
+	err := s.wait(c, process)
+	c.Assert(err, IsNil)
+}
+
 func (s *execSuite) TestExitNonZero(c *C) {
 	opts := &client.ExecOptions{
 		Command: []string{"false"},
@@ -135,26 +150,28 @@ func (s *execSuite) TestOtherOptions(c *C) {
 	userID := 1000
 	groupID := 2000
 	opts := &client.ExecOptions{
-		Command:     []string{"echo", "foo"},
-		Environment: map[string]string{"K1": "V1", "K2": "V2"},
-		WorkingDir:  "WD",
-		UserId:      &userID,
-		GroupId:     &groupID,
-		Terminal:    true,
-		Width:       12,
-		Height:      34,
-		Stderr:      io.Discard,
+		Command:       []string{"echo", "foo"},
+		CommandPrefix: []string{"sudo", "--"},
+		Environment:   map[string]string{"K1": "V1", "K2": "V2"},
+		WorkingDir:    "WD",
+		UserId:        &userID,
+		GroupId:       &groupID,
+		Terminal:      true,
+		Width:         12,
+		Height:        34,
+		Stderr:        io.Discard,
 	}
 	process, reqBody := s.exec(c, opts, 0)
 	c.Assert(reqBody, DeepEquals, map[string]any{
-		"command":     []any{"echo", "foo"},
-		"environment": map[string]any{"K1": "V1", "K2": "V2"},
-		"working-dir": "WD",
-		"user-id":     1000.0,
-		"group-id":    2000.0,
-		"terminal":    true,
-		"width":       12.0,
-		"height":      34.0,
+		"command":        []any{"echo", "foo"},
+		"command-prefix": []any{"sudo", "--"},
+		"environment":    map[string]any{"K1": "V1", "K2": "V2"},
+		"working-dir":    "WD",
+		"user-id":        1000.0,
+		"group-id":       2000.0,
+		"terminal":       true,
+		"width":          12.0,
+		"height":         34.0,
 	})
 	err := s.wait(c, process)
 	c.Assert(err, IsNil)

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -482,6 +482,10 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 	if args.action {
 		logger.Debugf("Running action %q", av)
 	} else {
+		// Obtain an exec session as close to a real login shell as possible.
+		// This is required as an lxd exec call is a simple namespace exec, and LXD
+		// ignores the instance configuration by design:
+		// https://documentation.ubuntu.com/lxd/en/latest/instance-exec/#user-groups-and-working-directory
 		commandPrefix = []string{
 			"sudo",
 			"-u",
@@ -503,7 +507,7 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 			"-c",
 			`exec -- "$0" "$@"`,
 		)
-		logger.Debugf("Running command %q with prefix %q", av, commandPrefix)
+		logger.Debugf("Running command %q", av)
 	}
 
 	// Record terminal state (and restore it before we exit).

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -478,32 +478,32 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		env[key] = value
 	}
 
+	var commandPrefix []string
 	if args.action {
 		logger.Debugf("Running action %q", av)
 	} else {
-		// Obtain an exec session as close to a real login shell as possible.
-		// This is required as an lxd exec call is a simple namespace exec, and LXD
-		// ignores the instance configuration by design:
-		// https://documentation.ubuntu.com/lxd/en/latest/instance-exec/#user-groups-and-working-directory
-		keys := slices.Sorted(maps.Keys(env))
-		command := []string{"sudo",
+		commandPrefix = []string{
+			"sudo",
 			"-u",
 			"#" + strconv.Itoa(flags.UserId),
 			"-g",
 			"#" + strconv.Itoa(flags.GroupId),
 		}
+
+		keys := slices.Sorted(maps.Keys(env))
 		for _, k := range keys {
-			command = append(command, "--preserve-env="+k)
+			commandPrefix = append(commandPrefix, "--preserve-env="+k)
 		}
-		command = append(command,
+
+		commandPrefix = append(
+			commandPrefix,
 			"--",
 			"bash",
 			"-l",
 			"-c",
 			`exec -- "$0" "$@"`,
 		)
-		av = append(command, av...)
-		logger.Debugf("Running %q", av)
+		logger.Debugf("Running command %q with prefix %q", av, commandPrefix)
 	}
 
 	// Record terminal state (and restore it before we exit).
@@ -532,19 +532,20 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 	// ls produces access errors, those will not be filtered out to null as LXD
 	// combines stderr and stdout in the interactive mode.
 	opts := &client.ExecOptions{
-		Command:     av,
-		Environment: env,
-		Action:      args.action,
-		WorkingDir:  flags.WorkingDir,
-		UserId:      &flags.UserId,
-		GroupId:     &flags.GroupId,
-		Interactive: interactive,
-		Timeout:     flags.Timeout,
-		Width:       width,
-		Height:      height,
-		Stdin:       Stdin,
-		Stdout:      Stdout,
-		Stderr:      Stderr,
+		Command:       av,
+		CommandPrefix: commandPrefix,
+		Environment:   env,
+		Action:        args.action,
+		WorkingDir:    flags.WorkingDir,
+		UserId:        &flags.UserId,
+		GroupId:       &flags.GroupId,
+		Interactive:   interactive,
+		Timeout:       flags.Timeout,
+		Width:         width,
+		Height:        height,
+		Stdin:         Stdin,
+		Stdout:        Stdout,
+		Stderr:        Stderr,
 	}
 
 	// Start the command.

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -134,34 +134,38 @@ func (m *workshopExec) TestWorkshopExecSendsUserCommand(c *check.C) {
 			c.Check(r.Method, check.Equals, "POST")
 			body := DecodedRequestBody(c, r)
 			userId := fmt.Sprint(workshop.Uid)
+			groupId := fmt.Sprint(workshop.Gid)
 			c.Check(body["command"], check.DeepEquals, []any{"echo", "foo"})
-			commandPrefix, ok := body["command-prefix"].([]any)
-			c.Assert(ok, check.Equals, true)
-			c.Check(
-				commandPrefix[:5],
-				check.DeepEquals,
-				[]any{"sudo", "-u", "#" + userId, "-g", "#" + fmt.Sprint(workshop.Gid)},
-			)
-			c.Check(
-				commandPrefix[len(commandPrefix)-5:],
-				check.DeepEquals,
-				[]any{"--", "bash", "-l", "-c", `exec -- "$0" "$@"`},
-			)
-			c.Check(body["user-id"], check.Equals, json.Number(userId))
-			c.Check(body["group-id"], check.Equals, json.Number(fmt.Sprint(workshop.Gid)))
+			c.Check(body["user-id"], check.DeepEquals, json.Number(userId))
+			c.Check(body["group-id"], check.DeepEquals, json.Number(groupId))
 
-			environment, ok := body["environment"].(map[string]any)
-			c.Assert(ok, check.Equals, true)
-			c.Check(
-				environment["XDG_RUNTIME_DIR"],
-				check.Equals,
-				"/run/user/"+userId,
+			expectedEnvironment := map[string]any{
+				"DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/" + userId + "/bus",
+				"XDG_RUNTIME_DIR":          "/run/user/" + userId,
+			}
+			if term, ok := os.LookupEnv("TERM"); ok {
+				expectedEnvironment["TERM"] = term
+			}
+			c.Check(body["environment"], check.DeepEquals, expectedEnvironment)
+
+			expectedPrefix := []any{"sudo", "-u", "#" + userId, "-g", "#" + groupId}
+			expectedPrefix = append(
+				expectedPrefix,
+				"--preserve-env=DBUS_SESSION_BUS_ADDRESS",
 			)
-			c.Check(
-				environment["DBUS_SESSION_BUS_ADDRESS"],
-				check.Equals,
-				"unix:path=/run/user/"+userId+"/bus",
+			if _, ok := os.LookupEnv("TERM"); ok {
+				expectedPrefix = append(expectedPrefix, "--preserve-env=TERM")
+			}
+			expectedPrefix = append(
+				expectedPrefix,
+				"--preserve-env=XDG_RUNTIME_DIR",
+				"--",
+				"bash",
+				"-l",
+				"-c",
+				`exec -- "$0" "$@"`,
 			)
+			c.Check(body["command-prefix"], check.DeepEquals, expectedPrefix)
 
 			w.WriteHeader(404)
 			fmt.Fprintln(w, mockWorkshopExecError)

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -15,12 +15,15 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 type workshopExec struct {
@@ -108,6 +111,73 @@ foo:
 	c.Check(err, check.ErrorMatches, "workshop not found")
 
 	c.Check(n, check.Equals, 7)
+}
+
+// TestWorkshopExecSendsUserCommand verifies the CLI sends the requested
+// command to the API and relies on the daemon for user/group execution.
+func (m *workshopExec) TestWorkshopExecSendsUserCommand(c *check.C) {
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/projects":
+			c.Check(r.Method, check.Equals, "POST")
+			res := fmt.Sprintf(
+				`{"type": "sync", "result": {"id":"%s","path":"%s"}}`,
+				m.prjId,
+				m.prjDir,
+			)
+			fmt.Fprintln(w, res)
+		case fmt.Sprintf("/v1/projects/%s/workshops", m.prjId):
+			c.Check(r.Method, check.Equals, "GET")
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
+		case fmt.Sprintf("/v1/projects/%s/workshops/ws/exec", m.prjId):
+			c.Check(r.Method, check.Equals, "POST")
+			body := DecodedRequestBody(c, r)
+			userId := fmt.Sprint(workshop.Uid)
+			c.Check(body["command"], check.DeepEquals, []any{"echo", "foo"})
+			commandPrefix, ok := body["command-prefix"].([]any)
+			c.Assert(ok, check.Equals, true)
+			c.Check(
+				commandPrefix[:5],
+				check.DeepEquals,
+				[]any{"sudo", "-u", "#" + userId, "-g", "#" + fmt.Sprint(workshop.Gid)},
+			)
+			c.Check(
+				commandPrefix[len(commandPrefix)-5:],
+				check.DeepEquals,
+				[]any{"--", "bash", "-l", "-c", `exec -- "$0" "$@"`},
+			)
+			c.Check(body["user-id"], check.Equals, json.Number(userId))
+			c.Check(body["group-id"], check.Equals, json.Number(fmt.Sprint(workshop.Gid)))
+
+			environment, ok := body["environment"].(map[string]any)
+			c.Assert(ok, check.Equals, true)
+			c.Check(
+				environment["XDG_RUNTIME_DIR"],
+				check.Equals,
+				"/run/user/"+userId,
+			)
+			c.Check(
+				environment["DBUS_SESSION_BUS_ADDRESS"],
+				check.Equals,
+				"unix:path=/run/user/"+userId+"/bus",
+			)
+
+			w.WriteHeader(404)
+			fmt.Fprintln(w, mockWorkshopExecError)
+		default:
+			c.Errorf("unexpected API call: %s", r.URL.Path)
+		}
+	})
+
+	cmd := &CmdExec{root: &CmdRoot{cwd: m.prjDir}}
+	exec := cmd.Command()
+	exec.SilenceUsage = true
+	exec.SilenceErrors = true
+	exec.SetArgs([]string{"-I", "ws", "--", "echo", "foo"})
+
+	err := exec.Execute()
+	c.Check(err, check.ErrorMatches, `(?s).*Install action "foo".*`)
 }
 
 func (m *workshopExec) TestSingleWorkshopRunErrors(c *check.C) {

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -27,18 +27,24 @@ import (
 )
 
 type execPayload struct {
-	Command     []string          `json:"command"`
-	Action      bool              `json:"action"`
-	Environment map[string]string `json:"environment"`
-	WorkingDir  string            `json:"working-dir"`
-	Timeout     string            `json:"timeout"`
-	UserId      *int              `json:"user-id"`
-	GroupId     *int              `json:"group-id"`
-	Terminal    bool              `json:"terminal"`
-	Interactive bool              `json:"interactive"`
-	SplitStderr bool              `json:"split-stderr"`
-	Width       int               `json:"width"`
-	Height      int               `json:"height"`
+	// Command is the user-requested command. It is used for user-facing
+	// summaries and diagnostics.
+	Command []string `json:"command"`
+
+	// CommandPrefix is a Workshop-managed wrapper prepended to [Command] at the
+	// execution boundary. Older clients may omit this field.
+	CommandPrefix []string          `json:"command-prefix"`
+	Action        bool              `json:"action"`
+	Environment   map[string]string `json:"environment"`
+	WorkingDir    string            `json:"working-dir"`
+	Timeout       string            `json:"timeout"`
+	UserId        *int              `json:"user-id"`
+	GroupId       *int              `json:"group-id"`
+	Terminal      bool              `json:"terminal"`
+	Interactive   bool              `json:"interactive"`
+	SplitStderr   bool              `json:"split-stderr"`
+	Width         int               `json:"width"`
+	Height        int               `json:"height"`
 }
 
 func normaliseUserGroupIds(usrId, grpId *int) (int, int, error) {
@@ -138,17 +144,18 @@ func v1PostWorkshopExec(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	var execArgs = &workshop.ExecArgs{
-		Command:     reqData.Command,
-		Environment: environment,
-		WorkDir:     reqData.WorkingDir,
-		UserId:      userId,
-		GroupId:     groupId,
-		Timeout:     timeout,
-		Terminal:    reqData.Terminal,
-		Interactive: reqData.Interactive,
-		SplitStderr: reqData.SplitStderr,
-		Width:       reqData.Width,
-		Height:      reqData.Height,
+		Command:       reqData.Command,
+		CommandPrefix: reqData.CommandPrefix,
+		Environment:   environment,
+		WorkDir:       reqData.WorkingDir,
+		UserId:        userId,
+		GroupId:       groupId,
+		Timeout:       timeout,
+		Terminal:      reqData.Terminal,
+		Interactive:   reqData.Interactive,
+		SplitStderr:   reqData.SplitStderr,
+		Width:         reqData.Width,
+		Height:        reqData.Height,
 	}
 
 	st := c.d.overlord.State()

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -163,6 +163,41 @@ func (s *apiSuite) TestExecSuccess(c *check.C) {
 	c.Assert(soon, check.Equals, 1)
 }
 
+// TestExecSuccessWithCommandPrefix verifies command prefixes are accepted but
+// are not used in user-facing change or task summaries.
+func (s *apiSuite) TestExecSuccessWithCommandPrefix(c *check.C) {
+	// Setup
+	projectsCmd := s.setupExec(c)
+
+	body := bytes.NewBufferString(`{"command":["ls"],"command-prefix":["sudo","--"],"working-dir":"/"}`)
+
+	req, err := s.createProjectsRequest("POST", "/v1/projects/"+s.project.ProjectId+"/workshops/ws/exec", body)
+	c.Assert(err, check.IsNil)
+
+	soon := 0
+	restoreEnsure := testutil.FakeFunc(func(st *state.State, d time.Duration) {
+		soon++
+	}, &ensureStateSoon)
+	defer restoreEnsure()
+
+	// Execute
+	rsp := v1PostWorkshopExec(projectsCmd, req, nil).(*resp)
+
+	// Verify
+	c.Assert(rsp.Status, check.Equals, http.StatusAccepted)
+	c.Assert(soon, check.Equals, 1)
+
+	st := s.d.Overlord().State()
+	st.Lock()
+	defer st.Unlock()
+	change := st.Change("1")
+	c.Assert(change, check.NotNil)
+	c.Check(change.Summary(), check.Equals, `Execute command "ls"`)
+	tasks := change.Tasks()
+	c.Assert(tasks, check.HasLen, 1)
+	c.Check(tasks[0].Summary(), check.Equals, `Exec command "ls"`)
+}
+
 func (s *apiSuite) TestExecActionSuccess(c *check.C) {
 	// Setup
 	projectsCmd := s.setupExec(c)

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -180,17 +180,35 @@ type SdkManager interface {
 }
 
 type ExecArgs struct {
-	Command     []string
-	UserId      int
-	GroupId     int
-	WorkDir     string
-	Timeout     time.Duration
-	Environment map[string]string
-	Interactive bool
-	Terminal    bool
-	SplitStderr bool
-	Width       int
-	Height      int
+	// Command is the user-requested command. It is used for user-facing
+	// summaries and diagnostics.
+	Command []string
+
+	// CommandPrefix is a Workshop-managed wrapper prepended to [Command] at the
+	// execution boundary. It is not part of the user-requested command.
+	CommandPrefix []string
+	UserId        int
+	GroupId       int
+	WorkDir       string
+	Timeout       time.Duration
+	Environment   map[string]string
+	Interactive   bool
+	Terminal      bool
+	SplitStderr   bool
+	Width         int
+	Height        int
+}
+
+// EffectiveCommand returns the command that should be sent to the execution
+// backend, including any Workshop-managed command prefix.
+func (args ExecArgs) EffectiveCommand() []string {
+	command := make(
+		[]string,
+		0,
+		len(args.CommandPrefix)+len(args.Command),
+	)
+	command = append(command, args.CommandPrefix...)
+	return append(command, args.Command...)
 }
 
 type ExecControls struct {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -649,7 +649,7 @@ func (s *Backend) execCommand(conn lxd.InstanceServer, ctx context.Context, name
 	}
 
 	req := api.InstanceExecPost{
-		Command:     args.Command,
+		Command:     args.EffectiveCommand(),
 		WaitForWS:   true,
 		Interactive: args.Interactive,
 		Environment: args.Environment,

--- a/internal/workshop/workshop_test.go
+++ b/internal/workshop/workshop_test.go
@@ -53,6 +53,36 @@ func writeFile(c *check.C, path string, content string) {
 	c.Assert(os.WriteFile(path, []byte(content), 0644), check.IsNil)
 }
 
+// TestExecArgsEffectiveCommand prepends Workshop-managed command prefixes
+// without mutating the stored user command.
+func (f *workshopSuite) TestExecArgsEffectiveCommand(c *check.C) {
+	args := workshop.ExecArgs{
+		Command:       []string{"echo", "foo"},
+		CommandPrefix: []string{"sudo", "--"},
+	}
+
+	command := args.EffectiveCommand()
+
+	c.Check(command, check.DeepEquals, []string{"sudo", "--", "echo", "foo"})
+	command[0] = "changed"
+	c.Check(args.CommandPrefix, check.DeepEquals, []string{"sudo", "--"})
+	c.Check(args.Command, check.DeepEquals, []string{"echo", "foo"})
+}
+
+// TestExecArgsEffectiveCommandNoPrefix returns the user command unchanged when
+// no Workshop-managed command prefix is supplied.
+func (f *workshopSuite) TestExecArgsEffectiveCommandNoPrefix(c *check.C) {
+	args := workshop.ExecArgs{
+		Command: []string{"echo", "foo"},
+	}
+
+	command := args.EffectiveCommand()
+
+	c.Check(command, check.DeepEquals, []string{"echo", "foo"})
+	command[0] = "changed"
+	c.Check(args.Command, check.DeepEquals, []string{"echo", "foo"})
+}
+
 func (f *workshopSuite) TestValidateSdkSyntax(c *check.C) {
 	defer sdk.MockSanitizePlugsSlots(func(sdkInfo *sdk.Info) {})()
 

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -1,5 +1,5 @@
 summary: Check major workshop exec scenarios
-prepare: |  
+prepare: |
   . "$TESTSLIB"/utils.sh
   workshop_exec launch
 restore: |
@@ -18,6 +18,20 @@ execute: |
   workshop_exec exec ws-exec echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
   workshop_exec exec -- echo -- -e '\x66oo' | MATCH '^-- -e \\x66oo$'
   ! workshop_exec exec echo -- -e '\x66oo' || false
+
+  echo "Check exec summaries show the user command"
+  workshop_exec exec -I ws-exec -- /bin/echo command-prefix-summary-check | MATCH '^command-prefix-summary-check$'
+  change_id="$(workshop_exec changes --no-headers | awk 'END{print $1}')"
+  workshop_exec changes --no-headers |
+    awk 'END{print}' |
+    MATCH 'Execute command "/bin/echo"$'
+  workshop_exec tasks --no-headers "$change_id" |
+    MATCH 'Exec command "/bin/echo"$'
+  workshop_exec changes --no-headers |
+    awk 'END{print}' |
+    NOMATCH 'Execute command "sudo"$'
+  workshop_exec tasks --no-headers "$change_id" |
+    NOMATCH 'Exec command "sudo"$'
 
   echo "Check an environment variable can be set"
   workshop_exec exec --env 'Foo=bar' ws-exec bash -c '[ "$Foo" = bar ]'


### PR DESCRIPTION
## Summary

Fix `workshop exec` change and task summaries so they show the user-requested command instead of Workshop’s internal `sudo` execution wrapper.

Previously, a command such as:

```sh
workshop exec -I dev -- /bin/echo hello
```

could show summaries like:

```text
Execute command "sudo"
Exec command "sudo"
```

This happened because the CLI prepended the `sudo`/login-shell wrapper directly to the command array sent to `workshopd`, and the daemon builds summaries from the first command element.

This change separates the user command from Workshop’s execution wrapper:

- `command`: the user-requested command, used for summaries and diagnostics
- `command-prefix`: Workshop-managed wrapper, applied only at the backend execution boundary

## Why not just remove the wrapper?

During investigation, we briefly tested removing the `sudo`/`bash -l` wrapper entirely. That fixed summaries, but it changed important runtime behaviour.

Without the wrapper, supplementary groups were lost. For example, `id -Gn` changed from the expected full group list:

```text
workshop adm cdrom sudo audio dip video plugdev lxd netdev render
```

to only:

```text
workshop
```

The login-shell environment was also lost. `PATH` changed from the expected workshop/login-shell path, including user and SDK paths:

```text
/home/workshop/.local/bin:/home/workshop/go/bin:/var/lib/workshop/sdk/go/bin:...
```

to a more minimal/default path:

```text
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
```

Further isolation showed:

- `bash -l` restores the login-shell `PATH`
- `sudo` restores supplementary groups
- LXD exec `User` and `Group` fields only set primary UID/GID
- LXD exec does not expose supplementary/init groups

So the wrapper is still required for correct runtime behaviour. The fix therefore keeps the wrapper, but stops treating it as the user command.

## Changes

- Add `command-prefix` support to exec API payloads.
- Keep `command` as the user-requested command for summaries and diagnostics.
- Add `CommandPrefix` and `EffectiveCommand()` to `workshop.ExecArgs`.
- Apply `CommandPrefix + Command` only at the LXD execution boundary.
- Update `workshop exec` to send the existing `sudo`/login-shell wrapper as `CommandPrefix`.
- Preserve existing runtime behaviour:
  - supplementary groups via `sudo`
  - login-shell environment/PATH via `bash -l`
  - preserved environment variables
- Sort environment keys when building the prefix so payload construction is deterministic.
- Add unit coverage for:
  - client payload encoding
  - empty/omitted command prefix handling
  - daemon summary generation
  - effective command composition
  - CLI request encoding
- Add Spread coverage for user-facing exec summaries.

## Behaviour after the fix

The API payload now keeps the requested command separate from the wrapper. For example:

```json
{
  "command": ["/bin/echo", "hello"],
  "command-prefix": [
    "sudo",
    "-u", "#1000",
    "-g", "#1000",
    "--preserve-env=...",
    "--",
    "bash",
    "-l",
    "-c",
    "exec -- \"$0\" \"$@\""
  ]
}
```

The daemon continues to build summaries from `command[0]`, so summaries now report the requested command:

```text
Execute command "/bin/echo"
Exec command "/bin/echo"
```

The LXD backend executes the effective command:

```text
command-prefix + command
```

so runtime behaviour remains unchanged.

## Validation

Passed:

```sh
go test ./cmd/workshop ./client ./internal/daemon ./internal/workshop
go test ./...
git --no-pager diff --check
git --no-pager diff --cached --check
```

Live QA passed locally after rebuilding and restarting `workshopd`:

```sh
workshop exec -I dev -- /bin/echo command-prefix-summary-check
workshop exec -I dev -- id -Gn
workshop exec -I dev -- printenv PATH
workshop exec -I --env WORKSHOP_QA_ENV=present dev -- printenv WORKSHOP_QA_ENV
```

Confirmed:

- summaries show the user command:
  ```text
  Execute command "/bin/echo"
  Exec command "/bin/echo"
  ```

- supplementary groups are preserved:
  ```text
  workshop adm cdrom sudo audio dip video plugdev lxd netdev render
  ```

- login-shell `PATH` is preserved:
  ```text
  /home/workshop/.local/bin:/home/workshop/go/bin:/var/lib/workshop/sdk/go/bin:...
  ```

- custom environment variables are preserved:
  ```text
  present
  ```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
