### PR TITLE
Align sketch-sdk wait-on-error message with launch and refresh

### DIFF
--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -339,11 +339,15 @@ func handleSketchRefreshErrors(wp string, chg *client.Change, err error) error {
 	case errors.Is(err, errUndone):
 		fmt.Fprintf(Stdout, "%q sketch refresh aborted\n", wp)
 	case errors.Is(err, errWaitOnError):
-		return fmt.Errorf(`cannot complete sketch refresh for %q, execution is paused
+		return fmt.Errorf(`
+cannot sketch %[1]q; paused
+To view details: "workshop tasks %[2]s"
 
-To proceed, resolve the issue and run "workshop refresh --continue %s"
-To cancel and undo: "workshop refresh --abort %s"
-To view more information: "workshop tasks %s"`, wp, wp, wp, chg.ID)
+To abort and undo: "workshop refresh --abort %[1]s"
+Otherwise, resolve the error, then run "workshop refresh --continue %[1]s"`[1:],
+			wp,
+			chg.ID,
+		)
 	default:
 		return fmt.Errorf("%v\n%s sketch refresh aborted", err, wp)
 	}

--- a/cmd/workshop/sketch_test.go
+++ b/cmd/workshop/sketch_test.go
@@ -554,10 +554,15 @@ hooks:
 	defer restore()
 
 	err := cmd.Run(cmd.Command(), []string{"ws"})
-	c.Assert(err, check.ErrorMatches, "cannot complete sketch refresh for \"ws\", execution is paused\n\n"+
-		"To proceed, resolve the issue and run \"workshop refresh --continue ws\"\n"+
-		"To cancel and undo: \"workshop refresh --abort ws\"\n"+
-		"To view more information: \"workshop tasks 43\"")
+	c.Assert(err, check.ErrorMatches, `cannot sketch "ws"; paused
+`+
+		`To view details: "workshop tasks 43"
+`+
+		`
+`+
+		`To abort and undo: "workshop refresh --abort ws"
+`+
+		`Otherwise, resolve the error, then run "workshop refresh --continue ws"`)
 
 	err = cmd.Run(cmd.Command(), []string{"ws"})
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
## Description

Aligns the `workshop sketch-sdk` wait-on-error message with the structure now used by `workshop launch` and `workshop refresh`, so users see a consistent message shape across all three commands.

The sketch-sdk command flows through the same `waitMixin.wait` path and `errWaitOnError` sentinel as launch and refresh, but rendered a different message.

**Before:**

```
cannot complete sketch refresh for "dev", execution is paused

To proceed, resolve the issue and run "workshop refresh --continue dev"
To cancel and undo: "workshop refresh --abort dev"
To view more information: "workshop tasks 184"
```

**After:**

```
cannot sketch "dev"; paused
To view details: "workshop tasks 184"

To abort and undo: "workshop refresh --abort dev"
Otherwise, resolve the error, then run "workshop refresh --continue dev"
```

The new wording mirrors `launch` and `refresh`: tasks hint first, then a blank line, then the abort and continue guidance.

## Note on command hints

The hints reference `workshop refresh --abort/--continue` rather than `workshop sketch-sdk --abort/--continue`. The `sketch-sdk` command has no `--abort` or `--continue` flags — it delegates to `CmdRefresh` internally (`cmd/workshop/sketch.go:494-498`), and the user-facing abort/continue flow for a paused sketch refresh is via `workshop refresh`. This matches the previous message's behaviour and is consistent with how the sketch flow actually works under the hood.

If `--abort`/`--continue` flags should be added to `workshop sketch-sdk` itself, that's a separate, larger piece of work.

## Changes

- `cmd/workshop/sketch.go` — Rewrote the `errWaitOnError` branch in `handleSketchRefreshErrors` to use the same `[1:]`-on-raw-string and indexed-args pattern as `launch.go` and `refresh.go`.
- `cmd/workshop/sketch_test.go` — Updated `TestSketchSdkFixRefreshError` to assert the new message.

## Testing

- `go test ./cmd/workshop/ -check.f 'workshopSketch'` — 29 passed
- `go test ./cmd/workshop/` — full package PASS
- Manually reproduced end-to-end by adding a sketch SDK with a failing `setup-base` hook via `workshop sketch-sdk dev`, confirming the new message surfaces on the automatic refresh.

## Out of scope

- Adding `--abort`/`--continue` flags to `workshop sketch-sdk` itself, which would let the hints reference `workshop sketch-sdk` directly. Flagged as a potential follow-up.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically.
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

This PR has no implications for documentation. The change is a user-facing string rewrite in an error message; no documented behaviour changes, and no existing docs reference the old wording.

* [x] I confirm the PR has no implications for documentation.
