### PR TITLE
Explain blocking changes during refresh

### DIFF
--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -164,10 +164,30 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 
 	chg, err := c.RunRefresh(cli, project, av)
 
+	var conflictErr client.ChangeConflictError
 	switch {
 	case err == nil:
 		fmt.Fprintf(Stdout, "%s refreshed\n", strutil.Quoted(av))
 	case errors.Is(err, errNoWait):
+	case errors.As(err, &conflictErr) && conflictErr.ChangeKind == "refresh" &&
+		conflictErr.ChangeStatus == "Wait":
+		return fmt.Errorf(`
+cannot refresh %[1]q; paused
+To view details: "workshop tasks %[2]s"
+
+To abort and undo: "workshop refresh --abort %[1]s"
+Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"`[1:],
+			conflictErr.Workshop,
+			conflictErr.ChangeID,
+		)
+	case errors.As(err, &conflictErr):
+		return fmt.Errorf(`
+cannot refresh %[1]q: change %[2]s is in progress
+To view details: "workshop tasks %[3]s"`[1:],
+			conflictErr.Workshop,
+			conflictErr.ChangeKind,
+			conflictErr.ChangeID,
+		)
 	case client.IsNoUpdatesAvailable(err):
 		fmt.Fprintf(Stdout, "no updates available for %s\n", strutil.Quoted(av))
 	case errors.Is(err, errUndone):

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -167,32 +167,31 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 	var conflictErr client.ChangeConflictError
 	switch {
 	case err == nil:
+		// The refresh ran to completion.
 		fmt.Fprintf(Stdout, "%s refreshed\n", strutil.Quoted(av))
 	case errors.Is(err, errNoWait):
-	case errors.As(err, &conflictErr) && conflictErr.ChangeKind == "refresh" &&
-		conflictErr.ChangeStatus == "Wait":
-		return fmt.Errorf(`
-cannot refresh %[1]q; paused
-To view details: "workshop tasks %[2]s"
-
-To abort and undo: "workshop refresh --abort %[1]s"
-Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"`[1:],
+		// --no-wait returned the change ID without waiting; nothing to report.
+	case errors.As(err, &conflictErr) && conflictErr.ChangeKind == "refresh":
+		// Rejected before starting: another refresh is already paused on error.
+		return fmt.Errorf(
+			"cannot refresh %[1]q; another refresh change is waiting on error",
 			conflictErr.Workshop,
-			conflictErr.ChangeID,
 		)
 	case errors.As(err, &conflictErr):
-		return fmt.Errorf(`
-cannot refresh %[1]q: change %[2]s is in progress
-To view details: "workshop tasks %[3]s"`[1:],
+		// Rejected before starting: a non-refresh change is blocking the workshop.
+		return fmt.Errorf(
+			"cannot refresh %[1]q: %[2]s change is in progress",
 			conflictErr.Workshop,
 			conflictErr.ChangeKind,
-			conflictErr.ChangeID,
 		)
 	case client.IsNoUpdatesAvailable(err):
+		// The workshops already match their definitions.
 		fmt.Fprintf(Stdout, "no updates available for %s\n", strutil.Quoted(av))
 	case errors.Is(err, errUndone):
+		// An explicit --abort reverted the paused refresh cleanly.
 		fmt.Fprintf(Stdout, "%s refresh aborted\n", strutil.Quoted(av))
 	case errors.Is(err, errWaitOnError):
+		// This refresh hit an error and paused under --wait-on-error.
 		w := workshopName(av[0])
 		return fmt.Errorf(`
 cannot refresh %[1]q; paused
@@ -204,13 +203,15 @@ Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"`[1:],
 			chg.ID,
 		)
 	case chg != nil:
+		// This refresh hit an error in transactional mode and was aborted.
 		return fmt.Errorf(`
-cannot refresh %s: aborted
+cannot refresh %s; aborted
 To view details: "workshop tasks %s"`[1:],
 			strutil.Quoted(av),
 			chg.ID,
 		)
 	default:
+		// The request failed before any change ran; surface the cause.
 		return fmt.Errorf("cannot refresh %s: %w", strutil.Quoted(av), err)
 	}
 

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -115,6 +115,119 @@ func (m *workshopRefresh) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
+// TestConflictInProgress checks that refresh explains a blocking in-progress
+// change and points the user to the task details.
+func (m *workshopRefresh) TestConflictInProgress(c *check.C) {
+	cmd := &CmdRefresh{root: &CmdRoot{}}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(
+				`{"type": "sync", "result": {"id":"%s","path":"%s"}}`,
+				m.prjId,
+				m.prjDir,
+			)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(
+				r.URL.Path,
+				check.Equals,
+				fmt.Sprintf("/v1/projects/%s/workshops", m.prjId),
+			)
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, `{
+				"type": "error",
+				"status-code": 400,
+				"result": {
+					"kind": "change-conflict",
+					"message": "cannot refresh \\\"dev\\\": change is in progress",
+					"value": {
+						"change-id": "30",
+						"change-kind": "launch",
+						"change-status": "Do",
+						"project-id": "42424242",
+						"workshop": "dev"
+					}
+				}
+			}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"dev"})
+	c.Assert(
+		err,
+		check.ErrorMatches,
+		`
+cannot refresh "dev": change launch is in progress
+To view details: "workshop tasks 30"`[1:],
+	)
+}
+
+// TestConflictWaitingOnRefresh checks that refresh explains a paused refresh
+// conflict and shows the recovery commands.
+func (m *workshopRefresh) TestConflictWaitingOnRefresh(c *check.C) {
+	cmd := &CmdRefresh{root: &CmdRoot{}}
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(
+				`{"type": "sync", "result": {"id":"%s","path":"%s"}}`,
+				m.prjId,
+				m.prjDir,
+			)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(
+				r.URL.Path,
+				check.Equals,
+				fmt.Sprintf("/v1/projects/%s/workshops", m.prjId),
+			)
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, `{
+				"type": "error",
+				"status-code": 400,
+				"result": {
+					"kind": "change-conflict",
+					"message": "cannot refresh \\\"dev\\\": waiting on error",
+					"value": {
+						"change-id": "29",
+						"change-kind": "refresh",
+						"change-status": "Wait",
+						"project-id": "42424242",
+						"workshop": "dev"
+					}
+				}
+			}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(cmd.Command(), []string{"dev"})
+	c.Assert(
+		err,
+		check.ErrorMatches,
+		`
+cannot refresh "dev"; paused
+To view details: "workshop tasks 29"
+
+To abort and undo: "workshop refresh --abort dev"
+Otherwise, resolve the error, then run "workshop refresh --continue dev"`[1:],
+	)
+}
+
 func (m *workshopRefresh) TestRefreshTransactionalSuccess(c *check.C) {
 	cmd := &CmdRefresh{root: &CmdRoot{}}
 	n := 0

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -115,8 +115,8 @@ func (m *workshopRefresh) SetUpTest(c *check.C) {
 	m.BaseWorkshopSuite.SetUpTest(c)
 }
 
-// TestConflictInProgress checks that refresh explains a blocking in-progress
-// change and points the user to the task details.
+// TestConflictInProgress checks that refresh reports a blocking non-refresh
+// change on a single line naming its kind.
 func (m *workshopRefresh) TestConflictInProgress(c *check.C) {
 	cmd := &CmdRefresh{root: &CmdRoot{}}
 	n := 0
@@ -145,11 +145,10 @@ func (m *workshopRefresh) TestConflictInProgress(c *check.C) {
 				"status-code": 400,
 				"result": {
 					"kind": "change-conflict",
-					"message": "cannot refresh \\\"dev\\\": change is in progress",
+					"message": "workshop \"dev\" has \"launch\" change in progress",
 					"value": {
 						"change-id": "30",
 						"change-kind": "launch",
-						"change-status": "Do",
 						"project-id": "42424242",
 						"workshop": "dev"
 					}
@@ -164,9 +163,7 @@ func (m *workshopRefresh) TestConflictInProgress(c *check.C) {
 	c.Assert(
 		err,
 		check.ErrorMatches,
-		`
-cannot refresh "dev": change launch is in progress
-To view details: "workshop tasks 30"`[1:],
+		`cannot refresh "dev": launch change is in progress`,
 	)
 }
 
@@ -200,11 +197,10 @@ func (m *workshopRefresh) TestConflictWaitingOnRefresh(c *check.C) {
 				"status-code": 400,
 				"result": {
 					"kind": "change-conflict",
-					"message": "cannot refresh \\\"dev\\\": waiting on error",
+					"message": "workshop \"dev\" has \"refresh\" change in progress",
 					"value": {
 						"change-id": "29",
 						"change-kind": "refresh",
-						"change-status": "Wait",
 						"project-id": "42424242",
 						"workshop": "dev"
 					}
@@ -219,12 +215,7 @@ func (m *workshopRefresh) TestConflictWaitingOnRefresh(c *check.C) {
 	c.Assert(
 		err,
 		check.ErrorMatches,
-		`
-cannot refresh "dev"; paused
-To view details: "workshop tasks 29"
-
-To abort and undo: "workshop refresh --abort dev"
-Otherwise, resolve the error, then run "workshop refresh --continue dev"`[1:],
+		`cannot refresh "dev"; another refresh change is waiting on error`,
 	)
 }
 
@@ -286,7 +277,7 @@ func (m *workshopRefresh) TestRefreshTransactionalFailedAndAborted(c *check.C) {
 
 	err := cmd.Run(cmd.Command(), []string{"ws", "ws-1"})
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `cannot refresh "ws", "ws-1": aborted
+	c.Assert(err, check.ErrorMatches, `cannot refresh "ws", "ws-1"; aborted
 To view details: "workshop tasks 42"`)
 	c.Check(n, check.Equals, 3)
 }

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4566,6 +4566,69 @@ func (s *apiSuite) TestRefreshConflictChange(c *check.C) {
 	c.Assert(s.secBackend.RemoveCalls, check.HasLen, 1)
 }
 
+// TestRefreshWorkshopChangeConflict checks that a refresh action blocked by a
+// waiting change returns a structured change-conflict API error.
+func (s *apiSuite) TestRefreshWorkshopChangeConflict(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.createWFile(c, "basic", basic)
+	defer s.store.SetDownloadCallback(storeDownload(c))()
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
+	}
+	expected := []*expectedResp{{
+		Type:    ResponseTypeAsync,
+		Status:  http.StatusAccepted,
+		Kind:    "launch",
+		Summary: `Launch "basic" workshop`,
+	}}
+	s.runActionTest(c, requests, expected)
+
+	st := s.d.state
+	st.Lock()
+	refresh := st.NewChange("refresh", `Refresh "basic" workshop`)
+	refresh.Set("project-id", s.project.ProjectId)
+	refresh.SetStatus(state.WaitStatus)
+	task := st.NewTask("run-hook", "Run refresh hook")
+	task.Set("workshop", "basic")
+	task.Set("project", s.project)
+	refresh.AddTask(task)
+	refreshID := refresh.ID()
+	st.Unlock()
+
+	s.vars = map[string]string{"id": s.project.ProjectId}
+	req, err := s.createProjectsRequest(
+		"POST",
+		"/v1/projects/"+s.project.ProjectId+"/workshops",
+		bytes.NewBufferString(`{"names":["basic"],"action":"refresh"}`),
+	)
+	c.Assert(err, check.IsNil)
+
+	rsp := v1PostProjectWorkshop(
+		apiCmd("/v1/projects/{id}/workshops"),
+		req,
+		nil,
+	).(*resp)
+
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Assert(rsp.Status, check.Equals, http.StatusBadRequest)
+	result := rsp.Result.(*errorResult)
+	c.Check(result, check.DeepEquals, &errorResult{
+		Message: `workshop "basic" has "refresh" change in progress`,
+		Kind:    errorKindChangeConflict,
+		Value: changeConflictValue{
+			ChangeID:     refreshID,
+			ChangeKind:   "refresh",
+			ChangeStatus: "Wait",
+			ProjectID:    s.project.ProjectId,
+			Workshop:     "basic",
+		},
+	})
+}
+
 func (s *apiSuite) TestSnapshotRemovedAfterFailedRefresh(c *check.C) {
 	s.daemon(c)
 	s.d.Overlord().Loop()

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4579,12 +4579,14 @@ func (s *apiSuite) TestRefreshWorkshopChangeConflict(c *check.C) {
 	requests := []*bytes.Buffer{
 		bytes.NewBufferString(`{"names":["basic"],"action":"launch"}`),
 	}
-	expected := []*expectedResp{{
-		Type:    ResponseTypeAsync,
-		Status:  http.StatusAccepted,
-		Kind:    "launch",
-		Summary: `Launch "basic" workshop`,
-	}}
+	expected := []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "launch",
+			Summary: `Launch "basic" workshop`,
+		},
+	}
 	s.runActionTest(c, requests, expected)
 
 	st := s.d.state
@@ -4620,11 +4622,10 @@ func (s *apiSuite) TestRefreshWorkshopChangeConflict(c *check.C) {
 		Message: `workshop "basic" has "refresh" change in progress`,
 		Kind:    errorKindChangeConflict,
 		Value: changeConflictValue{
-			ChangeID:     refreshID,
-			ChangeKind:   "refresh",
-			ChangeStatus: "Wait",
-			ProjectID:    s.project.ProjectId,
-			Workshop:     "basic",
+			ChangeID:   refreshID,
+			ChangeKind: "refresh",
+			ProjectID:  s.project.ProjectId,
+			Workshop:   "basic",
 		},
 	})
 }

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -314,21 +314,9 @@ func (w *WorkshopManager) workshopManifest(ctx context.Context, projectId, name 
 		return nil, err
 	}
 
-	health := healthstate.WorkshopHealth(w.state, wp)
-	if health.Status == healthstate.PendingStatus ||
-		health.Status == healthstate.WaitingStatus {
-		err := conflict.CheckChangeConflict(
-			w.state,
-			projectId,
-			name,
-			[]string{"exec"},
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if err := healthstate.CheckWorkshopHealth(w.state, wp, []healthstate.Status{healthstate.ReadyStatus}); err != nil {
+	err = healthstate.CheckWorkshopHealth(
+		w.state, wp, []healthstate.Status{healthstate.ReadyStatus})
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -314,6 +314,20 @@ func (w *WorkshopManager) workshopManifest(ctx context.Context, projectId, name 
 		return nil, err
 	}
 
+	health := healthstate.WorkshopHealth(w.state, wp)
+	if health.Status == healthstate.PendingStatus ||
+		health.Status == healthstate.WaitingStatus {
+		err := conflict.CheckChangeConflict(
+			w.state,
+			projectId,
+			name,
+			[]string{"exec"},
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err := healthstate.CheckWorkshopHealth(w.state, wp, []healthstate.Status{healthstate.ReadyStatus}); err != nil {
 		return nil, err
 	}

--- a/internal/overlord/workshopstate/manifest_test.go
+++ b/internal/overlord/workshopstate/manifest_test.go
@@ -409,6 +409,38 @@ func (s *manifestSuite) TestLaunchAvoidsConflicts(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `cannot launch "test-2": other changes in progress: workshop "test-2" has "launch" change in progress`)
 }
 
+// TestRefreshManifestsWaitingReturnsChangeConflict checks that refresh returns
+// the blocking change details when a workshop is waiting on an errored change.
+func (s *manifestSuite) TestRefreshManifestsWaitingReturnsChangeConflict(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.launchWorkshopWithSDKs(c, "test-1", "ubuntu@20.04", nil)
+	change := s.state.NewChange("refresh", "refresh test-1")
+	change.Set("project-id", s.project.ProjectId)
+	change.SetStatus(state.WaitStatus)
+	task := s.state.NewTask("run-hook", "Run refresh hook")
+	task.Set("workshop", "test-1")
+	task.Set("project", s.project)
+	change.AddTask(task)
+
+	_, _, err := s.manager.RefreshManifests(
+		s.ctx,
+		s.project,
+		[]string{"test-1"},
+		conflict.RefreshUpdate,
+	)
+	var conflictErr *conflict.ChangeConflictError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, &conflict.ChangeConflictError{
+		ProjectId:    s.project.ProjectId,
+		Workshop:     "test-1",
+		ChangeKind:   "refresh",
+		ChangeStatus: "Wait",
+		ChangeID:     change.ID(),
+	})
+}
+
 func (s *manifestSuite) TestRefreshRequiresWorkshopExistence(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/overlord/workshopstate/manifest_test.go
+++ b/internal/overlord/workshopstate/manifest_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/canonical/workshop/internal/arch"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord/conflict"
+	"github.com/canonical/workshop/internal/overlord/healthstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
@@ -409,38 +410,6 @@ func (s *manifestSuite) TestLaunchAvoidsConflicts(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `cannot launch "test-2": other changes in progress: workshop "test-2" has "launch" change in progress`)
 }
 
-// TestRefreshManifestsWaitingReturnsChangeConflict checks that refresh returns
-// the blocking change details when a workshop is waiting on an errored change.
-func (s *manifestSuite) TestRefreshManifestsWaitingReturnsChangeConflict(c *check.C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	s.launchWorkshopWithSDKs(c, "test-1", "ubuntu@20.04", nil)
-	change := s.state.NewChange("refresh", "refresh test-1")
-	change.Set("project-id", s.project.ProjectId)
-	change.SetStatus(state.WaitStatus)
-	task := s.state.NewTask("run-hook", "Run refresh hook")
-	task.Set("workshop", "test-1")
-	task.Set("project", s.project)
-	change.AddTask(task)
-
-	_, _, err := s.manager.RefreshManifests(
-		s.ctx,
-		s.project,
-		[]string{"test-1"},
-		conflict.RefreshUpdate,
-	)
-	var conflictErr *conflict.ChangeConflictError
-	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
-	c.Check(conflictErr, check.DeepEquals, &conflict.ChangeConflictError{
-		ProjectId:    s.project.ProjectId,
-		Workshop:     "test-1",
-		ChangeKind:   "refresh",
-		ChangeStatus: "Wait",
-		ChangeID:     change.ID(),
-	})
-}
-
 func (s *manifestSuite) TestRefreshRequiresWorkshopExistence(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -471,6 +440,40 @@ func (s *manifestSuite) TestRefreshRequiresStatusReady(c *check.C) {
 
 	_, _, err = s.manager.RefreshManifests(s.ctx, s.project, []string{"test-1", "test-2", "test-3"}, conflict.RefreshRestore)
 	c.Assert(err, check.ErrorMatches, `cannot refresh "test-2": not running`)
+}
+
+// TestRefreshManifestsWaitingReturnsChangeConflict checks that refresh returns a
+// typed [healthstate.ChangeInProgressError], rather than a generic health
+// error, when a workshop is waiting on an errored change.
+func (s *manifestSuite) TestRefreshManifestsWaitingReturnsChangeConflict(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.launchWorkshopWithSDKs(c, "test-1", "ubuntu@20.04", nil)
+	change := s.state.NewChange("refresh", "refresh test-1")
+	change.Set("project-id", s.project.ProjectId)
+	change.SetStatus(state.WaitStatus)
+	task := s.state.NewTask("run-hook", "Run refresh hook")
+	task.Set("workshop", "test-1")
+	task.Set("project", s.project)
+	change.AddTask(task)
+
+	expected := healthstate.ChangeInProgressError{
+		ChangeID:   change.ID(),
+		ChangeKind: "refresh",
+		ProjectID:  s.project.ProjectId,
+		Workshop:   "test-1",
+	}
+
+	_, _, err := s.manager.RefreshManifests(s.ctx, s.project, []string{"test-1"}, conflict.RefreshUpdate)
+	var updateErr healthstate.ChangeInProgressError
+	c.Assert(errors.As(err, &updateErr), check.Equals, true)
+	c.Check(updateErr, check.DeepEquals, expected)
+
+	_, _, err = s.manager.RefreshManifests(s.ctx, s.project, []string{"test-1"}, conflict.RefreshRestore)
+	var restoreErr healthstate.ChangeInProgressError
+	c.Assert(errors.As(err, &restoreErr), check.Equals, true)
+	c.Check(restoreErr, check.DeepEquals, expected)
 }
 
 func (s *manifestSuite) TestLaunchRequiresFile(c *check.C) {

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -1,4 +1,4 @@
-summary: Check a failed non-transactional refresh can be aborted successfully
+summary: Check a failed refresh reports the aborted error and can be reverted
 prepare: |
   . "$TESTSLIB"/utils.sh
   workshop_exec launch
@@ -10,18 +10,21 @@ execute: |
 
   echo "Update the workshop file to include a failing SDK"
   sed -i 's/test-sdk-basic-2/test-sdk-setup-fail/g' workshop.yaml
+
+  echo "Check a failed transactional refresh reports the aborted error"
+  ! workshop_exec refresh > error.log 2>&1 || false
+  MATCH '^error: cannot refresh "ws-refresh-abort"; aborted$' < error.log
+  MATCH '^To view details: "workshop tasks [0-9]+"$' < error.log
+
+  echo "Check the transactional refresh reverted the workshop to Ready"
+  workshop_exec list | MATCH "^ws-refresh-abort[[:space:]]+Ready[[:space:]]+-$"
+
+  echo "Pause a refresh on the same error with --wait-on-error"
   workshop_exec refresh --wait-on-error || true
   sed -i 's/test-sdk-setup-fail/test-sdk-basic-2/g' workshop.yaml
 
   echo "Check the workshop is in Waiting state"
   workshop_exec list | MATCH "^ws-refresh-abort[[:space:]]+Waiting[[:space:]]+wait-on-error$"
-
-  echo "Check refresh explains the blocking refresh conflict"
-  ! workshop_exec refresh > error.log 2>&1 || false
-  MATCH '^error: cannot refresh "ws-refresh-abort"; paused$' < error.log
-  MATCH '^To view details: "workshop tasks [0-9]+"$' < error.log
-  MATCH '^To abort and undo: "workshop refresh --abort ws-refresh-abort"$' < error.log
-  MATCH '^Otherwise, resolve the error, then run "workshop refresh --continue ws-refresh-abort"$' < error.log
 
   echo "Check the \"workshop refresh --abort\" command reverts to the previous state"
   workshop_exec refresh --abort | MATCH "\"ws-refresh-abort\" refresh aborted"

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -16,6 +16,13 @@ execute: |
   echo "Check the workshop is in Waiting state"
   workshop_exec list | MATCH "^ws-refresh-abort[[:space:]]+Waiting[[:space:]]+wait-on-error$"
 
+  echo "Check refresh explains the blocking refresh conflict"
+  ! workshop_exec refresh > error.log 2>&1 || false
+  MATCH '^error: cannot refresh "ws-refresh-abort"; paused$' < error.log
+  MATCH '^To view details: "workshop tasks [0-9]+"$' < error.log
+  MATCH '^To abort and undo: "workshop refresh --abort ws-refresh-abort"$' < error.log
+  MATCH '^Otherwise, resolve the error, then run "workshop refresh --continue ws-refresh-abort"$' < error.log
+
   echo "Check the \"workshop refresh --abort\" command reverts to the previous state"
   workshop_exec refresh --abort | MATCH "\"ws-refresh-abort\" refresh aborted"
   workshop_exec list | MATCH "^ws-refresh-abort[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/refresh-conflict/task.yaml
+++ b/tests/main/refresh-conflict/task.yaml
@@ -1,0 +1,28 @@
+summary: Check refreshing a workshop waiting on a refresh error fails clearly
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Update the workshop file to include a failing SDK"
+  sed -i 's/test-sdk-basic-2/test-sdk-setup-fail/g' workshop.yaml
+  workshop_exec refresh --wait-on-error || true
+  sed -i 's/test-sdk-setup-fail/test-sdk-basic-2/g' workshop.yaml
+
+  echo "Check the workshop is in Waiting state"
+  workshop_exec list | MATCH "^ws-refresh-conflict[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+
+  echo "Check refreshing a workshop waiting on a refresh error fails clearly"
+  ! workshop_exec refresh > error.log 2>&1 || false
+  MATCH '^error: cannot refresh "ws-refresh-conflict"; another refresh change is waiting on error$' < error.log
+
+  echo "Check the workshop is still in Waiting state"
+  workshop_exec list | MATCH "^ws-refresh-conflict[[:space:]]+Waiting[[:space:]]+wait-on-error$"
+
+  echo "Abort the refresh to restore the workshop to a clean state"
+  workshop_exec refresh --abort | MATCH "\"ws-refresh-conflict\" refresh aborted"
+  workshop_exec list | MATCH "^ws-refresh-conflict[[:space:]]+Ready[[:space:]]+-$"

--- a/tests/main/refresh-conflict/workshop.yaml
+++ b/tests/main/refresh-conflict/workshop.yaml
@@ -1,0 +1,4 @@
+name: ws-refresh-conflict
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic-2


### PR DESCRIPTION
# Description

Stacked on top of https://github.com/canonical/workshop/pull/831, applying
the change-conflict treatment centralised in
https://github.com/canonical/workshop/pull/829 and
https://github.com/canonical/workshop/pull/831 to `workshop refresh`.

Previously, a refresh blocked by another change surfaced a generic error:

```text
error: cannot refresh "dev": waiting on error
```

After this change, refresh reports the blocking change on a single line,
keyed on its kind. A paused refresh:

```text
error: cannot refresh "dev"; another refresh change is waiting on error
```

Any other blocking change names its kind:

```text
error: cannot refresh "dev": launch change is in progress
```

The refresh outcome messages are unchanged in spirit: a refresh that pauses
under `--wait-on-error` still shows the paused recovery block, and a failed
transactional refresh still reports it was aborted -- this PR aligns that
message with the "; <state>" wording of the paused case ("; aborted").

Layering:

- Detection reuses the centralised `healthstate.CheckWorkshopHealth` guard
  that already gates refresh; a workshop waiting on an errored change yields
  a typed `healthstate.ChangeInProgressError`. No bespoke conflict check is
  added to `RefreshManifests`.
- The daemon maps that error to a structured `change-conflict` response
  (from the #829 / #831 rework).
- The CLI formats the message from `client.ChangeConflictError`,
  distinguishing a paused refresh from other blocking changes by the kind.

Validation:

```text
go test ./cmd/workshop ./internal/overlord/workshopstate ./internal/daemon
/tmp/spread/spread-bin tests/main/refresh-abort tests/main/refresh-conflict
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically.
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
