### PR TITLE
handle hook Stat errors

### DIFF
--- a/internal/fsutil/sftp.go
+++ b/internal/fsutil/sftp.go
@@ -36,6 +36,7 @@ const (
 var sftpStatusError = regexp.MustCompile(`^sftp: (.*) \([^()]*\)$`)
 var dirNotEmptyError = regexp.MustCompile(`^([a-z]*) .*: directory not empty$`)
 var fileExistsError = regexp.MustCompile(`^([a-z]*) .*: file exists$`)
+var notDirError = regexp.MustCompile(`^([a-z]*) .*: not a directory$`)
 
 func NewSftpFs(client *sftp.Client, umask os.FileMode) Fs {
 	return Fs{&sftpFs{client, umask}}
@@ -242,6 +243,10 @@ func maybePathError(op, path string, err error) error {
 
 	if match = dirNotEmptyError.FindStringSubmatch(message); match != nil {
 		return &os.PathError{Op: match[1], Path: path, Err: syscall.ENOTEMPTY}
+	}
+
+	if match = notDirError.FindStringSubmatch(message); match != nil {
+		return &os.PathError{Op: match[1], Path: path, Err: syscall.ENOTDIR}
 	}
 
 	return errors.New(message)

--- a/internal/fsutil/sftp_test.go
+++ b/internal/fsutil/sftp_test.go
@@ -131,6 +131,14 @@ func (s *sftpSuite) TestStat(c *check.C) {
 	c.Check(info, check.IsNil)
 }
 
+func (s *sftpSuite) TestStatNotDir(c *check.C) {
+	c.Assert(s.fs.WriteFile("testfile", nil, 0644), check.IsNil)
+
+	info, err := s.fs.Stat("testfile/child")
+	c.Assert(err, testutil.ErrorIs, syscall.ENOTDIR)
+	c.Check(info, check.IsNil)
+}
+
 func (s *sftpSuite) TestLstat(c *check.C) {
 	info, err := s.fs.Lstat("notexist")
 	c.Assert(err, check.ErrorMatches, `lstat notexist: file does not exist`)

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -232,7 +232,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w strin
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("cannot inspect %q hook for %q SDK: %w", hook.Type(), hook.Sdk, err)
+		return fmt.Errorf("cannot read hook: %w", err)
 	}
 	if !info.Mode().IsRegular() {
 		logger.Debugf("%q SDK does not provide %q hook", hook.Sdk, hook.Type())

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"syscall"
 
 	"github.com/canonical/x-go/strutil"
 	"gopkg.in/tomb.v2"
@@ -227,7 +228,7 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w strin
 
 	info, err := wsFs.Stat(hookPath)
 	wsFs.Close()
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
 		logger.Debugf("%q SDK does not provide %q hook", hook.Sdk, hook.Type())
 		return nil
 	}

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -227,7 +227,14 @@ func (h *HookManager) executeHook(ctx context.Context, task *state.Task, w strin
 
 	info, err := wsFs.Stat(hookPath)
 	wsFs.Close()
-	if errors.Is(err, os.ErrNotExist) || !info.Mode().IsRegular() {
+	if errors.Is(err, os.ErrNotExist) {
+		logger.Debugf("%q SDK does not provide %q hook", hook.Sdk, hook.Type())
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("cannot inspect %q hook for %q SDK: %w", hook.Type(), hook.Sdk, err)
+	}
+	if !info.Mode().IsRegular() {
 		logger.Debugf("%q SDK does not provide %q hook", hook.Sdk, hook.Type())
 		return nil
 	}

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -169,7 +169,7 @@ func (s *hookSuite) TestExecHookPathError(c *check.C) {
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
 	c.Check(err, check.IsNil)
 
-	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
+	fs, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
 	defer ws.Close()
 	err = ws.MkdirAll(filepath.Dir(sdk.SdkHooksDir("one")), 0755)

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -151,6 +151,44 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 	c.Check(t1.Status(), check.Equals, state.DoneStatus)
 }
 
+func (s *hookSuite) TestExecHookPathError(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, "one", 0, hookstate.SetupBase)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	// Launch a workshop with a malformed SDK layout: hooks is a regular file
+	// instead of a directory. Stat() on sdk/hooks/setup-base then returns
+	// ENOTDIR and should be reported as a task error rather than panicking.
+	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
+	c.Check(err, check.IsNil)
+
+	ws, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Check(err, check.IsNil)
+	defer ws.Close()
+	err = ws.MkdirAll(filepath.Dir(sdk.SdkHooksDir("one")), 0755)
+	c.Check(err, check.IsNil)
+	err = ws.WriteFile(sdk.SdkHooksDir("one"), []byte("not a directory"), 0644)
+	c.Check(err, check.IsNil)
+
+	s.state.Unlock()
+	err = s.se.Ensure()
+	c.Assert(err, check.IsNil)
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
+	c.Check(t1.Log(), check.HasLen, 1)
+	c.Check(t1.Log()[0], check.Matches, `.*cannot inspect "setup-base" hook for "one" SDK:.*`)
+	c.Check(s.backend.ExecCalls, check.HasLen, 0)
+}
+
 func (s *hookSuite) TestExecSetupProject(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -21,6 +21,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"syscall"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/fsutil"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/hookstate"
@@ -54,6 +56,15 @@ type hookSuite struct {
 }
 
 var _ = check.Suite(&hookSuite{})
+
+type statErrorFs struct {
+	fsutil.Fs
+	err error
+}
+
+func (f statErrorFs) Stat(string) (os.FileInfo, error) {
+	return nil, f.err
+}
 
 func TestHookSuite(t *testing.T) { check.TestingT(t) }
 
@@ -151,7 +162,7 @@ func (s *hookSuite) TestExecHookDoesNotExist(c *check.C) {
 	c.Check(t1.Status(), check.Equals, state.DoneStatus)
 }
 
-func (s *hookSuite) TestExecHookPathError(c *check.C) {
+func (s *hookSuite) TestExecHookSkipsStrayHooksFile(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	t1 := hookstate.Hook(s.state, "one", 0, hookstate.SetupBase)
@@ -161,9 +172,6 @@ func (s *hookSuite) TestExecHookPathError(c *check.C) {
 	chg.Set("user", "testuser")
 	chg.AddTask(t1)
 
-	// Launch a workshop with a malformed SDK layout: hooks is a regular file
-	// instead of a directory. Stat() on sdk/hooks/setup-base then returns
-	// ENOTDIR and should be reported as a task error rather than panicking.
 	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
 	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
 	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
@@ -171,11 +179,51 @@ func (s *hookSuite) TestExecHookPathError(c *check.C) {
 
 	fs, err := s.backend.WorkshopFs(s.ctx, "ws")
 	c.Check(err, check.IsNil)
-	defer ws.Close()
-	err = ws.MkdirAll(filepath.Dir(sdk.SdkHooksDir("one")), 0755)
+	defer fs.Close()
+	err = fs.MkdirAll(filepath.Dir(sdk.SdkHooksDir("one")), 0755)
 	c.Check(err, check.IsNil)
-	err = ws.WriteFile(sdk.SdkHooksDir("one"), []byte("not a directory"), 0644)
+	err = fs.WriteFile(sdk.SdkHooksDir("one"), []byte("not a directory"), 0644)
 	c.Check(err, check.IsNil)
+
+	s.state.Unlock()
+	err = s.se.Ensure()
+	c.Assert(err, check.IsNil)
+	s.se.Wait()
+	s.state.Lock()
+
+	c.Check(t1.Status(), check.Equals, state.DoneStatus)
+	c.Check(t1.Log(), check.HasLen, 0)
+	c.Check(s.backend.ExecCalls, check.HasLen, 0)
+}
+
+func (s *hookSuite) TestExecHookStatError(c *check.C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+	t1 := hookstate.Hook(s.state, "one", 0, hookstate.SetupBase)
+
+	chg := s.state.NewChange("sample", "...")
+	setWorkshopProject("ws", s.project, t1)
+	chg.Set("user", "testuser")
+	chg.AddTask(t1)
+
+	wf := &workshop.File{Name: "ws", Base: "ubuntu@20.04"}
+	snapshot := workshop.BaseOnly(sdk.R(1), wf.Base, "fakeimage123")
+	err := s.backend.LaunchOrRebuildWorkshop(s.ctx, wf, snapshot)
+	c.Check(err, check.IsNil)
+
+	fs, err := s.backend.WorkshopFs(s.ctx, "ws")
+	c.Check(err, check.IsNil)
+
+	statErr := &os.PathError{
+		Op:   "stat",
+		Path: sdk.SdkHookPath("one", hookstate.SetupBase.String()),
+		Err:  syscall.EIO,
+	}
+
+	restore := s.backend.SetWorkshopFsCallback(func(context.Context, string) (fsutil.Fs, error) {
+		return fsutil.Fs{FsBackend: statErrorFs{Fs: fs, err: statErr}}, nil
+	})
+	defer restore()
 
 	s.state.Unlock()
 	err = s.se.Ensure()
@@ -185,7 +233,7 @@ func (s *hookSuite) TestExecHookPathError(c *check.C) {
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
-	c.Check(t1.Log()[0], check.Matches, `.*cannot inspect "setup-base" hook for "one" SDK:.*`)
+	c.Check(t1.Log()[0], check.Matches, `(?s).*cannot read hook: stat .*/setup-base: input/output error.*`)
 	c.Check(s.backend.ExecCalls, check.HasLen, 0)
 }
 


### PR DESCRIPTION
Fixes: #846

# Description
Fix a `workshopd` panic when inspecting malformed SDK hook paths.

If a project-local SDK has `sdk/hooks` as a regular file instead of a directory, hook inspection can return `not a directory`. Previously this could dereference a nil `FileInfo` and crash `workshopd`. This change returns a normal task error instead, while preserving the existing behavior for missing hooks.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
