### PR TITLE
Only lookup stash Manifest when discarding a refresh Change

### DIFF
--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1257,6 +1257,59 @@ func (s *apiSuite) TestLaunchWorkshopFailed(c *check.C) {
 	s.ensureSnapshotsAfterCooldown(c, nil, []string{"system", "test-sdk", "test-sdk-2"})
 }
 
+func (s *apiSuite) TestSnapshotsRemovedAfterRemoveMidLaunch(c *check.C) {
+	s.daemon(c)
+	s.d.Overlord().Loop()
+	defer s.d.Overlord().Stop()
+
+	s.createWFile(c, "manysdks", manysdks)
+	defer s.store.SetDownloadCallback(storeDownload(c))()
+
+	// Fail when snapshotting test-sdk-2.
+	s.b.SnapshotCallback = func(ctx context.Context, name string, snapshot workshop.Snapshot) error {
+		if len(snapshot.Sdks) > 2 {
+			return errors.New("cannot take snapshot")
+		}
+		return nil
+	}
+
+	requests := []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"launch","options":{"mode":"wait-on-error"}}`),
+	}
+	expected := []*expectedResp{
+		{
+			Type:      ResponseTypeAsync,
+			Status:    http.StatusAccepted,
+			Kind:      "launch",
+			Summary:   `Launch "manysdks" workshop`,
+			ChangeErr: `(?s).*cannot take snapshot.*`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	c.Assert(s.b.Snapshots, check.HasLen, 2)
+	st := s.d.state
+	st.Lock()
+	err := conflict.CheckChangeConflict(st, s.project.ProjectId, "manysdks", []string{"exec"})
+	st.Unlock()
+	c.Assert(err, check.NotNil)
+
+	requests = []*bytes.Buffer{
+		bytes.NewBufferString(`{"names":["manysdks"],"action":"remove"}`),
+	}
+	expected = []*expectedResp{
+		{
+			Type:    ResponseTypeAsync,
+			Status:  http.StatusAccepted,
+			Kind:    "remove",
+			Summary: `Remove "manysdks" workshop`,
+		},
+	}
+	s.runActionTest(c, requests, expected)
+
+	s.ensureSnapshotsAfterCooldown(c, nil, []string{"system", "test-sdk"})
+}
+
 //go:embed snapshot-format.yaml
 var snapshotFormat []byte
 

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -180,23 +180,27 @@ func (w *WorkshopManager) maybeDiscardWaitingRefresh(projectId string, file *wor
 		return nil, nil
 	}
 
-	format, err := handlersetup.WorkshopFormat(chg, file.Name, handlersetup.OldWorkshop)
-	if err != nil {
-		return nil, err
-	}
-	image, err := handlersetup.WorkshopBase(chg, file.Name, handlersetup.OldWorkshop)
-	if err != nil {
-		return nil, err
-	}
-	sdks, err := handlersetup.WorkshopSdks(chg, file.Name, handlersetup.OldWorkshop)
-	if err != nil {
-		return nil, err
+	var stashed *Manifest
+	if chg.Kind() == "refresh" {
+		format, err := handlersetup.WorkshopFormat(chg, file.Name, handlersetup.OldWorkshop)
+		if err != nil {
+			return nil, err
+		}
+		image, err := handlersetup.WorkshopBase(chg, file.Name, handlersetup.OldWorkshop)
+		if err != nil {
+			return nil, err
+		}
+		sdks, err := handlersetup.WorkshopSdks(chg, file.Name, handlersetup.OldWorkshop)
+		if err != nil {
+			return nil, err
+		}
+		// The file here is not quite right, but we only use the name field. If
+		// that changes in future, we should reconstruct it from chg.
+		stashed = &Manifest{File: file, Format: format, Image: image, Sdks: sdks}
 	}
 
 	conflict.BackgroundDiscard(chg, file.Name)
-	// The file here is not quite right, but we only use the name field. If
-	// that changes in future, we should reconstruct it from chg.
-	return &Manifest{File: file, Format: format, Image: image, Sdks: sdks}, nil
+	return stashed, nil
 }
 
 type artifactFinder struct {

--- a/tests/main/remove/task.yaml
+++ b/tests/main/remove/task.yaml
@@ -31,7 +31,7 @@ execute: |
   workshop_exec remove ws-remove-mount
   workshop_exec list | MATCH "^ws-remove-mount[[:space:]]+Off[[:space:]]+-$"
 
-  echo "Check the workshop can be removed if in Waiting"
+  echo "Check the workshop can be removed if waiting on refresh"
   workshop_exec launch ws-remove
   cp .workshop/ws-remove.yaml .workshop/ws-remove.yaml.old
   cat <<EOF >> .workshop/ws-remove.yaml
@@ -39,6 +39,10 @@ execute: |
     - name: test-sdk-setup-fail
   EOF
   ! workshop_exec refresh --wait-on-error ws-remove || false
+  workshop_exec remove ws-remove
+
+  echo "Check the workshop can be removed if waiting on launch"
+  ! workshop_exec launch --wait-on-error ws-remove || false
   workshop_exec remove ws-remove
   mv .workshop/ws-remove.yaml.old .workshop/ws-remove.yaml
   workshop_exec list | MATCH "^ws-remove[[:space:]]+Off[[:space:]]+-$"


### PR DESCRIPTION
# Description

Fixes #859.

In order to clean up snapshots after removing a workshop during a `refresh --wait-on-error`, we inspect the `refresh` Change to see what SDKs went into the stash. This inspection was also performed for `launch` Changes even though the stash doesn't exist. I neglected to test this case and it seems like there was no coverage.

Now we only consider the stash for `refresh` Changes, and test that removing a workshop mid-launch (a) works and (b) cleans up the appropriate snapshots.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
