### PR TITLE
Add go tool try for session-isolated dev shells

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,8 +58,8 @@ See [`docs/contributing.rst`](../docs/contributing.rst) for detailed standards. 
 - Run `make run` in `docs/` to build and serve locally.
 
 ### Running Locally
-- Install binaries: `go install ./...`
-- Run daemon: `workshopd run --create-dirs` (requires `WORKSHOP` env var set).
+- Quick path: `go tool try` — builds, starts `workshopd` against a temporary session, and drops into a pre-configured subshell. Exit to tear down; `--keep` retains the session.
+- Manual: `go install ./cmd/...` then `workshopd run --create-dirs` (requires `WORKSHOP` env var set).
 
 ## Available Resources
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@ See [`docs/contributing.rst`](../docs/contributing.rst) for detailed standards. 
 
 ### Running Locally
 - Quick path: `go tool try` — builds, starts `workshopd` against a temporary session, and drops into a pre-configured subshell. Exit to tear down; `--keep` retains the session.
-- Manual: `go install ./cmd/...` then `workshopd run --create-dirs` (requires `WORKSHOP` env var set).
+- Manual: `go install ./cmd/...` then `workshopd run --create-dirs` (requires `WORKSHOP` and `WORKSHOP_CACHE` env vars set).
 
 ## Available Resources
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ workshopctl
 *.snap
 cover.out
 coverage.out
+try_sessions/
 
 # docs
 gendocs

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -34,11 +34,27 @@ Environment setup
 -----------------
 #. ``Workshop`` has a client-server architecture.
    Its ``workshopd`` daemon exposes a RESTful API (see ``internal/daemon/api.go``) to the clients.
-   To run the daemon locally:
+
+   The recommended way to run the current sources is the ``try``
+   dev tool wired into ``go.mod``:
 
    .. code-block:: console
 
-      go install ./...
+      go tool try
+
+   This builds ``./cmd/...`` into a temporary session directory under
+   ``try_sessions/``, starts ``workshopd`` against it, and drops you
+   into a subshell with ``WORKSHOP``, ``WORKSHOP_CACHE``,
+   ``WORKSHOP_SOCKET`` and ``PATH`` pre-configured. Exit the shell to
+   tear the session down; pass ``--keep`` to retain the session
+   directory for inspection. Re-run ``go tool try`` from inside the
+   shell to rebuild and restart ``workshopd`` in place.
+
+   If you'd rather drive ``workshopd`` directly:
+
+   .. code-block:: console
+
+      go install ./cmd/...
       export WORKSHOP=~/workshop
       export WORKSHOP_CACHE=~/workshop-cache
       export WORKSHOP_DEBUG=1

--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,5 @@ require (
 	gopkg.in/errgo.v1 v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+tool github.com/canonical/workshop/tools/try

--- a/tools/try/main.go
+++ b/tools/try/main.go
@@ -401,8 +401,16 @@ func startWorkshopd(tmp string) error {
 	pidData := []byte(strconv.Itoa(cmd.Process.Pid))
 	err = os.WriteFile(pidPath, pidData, 0o644)
 	if err != nil {
-		// Tear down the child since we have nowhere to record it.
-		cmd.Process.Signal(syscall.SIGTERM)
+		// Tear down the child since we have nowhere to record it;
+		// best-effort, surface a warning if the signal itself fails.
+		sigErr := cmd.Process.Signal(syscall.SIGTERM)
+		if sigErr != nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"warning: signalling abandoned workshopd: %v\n",
+				sigErr,
+			)
+		}
 		return fmt.Errorf(
 			"writing PID file %q: %w", pidPath, err,
 		)

--- a/tools/try/main.go
+++ b/tools/try/main.go
@@ -1,0 +1,464 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Command try spawns an isolated subshell pre-configured to use a
+// freshly built copy of the workshop binaries. Each invocation creates
+// a session directory under ./try_sessions/, builds ./cmd/... into
+// <session>/bin, starts workshopd against <session>, and drops the
+// caller into a subshell with WORKSHOP, WORKSHOP_DEBUG and PATH set
+// for the session. When the subshell exits, workshopd is terminated
+// and the session directory is removed (unless --keep is given).
+//
+// When invoked from inside an existing try session (detected via
+// WORKSHOP_DEV_TMP), the tool instead rebuilds the binaries into the
+// same session directory, restarts workshopd, and returns without
+// spawning a nested shell.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	envDevName        = "WORKSHOP_DEV_ENV"
+	envDevTmp         = "WORKSHOP_DEV_TMP"
+	envWorkshop       = "WORKSHOP"
+	envWorkshopCache  = "WORKSHOP_CACHE"
+	envWorkshopDebug  = "WORKSHOP_DEBUG"
+	envWorkshopSocket = "WORKSHOP_SOCKET"
+	logFileName       = "workshopd.log"
+	pidFileName       = "workshopd.pid"
+	sessionsDir       = "try_sessions"
+)
+
+// buildBinaries runs `go install ./cmd/...` with GOBIN set to bin so
+// the freshly built binaries land in the session directory rather than
+// the user's $GOBIN.
+func buildBinaries(bin string) error {
+	fmt.Fprintln(os.Stderr, "building ./cmd/...")
+	cmd := exec.Command("go", "install", "./cmd/...")
+	cmd.Env = append(os.Environ(), "GOBIN="+bin)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("building ./cmd/...: %w", err)
+	}
+
+	fmt.Fprintln(os.Stderr, "build complete")
+	return nil
+}
+
+// detectReentry inspects WORKSHOP_DEV_TMP and returns the existing
+// session directory and true when the caller appears to already be
+// inside a try session whose directory still exists. On any
+// inconsistency it returns false, printing a warning so the caller can
+// fall through to a fresh session.
+func detectReentry() (string, bool) {
+	tmp, ok := os.LookupEnv(envDevTmp)
+	if !ok {
+		return "", false
+	}
+	info, err := os.Stat(tmp)
+	if err != nil || !info.IsDir() {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: %s=%q is not usable;"+
+				" starting a fresh session\n",
+			envDevTmp,
+			tmp,
+		)
+		return "", false
+	}
+	return tmp, true
+}
+
+// fail prints err to stderr and exits the process with status 1.
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}
+
+func main() {
+	keep := flag.Bool(
+		"keep",
+		false,
+		"keep the session directory after the subshell exits",
+	)
+	flag.Parse()
+
+	root, err := moduleRoot()
+	if err != nil {
+		fail(fmt.Errorf("locating module root: %w", err))
+	}
+	err = os.Chdir(root)
+	if err != nil {
+		fail(fmt.Errorf(
+			"changing to module root %q: %w", root, err,
+		))
+	}
+
+	tmp, reentry := detectReentry()
+	if reentry {
+		err = restartSession(tmp)
+		if err != nil {
+			fail(fmt.Errorf("restarting session: %w", err))
+		}
+		return
+	}
+
+	err = runFreshSession(*keep)
+	if err != nil {
+		fail(fmt.Errorf("starting fresh session: %w", err))
+	}
+}
+
+// moduleRoot returns the absolute path of the directory containing the
+// enclosing module's go.mod, as reported by `go env GOMOD`.
+func moduleRoot() (string, error) {
+	out, err := exec.Command("go", "env", "GOMOD").Output()
+	if err != nil {
+		return "", fmt.Errorf("running `go env GOMOD`: %w", err)
+	}
+
+	gomod := strings.TrimSpace(string(out))
+	if gomod == "" || gomod == os.DevNull {
+		return "", errors.New("not inside a Go module")
+	}
+
+	return filepath.Dir(gomod), nil
+}
+
+// printBanner emits a short message identifying the active session and
+// pointers to the workshopd log and re-entry behaviour.
+func printBanner(name, tmp, shell string) {
+	logPath := filepath.Join(tmp, logFileName)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "workshop try session: %s\n", name)
+	fmt.Fprintf(os.Stderr, "  directory : %s\n", tmp)
+	fmt.Fprintf(os.Stderr, "  workshopd : %s\n", logPath)
+	fmt.Fprintf(os.Stderr, "  socket    : %s\n", socketPath(tmp))
+	fmt.Fprintf(os.Stderr, "  shell     : %s\n", shell)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(
+		os.Stderr,
+		"Exit with Ctrl+D or `exit` to tear down the session.",
+	)
+	fmt.Fprintln(
+		os.Stderr,
+		"Re-run `go tool try` from inside this shell to"+
+			" rebuild and restart workshopd.",
+	)
+	fmt.Fprintln(os.Stderr)
+}
+
+// restartSession rebuilds the binaries into tmp/bin, stops the current
+// workshopd, and starts a fresh one against the same session. It does
+// not spawn a new shell; control returns to the caller's existing one.
+func restartSession(tmp string) error {
+	bin := filepath.Join(tmp, "bin")
+	err := buildBinaries(bin)
+	if err != nil {
+		return err
+	}
+	err = stopWorkshopd(tmp)
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: stopping previous workshopd: %v\n",
+			err,
+		)
+	}
+	// The new workshopd outlives this Go process; the original
+	// session will tear it down via the updated PID file when the
+	// user exits the shell.
+	err = startWorkshopd(tmp)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(
+		os.Stderr,
+		"rebuilt binaries and restarted workshopd in current"+
+			" session",
+	)
+	return nil
+}
+
+// runFreshSession creates a new session directory, builds binaries
+// into it, starts workshopd and spawns a configured subshell. Once the
+// subshell exits, workshopd is stopped and the session directory is
+// removed unless keep is true. When workshopd itself fails to start,
+// the session directory is preserved so its log can be inspected.
+func runFreshSession(keep bool) error {
+	err := os.MkdirAll(sessionsDir, 0o755)
+	if err != nil {
+		return fmt.Errorf(
+			"creating %s directory: %w", sessionsDir, err,
+		)
+	}
+
+	rel, err := os.MkdirTemp(sessionsDir, "session-*")
+	if err != nil {
+		return fmt.Errorf("creating session directory: %w", err)
+	}
+
+	tmp, err := filepath.Abs(rel)
+	if err != nil {
+		return fmt.Errorf("resolving session path: %w", err)
+	}
+
+	bin := filepath.Join(tmp, "bin")
+	err = os.MkdirAll(bin, 0o755)
+	if err != nil {
+		return fmt.Errorf("creating bin directory %q: %w", bin, err)
+	}
+
+	err = buildBinaries(bin)
+	if err != nil {
+		os.RemoveAll(tmp)
+		return err
+	}
+
+	err = startWorkshopd(tmp)
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"workshopd did not start;"+
+				" session kept at %s for inspection\n",
+			tmp,
+		)
+		return err
+	}
+
+	name := filepath.Base(tmp)
+	shell := userShell()
+	printBanner(name, tmp, shell)
+	shellErr := runShell(shell, tmp, bin, name)
+
+	stopErr := stopWorkshopd(tmp)
+	if stopErr != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: stopping workshopd: %v\n",
+			stopErr,
+		)
+	}
+
+	sock := socketPath(tmp)
+	rmSockErr := os.Remove(sock)
+	if rmSockErr != nil && !errors.Is(rmSockErr, os.ErrNotExist) {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: removing socket %s: %v\n",
+			sock,
+			rmSockErr,
+		)
+	}
+
+	if keep {
+		fmt.Fprintf(os.Stderr, "session kept at %s\n", tmp)
+		return shellErr
+	}
+
+	err = os.RemoveAll(tmp)
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: removing %s: %v\n",
+			tmp,
+			err,
+		)
+	}
+
+	return shellErr
+}
+
+// runShell launches the chosen shell with WORKSHOP, WORKSHOP_DEBUG,
+// PATH, WORKSHOP_DEV_ENV and WORKSHOP_DEV_TMP configured for the
+// session, and waits for it to exit. A non-zero exit from the shell
+// itself is reported but not propagated as an error from runShell.
+func runShell(shell, tmp, bin, name string) error {
+	env := append(
+		os.Environ(),
+		envWorkshop+"="+tmp,
+		envWorkshopCache+"="+filepath.Join(tmp, "cache"),
+		envWorkshopSocket+"="+socketPath(tmp),
+		envWorkshopDebug+"=1",
+		envDevName+"="+name,
+		envDevTmp+"="+tmp,
+		"PATH="+bin+":"+os.Getenv("PATH"),
+	)
+
+	cmd := exec.Command(shell)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = tmp
+
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+
+	// A non-zero exit from the shell itself (e.g. the last command
+	// failed) is the user's business, not a try failure.
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return nil
+	}
+
+	return fmt.Errorf("running shell %s: %w", shell, err)
+}
+
+// socketPath returns the path used for workshopd's Unix socket. It
+// lives under os.TempDir() rather than inside the session directory so
+// that long worktree paths do not exceed AF_UNIX's ~107-character
+// limit on Linux.
+func socketPath(tmp string) string {
+	return filepath.Join(
+		os.TempDir(),
+		"workshop-"+filepath.Base(tmp)+".sock",
+	)
+}
+
+// startWorkshopd starts workshopd as a background child of the current
+// process. Output is redirected to workshopd.log inside tmp by a
+// /bin/sh wrapper using `exec`, so the shell opens the file, dup2s
+// onto its own fds, and then replaces itself with workshopd in place,
+// preserving cmd.Process.Pid as workshopd's PID. The child runs with
+// WORKSHOP, WORKSHOP_CACHE, WORKSHOP_SOCKET and WORKSHOP_DEBUG set so
+// all of its state lives within or alongside the session directory.
+// The PID is recorded in workshopd.pid; callers use stopWorkshopd to
+// terminate the daemon.
+func startWorkshopd(tmp string) error {
+	logPath := filepath.Join(tmp, logFileName)
+	// Pre-create the log file so any path or permission problems
+	// surface here with a clear Go error rather than buried in a
+	// shell redirection failure.
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf(
+			"creating workshopd log %q: %w", logPath, err,
+		)
+	}
+	logFile.Close()
+
+	sock := socketPath(tmp)
+	// A leftover socket file from a previous run prevents bind.
+	err = os.Remove(sock)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf(
+			"removing stale socket %q: %w", sock, err,
+		)
+	}
+
+	binary := filepath.Join(tmp, "bin", "workshopd")
+	// Paths come from filepath.Join inside the session directory and
+	// are not expected to contain shell metacharacters; single quotes
+	// keep the shell from interpreting anything in them.
+	shellCmd := fmt.Sprintf(
+		"exec '%s' run --create-dirs > '%s' 2>&1",
+		binary,
+		logPath,
+	)
+	cmd := exec.Command("/bin/sh", "-c", shellCmd)
+	cmd.Env = append(
+		os.Environ(),
+		envWorkshop+"="+tmp,
+		envWorkshopCache+"="+filepath.Join(tmp, "cache"),
+		envWorkshopSocket+"="+sock,
+		envWorkshopDebug+"=1",
+	)
+
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("starting workshopd: %w", err)
+	}
+
+	pidPath := filepath.Join(tmp, pidFileName)
+	pidData := []byte(strconv.Itoa(cmd.Process.Pid))
+	err = os.WriteFile(pidPath, pidData, 0o644)
+	if err != nil {
+		// Tear down the child since we have nowhere to record it.
+		cmd.Process.Signal(syscall.SIGTERM)
+		return fmt.Errorf(
+			"writing PID file %q: %w", pidPath, err,
+		)
+	}
+	return nil
+}
+
+// stopWorkshopd reads the PID file in tmp and sends SIGTERM. We sleep
+// briefly to give workshopd time to flush before the caller removes
+// the session directory, but we do not poll for the PID to disappear:
+// because the child is never wait()ed it lingers as a zombie until our
+// parent process exits, at which point the kernel reaps it.
+func stopWorkshopd(tmp string) error {
+	pidPath := filepath.Join(tmp, pidFileName)
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return fmt.Errorf("reading PID file %q: %w", pidPath, err)
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return fmt.Errorf(
+			"parsing PID file %q: %w", pidPath, err,
+		)
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf(
+			"locating workshopd PID %d: %w", pid, err,
+		)
+	}
+
+	err = proc.Signal(syscall.SIGTERM)
+	if err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf(
+			"signalling workshopd PID %d: %w", pid, err,
+		)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	return nil
+}
+
+// userShell returns the path of the user's preferred shell from
+// $SHELL, falling back to /bin/bash.
+func userShell() string {
+	shell, ok := os.LookupEnv("SHELL")
+	if ok {
+		return shell
+	}
+
+	bash, err := exec.LookPath("bash")
+	if err == nil {
+		return bash
+	}
+
+	return "/bin/sh"
+}


### PR DESCRIPTION
# Description

> **Note:** This PR is a proposal — an expression of an idea rather than something that necessarily needs to land. Happy to close it if the approach isn't where the project wants to go.

Adds `go tool try`, a dev-loop helper for trying out the current workshop sources without touching the user's installed binaries or system state.

## Why

Wiring this into `go.mod`'s `tool` directive gives the repository a native Go developer experience: the tooling needed to work on the project ships with the project. A contributor can clone, run `go tool try`, and be in a working session within seconds — no separate install step, no `$PATH` plumbing, no risk of clobbering an existing system installation, and no per-machine setup README to consult.

Inspired by [this talk on Zig's in-repo tooling](https://youtu.be/jVC4DP-8xLM?si=k8U-dHhkAtfE3Fpt) — the same idea, applied here via Go's `tool` directive.

## What it does

Each invocation:

- Builds `./cmd/...` into a per-session directory under `try_sessions/` (gitignored).
- Starts `workshopd` against the session with `WORKSHOP`, `WORKSHOP_CACHE` (avoids `/var/cache/workshop`), `WORKSHOP_SOCKET` (avoids the AF_UNIX path-length limit on deep worktrees) and `WORKSHOP_DEBUG` configured.
- Drops the caller into a subshell with the freshly built binaries on `PATH`. Exit with `Ctrl+D`/`exit` to tear it down; `--keep` preserves the session directory.
- Re-running `go tool try` from inside the shell rebuilds and restarts `workshopd` in place.

`workshopd` is launched via a `/bin/sh -c "exec ... > log 2>&1"` wrapper so the daemon owns its own log file descriptors; the tool only briefly touches the log file to validate writeability.

## Docs

`docs/contributing.rst` and `.github/copilot-instructions.md` now lead with `go tool try`, and the manual `workshopd run` flow has been updated from `go install ./...` to `go install ./cmd/...` so it doesn't also install the `try` binary into `$GOBIN` and shadow `/usr/bin/install`.

## How to test

```sh
go tool try
# inside the spawned subshell:
workshop list                  # connects to the session's workshopd
exit                           # tears down workshopd + session dir
go tool try --keep             # same, but leaves try_sessions/ behind
```

# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically.
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [x] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
