### PR TITLE
Fix slot preservation check in sketch SDK

### DIFF
--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -325,7 +325,7 @@ func validateProjectSdk(document *yaml.Node, expected *SketchFile) error {
 	if !reflect.DeepEqual(expected.Plugs, actual.Plugs) {
 		return errors.New("internal error: sketch SDK plugs not preserved")
 	}
-	if !reflect.DeepEqual(actual.Slots, actual.Slots) {
+	if !reflect.DeepEqual(expected.Slots, actual.Slots) {
 		return errors.New("internal error: sketch SDK slots not preserved")
 	}
 	if len(actual.Hooks) > 0 {


### PR DESCRIPTION
# Description
While investigating #846, I noticed a typo in the slot validation logic in `validateProjectSdk()`.

The code was comparing `actual.Slots` with itself, which means the check always returned true.
I believe the intended comparison was between `expected.Slots` and `actual.Slots`, so this fixes that.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
