### PR TITLE
Explain blocking changes during start

### DIFF
--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -96,23 +96,15 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 	switch {
 	case err == nil:
 	case errors.As(err, &conflictErr) && conflictErr.ChangeKind == "refresh":
-		return fmt.Errorf(`
-cannot start %[1]q: refresh change is waiting on error
-To view details: "workshop tasks %[2]s"
-
-To abort and undo the refresh: "workshop refresh --abort %[1]s"
-Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"
-After that, run "workshop start %[1]s" again.`[1:],
+		return fmt.Errorf(
+			"cannot start %[1]q: refresh change is waiting on error",
 			conflictErr.Workshop,
-			conflictErr.ChangeID,
 		)
 	case errors.As(err, &conflictErr):
-		return fmt.Errorf(`
-cannot start %[1]q: change %[2]s is in progress
-To view details: "workshop tasks %[3]s"`[1:],
+		return fmt.Errorf(
+			"cannot start %[1]q: change %[2]s is in progress",
 			conflictErr.Workshop,
 			conflictErr.ChangeKind,
-			conflictErr.ChangeID,
 		)
 	default:
 		return err

--- a/cmd/workshop/start.go
+++ b/cmd/workshop/start.go
@@ -15,10 +15,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/canonical/x-go/strutil"
 	"github.com/spf13/cobra"
+
+	"github.com/canonical/workshop/client"
 )
 
 type CmdStart struct {
@@ -88,7 +91,30 @@ func (c *CmdStart) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	changeId, err := cli.Start(project.Id, av)
-	if err != nil {
+
+	var conflictErr client.ChangeConflictError
+	switch {
+	case err == nil:
+	case errors.As(err, &conflictErr) && conflictErr.ChangeKind == "refresh":
+		return fmt.Errorf(`
+cannot start %[1]q: refresh change is waiting on error
+To view details: "workshop tasks %[2]s"
+
+To abort and undo the refresh: "workshop refresh --abort %[1]s"
+Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"
+After that, run "workshop start %[1]s" again.`[1:],
+			conflictErr.Workshop,
+			conflictErr.ChangeID,
+		)
+	case errors.As(err, &conflictErr):
+		return fmt.Errorf(`
+cannot start %[1]q: change %[2]s is in progress
+To view details: "workshop tasks %[3]s"`[1:],
+			conflictErr.Workshop,
+			conflictErr.ChangeKind,
+			conflictErr.ChangeID,
+		)
+	default:
 		return err
 	}
 

--- a/cmd/workshop/start_test.go
+++ b/cmd/workshop/start_test.go
@@ -84,9 +84,7 @@ func (m *workshopStart) TestStartChangeConflictInProgress(c *check.C) {
 	c.Assert(
 		err,
 		check.ErrorMatches,
-		`
-cannot start "dev": change launch is in progress
-To view details: "workshop tasks 30"`[1:],
+		`cannot start "dev": change launch is in progress`,
 	)
 }
 
@@ -136,12 +134,7 @@ func (m *workshopStart) TestStartRefreshConflictWaiting(c *check.C) {
 	})
 
 	err := cmd.Run(cmd.Command(), []string{"dev"})
-	c.Assert(err, check.ErrorMatches, `cannot start "dev": refresh change is waiting on error
-To view details: "workshop tasks 29"
-
-To abort and undo the refresh: "workshop refresh --abort dev"
-Otherwise, resolve the error, then run "workshop refresh --continue dev"
-After that, run "workshop start dev" again\.`)
+	c.Assert(err, check.ErrorMatches, `cannot start "dev": refresh change is waiting on error`)
 }
 
 func (m *workshopStart) TestStartSuccess(c *check.C) {

--- a/cmd/workshop/start_test.go
+++ b/cmd/workshop/start_test.go
@@ -35,6 +35,115 @@ func (m *workshopStart) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
+// TestStartChangeConflictInProgress checks that start explains a blocking
+// in-progress change and points the user to the task details.
+func (m *workshopStart) TestStartChangeConflictInProgress(c *check.C) {
+	cmd := &CmdStart{root: &CmdRoot{}}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(
+				`{"type": "sync", "result": {"id":"%s","path":"%s"}}`,
+				m.prjId,
+				m.prjDir,
+			)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(
+				r.URL.Path,
+				check.Equals,
+				fmt.Sprintf("/v1/projects/%s/workshops", m.prjId),
+			)
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, `{
+				"type": "error",
+				"status-code": 400,
+				"result": {
+					"kind": "change-conflict",
+					"message": "cannot start \\\"dev\\\": change is in progress",
+					"value": {
+						"change-id": "30",
+						"change-kind": "launch",
+						"change-status": "Do",
+						"project-id": "42424242",
+						"workshop": "dev"
+					}
+				}
+			}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"dev"})
+	c.Assert(
+		err,
+		check.ErrorMatches,
+		`
+cannot start "dev": change launch is in progress
+To view details: "workshop tasks 30"`[1:],
+	)
+}
+
+// TestStartRefreshConflictWaiting checks that start explains a blocked refresh
+// waiting on error and shows the recovery commands.
+func (m *workshopStart) TestStartRefreshConflictWaiting(c *check.C) {
+	cmd := &CmdStart{root: &CmdRoot{}}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(
+				`{"type": "sync", "result": {"id":"%s","path":"%s"}}`,
+				m.prjId,
+				m.prjDir,
+			)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(
+				r.URL.Path,
+				check.Equals,
+				fmt.Sprintf("/v1/projects/%s/workshops", m.prjId),
+			)
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, `{
+				"type": "error",
+				"status-code": 400,
+				"result": {
+					"kind": "change-conflict",
+					"message": "cannot start \\\"dev\\\": waiting on error",
+					"value": {
+						"change-id": "29",
+						"change-kind": "refresh",
+						"change-status": "Wait",
+						"project-id": "42424242",
+						"workshop": "dev"
+					}
+				}
+			}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"dev"})
+	c.Assert(err, check.ErrorMatches, `cannot start "dev": refresh change is waiting on error
+To view details: "workshop tasks 29"
+
+To abort and undo the refresh: "workshop refresh --abort dev"
+Otherwise, resolve the error, then run "workshop refresh --continue dev"
+After that, run "workshop start dev" again\.`)
+}
+
 func (m *workshopStart) TestStartSuccess(c *check.C) {
 	cmd := &CmdStart{root: &CmdRoot{}}
 	n := 0

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4796,6 +4796,78 @@ func (s *apiSuite) TestStartWorkshop(c *check.C) {
 	c.Assert(wp.Running, check.Equals, true)
 }
 
+// TestStartWorkshopChangeConflict checks that a start action blocked by a
+// waiting change returns a structured change-conflict API error.
+func (s *apiSuite) TestStartWorkshopChangeConflict(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload(c))()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+		bytes.NewBufferString(`{"names":["basic"],"action":"stop"}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
+		},
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "stop",
+			Summary: `Stop "basic" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	st := s.d.state
+	st.Lock()
+	refresh := st.NewChange("refresh", `Refresh "basic" workshop`)
+	refresh.Set("project-id", s.project.ProjectId)
+	refresh.SetStatus(state.WaitStatus)
+	task := st.NewTask("run-hook", "Run refresh hook")
+	task.Set("workshop", "basic")
+	task.Set("project", s.project)
+	refresh.AddTask(task)
+	refreshID := refresh.ID()
+	st.Unlock()
+
+	s.vars = map[string]string{"id": s.project.ProjectId}
+	req, err := s.createProjectsRequest(
+		"POST",
+		"/v1/projects/"+s.project.ProjectId+"/workshops",
+		bytes.NewBufferString(`{"names":["basic"],"action":"start"}`),
+	)
+	c.Assert(err, check.IsNil)
+
+	rsp := v1PostProjectWorkshop(
+		apiCmd("/v1/projects/{id}/workshops"),
+		req,
+		nil,
+	).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Assert(rsp.Status, check.Equals, http.StatusBadRequest)
+	result := rsp.Result.(*errorResult)
+	c.Check(result, check.DeepEquals, &errorResult{
+		Message: `workshop "basic" has "refresh" change in progress`,
+		Kind:    errorKindChangeConflict,
+		Value: changeConflictValue{
+			ChangeID:     refreshID,
+			ChangeKind:   "refresh",
+			ChangeStatus: "Wait",
+			ProjectID:    s.project.ProjectId,
+			Workshop:     "basic",
+		},
+	})
+}
+
 // TestStopWorkshopChangeConflict checks that a stop action blocked by a
 // waiting change returns a structured change-conflict API error.
 func (s *apiSuite) TestStopWorkshopChangeConflict(c *check.C) {

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4859,11 +4859,10 @@ func (s *apiSuite) TestStartWorkshopChangeConflict(c *check.C) {
 		Message: `workshop "basic" has "refresh" change in progress`,
 		Kind:    errorKindChangeConflict,
 		Value: changeConflictValue{
-			ChangeID:     refreshID,
-			ChangeKind:   "refresh",
-			ChangeStatus: "Wait",
-			ProjectID:    s.project.ProjectId,
-			Workshop:     "basic",
+			ChangeID:   refreshID,
+			ChangeKind: "refresh",
+			ProjectID:  s.project.ProjectId,
+			Workshop:   "basic",
 		},
 	})
 }

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -574,6 +574,20 @@ func (w *WorkshopManager) StartMany(ctx context.Context, names []string, project
 		if err != nil {
 			return nil, fmt.Errorf("cannot start %q: %w", name, err)
 		}
+		health := healthstate.WorkshopHealth(w.state, wp)
+		if health.Status == healthstate.PendingStatus ||
+			health.Status == healthstate.WaitingStatus {
+			err := conflict.CheckChangeConflict(
+				w.state,
+				projectId,
+				name,
+				[]string{"exec"},
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		allowed := []healthstate.Status{healthstate.StoppedStatus}
 		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
 			return nil, fmt.Errorf("cannot start %q: %w", name, err)

--- a/internal/overlord/workshopstate/request.go
+++ b/internal/overlord/workshopstate/request.go
@@ -568,28 +568,17 @@ func runHooks(st *state.State, installed []sdk.Setup, timeout time.Duration, hoo
 }
 
 func (w *WorkshopManager) StartMany(ctx context.Context, names []string, projectId string) ([]*state.TaskSet, error) {
-	// check if all the workshops are stopped
+	var allowedHealthStatus = []healthstate.Status{
+		healthstate.StoppedStatus,
+	}
+
 	for _, name := range names {
 		wp, err := w.Workshop(ctx, name, projectId)
 		if err != nil {
 			return nil, fmt.Errorf("cannot start %q: %w", name, err)
 		}
-		health := healthstate.WorkshopHealth(w.state, wp)
-		if health.Status == healthstate.PendingStatus ||
-			health.Status == healthstate.WaitingStatus {
-			err := conflict.CheckChangeConflict(
-				w.state,
-				projectId,
-				name,
-				[]string{"exec"},
-			)
-			if err != nil {
-				return nil, err
-			}
-		}
 
-		allowed := []healthstate.Status{healthstate.StoppedStatus}
-		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowed); err != nil {
+		if err = healthstate.CheckWorkshopHealth(w.state, wp, allowedHealthStatus); err != nil {
 			return nil, fmt.Errorf("cannot start %q: %w", name, err)
 		}
 	}

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -723,6 +723,35 @@ func (s *requestSuite) TestStartMany(c *check.C) {
 	c.Assert(ts[1].Tasks()[0].Kind(), check.Equals, "start-workshop")
 }
 
+// TestStartManyWaitingReturnsChangeConflict checks that start returns a typed
+// [conflict.ChangeConflictError], rather than a generic health error, when a
+// workshop is waiting on an errored change.
+func (s *requestSuite) TestStartManyWaitingReturnsChangeConflict(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.launchWorkshopWithSDKs(c, "ws", nil)
+	c.Assert(s.backend.StopWorkshop(s.ctx, "ws", true), check.IsNil)
+	change := s.state.NewChange("refresh", "refresh ws")
+	change.Set("project-id", s.project.ProjectId)
+	change.SetStatus(state.WaitStatus)
+	task := s.state.NewTask("run-hook", "Run refresh hook")
+	task.Set("workshop", "ws")
+	task.Set("project", s.project)
+	change.AddTask(task)
+
+	_, err := s.mgr.StartMany(s.ctx, []string{"ws"}, s.project.ProjectId)
+	var conflictErr *conflict.ChangeConflictError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, &conflict.ChangeConflictError{
+		ProjectId:    s.project.ProjectId,
+		Workshop:     "ws",
+		ChangeKind:   "refresh",
+		ChangeStatus: "Wait",
+		ChangeID:     change.ID(),
+	})
+}
+
 func (s *requestSuite) TestStopMany(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/overlord/workshopstate/request_test.go
+++ b/internal/overlord/workshopstate/request_test.go
@@ -724,8 +724,8 @@ func (s *requestSuite) TestStartMany(c *check.C) {
 }
 
 // TestStartManyWaitingReturnsChangeConflict checks that start returns a typed
-// [conflict.ChangeConflictError], rather than a generic health error, when a
-// workshop is waiting on an errored change.
+// [healthstate.ChangeInProgressError], rather than a generic health error, when
+// a workshop is waiting on an errored change.
 func (s *requestSuite) TestStartManyWaitingReturnsChangeConflict(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -741,14 +741,13 @@ func (s *requestSuite) TestStartManyWaitingReturnsChangeConflict(c *check.C) {
 	change.AddTask(task)
 
 	_, err := s.mgr.StartMany(s.ctx, []string{"ws"}, s.project.ProjectId)
-	var conflictErr *conflict.ChangeConflictError
+	var conflictErr healthstate.ChangeInProgressError
 	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
-	c.Check(conflictErr, check.DeepEquals, &conflict.ChangeConflictError{
-		ProjectId:    s.project.ProjectId,
-		Workshop:     "ws",
-		ChangeKind:   "refresh",
-		ChangeStatus: "Wait",
-		ChangeID:     change.ID(),
+	c.Check(conflictErr, check.DeepEquals, healthstate.ChangeInProgressError{
+		ChangeID:   change.ID(),
+		ChangeKind: "refresh",
+		ProjectID:  s.project.ProjectId,
+		Workshop:   "ws",
 	})
 }
 

--- a/tests/main/start-conflict/task.yaml
+++ b/tests/main/start-conflict/task.yaml
@@ -1,0 +1,28 @@
+summary: Check starting a workshop waiting on a refresh error fails clearly
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Update the workshop file to include a failing SDK"
+  sed -i 's/test-sdk-basic-2/test-sdk-setup-fail/g' workshop.yaml
+  workshop_exec refresh --wait-on-error || true
+  sed -i 's/test-sdk-setup-fail/test-sdk-basic-2/g' workshop.yaml
+
+  echo "Check the workshop is in Waiting state"
+  workshop_exec list | MATCH "^ws-start-conflict[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+
+  echo "Check starting a workshop waiting on a refresh error fails clearly"
+  start_output="$(workshop_exec start || true)"
+  echo "$start_output" | MATCH 'cannot start "ws-start-conflict": refresh change is waiting on error'
+
+  echo "Check the workshop is still in Waiting state"
+  workshop_exec list | MATCH "^ws-start-conflict[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+
+  echo "Abort the refresh to restore the workshop to a clean state"
+  workshop_exec refresh --abort | MATCH "\"ws-start-conflict\" refresh aborted"
+  workshop_exec list | MATCH "^ws-start-conflict[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/start-conflict/workshop.yaml
+++ b/tests/main/start-conflict/workshop.yaml
@@ -1,0 +1,4 @@
+name: ws-start-conflict
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic-2


### PR DESCRIPTION
# Description

This PR is stacked on top of https://github.com/canonical/workshop/pull/829.
It builds on the structured change-conflict errors added there and applies the
same user-facing treatment to `workshop start`.

Previously, if `workshop start` was blocked by another change, the CLI surfaced
only the generic daemon error. When the blocking change is a refresh paused on
error, users did not get the change ID or the refresh recovery commands needed
before retrying start.

After this change, `workshop start` explains the blocking change and points to
the relevant tasks output. For a refresh paused on error, it also shows the
abort/continue recovery commands and tells the user to retry start afterwards:

```text
error: cannot start "dev": refresh change is waiting on error
To view details: "workshop tasks 29"

To abort and undo the refresh: "workshop refresh --abort dev"
Otherwise, resolve the error, then run "workshop refresh --continue dev"
After that, run "workshop start dev" again.
```

For non-refresh conflicts, the message identifies the blocking change kind:

```text
error: cannot start "dev": change launch is in progress
To view details: "workshop tasks 30"
```

The change keeps the same layering as PR #829:

- `workshopstate.StartMany` preserves typed change-conflict details when a
  workshop is pending or waiting on another change.
- The daemon API continues returning structured `change-conflict` errors.
- The CLI formats start-specific user guidance from `client.ChangeConflictError`.

Validation run:

```text
go test ./cmd/workshop -check.f TestStartChangeConflict
go test ./internal/overlord/workshopstate -check.f TestStartManyWaitingReturnsChangeConflict
go test ./internal/daemon -check.f TestStartWorkshopChangeConflict
go test ./cmd/workshop ./internal/overlord/workshopstate ./internal/daemon
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically.
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
