### PR TITLE
Report a clear error when aborting with no paused change

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -450,6 +450,10 @@ const (
 	ErrorKindNoDefaultServices  = "no-default-services"
 	ErrorKindUnsuccessful       = "unsuccessful"
 	ErrorKindNoUpdatesAvailable = "no-updates-available"
+
+	// ErrorKindNoWaitingChange identifies an abort or continue request made
+	// when no paused change is waiting for the workshop.
+	ErrorKindNoWaitingChange = "no-waiting-change-in-progress"
 )
 
 func IsNoUpdatesAvailable(err error) bool {

--- a/client/error.go
+++ b/client/error.go
@@ -31,6 +31,29 @@ type ChangeConflictError struct {
 	Workshop string
 }
 
+// WaitingChangeError describes an abort or continue request that could not be
+// applied because no change is paused waiting on error for the workshop.
+type WaitingChangeError struct {
+	// Reason classifies why no waiting change was available. It is one of the
+	// WaitingChange* reason constants.
+	Reason WaitingChangeReason
+}
+
+// WaitingChangeReason classifies why an abort or continue had no change paused
+// waiting on error to act on. Its values are carried in the change-not-waiting
+// API error.
+type WaitingChangeReason string
+
+const (
+	// WaitingChangeNoChange indicates no change is in progress for the
+	// workshop, so there is nothing for an abort or continue to act on.
+	WaitingChangeNoChange WaitingChangeReason = "no-change"
+
+	// WaitingChangeRunning indicates the change to be resumed exists but is
+	// still running rather than paused waiting on error.
+	WaitingChangeRunning WaitingChangeReason = "running"
+)
+
 // As maps generic API errors into richer client-side error types.
 func (e *Error) As(target any) bool {
 	switch e.Kind {
@@ -40,9 +63,33 @@ func (e *Error) As(target any) bool {
 			return false
 		}
 		return toChangeConflictError(*e, conflict)
+	case ErrorKindNoWaitingChange:
+		waiting, ok := target.(*WaitingChangeError)
+		if !ok {
+			return false
+		}
+		return toWaitingChangeError(*e, waiting)
 	default:
 		return false
 	}
+}
+
+// Error returns a human-readable description of the blocking change.
+func (e ChangeConflictError) Error() string {
+	if e.ChangeKind != "" {
+		return fmt.Sprintf(
+			"workshop %q has %q change in progress",
+			e.Workshop,
+			e.ChangeKind,
+		)
+	}
+	return fmt.Sprintf("workshop %q has changes in progress", e.Workshop)
+}
+
+// Error returns a human-readable fallback description. Callers that can render
+// their own message should branch on [WaitingChangeError.Reason] instead.
+func (e WaitingChangeError) Error() string {
+	return "no waiting change in progress"
 }
 
 // toChangeConflictError extracts change-conflict details from a generic API
@@ -71,14 +118,21 @@ func toChangeConflictError(err Error, conflict *ChangeConflictError) bool {
 	return true
 }
 
-// Error returns a human-readable description of the blocking change.
-func (e ChangeConflictError) Error() string {
-	if e.ChangeKind != "" {
-		return fmt.Sprintf(
-			"workshop %q has %q change in progress",
-			e.Workshop,
-			e.ChangeKind,
-		)
+// toWaitingChangeError extracts change-not-waiting details from a generic API
+// error. It returns true when the error value has the expected object shape,
+// even if the reason is missing or not a string; in that case the
+// [WaitingChangeError.Reason] field remains empty. It returns false when the
+// error value is not an object and therefore cannot represent the payload.
+func toWaitingChangeError(err Error, waiting *WaitingChangeError) bool {
+	value, ok := err.Value.(map[string]any)
+	if !ok {
+		return false
 	}
-	return fmt.Sprintf("workshop %q has changes in progress", e.Workshop)
+
+	reason, _ := value["reason"].(string)
+
+	*waiting = WaitingChangeError{
+		Reason: WaitingChangeReason(reason),
+	}
+	return true
 }

--- a/client/error.go
+++ b/client/error.go
@@ -14,7 +14,10 @@
 
 package client
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // ChangeConflictError describes an operation blocked by another change.
 type ChangeConflictError struct {
@@ -31,28 +34,10 @@ type ChangeConflictError struct {
 	Workshop string
 }
 
-// WaitingChangeError describes an abort or continue request that could not be
-// applied because no change is paused waiting on error for the workshop.
-type WaitingChangeError struct {
-	// Reason classifies why no waiting change was available. It is one of the
-	// WaitingChange* reason constants.
-	Reason WaitingChangeReason
-}
-
-// WaitingChangeReason classifies why an abort or continue had no change paused
-// waiting on error to act on. Its values are carried in the change-not-waiting
-// API error.
-type WaitingChangeReason string
-
-const (
-	// WaitingChangeNoChange indicates no change is in progress for the
-	// workshop, so there is nothing for an abort or continue to act on.
-	WaitingChangeNoChange WaitingChangeReason = "no-change"
-
-	// WaitingChangeRunning indicates the change to be resumed exists but is
-	// still running rather than paused waiting on error.
-	WaitingChangeRunning WaitingChangeReason = "running"
-)
+// ErrorNoWaitingChange signals that an abort or continue request could not be
+// applied because no change is in progress to resume for the workshop. Match
+// it with [errors.Is].
+var ErrorNoWaitingChange = errors.New("no waiting change in progress")
 
 // As maps generic API errors into richer client-side error types.
 func (e *Error) As(target any) bool {
@@ -63,12 +48,16 @@ func (e *Error) As(target any) bool {
 			return false
 		}
 		return toChangeConflictError(*e, conflict)
-	case ErrorKindNoWaitingChange:
-		waiting, ok := target.(*WaitingChangeError)
-		if !ok {
-			return false
-		}
-		return toWaitingChangeError(*e, waiting)
+	default:
+		return false
+	}
+}
+
+// Is reports whether the error matches a sentinel for the error's kind.
+func (e *Error) Is(target error) bool {
+	switch target {
+	case ErrorNoWaitingChange:
+		return e.Kind == ErrorKindNoWaitingChange
 	default:
 		return false
 	}
@@ -84,12 +73,6 @@ func (e ChangeConflictError) Error() string {
 		)
 	}
 	return fmt.Sprintf("workshop %q has changes in progress", e.Workshop)
-}
-
-// Error returns a human-readable fallback description. Callers that can render
-// their own message should branch on [WaitingChangeError.Reason] instead.
-func (e WaitingChangeError) Error() string {
-	return "no waiting change in progress"
 }
 
 // toChangeConflictError extracts change-conflict details from a generic API
@@ -114,25 +97,6 @@ func toChangeConflictError(err Error, conflict *ChangeConflictError) bool {
 		ChangeKind: changeKind,
 		ProjectID:  projectID,
 		Workshop:   workshop,
-	}
-	return true
-}
-
-// toWaitingChangeError extracts change-not-waiting details from a generic API
-// error. It returns true when the error value has the expected object shape,
-// even if the reason is missing or not a string; in that case the
-// [WaitingChangeError.Reason] field remains empty. It returns false when the
-// error value is not an object and therefore cannot represent the payload.
-func toWaitingChangeError(err Error, waiting *WaitingChangeError) bool {
-	value, ok := err.Value.(map[string]any)
-	if !ok {
-		return false
-	}
-
-	reason, _ := value["reason"].(string)
-
-	*waiting = WaitingChangeError{
-		Reason: WaitingChangeReason(reason),
 	}
 	return true
 }

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -95,56 +95,22 @@ func (errorSuite) TestChangeConflictErrorAsWrongKind(c *check.C) {
 	c.Check(errors.As(err, &conflictErr), check.Equals, false)
 }
 
-// TestWaitingChangeErrorAsMissingReason checks that a value object without a
-// reason still maps, leaving the reason empty.
-func (errorSuite) TestWaitingChangeErrorAsMissingReason(c *check.C) {
-	err := &client.Error{
-		Kind:  client.ErrorKindNoWaitingChange,
-		Value: map[string]any{},
-	}
-
-	var waitingErr client.WaitingChangeError
-	c.Assert(errors.As(err, &waitingErr), check.Equals, true)
-	c.Check(waitingErr.Reason, check.Equals, client.WaitingChangeReason(""))
-}
-
-// TestWaitingChangeErrorAsNonMapValue checks that unexpected API error value
-// shapes do not map to [client.WaitingChangeError].
-func (errorSuite) TestWaitingChangeErrorAsNonMapValue(c *check.C) {
-	err := &client.Error{
-		Kind:  client.ErrorKindNoWaitingChange,
-		Value: "not a map",
-	}
-
-	var waitingErr client.WaitingChangeError
-	c.Check(errors.As(err, &waitingErr), check.Equals, false)
-}
-
-// TestWaitingChangeErrorAsReason checks that a change-not-waiting API error
-// maps to [client.WaitingChangeError] carrying its reason.
-func (errorSuite) TestWaitingChangeErrorAsReason(c *check.C) {
+// TestWaitingChangeErrorIs checks that a no-waiting-change API error matches
+// the [client.ErrorNoWaitingChange] sentinel via errors.Is.
+func (errorSuite) TestWaitingChangeErrorIs(c *check.C) {
 	err := &client.Error{
 		Kind: client.ErrorKindNoWaitingChange,
-		Value: map[string]any{
-			"reason": string(client.WaitingChangeNoChange),
-		},
 	}
 
-	var waitingErr client.WaitingChangeError
-	c.Assert(errors.As(err, &waitingErr), check.Equals, true)
-	c.Check(waitingErr, check.DeepEquals, client.WaitingChangeError{
-		Reason: client.WaitingChangeNoChange,
-	})
+	c.Check(errors.Is(err, client.ErrorNoWaitingChange), check.Equals, true)
 }
 
-// TestWaitingChangeErrorAsWrongKind checks that unrelated API error kinds do
-// not map to [client.WaitingChangeError].
-func (errorSuite) TestWaitingChangeErrorAsWrongKind(c *check.C) {
+// TestWaitingChangeErrorIsWrongKind checks that unrelated API error kinds do
+// not match the [client.ErrorNoWaitingChange] sentinel.
+func (errorSuite) TestWaitingChangeErrorIsWrongKind(c *check.C) {
 	err := &client.Error{
-		Kind:  client.ErrorKindChangeConflict,
-		Value: map[string]any{"reason": string(client.WaitingChangeNoChange)},
+		Kind: client.ErrorKindChangeConflict,
 	}
 
-	var waitingErr client.WaitingChangeError
-	c.Check(errors.As(err, &waitingErr), check.Equals, false)
+	c.Check(errors.Is(err, client.ErrorNoWaitingChange), check.Equals, false)
 }

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -50,6 +50,18 @@ func (errorSuite) TestChangeConflictErrorAsFullValue(c *check.C) {
 	})
 }
 
+// TestChangeConflictErrorAsNonMapValue checks that unexpected API error value
+// shapes do not map to [client.ChangeConflictError].
+func (errorSuite) TestChangeConflictErrorAsNonMapValue(c *check.C) {
+	err := &client.Error{
+		Kind:  client.ErrorKindChangeConflict,
+		Value: "not a map",
+	}
+
+	var conflictErr client.ChangeConflictError
+	c.Check(errors.As(err, &conflictErr), check.Equals, false)
+}
+
 // TestChangeConflictErrorAsPartialValue checks that incomplete API error values
 // still map to a partial [client.ChangeConflictError].
 func (errorSuite) TestChangeConflictErrorAsPartialValue(c *check.C) {
@@ -83,14 +95,56 @@ func (errorSuite) TestChangeConflictErrorAsWrongKind(c *check.C) {
 	c.Check(errors.As(err, &conflictErr), check.Equals, false)
 }
 
-// TestChangeConflictErrorAsNonMapValue checks that unexpected API error value
-// shapes do not map to [client.ChangeConflictError].
-func (errorSuite) TestChangeConflictErrorAsNonMapValue(c *check.C) {
+// TestWaitingChangeErrorAsMissingReason checks that a value object without a
+// reason still maps, leaving the reason empty.
+func (errorSuite) TestWaitingChangeErrorAsMissingReason(c *check.C) {
 	err := &client.Error{
-		Kind:  client.ErrorKindChangeConflict,
+		Kind:  client.ErrorKindNoWaitingChange,
+		Value: map[string]any{},
+	}
+
+	var waitingErr client.WaitingChangeError
+	c.Assert(errors.As(err, &waitingErr), check.Equals, true)
+	c.Check(waitingErr.Reason, check.Equals, client.WaitingChangeReason(""))
+}
+
+// TestWaitingChangeErrorAsNonMapValue checks that unexpected API error value
+// shapes do not map to [client.WaitingChangeError].
+func (errorSuite) TestWaitingChangeErrorAsNonMapValue(c *check.C) {
+	err := &client.Error{
+		Kind:  client.ErrorKindNoWaitingChange,
 		Value: "not a map",
 	}
 
-	var conflictErr client.ChangeConflictError
-	c.Check(errors.As(err, &conflictErr), check.Equals, false)
+	var waitingErr client.WaitingChangeError
+	c.Check(errors.As(err, &waitingErr), check.Equals, false)
+}
+
+// TestWaitingChangeErrorAsReason checks that a change-not-waiting API error
+// maps to [client.WaitingChangeError] carrying its reason.
+func (errorSuite) TestWaitingChangeErrorAsReason(c *check.C) {
+	err := &client.Error{
+		Kind: client.ErrorKindNoWaitingChange,
+		Value: map[string]any{
+			"reason": string(client.WaitingChangeNoChange),
+		},
+	}
+
+	var waitingErr client.WaitingChangeError
+	c.Assert(errors.As(err, &waitingErr), check.Equals, true)
+	c.Check(waitingErr, check.DeepEquals, client.WaitingChangeError{
+		Reason: client.WaitingChangeNoChange,
+	})
+}
+
+// TestWaitingChangeErrorAsWrongKind checks that unrelated API error kinds do
+// not map to [client.WaitingChangeError].
+func (errorSuite) TestWaitingChangeErrorAsWrongKind(c *check.C) {
+	err := &client.Error{
+		Kind:  client.ErrorKindChangeConflict,
+		Value: map[string]any{"reason": string(client.WaitingChangeNoChange)},
+	}
+
+	var waitingErr client.WaitingChangeError
+	c.Check(errors.As(err, &waitingErr), check.Equals, false)
 }

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -99,6 +99,19 @@ $ workshop launch`,
 	return cmd
 }
 
+// waitingChangeError renders the message for an abort or continue that could
+// not be applied to a launch.
+func (c *CmdLaunch) waitingChangeError(e client.WaitingChangeError) error {
+	verb := "abort"
+	if c.Continue {
+		verb = "continue"
+	}
+	if e.Reason == client.WaitingChangeRunning {
+		return fmt.Errorf("cannot %s: launch is in progress", verb)
+	}
+	return fmt.Errorf("cannot %s: no launch in progress", verb)
+}
+
 func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	av = strutil.Deduplicate(av)
 
@@ -132,7 +145,13 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 	}
 
 	changeId, err := cli.Launch(project.Id, av, mode, c.verbose)
-	if err != nil {
+
+	var waitingErr client.WaitingChangeError
+	switch {
+	case err == nil:
+	case errors.As(err, &waitingErr):
+		return c.waitingChangeError(waitingErr)
+	default:
 		return err
 	}
 

--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -99,15 +99,12 @@ $ workshop launch`,
 	return cmd
 }
 
-// waitingChangeError renders the message for an abort or continue that could
-// not be applied to a launch.
-func (c *CmdLaunch) waitingChangeError(e client.WaitingChangeError) error {
+// waitingChangeError renders the message for an abort or continue requested
+// when no launch is in progress to resume.
+func (c *CmdLaunch) waitingChangeError() error {
 	verb := "abort"
 	if c.Continue {
 		verb = "continue"
-	}
-	if e.Reason == client.WaitingChangeRunning {
-		return fmt.Errorf("cannot %s: launch is in progress", verb)
 	}
 	return fmt.Errorf("cannot %s: no launch in progress", verb)
 }
@@ -146,11 +143,17 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 
 	changeId, err := cli.Launch(project.Id, av, mode, c.verbose)
 
-	var waitingErr client.WaitingChangeError
+	var conflictErr client.ChangeConflictError
 	switch {
 	case err == nil:
-	case errors.As(err, &waitingErr):
-		return c.waitingChangeError(waitingErr)
+	case errors.Is(err, client.ErrorNoWaitingChange):
+		return c.waitingChangeError()
+	case errors.As(err, &conflictErr):
+		return fmt.Errorf(
+			"cannot launch %[1]q: %[2]s change is in progress",
+			conflictErr.Workshop,
+			conflictErr.ChangeKind,
+		)
 	default:
 		return err
 	}

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -161,7 +161,7 @@ func (m *workshopLaunch) TestLaunchAbortNoWaitingChange(c *check.C) {
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "launch",
 				"names": []any{"ws"}, "options": map[string]any{"mode": "abort"}})
 			w.WriteHeader(400)
-			fmt.Fprintln(w, `{"type":"error","status-code":400,"result":{"message":"cannot abort: no waiting change in progress","kind":"no-waiting-change-in-progress","value":{"reason":"no-change"}}}`)
+			fmt.Fprintln(w, `{"type":"error","status-code":400,"result":{"message":"cannot abort: no waiting change in progress","kind":"no-waiting-change-in-progress"}}`)
 		default:
 			c.Errorf("expected 2 calls, now on %d", n)
 		}
@@ -170,6 +170,37 @@ func (m *workshopLaunch) TestLaunchAbortNoWaitingChange(c *check.C) {
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, "cannot abort: no launch in progress")
+	c.Check(n, check.Equals, 2)
+}
+
+// TestLaunchAbortChangeConflict checks that aborting while another change is in
+// progress reports the blocking change's kind.
+func (m *workshopLaunch) TestLaunchAbortChangeConflict(c *check.C) {
+	cmd := &CmdLaunch{root: &CmdRoot{}}
+	cmd.Abort = true
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(400)
+			fmt.Fprintln(w, `{"type":"error","status-code":400,"result":{"message":"workshop \"ws\" has \"refresh\" change in progress","kind":"change-conflict","value":{"change-kind":"refresh","workshop":"ws"}}}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(nil, []string{"ws"})
+	c.Assert(err, check.NotNil)
+	c.Check(err.Error(), check.Equals, `cannot launch "ws": refresh change is in progress`)
 	c.Check(n, check.Equals, 2)
 }
 

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -139,6 +139,40 @@ func (m *workshopLaunch) TestLaunchWaitOnErrorAbortedSuccessfully(c *check.C) {
 	c.Assert(m.stdout.String(), check.Matches, `"ws" launch aborted\n`)
 }
 
+// TestLaunchAbortNoWaitingChange checks that aborting with no paused launch
+// reports the spec message built from the command's own context, without the
+// generic launch-aborted wrapper.
+func (m *workshopLaunch) TestLaunchAbortNoWaitingChange(c *check.C) {
+	cmd := &CmdLaunch{root: &CmdRoot{}}
+	cmd.Abort = true
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "launch",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "abort"}})
+			w.WriteHeader(400)
+			fmt.Fprintln(w, `{"type":"error","status-code":400,"result":{"message":"cannot abort: no waiting change in progress","kind":"no-waiting-change-in-progress","value":{"reason":"no-change"}}}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(nil, []string{"ws"})
+	c.Assert(err, check.NotNil)
+	c.Check(err.Error(), check.Equals, "cannot abort: no launch in progress")
+	c.Check(n, check.Equals, 2)
+}
+
 func (m *workshopLaunch) TestLaunchWaitOnErrorContinuedSuccessfully(c *check.C) {
 	cmd := &CmdLaunch{root: &CmdRoot{}}
 	cmd.Continue = true

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -142,15 +142,12 @@ func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av 
 	return c.wait(cli, changeId)
 }
 
-// waitingChangeError renders the message for an abort or continue that could
-// not be applied to a refresh.
-func (c *CmdRefresh) waitingChangeError(e client.WaitingChangeError) error {
+// waitingChangeError renders the message for an abort or continue requested
+// when no refresh is in progress to resume.
+func (c *CmdRefresh) waitingChangeError() error {
 	verb := "abort"
 	if c.Continue {
 		verb = "continue"
-	}
-	if e.Reason == client.WaitingChangeRunning {
-		return fmt.Errorf("cannot %s: refresh is in progress", verb)
 	}
 	return fmt.Errorf("cannot %s: no refresh in progress", verb)
 }
@@ -177,7 +174,7 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 
 	chg, err := c.RunRefresh(cli, project, av)
 
-	var waitingErr client.WaitingChangeError
+	var conflictErr client.ChangeConflictError
 	switch {
 	case err == nil:
 		fmt.Fprintf(Stdout, "%s refreshed\n", strutil.Quoted(av))
@@ -186,8 +183,14 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		fmt.Fprintf(Stdout, "no updates available for %s\n", strutil.Quoted(av))
 	case errors.Is(err, errUndone):
 		fmt.Fprintf(Stdout, "%s refresh aborted\n", strutil.Quoted(av))
-	case errors.As(err, &waitingErr):
-		return c.waitingChangeError(waitingErr)
+	case errors.Is(err, client.ErrorNoWaitingChange):
+		return c.waitingChangeError()
+	case errors.As(err, &conflictErr):
+		return fmt.Errorf(
+			"cannot refresh %[1]q: %[2]s change is in progress",
+			conflictErr.Workshop,
+			conflictErr.ChangeKind,
+		)
 	case errors.Is(err, errWaitOnError):
 		w := workshopName(av[0])
 		return fmt.Errorf(`

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -142,6 +142,19 @@ func (c *CmdRefresh) RunRefresh(cli *client.Client, project *client.Project, av 
 	return c.wait(cli, changeId)
 }
 
+// waitingChangeError renders the message for an abort or continue that could
+// not be applied to a refresh.
+func (c *CmdRefresh) waitingChangeError(e client.WaitingChangeError) error {
+	verb := "abort"
+	if c.Continue {
+		verb = "continue"
+	}
+	if e.Reason == client.WaitingChangeRunning {
+		return fmt.Errorf("cannot %s: refresh is in progress", verb)
+	}
+	return fmt.Errorf("cannot %s: no refresh in progress", verb)
+}
+
 func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 	cli, err := c.root.client()
 	if err != nil {
@@ -164,6 +177,7 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 
 	chg, err := c.RunRefresh(cli, project, av)
 
+	var waitingErr client.WaitingChangeError
 	switch {
 	case err == nil:
 		fmt.Fprintf(Stdout, "%s refreshed\n", strutil.Quoted(av))
@@ -172,6 +186,8 @@ func (c *CmdRefresh) Run(cmd *cobra.Command, av []string) error {
 		fmt.Fprintf(Stdout, "no updates available for %s\n", strutil.Quoted(av))
 	case errors.Is(err, errUndone):
 		fmt.Fprintf(Stdout, "%s refresh aborted\n", strutil.Quoted(av))
+	case errors.As(err, &waitingErr):
+		return c.waitingChangeError(waitingErr)
 	case errors.Is(err, errWaitOnError):
 		w := workshopName(av[0])
 		return fmt.Errorf(`

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -261,6 +261,40 @@ func (m *workshopRefresh) TestRefreshWaitOnErrorAbortedSuccessfully(c *check.C) 
 	c.Check(n, check.Equals, 3)
 }
 
+// TestRefreshAbortNoWaitingChange checks that aborting with no paused refresh
+// reports the spec message built from the command's own context, without the
+// generic "cannot refresh" wrapper.
+func (m *workshopRefresh) TestRefreshAbortNoWaitingChange(c *check.C) {
+	cmd := &CmdRefresh{root: &CmdRoot{}}
+	cmd.Abort = true
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
+				"names": []any{"ws"}, "options": map[string]any{"mode": "abort"}})
+			w.WriteHeader(400)
+			fmt.Fprintln(w, `{"type":"error","status-code":400,"result":{"message":"cannot abort: no waiting change in progress","kind":"no-waiting-change-in-progress","value":{"reason":"no-change"}}}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(nil, []string{"ws"})
+	c.Assert(err, check.NotNil)
+	c.Check(err.Error(), check.Equals, "cannot abort: no refresh in progress")
+	c.Check(n, check.Equals, 2)
+}
+
 func (m *workshopRefresh) TestRefreshWaitOnErrorContinuedSuccessfully(c *check.C) {
 	cmd := &CmdRefresh{root: &CmdRoot{}}
 	cmd.Continue = true

--- a/cmd/workshop/refresh_test.go
+++ b/cmd/workshop/refresh_test.go
@@ -283,7 +283,7 @@ func (m *workshopRefresh) TestRefreshAbortNoWaitingChange(c *check.C) {
 			c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]any{"action": "refresh",
 				"names": []any{"ws"}, "options": map[string]any{"mode": "abort"}})
 			w.WriteHeader(400)
-			fmt.Fprintln(w, `{"type":"error","status-code":400,"result":{"message":"cannot abort: no waiting change in progress","kind":"no-waiting-change-in-progress","value":{"reason":"no-change"}}}`)
+			fmt.Fprintln(w, `{"type":"error","status-code":400,"result":{"message":"cannot abort: no waiting change in progress","kind":"no-waiting-change-in-progress"}}`)
 		default:
 			c.Errorf("expected 2 calls, now on %d", n)
 		}
@@ -292,6 +292,37 @@ func (m *workshopRefresh) TestRefreshAbortNoWaitingChange(c *check.C) {
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.NotNil)
 	c.Check(err.Error(), check.Equals, "cannot abort: no refresh in progress")
+	c.Check(n, check.Equals, 2)
+}
+
+// TestRefreshAbortChangeConflict checks that aborting while another change is
+// in progress reports the blocking change's kind.
+func (m *workshopRefresh) TestRefreshAbortChangeConflict(c *check.C) {
+	cmd := &CmdRefresh{root: &CmdRoot{}}
+	cmd.Abort = true
+
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(400)
+			fmt.Fprintln(w, `{"type":"error","status-code":400,"result":{"message":"workshop \"ws\" has \"launch\" change in progress","kind":"change-conflict","value":{"change-kind":"launch","workshop":"ws"}}}`)
+		default:
+			c.Errorf("expected 2 calls, now on %d", n)
+		}
+	})
+
+	err := cmd.Run(nil, []string{"ws"})
+	c.Assert(err, check.NotNil)
+	c.Check(err.Error(), check.Equals, `cannot refresh "ws": launch change is in progress`)
 	c.Check(n, check.Equals, 2)
 }
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -55,6 +55,14 @@ type changeConflictValue struct {
 	Workshop   string `json:"workshop"`
 }
 
+// waitingChangeValue is the value of a no-waiting-change-in-progress API
+// error. It carries the reason an abort or continue had no change paused
+// waiting on error to act on, letting the client render its own message.
+type waitingChangeValue struct {
+	// Reason is a [conflict.WaitingChangeReason], such as "no-change".
+	Reason string `json:"reason"`
+}
+
 type workshopReq struct {
 	Names   []string   `json:"names"`
 	Action  string     `json:"action"`
@@ -147,6 +155,22 @@ func changeInProgressErrorResponse(
 				ChangeKind: conflictErr.ChangeKind,
 				ProjectID:  conflictErr.ProjectID,
 				Workshop:   conflictErr.Workshop,
+			},
+		},
+	}
+}
+
+// noWaitingChangeResponse converts a [conflict.WaitingChangeError] into a
+// no-waiting-change-in-progress API error response carrying its reason.
+func noWaitingChangeResponse(waitingErr conflict.WaitingChangeError) Response {
+	return &resp{
+		Type:   ResponseTypeError,
+		Status: http.StatusBadRequest,
+		Result: &errorResult{
+			Kind:    errorKindNoWaitingChange,
+			Message: waitingErr.Error(),
+			Value: waitingChangeValue{
+				Reason: waitingErr.Reason.String(),
 			},
 		},
 	}
@@ -606,10 +630,13 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 	}
 
 	var conflictErr healthstate.ChangeInProgressError
+	var waitingErr conflict.WaitingChangeError
 	switch {
 	case err == nil:
 	case errors.As(err, &conflictErr):
 		return changeInProgressErrorResponse(conflictErr)
+	case errors.As(err, &waitingErr):
+		return noWaitingChangeResponse(waitingErr)
 	case err != nil:
 		return statusBadRequest("%w", err)
 	}

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -55,14 +55,6 @@ type changeConflictValue struct {
 	Workshop   string `json:"workshop"`
 }
 
-// waitingChangeValue is the value of a no-waiting-change-in-progress API
-// error. It carries the reason an abort or continue had no change paused
-// waiting on error to act on, letting the client render its own message.
-type waitingChangeValue struct {
-	// Reason is a [conflict.WaitingChangeReason], such as "no-change".
-	Reason string `json:"reason"`
-}
-
 type workshopReq struct {
 	Names   []string   `json:"names"`
 	Action  string     `json:"action"`
@@ -160,18 +152,35 @@ func changeInProgressErrorResponse(
 	}
 }
 
-// noWaitingChangeResponse converts a [conflict.WaitingChangeError] into a
-// no-waiting-change-in-progress API error response carrying its reason.
-func noWaitingChangeResponse(waitingErr conflict.WaitingChangeError) Response {
+// changeConflictErrorResponse converts a [conflict.ChangeConflictError] into a
+// change-conflict API error response.
+func changeConflictErrorResponse(conflictErr *conflict.ChangeConflictError) Response {
+	return &resp{
+		Type:   ResponseTypeError,
+		Status: http.StatusBadRequest,
+		Result: &errorResult{
+			Kind:    errorKindChangeConflict,
+			Message: conflictErr.Error(),
+			Value: changeConflictValue{
+				ChangeID:   conflictErr.ChangeID,
+				ChangeKind: conflictErr.ChangeKind,
+				ProjectID:  conflictErr.ProjectId,
+				Workshop:   conflictErr.Workshop,
+			},
+		},
+	}
+}
+
+// noWaitingChangeResponse converts a [conflict.ErrorNoWaitingChange] into a
+// no-waiting-change-in-progress API error response, preserving the wrapped
+// message.
+func noWaitingChangeResponse(err error) Response {
 	return &resp{
 		Type:   ResponseTypeError,
 		Status: http.StatusBadRequest,
 		Result: &errorResult{
 			Kind:    errorKindNoWaitingChange,
-			Message: waitingErr.Error(),
-			Value: waitingChangeValue{
-				Reason: waitingErr.Reason.String(),
-			},
+			Message: err.Error(),
 		},
 	}
 }
@@ -629,14 +638,16 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		change.SetStatus(state.ErrorStatus)
 	}
 
-	var conflictErr healthstate.ChangeInProgressError
-	var waitingErr conflict.WaitingChangeError
+	var inProgressErr healthstate.ChangeInProgressError
+	var changeConflictErr *conflict.ChangeConflictError
 	switch {
 	case err == nil:
-	case errors.As(err, &conflictErr):
-		return changeInProgressErrorResponse(conflictErr)
-	case errors.As(err, &waitingErr):
-		return noWaitingChangeResponse(waitingErr)
+	case errors.As(err, &inProgressErr):
+		return changeInProgressErrorResponse(inProgressErr)
+	case errors.As(err, &changeConflictErr):
+		return changeConflictErrorResponse(changeConflictErr)
+	case errors.Is(err, conflict.ErrorNoWaitingChange):
+		return noWaitingChangeResponse(err)
 	case err != nil:
 		return statusBadRequest("%w", err)
 	}

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -914,7 +914,6 @@ type expectedResp struct {
 	Status    int
 	Message   string
 	Kind      string
-	Reason    string // expected reason in a no-waiting-change error value
 	Summary   string
 	ChangeErr string // an error that happens during the change execution
 }
@@ -948,12 +947,6 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 		if rsp.Type == ResponseTypeError {
 			c.Check(string(rsp.Result.(*errorResult).Kind), check.Equals, expected[num].Kind)
 			c.Check(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
-		}
-
-		if expected[num].Reason != "" {
-			value, ok := rsp.Result.(*errorResult).Value.(waitingChangeValue)
-			c.Assert(ok, check.Equals, true)
-			c.Check(value.Reason, check.Equals, expected[num].Reason)
 		}
 
 		if rsp.Type == ResponseTypeAsync {
@@ -3802,14 +3795,12 @@ func (s *apiSuite) TestRefreshNoRefreshInProgress(c *check.C) {
 			Status:  http.StatusBadRequest,
 			Kind:    "no-waiting-change-in-progress",
 			Message: "cannot continue: no waiting change in progress",
-			Reason:  "no-change",
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
 			Kind:    "no-waiting-change-in-progress",
 			Message: "cannot abort: no waiting change in progress",
-			Reason:  "no-change",
 		},
 	}
 
@@ -4251,7 +4242,8 @@ func (s *apiSuite) TestLaunchWorkshopRefreshLaunchInProgress(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot continue: refresh requested but launch is in progress",
+			Kind:    "change-conflict",
+			Message: `workshop "manysdks" has "launch" change in progress`,
 		},
 	}
 	s.runActionTest(c, requests, expected)
@@ -4335,14 +4327,12 @@ func (s *apiSuite) TestLaunchWorkshopNoRefreshInProgress(c *check.C) {
 			Status:  http.StatusBadRequest,
 			Kind:    "no-waiting-change-in-progress",
 			Message: "cannot continue: no waiting change in progress",
-			Reason:  "no-change",
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
 			Kind:    "no-waiting-change-in-progress",
 			Message: "cannot abort: no waiting change in progress",
-			Reason:  "no-change",
 		},
 	}
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -914,6 +914,7 @@ type expectedResp struct {
 	Status    int
 	Message   string
 	Kind      string
+	Reason    string // expected reason in a no-waiting-change error value
 	Summary   string
 	ChangeErr string // an error that happens during the change execution
 }
@@ -947,6 +948,12 @@ func (s *apiSuite) runActionTest(c *check.C, buffers []*bytes.Buffer, expected [
 		if rsp.Type == ResponseTypeError {
 			c.Check(string(rsp.Result.(*errorResult).Kind), check.Equals, expected[num].Kind)
 			c.Check(rsp.Result.(*errorResult).Message, check.Equals, expected[num].Message)
+		}
+
+		if expected[num].Reason != "" {
+			value, ok := rsp.Result.(*errorResult).Value.(waitingChangeValue)
+			c.Assert(ok, check.Equals, true)
+			c.Check(value.Reason, check.Equals, expected[num].Reason)
 		}
 
 		if rsp.Type == ResponseTypeAsync {
@@ -3793,12 +3800,16 @@ func (s *apiSuite) TestRefreshNoRefreshInProgress(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot continue: no wait in progress",
+			Kind:    "no-waiting-change-in-progress",
+			Message: "cannot continue: no waiting change in progress",
+			Reason:  "no-change",
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot abort: no wait in progress",
+			Kind:    "no-waiting-change-in-progress",
+			Message: "cannot abort: no waiting change in progress",
+			Reason:  "no-change",
 		},
 	}
 
@@ -3956,8 +3967,8 @@ func (s *apiSuite) TestValidateIncorrectActionModeInputs(c *check.C) {
 				"":              `cannot launch "basic": workshop definition .*`,
 				"transactional": `cannot launch "basic": workshop definition .*`,
 				"wait-on-error": `cannot launch "basic": workshop definition .*`,
-				"continue":      "cannot continue: no wait in progress",
-				"abort":         "cannot abort: no wait in progress",
+				"continue":      "cannot continue: no waiting change in progress",
+				"abort":         "cannot abort: no waiting change in progress",
 				"invalid-mode":  `cannot launch: "invalid-mode" is not a valid mode`,
 			},
 		}, {
@@ -3966,8 +3977,8 @@ func (s *apiSuite) TestValidateIncorrectActionModeInputs(c *check.C) {
 				"":              `cannot refresh "basic": workshop definition .*`,
 				"transactional": `cannot refresh "basic": workshop definition .*`,
 				"wait-on-error": `cannot refresh "basic": workshop definition .*`,
-				"continue":      "cannot continue: no wait in progress",
-				"abort":         "cannot abort: no wait in progress",
+				"continue":      "cannot continue: no waiting change in progress",
+				"abort":         "cannot abort: no waiting change in progress",
 				"invalid-mode":  `cannot refresh: "invalid-mode" is not a valid mode`,
 			},
 		}, {
@@ -4322,12 +4333,16 @@ func (s *apiSuite) TestLaunchWorkshopNoRefreshInProgress(c *check.C) {
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot continue: no wait in progress",
+			Kind:    "no-waiting-change-in-progress",
+			Message: "cannot continue: no waiting change in progress",
+			Reason:  "no-change",
 		},
 		{
 			Type:    ResponseTypeError,
 			Status:  http.StatusBadRequest,
-			Message: "cannot abort: no wait in progress",
+			Kind:    "no-waiting-change-in-progress",
+			Message: "cannot abort: no waiting change in progress",
+			Reason:  "no-change",
 		},
 	}
 

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -119,6 +119,7 @@ type errorKind string
 
 const (
 	errorKindChangeConflict     = errorKind("change-conflict")
+	errorKindNoWaitingChange    = errorKind("no-waiting-change-in-progress")
 	errorKindLoginRequired      = errorKind("login-required")
 	errorKindDaemonRestart      = errorKind("daemon-restart")
 	errorKindSystemRestart      = errorKind("system-restart")

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -132,6 +132,12 @@ func (e *ChangeConflictError) Error() string {
 	return fmt.Sprintf("workshop %q has changes in progress", e.Workshop)
 }
 
+// String returns the reason value, such as "no-change", implementing
+// [fmt.Stringer].
+func (w WaitingChangeReason) String() string {
+	return string(w)
+}
+
 // Error returns a human-readable fallback description of the resume failure.
 // Callers that can render their own message should branch on
 // [WaitingChangeError.Reason] instead.

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -23,6 +23,20 @@ import (
 	"github.com/canonical/workshop/internal/sdk"
 )
 
+type ChangeActionMismatch string
+
+// ChangeConflictError represents an error because of snap conflicts between changes.
+type ChangeConflictError struct {
+	ProjectId    string
+	Workshop     string
+	ChangeKind   string
+	ChangeStatus string
+	// a Message is optional, otherwise one is composed from the other information
+	Message string
+	// ChangeID can optionally be set to the ID of the change with which the operation conflicts
+	ChangeID string
+}
+
 type ChangeSetup struct {
 	Mode string `json:"mode"`
 }
@@ -35,6 +49,31 @@ const (
 	ChangeContinue
 	ChangeAbort
 )
+
+// WaitingChangeReason classifies why an abort or continue had no change paused
+// waiting on error to act on. Its values are carried in the change-not-waiting
+// API error.
+type WaitingChangeReason string
+
+const (
+	// WaitingChangeNoChange indicates no change is in progress for the
+	// workshop, so there is nothing for an abort or continue to act on.
+	WaitingChangeNoChange WaitingChangeReason = "no-change"
+
+	// WaitingChangeRunning indicates the change to be resumed exists but is
+	// still running rather than paused waiting on error.
+	WaitingChangeRunning WaitingChangeReason = "running"
+)
+
+// WaitingChangeError reports that an abort or continue had no change paused
+// waiting on error to act on.
+type WaitingChangeError struct {
+	// Mode is the resume mode requested, abort or continue.
+	Mode Mode
+
+	// Reason classifies why no waiting change was available.
+	Reason WaitingChangeReason
+}
 
 func (s Mode) String() string {
 	return [...]string{"transactional", "wait-on-error", "continue", "abort"}[s]
@@ -79,16 +118,8 @@ func ParseRefreshSetting(s string) (RefreshOption, error) {
 	return -1, errors.New(`refresh behaviour must be any of: "update", "restore"`)
 }
 
-// ChangeConflictError represents an error because of snap conflicts between changes.
-type ChangeConflictError struct {
-	ProjectId    string
-	Workshop     string
-	ChangeKind   string
-	ChangeStatus string
-	// a Message is optional, otherwise one is composed from the other information
-	Message string
-	// ChangeID can optionally be set to the ID of the change with which the operation conflicts
-	ChangeID string
+func (e ChangeActionMismatch) Error() string {
+	return string(e)
 }
 
 func (e *ChangeConflictError) Error() string {
@@ -99,6 +130,16 @@ func (e *ChangeConflictError) Error() string {
 		return fmt.Sprintf("workshop %q has %q change in progress", e.Workshop, e.ChangeKind)
 	}
 	return fmt.Sprintf("workshop %q has changes in progress", e.Workshop)
+}
+
+// Error returns a human-readable fallback description of the resume failure.
+// Callers that can render their own message should branch on
+// [WaitingChangeError.Reason] instead.
+func (e WaitingChangeError) Error() string {
+	if e.Reason == WaitingChangeRunning {
+		return fmt.Sprintf("cannot %s: change is running", e.Mode)
+	}
+	return fmt.Sprintf("cannot %s: no waiting change in progress", e.Mode)
 }
 
 func checkWorkshop(task *state.Task, projectId, workshop string) (bool, error) {
@@ -226,11 +267,12 @@ func ResumeAfterWait(st *state.State,
 		return nil, err
 	}
 	if chg == nil {
-		return nil, fmt.Errorf("cannot %s: no wait in progress", mode)
+		return nil, WaitingChangeError{Mode: mode, Reason: WaitingChangeNoChange}
 	}
 
 	if chg.Kind() != action {
 		return nil, fmt.Errorf("cannot %s: %s requested but %s is in progress", mode, action, chg.Kind())
+
 	}
 
 	if chg.Kind() != "refresh" && chg.Kind() != "launch" {
@@ -238,7 +280,7 @@ func ResumeAfterWait(st *state.State,
 	}
 
 	if chg.Status() != state.WaitStatus {
-		return nil, fmt.Errorf("cannot %s: no wait in progress", mode)
+		return nil, WaitingChangeError{Mode: mode, Reason: WaitingChangeRunning}
 	}
 
 	if mode == ChangeContinue {

--- a/internal/overlord/conflict/conflict.go
+++ b/internal/overlord/conflict/conflict.go
@@ -50,30 +50,10 @@ const (
 	ChangeAbort
 )
 
-// WaitingChangeReason classifies why an abort or continue had no change paused
-// waiting on error to act on. Its values are carried in the change-not-waiting
-// API error.
-type WaitingChangeReason string
-
-const (
-	// WaitingChangeNoChange indicates no change is in progress for the
-	// workshop, so there is nothing for an abort or continue to act on.
-	WaitingChangeNoChange WaitingChangeReason = "no-change"
-
-	// WaitingChangeRunning indicates the change to be resumed exists but is
-	// still running rather than paused waiting on error.
-	WaitingChangeRunning WaitingChangeReason = "running"
-)
-
-// WaitingChangeError reports that an abort or continue had no change paused
-// waiting on error to act on.
-type WaitingChangeError struct {
-	// Mode is the resume mode requested, abort or continue.
-	Mode Mode
-
-	// Reason classifies why no waiting change was available.
-	Reason WaitingChangeReason
-}
+// ErrorNoWaitingChange signals that an abort or continue had no change to
+// resume: no change is in progress for the workshop at all. Match it with
+// [errors.Is].
+var ErrorNoWaitingChange = errors.New("no waiting change in progress")
 
 func (s Mode) String() string {
 	return [...]string{"transactional", "wait-on-error", "continue", "abort"}[s]
@@ -130,22 +110,6 @@ func (e *ChangeConflictError) Error() string {
 		return fmt.Sprintf("workshop %q has %q change in progress", e.Workshop, e.ChangeKind)
 	}
 	return fmt.Sprintf("workshop %q has changes in progress", e.Workshop)
-}
-
-// String returns the reason value, such as "no-change", implementing
-// [fmt.Stringer].
-func (w WaitingChangeReason) String() string {
-	return string(w)
-}
-
-// Error returns a human-readable fallback description of the resume failure.
-// Callers that can render their own message should branch on
-// [WaitingChangeError.Reason] instead.
-func (e WaitingChangeError) Error() string {
-	if e.Reason == WaitingChangeRunning {
-		return fmt.Sprintf("cannot %s: change is running", e.Mode)
-	}
-	return fmt.Sprintf("cannot %s: no waiting change in progress", e.Mode)
 }
 
 func checkWorkshop(task *state.Task, projectId, workshop string) (bool, error) {
@@ -262,8 +226,9 @@ func BackgroundDiscard(chg *state.Change, workshop string) {
 // Attempt to resume the change associated with the Resume/Launch operation
 // for the given workshop. Depending on the mode the change will either be
 // turned into Doing (Continue mode) or Abort (Abort mode).
-func ResumeAfterWait(st *state.State,
-	workshop string, projectId string, mode Mode, action string) (*state.Change, error) {
+func ResumeAfterWait(
+	st *state.State, workshop string, projectId string, mode Mode, action string,
+) (*state.Change, error) {
 	if mode != ChangeAbort && mode != ChangeContinue {
 		return nil, fmt.Errorf("cannot resume: only abort or continue can be used to resume the operation")
 	}
@@ -273,20 +238,20 @@ func ResumeAfterWait(st *state.State,
 		return nil, err
 	}
 	if chg == nil {
-		return nil, WaitingChangeError{Mode: mode, Reason: WaitingChangeNoChange}
+		return nil, fmt.Errorf("cannot %s: %w", mode, ErrorNoWaitingChange)
 	}
 
-	if chg.Kind() != action {
-		return nil, fmt.Errorf("cannot %s: %s requested but %s is in progress", mode, action, chg.Kind())
-
-	}
-
-	if chg.Kind() != "refresh" && chg.Kind() != "launch" {
-		return nil, fmt.Errorf("cannot %s: no wait in progress (%q is in progress)", chg.Kind(), mode)
-	}
-
-	if chg.Status() != state.WaitStatus {
-		return nil, WaitingChangeError{Mode: mode, Reason: WaitingChangeRunning}
+	// The change exists but cannot be resumed: it is either a different kind
+	// than requested, or the matching kind still running rather than paused
+	// waiting on error. Either way a change is in progress for the workshop.
+	if chg.Kind() != action || chg.Status() != state.WaitStatus {
+		return nil, &ChangeConflictError{
+			ProjectId:    projectId,
+			Workshop:     workshop,
+			ChangeKind:   chg.Kind(),
+			ChangeStatus: chg.Status().String(),
+			ChangeID:     chg.ID(),
+		}
 	}
 
 	if mode == ChangeContinue {

--- a/internal/overlord/conflict/conflict_test.go
+++ b/internal/overlord/conflict/conflict_test.go
@@ -187,12 +187,8 @@ func (s *conflictSuite) TestResumeAfterWaitNothingInProgress(c *check.C) {
 	defer s.state.Unlock()
 
 	_, err := conflict.ResumeAfterWait(s.state, "ws", s.project.ProjectId, conflict.ChangeContinue, "refresh")
-	var waitingErr conflict.WaitingChangeError
-	c.Assert(errors.As(err, &waitingErr), check.Equals, true)
-	c.Check(waitingErr, check.DeepEquals, conflict.WaitingChangeError{
-		Mode:   conflict.ChangeContinue,
-		Reason: conflict.WaitingChangeNoChange,
-	})
+	c.Check(errors.Is(err, conflict.ErrorNoWaitingChange), check.Equals, true)
+	c.Check(err, check.ErrorMatches, "cannot continue: no waiting change in progress")
 }
 
 func (s *conflictSuite) TestResumeAfterWaitIncorrectMode(c *check.C) {
@@ -207,24 +203,35 @@ func (s *conflictSuite) TestResumeAfterWaitWrongChangeKindInProgress(c *check.C)
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	_ = s.newChange("launch")
+	change := s.newChange("launch")
 
 	_, err := conflict.ResumeAfterWait(s.state, "ws", s.project.ProjectId, conflict.ChangeContinue, "refresh")
-	c.Check(err, check.ErrorMatches, `.* refresh requested but launch is in progress`)
+	var conflictErr *conflict.ChangeConflictError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, &conflict.ChangeConflictError{
+		ProjectId:    s.project.ProjectId,
+		Workshop:     "ws",
+		ChangeKind:   "launch",
+		ChangeStatus: change.Status().String(),
+		ChangeID:     change.ID(),
+	})
 }
 
 func (s *conflictSuite) TestResumeAfterWaitNoWaitingOnError(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	_ = s.newChange("refresh")
+	change := s.newChange("refresh")
 
 	_, err := conflict.ResumeAfterWait(s.state, "ws", s.project.ProjectId, conflict.ChangeContinue, "refresh")
-	var waitingErr conflict.WaitingChangeError
-	c.Assert(errors.As(err, &waitingErr), check.Equals, true)
-	c.Check(waitingErr, check.DeepEquals, conflict.WaitingChangeError{
-		Mode:   conflict.ChangeContinue,
-		Reason: conflict.WaitingChangeRunning,
+	var conflictErr *conflict.ChangeConflictError
+	c.Assert(errors.As(err, &conflictErr), check.Equals, true)
+	c.Check(conflictErr, check.DeepEquals, &conflict.ChangeConflictError{
+		ProjectId:    s.project.ProjectId,
+		Workshop:     "ws",
+		ChangeKind:   "refresh",
+		ChangeStatus: change.Status().String(),
+		ChangeID:     change.ID(),
 	})
 }
 

--- a/internal/overlord/conflict/conflict_test.go
+++ b/internal/overlord/conflict/conflict_test.go
@@ -15,6 +15,7 @@
 package conflict_test
 
 import (
+	"errors"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -186,7 +187,12 @@ func (s *conflictSuite) TestResumeAfterWaitNothingInProgress(c *check.C) {
 	defer s.state.Unlock()
 
 	_, err := conflict.ResumeAfterWait(s.state, "ws", s.project.ProjectId, conflict.ChangeContinue, "refresh")
-	c.Check(err, check.ErrorMatches, ".* no wait in progress")
+	var waitingErr conflict.WaitingChangeError
+	c.Assert(errors.As(err, &waitingErr), check.Equals, true)
+	c.Check(waitingErr, check.DeepEquals, conflict.WaitingChangeError{
+		Mode:   conflict.ChangeContinue,
+		Reason: conflict.WaitingChangeNoChange,
+	})
 }
 
 func (s *conflictSuite) TestResumeAfterWaitIncorrectMode(c *check.C) {
@@ -214,7 +220,12 @@ func (s *conflictSuite) TestResumeAfterWaitNoWaitingOnError(c *check.C) {
 	_ = s.newChange("refresh")
 
 	_, err := conflict.ResumeAfterWait(s.state, "ws", s.project.ProjectId, conflict.ChangeContinue, "refresh")
-	c.Check(err, check.ErrorMatches, ".* no wait in progress")
+	var waitingErr conflict.WaitingChangeError
+	c.Assert(errors.As(err, &waitingErr), check.Equals, true)
+	c.Check(waitingErr, check.DeepEquals, conflict.WaitingChangeError{
+		Mode:   conflict.ChangeContinue,
+		Reason: conflict.WaitingChangeRunning,
+	})
 }
 
 func (s *conflictSuite) TestResumeChangeContinue(c *check.C) {

--- a/tests/main/launch-abort/task.yaml
+++ b/tests/main/launch-abort/task.yaml
@@ -3,6 +3,11 @@ execute: |
   . "$TESTSLIB"/utils.sh
 
   cp workshop.setup-fail.yaml workshop.yaml
+
+  echo "Check launch --abort with no paused launch reports a clear error"
+  output="$(workshop_exec launch --abort || true)"
+  echo "$output" | MATCH 'cannot abort: no launch in progress'
+
   workshop_exec launch --wait-on-error || true
 
   echo "Check the workshop is in Waiting state"

--- a/tests/main/refresh-abort/task.yaml
+++ b/tests/main/refresh-abort/task.yaml
@@ -8,6 +8,10 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
+  echo "Check refresh --abort with no paused refresh reports a clear error"
+  output="$(workshop_exec refresh --abort || true)"
+  echo "$output" | MATCH 'cannot abort: no refresh in progress'
+
   echo "Update the workshop file to include a failing SDK"
   sed -i 's/test-sdk-basic-2/test-sdk-setup-fail/g' workshop.yaml
   workshop_exec refresh --wait-on-error || true


### PR DESCRIPTION
# Description

This improves the output of `workshop refresh --abort` / `--continue` (and the
`launch` equivalents) when there is no paused change to act on. It is part of
the WSP-960 error-output work and follows the same layering as #829 and #831.

Previously, aborting or continuing when nothing was paused surfaced an awkward,
doubled-up daemon error:

```text
error: cannot refresh "dev": cannot abort: no wait in progress
```

After this change the CLI reports a concise, command-specific message built
from its own context:

```text
error: cannot abort: no refresh in progress
error: cannot abort: no launch in progress
```

The same applies to `--continue` (`cannot continue: no refresh in progress`).

## Design

A typed error flows from the overlord up to the CLI, with each layer owning its
own representation:

- `conflict.ResumeAfterWait` returns a typed `conflict.WaitingChangeError`
  carrying the resume `Mode` and a typed `WaitingChangeReason`. Two reasons are
  defined: `no-change` (nothing in progress) and `running` (a matching change
  exists but is not paused waiting on error).
- The daemon maps `WaitingChangeError` to a structured
  `no-waiting-change-in-progress` API error whose value carries the reason
  (`{ "reason": "no-change" }`). The message field is a non-authoritative
  fallback; clients branch on the reason rather than parsing it.
- The client decodes the value into `client.WaitingChangeError` via
  `errors.As`, mirroring `client.ChangeConflictError`.
- The `refresh` and `launch` commands render the user-facing message from their
  own context: the verb from the abort/continue flag and the operation label
  ("refresh" / "launch"). Keeping the wording on the CLI is what lets each
  command name itself rather than echoing a generic daemon string.

The kind string is `no-waiting-change-in-progress` on both ends, and the value
deliberately carries only the reason — the client already knows the verb and
operation from the request it sent.

## Example API error value

```json
{
  "kind": "no-waiting-change-in-progress",
  "message": "cannot abort: no waiting change in progress",
  "value": { "reason": "no-change" }
}
```

## QA

Unit tests run:

```sh
go test ./internal/overlord/conflict
go test ./internal/daemon -check.f TestRefreshNoRefreshInProgress
go test ./internal/daemon -check.f TestLaunchWorkshopNoRefreshInProgress
go test ./client
go test ./cmd/workshop -check.f TestRefreshAbortNoWaitingChange
go test ./cmd/workshop -check.f TestLaunchAbortNoWaitingChange
```

End-to-end coverage is added to the existing per-command abort spread tests
(`tests/main/refresh-abort`, `tests/main/launch-abort`): each asserts that an
abort with no paused change reports the concise message, exercising the real
daemon, client and CLI together.

## Not included / follow-ups

- The `running` reason is wired through all layers but is not yet exercised
  end-to-end (it requires an actively-running, non-paused change at abort time,
  which is racy to provoke deterministically).
- Routing a wrong-kind blocking change to a `change-conflict` response is a
  separate follow-up.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically.
 * [x] Check that coupled code elements, files, and directories are adjacent.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the style guide for new error messages.

## Docs

* [x] I confirm the PR has no implications for documentation.
