### PR TITLE
Consolidate hostname notes

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -865,7 +865,7 @@ func (s *Backend) Workshop(ctx context.Context, name string) (*workshop.Workshop
 		cnames, _ = unmarshalDnsmasq(network.Config["raw.dnsmasq"])
 	}
 	if cnames == nil {
-		// Tell loadWorkshop to add the hostname-not-found note.
+		// Tell loadWorkshop to add the hostname-missing note.
 		cnames = []cname{}
 	}
 
@@ -959,7 +959,7 @@ func (s *Backend) hostname(name string, p workshop.Project, format sdk.Revision,
 		hostname.Domain = cnames[idx].friendly()
 		hostname.Note = cnames[idx].Note
 	} else if running && format.N > 3 {
-		hostname.Note = "hostname-not-found"
+		hostname.Note = "hostname-missing"
 	}
 
 	return hostname

--- a/internal/workshop/lxd/lxd_backend_dns.go
+++ b/internal/workshop/lxd/lxd_backend_dns.go
@@ -151,7 +151,7 @@ func generateCNAME(cnames []cname, projects []workshop.Project, projectId string
 
 	projectAlias, err := idna.Lookup.ToASCII(projectName)
 	if err != nil {
-		result.Note = "invalid-project-name"
+		result.Note = "hostname-fallback"
 		return result, nil //nolint:nilerr
 	}
 
@@ -162,7 +162,7 @@ func generateCNAME(cnames []cname, projects []workshop.Project, projectId string
 		return strings.EqualFold(c.ProjectId, projectAlias) || strings.EqualFold(c.ProjectAlias, projectAlias)
 	})
 	if conflict {
-		result.Note = "project-name-in-use"
+		result.Note = "hostname-fallback"
 		return result, nil
 	}
 

--- a/internal/workshop/lxd/lxd_backend_dns_test.go
+++ b/internal/workshop/lxd/lxd_backend_dns_test.go
@@ -84,7 +84,7 @@ func (s *dnsSuite) TestGenerateCNAMEValidation(c *check.C) {
 		ProjectId:    "42424242",
 		ProjectName:  "42424242",
 		ProjectAlias: "42424242",
-		Note:         "invalid-project-name",
+		Note:         "hostname-fallback",
 	}
 	replaced := lxdbackend.CNAME{
 		Workshop:     "dev",
@@ -160,7 +160,7 @@ func (s *dnsSuite) TestGenerateCNAMETakenByID(c *check.C) {
 		ProjectId:    "42424242",
 		ProjectName:  "42424242",
 		ProjectAlias: "42424242",
-		Note:         "project-name-in-use",
+		Note:         "hostname-fallback",
 	})
 }
 
@@ -182,7 +182,7 @@ func (s *dnsSuite) TestGenerateCNAMETakenByName(c *check.C) {
 		ProjectId:    "42424242",
 		ProjectName:  "42424242",
 		ProjectAlias: "42424242",
-		Note:         "project-name-in-use",
+		Note:         "hostname-fallback",
 	})
 }
 

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -1334,7 +1334,7 @@ cname=other.24242424.wp,other.testprj.wp,other-24242424.wp,0
 	c.Assert(err, check.IsNil)
 	want = `
 cname=other.24242424.wp,other.testprj.wp,other-24242424.wp,0
-cname=test.42424242.wp,test-42424242.wp,0  # project-name-in-use
+cname=test.42424242.wp,test-42424242.wp,0  # hostname-fallback
 # fake custom config line
 # fake custom config line 2
 `[1:]
@@ -1349,7 +1349,7 @@ cname=test.42424242.wp,test-42424242.wp,0  # project-name-in-use
 	network, _, err = conn.GetNetwork(network.Name)
 	c.Assert(err, check.IsNil)
 	want = `
-cname=test.42424242.wp,test-42424242.wp,0  # project-name-in-use
+cname=test.42424242.wp,test-42424242.wp,0  # hostname-fallback
 # fake custom config line
 # fake custom config line 2
 `[1:]


### PR DESCRIPTION
# Description

Fix these to make explicit mention of the hostname and drop the reason why the ideal hostname wasn't used. We should explain this in the docs at some point:
- for `hostname-fallback`, either the friendly project name was already taken by another project, or the name is invalid for a hostname (e.g. `foo@bar`; we do support some invalid names: `foo_bar`, `foo.bar` and `foo bar` all become `foo-bar`)
- for `hostname-missing`, an error occurred and should have been logged in `journalctl -u snap.workshop.workshopd.service`; the most likely one is a clash between an existing project name and a new project ID (which is very unlikely)

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
