### PR TITLE
Align launch --wait-on-error message with refresh

### DIFF
--- a/cmd/workshop/launch.go
+++ b/cmd/workshop/launch.go
@@ -168,11 +168,15 @@ func (c *CmdLaunch) Run(cmd *cobra.Command, av []string) error {
 		fmt.Fprintf(Stdout, "%s launch aborted\n", strutil.Quoted(av))
 	case errors.Is(err, errWaitOnError):
 		w := workshopName(av[0])
-		return fmt.Errorf(`cannot complete launch for %q, execution is paused
+		return fmt.Errorf(`
+cannot launch %[1]q; paused
+To view details: "workshop tasks %[2]s"
 
-To proceed, resolve the issue and run "workshop launch --continue %s"
-To cancel and undo: "workshop launch --abort %s"
-To view more information: "workshop tasks %s"`, w, w, w, changeId)
+To abort and undo: "workshop launch --abort %[1]s"
+Otherwise, resolve the error, then run "workshop launch --continue %[1]s"`[1:],
+			w,
+			changeId,
+		)
 	default:
 		return fmt.Errorf("%v\n%s launch aborted", err, strutil.Quoted(av))
 	}

--- a/cmd/workshop/launch_test.go
+++ b/cmd/workshop/launch_test.go
@@ -99,10 +99,15 @@ func (m *workshopLaunch) TestLaunchWaitOnErrorFailed(c *check.C) {
 
 	err := cmd.Run(nil, []string{"ws"})
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "cannot complete launch for \"ws\", execution is paused\n\n"+
-		"To proceed, resolve the issue and run \"workshop launch --continue ws\"\n"+
-		"To cancel and undo: \"workshop launch --abort ws\"\n"+
-		"To view more information: \"workshop tasks 42\"")
+	c.Assert(err, check.ErrorMatches, `cannot launch "ws"; paused
+`+
+		`To view details: "workshop tasks 42"
+`+
+		`
+`+
+		`To abort and undo: "workshop launch --abort ws"
+`+
+		`Otherwise, resolve the error, then run "workshop launch --continue ws"`)
 }
 
 func (m *workshopLaunch) TestLaunchWaitOnErrorAbortedSuccessfully(c *check.C) {


### PR DESCRIPTION
# Description

Aligns the `workshop launch --wait-on-error` paused message with the structure already used by `workshop refresh --wait-on-error`, so users see a consistent message shape across both commands.

Both `launch` and `refresh` flow through the same `waitMixin.wait` path and return the shared `errWaitOnError` sentinel when a task enters `Wait` status. However, the two commands rendered different messages.

**Before (launch):**

```
cannot complete launch for "dev", execution is paused

To proceed, resolve the issue and run "workshop launch --continue dev"
To cancel and undo: "workshop launch --abort dev"
To view more information: "workshop tasks 184"
```

**After (launch):**

```
cannot launch "dev"; paused
To view details: "workshop tasks 184"

To abort and undo: "workshop launch --abort dev"
Otherwise, resolve the error, then run "workshop launch --continue dev"
```

The new wording mirrors `refresh` (`cmd/workshop/refresh.go:214-219`): tasks hint first, then a blank line, then the abort and continue guidance.

## Changes

- `cmd/workshop/launch.go` — Rewrote the `errWaitOnError` branch in `CmdLaunch.Run` to use the same `[1:]`-on-raw-string and indexed-args pattern as `refresh.go`.
- `cmd/workshop/launch_test.go` — Updated `TestLaunchWaitOnErrorFailed` to assert the new message.

## Testing

- `go test ./cmd/workshop/ -check.f 'workshopLaunch.TestLaunchWaitOnErrorFailed'` — PASS
- `go test ./cmd/workshop/ -check.f 'workshopLaunch|workshopSketch'` — 36 passed
- `go test ./cmd/workshop/` — full package PASS
- Manually reproduced end-to-end with a `try-` SDK whose `setup-base` hook exits non-zero; confirmed the new message surfaces on `workshop launch --wait-on-error`.

## Out of scope

- `cmd/workshop/sketch.go` still emits the older `cannot complete sketch refresh for %q, execution is paused` wording for the sketch-refresh flow. Left unchanged here; could be aligned in a follow-up if desired.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically.
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

This PR has no implications for documentation. The change is a user-facing
string rewrite in an error message; no documented behaviour changes, and
no existing docs reference the old wording.

* [x] I confirm the PR has no implications for documentation.
