### PR TITLE
Improve LXD checks

### DIFF
--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -196,9 +196,14 @@ out:
 		case <-tic.C:
 			if err := syscheck.CheckSystem(); err != nil {
 				degradedErr := fmt.Errorf("system is not healthy: %w", err)
-				logger.Noticef("%s", degradedErr)
+				if !d.IsDegraded() {
+					logger.Noticef("%s", degradedErr)
+				}
 				d.SetDegradedMode(degradedErr)
 			} else {
+				if d.IsDegraded() {
+					logger.Noticef("System is healthy.")
+				}
 				d.SetDegradedMode(nil)
 			}
 		case <-stop:

--- a/cmd/workshopd/run.go
+++ b/cmd/workshopd/run.go
@@ -149,15 +149,17 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	// Run sanity check now, if anything goes wrong with the
 	// check we go into "degraded" mode where we always report
 	// the given error to any client.
-	var checkTicker <-chan time.Time
-	var tic *time.Ticker
+	//
+	// Keep the ticker running even when the initial check passes so the
+	// daemon can detect and recover from LXD becoming unavailable after
+	// startup (e.g. due to a refresh).
 	if err := syscheck.CheckSystem(); err != nil {
 		degradedErr := fmt.Errorf("system is not healthy: %w", err)
 		logger.Noticef("%s", degradedErr)
 		d.SetDegradedMode(degradedErr)
-		tic = time.NewTicker(checkRunningConditionsRetryDelay)
-		checkTicker = tic.C
 	}
+	tic := time.NewTicker(checkRunningConditionsRetryDelay)
+	defer tic.Stop()
 
 	d.Version = version.Version
 	if err = d.Start(); err != nil {
@@ -191,10 +193,13 @@ out:
 			// something called Stop()
 			logger.Noticef("Server exiting!")
 			break out
-		case <-checkTicker:
-			if err := syscheck.CheckSystem(); err == nil {
+		case <-tic.C:
+			if err := syscheck.CheckSystem(); err != nil {
+				degradedErr := fmt.Errorf("system is not healthy: %w", err)
+				logger.Noticef("%s", degradedErr)
+				d.SetDegradedMode(degradedErr)
+			} else {
 				d.SetDegradedMode(nil)
-				tic.Stop()
 			}
 		case <-stop:
 			break out

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -414,6 +414,10 @@ func (d *Daemon) SetDegradedMode(err error) {
 	d.degradedErr = err
 }
 
+func (d *Daemon) IsDegraded() bool {
+	return d.degradedErr != nil
+}
+
 func (d *Daemon) addRoutes() {
 	d.router = mux.NewRouter()
 

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -30,14 +30,16 @@ import (
 	. "github.com/canonical/workshop/internal/overlord/handlersetup"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/syscheck"
 	"github.com/canonical/workshop/internal/workshop"
 	"github.com/canonical/workshop/internal/x11"
 )
 
 type InterfaceManager struct {
-	state   *state.State
-	backend workshop.Backend
-	repo    *interfaces.Repository
+	state        *state.State
+	backend      workshop.Backend
+	repo         *interfaces.Repository
+	backendReady bool
 }
 
 func New(s *state.State, r *state.TaskRunner) *InterfaceManager {
@@ -49,6 +51,11 @@ func New(s *state.State, r *state.TaskRunner) *InterfaceManager {
 	s.Lock()
 	m.backend = workshop.WorkshopBackend(s)
 	s.Unlock()
+
+	// Register the LXD-dependent initialization as a system check so the
+	// daemon stays in degraded mode until both LXD is healthy and the
+	// interface manager has loaded all existing workshops and connections.
+	syscheck.RegisterCheck(m.ensureBackendInit)
 
 	r.AddHandler("resolve-interfaces", OnDo(m.doResolveInterfaces), nil)
 	r.AddHandler("auto-connect", OnDo(m.doAutoConnect), nil)
@@ -133,25 +140,49 @@ func (m *InterfaceManager) ConnectionStates() (connStateByRef map[string]Connect
 
 func (m *InterfaceManager) StartUp() error {
 	m.state.Lock()
-	defer m.state.Unlock()
 	for _, backend := range allSecurityBackends() {
 		if err := backend.Initialize(); err != nil {
+			m.state.Unlock()
 			return err
 		}
 		if err := m.repo.AddBackend(backend); err != nil {
+			m.state.Unlock()
 			return err
 		}
 	}
 
 	for _, iface := range builtin.Interfaces() {
 		if err := m.repo.AddInterface(iface); err != nil {
+			m.state.Unlock()
 			return err
 		}
 	}
+	m.state.Unlock()
+
+	if err := m.ensureBackendInit(); err != nil {
+		// LXD may not be available yet; do not propagate the error so the
+		// daemon can start. The syscheck registered in New() keeps the daemon
+		// in degraded mode and retries via the recovery ticker until it succeeds.
+		logger.Noticef("Interface manager backend init deferred: %v", err)
+	}
+	return nil
+}
+
+// ensureBackendInit performs the LXD-dependent part of startup: it loads all
+// existing projects and workshops, recreates internal mounts, registers SDK
+// interfaces, and reloads connections. It is registered as a syscheck (see
+// New) so the daemon stays in degraded mode until it succeeds.
+func (m *InterfaceManager) ensureBackendInit() error {
+	if m.backendReady {
+		return nil
+	}
+
+	m.state.Lock()
+	defer m.state.Unlock()
 
 	allprojects, err := m.backend.Projects(context.Background())
 	if err != nil {
-		return err
+		return fmt.Errorf("interface manager not ready: %w", err)
 	}
 
 	for user, projects := range allprojects {
@@ -196,9 +227,11 @@ func (m *InterfaceManager) StartUp() error {
 			logger.Noticef("cannot copy Xauthority file for user %q, X11 applications may not work: %v", user, err)
 		}
 	}
-	if _, err := m.reloadConnections("", "", ""); err != nil {
+	_, err = m.reloadConnections("", "", "")
+	if err != nil {
 		return err
 	}
+	m.backendReady = true
 	return nil
 }
 

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -135,9 +135,12 @@ func New(dir string, restartHandler restart.Handler) (*Overlord, error) {
 	if workshopBackendOverride != nil {
 		workshop.ReplaceBackend(s, workshopBackendOverride)
 	} else {
+		// New always returns a usable backend even when LXD is not yet ready.
+		// Any setup error is reported by the system check, which puts the
+		// daemon into degraded mode and retries until LXD becomes available.
 		wbe, err := lxdbackend.New()
 		if err != nil {
-			return nil, err
+			logger.Noticef("LXD backend setup failed, will retry: %v", err)
 		}
 		workshop.ReplaceBackend(s, wbe)
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -209,6 +209,16 @@ func New() (*Backend, error) {
 		imageServer = srv
 	}
 
+	if err := ensureBackendReady(); err != nil {
+		return nil, err
+	}
+
+	return &server, nil
+}
+
+// ensureBackendReady creates the LXD storage pool and network the backend
+// relies on, it is idempotent.
+func ensureBackendReady() error {
 	// TODO: run this logic for a specific user. The code below implies the
 	// default project activated for the connection. As we have seen, every user
 	// has to create its own storage pool to avoid issues with id mapping of a
@@ -216,14 +226,14 @@ func New() (*Backend, error) {
 	// system SDK that cannot be successfully mounted for another user).
 	conn, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {
-		return nil, ErrorLxdBackend(err)
+		return ErrorLxdBackend(err)
 	}
 	defer conn.Disconnect()
 
 	// Create LXD storage pool if it doesn't exist.
 	pools, err := conn.GetStoragePools()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if idx := slices.IndexFunc(pools, func(p api.StoragePool) bool { return p.Name == storagePool }); idx < 0 {
 		req := api.StoragePoolsPost{
@@ -232,21 +242,21 @@ func New() (*Backend, error) {
 		}
 		op, err := conn.CreateStoragePool(req)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if err := op.Wait(); err != nil {
-			return nil, err
+			return err
 		}
 
 		// Ensure the new pool has enough total space available.
 		pool, etag, err := conn.GetStoragePool(storagePool)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		res, err := conn.GetStoragePoolResources(storagePool)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		gibTotal := uint64(res.Space.Total) / (1024 * 1024 * 1024)
@@ -258,17 +268,17 @@ func New() (*Backend, error) {
 			pool.Config["size"] = strconv.FormatUint(storagePoolMinimalGiB*1024*1024*1024, 10)
 			op, err = conn.UpdateStoragePool(storagePool, pool.Writable(), etag)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			if err := op.Wait(); err != nil {
-				logger.Noticef("On Backend.New: failed to set storage pool to the minimal size: %dGiB, %s", storagePoolMinimalGiB, err)
-				return nil, err
+				logger.Noticef("On ensureBackendReady: failed to set storage pool to the minimal size: %dGiB, %s", storagePoolMinimalGiB, err)
+				return err
 			}
 
-			logger.Noticef("On Backend.New: set storage pool to the minimal size: %dGiB", storagePoolMinimalGiB)
+			logger.Noticef("On ensureBackendReady: set storage pool to the minimal size: %dGiB", storagePoolMinimalGiB)
 		}
 	} else if pools[idx].Driver != storagePoolDriver {
-		return nil, fmt.Errorf("storage pool %q already exists with a different driver: %q (expected %q)", storagePool, pools[idx].Driver, storagePoolDriver)
+		return fmt.Errorf("storage pool %q already exists with a different driver: %q (expected %q)", storagePool, pools[idx].Driver, storagePoolDriver)
 	}
 
 	network, etag, err := conn.GetNetwork(networkName)
@@ -286,27 +296,27 @@ func New() (*Backend, error) {
 
 		op, err := conn.CreateNetwork(req)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if err := op.Wait(); err != nil {
-			return nil, err
+			return err
 		}
 	} else if err != nil {
-		return nil, err
+		return err
 	} else if network.Type != networkType {
-		return nil, fmt.Errorf("network %q already exists with a different type: %q", networkName, network.Type)
+		return fmt.Errorf("network %q already exists with a different type: %q", networkName, network.Type)
 	} else if network.Config["dns.domain"] != networkDomain {
 		network.Config["dns.domain"] = networkDomain
 		op, err := conn.UpdateNetwork(network.Name, network.Writable(), etag)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if err := op.Wait(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return &server, nil
+	return nil
 }
 
 func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.File, snapshot workshop.Snapshot) error {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -88,7 +88,12 @@ func init() {
 		storagePoolDriver = "btrfs"
 	}
 
+	// Order matters: capabilities (version and storage) must be validated
+	// before ensureBackendReady attempts to create the storage pool and
+	// network. Registering it as a check also lets the daemon recover after
+	// LXD is installed or refreshed, without a restart.
 	syscheck.RegisterCheck(checkServerCapabilities)
+	syscheck.RegisterCheck(ensureBackendReady)
 }
 
 type Backend struct {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -207,6 +207,10 @@ func checkServerCapabilities() error {
 	return checkStorage(info.Environment.StorageSupportedDrivers)
 }
 
+// New constructs the LXD backend and attempts to prepare the required LXD
+// storage pool and network. It always returns a usable backend; if LXD is not
+// yet ready the error is reported by the system check (see init), which puts
+// the daemon into degraded mode and retries until LXD becomes available.
 func New() (*Backend, error) {
 	server := Backend{}
 
@@ -214,11 +218,7 @@ func New() (*Backend, error) {
 		imageServer = srv
 	}
 
-	if err := ensureBackendReady(); err != nil {
-		return nil, err
-	}
-
-	return &server, nil
+	return &server, ensureBackendReady()
 }
 
 // ensureBackendReady creates the LXD storage pool and network the backend

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -133,14 +133,12 @@ func ErrorLxdBackend(err error) error {
 		return fmt.Errorf(`cannot connect to LXD: %w
 
 Maybe LXD daemon isn't active?
-To start the LXD daemon: 'sudo snap start lxd'
-To restart the workshop daemon: 'sudo snap restart workshop'`, err)
+To start the LXD daemon: 'sudo snap start lxd'`, err)
 	case errors.Is(err, os.ErrNotExist):
 		return fmt.Errorf(`cannot connect to LXD: %w
 
 Maybe LXD isn't installed?
-To install LXD: 'sudo snap install lxd'
-To restart the workshop daemon: 'sudo snap restart workshop'`, err)
+To install LXD: 'sudo snap install --channel=6/stable lxd'`, err)
 	default:
 		return err
 	}
@@ -165,7 +163,7 @@ func checkVersion(version string) error {
 	}
 
 	if major < minimalLXDMajor || (major == minimalLXDMajor && minor < minimalLXDMinor) {
-		return fmt.Errorf("%w: LXD server version %q is not supported; required >= %d.%d.*", workshop.ErrIncompatibleBackend, version, minimalLXDMajor, minimalLXDMinor)
+		return fmt.Errorf("%w: LXD server version %q is not supported; required >= %d.%d.*\nTo refresh LXD: 'sudo snap refresh --channel=6/stable lxd'", workshop.ErrIncompatibleBackend, version, minimalLXDMajor, minimalLXDMinor)
 	}
 	return nil
 }

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -114,10 +114,10 @@ func (f *LxdBeTests) TestCheckLxdVersion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	err = lxdbackend.CheckServerVersion("6.7")
-	c.Assert(err, check.ErrorMatches, ".*LXD server version.*is not supported.*")
+	c.Assert(err, check.ErrorMatches, `(?s).*LXD server version.*is not supported.*`)
 
 	err = lxdbackend.CheckServerVersion("5.9")
-	c.Assert(err, check.ErrorMatches, ".*LXD server version.*is not supported.*")
+	c.Assert(err, check.ErrorMatches, `(?s).*LXD server version.*is not supported.*`)
 
 	err = lxdbackend.CheckServerVersion("unreachable")
 	c.Assert(err, check.ErrorMatches, ".*cannot parse LXD server version.*")
@@ -132,5 +132,5 @@ func (f *LxdBeTests) TestCheckLxdVersion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	err = lxdbackend.CheckServerVersion("6.7.9")
-	c.Assert(err, check.ErrorMatches, ".*LXD server version.*is not supported.*")
+	c.Assert(err, check.ErrorMatches, `(?s).*LXD server version.*is not supported.*`)
 }

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -66,7 +66,6 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 	c.Assert(dirs.CreateDirs(), check.IsNil)
 
 	var err error
-
 	f.bd, err = lxdbackend.New()
 	c.Assert(err, check.IsNil)
 
@@ -839,10 +838,11 @@ func (f *wsOps) TestLxdBackendWorkshopLaunch(c *check.C) {
 	c.Check(w.Image, check.Equals, image)
 }
 
-func (f *wsOps) TestLxdBackendNewIsIdempotent(c *check.C) {
-	// New already ran once in SetUpSuite, creating the storage pool and
-	// network. Running it again must reconcile the existing resources rather
-	// than fail, so that it is safe to re-run as a system check.
+func (f *wsOps) TestLxdBackendSetupIsIdempotent(c *check.C) {
+	// The backend setup already ran once in SetUpSuite, creating the storage
+	// pool and network. Running it again must reconcile the existing resources
+	// rather than fail, so the degraded-mode recovery loop can safely re-run it
+	// once LXD is installed or refreshed.
 	_, err := lxdbackend.New()
 	c.Check(err, check.IsNil)
 

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -839,6 +839,17 @@ func (f *wsOps) TestLxdBackendWorkshopLaunch(c *check.C) {
 	c.Check(w.Image, check.Equals, image)
 }
 
+func (f *wsOps) TestLxdBackendNewIsIdempotent(c *check.C) {
+	// New already ran once in SetUpSuite, creating the storage pool and
+	// network. Running it again must reconcile the existing resources rather
+	// than fail, so that it is safe to re-run as a system check.
+	_, err := lxdbackend.New()
+	c.Check(err, check.IsNil)
+
+	_, err = lxdbackend.New()
+	c.Check(err, check.IsNil)
+}
+
 func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {
 	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
 	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -16,9 +16,9 @@ function setup_lxd() {
     fi
     lxd waitready --timeout=180
 
-    # can already be initialised if reused
+    # can already be initialised if reused or if a non-default pool exists
     # https://discuss.linuxcontainers.org/t/how-do-i-know-if-lxd-is-initialized/15473/3
-    if [ "$(lxc storage list -f compact | grep -c default)" -eq 0 ]; then
+    if [ "$(lxc storage list --format=csv | wc -l)" -eq 0 ]; then
         lxd init --auto --storage-backend=zfs
     fi
 }

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -1,5 +1,7 @@
 summary: Test workshopd checks LXD compatibility
 priority: -101
+debug: |
+  journalctl -xeu snap.workshop.workshopd.service
 execute: |
   . "$TESTSLIB"/utils.sh
 

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -13,8 +13,18 @@ execute: |
   ! workshop_exec list > error.log 2>&1 || false
   MATCH "^error: system is not healthy: incompatible backend: LXD server version .+ is not supported; required >= 6.8.\*$" < error.log
 
+  # Check that workshopd reports a clear error when LXD is not installed,
+  # and that it recovers automatically once LXD is installed again without
+  # requiring a restart of the workshop snap.
   "$TESTSLIB"/wait-snapshots-unmounted.sh
   snap remove lxd --purge
-  setup_lxd
+  # restart to clear incompatibility error
   snap restart workshop
+  ! workshop_exec list > error.log 2>&1 || false
+  MATCH "^error: system is not healthy: cannot connect to LXD:.*$" < error.log
+  MATCH "To install LXD: 'sudo snap install --channel=6/stable lxd'" < error.log
+
+  setup_lxd
+  # The daemon has a 5-second recovery ticker; no restart required.
+  retry 30 workshop_exec list
   workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"

--- a/tests/main/compatible-backend/task.yaml
+++ b/tests/main/compatible-backend/task.yaml
@@ -30,3 +30,17 @@ execute: |
   # The daemon has a 5-second recovery ticker; no restart required.
   retry 30 workshop_exec list
   workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"
+
+  # Check that workshopd reports a clear error when the LXD daemon is stopped,
+  # and that it recovers automatically once LXD is started again.
+  snap stop lxd
+  # restart to pick the connectivity issue straight away
+  snap restart workshop
+  ! workshop_exec list > error.log 2>&1 || false
+  MATCH "^error: system is not healthy: cannot connect to LXD:.*$" < error.log
+  MATCH "To start the LXD daemon: 'sudo snap start lxd'" < error.log
+  snap start lxd
+  lxd waitready --timeout=180
+  # The daemon has a 5-second recovery ticker; no restart required.
+  retry 30 workshop_exec list
+  workshop_exec list | MATCH "^comp-check[[:space:]]+Off[[:space:]]+-$"

--- a/tests/main/firewall-docker/task.yaml
+++ b/tests/main/firewall-docker/task.yaml
@@ -5,6 +5,7 @@ prepare: |
   # Remove LXD so Docker is the first to enable ip_forward and sets FORWARD
   # policy to DROP.
   "$TESTSLIB"/wait-snapshots-unmounted.sh
+  snap stop workshop
   snap remove lxd --purge
   sysctl -w net.ipv4.ip_forward=0
 
@@ -23,7 +24,7 @@ prepare: |
 
   # Bring LXD back and reinstall workshop with clean state.
   setup_lxd
-  snap restart workshop
+  snap start workshop
 restore: |
   . "$TESTSLIB"/utils.sh
 
@@ -34,6 +35,7 @@ restore: |
   # to clean state. LXD recreates its own rules on setup.
   nft flush ruleset
   "$TESTSLIB"/wait-snapshots-unmounted.sh
+  snap stop workshop
   snap remove lxd --purge
   setup_lxd
   rm -f /home/ubuntu/.cache/workshop/warnings.json


### PR DESCRIPTION
# Description

This PR addresses a few first user common issues:

- No manual restart required when LXD comes back online, gets installed or refreshed (due to LXD incompatibility or absence).
- Actionable error messages for the described scenarios.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
