### PR TITLE
Add workshop user to netdev and render groups for other bases

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1004,8 +1004,8 @@ users:
   - name: workshop
     primary_group: workshop
     sudo: ALL=(ALL) NOPASSWD:ALL
-    groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video,render
     shell: /bin/bash
+    {GROUPS}
 apt:
   conf: |
     # Installed by workshop
@@ -1039,6 +1039,50 @@ runcmd:
   # Required to load above DHCP config.
   - networkctl reload
 `
+
+	groups := `create_groups: false
+    groups:
+    - 'adm'
+    - 'cdrom'
+    - 'sudo'
+    - 'dip'
+    - 'plugdev'
+    - 'audio'
+    - 'netdev'
+    - 'lxd'
+    - 'video'
+    - 'render'
+    # Compatibility GIDs for various host systems:
+    - '108' # netdev on 26.04
+    - '111' # netdev on 24.04
+    - '118' # netdev on 20.04
+    - '119' # netdev on 22.04
+    - '109' # render on 20.04
+    - '110' # render on 22.04
+    - '990' # render on 26.04
+    - '992' # render on 24.04
+bootcmd:
+- |
+  set -e
+  maybe_groupadd() {
+      # Ignore GID not unique (exit code 4) or group name not unique (exit code 9)
+      groupadd -g "$1" -r "$2" || case $? in 4|9) ;; *) return $? ;; esac
+  }
+  maybe_groupadd 1000 workshop
+  maybe_groupadd 108 netdev-compat-108
+  maybe_groupadd 111 netdev-compat-111
+  maybe_groupadd 118 netdev-compat-118
+  maybe_groupadd 119 netdev-compat-119
+  maybe_groupadd 109 render-compat-109
+  maybe_groupadd 110 render-compat-110
+  maybe_groupadd 990 render-compat-990
+  maybe_groupadd 992 render-compat-992
+`
+	if format.N < 2 {
+		groups = `groups: adm,cdrom,sudo,dip,plugdev,audio,netdev,lxd,video,render
+`
+	}
+	cloudInitConfig = strings.Replace(cloudInitConfig, "{GROUPS}\n", groups, 1)
 
 	// Based on lxd-imagebuilder Ubuntu template. By default
 	// systemd-networkd derives the DHCP client ID from /etc/machine-id,

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -859,7 +859,7 @@ func (s *Backend) snapshotClients(ctx context.Context) (lxd.InstanceServer, lxd.
 // replay some of the install-sdk and setup-base tasks. These can be handled in
 // the same way as in-progress launches and refreshes.
 func (s *Backend) FormatRevision() sdk.Revision {
-	return sdk.R(1)
+	return sdk.R(2)
 }
 
 func (s *Backend) HashSnapshot(snapshot workshop.Snapshot) (string, error) {

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -16,7 +16,7 @@ launched:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '59c339a3a3271e1ae41686809a3c1607cced545f64c625fb6219d6d5f3147b205cf96d3ffca74c94be7dabcdf309b9cd'
+    user.user-data: '3d5ea3cb0e8e195272207f49a626ff7c17367d021f0b3a36483ee49f557a962429a5e3ebacc3b9a4dbdbc1f47d48bc78'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -55,7 +55,7 @@ started:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '59c339a3a3271e1ae41686809a3c1607cced545f64c625fb6219d6d5f3147b205cf96d3ffca74c94be7dabcdf309b9cd'
+    user.user-data: '3d5ea3cb0e8e195272207f49a626ff7c17367d021f0b3a36483ee49f557a962429a5e3ebacc3b9a4dbdbc1f47d48bc78'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -94,7 +94,7 @@ sdk-attached:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '59c339a3a3271e1ae41686809a3c1607cced545f64c625fb6219d6d5f3147b205cf96d3ffca74c94be7dabcdf309b9cd'
+    user.user-data: '3d5ea3cb0e8e195272207f49a626ff7c17367d021f0b3a36483ee49f557a962429a5e3ebacc3b9a4dbdbc1f47d48bc78'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -145,7 +145,7 @@ sdk-mounted:
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
     user.network-config: '5842bd1995c03c7f704de0db9e91dac3f61f5a1cd9395c813d613a1c6ace81c8c7a76be30770382e95979c2932fa9565'
-    user.user-data: '59c339a3a3271e1ae41686809a3c1607cced545f64c625fb6219d6d5f3147b205cf96d3ffca74c94be7dabcdf309b9cd'
+    user.user-data: '3d5ea3cb0e8e195272207f49a626ff7c17367d021f0b3a36483ee49f557a962429a5e3ebacc3b9a4dbdbc1f47d48bc78'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''

--- a/tests/main/interface-gpu/task.yaml
+++ b/tests/main/interface-gpu/task.yaml
@@ -36,3 +36,12 @@ execute: |
   echo "Check a user cannot install a GPU slot (violates slot declaration)"
   workshop_exec launch ws-gpu-fail > launch.log || true
   MATCH ".*installation not allowed by \"user-gpu\" slot rule of interface \"gpu\"" < launch.log
+
+  echo "Check the user belongs to the render group for all supported bases"
+  workshop_exec exec ws-gpu id -Gz > groups.log
+  mapfile -d '' -t groups < groups.log
+  printf '%s\n' "${groups[@]}" > groups.log
+  MATCH '^109$' < groups.log
+  MATCH '^110$' < groups.log
+  MATCH '^990$' < groups.log
+  MATCH '^992$' < groups.log


### PR DESCRIPTION
# Description

Different bases can have different IDs for a named group. This affects devices in the render group, for example GPU devices are given the `clock` group in a 26.04 container on a 24.04 host.

This PR works around the issue by adding the workshop user to all variants of the `render` group on supported hosts (Ubuntu 20.04 through 26.04). We can add more numbers as necessary for other distributions.

To keep cloud-config the same for all bases, we list the groups by ID and set `create_groups: false`. This means cloud-init passes the group IDs directly to `useradd` without trying to overwrite existing groups.

Since `useradd` requires the groups to exist, so we need to create them ourselves. I don't think cloud-init provides a way to specify the ID of a new group, so we manually run `groupadd` as part of a `bootcmd` and ignore the "already exists" error codes.

## Compatibility

The GID changes will be picked up when users refresh their workshops, since I bumped the snapshot format revision. This is the first time we've done this, so I verified that old workshops continue to function after refreshing the snap (namely `launch --continue` and `restore`).

At some point we can drop support for format revision 1, maybe after adding a warning. We should probably also make relevant tasks more robust to daemon downgrades (e.g. refuse to launch a workshop with format=3).

## Futureproofing

This is intended to be a temporary workaround, but it might take some time to fix properly. So here's a script that generates the cloud-config. It's AI-generated but I think it's pretty solid:
```python
import subprocess
import sys
import yaml

GROUPS = ["adm", "cdrom", "sudo", "dip", "plugdev", "audio", "netdev", "lxd", "video", "render"]
VERSIONS = ["20.04", "22.04", "24.04", "26.04"]

# Groups related to host resources, peripheral devices, virtual interfaces, or tunnels passed to containers:
# - render/video/audio (GPUs/media)
# - cdrom (optical drives)
# - plugdev (hotplugged USB/HID devices)
# - netdev/dip (virtual network interfaces, tunnels like TUN/TAP, or dialup/cellular modems)
# purely administrative or system auth gates (adm, sudo, lxd) are excluded as GID mismatches do not influence device/resource permissions.
EXCLUDED_COMPAT_GROUPS = ["adm", "sudo", "lxd"]

def get_group_gid(container, group):
    try:
        # Run getent group <group> inside the container
        res = subprocess.run(
            ["lxc", "exec", container, "--", "getent", "group", group],
            capture_output=True,
            text=True,
            check=True
        )
        # Parse output e.g. "adm:x:4:syslog,ubuntu" -> GID is the 3rd field
        parts = res.stdout.strip().split(":")
        if len(parts) >= 3:
            return int(parts[2])
    except subprocess.CalledProcessError:
        pass
    return None

def main():
    print("Launching temporary LXD containers to inspect group mappings...", file=sys.stderr)
    
    # Launch containers in parallel
    for v in VERSIONS:
        name = f"inspect-u{v.replace('.', '')}"
        subprocess.run(["lxc", "launch", f"ubuntu:{v}", name, "--ephemeral"], check=True, capture_output=True)

    print("Retrieving GID mappings from containers...", file=sys.stderr)
    
    # Gather GIDs: {group: {version: gid}}
    mappings = {g: {} for g in GROUPS}
    for v in VERSIONS:
        name = f"inspect-u{v.replace('.', '')}"
        for g in GROUPS:
            gid = get_group_gid(name, g)
            mappings[g][v] = gid

    # Clean up containers
    print("Cleaning up temporary containers...", file=sys.stderr)
    for v in VERSIONS:
        name = f"inspect-u{v.replace('.', '')}"
        subprocess.run(["lxc", "delete", "-f", name], check=True, capture_output=True)

    # Figure out which non-excluded groups have varying GIDs across releases
    # and map GID back to the versions they belong to: {group: {gid: [versions]}}
    group_gid_versions = {}
    for g in GROUPS:
        if g in EXCLUDED_COMPAT_GROUPS:
            continue
            
        g_map = {}
        for v in VERSIONS:
            gid = mappings[g][v]
            if gid is not None:
                g_map.setdefault(gid, []).append(v)
        
        unique_gids = sorted(list(g_map.keys()))
        if len(unique_gids) > 1:
            group_gid_versions[g] = g_map

    # 1. Generate multi-line bootcmd script
    bootcmd_lines = [
        "set -e",
        "maybe_groupadd() {",
        "    # Ignore GID not unique (exit code 4) or group name not unique (exit code 9)",
        "    groupadd -g \"$1\" -r \"$2\" || case $? in 4|9) ;; *) return $? ;; esac",
        "}",
        "maybe_groupadd 1000 workshop"
    ]
    
    for group in sorted(group_gid_versions.keys()):
        for gid in sorted(group_gid_versions[group].keys()):
            compat_name = f"{group}-compat-{gid}"
            bootcmd_lines.append(f"maybe_groupadd {gid} {compat_name}")

    # 2. Generate user group membership list with comments
    yaml_lines = [
        "#cloud-config",
        "bootcmd:",
        "- |"
    ]
    for line in bootcmd_lines:
        yaml_lines.append(f"  {line}")
        
    yaml_lines.append("users:")
    yaml_lines.append("- default")
    yaml_lines.append("- name: workshop")
    yaml_lines.append("  uid: 1000")
    yaml_lines.append("  primary_group: workshop")
    yaml_lines.append("  sudo: ALL=(ALL) NOPASSWD:ALL")
    yaml_lines.append("  create_groups: false")
    yaml_lines.append("  groups:")
    yaml_lines.append("  # Standard system groups")
    for group in GROUPS:
        yaml_lines.append(f"  - '{group}'")
        
    yaml_lines.append("  # Compatibility GIDs for various host systems:")
    for group in sorted(group_gid_versions.keys()):
        for gid in sorted(group_gid_versions[group].keys()):
            versions_str = ", ".join(group_gid_versions[group][gid])
            yaml_lines.append(f"  - '{gid}' # {group} on {versions_str}")
        
    yaml_lines.append("  shell: /bin/bash")

    # Print markdown table
    print("# Group to GID Mappings Table\n")
    headers = ["Group"] + VERSIONS
    print("| " + " | ".join(headers) + " |")
    print("|" + "|".join(["---" for _ in range(len(headers))]) + "|")
    for g in GROUPS:
        row = [g] + [str(mappings[g][v] if mappings[g][v] is not None else "N/A") for v in VERSIONS]
        print("| " + " | ".join(row) + " |")
    print("\n")

    print("# Generated cloud-init config\n")
    print("```yaml")
    print("\n".join(yaml_lines))
    print("```")

if __name__ == "__main__":
    main()
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
