### PR TITLE
Add workaround for LXD not unmounting stopped containers

### DIFF
--- a/tests/lib/wait-snapshots-unmounted.sh
+++ b/tests/lib/wait-snapshots-unmounted.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Workaround for https://github.com/canonical/lxd/issues/18362.
+
+set -e
+
+pid=$(</var/snap/lxd/common/lxd.pid)
+
+pending() {
+    findmnt --noheadings --output=TARGET --raw --task="$pid" > mounted.log
+    grep '/storage-pools/workshop/containers/workshop-snapshots\.' < mounted.log > mounted-snapshots.log
+}
+
+for ((i = 0; i < 120; i++)); do
+    status=0
+    pending || status="$?"
+    if [ "$status" -eq 0 ]; then
+        echo 'Still mounted:'
+        cat mounted-snapshots.log
+        sleep 1
+    elif [ "$status" -eq 1 ]; then
+        exit 0
+    else
+        exit "$status"
+    fi
+done
+
+echo "Timed out!"
+exit 1

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -5,7 +5,7 @@ execute: |
 
   workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"
 
-  zpool wait workshop || true
+  "$TESTSLIB"/wait-snapshots-unmounted.sh
   snap remove lxd --purge
   retry 5 snap install lxd --channel=5.21/stable
   lxd waitready
@@ -13,7 +13,7 @@ execute: |
   ! workshop_exec list > error.log 2>&1 || false
   MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.8.\*$" < error.log
 
-  zpool wait workshop || true
+  "$TESTSLIB"/wait-snapshots-unmounted.sh
   snap remove lxd --purge
   setup_lxd
   snap restart workshop

--- a/tests/main/firewall-docker/task.yaml
+++ b/tests/main/firewall-docker/task.yaml
@@ -4,7 +4,7 @@ prepare: |
 
   # Remove LXD so Docker is the first to enable ip_forward and sets FORWARD
   # policy to DROP.
-  zpool wait workshop || true
+  "$TESTSLIB"/wait-snapshots-unmounted.sh
   snap remove lxd --purge
   sysctl -w net.ipv4.ip_forward=0
 
@@ -33,7 +33,7 @@ restore: |
   # Flush leftover Docker nft rules, then restore LXD and workshop
   # to clean state. LXD recreates its own rules on setup.
   nft flush ruleset
-  zpool wait workshop || true
+  "$TESTSLIB"/wait-snapshots-unmounted.sh
   snap remove lxd --purge
   setup_lxd
   rm -f /home/ubuntu/.cache/workshop/warnings.json


### PR DESCRIPTION
# Description

Adds a helper script that waits for LXD to unmount stopped container volumes before `zpool export` runs during LXD shutdown. Without this, `zpool export` can fail with "pool is busy" because LXD's forkfile helper keeps container rootfs mounts alive after a `lxc file` operation. See https://github.com/canonical/lxd/issues/18362.

Tested locally, and remotely (`tests/main` passed 5 times; that was also happening with the previous workaround but hopefully this one will hold up better).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.