### PR TITLE
Remove obsolete SDK info fields from InfoSuite

### DIFF
--- a/internal/sdkstore/info_test.go
+++ b/internal/sdkstore/info_test.go
@@ -154,15 +154,11 @@ func (s *InfoSuite) TestInfoPayload(c *check.C) {
 }
 
 var allInfoFields = []string{
-	"categories",
 	"channel-map",
-	"contact",
 	"created-at",
 	"description",
 	"download",
 	"license",
-	"links",
-	"media",
 	"private",
 	"publisher",
 	"revision",
@@ -170,7 +166,6 @@ var allInfoFields = []string{
 	"summary",
 	"title",
 	"version",
-	"website",
 }
 
 func (s *InfoSuite) TestInfoPayloadMultiBase(c *check.C) {

--- a/internal/sdkstore/test-sdk-info-multi-base.raw.json
+++ b/internal/sdkstore/test-sdk-info-multi-base.raw.json
@@ -603,12 +603,8 @@
   ],
   "default-track": null,
   "metadata": {
-    "categories": [],
-    "contact": "",
     "description": "Test SDK info multi-base description",
     "license": "LGPL-3.0",
-    "links": {},
-    "media": [],
     "private": false,
     "publisher": {
       "display-name": "Dmitry Lyfar",
@@ -617,8 +613,7 @@
       "validation": "unproven"
     },
     "summary": "Test SDK which supports multiple bases and architectures",
-    "title": "Test SDK info multi-base title",
-    "website": null
+    "title": "Test SDK info multi-base title"
   },
   "name": "test-sdk-info-multi-base-1",
   "package-id": "x2hQwbuopxeELn5p1G9h3b9ZB3XM0JeG"


### PR DESCRIPTION
# Description

These fields are no longer supported by the Store. Fortunately we weren't using them for anything, the tests just take a maximalist approach so that we can easily see what information is available.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
