### PR TITLE
Explain blocking changes during stop

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -442,6 +442,8 @@ func (e *Error) Error() string {
 }
 
 const (
+	// ErrorKindChangeConflict identifies an operation blocked by another change.
+	ErrorKindChangeConflict     = "change-conflict"
 	ErrorKindLoginRequired      = "login-required"
 	ErrorKindSystemRestart      = "system-restart"
 	ErrorKindDaemonRestart      = "daemon-restart"

--- a/client/error.go
+++ b/client/error.go
@@ -24,9 +24,6 @@ type ChangeConflictError struct {
 	// ChangeKind is the kind of the blocking change, such as "refresh".
 	ChangeKind string
 
-	// ChangeStatus is the status of the blocking change, such as "Wait".
-	ChangeStatus string
-
 	// ProjectID is the ID of the project containing the blocked workshop.
 	ProjectID string
 
@@ -62,16 +59,14 @@ func toChangeConflictError(err Error, conflict *ChangeConflictError) bool {
 
 	changeID, _ := value["change-id"].(string)
 	changeKind, _ := value["change-kind"].(string)
-	changeStatus, _ := value["change-status"].(string)
 	projectID, _ := value["project-id"].(string)
 	workshop, _ := value["workshop"].(string)
 
 	*conflict = ChangeConflictError{
-		ChangeID:     changeID,
-		ChangeKind:   changeKind,
-		ChangeStatus: changeStatus,
-		ProjectID:    projectID,
-		Workshop:     workshop,
+		ChangeID:   changeID,
+		ChangeKind: changeKind,
+		ProjectID:  projectID,
+		Workshop:   workshop,
 	}
 	return true
 }

--- a/client/error.go
+++ b/client/error.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import "fmt"
+
+// ChangeConflictError describes an operation blocked by another change.
+type ChangeConflictError struct {
+	// ChangeID is the ID of the blocking change.
+	ChangeID string
+
+	// ChangeKind is the kind of the blocking change, such as "refresh".
+	ChangeKind string
+
+	// ChangeStatus is the status of the blocking change, such as "Wait".
+	ChangeStatus string
+
+	// ProjectID is the ID of the project containing the blocked workshop.
+	ProjectID string
+
+	// Workshop is the name of the blocked workshop.
+	Workshop string
+}
+
+// As maps generic API errors into richer client-side error types.
+func (e *Error) As(target any) bool {
+	switch e.Kind {
+	case ErrorKindChangeConflict:
+		conflict, ok := target.(*ChangeConflictError)
+		if !ok {
+			return false
+		}
+		return toChangeConflictError(*e, conflict)
+	default:
+		return false
+	}
+}
+
+// toChangeConflictError extracts change-conflict details from a generic API
+// error. It returns true when the error value has the expected object shape,
+// even if some individual fields are missing or not strings; in that case the
+// corresponding [ChangeConflictError] fields remain empty. It returns false
+// when the error value is not an object and therefore cannot represent a
+// change conflict payload.
+func toChangeConflictError(err Error, conflict *ChangeConflictError) bool {
+	value, ok := err.Value.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	changeID, _ := value["change-id"].(string)
+	changeKind, _ := value["change-kind"].(string)
+	changeStatus, _ := value["change-status"].(string)
+	projectID, _ := value["project-id"].(string)
+	workshop, _ := value["workshop"].(string)
+
+	*conflict = ChangeConflictError{
+		ChangeID:     changeID,
+		ChangeKind:   changeKind,
+		ChangeStatus: changeStatus,
+		ProjectID:    projectID,
+		Workshop:     workshop,
+	}
+	return true
+}
+
+// Error returns a human-readable description of the blocking change.
+func (e ChangeConflictError) Error() string {
+	if e.ChangeKind != "" {
+		return fmt.Sprintf(
+			"workshop %q has %q change in progress",
+			e.Workshop,
+			e.ChangeKind,
+		)
+	}
+	return fmt.Sprintf("workshop %q has changes in progress", e.Workshop)
+}

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client_test
+
+import (
+	"errors"
+
+	"github.com/canonical/workshop/client"
+	"gopkg.in/check.v1"
+)
+
+// errorSuite checks structured API error conversion behaviour.
+type errorSuite struct{}
+
+var _ = check.Suite(&errorSuite{})
+
+// TestChangeConflictErrorAsFullValue checks that a complete API error value
+// maps to [client.ChangeConflictError].
+func (errorSuite) TestChangeConflictErrorAsFullValue(c *check.C) {
+	err := &client.Error{
+		Kind: client.ErrorKindChangeConflict,
+		Value: map[string]any{
+			"change-id":     "29",
+			"change-kind":   "refresh",
+			"change-status": "Wait",
+			"project-id":    "project-1",
+			"workshop":      "dev",
+		},
+	}
+
+	var conflictErr client.ChangeConflictError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, client.ChangeConflictError{
+		ChangeID:     "29",
+		ChangeKind:   "refresh",
+		ChangeStatus: "Wait",
+		ProjectID:    "project-1",
+		Workshop:     "dev",
+	})
+}
+
+// TestChangeConflictErrorAsPartialValue checks that incomplete API error values
+// still map to a partial [client.ChangeConflictError].
+func (errorSuite) TestChangeConflictErrorAsPartialValue(c *check.C) {
+	err := &client.Error{
+		Kind: client.ErrorKindChangeConflict,
+		Value: map[string]any{
+			"change-id": "29",
+			"workshop":  "dev",
+		},
+	}
+
+	var conflictErr client.ChangeConflictError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, client.ChangeConflictError{
+		ChangeID: "29",
+		Workshop: "dev",
+	})
+}
+
+// TestChangeConflictErrorAsWrongKind checks that unrelated API error kinds do
+// not map to [client.ChangeConflictError].
+func (errorSuite) TestChangeConflictErrorAsWrongKind(c *check.C) {
+	err := &client.Error{
+		Kind: client.ErrorKindNoUpdatesAvailable,
+		Value: map[string]any{
+			"change-id": "29",
+		},
+	}
+
+	var conflictErr client.ChangeConflictError
+	c.Check(errors.As(err, &conflictErr), check.Equals, false)
+}
+
+// TestChangeConflictErrorAsNonMapValue checks that unexpected API error value
+// shapes do not map to [client.ChangeConflictError].
+func (errorSuite) TestChangeConflictErrorAsNonMapValue(c *check.C) {
+	err := &client.Error{
+		Kind:  client.ErrorKindChangeConflict,
+		Value: "not a map",
+	}
+
+	var conflictErr client.ChangeConflictError
+	c.Check(errors.As(err, &conflictErr), check.Equals, false)
+}

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -17,8 +17,9 @@ package client_test
 import (
 	"errors"
 
-	"github.com/canonical/workshop/client"
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
 )
 
 // errorSuite checks structured API error conversion behaviour.

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -33,22 +33,20 @@ func (errorSuite) TestChangeConflictErrorAsFullValue(c *check.C) {
 	err := &client.Error{
 		Kind: client.ErrorKindChangeConflict,
 		Value: map[string]any{
-			"change-id":     "29",
-			"change-kind":   "refresh",
-			"change-status": "Wait",
-			"project-id":    "project-1",
-			"workshop":      "dev",
+			"change-id":   "29",
+			"change-kind": "refresh",
+			"project-id":  "project-1",
+			"workshop":    "dev",
 		},
 	}
 
 	var conflictErr client.ChangeConflictError
 	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
 	c.Check(conflictErr, check.DeepEquals, client.ChangeConflictError{
-		ChangeID:     "29",
-		ChangeKind:   "refresh",
-		ChangeStatus: "Wait",
-		ProjectID:    "project-1",
-		Workshop:     "dev",
+		ChangeID:   "29",
+		ChangeKind: "refresh",
+		ProjectID:  "project-1",
+		Workshop:   "dev",
 	})
 }
 

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -102,7 +102,7 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 		)
 	case errors.As(err, &conflictErr):
 		return fmt.Errorf(`
-cannot stop %[1]q: tasks are in progress
+cannot stop %[1]q: change is in progress
 To view details: "workshop tasks %[2]s"`[1:],
 			conflictErr.Workshop,
 			conflictErr.ChangeID,

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -15,10 +15,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
+
+	"github.com/canonical/workshop/client"
 )
 
 type CmdStop struct {
@@ -88,7 +91,30 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	changeId, err := cli.Stop(project.Id, av)
-	if err != nil {
+
+	var conflictErr client.ChangeConflictError
+	switch {
+	case err == nil:
+	case errors.As(err, &conflictErr) && conflictErr.ChangeKind == "refresh":
+		return fmt.Errorf(`
+cannot stop %[1]q: refresh change is waiting on error
+To view details: "workshop tasks %[2]s"
+
+To abort and undo the refresh: "workshop refresh --abort %[1]s"
+Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"
+After that, run "workshop stop %[1]s" again.`[1:],
+			conflictErr.Workshop,
+			conflictErr.ChangeID,
+		)
+	case errors.As(err, &conflictErr):
+		return fmt.Errorf(`
+cannot stop %[1]q: change %[2]s is in progress
+To view details: "workshop tasks %[3]s"`[1:],
+			conflictErr.Workshop,
+			conflictErr.ChangeKind,
+			conflictErr.ChangeID,
+		)
+	default:
 		return err
 	}
 

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -96,15 +96,9 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	switch {
 	case err == nil:
 	case errors.As(err, &conflictErr) && conflictErr.ChangeKind == "refresh":
-		return fmt.Errorf(`
-cannot stop %[1]q: a refresh task is waiting on error
-To view details: "workshop tasks %[2]s"
-
-To abort and undo the refresh: "workshop refresh --abort %[1]s"
-Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"
-After that, run "workshop stop %[1]s" again.`[1:],
+		return fmt.Errorf(
+			"cannot stop %[1]q: refresh change is waiting on error",
 			conflictErr.Workshop,
-			conflictErr.ChangeID,
 		)
 	case errors.As(err, &conflictErr):
 		return fmt.Errorf(`

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -97,7 +97,7 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 	case err == nil:
 	case errors.As(err, &conflictErr) && conflictErr.ChangeKind == "refresh":
 		return fmt.Errorf(`
-cannot stop %[1]q: refresh change is waiting on error
+cannot stop %[1]q: a refresh task is waiting on error
 To view details: "workshop tasks %[2]s"
 
 To abort and undo the refresh: "workshop refresh --abort %[1]s"
@@ -108,10 +108,9 @@ After that, run "workshop stop %[1]s" again.`[1:],
 		)
 	case errors.As(err, &conflictErr):
 		return fmt.Errorf(`
-cannot stop %[1]q: change %[2]s is in progress
-To view details: "workshop tasks %[3]s"`[1:],
+cannot stop %[1]q: tasks are in progress
+To view details: "workshop tasks %[2]s"`[1:],
 			conflictErr.Workshop,
-			conflictErr.ChangeKind,
 			conflictErr.ChangeID,
 		)
 	default:

--- a/cmd/workshop/stop.go
+++ b/cmd/workshop/stop.go
@@ -101,11 +101,10 @@ func (c *CmdStop) Run(cmd *cobra.Command, av []string) error {
 			conflictErr.Workshop,
 		)
 	case errors.As(err, &conflictErr):
-		return fmt.Errorf(`
-cannot stop %[1]q: change is in progress
-To view details: "workshop tasks %[2]s"`[1:],
+		return fmt.Errorf(
+			"cannot stop %[1]q: %[2]s change is in progress",
 			conflictErr.Workshop,
-			conflictErr.ChangeID,
+			conflictErr.ChangeKind,
 		)
 	default:
 		return err

--- a/cmd/workshop/stop_test.go
+++ b/cmd/workshop/stop_test.go
@@ -35,6 +35,107 @@ func (m *workshopStop) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
+func (m *workshopStop) TestStopChangeConflictInProgress(c *check.C) {
+	cmd := &CmdStop{root: &CmdRoot{}}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(
+				`{"type": "sync", "result": {"id":"%s","path":"%s"}}`,
+				m.prjId,
+				m.prjDir,
+			)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(
+				r.URL.Path,
+				check.Equals,
+				fmt.Sprintf("/v1/projects/%s/workshops", m.prjId),
+			)
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, `{
+				"type": "error",
+				"status-code": 400,
+				"result": {
+					"kind": "change-conflict",
+					"message": "cannot stop \\\"dev\\\": change is in progress",
+					"value": {
+						"change-id": "30",
+						"change-kind": "launch",
+						"change-status": "Do",
+						"project-id": "42424242",
+						"workshop": "dev"
+					}
+				}
+			}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"dev"})
+	c.Assert(err, check.ErrorMatches,
+		"cannot stop \\\"dev\\\": change launch is in progress\n"+
+			"To view details: \\\"workshop tasks 30\\\"")
+}
+
+func (m *workshopStop) TestStopChangeConflictWaiting(c *check.C) {
+	cmd := &CmdStop{root: &CmdRoot{}}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(
+				`{"type": "sync", "result": {"id":"%s","path":"%s"}}`,
+				m.prjId,
+				m.prjDir,
+			)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(
+				r.URL.Path,
+				check.Equals,
+				fmt.Sprintf("/v1/projects/%s/workshops", m.prjId),
+			)
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, `{
+				"type": "error",
+				"status-code": 400,
+				"result": {
+					"kind": "change-conflict",
+					"message": "cannot stop \\\"dev\\\": waiting on error",
+					"value": {
+						"change-id": "29",
+						"change-kind": "refresh",
+						"change-status": "Wait",
+						"project-id": "42424242",
+						"workshop": "dev"
+					}
+				}
+			}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"dev"})
+	c.Assert(err, check.ErrorMatches,
+		"cannot stop \\\"dev\\\": refresh change is waiting on error\n"+
+			"To view details: \\\"workshop tasks 29\\\"\n\n"+
+			"To abort and undo the refresh: \\\"workshop refresh --abort dev\\\"\n"+
+			"Otherwise, resolve the error, then run \\\"workshop refresh --continue dev\\\"\n"+
+			"After that, run \\\"workshop stop dev\\\" again\\.")
+}
+
 func (m *workshopStop) TestStopSuccess(c *check.C) {
 	cmd := &CmdStop{root: &CmdRoot{}}
 	n := 0

--- a/cmd/workshop/stop_test.go
+++ b/cmd/workshop/stop_test.go
@@ -129,11 +129,7 @@ func (m *workshopStop) TestStopChangeConflictWaiting(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"dev"})
 	c.Assert(err, check.ErrorMatches,
-		"cannot stop \\\"dev\\\": a refresh task is waiting on error\n"+
-			"To view details: \\\"workshop tasks 29\\\"\n\n"+
-			"To abort and undo the refresh: \\\"workshop refresh --abort dev\\\"\n"+
-			"Otherwise, resolve the error, then run \\\"workshop refresh --continue dev\\\"\n"+
-			"After that, run \\\"workshop stop dev\\\" again\\.")
+		"cannot stop \\\"dev\\\": refresh change is waiting on error")
 }
 
 func (m *workshopStop) TestStopSuccess(c *check.C) {

--- a/cmd/workshop/stop_test.go
+++ b/cmd/workshop/stop_test.go
@@ -80,7 +80,7 @@ func (m *workshopStop) TestStopChangeConflictInProgress(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"dev"})
 	c.Assert(err, check.ErrorMatches,
-		"cannot stop \\\"dev\\\": tasks are in progress\n"+
+		"cannot stop \\\"dev\\\": change is in progress\n"+
 			"To view details: \\\"workshop tasks 30\\\"")
 }
 

--- a/cmd/workshop/stop_test.go
+++ b/cmd/workshop/stop_test.go
@@ -80,8 +80,7 @@ func (m *workshopStop) TestStopChangeConflictInProgress(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"dev"})
 	c.Assert(err, check.ErrorMatches,
-		"cannot stop \\\"dev\\\": change is in progress\n"+
-			"To view details: \\\"workshop tasks 30\\\"")
+		"cannot stop \\\"dev\\\": launch change is in progress")
 }
 
 func (m *workshopStop) TestStopChangeConflictWaiting(c *check.C) {

--- a/cmd/workshop/stop_test.go
+++ b/cmd/workshop/stop_test.go
@@ -80,7 +80,7 @@ func (m *workshopStop) TestStopChangeConflictInProgress(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"dev"})
 	c.Assert(err, check.ErrorMatches,
-		"cannot stop \\\"dev\\\": change launch is in progress\n"+
+		"cannot stop \\\"dev\\\": tasks are in progress\n"+
 			"To view details: \\\"workshop tasks 30\\\"")
 }
 
@@ -129,7 +129,7 @@ func (m *workshopStop) TestStopChangeConflictWaiting(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"dev"})
 	c.Assert(err, check.ErrorMatches,
-		"cannot stop \\\"dev\\\": refresh change is waiting on error\n"+
+		"cannot stop \\\"dev\\\": a refresh task is waiting on error\n"+
 			"To view details: \\\"workshop tasks 29\\\"\n\n"+
 			"To abort and undo the refresh: \\\"workshop refresh --abort dev\\\"\n"+
 			"Otherwise, resolve the error, then run \\\"workshop refresh --continue dev\\\"\n"+

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1427,7 +1427,7 @@ func (s *apiSuite) TestConnectFailureOnConflict(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `cannot connect "producer-ws/producer:slot": other change in progress`,
+			"message": `cannot connect "producer-ws/producer:slot": workshop "producer-ws" has "conflict" change in progress`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1939,7 +1939,7 @@ func (s *apiSuite) TestDisconnectFailureOnConflict(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `cannot disconnect "consumer-ws/consumer:plug": other change in progress`,
+			"message": `cannot disconnect "consumer-ws/consumer:plug": workshop "consumer-ws" has "conflict" change in progress`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1427,7 +1427,7 @@ func (s *apiSuite) TestConnectFailureOnConflict(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `cannot connect "producer-ws/producer:slot": other changes in progress`,
+			"message": `cannot connect "producer-ws/producer:slot": other change in progress`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1939,7 +1939,7 @@ func (s *apiSuite) TestDisconnectFailureOnConflict(c *check.C) {
 	c.Check(err, check.IsNil)
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
-			"message": `cannot disconnect "consumer-ws/consumer:plug": other changes in progress`,
+			"message": `cannot disconnect "consumer-ws/consumer:plug": other change in progress`,
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -48,6 +48,14 @@ type actionOpts struct {
 	Verbose       bool   `json:"verbose"`
 }
 
+type changeConflictValue struct {
+	ChangeID     string `json:"change-id"`
+	ChangeKind   string `json:"change-kind"`
+	ChangeStatus string `json:"change-status"`
+	ProjectID    string `json:"project-id"`
+	Workshop     string `json:"workshop"`
+}
+
 type workshopReq struct {
 	Names   []string   `json:"names"`
 	Action  string     `json:"action"`
@@ -123,6 +131,25 @@ type Action struct {
 }
 
 var ensureStateSoon = stateEnsureBefore
+
+// changeConflictErrorResponse converts a change conflict into an API error.
+func changeConflictErrorResponse(conflictErr *conflict.ChangeConflictError) Response {
+	return &resp{
+		Type:   ResponseTypeError,
+		Status: http.StatusBadRequest,
+		Result: &errorResult{
+			Kind:    errorKindChangeConflict,
+			Message: conflictErr.Error(),
+			Value: changeConflictValue{
+				ChangeID:     conflictErr.ChangeID,
+				ChangeKind:   conflictErr.ChangeKind,
+				ChangeStatus: conflictErr.ChangeStatus,
+				ProjectID:    conflictErr.ProjectId,
+				Workshop:     conflictErr.Workshop,
+			},
+		},
+	}
+}
 
 func workshopFileToInfo(pid string, name string, path string) *WorkshopFileInfo {
 	var ws WorkshopFileInfo
@@ -573,10 +600,16 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		}
 	}
 
-	if err != nil {
-		if change != nil {
-			change.SetStatus(state.ErrorStatus)
-		}
+	if err != nil && change != nil {
+		change.SetStatus(state.ErrorStatus)
+	}
+
+	var conflictErr *conflict.ChangeConflictError
+	switch {
+	case err == nil:
+	case errors.As(err, &conflictErr):
+		return changeConflictErrorResponse(conflictErr)
+	case err != nil:
 		return statusBadRequest("%w", err)
 	}
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -49,11 +49,10 @@ type actionOpts struct {
 }
 
 type changeConflictValue struct {
-	ChangeID     string `json:"change-id"`
-	ChangeKind   string `json:"change-kind"`
-	ChangeStatus string `json:"change-status"`
-	ProjectID    string `json:"project-id"`
-	Workshop     string `json:"workshop"`
+	ChangeID   string `json:"change-id"`
+	ChangeKind string `json:"change-kind"`
+	ProjectID  string `json:"project-id"`
+	Workshop   string `json:"workshop"`
 }
 
 type workshopReq struct {
@@ -132,9 +131,10 @@ type Action struct {
 
 var ensureStateSoon = stateEnsureBefore
 
-// changeConflictErrorResponse converts a change conflict into an API error.
-func changeConflictErrorResponse(
-	conflictErr workshopstate.RequestChangeConflictError,
+// changeInProgressErrorResponse converts a [healthstate.ChangeInProgressError]
+// into a change-conflict API error response.
+func changeInProgressErrorResponse(
+	conflictErr healthstate.ChangeInProgressError,
 ) Response {
 	return &resp{
 		Type:   ResponseTypeError,
@@ -143,11 +143,10 @@ func changeConflictErrorResponse(
 			Kind:    errorKindChangeConflict,
 			Message: conflictErr.Error(),
 			Value: changeConflictValue{
-				ChangeID:     conflictErr.ChangeID,
-				ChangeKind:   conflictErr.ChangeKind,
-				ChangeStatus: conflictErr.ChangeStatus,
-				ProjectID:    conflictErr.ProjectID,
-				Workshop:     conflictErr.Workshop,
+				ChangeID:   conflictErr.ChangeID,
+				ChangeKind: conflictErr.ChangeKind,
+				ProjectID:  conflictErr.ProjectID,
+				Workshop:   conflictErr.Workshop,
 			},
 		},
 	}
@@ -606,11 +605,11 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		change.SetStatus(state.ErrorStatus)
 	}
 
-	var conflictErr workshopstate.RequestChangeConflictError
+	var conflictErr healthstate.ChangeInProgressError
 	switch {
 	case err == nil:
 	case errors.As(err, &conflictErr):
-		return changeConflictErrorResponse(conflictErr)
+		return changeInProgressErrorResponse(conflictErr)
 	case err != nil:
 		return statusBadRequest("%w", err)
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -133,7 +133,9 @@ type Action struct {
 var ensureStateSoon = stateEnsureBefore
 
 // changeConflictErrorResponse converts a change conflict into an API error.
-func changeConflictErrorResponse(conflictErr *conflict.ChangeConflictError) Response {
+func changeConflictErrorResponse(
+	conflictErr workshopstate.RequestChangeConflictError,
+) Response {
 	return &resp{
 		Type:   ResponseTypeError,
 		Status: http.StatusBadRequest,
@@ -144,7 +146,7 @@ func changeConflictErrorResponse(conflictErr *conflict.ChangeConflictError) Resp
 				ChangeID:     conflictErr.ChangeID,
 				ChangeKind:   conflictErr.ChangeKind,
 				ChangeStatus: conflictErr.ChangeStatus,
-				ProjectID:    conflictErr.ProjectId,
+				ProjectID:    conflictErr.ProjectID,
 				Workshop:     conflictErr.Workshop,
 			},
 		},
@@ -604,7 +606,7 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		change.SetStatus(state.ErrorStatus)
 	}
 
-	var conflictErr *conflict.ChangeConflictError
+	var conflictErr workshopstate.RequestChangeConflictError
 	switch {
 	case err == nil:
 	case errors.As(err, &conflictErr):

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4547,13 +4547,15 @@ func (s *apiSuite) TestRefreshConflictChange(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot refresh "basic": waiting on error`,
+			Kind:    errorKindChangeConflict.String(),
+			Message: `workshop "basic" has "refresh" change in progress`,
 			Summary: `Refresh "basic" workshop`,
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot refresh "basic": waiting on error`,
+			Kind:    errorKindChangeConflict.String(),
+			Message: `workshop "basic" has "refresh" change in progress`,
 			Summary: `Refresh "basic" workshop`,
 		},
 	}
@@ -4783,7 +4785,7 @@ func (s *apiSuite) TestStartWorkshop(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: `cannot start "basic": workshop already running`,
+			Message: `cannot start "basic": already running`,
 		},
 	}
 
@@ -4845,14 +4847,13 @@ func (s *apiSuite) TestStopWorkshopChangeConflict(c *check.C) {
 	c.Assert(rsp.Status, check.Equals, http.StatusBadRequest)
 	result := rsp.Result.(*errorResult)
 	c.Check(result, check.DeepEquals, &errorResult{
-		Message: `cannot stop workshop "basic": conflicting "refresh" change in progress`,
+		Message: `workshop "basic" has "refresh" change in progress`,
 		Kind:    errorKindChangeConflict,
 		Value: changeConflictValue{
-			ChangeID:     refreshID,
-			ChangeKind:   "refresh",
-			ChangeStatus: "Wait",
-			ProjectID:    s.project.ProjectId,
-			Workshop:     "basic",
+			ChangeID:   refreshID,
+			ChangeKind: "refresh",
+			ProjectID:  s.project.ProjectId,
+			Workshop:   "basic",
 		},
 	})
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4845,7 +4845,7 @@ func (s *apiSuite) TestStopWorkshopChangeConflict(c *check.C) {
 	c.Assert(rsp.Status, check.Equals, http.StatusBadRequest)
 	result := rsp.Result.(*errorResult)
 	c.Check(result, check.DeepEquals, &errorResult{
-		Message: `workshop "basic" has "refresh" change in progress`,
+		Message: `cannot stop workshop "basic": conflicting "refresh" change in progress`,
 		Kind:    errorKindChangeConflict,
 		Value: changeConflictValue{
 			ChangeID:     refreshID,

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4794,6 +4794,69 @@ func (s *apiSuite) TestStartWorkshop(c *check.C) {
 	c.Assert(wp.Running, check.Equals, true)
 }
 
+// TestStopWorkshopChangeConflict checks that a stop action blocked by a
+// waiting change returns a structured change-conflict API error.
+func (s *apiSuite) TestStopWorkshopChangeConflict(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload(c))()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{{
+		Type:    ResponseTypeAsync,
+		Status:  http.StatusAccepted,
+		Kind:    "launch",
+		Summary: `Launch "basic" workshop`,
+	}}
+	s.runActionTest(c, requests, expected)
+
+	st := s.d.state
+	st.Lock()
+	refresh := st.NewChange("refresh", `Refresh "basic" workshop`)
+	refresh.Set("project-id", s.project.ProjectId)
+	refresh.SetStatus(state.WaitStatus)
+	task := st.NewTask("run-hook", "Run refresh hook")
+	task.Set("workshop", "basic")
+	task.Set("project", s.project)
+	refresh.AddTask(task)
+	refreshID := refresh.ID()
+	st.Unlock()
+
+	s.vars = map[string]string{"id": s.project.ProjectId}
+	req, err := s.createProjectsRequest(
+		"POST",
+		"/v1/projects/"+s.project.ProjectId+"/workshops",
+		bytes.NewBufferString(`{"names":["basic"],"action":"stop"}`),
+	)
+	c.Assert(err, check.IsNil)
+
+	rsp := v1PostProjectWorkshop(
+		apiCmd("/v1/projects/{id}/workshops"),
+		req,
+		nil,
+	).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Assert(rsp.Status, check.Equals, http.StatusBadRequest)
+	result := rsp.Result.(*errorResult)
+	c.Check(result, check.DeepEquals, &errorResult{
+		Message: `workshop "basic" has "refresh" change in progress`,
+		Kind:    errorKindChangeConflict,
+		Value: changeConflictValue{
+			ChangeID:     refreshID,
+			ChangeKind:   "refresh",
+			ChangeStatus: "Wait",
+			ProjectID:    s.project.ProjectId,
+			Workshop:     "basic",
+		},
+	})
+}
+
 func (s *apiSuite) TestStopWorkshop(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -137,6 +137,11 @@ type errorResult struct {
 	Value   errorValue `json:"value,omitempty"`
 }
 
+// String returns the error kind as a string, implementing [fmt.Stringer].
+func (k errorKind) String() string {
+	return string(k)
+}
+
 func SyncResponse(result any, status int) Response {
 	if err, ok := result.(error); ok {
 		return statusInternalError("internal error: %w", err)

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -118,6 +118,7 @@ func (r *resp) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 type errorKind string
 
 const (
+	errorKindChangeConflict     = errorKind("change-conflict")
 	errorKindLoginRequired      = errorKind("login-required")
 	errorKindDaemonRestart      = errorKind("daemon-restart")
 	errorKindSystemRestart      = errorKind("system-restart")

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -81,9 +81,10 @@ func ParseRefreshSetting(s string) (RefreshOption, error) {
 
 // ChangeConflictError represents an error because of snap conflicts between changes.
 type ChangeConflictError struct {
-	ProjectId  string
-	Workshop   string
-	ChangeKind string
+	ProjectId    string
+	Workshop     string
+	ChangeKind   string
+	ChangeStatus string
 	// a Message is optional, otherwise one is composed from the other information
 	Message string
 	// ChangeID can optionally be set to the ID of the change with which the operation conflicts
@@ -187,10 +188,11 @@ func CheckChangeConflict(st *state.State, projectId, workshop string, ignoreKind
 		return nil
 	}
 	return &ChangeConflictError{
-		ProjectId:  projectId,
-		Workshop:   workshop,
-		ChangeKind: chg.Kind(),
-		ChangeID:   chg.ID(),
+		ProjectId:    projectId,
+		Workshop:     workshop,
+		ChangeKind:   chg.Kind(),
+		ChangeStatus: chg.Status().String(),
+		ChangeID:     chg.ID(),
 	}
 }
 

--- a/internal/overlord/conflict/conflict_test.go
+++ b/internal/overlord/conflict/conflict_test.go
@@ -77,6 +77,7 @@ func (s *conflictSuite) TestCheckChangeConflictFound(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 	c.Assert(conflictErr.ChangeID, check.Equals, change.ID())
 	c.Assert(conflictErr.ChangeKind, check.Equals, "launch")
+	c.Assert(conflictErr.ChangeStatus, check.Equals, "Do")
 	c.Assert(conflictErr.Workshop, check.Equals, "ws")
 	c.Assert(conflictErr.ProjectId, check.Equals, s.project.ProjectId)
 }
@@ -93,6 +94,7 @@ func (s *conflictSuite) TestCheckChangeDisconnectConflictFound(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 	c.Assert(conflictErr.ChangeID, check.Equals, change.ID())
 	c.Assert(conflictErr.ChangeKind, check.Equals, "disconnect")
+	c.Assert(conflictErr.ChangeStatus, check.Equals, "Do")
 	c.Assert(conflictErr.Workshop, check.Equals, "ws")
 	c.Assert(conflictErr.ProjectId, check.Equals, s.project.ProjectId)
 
@@ -102,6 +104,7 @@ func (s *conflictSuite) TestCheckChangeDisconnectConflictFound(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 	c.Assert(conflictErr.ChangeID, check.Equals, change.ID())
 	c.Assert(conflictErr.ChangeKind, check.Equals, "disconnect")
+	c.Assert(conflictErr.ChangeStatus, check.Equals, "Do")
 	c.Assert(conflictErr.Workshop, check.Equals, "another-ws")
 	c.Assert(conflictErr.ProjectId, check.Equals, s.project.ProjectId)
 }

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -30,6 +30,22 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
+// ChangeInProgressError reports that an operation on a workshop cannot
+// proceed because a conflicting change is already in progress for it.
+type ChangeInProgressError struct {
+	// ChangeID is the identifier of the change that blocks the operation.
+	ChangeID string
+
+	// ChangeKind is the kind of the conflicting change, such as "refresh".
+	ChangeKind string
+
+	// ProjectID identifies the project the targeted workshop belongs to.
+	ProjectID string
+
+	// Workshop is the name of the workshop the operation targeted.
+	Workshop string
+}
+
 type Status int
 
 const (
@@ -39,6 +55,30 @@ const (
 	WaitingStatus
 	ErrorStatus
 	StoppedStatus
+)
+
+var (
+	// ErrorWorkshopHealthError reports that the workshop is unhealthy because
+	// a change has stopped in error.
+	ErrorWorkshopHealthError = errors.New("unhealthy in error")
+
+	// ErrorWorkshopHealthPending reports that another change is already in
+	// progress for the workshop.
+	ErrorWorkshopHealthPending = errors.New("other change in progress")
+
+	// ErrorWorkshopHealthReady reports that the workshop is already running.
+	ErrorWorkshopHealthReady = errors.New("already running")
+
+	// ErrorWorkshopHealthStopped reports that the workshop is not running.
+	ErrorWorkshopHealthStopped = errors.New("not running")
+
+	// ErrorWorkshopHealthUnknown reports that the workshop health could not be
+	// determined.
+	ErrorWorkshopHealthUnknown = errors.New("health unknown")
+
+	// ErrorWorkshopHealthWaiting reports that a change is paused waiting on an
+	// error in the workshop.
+	ErrorWorkshopHealthWaiting = errors.New("waiting on error")
 )
 
 var knownStatuses = []string{"Unknown", "Ready", "Pending", "Waiting", "Error", "Stopped"}
@@ -222,27 +262,50 @@ func sdksHealthCheckSummary(st *state.State, changeID string) map[string]HealthC
 	return sdkChecks
 }
 
-// Checks the provided workshop has one of the allowed health statuses.
-func CheckWorkshopHealth(st *state.State, ws *workshop.Workshop, allowedStatuses []Status) error {
-	health := WorkshopHealth(st, ws)
+// Error implements the error interface, describing the change responsible for
+// the conflict.
+func (e ChangeInProgressError) Error() string {
+	return fmt.Sprintf(
+		"workshop %q has %q change in progress", e.Workshop, e.ChangeKind)
+}
 
-	if !slices.Contains(allowedStatuses, health.Status) {
-		switch health.Status {
-		case ReadyStatus:
-			return errors.New("workshop already running")
-		case PendingStatus:
-			return errors.New("other changes in progress")
-		case WaitingStatus:
-			return errors.New("waiting on error")
-		case ErrorStatus:
-			return errors.New("workshop unhealthy")
-		case StoppedStatus:
-			return errors.New("workshop not running")
-		default:
-			return errors.New("workshop health unknown")
+// CheckWorkshopHealth returns an error when the workshop's health is not one of
+// the allowed statuses. A workshop blocked by a change waiting on error yields
+// a [ChangeInProgressError]; any other disallowed status yields the matching
+// ErrorWorkshopHealth sentinel.
+func CheckWorkshopHealth(
+	st *state.State,
+	ws *workshop.Workshop,
+	allowedStatuses []Status,
+) error {
+	health := WorkshopHealth(st, ws)
+	if health.HasStatusIn(allowedStatuses...) {
+		return nil
+	}
+
+	if health.Status == WaitingStatus && health.Cause.HasChangeRef() {
+		return ChangeInProgressError{
+			ChangeID:   health.Cause.ChangeRef.ID,
+			ChangeKind: health.Cause.ChangeRef.Kind,
+			ProjectID:  ws.Project.ProjectId,
+			Workshop:   ws.Name,
 		}
 	}
-	return nil
+
+	switch health.Status {
+	case ReadyStatus:
+		return ErrorWorkshopHealthReady
+	case PendingStatus:
+		return ErrorWorkshopHealthPending
+	case WaitingStatus:
+		return ErrorWorkshopHealthWaiting
+	case ErrorStatus:
+		return ErrorWorkshopHealthError
+	case StoppedStatus:
+		return ErrorWorkshopHealthStopped
+	default:
+		return ErrorWorkshopHealthUnknown
+	}
 }
 
 func Init(hookManager *hookstate.HookManager) {

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -145,6 +145,17 @@ type HealthStateCause struct {
 	ChangeRef *ChangeRef
 }
 
+// HasChangeRef reports whether a change is referenced by the cause.
+func (c HealthStateCause) HasChangeRef() bool {
+	return c.ChangeRef != nil
+}
+
+// HasStatusIn reports whether the health status matches any of the provided
+// statuses.
+func (h HealthState) HasStatusIn(statuses ...Status) bool {
+	return slices.Contains(statuses, h.Status)
+}
+
 // Infers the state of a workshop based on the container's state and any of the
 // operations in progress for the workshop. The state must be locked.
 func WorkshopHealth(st *state.State, ws *workshop.Workshop) HealthState {

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -270,9 +270,9 @@ func (e ChangeInProgressError) Error() string {
 }
 
 // CheckWorkshopHealth returns an error when the workshop's health is not one of
-// the allowed statuses. A workshop blocked by a change waiting on error yields
-// a [ChangeInProgressError]; any other disallowed status yields the matching
-// ErrorWorkshopHealth sentinel.
+// the allowed statuses. A workshop blocked by a pending change, or a change
+// waiting on error, yields a [ChangeInProgressError]; any other disallowed
+// status yields the matching ErrorWorkshopHealth sentinel.
 func CheckWorkshopHealth(
 	st *state.State,
 	ws *workshop.Workshop,
@@ -283,7 +283,8 @@ func CheckWorkshopHealth(
 		return nil
 	}
 
-	if health.Status == WaitingStatus && health.Cause.HasChangeRef() {
+	if health.HasStatusIn(WaitingStatus, PendingStatus) &&
+		health.Cause.HasChangeRef() {
 		return ChangeInProgressError{
 			ChangeID:   health.Cause.ChangeRef.ID,
 			ChangeKind: health.Cause.ChangeRef.Kind,

--- a/internal/overlord/healthstate/healthstate.go
+++ b/internal/overlord/healthstate/healthstate.go
@@ -103,6 +103,19 @@ func (s HealthCheckResult) String() string {
 	return knownSetHealthStatuses[s]
 }
 
+// ChangeRef identifies a [state.Change] and its progress at a point in time.
+type ChangeRef struct {
+	// ID is the unique identifier of the change.
+	ID string
+
+	// Kind is the kind of the change, such as "refresh" or "launch".
+	Kind string
+
+	// Status is the status of the change when the reference was made, such
+	// as "Wait" or "Doing".
+	Status string
+}
+
 type HealthCheck struct {
 	Sdk         string            `json:"sdk"`
 	Timestamp   time.Time         `json:"timestamp,omitzero"`
@@ -112,11 +125,24 @@ type HealthCheck struct {
 }
 
 type HealthState struct {
+	// Cause carries the supporting detail behind Status, identifying what
+	// is responsible for the current value.
+	Cause HealthStateCause
+
 	Timestamp time.Time              `json:"timestamp,omitzero"`
 	Status    Status                 `json:"status"`
 	Message   string                 `json:"message,omitempty"`
 	Code      string                 `json:"code,omitempty"`
 	SdkHealth map[string]HealthCheck `json:"sdk-health,omitempty"`
+}
+
+// HealthStateCause describes what is responsible for the status reported in a
+// [HealthState], providing the supporting detail behind the status value.
+type HealthStateCause struct {
+	// ChangeRef identifies the change driving the current status, such as a
+	// refresh waiting on error. It is nil when no change is involved, e.g.
+	// when the workshop is simply running or stopped.
+	ChangeRef *ChangeRef
 }
 
 // Infers the state of a workshop based on the container's state and any of the
@@ -135,35 +161,44 @@ func WorkshopHealth(st *state.State, ws *workshop.Workshop) HealthState {
 		return healthState
 	}
 
-	if err := conflict.CheckChangeConflict(st, ws.Project.ProjectId, ws.Name, []string{"exec"}); err != nil {
-		conflict, ok := err.(*conflict.ChangeConflictError)
-		if !ok || conflict.ChangeID == "" {
-			healthState.Status = ErrorStatus
-			return healthState
-		}
-
-		change := st.Change(conflict.ChangeID)
-		if change.Status() == state.WaitStatus {
+	err := conflict.CheckChangeConflict(
+		st, ws.Project.ProjectId, ws.Name, []string{"exec"})
+	var changeConflictError *conflict.ChangeConflictError
+	switch {
+	case errors.As(err, &changeConflictError):
+		if changeConflictError.ChangeStatus == state.WaitStatus.String() {
 			healthState.Code = "wait-on-error"
 			healthState.Status = WaitingStatus
 		} else {
 			healthState.Status = PendingStatus
 		}
 
-		healthState.SdkHealth = sdksHealthCheckSummary(change)
-	} else {
-		if ws.Running {
-			healthState.Status = ReadyStatus
-		} else {
-			healthState.Status = StoppedStatus
+		// Set the change information that is contributing to the current health
+		// status.
+		healthState.Cause.ChangeRef = &ChangeRef{
+			ID:     changeConflictError.ChangeID,
+			Kind:   changeConflictError.ChangeKind,
+			Status: changeConflictError.ChangeStatus,
 		}
+
+		healthState.SdkHealth = sdksHealthCheckSummary(
+			st, changeConflictError.ChangeID)
+	case err != nil:
+		healthState.Status = ErrorStatus
+	case ws.Running:
+		healthState.Status = ReadyStatus
+	default:
+		healthState.Status = StoppedStatus
 	}
+
 	return healthState
 }
 
 // Examine the tasks of the change to fetch possible check-health hook results
 // for the workshop's SDKs.
-func sdksHealthCheckSummary(chg *state.Change) map[string]HealthCheck {
+func sdksHealthCheckSummary(st *state.State, changeID string) map[string]HealthCheck {
+	chg := st.Change(changeID)
+
 	var sdkChecks = map[string]HealthCheck{}
 	for _, task := range chg.Tasks() {
 		if task.Kind() == "run-hook" {

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -19,6 +19,7 @@ package healthstate_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -188,6 +189,18 @@ func (*healthSuite) TestHasStatusInEmpty(c *check.C) {
 	c.Check(health.HasStatusIn(), check.Equals, false)
 }
 
+// ChangeInProgressError describes the workshop and the kind of change that is
+// blocking the operation.
+func (*healthSuite) TestChangeInProgressErrorMessage(c *check.C) {
+	err := healthstate.ChangeInProgressError{
+		Workshop:   "ws",
+		ChangeKind: "refresh",
+	}
+
+	c.Check(err.Error(), check.Equals,
+		`workshop "ws" has "refresh" change in progress`)
+}
+
 func (s *healthSuite) TestWorkshopHealthReady(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -329,7 +342,7 @@ func (s *healthSuite) TestCheckStatusReady(c *check.C) {
 
 	// All other status' should return an error
 	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ErrorStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "workshop already running")
+	c.Assert(err, check.ErrorMatches, "already running")
 }
 
 func (s *healthSuite) TestCheckStatusPending(c *check.C) {
@@ -355,7 +368,7 @@ func (s *healthSuite) TestCheckStatusPending(c *check.C) {
 
 	// All other status' should return an error
 	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "other changes in progress")
+	c.Assert(err, check.ErrorMatches, "other change in progress")
 }
 
 func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
@@ -379,9 +392,17 @@ func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {
 	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.WaitingStatus})
 	c.Assert(err, check.IsNil)
 
-	// All other status' should return an error
+	// All other status' should return a structured change-in-progress error
+	// identifying the blocking change.
 	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "waiting on error")
+	var conflictErr healthstate.ChangeInProgressError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, healthstate.ChangeInProgressError{
+		ChangeID:   chg.ID(),
+		ChangeKind: "refresh",
+		ProjectID:  s.project.ProjectId,
+		Workshop:   "ws",
+	})
 }
 
 func (s *healthSuite) TestCheckStatusError(c *check.C) {
@@ -396,7 +417,7 @@ func (s *healthSuite) TestCheckStatusError(c *check.C) {
 
 	// All other status' should return an error
 	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "workshop unhealthy")
+	c.Assert(err, check.ErrorMatches, "unhealthy in error")
 }
 
 func (s *healthSuite) TestCheckStatusStopped(c *check.C) {
@@ -411,7 +432,7 @@ func (s *healthSuite) TestCheckStatusStopped(c *check.C) {
 
 	// All other status' should return an error
 	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ReadyStatus, healthstate.PendingStatus, healthstate.WaitingStatus, healthstate.ErrorStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "workshop not running")
+	c.Assert(err, check.ErrorMatches, "not running")
 }
 
 func (s *healthSuite) TestExecCheckHealthNotProvided(c *check.C) {

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -150,6 +150,44 @@ func (*healthSuite) TestStatusUnhappy(c *check.C) {
 	c.Check(status.String(), check.Equals, "invalid (-1)")
 }
 
+// HasChangeRef reports true when a change is referenced by the cause.
+func (*healthSuite) TestHasChangeRefPresent(c *check.C) {
+	cause := healthstate.HealthStateCause{ChangeRef: &healthstate.ChangeRef{}}
+
+	c.Check(cause.HasChangeRef(), check.Equals, true)
+}
+
+// HasChangeRef reports false when no change is referenced by the cause.
+func (*healthSuite) TestHasChangeRefAbsent(c *check.C) {
+	cause := healthstate.HealthStateCause{}
+
+	c.Check(cause.HasChangeRef(), check.Equals, false)
+}
+
+// HasStatusIn reports true when the health status is among those provided.
+func (*healthSuite) TestHasStatusInMatch(c *check.C) {
+	health := healthstate.HealthState{Status: healthstate.WaitingStatus}
+
+	c.Check(health.HasStatusIn(healthstate.WaitingStatus), check.Equals, true)
+	c.Check(health.HasStatusIn(
+		healthstate.ReadyStatus, healthstate.WaitingStatus,
+	), check.Equals, true)
+}
+
+// HasStatusIn reports false when the health status is not among those provided.
+func (*healthSuite) TestHasStatusInNoMatch(c *check.C) {
+	health := healthstate.HealthState{Status: healthstate.WaitingStatus}
+
+	c.Check(health.HasStatusIn(healthstate.ReadyStatus), check.Equals, false)
+}
+
+// HasStatusIn reports false when no statuses are provided.
+func (*healthSuite) TestHasStatusInEmpty(c *check.C) {
+	health := healthstate.HealthState{Status: healthstate.WaitingStatus}
+
+	c.Check(health.HasStatusIn(), check.Equals, false)
+}
+
 func (s *healthSuite) TestWorkshopHealthReady(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -366,9 +366,17 @@ func (s *healthSuite) TestCheckStatusPending(c *check.C) {
 	err := healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.PendingStatus})
 	c.Assert(err, check.IsNil)
 
-	// All other status' should return an error
+	// All other status' should return a structured change-in-progress error
+	// identifying the blocking change.
 	err = healthstate.CheckWorkshopHealth(s.state, workshop, []healthstate.Status{healthstate.ErrorStatus, healthstate.ReadyStatus, healthstate.WaitingStatus, healthstate.StoppedStatus, healthstate.UnknownStatus})
-	c.Assert(err, check.ErrorMatches, "other change in progress")
+	var conflictErr healthstate.ChangeInProgressError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, healthstate.ChangeInProgressError{
+		ChangeID:   chg.ID(),
+		ChangeKind: "refresh",
+		ProjectID:  s.project.ProjectId,
+		Workshop:   "ws",
+	})
 }
 
 func (s *healthSuite) TestCheckStatusWaiting(c *check.C) {

--- a/internal/overlord/healthstate/healthstate_test.go
+++ b/internal/overlord/healthstate/healthstate_test.go
@@ -217,6 +217,11 @@ func (s *healthSuite) TestWorkshopHealthOperationInProgress(c *check.C) {
 	c.Check(health.SdkHealth, check.HasLen, 0)
 	c.Check(health.Message, check.HasLen, 0)
 	c.Check(health.Code, check.HasLen, 0)
+	c.Check(health.Cause.ChangeRef, check.DeepEquals, &healthstate.ChangeRef{
+		ID:     chg.ID(),
+		Kind:   "launch",
+		Status: chg.Status().String(),
+	})
 }
 
 func (s *healthSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
@@ -241,6 +246,11 @@ func (s *healthSuite) TestWorkshopHealthOperationWaitingWithNotes(c *check.C) {
 	c.Check(health.SdkHealth, check.HasLen, 0)
 	c.Check(health.Message, check.HasLen, 0)
 	c.Check(health.Code, check.Equals, "wait-on-error")
+	c.Check(health.Cause.ChangeRef, check.DeepEquals, &healthstate.ChangeRef{
+		ID:     chg.ID(),
+		Kind:   "refresh",
+		Status: state.WaitStatus.String(),
+	})
 }
 
 func (s *healthSuite) TestWorkshopHealthSdkHealth(c *check.C) {

--- a/internal/overlord/workshopstate/handlers_test.go
+++ b/internal/overlord/workshopstate/handlers_test.go
@@ -994,12 +994,18 @@ func (s *workshopHandlers) TestSnapshotRemovedAfterRemoveMidRefresh(c *check.C) 
 	c.Check(s2.Workshops[s.project.ProjectId], check.DeepEquals, []string{"ws"})
 
 	// Next, remove the partially-refreshed workshop.
-	err = conflict.CheckChangeConflict(s.state, s.project.ProjectId, "ws", []string{"exec"})
+	err = conflict.CheckChangeConflict(
+		s.state,
+		s.project.ProjectId,
+		"ws",
+		[]string{"exec"},
+	)
 	c.Assert(err, check.DeepEquals, &conflict.ChangeConflictError{
-		ProjectId:  s.project.ProjectId,
-		Workshop:   "ws",
-		ChangeKind: refresh.Kind(),
-		ChangeID:   refresh.ID(),
+		ProjectId:    s.project.ProjectId,
+		Workshop:     "ws",
+		ChangeKind:   refresh.Kind(),
+		ChangeStatus: state.WaitStatus.String(),
+		ChangeID:     refresh.ID(),
 	})
 	conflict.BackgroundDiscard(refresh, "ws")
 

--- a/internal/overlord/workshopstate/manifest_test.go
+++ b/internal/overlord/workshopstate/manifest_test.go
@@ -435,10 +435,10 @@ func (s *manifestSuite) TestRefreshRequiresStatusReady(c *check.C) {
 	s.launchWorkshopWithSDKs(c, "test-3", "ubuntu@20.04", nil)
 
 	_, _, err = s.manager.RefreshManifests(s.ctx, s.project, []string{"test-1", "test-2", "test-3"}, conflict.RefreshUpdate)
-	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop not running`)
+	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": not running`)
 
 	_, _, err = s.manager.RefreshManifests(s.ctx, s.project, []string{"test-1", "test-2", "test-3"}, conflict.RefreshRestore)
-	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": workshop not running`)
+	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": not running`)
 }
 
 func (s *manifestSuite) TestLaunchRequiresFile(c *check.C) {

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -35,29 +35,6 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
-// RequestChangeConflictError reports that a request cannot proceed because a
-// conflicting change is already in progress for the target workshop.
-type RequestChangeConflictError struct {
-	// ChangeID is the identifier of the change that blocks the request.
-	ChangeID string
-
-	// ChangeKind is the kind of the conflicting change, such as "refresh".
-	ChangeKind string
-
-	// ChangeStatus is the status of the conflicting change, such as "Wait".
-	ChangeStatus string
-
-	// ProjectID identifies the project the targeted workshop belongs to.
-	ProjectID string
-
-	// Request names the operation that could not proceed, such as "stop" or
-	// "start".
-	Request string
-
-	// Workshop is the name of the workshop the request targeted.
-	Workshop string
-}
-
 const (
 	checkHealthTimeout = 5 * time.Second
 
@@ -69,66 +46,6 @@ const (
 	// removing state storage and the old workshop copy)
 	EdgeRefreshFirstCleanupTask = state.TaskSetEdge("refresh-cleanup")
 )
-
-var (
-	// ErrorWorkshopHealthError reports that the workshop is unhealthy because
-	// a change has stopped in error.
-	ErrorWorkshopHealthError = errors.New("unhealthy in error")
-
-	// ErrorWorkshopHealthPending reports that another change is already in
-	// progress for the workshop.
-	ErrorWorkshopHealthPending = errors.New("other change in progress")
-
-	// ErrorWorkshopHealthReady reports that the workshop is already running.
-	ErrorWorkshopHealthReady = errors.New("already running")
-
-	// ErrorWorkshopHealthStopped reports that the workshop is not running.
-	ErrorWorkshopHealthStopped = errors.New("not running")
-
-	// ErrorWorkshopHealthUnknown reports that the workshop health could not be
-	// determined.
-	ErrorWorkshopHealthUnknown = errors.New("health unknown")
-
-	// ErrorWorkshopHealthWaiting reports that a change is paused waiting on an
-	// error in the workshop.
-	ErrorWorkshopHealthWaiting = errors.New("waiting on error")
-)
-
-// Error implements the error interface, describing the blocked request and the
-// change responsible for the conflict.
-func (e RequestChangeConflictError) Error() string {
-	return fmt.Sprintf(
-		"cannot %s workshop %q: conflicting %q change in progress",
-		e.Request,
-		e.Workshop,
-		e.ChangeKind,
-	)
-}
-
-// workshopHealthError builds an error explaining why action cannot be performed
-// on the named workshop given its current health. The returned error wraps the
-// matching ErrorWorkshopHealth sentinel so callers can match it with
-// [errors.Is].
-func workshopHealthError(
-	action, name string, healthStatus healthstate.Status,
-) error {
-	var reason error
-	switch healthStatus {
-	case healthstate.ReadyStatus:
-		reason = ErrorWorkshopHealthReady
-	case healthstate.PendingStatus:
-		reason = ErrorWorkshopHealthPending
-	case healthstate.WaitingStatus:
-		reason = ErrorWorkshopHealthWaiting
-	case healthstate.ErrorStatus:
-		reason = ErrorWorkshopHealthError
-	case healthstate.StoppedStatus:
-		reason = ErrorWorkshopHealthStopped
-	default:
-		reason = ErrorWorkshopHealthUnknown
-	}
-	return fmt.Errorf("cannot %s workshop %q: %w", action, name, reason)
-}
 
 func (w *WorkshopManager) LaunchMany(ctx context.Context, project workshop.Project, manifests []Manifest) ([]*state.TaskSet, error) {
 	tasksets := make([]*state.TaskSet, 0, len(manifests))
@@ -686,28 +603,19 @@ func startMany(st *state.State, names []string, project workshop.Project) []*sta
 }
 
 func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
+	var allowedHealthStatus = []healthstate.Status{
+		healthstate.ReadyStatus,
+		healthstate.StoppedStatus,
+	}
+
 	for _, name := range names {
 		wp, err := w.Workshop(ctx, name, projectId)
 		if err != nil {
 			return nil, fmt.Errorf("cannot stop %q: %w", name, err)
 		}
 
-		health := healthstate.WorkshopHealth(w.state, wp)
-		switch {
-		case health.HasStatusIn(healthstate.ReadyStatus, healthstate.StoppedStatus):
-			// Workshop has an acceptable health to be stopped.
-			continue
-		case health.HasStatusIn(healthstate.WaitingStatus) && health.Cause.HasChangeRef():
-			return nil, RequestChangeConflictError{
-				ChangeID:     health.Cause.ChangeRef.ID,
-				ChangeKind:   health.Cause.ChangeRef.Kind,
-				ChangeStatus: health.Cause.ChangeRef.Status,
-				ProjectID:    projectId,
-				Request:      "stop",
-				Workshop:     wp.Name,
-			}
-		default:
-			return nil, workshopHealthError("stop", wp.Name, health.Status)
+		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowedHealthStatus); err != nil {
+			return nil, fmt.Errorf("cannot stop %q: %w", name, err)
 		}
 	}
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -35,7 +35,32 @@ import (
 	"github.com/canonical/workshop/internal/workshop"
 )
 
+// RequestChangeConflictError reports that a request cannot proceed because a
+// conflicting change is already in progress for the target workshop.
+type RequestChangeConflictError struct {
+	// ChangeID is the identifier of the change that blocks the request.
+	ChangeID string
+
+	// ChangeKind is the kind of the conflicting change, such as "refresh".
+	ChangeKind string
+
+	// ChangeStatus is the status of the conflicting change, such as "Wait".
+	ChangeStatus string
+
+	// ProjectID identifies the project the targeted workshop belongs to.
+	ProjectID string
+
+	// Request names the operation that could not proceed, such as "stop" or
+	// "start".
+	Request string
+
+	// Workshop is the name of the workshop the request targeted.
+	Workshop string
+}
+
 const (
+	checkHealthTimeout = 5 * time.Second
+
 	// mark the last task in a taskset after which refresh becomes irreversible (i.e. the following tasks
 	// will not be possible to undo, e.g. removing an old workshop copy)
 	EdgeRefreshLastTaskBeforeCleanup = state.TaskSetEdge("last-before-irreversible")
@@ -45,7 +70,65 @@ const (
 	EdgeRefreshFirstCleanupTask = state.TaskSetEdge("refresh-cleanup")
 )
 
-var checkHealthTimeout = 5 * time.Second
+var (
+	// ErrorWorkshopHealthError reports that the workshop is unhealthy because
+	// a change has stopped in error.
+	ErrorWorkshopHealthError = errors.New("unhealthy in error")
+
+	// ErrorWorkshopHealthPending reports that another change is already in
+	// progress for the workshop.
+	ErrorWorkshopHealthPending = errors.New("other change in progress")
+
+	// ErrorWorkshopHealthReady reports that the workshop is already running.
+	ErrorWorkshopHealthReady = errors.New("already running")
+
+	// ErrorWorkshopHealthStopped reports that the workshop is not running.
+	ErrorWorkshopHealthStopped = errors.New("not running")
+
+	// ErrorWorkshopHealthUnknown reports that the workshop health could not be
+	// determined.
+	ErrorWorkshopHealthUnknown = errors.New("health unknown")
+
+	// ErrorWorkshopHealthWaiting reports that a change is paused waiting on an
+	// error in the workshop.
+	ErrorWorkshopHealthWaiting = errors.New("waiting on error")
+)
+
+// Error implements the error interface, describing the blocked request and the
+// change responsible for the conflict.
+func (e RequestChangeConflictError) Error() string {
+	return fmt.Sprintf(
+		"cannot %s workshop %q: conflicting %q change in progress",
+		e.Request,
+		e.Workshop,
+		e.ChangeKind,
+	)
+}
+
+// workshopHealthError builds an error explaining why action cannot be performed
+// on the named workshop given its current health. The returned error wraps the
+// matching ErrorWorkshopHealth sentinel so callers can match it with
+// [errors.Is].
+func workshopHealthError(
+	action, name string, healthStatus healthstate.Status,
+) error {
+	var reason error
+	switch healthStatus {
+	case healthstate.ReadyStatus:
+		reason = ErrorWorkshopHealthReady
+	case healthstate.PendingStatus:
+		reason = ErrorWorkshopHealthPending
+	case healthstate.WaitingStatus:
+		reason = ErrorWorkshopHealthWaiting
+	case healthstate.ErrorStatus:
+		reason = ErrorWorkshopHealthError
+	case healthstate.StoppedStatus:
+		reason = ErrorWorkshopHealthStopped
+	default:
+		reason = ErrorWorkshopHealthUnknown
+	}
+	return fmt.Errorf("cannot %s workshop %q: %w", action, name, reason)
+}
 
 func (w *WorkshopManager) LaunchMany(ctx context.Context, project workshop.Project, manifests []Manifest) ([]*state.TaskSet, error) {
 	tasksets := make([]*state.TaskSet, 0, len(manifests))
@@ -610,23 +693,21 @@ func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectI
 		}
 
 		health := healthstate.WorkshopHealth(w.state, wp)
-		// Waiting health means a non-exec change is paused on error. Re-check
-		// the conflict so callers get the blocking change kind, status, and ID.
-		if health.Status == healthstate.WaitingStatus {
-			err := conflict.CheckChangeConflict(
-				w.state,
-				projectId,
-				name,
-				[]string{"exec"},
-			)
-			if err != nil {
-				return nil, err
+		switch {
+		case health.HasStatusIn(healthstate.ReadyStatus, healthstate.StoppedStatus):
+			// Workshop has an acceptable health to be stopped.
+			continue
+		case health.HasStatusIn(healthstate.WaitingStatus) && health.Cause.HasChangeRef():
+			return nil, RequestChangeConflictError{
+				ChangeID:     health.Cause.ChangeRef.ID,
+				ChangeKind:   health.Cause.ChangeRef.Kind,
+				ChangeStatus: health.Cause.ChangeRef.Status,
+				ProjectID:    projectId,
+				Request:      "stop",
+				Workshop:     wp.Name,
 			}
-		}
-
-		allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus}
-		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
-			return nil, fmt.Errorf("cannot stop %q: %w", name, err)
+		default:
+			return nil, workshopHealthError("stop", wp.Name, health.Status)
 		}
 	}
 

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -608,6 +608,22 @@ func (w *WorkshopManager) StopMany(ctx context.Context, names []string, projectI
 		if err != nil {
 			return nil, fmt.Errorf("cannot stop %q: %w", name, err)
 		}
+
+		health := healthstate.WorkshopHealth(w.state, wp)
+		// Waiting health means a non-exec change is paused on error. Re-check
+		// the conflict so callers get the blocking change kind, status, and ID.
+		if health.Status == healthstate.WaitingStatus {
+			err := conflict.CheckChangeConflict(
+				w.state,
+				projectId,
+				name,
+				[]string{"exec"},
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		allowed := []healthstate.Status{healthstate.ReadyStatus, healthstate.StoppedStatus}
 		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
 			return nil, fmt.Errorf("cannot stop %q: %w", name, err)

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -819,5 +819,5 @@ func (s *requestSuite) TestRemountWorkshopNotReady(c *check.C) {
 	change.Set("project-id", s.project.ProjectId)
 
 	_, err := s.mgr.Remount(s.ctx, s.state, plug, c.MkDir())
-	c.Assert(err, check.ErrorMatches, `cannot remount "ws-1/sdk-1:plug": other change in progress`)
+	c.Assert(err, check.ErrorMatches, `cannot remount "ws-1/sdk-1:plug": workshop "ws-1" has "refresh" change in progress`)
 }

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha3"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"html/template"
 	"os"
@@ -736,6 +737,34 @@ func (s *requestSuite) TestStopMany(c *check.C) {
 
 	ts[0].Tasks()[0].Get("force", &force)
 	c.Assert(force, check.Equals, false)
+}
+
+// TestStopManyWaitingReturnsChangeConflict checks that stop returns a typed
+// [conflict.ChangeConflictError], rather than a generic health error, when a
+// workshop is waiting on an errored change.
+func (s *requestSuite) TestStopManyWaitingReturnsChangeConflict(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.launchWorkshopWithSDKs(c, "ws", nil)
+	change := s.state.NewChange("refresh", "refresh ws")
+	change.Set("project-id", s.project.ProjectId)
+	change.SetStatus(state.WaitStatus)
+	task := s.state.NewTask("run-hook", "Run refresh hook")
+	task.Set("workshop", "ws")
+	task.Set("project", s.project)
+	change.AddTask(task)
+
+	_, err := s.mgr.StopMany(s.ctx, []string{"ws"}, s.project.ProjectId)
+	var conflictErr *conflict.ChangeConflictError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, &conflict.ChangeConflictError{
+		ProjectId:    s.project.ProjectId,
+		Workshop:     "ws",
+		ChangeKind:   "refresh",
+		ChangeStatus: "Wait",
+		ChangeID:     change.ID(),
+	})
 }
 
 func (s *requestSuite) TestRemountSuccess(c *check.C) {

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
 	"github.com/canonical/workshop/internal/overlord/handlersetup"
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
@@ -756,15 +757,13 @@ func (s *requestSuite) TestStopManyWaitingReturnsChangeConflict(c *check.C) {
 	change.AddTask(task)
 
 	_, err := s.mgr.StopMany(s.ctx, []string{"ws"}, s.project.ProjectId)
-	var conflictErr workshopstate.RequestChangeConflictError
+	var conflictErr healthstate.ChangeInProgressError
 	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
-	c.Check(conflictErr, check.DeepEquals, workshopstate.RequestChangeConflictError{
-		ChangeID:     change.ID(),
-		ChangeKind:   "refresh",
-		ChangeStatus: "Wait",
-		ProjectID:    s.project.ProjectId,
-		Request:      "stop",
-		Workshop:     "ws",
+	c.Check(conflictErr, check.DeepEquals, healthstate.ChangeInProgressError{
+		ChangeID:   change.ID(),
+		ChangeKind: "refresh",
+		ProjectID:  s.project.ProjectId,
+		Workshop:   "ws",
 	})
 }
 
@@ -820,5 +819,5 @@ func (s *requestSuite) TestRemountWorkshopNotReady(c *check.C) {
 	change.Set("project-id", s.project.ProjectId)
 
 	_, err := s.mgr.Remount(s.ctx, s.state, plug, c.MkDir())
-	c.Assert(err, check.ErrorMatches, `cannot remount "ws-1/sdk-1:plug": other changes in progress`)
+	c.Assert(err, check.ErrorMatches, `cannot remount "ws-1/sdk-1:plug": other change in progress`)
 }

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -756,14 +756,15 @@ func (s *requestSuite) TestStopManyWaitingReturnsChangeConflict(c *check.C) {
 	change.AddTask(task)
 
 	_, err := s.mgr.StopMany(s.ctx, []string{"ws"}, s.project.ProjectId)
-	var conflictErr *conflict.ChangeConflictError
+	var conflictErr workshopstate.RequestChangeConflictError
 	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
-	c.Check(conflictErr, check.DeepEquals, &conflict.ChangeConflictError{
-		ProjectId:    s.project.ProjectId,
-		Workshop:     "ws",
+	c.Check(conflictErr, check.DeepEquals, workshopstate.RequestChangeConflictError{
+		ChangeID:     change.ID(),
 		ChangeKind:   "refresh",
 		ChangeStatus: "Wait",
-		ChangeID:     change.ID(),
+		ProjectID:    s.project.ProjectId,
+		Request:      "stop",
+		Workshop:     "ws",
 	})
 }
 

--- a/tests/main/exec/task.yaml
+++ b/tests/main/exec/task.yaml
@@ -100,4 +100,4 @@ execute: |
 
   echo "Check stopped workshop"
   workshop_exec stop
-  workshop_exec exec ws-exec pwd | MATCH '.*cannot exec command in "ws-exec": workshop not running$'
+  workshop_exec exec ws-exec pwd | MATCH '.*cannot exec command in "ws-exec": not running$'

--- a/tests/main/stop-conflict/task.yaml
+++ b/tests/main/stop-conflict/task.yaml
@@ -1,0 +1,28 @@
+summary: Check stopping a workshop waiting on a refresh error fails clearly
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Update the workshop file to include a failing SDK"
+  sed -i 's/test-sdk-basic-2/test-sdk-setup-fail/g' workshop.yaml
+  workshop_exec refresh --wait-on-error || true
+  sed -i 's/test-sdk-setup-fail/test-sdk-basic-2/g' workshop.yaml
+
+  echo "Check the workshop is in Waiting state"
+  workshop_exec list | MATCH "^ws-stop-conflict[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+
+  echo "Check stopping a workshop waiting on a refresh error fails clearly"
+  stop_output="$(workshop_exec stop || true)"
+  echo "$stop_output" | MATCH 'cannot stop "ws-stop-conflict": refresh change is waiting on error'
+
+  echo "Check the workshop is still in Waiting state"
+  workshop_exec list | MATCH "^ws-stop-conflict[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+
+  echo "Abort the refresh to restore the workshop to a clean state"
+  workshop_exec refresh --abort | MATCH "\"ws-stop-conflict\" refresh aborted"
+  workshop_exec list | MATCH "^ws-stop-conflict[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/stop-conflict/workshop.yaml
+++ b/tests/main/stop-conflict/workshop.yaml
@@ -1,0 +1,4 @@
+name: ws-stop-conflict
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic-2


### PR DESCRIPTION
# Description

This improves the `workshop stop` UX when the stop action is blocked by another
workshop change, especially a refresh that is paused on error.

Previously, if a user ran `workshop stop dev` while a refresh was paused on
error, the CLI only received a generic daemon error. The output did not explain
which change was blocking the stop.

Before:

```text
error: cannot stop "dev": waiting on error
```

After, a refresh paused on error reports a concise, specific reason:

```text
error: cannot stop "dev": refresh change is waiting on error
```

For other (non-refresh) change conflicts, the CLI now has enough context to
point the user at the blocking change:

```text
error: cannot stop "dev": change is in progress
To view details: "workshop tasks 30"
```

## Design

This change keeps the existing project layering:

- The daemon API layer translates typed domain errors into API error responses.
- The client translates API error values into typed client errors via
  `errors.As`.
- The CLI formats the user-facing message.

The notable changes:

- `WorkshopHealth` records the change driving the current status on
  `HealthState.Cause.ChangeRef` (id, kind and status). New query helpers
  `HealthState.HasStatusIn` and `HealthStateCause.HasChangeRef` make the status
  and cause easy to inspect.
- `healthstate.CheckWorkshopHealth` now owns the decision of why an operation
  cannot proceed. When the workshop is blocked by a change waiting on error it
  returns a `healthstate.ChangeInProgressError` carrying the conflicting
  change's id and kind plus the project and workshop; any other disallowed
  status returns the matching `ErrorWorkshopHealth*` sentinel. This keeps the
  mapping in one place instead of repeating a switch in every request handler,
  so `StopMany` (and the other operations) simply call `CheckWorkshopHealth`
  with their allowed statuses and wrap the result.
- The change details come from the health cause rather than a second
  `conflict.CheckChangeConflict` call.
- The daemon workshops handler recognises `healthstate.ChangeInProgressError`
  and returns a structured `change-conflict` API error built from its fields.

Because the mapping is centralised, every blocked workshop operation (stop,
start, exec, refresh, remount, …) now yields the structured `change-conflict`
response, not just stop. What remains stop-specific is the CLI's tailored
recovery message; the equivalent `start` CLI message is handled on a separate
branch (`wsp-960-start-error-output`).

Example API error value:

```json
{
  "kind": "change-conflict",
  "message": "workshop \"dev\" has \"refresh\" change in progress",
  "value": {
    "change-id": "29",
    "change-kind": "refresh",
    "project-id": "...",
    "workshop": "dev"
  }
}
```

The client exposes this through `client.ChangeConflictError`, allowing CLI
commands to inspect structured change details without parsing human-readable
daemon messages.

The blocking change's status is intentionally not carried on the error or the
API value: it is stale the moment the state lock is released and is read by
neither the server nor the client.

## QA

Unit and package tests run:

```sh
go test ./client
go test ./cmd/workshop -check.f TestStopChangeConflictWaiting
go test ./cmd/workshop -check.f TestStopChangeConflictInProgress
go test ./internal/overlord/healthstate -check.f TestCheckStatusWaiting
go test ./internal/overlord/workshopstate -check.f TestStopManyWaitingReturnsChangeConflict
go test ./internal/daemon -check.f TestStopWorkshopChangeConflict
```

End-to-end coverage is automated by a new spread test,
`tests/main/stop-conflict`, which:

1. Launches a workshop.
2. Swaps in a failing SDK and runs `refresh --wait-on-error` to pause the
   refresh on error.
3. Asserts `workshop stop` is rejected with
   `cannot stop "ws-stop-conflict": refresh change is waiting on error`.
4. Confirms the workshop stays in the waiting state.
5. Aborts the refresh to return the workshop to a ready state.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
