### PR TITLE
Improve run action completion with local resolution

### DIFF
--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -340,6 +340,14 @@ func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveDefault
 	}
 
+	// For action completion, prefer resolving actions from local workshop files.
+	// If local resolution fails, fall back to the existing daemon-based lookup.
+	if args.argsLenAtDash >= 0 {
+		if actions, ok := completeLocalActions(c.root.project(), args.av); ok {
+			return actions, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+
 	cli, err := c.root.noRetryClient()
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
@@ -352,7 +360,6 @@ func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	// Argument after a separator must be an action.
 	if args.argsLenAtDash >= 0 {
 		return completeActions(cli, project, args.av)
 	}
@@ -384,6 +391,10 @@ func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([
 }
 
 func completeActions(cli *client.Client, p *client.Project, args []string) ([]string, cobra.ShellCompDirective) {
+	if actions, ok := completeLocalActions(p.Path, args); ok {
+		return actions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	actions, err := listActions(cli, p, args)
 	if err != nil {
 		cobra.CompDebugln(err.Error(), false)
@@ -396,6 +407,32 @@ func completeActions(cli *client.Client, p *client.Project, args []string) ([]st
 	slices.Sort(names)
 
 	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeLocalActions(projectPath string, args []string) ([]string, bool) {
+	project := &workshop.Project{Path: projectPath}
+
+	var name string
+	if len(args) == 0 {
+		workshops, err := project.ReadWorkshops()
+		if err != nil || len(workshops) != 1 {
+			return nil, false
+		}
+
+		for workshopName := range workshops {
+			name = workshopName
+		}
+	} else {
+		name = args[0]
+	}
+
+	file, err := project.Workshop(name)
+	if err != nil {
+		return nil, false
+	}
+
+	names := slices.Sorted(maps.Keys(file.Actions))
+	return names, true
 }
 
 func commonVars(f *pflag.FlagSet, flags *ExecFlags) {

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -360,6 +360,7 @@ func (c *CmdRun) complete(cmd *cobra.Command, av []string, toComplete string) ([
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	// Argument after a separator must be an action.
 	if args.argsLenAtDash >= 0 {
 		return completeActions(cli, project, args.av)
 	}

--- a/cmd/workshop/exec_test.go
+++ b/cmd/workshop/exec_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/check.v1"
@@ -393,6 +394,135 @@ func (m *workshopExec) TestSingleWorkshopRunCompletion(c *check.C) {
 	result, compDirective = run.ValidArgsFunction(run, []string{"ws", "--", "foo"}, "")
 	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveDefault)
 	c.Check(result, check.HasLen, 0)
+}
+
+func (m *workshopExec) TestRunCompletionUsesLocalSingleWorkshopActions(c *check.C) {
+	writeRunCompletionWorkshopFile(c, m.prjDir, "workshop.yaml", "ws")
+
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Errorf("unexpected API call: %s", r.URL.Path)
+	})
+
+	cmd := &CmdRun{root: &CmdRoot{cwd: m.prjDir}}
+	run := cmd.Command()
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	os.Args = []string{"workshop", "__complete", "run", "--", ""}
+	result, compDirective := run.ValidArgsFunction(run, nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bootstrap", "build"})
+}
+
+func (m *workshopExec) TestRunCompletionUsesLocalNamedWorkshopActions(c *check.C) {
+	c.Assert(os.Mkdir(filepath.Join(m.prjDir, workshop.Directory), 0755), check.IsNil)
+	writeRunCompletionWorkshopFile(c, filepath.Join(m.prjDir, workshop.Directory), "ws1.yaml", "ws1")
+	writeRunCompletionWorkshopFile(c, filepath.Join(m.prjDir, workshop.Directory), "ws2.yaml", "ws2")
+
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Errorf("unexpected API call: %s", r.URL.Path)
+	})
+
+	cmd := &CmdRun{root: &CmdRoot{cwd: m.prjDir}}
+	run := cmd.Command()
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	os.Args = []string{"workshop", "__complete", "run", "ws1", "--", ""}
+	result, compDirective := run.ValidArgsFunction(run, []string{"ws1", "--"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bootstrap", "build"})
+}
+
+func (m *workshopExec) TestRunCompletionFallsBackToDaemonForSingleWorkshopActions(c *check.C) {
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockSingleWorkshopSpecifyStatus("Ready"))
+		case 3:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws/actions", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithActions)
+		default:
+			c.Errorf("unexpected API call %d: %s", n, r.URL.Path)
+		}
+	})
+
+	cmd := &CmdRun{root: &CmdRoot{cwd: m.prjDir}}
+	run := cmd.Command()
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	os.Args = []string{"workshop", "__complete", "run", "--", ""}
+	result, compDirective := run.ValidArgsFunction(run, nil, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+	c.Check(n, check.Equals, 3)
+}
+
+func (m *workshopExec) TestRunCompletionFallsBackToDaemonForNamedWorkshopActions(c *check.C) {
+	n := 0
+	m.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		switch n {
+		case 1:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Assert(r.URL.Path, check.Equals, "/v1/projects")
+			r := fmt.Sprintf(`{"type": "sync", "result": {"id":"%s","path":"%s"}}`, m.prjId, m.prjDir)
+			fmt.Fprintln(w, r)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Assert(r.URL.Path, check.Equals, fmt.Sprintf("/v1/projects/%s/workshops/ws/actions", m.prjId))
+			w.WriteHeader(200)
+			fmt.Fprintln(w, mockWorkshopWithActions)
+		default:
+			c.Errorf("unexpected API call %d: %s", n, r.URL.Path)
+		}
+	})
+
+	cmd := &CmdRun{root: &CmdRoot{cwd: m.prjDir}}
+	run := cmd.Command()
+
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	os.Args = []string{"workshop", "__complete", "run", "ws", "--", ""}
+	result, compDirective := run.ValidArgsFunction(run, []string{"ws", "--"}, "")
+	c.Assert(compDirective, check.Equals, cobra.ShellCompDirectiveNoFileComp)
+	c.Check(result, check.DeepEquals, []string{"bar", "foo"})
+	c.Check(n, check.Equals, 2)
+}
+
+func writeRunCompletionWorkshopFile(c *check.C, dir, filename, name string) {
+	path := filepath.Join(dir, filename)
+	content := fmt.Sprintf(`name: %s
+base: ubuntu@24.04
+sdks:
+  - name: go
+    channel: latest/stable
+actions:
+  bootstrap: |
+    cd /project
+    ./scripts/build.sh bootstrap "$@"
+  build: |
+    cd /project
+    ./scripts/build.sh build "$@"
+`, name)
+	c.Assert(os.WriteFile(path, []byte(content), 0644), check.IsNil)
 }
 
 func (m *workshopExec) TestMultipleWorkshopRunCompletion(c *check.C) {


### PR DESCRIPTION
Fixes: #878 

# Description

This PR improves `workshop run` action name completion by resolving actions from local workshop files first.

Previously, action completion could involve daemon communication even though action names can be read from the local workshop file. This made shell completion feel slow in some cases.

With this change, completion first tries local resolution and falls back to the existing daemon-based lookup if local resolution is unavailable, preserving the current behavior.

## Testing

- Added tests for local action completion.
- Added tests for daemon fallback behavior.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
