### PR TITLE
Retry transient HTTP network timeouts

### DIFF
--- a/internal/https/middleware.go
+++ b/internal/https/middleware.go
@@ -230,9 +230,9 @@ func (m retryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 			if err != nil {
 				if retryable {
 					// Convert retryable transport errors into retryableErr so retry.Call
-					// treats them the same way as retryable HTTP status response. Keep the
+					// treats them the same way as retryable HTTP status responses. Keep the
 					// original error wrapped so the final error still explains what failed
-					// it all attempts are exhausted.
+					// if all attempts are exhausted.
 					return retryableErr{err: err}
 				}
 				return err

--- a/internal/https/middleware.go
+++ b/internal/https/middleware.go
@@ -250,6 +250,13 @@ func (m retryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 		Attempts: m.policy.Attempts,
 		Delay:    m.policy.Delay,
 		BackoffFunc: func(delay time.Duration, attempts int) time.Duration {
+			if res == nil {
+				// Transport errors do not have an HTTP response, so there is
+				// no Retry-After header to inspect. Fall back to the policy backoff.
+				var duration time.Duration
+				duration, backOffErr = m.clampBackoff(delay)
+				return duration
+			}
 			var duration time.Duration
 			duration, backOffErr = m.defaultBackoff(res, delay)
 			return duration
@@ -320,12 +327,6 @@ func isSafeMethod(method string) bool {
 //   - Retry-After: <http-date>
 //   - Retry-After: <delay-seconds>
 func (m retryMiddleware) defaultBackoff(resp *http.Response, backoff time.Duration) (time.Duration, error) {
-	if resp == nil {
-		// Transport errors do not have an HTTP response, so there is no
-		// Retry-After header to inspect. Fall back to the policy backoff.
-		return m.clampBackoff(backoff)
-	}
-
 	if header := resp.Header.Get("Retry-After"); header != "" {
 		// Attempt to parse the header from the request.
 		//

--- a/internal/https/middleware.go
+++ b/internal/https/middleware.go
@@ -154,7 +154,8 @@ func (lr roundTripRecorder) RoundTrip(req *http.Request) (*http.Response, error)
 }
 
 // RetryMiddleware allows retrying of certain retryable http errors.
-// This only handles very specific status codes, ones that are deemed retryable:
+// This only handles transient network timeout errors for safe requests
+// and specific status codes that are deemed retryable:
 //
 //   - 502 Bad Gateway
 //   - 503 Service Unavailable
@@ -191,10 +192,19 @@ func makeRetryMiddleware(transport http.RoundTripper, policy RetryPolicy, clock 
 	}
 }
 
-type retryableErr struct{}
+type retryableErr struct {
+	err error
+}
 
-func (retryableErr) Error() string {
+func (e retryableErr) Error() string {
+	if e.err != nil {
+		return e.err.Error()
+	}
 	return "retryable error"
+}
+
+func (e retryableErr) Unwrap() error {
+	return e.err
 }
 
 // RoundTrip defines a strategy for handling retries based on the status code.
@@ -215,8 +225,16 @@ func (m retryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 
 			var retryable bool
 			var err error
+			res = nil
 			res, retryable, err = m.roundTrip(req) //nolint:bodyclose // Body closed by caller.
 			if err != nil {
+				if retryable {
+					// Convert retryable transport errors into retryableErr so retry.Call
+					// treats them the same way as retryable HTTP status response. Keep the
+					// original error wrapped so the final error still explains what failed
+					// it all attempts are exhausted.
+					return retryableErr{err: err}
+				}
 				return err
 			}
 			if retryable {
@@ -244,7 +262,7 @@ func (m retryMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
 func (m retryMiddleware) roundTrip(req *http.Request) (*http.Response, bool, error) {
 	res, err := m.wrappedRoundTripper.RoundTrip(req)
 	if err != nil {
-		return nil, false, err
+		return nil, isRetryableNetworkError(req, err), err
 	}
 
 	switch res.StatusCode {
@@ -261,6 +279,39 @@ func (m retryMiddleware) roundTrip(req *http.Request) (*http.Response, bool, err
 	}
 }
 
+func isRetryableNetworkError(req *http.Request, err error) bool {
+	// Network failures can happen before an HTTP response exists. For example,
+	// a TLS handshake timeout from net/http is returned as an error from
+	// RoundTrip rather than as an HTTP 5xx response. Treat timeout errors as
+	// retryable so transient connection setup failures can use the same retry
+	// policy as retryable status codes.
+	if !isSafeMethod(req.Method) {
+		return false
+	}
+
+	// Do not retry explicit caller cancellation or request deadline expiry.
+	// These indicate that the request context itself is done, so retrying would
+	// ignore the caller's intent rather than recover from a transient network failure.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func isSafeMethod(method string) bool {
+	// RoundTrip errors happen before we receive a response, so for methods that
+	// may have side effects we cannot know whether the server processed the
+	// request. Limit transport-level retries to HTTP safe methods to avoid
+	// repeating requests that may have side effects.
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}
+
 // defaultBackoff attempts to workout a good backoff strategy based on the
 // backoff policy or the status code from the response.
 //
@@ -269,6 +320,12 @@ func (m retryMiddleware) roundTrip(req *http.Request) (*http.Response, bool, err
 //   - Retry-After: <http-date>
 //   - Retry-After: <delay-seconds>
 func (m retryMiddleware) defaultBackoff(resp *http.Response, backoff time.Duration) (time.Duration, error) {
+	if resp == nil {
+		// Transport errors do not have an HTTP response, so there is no
+		// Retry-After header to inspect. Fall back to the policy backoff.
+		return m.clampBackoff(backoff)
+	}
+
 	if header := resp.Header.Get("Retry-After"); header != "" {
 		// Attempt to parse the header from the request.
 		//

--- a/internal/https/middleware_test.go
+++ b/internal/https/middleware_test.go
@@ -105,6 +105,20 @@ type RetrySuite struct{}
 
 var _ = check.Suite(&RetrySuite{})
 
+type timeoutError struct{}
+
+func (timeoutError) Error() string {
+	return "net/http: TLS handshake timeout"
+}
+
+func (timeoutError) Timeout() bool {
+	return true
+}
+
+func (timeoutError) Temporary() bool {
+	return true
+}
+
 func (s *RetrySuite) TestRetryNotRequired(c *check.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -165,6 +179,67 @@ func (s *RetrySuite) TestRetryRequired(c *check.C) {
 	resp, err := middleware.RoundTrip(req) //nolint:bodyclose
 	c.Assert(err, check.IsNil)
 	c.Assert(resp.StatusCode, check.Equals, http.StatusOK)
+}
+
+func (s *RetrySuite) TestRetryRequiredForSafeMethodNetworkTimeout(c *check.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	req, err := http.NewRequest("GET", "http://meshuggah.rocks", nil)
+	c.Assert(err, check.IsNil)
+
+	transport := NewMockRoundTripper(ctrl)
+	transport.EXPECT().RoundTrip(req).Return(nil, timeoutError{}).Times(2)
+	transport.EXPECT().RoundTrip(req).Return(&http.Response{
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	ch := make(chan time.Time)
+
+	clock := NewMockClock(ctrl)
+	clock.EXPECT().Now().Return(time.Now()).AnyTimes()
+	clock.EXPECT().After(gomock.Any()).Return(ch).AnyTimes()
+
+	retries := 3
+	go func() {
+		for range retries {
+			ch <- time.Now()
+		}
+	}()
+
+	middleware := makeRetryMiddleware(transport, RetryPolicy{
+		Attempts: retries,
+		Delay:    time.Second,
+		MaxDelay: time.Minute,
+	}, clock)
+
+	resp, err := middleware.RoundTrip(req) //nolint:bodyclose
+	c.Assert(err, check.IsNil)
+	c.Assert(resp.StatusCode, check.Equals, http.StatusOK)
+}
+
+func (s *RetrySuite) TestRetryNotRequiredForUnsafeMethodNetworkTimeout(c *check.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	req, err := http.NewRequest("POST", "http://meshuggah.rocks", nil)
+	c.Assert(err, check.IsNil)
+
+	transport := NewMockRoundTripper(ctrl)
+	transport.EXPECT().RoundTrip(req).Return(nil, timeoutError{})
+
+	clock := NewMockClock(ctrl)
+	clock.EXPECT().Now().Return(time.Now())
+
+	retries := 3
+	middleware := makeRetryMiddleware(transport, RetryPolicy{
+		Attempts: retries,
+		Delay:    time.Second,
+		MaxDelay: time.Minute,
+	}, clock)
+
+	_, err = middleware.RoundTrip(req) //nolint:bodyclose
+	c.Assert(err, check.ErrorMatches, `net/http: TLS handshake timeout`)
 }
 
 func (s *RetrySuite) TestRetryRequiredUsingBackoff(c *check.C) {
@@ -362,6 +437,39 @@ func (s *RetrySuite) TestRetryRequiredAndExceeded(c *check.C) {
 
 	_, err = middleware.RoundTrip(req) //nolint:bodyclose
 	c.Assert(err, check.ErrorMatches, `attempt count exceeded: retryable error`)
+}
+
+func (s *RetrySuite) TestRetryRequiredForNetworkTimeoutAndExceeded(c *check.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	req, err := http.NewRequest("GET", "http://meshuggah.rocks", nil)
+	c.Assert(err, check.IsNil)
+
+	transport := NewMockRoundTripper(ctrl)
+	transport.EXPECT().RoundTrip(req).Return(nil, timeoutError{}).Times(3)
+
+	ch := make(chan time.Time)
+
+	clock := NewMockClock(ctrl)
+	clock.EXPECT().Now().Return(time.Now()).AnyTimes()
+	clock.EXPECT().After(gomock.Any()).Return(ch).AnyTimes()
+
+	retries := 3
+	go func() {
+		for range retries {
+			ch <- time.Now()
+		}
+	}()
+
+	middleware := makeRetryMiddleware(transport, RetryPolicy{
+		Attempts: retries,
+		Delay:    time.Second,
+		MaxDelay: time.Minute,
+	}, clock)
+
+	_, err = middleware.RoundTrip(req) //nolint:bodyclose
+	c.Assert(err, check.ErrorMatches, `attempt count exceeded: net/http: TLS handshake timeout`)
 }
 
 func (s *RetrySuite) TestRetryRequiredContextKilled(c *check.C) {

--- a/internal/sdkstore/http.go
+++ b/internal/sdkstore/http.go
@@ -34,8 +34,9 @@ const (
 
 	// defaultRetryAttempts defines the number of attempts that a default
 	// HTTPClient will retry before giving up.
-	// Retries are only performed on certain status codes, nothing in the 200 to
-	// 400 range and a select few from the 500 range (deemed retryable):
+	// Retries are performed on transient network timeout errors and certain
+	// status codes, nothing in the 200 to 400 range and a select few from the
+	// 500 range (deemed retryable):
 	//
 	// - http.StatusBadGateway
 	// - http.StatusGatewayTimeout


### PR DESCRIPTION
Fixes: #825

# Description
This PR improves HTTP retry handling for transient network timeout errors.

In GitHub-hosted Actions runners, SDK downloads from the SDK Store can occasionally fail with a TLS handshake timeout before an HTTP response is returned. Previously, those transport-level timeout errors were returned immediately and did not use the existing retry policy.

This change makes the HTTP retry middleware retry transient network timeout errors for safe HTTP methods, such as `GET`. It keeps the existing timeout values unchanged and does not retry requests that may have side effects.

The original timeout error is preserved if all retry attempts are exhausted.

Tests were added for:

* retrying a network timeout for a safe method;
* not retrying a network timeout for an unsafe method;
* preserving the original timeout error after retry exhaustion.


# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
