### PR TITLE
Proxy daemon socket to a fixed path inside workshops

### DIFF
--- a/cmd/workshopctl/main.go
+++ b/cmd/workshopctl/main.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"syscall"
 
 	"github.com/canonical/workshop/client"
@@ -31,8 +30,9 @@ import (
 )
 
 var clientConfig = client.Config{
-	// we need the less privileged workshop socket in workshopctl
-	Socket: filepath.Join(dirs.WorkshopRunDir, filepath.Base(dirs.SocketPath)+".untrusted"),
+	// we need the less privileged workshop socket in workshopctl, proxied to a
+	// fixed path inside the workshop by the daemon (see dirs.WorkshopSocketPath)
+	Socket: dirs.WorkshopSocketPath + ".untrusted",
 }
 
 func main() {

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -20,14 +20,16 @@ import (
 	"path/filepath"
 )
 
-// defaultBaseDir is the Workshop directory used if $WORKSHOP is not set. It is
-// created by the daemon ("workshopd run") if it doesn't exist, and also used by
-// the workshop client.
-const defaultBaseDir = "/var/lib/workshop"
+const (
+	// defaultBaseDir is the Workshop directory used if $WORKSHOP is not set. It is
+	// created by the daemon ("workshopd run") if it doesn't exist, and also used by
+	// the workshop client.
+	defaultBaseDir = "/var/lib/workshop"
 
-// defaultCacheDir is the Workshop directory used if $WORKSHOP_CACHE is not set. It is
-// created by the daemon ("workshopd run") if it doesn't exist.
-const defaultCacheDir = "/var/cache/workshop"
+	// defaultCacheDir is the Workshop directory used if $WORKSHOP_CACHE is not
+	// set. It is created by the daemon ("workshopd run") if it doesn't exist.
+	defaultCacheDir = "/var/cache/workshop"
+)
 
 // Variables for paths inside a workshop
 var (
@@ -45,6 +47,12 @@ var (
 
 	// Run directory inside workshop
 	WorkshopRunDir = filepath.Join(WorkshopBaseDir, "run")
+
+	// Path to the daemon's unix socket as seen from inside a workshop. The
+	// host daemon's untrusted socket is proxied to this fixed path so that
+	// workshopctl and hooks always find it regardless of the daemon's host
+	// socket name (which varies, e.g. under "go tool try").
+	WorkshopSocketPath = filepath.Join(WorkshopRunDir, "workshop.socket")
 
 	// Directory for actions inside workshop
 	WorkshopActionsDir = filepath.Join(WorkshopRunDir, "actions")

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -147,8 +147,12 @@ func defaultDevices(pid, w string) ([]Mount, []ProxyEntry) {
 		Where: dirs.AptCacheDir,
 	}}
 
+	// Connect to this daemon's untrusted socket on the host, but always expose
+	// it inside the workshop at a fixed path. The host socket name varies (e.g.
+	// under "go tool try"), so deriving the instance-side name from it would
+	// leave workshopctl and hooks looking for a socket that does not exist.
 	socketHost := dirs.SocketPath + ".untrusted"
-	socketWorkshop := filepath.Join(dirs.WorkshopRunDir, filepath.Base(socketHost))
+	socketWorkshop := dirs.WorkshopSocketPath + ".untrusted"
 	proxies := []ProxyEntry{{
 		Name:      "workshop.socket",
 		Connect:   ProxyTarget{Address: socketHost, Protocol: "unix"},

--- a/internal/workshop/device_test.go
+++ b/internal/workshop/device_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package workshop_test
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+// deviceSuite covers the default devices wired into every workshop.
+type deviceSuite struct {
+	restoreSocketPath string
+}
+
+var _ = check.Suite(&deviceSuite{})
+
+func (s *deviceSuite) SetUpTest(c *check.C) {
+	s.restoreSocketPath = dirs.SocketPath
+}
+
+func (s *deviceSuite) TearDownTest(c *check.C) {
+	dirs.SocketPath = s.restoreSocketPath
+}
+
+func (s *deviceSuite) socketProxy(c *check.C) workshop.ProxyEntry {
+	_, proxies := workshop.DefaultDevices("proj-id", "ws")
+	for _, p := range proxies {
+		if p.Name == "workshop.socket" {
+			return p
+		}
+	}
+	c.Fatalf("no workshop.socket proxy in default devices")
+	return workshop.ProxyEntry{}
+}
+
+// The daemon socket must always be exposed inside the workshop at a fixed
+// path, regardless of the daemon's host socket name. Deriving the in-workshop
+// path from the host socket (as a non-default WORKSHOP_SOCKET, e.g. under
+// "go tool try") used to leave workshopctl and hooks looking for a socket the
+// proxy never created.
+func (s *deviceSuite) TestSocketProxyListensOnFixedWorkshopPath(c *check.C) {
+	dirs.SocketPath = "/tmp/workshop-7f3c9a.sock"
+
+	proxy := s.socketProxy(c)
+	c.Check(proxy.Direction, check.Equals, workshop.WorkshopToHost)
+	c.Check(proxy.Listen.Address, check.Equals, dirs.WorkshopSocketPath+".untrusted")
+	c.Check(proxy.Connect.Address, check.Equals, dirs.SocketPath+".untrusted")
+}
+
+// The in-workshop listen path is independent of the daemon's host socket
+// name: two daemons with different sockets expose the socket at the same
+// fixed path inside their workshops.
+func (s *deviceSuite) TestSocketProxyListenPathIsStable(c *check.C) {
+	dirs.SocketPath = "/var/lib/workshop/workshop.socket"
+	defaultListen := s.socketProxy(c).Listen.Address
+
+	dirs.SocketPath = "/tmp/workshop-7f3c9a.sock"
+	tryListen := s.socketProxy(c).Listen.Address
+
+	c.Check(tryListen, check.Equals, defaultListen)
+}


### PR DESCRIPTION
# Description

SDKs with hooks could not reach their own `workshopd` when the daemon ran
with a non-default socket — most visibly under `go tool try`, which starts
each daemon with a custom `WORKSHOP_SOCKET`.

Inside a workshop, hooks and `workshopctl` talk to the daemon through an LXD
proxy device. The two ends of that proxy disagreed on the instance-side path:

- The proxy's `Listen` (instance) address derived its filename from the
  daemon's *host* socket name (`filepath.Base(dirs.SocketPath)`), so a custom
  socket produced `…/run/<custom>.untrusted`.
- `workshopctl` always connected to the fixed default name,
  `…/run/workshop.socket.untrusted`.

These coincided only when the daemon used the default socket name. With a
custom `WORKSHOP_SOCKET` the proxy exposed the socket at a path `workshopctl`
never looked at, so hooked SDKs failed to reach the right daemon.

Fix: add `dirs.WorkshopSocketPath`, the fixed in-workshop socket path, and use
it for both the proxy `Listen` address (`internal/workshop/device.go`) and the
`workshopctl` client config (`cmd/workshopctl/main.go`). The host-side
`Connect` address still follows the per-daemon `dirs.SocketPath`, so each
workshop reaches its own daemon. Adds a regression test asserting the listen
path stays fixed for a non-default daemon socket while connect follows it.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

---

* [x] I confirm the PR has no implications for documentation.
