### PR TITLE
Avoid using Change ID in synchronous error messages

### DIFF
--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -183,13 +183,15 @@ Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"`[1:],
 			w,
 			chg.ID,
 		)
-	default:
+	case chg != nil:
 		return fmt.Errorf(`
 cannot refresh %s: aborted
 To view details: "workshop tasks %s"`[1:],
 			strutil.Quoted(av),
 			chg.ID,
 		)
+	default:
+		return fmt.Errorf("cannot refresh %s: %w", strutil.Quoted(av), err)
 	}
 
 	return nil

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -105,6 +105,10 @@ var mockChangeWithError = `{"type": "sync", "result":{
     "tasks": [{"kind": "bar", "summary": "some summary", "status": "Undone", "progress": {"done": 1, "total": 1}, "spawn-time": "2015-02-21T01:02:03Z", "ready-time": "2015-02-21T01:02:04Z"},{"kind": "foo", "summary": "some summary", "status": "Error", "progress": {"done": 1, "total": 1}, "spawn-time": "2015-02-21T01:02:03Z", "ready-time": "2015-02-21T01:02:04Z" , "log":["2015-02-21T01:02:03Z ERROR No answer found"], "data":{"workshop":["ws","ws-1"]}}]
 }}`
 
+var mockSyncError = `{"type":"error","status-code":400,"status":"Bad Request","result":{
+    "message":"\"dev\" workshop file must be named \"dev.yaml\" (now: \"workshop.yaml\")"
+}}`
+
 func (m *workshopRefresh) SetUpTest(c *check.C) {
 	m.prjDir = c.MkDir()
 	m.prjId = "42424242"
@@ -290,4 +294,31 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C
 	c.Assert(err, check.IsNil)
 	c.Assert(m.stdout.String(), check.Matches, `"ws" refreshed\n`)
 	c.Check(n, check.Equals, 3)
+}
+
+func (m *workshopRefresh) TestRefreshHandlesSyncError(c *check.C) {
+	cmd := &CmdRefresh{root: &CmdRoot{}}
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(400)
+			fmt.Fprintln(w, mockSyncError)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(nil, []string{"workshop"})
+	c.Assert(err, check.ErrorMatches, `cannot refresh "workshop": "dev" workshop file must be named "dev.yaml" \(now: "workshop.yaml"\)`)
+	c.Check(n, check.Equals, 2)
 }


### PR DESCRIPTION
# Description

Keeps the new error message format, but falls back to a different one if the Change ID is unavailable.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
