### PR TITLE
Skip snap publishing for fork PRs

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -85,7 +85,7 @@ jobs:
           if-no-files-found: ignore
   publish:
     needs: [build-deps, snap-tests]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
     steps:
       - name: Download snap artifact

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -85,6 +85,7 @@ jobs:
           if-no-files-found: ignore
   publish:
     needs: [build-deps, snap-tests]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Download snap artifact


### PR DESCRIPTION
## Summary

Skip the snap publish job for pull requests opened from forks.

## Details

Fork PRs do not receive repository secrets, so STORE_CREDENTIALS is empty. The spread workflow still tried to run canonical/action-publish, which caused the publish job to fail with:


gh
Error: login_data is empty


This change keeps the existing publish behaviour for:

- pushes
- same-repository PRs

but skips publishing for fork PRs, where store credentials are unavailable.