### PR TITLE
Fix tunnel slot permissions

### DIFF
--- a/internal/interfaces/builtin/desktop.go
+++ b/internal/interfaces/builtin/desktop.go
@@ -101,7 +101,7 @@ func (iface *desktopInterface) MountConnectedPlug(spec *lxd_device.Specification
 				Protocol: "unix",
 			},
 			Listen: workshop.ProxyTarget{
-				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0-inside-workshop"),
+				Address:  filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0"),
 				Protocol: "unix",
 			},
 			Direction: workshop.WorkshopToHost,

--- a/internal/interfaces/builtin/desktop_test.go
+++ b/internal/interfaces/builtin/desktop_test.go
@@ -99,7 +99,7 @@ slots:
 				Address:  "/tmp/wayland-1",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/run/user/1000/wayland-0-inside-workshop",
+				Address:  "/run/user/1000/wayland-0",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)
@@ -182,7 +182,7 @@ slots:
 				Address:  "/var/run/wayland-0",
 				Protocol: "unix"},
 			Listen: workshop.ProxyTarget{
-				Address:  "/run/user/1000/wayland-0-inside-workshop",
+				Address:  "/run/user/1000/wayland-0",
 				Protocol: "unix"},
 			Direction: workshop.WorkshopToHost}}
 	c.Assert(deviceSpec.Profile.Desktop, check.DeepEquals, expectedProxy)

--- a/internal/interfaces/lxd_device/backend.go
+++ b/internal/interfaces/lxd_device/backend.go
@@ -760,27 +760,6 @@ func cleanupProfile(conn lxd.InstanceServer, sdkRef sdk.Ref) error {
 	return cmp.Or(err, err2, err3)
 }
 
-func checkListenSocketPaths(devices map[string]map[string]string) error {
-	for _, dev := range devices {
-		if dev["type"] != "proxy" || dev["bind"] != "instance" {
-			continue
-		}
-		listen := dev["listen"]
-		if !strings.HasPrefix(listen, "unix:/") {
-			continue
-		}
-		listen = strings.TrimPrefix(listen, "unix:")
-		if strings.HasPrefix(listen, "/tmp/") || strings.HasPrefix(listen, dirs.WorkshopRunDir+"/") {
-			continue
-		}
-		if listen == filepath.Join(dirs.XdgRuntimeDirBase, workshop.User.Uid, "wayland-0-inside-workshop") {
-			continue
-		}
-		return fmt.Errorf("currently unsafe to create socket %q using LXD", listen)
-	}
-	return nil
-}
-
 // Setup creates mount profile specific to a given sdk.
 func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Repository) error {
 	s, err := repo.SdkSpecification(ctx, b.Name(), sdkRef)
@@ -788,10 +767,6 @@ func (b *Backend) Setup(ctx context.Context, sdkRef sdk.Ref, repo *interfaces.Re
 		return err
 	}
 	spec := s.(*Specification)
-
-	if err := checkListenSocketPaths(spec.devices); err != nil {
-		return err
-	}
 
 	conn, err := lxdbackend.ConnectLxd(ctx)
 	if err != nil {

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -324,6 +324,8 @@ func (s *Specification) addProxyEntry(entry *workshop.ProxyEntry, configKey stri
 			device["uid"] = workshop.User.Uid
 			device["gid"] = workshop.User.Gid
 		}
+		device["security.uid"] = s.User.Uid
+		device["security.gid"] = s.User.Gid
 	case workshop.HostToWorkshop:
 		device["bind"] = "host"
 		if entry.Listen.Protocol == "unix" && !strings.HasPrefix(entry.Listen.Address, "@") {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -400,7 +400,7 @@ func (s *Backend) LaunchOrRebuildWorkshop(ctx context.Context, file *workshop.Fi
 	req := api.InstancesPost{
 		InstancePut: api.InstancePut{
 			Config:  config,
-			Devices: defaultDevices(projectId, file.Name),
+			Devices: defaultDevices(usr, projectId, file.Name),
 		},
 		Name: InstanceName(file.Name, projectId),
 		Type: api.InstanceTypeContainer,
@@ -1197,7 +1197,7 @@ func (s *Backend) LxdClient(ctx context.Context) (lxd.InstanceServer, error) {
 	return ConnectLxd(ctx)
 }
 
-func defaultDevices(pid, w string) map[string]map[string]string {
+func defaultDevices(usr *user.User, pid, w string) map[string]map[string]string {
 	devices := map[string]map[string]string{
 		"root":             {"type": "disk", "pool": storagePool, "path": "/"},
 		"workshop.network": {"type": "nic", "network": networkName, "name": "eth0"},
@@ -1209,13 +1209,13 @@ func defaultDevices(pid, w string) map[string]map[string]string {
 	}
 
 	for _, proxy := range proxies {
-		devices[proxy.Name] = proxyToLxdDevice(proxy)
+		devices[proxy.Name] = proxyToLxdDevice(usr, proxy)
 	}
 
 	return devices
 }
 
-func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
+func proxyToLxdDevice(usr *user.User, proxy workshop.ProxyEntry) map[string]string {
 	device := map[string]string{
 		"type":    "proxy",
 		"connect": proxy.Connect.Protocol + ":" + proxy.Connect.Address,
@@ -1225,6 +1225,8 @@ func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
 	switch proxy.Direction {
 	case workshop.WorkshopToHost:
 		device["bind"] = "instance"
+		device["security.uid"] = usr.Uid
+		device["security.gid"] = usr.Gid
 	case workshop.HostToWorkshop:
 		device["bind"] = "host"
 	}

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -36,6 +36,8 @@ launched:
       bind: instance
       listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
       mode: '0666'
+      security.gid: '1000'
+      security.uid: '1000'
       type: proxy
     workshop.workshopctl:
       path: /usr/bin/workshopctl
@@ -74,6 +76,8 @@ started:
       bind: instance
       listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
       mode: '0666'
+      security.gid: '1000'
+      security.uid: '1000'
       type: proxy
     workshop.workshopctl:
       path: /usr/bin/workshopctl
@@ -124,6 +128,8 @@ sdk-attached:
       bind: instance
       listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
       mode: '0666'
+      security.gid: '1000'
+      security.uid: '1000'
       type: proxy
     workshop.workshopctl:
       path: /usr/bin/workshopctl
@@ -182,6 +188,8 @@ sdk-mounted:
       bind: instance
       listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
       mode: '0666'
+      security.gid: '1000'
+      security.uid: '1000'
       type: proxy
     workshop.workshopctl:
       path: /usr/bin/workshopctl


### PR DESCRIPTION
# Description

Fixes an issue where workshop->host tunnels have more privileges than necessary. Also removes a workaround for an old LXD bug.

## Testing

Long-running LXD forkproxy processes now run as my normal user or the namespaced `root` user. I can no longer connect to LXD from inside a workshop (since my user isn't in the `lxd` group usually).

Disconnecting the desktop interface doesn't delete `$XDG_RUNTIME_DIR/wayland-0` anymore.

`workshopctl check-health` can still communicate with the daemon (I made the `tools` SDK in this repo fail).

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
