### PR TITLE
Add vendorid and productid properties to custom-device interface

### DIFF
--- a/docs/explanation/interfaces/custom-device-interface.rst
+++ b/docs/explanation/interfaces/custom-device-interface.rst
@@ -32,7 +32,9 @@ which is declared in the SDK definition.
 
 Its structure includes the name of the plug,
 the interface (:samp:`custom-device`),
-and a :samp:`subsystem` attribute.
+and the optional :samp:`subsystem`, :samp:`vendorid`,
+and :samp:`productid` device filters.
+At least one of these filters must be set.
 
 Defining the plug in an SDK
 allows the workshops using this SDK to connect to matching devices,
@@ -55,6 +57,29 @@ One way to query device properties is :command:`udevadm info`:
    $ udevadm info --query=property --property=SUBSYSTEM /dev/input/event0
 
      SUBSYSTEM=input
+
+
+.. _exp_custom_device_filters:
+
+Product and vendor filters
+--------------------------
+
+When a subsystem matches more devices than wanted,
+the optional :samp:`vendorid` and :samp:`productid` attributes
+narrow the selection down to devices
+reporting the given vendor and product ID.
+Both are matched against the respective identifiers reported by the kernel,
+which can be queried with :command:`udevadm info`:
+
+.. code-block:: console
+
+   $ udevadm info --query=property --property=ID_VENDOR_ID --property=ID_MODEL_ID /dev/ttyUSB0
+
+     ID_VENDOR_ID=0403
+     ID_MODEL_ID=6001
+
+Because a product ID is only meaningful within a vendor's namespace,
+setting :samp:`productid` also requires :samp:`vendorid`.
 
 
 .. _exp_custom_device_slot:

--- a/docs/reference/definition-files/_interfaces/custom-device.rst
+++ b/docs/reference/definition-files/_interfaces/custom-device.rst
@@ -11,7 +11,7 @@ Custom device interface
 The custom device interface exposes host devices
 that belong to a Linux kernel subsystem.
 
-A custom device plug is described by this attribute:
+A custom device plug is described by these attributes:
 
 .. @artefact custom-device interface attributes
 
@@ -24,10 +24,25 @@ A custom device plug is described by this attribute:
      - Value
      - Description
 
-   * - :samp:`subsystem` (required)
+   * - :samp:`subsystem` (optional)
      - string
      - The Linux kernel subsystem of the host devices to expose,
        for example :samp:`input`, :samp:`tty`, or :samp:`usb`.
+
+   * - :samp:`vendorid` (optional)
+     - string
+     - Restrict the exposed devices to those with this vendor ID,
+       quoted so it is read as a string, for example :samp:`"0403"`.
+
+   * - :samp:`productid` (optional)
+     - string
+     - Restrict the exposed devices to those with this product ID,
+       quoted so it is read as a string, for example :samp:`"6001"`.
+
+At least one of :samp:`subsystem`, :samp:`vendorid`, or :samp:`productid`
+must be set.
+Setting :samp:`productid` also requires :samp:`vendorid`,
+since a product ID is only meaningful within a vendor's namespace.
 
 Plug owner: any regular SDK; not the system SDK.
 

--- a/docs/reference/definition-files/schema-sdk.json
+++ b/docs/reference/definition-files/schema-sdk.json
@@ -20,6 +20,9 @@
       "type": "string"
     },
     "CustomDevicePlug": {
+      "$ref": "#/$defs/CustomDevicePlugModel"
+    },
+    "CustomDevicePlugModel": {
       "additionalProperties": false,
       "description": "SDKcraft project custom-device plug definition.",
       "properties": {
@@ -29,21 +32,38 @@
           "type": "string"
         },
         "subsystem": {
+          "default": "",
           "description": "Device subsystem.",
           "examples": [
             "accel",
             "usb"
           ],
-          "minLength": 1,
           "title": "Subsystem",
           "type": "string"
+        },
+        "vendorid": {
+          "$ref": "#/$defs/DeviceID",
+          "default": "",
+          "description": "Restrict the exposed devices to those with this vendor ID.",
+          "examples": [
+            "0403"
+          ],
+          "title": "Vendor ID"
+        },
+        "productid": {
+          "$ref": "#/$defs/DeviceID",
+          "default": "",
+          "description": "Restrict the exposed devices to those with this product ID.",
+          "examples": [
+            "6001"
+          ],
+          "title": "Product ID"
         }
       },
       "required": [
-        "interface",
-        "subsystem"
+        "interface"
       ],
-      "title": "CustomDevicePlug",
+      "title": "CustomDevicePlugModel",
       "type": "object"
     },
     "DesktopPlug": {
@@ -61,6 +81,10 @@
       ],
       "title": "DesktopPlug",
       "type": "object"
+    },
+    "DeviceID": {
+      "pattern": "^(?:0x)?[a-fA-F0-9]+$",
+      "type": "string"
     },
     "Endpoint": {
       "type": "string"
@@ -442,6 +466,20 @@
       ],
       "default": null,
       "title": "Source-Code"
+    },
+    "website": {
+      "anyOf": [
+        {
+          "format": "uri",
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Website"
     },
     "license": {
       "anyOf": [

--- a/docs/reference/definition-files/schema-sdkcraft.json
+++ b/docs/reference/definition-files/schema-sdkcraft.json
@@ -20,6 +20,9 @@
       "type": "string"
     },
     "CustomDevicePlug": {
+      "$ref": "#/$defs/CustomDevicePlugModel"
+    },
+    "CustomDevicePlugModel": {
       "additionalProperties": false,
       "description": "SDKcraft project custom-device plug definition.",
       "properties": {
@@ -29,21 +32,38 @@
           "type": "string"
         },
         "subsystem": {
+          "default": "",
           "description": "Device subsystem.",
           "examples": [
             "accel",
             "usb"
           ],
-          "minLength": 1,
           "title": "Subsystem",
           "type": "string"
+        },
+        "vendorid": {
+          "$ref": "#/$defs/DeviceID",
+          "default": "",
+          "description": "Restrict the exposed devices to those with this vendor ID.",
+          "examples": [
+            "0403"
+          ],
+          "title": "Vendor ID"
+        },
+        "productid": {
+          "$ref": "#/$defs/DeviceID",
+          "default": "",
+          "description": "Restrict the exposed devices to those with this product ID.",
+          "examples": [
+            "6001"
+          ],
+          "title": "Product ID"
         }
       },
       "required": [
-        "interface",
-        "subsystem"
+        "interface"
       ],
-      "title": "CustomDevicePlug",
+      "title": "CustomDevicePlugModel",
       "type": "object"
     },
     "DesktopPlug": {
@@ -61,6 +81,10 @@
       ],
       "title": "DesktopPlug",
       "type": "object"
+    },
+    "DeviceID": {
+      "pattern": "^(?:0x)?[a-fA-F0-9]+$",
+      "type": "string"
     },
     "Endpoint": {
       "type": "string"
@@ -684,6 +708,20 @@
         "[{type: apt,                components: [main],                suites: [xenial],                key-id: 78E1918602959B9C59103100F1831DDAFC42E99D,                url: http://ppa.launchpad.net/snappy-dev/snapcraft-daily/ubuntu}]"
       ],
       "title": "Package-Repositories"
+    },
+    "website": {
+      "anyOf": [
+        {
+          "format": "uri",
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Website"
     },
     "plugs": {
       "$ref": "#/$defs/Plugs",

--- a/internal/interfaces/builtin/custom_device.go
+++ b/internal/interfaces/builtin/custom_device.go
@@ -20,8 +20,11 @@
 package builtin
 
 import (
+	"errors"
 	"fmt"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/lxd_device"
@@ -51,7 +54,7 @@ const customDeviceBaseDeclarationPlugs = `
     deny-auto-connection: true
 `
 
-var knownCustomDeviceAttributes = []string{"subsystem"}
+var knownCustomDeviceAttributes = []string{"subsystem", "vendorid", "productid"}
 
 type customDeviceInterface struct{}
 
@@ -75,15 +78,64 @@ func (iface *customDeviceInterface) BeforePreparePlug(plug *sdk.PlugInfo) error 
 		}
 	}
 
-	var subsystem string
-	if err := plug.Attr("subsystem", &subsystem); err != nil {
+	// Every attribute is optional, so the map may be nil; make it writable for
+	// the parse helpers, which default absent attributes.
+	if plug.Attrs == nil {
+		plug.Attrs = make(map[string]any)
+	}
+
+	subsystem, err := parseString(plug.Attrs, "subsystem")
+	if err != nil {
 		return err
 	}
-	if subsystem == "" {
-		return fmt.Errorf(`custom-device plug "subsystem" is empty`)
+	vendorID, err := parseDeviceID(plug.Attrs, "vendorid")
+	if err != nil {
+		return err
+	}
+	productID, err := parseDeviceID(plug.Attrs, "productid")
+	if err != nil {
+		return err
+	}
+
+	// subsystem, productid, and vendorid are each optional, but the plug must
+	// narrow the exposed host devices with at least one of them.
+	if subsystem == nil && vendorID == "" && productID == "" {
+		return fmt.Errorf(`custom-device plug must contain "subsystem", "vendorid", or "productid"`)
+	}
+	// A product ID only identifies a device within a vendor's namespace.
+	if vendorID == "" && productID != "" {
+		return fmt.Errorf(`custom-device plug contains "productid" without "vendorid"`)
 	}
 
 	return nil
+}
+
+func parseString(attrs map[string]any, key string) (*string, error) {
+	object, ok := attrs[key]
+	if !ok {
+		return nil, nil
+	}
+	value, ok := object.(string)
+	if !ok {
+		return nil, fmt.Errorf("custom-device plug %q is not a string (found %T)", key, object)
+	}
+	return &value, nil
+}
+
+func parseDeviceID(attrs map[string]any, key string) (string, error) {
+	value, err := parseString(attrs, key)
+	if value == nil || err != nil {
+		return "", err
+	}
+
+	id, err := strconv.ParseUint(strings.TrimPrefix(*value, "0x"), 16, 16)
+	if err != nil {
+		return "", fmt.Errorf("custom-device plug %q must be a hexadecimal number", key)
+	}
+
+	udevForm := fmt.Sprintf("%04x", id)
+	attrs[key] = udevForm
+	return udevForm, nil
 }
 
 func (iface *customDeviceInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
@@ -92,11 +144,20 @@ func (iface *customDeviceInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.Sl
 }
 
 func (iface *customDeviceInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	var subsystem string
-	if err := plug.Attr("subsystem", &subsystem); err != nil {
+	device := workshop.CustomDevice{Name: plug.Name()}
+
+	var attrErr *sdk.AttributeNotFoundError
+	if err := plug.Attr("subsystem", &device.Subsystem); err != nil && !errors.As(err, &attrErr) {
 		return err
 	}
-	return spec.AddCustomDevice(workshop.CustomDevice{Name: plug.Name(), Subsystem: subsystem})
+	if err := plug.Attr("vendorid", &device.VendorID); err != nil && !errors.As(err, &attrErr) {
+		return err
+	}
+	if err := plug.Attr("productid", &device.ProductID); err != nil && !errors.As(err, &attrErr) {
+		return err
+	}
+
+	return spec.AddCustomDevice(device)
 }
 
 func init() {

--- a/internal/interfaces/builtin/custom_device_test.go
+++ b/internal/interfaces/builtin/custom_device_test.go
@@ -76,6 +76,7 @@ plugs:
     interface: custom-device
     subsystem: accel
 `, s.projectId, "ws", "consumer", "mydevice")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
 
 	slot := builtin.MockSlot(c, `name: producer
@@ -94,6 +95,101 @@ slots:
 	c.Assert(deviceSpec.Profile.CustomDevices, check.DeepEquals, expectedDevices)
 }
 
+func (s *customDeviceSuite) TestCustomDeviceInterfaceWithFilters(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: tty
+    vendorid: "0403"
+    productid: "6001"
+`, s.projectId, "ws", "consumer", "mydevice")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@24.04
+slots:
+  custom-device:
+`, s.projectId, "ws", "producer", "custom-device")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	expectedDevices := []workshop.CustomDevice{{
+		Name:      "mydevice",
+		Subsystem: "tty",
+		VendorID:  "0403",
+		ProductID: "6001",
+	}}
+	c.Assert(deviceSpec.Profile.CustomDevices, check.DeepEquals, expectedDevices)
+}
+
+func (s *customDeviceSuite) TestCustomDeviceInterfaceWithVendorIdFilter(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: tty
+    vendorid: "0403"
+`, s.projectId, "ws", "consumer", "mydevice")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@24.04
+slots:
+  custom-device:
+`, s.projectId, "ws", "producer", "custom-device")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	expectedDevices := []workshop.CustomDevice{{
+		Name:      "mydevice",
+		Subsystem: "tty",
+		VendorID:  "0403",
+	}}
+	c.Assert(deviceSpec.Profile.CustomDevices, check.DeepEquals, expectedDevices)
+}
+
+func (s *customDeviceSuite) TestCustomDeviceInterfaceWithoutSubsystem(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    vendorid: "0403"
+    productid: "6001"
+`, s.projectId, "ws", "consumer", "mydevice")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@24.04
+slots:
+  custom-device:
+`, s.projectId, "ws", "producer", "custom-device")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	expectedDevices := []workshop.CustomDevice{{
+		Name:      "mydevice",
+		VendorID:  "0403",
+		ProductID: "6001",
+	}}
+	c.Assert(deviceSpec.Profile.CustomDevices, check.DeepEquals, expectedDevices)
+}
+
 func (s *customDeviceSuite) TestSanitizePlugUnknownAttribute(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
 base: ubuntu@22.04
@@ -106,7 +202,7 @@ plugs:
 	c.Check(err, check.ErrorMatches, `unknown attribute for custom-device interface plug: "workshop-target"`)
 }
 
-func (s *customDeviceSuite) TestSanitizePlugMissingSubsystem(c *check.C) {
+func (s *customDeviceSuite) TestSanitizePlugNoFilters(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
 base: ubuntu@22.04
 plugs:
@@ -114,17 +210,94 @@ plugs:
     interface: custom-device
 `, s.projectId, "ws", "consumer", "mydevice")
 	err := interfaces.BeforePreparePlug(s.iface, plug)
-	c.Check(err, check.ErrorMatches, `attribute "subsystem" not found for plug "ws/consumer:mydevice"`)
+	c.Check(err, check.ErrorMatches, `custom-device plug must contain "subsystem", "vendorid", or "productid"`)
 }
 
-func (s *customDeviceSuite) TestSanitizePlugEmptySubsystem(c *check.C) {
+func (s *customDeviceSuite) TestSanitizePlugWithFilters(c *check.C) {
 	plug := builtin.MockPlug(c, `name: consumer
-base: ubuntu@22.04
+base: ubuntu@24.04
 plugs:
   mydevice:
     interface: custom-device
-    subsystem: ""
+    subsystem: tty
+    vendorid: "0403"
+    productid: "6001"
+`, s.projectId, "ws", "consumer", "mydevice")
+	c.Check(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugWithVendorIdFilter(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: tty
+    vendorid: "0403"
+`, s.projectId, "ws", "consumer", "mydevice")
+	c.Check(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugProductIdRequiresVendorId(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: tty
+    productid: "6001"
 `, s.projectId, "ws", "consumer", "mydevice")
 	err := interfaces.BeforePreparePlug(s.iface, plug)
-	c.Check(err, check.ErrorMatches, `custom-device plug "subsystem" is empty`)
+	c.Check(err, check.ErrorMatches, `custom-device plug contains "productid" without "vendorid"`)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugInvalidProductId(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: tty
+    productid: "60019"
+`, s.projectId, "ws", "consumer", "mydevice")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `custom-device plug "productid" must be a hexadecimal number`)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugInvalidVendorId(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: tty
+    vendorid: "wxyz"
+`, s.projectId, "ws", "consumer", "mydevice")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `custom-device plug "vendorid" must be a hexadecimal number`)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugSubsystemOnly(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    subsystem: tty
+`, s.projectId, "ws", "consumer", "mydevice")
+	c.Check(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+}
+
+func (s *customDeviceSuite) TestSanitizePlugNormalizesIds(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@24.04
+plugs:
+  mydevice:
+    interface: custom-device
+    vendorid: "EF01"
+    productid: "ABCD"
+`, s.projectId, "ws", "consumer", "mydevice")
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), check.IsNil)
+	c.Check(plug.Attrs["vendorid"], check.Equals, "ef01")
+	c.Check(plug.Attrs["productid"], check.Equals, "abcd")
 }

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -286,12 +286,24 @@ func (s *Specification) AddCustomDevice(device workshop.CustomDevice) error {
 	s.Profile.CustomDevices = append(s.Profile.CustomDevices, device)
 
 	name := lxdbackend.DeviceName(s.Profile.Sdk, device.Name)
-	s.devices[name] = map[string]string{
+	lxdDevice := map[string]string{
 		"type":              "unix-hotplug",
-		"subsystem":         device.Subsystem,
 		"required":          "false",
 		"ownership.inherit": "true",
 	}
+	// Only set the device identifiers that are provided so that an unset one does
+	// not constrain which host devices match.
+	if device.Subsystem != "" {
+		lxdDevice["subsystem"] = device.Subsystem
+	}
+	if device.VendorID != "" {
+		lxdDevice["vendorid"] = device.VendorID
+	}
+	if device.ProductID != "" {
+		lxdDevice["productid"] = device.ProductID
+	}
+
+	s.devices[name] = lxdDevice
 	s.config[lxdbackend.DeviceTypeConfigKey(name)] = "custom-device"
 
 	return nil

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -65,7 +65,9 @@ type Camera struct {
 
 type CustomDevice struct {
 	Name      string `json:"name"`
-	Subsystem string `json:"subsystem"`
+	Subsystem string `json:"subsystem,omitempty"`
+	VendorID  string `json:"vendorid,omitempty"`
+	ProductID string `json:"productid,omitempty"`
 }
 
 type Mount struct {

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -164,6 +164,8 @@ func LxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 				pr.CustomDevices = append(pr.CustomDevices, workshop.CustomDevice{
 					Name:      name,
 					Subsystem: dev["subsystem"],
+					VendorID:  dev["vendorid"],
+					ProductID: dev["productid"],
 				})
 			default:
 				logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -101,9 +101,13 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 					Where: "/etc",
 					Type:  workshop.WorkshopWorkshop}}},
 		{
-			Sdk:           "sdk",
-			Mounts:        map[string]workshop.Mount{},
-			CustomDevices: []workshop.CustomDevice{{Name: "mydevice", Subsystem: "accel"}},
+			Sdk:    "sdk",
+			Mounts: map[string]workshop.Mount{},
+			CustomDevices: []workshop.CustomDevice{{
+				Name:      "mydevice",
+				Subsystem: "tty",
+				VendorID:  "0403",
+				ProductID: "6001"}},
 		},
 	}
 
@@ -207,7 +211,9 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 			map[string]map[string]string{
 				"sdk_mydevice": {
 					"type":              "unix-hotplug",
-					"subsystem":         "accel",
+					"subsystem":         "tty",
+					"vendorid":          "0403",
+					"productid":         "6001",
 					"required":          "false",
 					"ownership.inherit": "true"}},
 			map[string]string{


### PR DESCRIPTION
# Description

Add the optinal  `productid` and `vendorid` properties for custom-device interface.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialization together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes. **(doesn't apply, I believe)**
* [ ] I have included the technical author in the review.

Content:

* [x] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
