### PR TITLE
fix(refresh): simplify refresh failure messages

### DIFF
--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -180,7 +180,12 @@ To proceed, resolve the issue and run "workshop refresh --continue %s"
 To cancel and undo: "workshop refresh --abort %s"
 To view more information: "workshop tasks %s"`, w, w, w, chg.ID)
 	default:
-		return fmt.Errorf("%v\n%s refresh aborted", err, strutil.Quoted(av))
+		return fmt.Errorf(`
+cannot refresh %s: aborted
+To view details: "workshop tasks %s"`[1:],
+			strutil.Quoted(av),
+			chg.ID,
+		)
 	}
 
 	return nil

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -174,11 +174,15 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		fmt.Fprintf(Stdout, "%s refresh aborted\n", strutil.Quoted(av))
 	case errors.Is(err, errWaitOnError):
 		w := workshopName(av[0])
-		return fmt.Errorf(`cannot complete refresh for %q, execution is paused
+		return fmt.Errorf(`
+cannot refresh %[1]q; paused
+To view details: "workshop tasks %[2]s"
 
-To proceed, resolve the issue and run "workshop refresh --continue %s"
-To cancel and undo: "workshop refresh --abort %s"
-To view more information: "workshop tasks %s"`, w, w, w, chg.ID)
+To abort and undo: "workshop refresh --abort %[1]s"
+Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"`[1:],
+			w,
+			chg.ID,
+		)
 	default:
 		return fmt.Errorf(`
 cannot refresh %s: aborted

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -210,10 +210,11 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 
 	err := cmd.Run(nil, nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "cannot complete refresh for \"ws\", execution is paused\n\n"+
-		"To proceed, resolve the issue and run \"workshop refresh --continue ws\"\n"+
-		"To cancel and undo: \"workshop refresh --abort ws\"\n"+
-		"To view more information: \"workshop tasks 42\"")
+	c.Assert(err, check.ErrorMatches,
+		"cannot refresh \\\"ws\\\"; paused\n"+
+			"To view details: \\\"workshop tasks 42\\\"\n\n"+
+			"To abort and undo: \\\"workshop refresh --abort ws\\\"\n"+
+			"Otherwise, resolve the error, then run \\\"workshop refresh --continue ws\\\"")
 	c.Check(n, check.Equals, 4)
 }
 

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -169,9 +169,8 @@ func (m *workshopRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1"})
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches,
-		"cannot refresh \\\"ws\\\", \\\"ws-1\\\": aborted\n"+
-			"To view details: \\\"workshop tasks 42\\\"")
+	c.Assert(err, check.ErrorMatches, `cannot refresh "ws", "ws-1": aborted
+To view details: "workshop tasks 42"`)
 	c.Check(n, check.Equals, 3)
 }
 
@@ -210,11 +209,16 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorFailed(c *check.C) {
 
 	err := cmd.Run(nil, nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches,
-		"cannot refresh \\\"ws\\\"; paused\n"+
-			"To view details: \\\"workshop tasks 42\\\"\n\n"+
-			"To abort and undo: \\\"workshop refresh --abort ws\\\"\n"+
-			"Otherwise, resolve the error, then run \\\"workshop refresh --continue ws\\\"")
+	c.Assert(
+		err,
+		check.ErrorMatches,
+		`
+cannot refresh "ws"; paused
+To view details: "workshop tasks 42"
+
+To abort and undo: "workshop refresh --abort ws"
+Otherwise, resolve the error, then run "workshop refresh --continue ws"`[1:],
+	)
 	c.Check(n, check.Equals, 4)
 }
 

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -169,7 +169,9 @@ func (m *workshopRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1"})
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `(?s).*"ws", "ws-1" refresh aborted`)
+	c.Assert(err, check.ErrorMatches,
+		"cannot refresh \\\"ws\\\", \\\"ws-1\\\": aborted\n"+
+			"To view details: \\\"workshop tasks 42\\\"")
 	c.Check(n, check.Equals, 3)
 }
 


### PR DESCRIPTION
# Description

This updates the user-facing output for refresh failures so the CLI points
users directly at the change details they need to inspect.

For a normal refresh failure that is aborted, the old output included the
low-level task failure and a separate aborted line:

```text
error: cannot perform the following tasks:
- Run hook "setup-project" for "bad-hook" SDK (command exit code 42)
"refresh-output" refresh aborted
```

The new output is concise and includes the task details command:

```text
error: cannot refresh "refresh-output": aborted
To view details: "workshop tasks 61"
```

For `--wait-on-error`, the old output explained that execution was paused but
put the task details command after the continue/abort instructions:

```text
error: cannot complete refresh for "refresh-output", execution is paused

To proceed, resolve the issue and run "workshop refresh --continue refresh-output"
To cancel and undo: "workshop refresh --abort refresh-output"
To view more information: "workshop tasks 56"
```

The new output first states the paused state and gives the details command,
then explains the two possible recovery paths:

```text
error: cannot refresh "refresh-output"; paused
To view details: "workshop tasks 62"

To abort and undo: "workshop refresh --abort refresh-output"
Otherwise, resolve the error, then run "workshop refresh --continue refresh-output"
```

This gives users more useful context at the point of failure: the operation
state, the exact command to inspect task logs, and the recovery commands for
paused refreshes.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
