### PR TITLE
Storage space monitoring

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -94,6 +94,7 @@ func init() {
 	// LXD is installed or refreshed, without a restart.
 	syscheck.RegisterCheck(checkServerCapabilities)
 	syscheck.RegisterCheck(ensureBackendReady)
+	syscheck.RegisterCheck(checkStorageSpace)
 }
 
 type Backend struct {
@@ -168,7 +169,7 @@ func checkVersion(version string) error {
 	return nil
 }
 
-func checkStorage(drivers []api.ServerStorageDriverInfo) error {
+func checkStorageDriver(drivers []api.ServerStorageDriverInfo) error {
 	hasDriver := func(driver api.ServerStorageDriverInfo) bool {
 		return driver.Name == storagePoolDriver
 	}
@@ -181,6 +182,46 @@ func checkStorage(drivers []api.ServerStorageDriverInfo) error {
 	//  exit status 1 (modprobe: FATAL: Module zfs not found ...)
 	// We keep the first part for consistency, the rest doesn't add much.
 	return fmt.Errorf(`suitable storage backend not found: error loading %q module`, storagePoolDriver)
+}
+
+// checkStorageSpace puts the daemon into degraded mode when the workshop
+// storage pool is 90% or more full, preventing further launches from failing
+// weirdly (e.g. on workshop remove causing troubles with backup yaml files
+// removal) due to lack of space.
+func checkStorageSpace() error {
+	const fullThresholdPct = 90
+
+	conn, err := lxd.ConnectLXDUnix("", nil)
+	if err != nil {
+		// LXD is not available; checkServerCapabilities handles this case.
+		return nil
+	}
+	defer conn.Disconnect()
+
+	res, err := conn.GetStoragePoolResources(storagePool)
+	if api.StatusErrorCheck(err, http.StatusNotFound) {
+		// Pool not yet created; ensureBackendReady handles this case.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if res.Space.Total == 0 {
+		// Cannot determine usage (e.g. directory-backed pools report zero).
+		return nil
+	}
+
+	usedPct := float64(res.Space.Used) / float64(res.Space.Total) * 100
+	if usedPct >= fullThresholdPct {
+		availGiB := float64(res.Space.Total-res.Space.Used) / (1024 * 1024 * 1024)
+		return fmt.Errorf("storage pool %q is %.0f%% full (%.1f GiB available); "+
+			"free up space or expand the pool with `lxc storage volume set workshop size=<N>GiB`\n"+
+			"For details see: https://ubuntu.com/workshop/docs/reference/workshops/#storage-pools-and-drivers",
+			storagePool, usedPct, availGiB)
+	}
+
+	return nil
 }
 
 func checkServerCapabilities() error {
@@ -202,7 +243,7 @@ func checkServerCapabilities() error {
 		return err
 	}
 
-	return checkStorage(info.Environment.StorageSupportedDrivers)
+	return checkStorageDriver(info.Environment.StorageSupportedDrivers)
 }
 
 // New constructs the LXD backend and attempts to prepare the required LXD

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/progress"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/syscheck"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	lxdbackend "github.com/canonical/workshop/internal/workshop/lxd"
@@ -848,6 +849,12 @@ func (f *wsOps) TestLxdBackendSetupIsIdempotent(c *check.C) {
 
 	_, err = lxdbackend.New()
 	c.Check(err, check.IsNil)
+}
+
+func (f *wsOps) TestLxdBackendStorageSpaceCheckHealthy(c *check.C) {
+	// With a freshly created pool the storage space check must not put the
+	// daemon into degraded mode.
+	c.Check(syscheck.CheckSystem(), check.IsNil)
 }
 
 func (f *wsOps) TestLxdBackendWorkshopRebuild(c *check.C) {

--- a/tests/main/autostart/task.yaml
+++ b/tests/main/autostart/task.yaml
@@ -1,4 +1,10 @@
 summary: Ensure that workshop autostart behavior performs correctly
+debug: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec list --global || true
+  lxc list --project workshop.ubuntu || true
+  resolvectl status workshopbr0 || true
+  journalctl -xeu snap.workshop.workshopd.service || true
 prepare: |
   . "$TESTSLIB"/utils.sh
   workshop_exec launch
@@ -8,13 +14,17 @@ restore: |
 execute: |
   . "$TESTSLIB"/utils.sh
 
+  check_dns() {
+    resolvectl query "ws-autostart-$(< .workshop.lock).wp" | MATCH 'link: workshopbr0'
+  }
+
   echo "Make sure a running workshop automatically starts after reboot"
   if [ $SPREAD_REBOOT = 0 ]; then
     REBOOT
   fi
   if [ $SPREAD_REBOOT = 1 ]; then
     workshop_exec list | MATCH 'Ready'
-    resolvectl query "ws-autostart-$(< .workshop.lock).wp" | MATCH 'link: workshopbr0'
+    retry 3 check_dns
   fi
 
   echo "Make sure a workshop can start independently of the workshop daemon"
@@ -25,7 +35,7 @@ execute: |
   if [ $SPREAD_REBOOT = 2 ]; then
     snap start --enable workshop
     workshop_exec list | MATCH 'Ready'
-    resolvectl query "ws-autostart-$(< .workshop.lock).wp" | MATCH 'link: workshopbr0'
+    retry 3 check_dns
   fi
 
   echo "Make sure a stopped workshop remains stopped after reboot"


### PR DESCRIPTION
# Description

Puts the daemon in a degraded mode when threshold is met to avoid issues with operating workshops when the storage is full.

Based on https://github.com/canonical/workshop/pull/908

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
