### PR TITLE
Add Virtualization/KVM interface

### DIFF
--- a/docs/.coverage.yaml
+++ b/docs/.coverage.yaml
@@ -394,6 +394,11 @@
   specs:
   - SK033
 
+"virtualization interface":
+  category: interface
+  type: concept
+  specs: []
+
 "try SDK":
   category: SDK
   type: concept

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -161,6 +161,15 @@
                 <td><a href="reference/definition-files/_interfaces/tunnel.rst#L9">[tunnel.rst]</a><br><a href="reference/sdks.rst#L328">[sdks.rst]</a></td>
                 <td>SK033</td>
             </tr><tr>
+                <td>virtualization interface</td>
+                <td>interface</td>
+                <td>concept</td>
+                <td></td>
+                <td></td>
+                <td><a href="explanation/interfaces/virtualization-interface.rst#L12">[virtualization-interface.rst]</a></td>
+                <td></td>
+                <td></td>
+            </tr><tr>
                 <td>in-project SDK</td>
                 <td>project</td>
                 <td>concept</td>

--- a/docs/explanation/interfaces/index.rst
+++ b/docs/explanation/interfaces/index.rst
@@ -37,6 +37,7 @@ such as displays, GPUs, and cameras:
    custom-device-interface
    desktop-interface
    gpu-interface
+   virtualization-interface
 
 
 Data and connectivity

--- a/docs/explanation/interfaces/virtualization-interface.rst
+++ b/docs/explanation/interfaces/virtualization-interface.rst
@@ -1,0 +1,140 @@
+.. _exp_virtualization_interface:
+
+.. meta::
+   :description: Documentation of the virtualization interface that enables
+                 workshops to run hardware-accelerated virtual machines by
+                 passing through the host's KVM and vhost/vsock character
+                 devices.
+
+Virtualization interface
+========================
+
+.. @artefact virtualization interface
+
+The virtualization interface
+enables hardware-accelerated virtual machines inside a workshop
+by passing through the host's virtualization character devices.
+
+By using the interface,
+the SDK publisher allows the workshop to directly access the host's
+:file:`/dev/kvm` device (for KVM acceleration)
+together with the :samp:`vhost` and :samp:`vsock` devices
+that accelerate virtual machine networking and host/guest communication.
+
+
+.. _exp_virtualization_plug:
+
+Virtualization interface plug
+-----------------------------
+
+An essential element here is the virtualization interface plug,
+which is declared in the SDK definition.
+
+Its structure includes just the name of the plug and the interface;
+both must be set to :samp:`virtualization`.
+
+Defining the plug in an SDK
+allows the workshops using this SDK to run hardware-accelerated
+virtual machines.
+
+
+.. _exp_virtualization_slot:
+
+Virtualization interface slot
+-----------------------------
+
+To let SDKs in a workshop access the host's virtualization devices,
+|ws_markup| provides a virtualization interface slot
+that multiple virtualization interface plugs can access.
+
+When the SDK is installed at runtime during launch and refresh operations,
+|ws_markup| checks that the plug targeting the slot
+passes :ref:`validation <exp_interfaces_validation>`;
+if it does,
+it can be connected.
+
+
+Devices and permissions
+-----------------------
+
+When the interface is connected,
+the following host devices are exposed inside the workshop
+as :samp:`unix-char` devices:
+
+- :file:`/dev/kvm`
+- :file:`/dev/vhost-net`
+- :file:`/dev/vhost-vsock`
+- :file:`/dev/vsock`
+
+The devices are owned by the workshop user with mode :samp:`0660`,
+so the passed-through devices are accessible without granting world access.
+Devices that are not present on the host
+(for example when the :samp:`vsock` kernel modules are not loaded)
+are skipped and do not prevent the workshop from starting.
+
+:file:`/dev/net/tun`, which virtual machine networking also relies on,
+is already available inside the workshop
+and therefore is not part of this list.
+
+
+Connection
+----------
+
+Unlike the GPU interface,
+the virtualization interface is not connected automatically;
+it must be connected manually
+because it grants a workshop privileged access to host virtualization devices.
+
+The plug can be matched to the slot by its name
+or via a :samp:`connections` entry in the :ref:`definition <exp_workshop_definition>`,
+both subject to |ws_markup|'s
+:ref:`validation rules <exp_interfaces_validation>`.
+
+After the workshop has started,
+the :command:`workshop connect` and :command:`workshop disconnect` commands
+can be used to manage the connection manually.
+
+Establishing a connection means
+the host's virtualization devices are directly available inside the workshop.
+
+To check if the interface is connected:
+
+.. code-block:: console
+
+   $ workshop connections --all
+
+     INTERFACE       PLUG                          SLOT                      NOTES
+     ...
+     virtualization  ws/vm-sdk:virtualization      ws/system:virtualization  -
+
+
+This means the host's virtualization devices are directly available
+inside the workshop:
+
+.. code-block:: console
+
+   $ workshop shell ws
+   workshop@ws-8584e571$ ls -h /dev/kvm /dev/vhost-net /dev/vsock
+
+     /dev/kvm  /dev/vhost-net  /dev/vsock
+
+
+See also
+--------
+
+Explanation:
+
+- :ref:`exp_interface_concepts`
+- :ref:`exp_plugs_slots`
+- :ref:`exp_sdk_definition`
+- :ref:`exp_workshop_definition`
+
+
+Reference:
+
+- :ref:`ref_workshop_connect`
+- :ref:`ref_workshop_connections`
+- :ref:`ref_workshop_disconnect`
+- :ref:`ref_workshop_launch`
+- :ref:`ref_workshop_refresh`
+- :ref:`ref_workshop_shell`

--- a/docs/reference/definition-files/_interfaces/virtualization.rst
+++ b/docs/reference/definition-files/_interfaces/virtualization.rst
@@ -1,0 +1,29 @@
+..
+   Single-sourced snippet. Included by workshop-definition.rst,
+   sdk-definition.rst, and sdkcraft-definition.rst.
+   Do not add a top-level label; the including page provides the anchor.
+
+Virtualization interface
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The virtualization interface exposes the host character devices required to run
+hardware-accelerated virtual machines (KVM) inside a workshop.
+
+- Plug attributes: none.
+- Plug name: must be :samp:`virtualization`.
+- Plug owner: any regular SDK; not the system SDK.
+- Slot: the system SDK provides a single :samp:`system:virtualization` slot.
+  Other SDKs cannot declare virtualization slots.
+
+When connected, the following host devices are passed through to the workshop as
+:samp:`unix-char` devices, owned by the :samp:`kvm` group with mode
+:samp:`0660`, and the workshop user is made a member of that group:
+
+- :file:`/dev/kvm`
+- :file:`/dev/vhost-net`
+- :file:`/dev/vhost-vsock`
+- :file:`/dev/vsock`
+
+Devices that are not present on the host (for example when the :samp:`vsock`
+kernel modules are not loaded) are skipped and do not prevent the workshop from
+starting.

--- a/docs/reference/definition-files/schema-sdk.json
+++ b/docs/reference/definition-files/schema-sdk.json
@@ -176,7 +176,8 @@
           "gpu": "#/$defs/GPUPlug",
           "mount": "#/$defs/MountPlug",
           "ssh-agent": "#/$defs/SSHAgentPlug",
-          "tunnel": "#/$defs/TunnelPlug"
+          "tunnel": "#/$defs/TunnelPlug",
+          "virtualization": "#/$defs/VirtualizationPlug"
         },
         "propertyName": "interface"
       },
@@ -201,6 +202,9 @@
         },
         {
           "$ref": "#/$defs/TunnelPlug"
+        },
+        {
+          "$ref": "#/$defs/VirtualizationPlug"
         }
       ]
     },
@@ -337,6 +341,22 @@
       "$ref": "#/$defs/Int",
       "ge": 0,
       "lt": 4294967295
+    },
+    "VirtualizationPlug": {
+      "additionalProperties": false,
+      "description": "SDKcraft project virtualization plug definition.",
+      "properties": {
+        "interface": {
+          "const": "virtualization",
+          "title": "Interface",
+          "type": "string"
+        }
+      },
+      "required": [
+        "interface"
+      ],
+      "title": "VirtualizationPlug",
+      "type": "object"
     }
   },
   "additionalProperties": true,

--- a/docs/reference/definition-files/schema-sdkcraft.json
+++ b/docs/reference/definition-files/schema-sdkcraft.json
@@ -237,7 +237,8 @@
           "gpu": "#/$defs/GPUPlug",
           "mount": "#/$defs/MountPlug",
           "ssh-agent": "#/$defs/SSHAgentPlug",
-          "tunnel": "#/$defs/TunnelPlug"
+          "tunnel": "#/$defs/TunnelPlug",
+          "virtualization": "#/$defs/VirtualizationPlug"
         },
         "propertyName": "interface"
       },
@@ -262,6 +263,9 @@
         },
         {
           "$ref": "#/$defs/TunnelPlug"
+        },
+        {
+          "$ref": "#/$defs/VirtualizationPlug"
         }
       ]
     },
@@ -398,6 +402,22 @@
       "$ref": "#/$defs/Int",
       "ge": 0,
       "lt": 4294967295
+    },
+    "VirtualizationPlug": {
+      "additionalProperties": false,
+      "description": "SDKcraft project virtualization plug definition.",
+      "properties": {
+        "interface": {
+          "const": "virtualization",
+          "title": "Interface",
+          "type": "string"
+        }
+      },
+      "required": [
+        "interface"
+      ],
+      "title": "VirtualizationPlug",
+      "type": "object"
     }
   },
   "additionalProperties": false,

--- a/docs/reference/definition-files/sdk-definition.rst
+++ b/docs/reference/definition-files/sdk-definition.rst
@@ -179,6 +179,8 @@ and any interface-specific attributes.
 
 .. include:: _interfaces/tunnel.rst
 
+.. include:: _interfaces/virtualization.rst
+
 
 JSON Schema
 -----------

--- a/docs/reference/definition-files/sdkcraft-definition.rst
+++ b/docs/reference/definition-files/sdkcraft-definition.rst
@@ -231,6 +231,8 @@ and any interface-specific attributes.
 
 .. include:: _interfaces/tunnel.rst
 
+.. include:: _interfaces/virtualization.rst
+
 
 JSON Schema
 -----------

--- a/docs/reference/definition-files/workshop-definition.rst
+++ b/docs/reference/definition-files/workshop-definition.rst
@@ -302,6 +302,8 @@ a workshop may graft additional plugs and slots that follow them.
 
 .. include:: _interfaces/tunnel.rst
 
+.. include:: _interfaces/virtualization.rst
+
 
 JSON Schema
 -----------

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -1162,7 +1162,7 @@ line 1: cannot unmarshal !!seq into string`,
 	c.Assert(err, check.IsNil)
 	c.Assert(s.secBackend.SetupCalls, check.HasLen, 0)
 	repo := s.d.overlord.InterfaceManager().Repository()
-	c.Assert(repo.Slots(s.project.ProjectId, "basic", sdk.System.String()), check.HasLen, 6)
+	c.Assert(repo.Slots(s.project.ProjectId, "basic", sdk.System.String()), check.HasLen, 7)
 
 	c.Assert(s.b.DownloadBaseCalls, check.HasLen, 1)
 
@@ -2162,6 +2162,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}, {
 		name: "basic",
@@ -2176,6 +2177,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}, {
 		name: "manysdks",
@@ -2190,6 +2192,7 @@ func (s *apiSuite) TestRefreshMany(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -2292,6 +2295,7 @@ func (s *apiSuite) TestRefreshAddSdk(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -2373,6 +2377,7 @@ func (s *apiSuite) TestRefreshInsertNewSdk(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -2453,6 +2458,7 @@ func (s *apiSuite) TestRefreshRemoveSdk(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -2550,6 +2556,7 @@ func (s *apiSuite) TestRefreshSdkNewRevision(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 	s.ensureWorkshops(c, want)
@@ -2760,6 +2767,7 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 	s.ensureWorkshops(c, want)
@@ -2808,6 +2816,7 @@ func (s *apiSuite) TestRefreshTrySdk(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 	s.ensureWorkshops(c, want)
@@ -2875,6 +2884,7 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 	s.ensureWorkshops(c, want)
@@ -2922,6 +2932,7 @@ func (s *apiSuite) TestRefreshSdkNewProjectFiles(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 	s.ensureWorkshops(c, want)
@@ -3003,6 +3014,7 @@ func (s *apiSuite) TestRefreshConnectionsChanged(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3085,6 +3097,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugChanged(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3159,6 +3172,7 @@ func (s *apiSuite) TestRefreshSystemDefinitionExtended(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 			"system:tunnel",
 		},
 	}}
@@ -3240,6 +3254,7 @@ func (s *apiSuite) TestRefreshSdkRecordPlugRemoved(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3318,6 +3333,7 @@ func (s *apiSuite) TestRefreshNoChanges(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3397,6 +3413,7 @@ func (s *apiSuite) TestRefreshRestore(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3479,6 +3496,7 @@ func (s *apiSuite) TestRefreshBaseChange(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3578,6 +3596,7 @@ func (s *apiSuite) TestRefreshBaseUpdate(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3655,6 +3674,7 @@ func (s *apiSuite) TestRefreshSystemSdkInstalledFirst(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3724,6 +3744,7 @@ func (s *apiSuite) TestRefreshAllSdksRemoved(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -3805,6 +3826,7 @@ func (s *apiSuite) TestRefreshRestoreFromStash(c *check.C) {
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -4499,6 +4521,7 @@ base: ubuntu@22.04
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 
@@ -4552,6 +4575,7 @@ plugs:
 			"system:gpu",
 			"system:mount",
 			"system:ssh-agent",
+			"system:virtualization",
 		},
 	}}
 

--- a/internal/interfaces/builtin/virtualization.go
+++ b/internal/interfaces/builtin/virtualization.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+const virtualizationSummary = `allows launching hardware-accelerated virtual machines`
+
+const virtualizationBaseDeclarationSlots = `
+  virtualization:
+    allow-installation:
+      slot-sdk-type:
+        - system
+      slot-names:
+        - $INTERFACE
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+const virtualizationBaseDeclarationPlugs = `
+  virtualization:
+    allow-installation:
+      plug-sdk-type:
+        - regular
+      plug-names:
+        - $INTERFACE
+    allow-connection: true
+    deny-auto-connection: true
+`
+
+type virtualizationInterface struct{}
+
+func (iface *virtualizationInterface) Name() string {
+	return "virtualization"
+}
+
+func (iface *virtualizationInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              virtualizationSummary,
+		BaseDeclarationPlugs: virtualizationBaseDeclarationPlugs,
+		BaseDeclarationSlots: virtualizationBaseDeclarationSlots,
+		AffectsPlugOnRefresh: true,
+	}
+}
+
+func (iface *virtualizationInterface) AutoConnect(plug *sdk.PlugInfo, slot *sdk.SlotInfo) bool {
+	// allow what declarations allowed
+	return true
+}
+
+func (iface *virtualizationInterface) MountConnectedPlug(spec *lxd_device.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	return spec.SetVirtualization(workshop.Virtualization{Name: plug.Name()})
+}
+
+func init() {
+	registerIface(&virtualizationInterface{})
+}

--- a/internal/interfaces/builtin/virtualization_test.go
+++ b/internal/interfaces/builtin/virtualization_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package builtin_test
+
+import (
+	"context"
+	"os/user"
+
+	"github.com/canonical/lxd/shared/api"
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/interfaces/builtin"
+	"github.com/canonical/workshop/internal/interfaces/lxd_device"
+	"github.com/canonical/workshop/internal/osutil"
+	"github.com/canonical/workshop/internal/testutil"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+type virtualizationSuite struct {
+	iface     interfaces.Interface
+	projectId string
+
+	restoreUserLookup func()
+	restoreUserEnv    func()
+	restoreLxdInfo    func()
+}
+
+var _ = check.Suite(&virtualizationSuite{
+	iface: builtin.MustInterface("virtualization"),
+})
+
+func (s *virtualizationSuite) SetUpSuite(c *check.C) {
+	s.projectId = "42424242"
+	s.restoreUserLookup = osutil.FakeUserLookup(func(name string) (*user.User, error) {
+		return &testuser, nil
+	})
+	s.restoreUserEnv = osutil.FakeUserEnvironment(func(user *user.User) (map[string]string, error) {
+		return nil, nil
+	})
+	s.restoreLxdInfo = lxd_device.MockLxdServerInfo(func(ctx context.Context) (*api.Resources, error) {
+		return &api.Resources{}, nil
+	})
+}
+
+func (s *virtualizationSuite) TearDownSuite(c *check.C) {
+	s.restoreLxdInfo()
+	s.restoreUserEnv()
+	s.restoreUserLookup()
+}
+
+func (s *virtualizationSuite) TestName(c *check.C) {
+	c.Assert(s.iface.Name(), check.Equals, "virtualization")
+}
+
+func (s *virtualizationSuite) TestInterfaces(c *check.C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}
+
+func (s *virtualizationSuite) TestVirtualizationInterface(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+ virtualization:
+  interface: virtualization
+`, s.projectId, "ws", "consumer", "virtualization")
+	connectedPlug := interfaces.NewConnectedPlug(plug, nil, nil)
+
+	slot := builtin.MockSlot(c, `name: producer
+base: ubuntu@22.04
+slots:
+ virtualization:
+`, s.projectId, "ws", "producer", "virtualization")
+	connectedSlot := interfaces.NewConnectedSlot(slot, nil, nil)
+
+	deviceSpec, err := lxd_device.NewSpecification(testuser.Username, "consumer")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(deviceSpec.AddConnectedPlug(s.iface, connectedPlug, connectedSlot), check.IsNil)
+
+	// Validate the device specification.
+	expectedDevice := &workshop.Virtualization{Name: plug.Name}
+	c.Assert(deviceSpec.Profile.Virtualization, check.DeepEquals, expectedDevice)
+}
+
+func (s *virtualizationSuite) TestSanitizePlugUnknownAttribute(c *check.C) {
+	plug := builtin.MockPlug(c, `name: consumer
+base: ubuntu@22.04
+plugs:
+  virtualization:
+    interface: virtualization
+    subsystem: kvm
+`, s.projectId, "ws", "consumer", "virtualization")
+	err := interfaces.BeforePreparePlug(s.iface, plug)
+	c.Check(err, check.ErrorMatches, `unknown attribute for virtualization interface plug: "subsystem"`)
+}

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -277,6 +278,51 @@ func (s *Specification) SetCamera(camera workshop.Camera) error {
 			"ownership.inherit": "true",
 		}
 		s.config[lxdbackend.DeviceTypeConfigKey(name)] = "camera"
+	}
+
+	return nil
+}
+
+// virtualizationDevices are the host character devices exposed to the workshop
+// by the virtualization interface. They enable hardware-accelerated virtual
+// machines (KVM) together with vhost/vsock acceleration. /dev/net/tun is not
+// listed here because LXD already provides it inside the container.
+var virtualizationDevices = []string{
+	"/dev/kvm",
+	"/dev/vhost-net",
+	"/dev/vhost-vsock",
+	"/dev/vsock",
+}
+
+// SetVirtualization exposes the virtualization character devices to the
+// workshop as LXD "unix-char" devices. Each device is owned by the workshop
+// user (uid/gid) with mode 0660 so that the user can access them directly. The
+// devices are marked non-required so that a host missing e.g. the vsock modules
+// does not prevent the workshop from starting.
+func (s *Specification) SetVirtualization(virt workshop.Virtualization) error {
+	s.Profile.Virtualization = &virt
+
+	name := lxdbackend.DeviceName(s.Profile.Sdk, virt.Name)
+	s.devices[name] = map[string]string{"type": "none"}
+	buf, err := json.Marshal(virt)
+	if err != nil {
+		return err
+	}
+	s.config[lxdbackend.DeviceConfigKey(name)] = string(buf)
+	s.config[lxdbackend.DeviceTypeConfigKey(name)] = "virtualization"
+
+	for _, dev := range virtualizationDevices {
+		name := lxdbackend.DeviceName(s.Profile.Sdk, virt.Name, filepath.Base(dev))
+		s.devices[name] = map[string]string{
+			"type":     "unix-char",
+			"source":   dev,
+			"path":     dev,
+			"uid":      workshop.User.Uid,
+			"gid":      workshop.User.Gid,
+			"mode":     "0660",
+			"required": "false",
+		}
+		s.config[lxdbackend.DeviceTypeConfigKey(name)] = "virtualization"
 	}
 
 	return nil

--- a/internal/sdk/system/meta/sdk.yaml
+++ b/internal/sdk/system/meta/sdk.yaml
@@ -14,3 +14,5 @@ slots:
     interface: custom-device
   desktop:
     interface: desktop
+  virtualization:
+    interface: virtualization

--- a/internal/sdk/system/system.go
+++ b/internal/sdk/system/system.go
@@ -32,13 +32,13 @@ var (
 	//go:embed meta/*
 	SystemSdkFs embed.FS
 
-	SystemSdkRevision = sdk.R(2)
+	SystemSdkRevision = sdk.R(3)
 
 	RetrieveSystemSdk = retrieveSystemSdk
 )
 
 // Update the system SDK revision number when this hash changes.
-const SystemSdkDigest = "9fe8becc4142397ed62404170155290b559afc08fef418211e8032c17b29a35dbad4946b7fee7fe8bd67ac8ee40ae5c4"
+const SystemSdkDigest = "d3ed8a756f476594ac0bf8337832874f5f842a14a19755fcc74e89a1471a5311735ef153f50366e021b32e0c55214fef"
 
 func SystemSdkMeta() (*sdk.Meta, error) {
 	setup := sdk.Setup{

--- a/internal/sdk/system/system_test.go
+++ b/internal/sdk/system/system_test.go
@@ -85,7 +85,7 @@ func (s *systemSdk) TestRetrieveSystemSdkSuccess(c *check.C) {
 
 	digest := hex.EncodeToString(hash.Sum(nil))
 	c.Check(digest, check.Equals, system.SystemSdkDigest, check.Commentf("system SDK revision needs updating"))
-	c.Check(system.SystemSdkRevision, check.Equals, sdk.R(2))
+	c.Check(system.SystemSdkRevision, check.Equals, sdk.R(3))
 }
 
 func (s *systemSdk) TestRetrieveSystemSdkWrongRevision(c *check.C) {

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -116,16 +116,21 @@ type Gpu struct {
 	Name string
 }
 
+type Virtualization struct {
+	Name string `json:"name"`
+}
+
 type SdkProfile struct {
 	Sdk string
 
-	Camera        *Camera
-	CustomDevices []CustomDevice
-	Mounts        map[string]Mount
-	Tunnels       []Tunnel
-	Agent         *SshAgent
-	Gpu           *Gpu
-	Desktop       *Desktop
+	Camera         *Camera
+	CustomDevices  []CustomDevice
+	Mounts         map[string]Mount
+	Tunnels        []Tunnel
+	Agent          *SshAgent
+	Gpu            *Gpu
+	Desktop        *Desktop
+	Virtualization *Virtualization
 }
 
 func NewSdkProfile(sdkName string) SdkProfile {

--- a/internal/workshop/lxd/lxd_backend_profile.go
+++ b/internal/workshop/lxd/lxd_backend_profile.go
@@ -170,6 +170,14 @@ func LxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 			default:
 				logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
 			}
+		case "unix-char":
+			devtype := config[DeviceTypeConfigKey(devname)]
+			switch devtype {
+			case "virtualization":
+				// Ignore the real virtualization devices, config is under type=none.
+			default:
+				logger.Noticef("On reading %q SDK profile: unknown device type %q", profile, devtype)
+			}
 		case "none":
 			cfg, exist := config[DeviceConfigKey(devname)]
 			if !exist {
@@ -185,6 +193,12 @@ func LxdToSdkProfile(profile string, devs map[string]map[string]string, config m
 					return pr, err
 				}
 				pr.Camera = &camera
+			case "virtualization":
+				var virt workshop.Virtualization
+				if err := json.Unmarshal([]byte(cfg), &virt); err != nil {
+					return pr, err
+				}
+				pr.Virtualization = &virt
 			case "mount":
 				var mnt workshop.Mount
 				if err := json.Unmarshal([]byte(cfg), &mnt); err != nil {

--- a/internal/workshop/lxd/lxd_backend_profile_test.go
+++ b/internal/workshop/lxd/lxd_backend_profile_test.go
@@ -109,6 +109,11 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 				VendorID:  "0403",
 				ProductID: "6001"}},
 		},
+		{
+			Sdk:            "sdk",
+			Mounts:         map[string]workshop.Mount{},
+			Virtualization: &workshop.Virtualization{Name: "virtualization"},
+		},
 	}
 
 	for i, t := range []struct {
@@ -218,6 +223,30 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 					"ownership.inherit": "true"}},
 			map[string]string{
 				"user.workshop.sdk_mydevice.type": "custom-device"},
+		}, {
+			"sdk",
+			map[string]map[string]string{
+				"sdk_virtualization": {
+					"type": "none"},
+				"sdk_virtualization_kvm": {
+					"type":     "unix-char",
+					"source":   "/dev/kvm",
+					"path":     "/dev/kvm",
+					"gid":      "1000",
+					"mode":     "0660",
+					"required": "false"},
+				"sdk_virtualization_vhost-net": {
+					"type":     "unix-char",
+					"source":   "/dev/vhost-net",
+					"path":     "/dev/vhost-net",
+					"gid":      "1000",
+					"mode":     "0660",
+					"required": "false"}},
+			map[string]string{
+				"user.workshop.sdk_virtualization":                `{"name": "virtualization"}`,
+				"user.workshop.sdk_virtualization.type":           "virtualization",
+				"user.workshop.sdk_virtualization_kvm.type":       "virtualization",
+				"user.workshop.sdk_virtualization_vhost-net.type": "virtualization"},
 		},
 	} {
 		res, err := lxdbackend.LxdToSdkProfile(t.name, t.devs, t.cfg)
@@ -227,6 +256,7 @@ func (f *LxdBeTests) TestLxdToSdkProfileOK(c *check.C) {
 		c.Assert(res.Camera, check.DeepEquals, expected[i].Camera)
 		c.Assert(res.CustomDevices, testutil.DeepUnsortedMatches, expected[i].CustomDevices)
 		c.Assert(res.Gpu, check.DeepEquals, expected[i].Gpu)
+		c.Assert(res.Virtualization, check.DeepEquals, expected[i].Virtualization)
 		c.Assert(res.Mounts, testutil.DeepUnsortedMatches, expected[i].Mounts)
 		c.Assert(res.Tunnels, testutil.DeepUnsortedMatches, expected[i].Tunnels)
 	}


### PR DESCRIPTION
# Description

Adds a `virtualization` interface (name still TBD) that lets a workshop launch hardware-accelerated (KVM) virtual machines from inside its container, without requiring the workshop itself to run as a VM.

The system SDK gains a single `virtualization` slot; any regular SDK can declare a matching `virtualization` plug. When plug and slot are connected, these host character devices are passed through as LXD `unix-char` devices:

- `/dev/kvm`
- `/dev/vhost-net`
- `/dev/vhost-vsock`
- `/dev/vsock`

They are group-owned by the `workshop` user, mode `0660`,  so no world access is granted. `/dev/net/tun` is not passed through because LXD already provides it in the container. Devices absent on the host (e.g. vsock modules not loaded) are marked `required: false` and do not block launch.

The interface follows the existing device-interface pattern (`gpu`, `camera`): a `type=none` config device carries the serialized config, round-tripped by `LxdToSdkProfile`. It is **not** auto-connected (`deny-auto-connection: true`) because it grants privileged access to host virtualization devices; it must be connected manually via `workshop connect` command.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* ~~[ ] I have checked and added or updated relevant release notes.~~
* [ ] I have included the technical author in the review.

Content:

* [x] Headings and titles accurately describe the content.
* [x] New and updated pages include correct metadata.
* [x] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [x] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [x] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
