### PR TITLE
Add instance readiness service

### DIFF
--- a/cmd/workshopctl/main.go
+++ b/cmd/workshopctl/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/canonical/workshop/client"
 	"github.com/canonical/workshop/internal/dirs"
+	"github.com/canonical/workshop/internal/waitready"
 )
 
 var clientConfig = client.Config{
@@ -36,6 +37,14 @@ var clientConfig = client.Config{
 }
 
 func main() {
+	if waitready.IsWaitreadyInvocation() {
+		if err := waitready.WaitReady(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// Set the user and group IDs to the workshop user
 	uid := uint32(1000) // Change this to the workshop UID
 

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -36,6 +36,9 @@ var (
 	// base directory inside a workshop
 	WorkshopBaseDir = defaultBaseDir
 
+	// Directory for mounted binaries (i.e. workshopctl)
+	WorkshopGuestBinDir = filepath.Join(WorkshopBaseDir, "bin")
+
 	// SDKs directory to install an SDK in a workshop
 	WorkshopSdksDir = filepath.Join(WorkshopBaseDir, "sdk")
 
@@ -64,8 +67,8 @@ var (
 	BaseDir string
 	// Cache directory for workshopd
 	CacheDir string
-	// Work directory
-	ExecDir string
+	// Path for workshopctl executable
+	WorkshopCtlPath string
 	// The directory to store downloaded base images and associated metadata
 	BaseDownloads string
 	// The directory to store downloaded SDKs
@@ -102,19 +105,30 @@ func getEnvPaths() (workshopdDir, cacheDir, socketPath string) {
 	return workshopdDir, cacheDir, socketPath
 }
 
-func init() {
-	var err error
-	var execPath string
-	execPath, err = os.Executable()
+func getWorkshopCtlPath() string {
+	execPath, err := os.Executable()
 	if err != nil {
-		panic("cannot get working directory")
+		panic(fmt.Errorf("cannot get executable path: %w", err))
 	}
 
-	ExecDir = filepath.Dir(execPath)
+	// Packages use a dedicated $prefix/lib/workshop/guest directory.
+	binDir := filepath.Dir(execPath)
+	workshopctl := filepath.Join(filepath.Dir(binDir), "lib", "workshop", "guest", "workshopctl")
+	if _, err := os.Stat(workshopctl); err == nil {
+		return workshopctl
+	}
+
+	// Local development often uses `go install`, which places all binaries in
+	// the same directory.
+	return filepath.Join(binDir, "workshopctl")
+}
+
+func init() {
 	XdgRuntimeDirBase = "/run/user"
 	BaseDir, CacheDir, SocketPath = getEnvPaths()
 	SetRootDir(BaseDir)
 	SetCacheDir(CacheDir)
+	WorkshopCtlPath = getWorkshopCtlPath()
 }
 
 func SetRootDir(rootdir string) {

--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -42,9 +42,6 @@ var (
 	// Base directory for the state storage
 	WorkshopStateDir = filepath.Join(WorkshopBaseDir, "state")
 
-	// Base directory for the SDK state storage
-	WorkshopSdkStateDir = filepath.Join(WorkshopStateDir, "sdk")
-
 	// Run directory inside workshop
 	WorkshopRunDir = filepath.Join(WorkshopBaseDir, "run")
 

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -351,22 +351,29 @@ func (m *InterfaceManager) ResolveDisconnect(
 // invalid on the daemon restart / update. Thus, recreating it upon every
 // daemon restart makes sure it still points to the correct files.
 func (m *InterfaceManager) recreateInternalMounts(pctx context.Context, w string) error {
-	// Recreate workshopctl bind mount, this has to be done if, for example,
-	// workshopctl was updated to a new version and is shown as /deleted in a
-	// workshop.
-	workshopctl := workshop.Mount{
-		Name:     "workshop.workshopctl",
+	// Recreate the workshopctl bind mount, this has to be done if, for
+	// example, the Workshop snap was updated to a new revision.
+	mount := workshop.Mount{
+		Name:     "workshop.bin",
 		Type:     workshop.HostWorkshop,
-		What:     filepath.Join(dirs.ExecDir, "workshopctl"),
-		Where:    "/usr/bin/workshopctl",
+		What:     filepath.Dir(dirs.WorkshopCtlPath),
+		Where:    dirs.WorkshopGuestBinDir,
 		ReadOnly: true,
 	}
 
-	_ = m.backend.RemoveWorkshopMount(pctx, w, workshopctl.Name)
+	_ = m.backend.RemoveWorkshopMount(pctx, w, mount.Name)
 
-	if err := m.backend.AddWorkshopMount(pctx, w, workshopctl); err != nil {
+	if err := m.backend.AddWorkshopMount(pctx, w, mount); err != nil {
 		return err
 	}
+
+	// TODO: remove this in future. Old workshops may still have a single-file
+	// workshopctl mount. At some point the source path will no longer exist,
+	// and LXD will complain about it. Currently workshopctl is only used
+	// during launch, refresh and restore. The first two will use the new
+	// symlink in /usr/local/bin/workshopctl. Restore won't happen because
+	// we disallow restoring to an unsupported snapshot revision.
+	_ = m.backend.RemoveWorkshopMount(pctx, w, "workshop.workshopctl")
 
 	return nil
 }

--- a/internal/waitready/waitready.go
+++ b/internal/waitready/waitready.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package waitready
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	lxd "github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/godbus/dbus/v5"
+
+	"github.com/canonical/workshop/internal/systemd"
+)
+
+const Timeout = 5 * time.Minute
+
+// IsWaitreadyInvocation reports whether the process was invoked via a symlink
+// named waitready. This allows multiple logically unrelated commands to be
+// embedded in a single multi-call binary (even in tests).
+func IsWaitreadyInvocation() bool {
+	return len(os.Args) > 0 && filepath.Base(os.Args[0]) == "waitready"
+}
+
+// WaitReady waits for the system to finish booting and then sets the instance
+// to Ready via the DevLXD socket.
+func WaitReady() error {
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+
+	server, err := lxd.ConnectDevLXDWithContext(ctx, "/dev/lxd/sock", nil)
+	if errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintf(os.Stderr, "nothing to do: %v\n", err)
+		return maybeSdNotifyReady()
+	}
+	if err != nil {
+		return err
+	}
+	defer server.Disconnect()
+
+	if err := waitReady(ctx); err != nil {
+		return err
+	}
+
+	return server.UpdateState(api.DevLXDPut{State: api.Ready.String()})
+}
+
+func maybeSdNotifyReady() error {
+	if !systemd.SocketAvailable() {
+		return nil
+	}
+	return systemd.SdNotify("READY=1")
+}
+
+func waitReady(ctx context.Context) error {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	signal := make(chan *dbus.Signal, 1)
+	conn.Signal(signal)
+
+	options := []dbus.MatchOption{
+		dbus.WithMatchInterface("org.freedesktop.systemd1.Manager"),
+		dbus.WithMatchMember("StartupFinished"),
+	}
+	if err := conn.AddMatchSignalContext(ctx, options...); err != nil {
+		return err
+	}
+
+	ready, err := isReady(conn)
+	if err != nil {
+		return err
+	}
+
+	if err := maybeSdNotifyReady(); err != nil {
+		return err
+	}
+
+	if ready {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-signal:
+		return nil
+	}
+}
+
+func isReady(conn *dbus.Conn) (bool, error) {
+	manager := conn.Object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+	variant, err := manager.GetProperty("org.freedesktop.systemd1.Manager.SystemState")
+	if err != nil {
+		return false, err
+	}
+
+	var state string
+	if err := variant.Store(&state); err != nil {
+		return false, err
+	}
+
+	// Based on `systemctl is-system-running --wait`.
+	return state != "initializing" && state != "starting", nil
+}

--- a/internal/workshop/device.go
+++ b/internal/workshop/device.go
@@ -137,10 +137,10 @@ func NewSdkProfile(sdkName string) SdkProfile {
 
 func defaultDevices(pid, w string) ([]Mount, []ProxyEntry) {
 	mounts := []Mount{{
-		Name:     "workshop.workshopctl",
+		Name:     "workshop.bin",
 		Type:     HostWorkshop,
-		What:     filepath.Join(dirs.ExecDir, "workshopctl"),
-		Where:    "/usr/bin/workshopctl",
+		What:     filepath.Dir(dirs.WorkshopCtlPath),
+		Where:    dirs.WorkshopGuestBinDir,
 		ReadOnly: true,
 	}, {
 		Name:  "cache.apt",

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -33,10 +33,12 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"text/template"
 	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/x-go/strutil/shlex"
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 
@@ -1232,7 +1234,7 @@ func proxyToLxdDevice(proxy workshop.ProxyEntry) map[string]string {
 }
 
 func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File, format sdk.Revision, baseFingerprint string) (map[string]string, error) {
-	cloudConfig := `
+	cloudConfigTemplate := `
 #cloud-config
 users:
   - default
@@ -1303,12 +1305,26 @@ write_files:
       TrustedUserCAKeys /etc/ssh/ssh_ca_ed25519_key.pub
 runcmd:
   # Project directory is required for 'workshop exec'.
-  - install --directory --mode=755 /project
+  - install --directory --mode=755 /project {{shquote .WorkshopStateDir}}
   # Create XDG base directories so SDKs don't need an extra mode=700 step.
   - install --directory --mode=700 --owner=workshop --group=workshop /home/workshop/.cache /home/workshop/.config /home/workshop/.local
   # Create ~/.local/bin so SDKs don't need to source ~/.profile to add it to the PATH.
   - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/.local/bin
 `[1:]
+
+	var cloudConfig strings.Builder
+	funcs := map[string]any{
+		"shquote": shlex.Quote,
+	}
+	dot := struct {
+		WorkshopStateDir string
+	}{
+		WorkshopStateDir: dirs.WorkshopStateDir,
+	}
+	t := template.Must(template.New("cloud-config").Funcs(funcs).Parse(cloudConfigTemplate))
+	if err := t.Execute(&cloudConfig, dot); err != nil {
+		return nil, err
+	}
 
 	f, err := yaml.Marshal(file)
 	if err != nil {
@@ -1321,7 +1337,7 @@ runcmd:
 		"boot.autostart":                 "false",
 		"raw.idmap":                      fmt.Sprintf("uid %s %s\ngid %s %s", userid, workshop.User.Uid, groupid, workshop.User.Gid),
 		"security.nesting":               "true",
-		"cloud-init.user-data":           cloudConfig,
+		"cloud-init.user-data":           cloudConfig.String(),
 		"user.workshop.format-revision":  format.String(),
 		"user.workshop.project-id":       projectId,
 		"user.workshop.name":             file.Name,

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -671,9 +671,20 @@ func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, na
 		return err
 	}
 
-	// Workshop started, enable autostart.
-	if err := s.setAutoStart(conn, ctx, name, true); err != nil {
-		return err
+	for i := range 2 {
+		// Workshop started, enable autostart.
+		if err := s.setAutoStart(conn, ctx, name, true); err != nil {
+			if i == 0 && api.StatusErrorCheck(err, http.StatusPreconditionFailed) && strings.HasPrefix(err.Error(), "ETag does not match: ") {
+				// TODO: remove the loop after modifying the logic to wait for
+				// LXD's instance ready event. Currently, the instance may or
+				// may not set itself to Ready, so we can't rely on it. When it
+				// does so, LXD sets volatile.last_state.ready, which can
+				// invalidates the ETag; a single retry is enough to fix it.
+				continue
+			}
+			return err
+		}
+		break
 	}
 
 	var stderr strings.Builder
@@ -1303,15 +1314,28 @@ write_files:
     content: |
       HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub
       TrustedUserCAKeys /etc/ssh/ssh_ca_ed25519_key.pub
+  - path: /etc/systemd/system/workshop-waitready.service
+    content: |
+      [Unit]
+      Description=Signal workshop readiness to LXD
+
+      [Service]
+      Type=notify
+      ExecStart=/usr/local/lib/workshop/waitready
+
+      [Install]
+      WantedBy=multi-user.target
 runcmd:
   # Project directory is required for 'workshop exec'.
-  - install --directory --mode=755 /project /usr/local/bin {{shquote .WorkshopStateDir}}
+  - install --directory --mode=755 /project /usr/local/bin /usr/local/lib/workshop {{shquote .WorkshopStateDir}}
   # Create XDG base directories so SDKs don't need an extra mode=700 step.
   - install --directory --mode=700 --owner=workshop --group=workshop /home/workshop/.cache /home/workshop/.config /home/workshop/.local
   # Create ~/.local/bin so SDKs don't need to source ~/.profile to add it to the PATH.
   - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/.local/bin
   # Put workshopctl on the PATH.
   - ln -sf {{shquote .WorkshopCtlPath}} /usr/local/bin/workshopctl
+  - ln -sf ../../bin/workshopctl /usr/local/lib/workshop/waitready
+  - systemctl enable --now workshop-waitready.service
 `[1:]
 
 	var cloudConfig strings.Builder

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1305,11 +1305,13 @@ write_files:
       TrustedUserCAKeys /etc/ssh/ssh_ca_ed25519_key.pub
 runcmd:
   # Project directory is required for 'workshop exec'.
-  - install --directory --mode=755 /project {{shquote .WorkshopStateDir}}
+  - install --directory --mode=755 /project /usr/local/bin {{shquote .WorkshopStateDir}}
   # Create XDG base directories so SDKs don't need an extra mode=700 step.
   - install --directory --mode=700 --owner=workshop --group=workshop /home/workshop/.cache /home/workshop/.config /home/workshop/.local
   # Create ~/.local/bin so SDKs don't need to source ~/.profile to add it to the PATH.
   - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/.local/bin
+  # Put workshopctl on the PATH.
+  - ln -sf {{shquote .WorkshopCtlPath}} /usr/local/bin/workshopctl
 `[1:]
 
 	var cloudConfig strings.Builder
@@ -1317,8 +1319,10 @@ runcmd:
 		"shquote": shlex.Quote,
 	}
 	dot := struct {
+		WorkshopCtlPath  string
 		WorkshopStateDir string
 	}{
+		WorkshopCtlPath:  filepath.Join(dirs.WorkshopGuestBinDir, filepath.Base(dirs.WorkshopCtlPath)),
 		WorkshopStateDir: dirs.WorkshopStateDir,
 	}
 	t := template.Must(template.New("cloud-config").Funcs(funcs).Parse(cloudConfigTemplate))

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -834,7 +834,7 @@ func (s *Backend) snapshotClients(ctx context.Context) (lxd.InstanceServer, lxd.
 // replay some of the install-sdk and setup-base tasks. These can be handled in
 // the same way as in-progress launches and refreshes.
 func (s *Backend) FormatRevision() sdk.Revision {
-	return sdk.R(10)
+	return sdk.R(11)
 }
 
 func (s *Backend) HashSnapshot(snapshot workshop.Snapshot) (string, error) {

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -834,7 +834,7 @@ func (s *Backend) snapshotClients(ctx context.Context) (lxd.InstanceServer, lxd.
 // replay some of the install-sdk and setup-base tasks. These can be handled in
 // the same way as in-progress launches and refreshes.
 func (s *Backend) FormatRevision() sdk.Revision {
-	return sdk.R(9)
+	return sdk.R(10)
 }
 
 func (s *Backend) HashSnapshot(snapshot workshop.Snapshot) (string, error) {

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -15,7 +15,7 @@ launched:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'e2e2ae8e679e632b6aefd9e2378ec5b0695e1d03ba0418a04aa2d304328e9bb61ee5aae99c0b53254895b1e39555c0f2'
+    cloud-init.user-data: 'b6a1a0844c3cce8ff2d60991700eb2d94f0f95cbef27f42f65d6bf397bfd1ae0d521b695df367f72e89d7ab280f1486a'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -53,7 +53,7 @@ started:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'e2e2ae8e679e632b6aefd9e2378ec5b0695e1d03ba0418a04aa2d304328e9bb61ee5aae99c0b53254895b1e39555c0f2'
+    cloud-init.user-data: 'b6a1a0844c3cce8ff2d60991700eb2d94f0f95cbef27f42f65d6bf397bfd1ae0d521b695df367f72e89d7ab280f1486a'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -91,7 +91,7 @@ sdk-attached:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'e2e2ae8e679e632b6aefd9e2378ec5b0695e1d03ba0418a04aa2d304328e9bb61ee5aae99c0b53254895b1e39555c0f2'
+    cloud-init.user-data: 'b6a1a0844c3cce8ff2d60991700eb2d94f0f95cbef27f42f65d6bf397bfd1ae0d521b695df367f72e89d7ab280f1486a'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -141,7 +141,7 @@ sdk-mounted:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'e2e2ae8e679e632b6aefd9e2378ec5b0695e1d03ba0418a04aa2d304328e9bb61ee5aae99c0b53254895b1e39555c0f2'
+    cloud-init.user-data: 'b6a1a0844c3cce8ff2d60991700eb2d94f0f95cbef27f42f65d6bf397bfd1ae0d521b695df367f72e89d7ab280f1486a'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -15,7 +15,7 @@ launched:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'b6a1a0844c3cce8ff2d60991700eb2d94f0f95cbef27f42f65d6bf397bfd1ae0d521b695df367f72e89d7ab280f1486a'
+    cloud-init.user-data: 'f3250ef105cf4f516d283ba8534392391fe34bb5d597324bf3ceb65435ef2ad255457a2997137c32ce5494549a34009c'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -37,8 +37,8 @@ launched:
       listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
       mode: '0666'
       type: proxy
-    workshop.workshopctl:
-      path: /usr/bin/workshopctl
+    workshop.bin:
+      path: /var/lib/workshop/bin
       readonly: 'true'
       type: disk
   ephemeral: false
@@ -53,7 +53,7 @@ started:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'b6a1a0844c3cce8ff2d60991700eb2d94f0f95cbef27f42f65d6bf397bfd1ae0d521b695df367f72e89d7ab280f1486a'
+    cloud-init.user-data: 'f3250ef105cf4f516d283ba8534392391fe34bb5d597324bf3ceb65435ef2ad255457a2997137c32ce5494549a34009c'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -75,8 +75,8 @@ started:
       listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
       mode: '0666'
       type: proxy
-    workshop.workshopctl:
-      path: /usr/bin/workshopctl
+    workshop.bin:
+      path: /var/lib/workshop/bin
       readonly: 'true'
       type: disk
   ephemeral: false
@@ -91,7 +91,7 @@ sdk-attached:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'b6a1a0844c3cce8ff2d60991700eb2d94f0f95cbef27f42f65d6bf397bfd1ae0d521b695df367f72e89d7ab280f1486a'
+    cloud-init.user-data: 'f3250ef105cf4f516d283ba8534392391fe34bb5d597324bf3ceb65435ef2ad255457a2997137c32ce5494549a34009c'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -125,8 +125,8 @@ sdk-attached:
       listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
       mode: '0666'
       type: proxy
-    workshop.workshopctl:
-      path: /usr/bin/workshopctl
+    workshop.bin:
+      path: /var/lib/workshop/bin
       readonly: 'true'
       type: disk
   ephemeral: false
@@ -141,7 +141,7 @@ sdk-mounted:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'b6a1a0844c3cce8ff2d60991700eb2d94f0f95cbef27f42f65d6bf397bfd1ae0d521b695df367f72e89d7ab280f1486a'
+    cloud-init.user-data: 'f3250ef105cf4f516d283ba8534392391fe34bb5d597324bf3ceb65435ef2ad255457a2997137c32ce5494549a34009c'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -183,8 +183,8 @@ sdk-mounted:
       listen: unix:/var/lib/workshop/run/workshop.socket.untrusted
       mode: '0666'
       type: proxy
-    workshop.workshopctl:
-      path: /usr/bin/workshopctl
+    workshop.bin:
+      path: /var/lib/workshop/bin
       readonly: 'true'
       type: disk
   ephemeral: false

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -15,7 +15,7 @@ launched:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'f3250ef105cf4f516d283ba8534392391fe34bb5d597324bf3ceb65435ef2ad255457a2997137c32ce5494549a34009c'
+    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -53,7 +53,7 @@ started:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'f3250ef105cf4f516d283ba8534392391fe34bb5d597324bf3ceb65435ef2ad255457a2997137c32ce5494549a34009c'
+    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -91,7 +91,7 @@ sdk-attached:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'f3250ef105cf4f516d283ba8534392391fe34bb5d597324bf3ceb65435ef2ad255457a2997137c32ce5494549a34009c'
+    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -141,7 +141,7 @@ sdk-mounted:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'f3250ef105cf4f516d283ba8534392391fe34bb5d597324bf3ceb65435ef2ad255457a2997137c32ce5494549a34009c'
+    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''

--- a/internal/workshop/lxd/tests/integration/snapshot_test.go
+++ b/internal/workshop/lxd/tests/integration/snapshot_test.go
@@ -78,10 +78,9 @@ func (s *snapshotSuite) SetUpSuite(c *check.C) {
 
 	dirs.SetRootDir(c.MkDir())
 	dirs.SetCacheDir(c.MkDir())
-	dirs.ExecDir = c.MkDir()
+	dirs.WorkshopCtlPath = filepath.Join(c.MkDir(), "workshopctl")
 	dirs.SocketPath = filepath.Join(dirs.BaseDir, "workshop.socket")
 	c.Assert(dirs.CreateDirs(), check.IsNil)
-	c.Assert(os.WriteFile(filepath.Join(dirs.ExecDir, "workshopctl"), nil, 0644), check.IsNil)
 
 	var err error
 	s.bd, err = lxdbackend.New()
@@ -262,7 +261,7 @@ func (s *snapshotSuite) workshopFormat(c *check.C, file *workshop.File, snapshot
 	// Host paths of default devices can change without affecting the
 	// workshop, so we exclude them from the hash. Other device options
 	// should be included in case they influence the rootfs.
-	delete(inst.Devices["workshop.workshopctl"], "source")
+	delete(inst.Devices["workshop.bin"], "source")
 	delete(inst.Devices["cache.apt"], "source")
 	delete(inst.Devices["workshop.socket"], "connect")
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,8 +36,6 @@ apps:
       unix:
         listen-stream: $SNAP_COMMON/workshop/workshop.socket
         socket-mode: 0666
-  workshopctl:
-    command: bin/workshopctl
   configure-dns:
     command: bin/workshopd configure-dns
   sdk:
@@ -66,7 +64,7 @@ parts:
       fi
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshop" ./cmd/workshop
       CGO_ENABLED=1 go build -o "${CRAFT_PART_INSTALL}/bin/workshopd" ./cmd/workshopd
-      CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/workshopctl" ./cmd/workshopctl
+      CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/lib/workshop/guest/workshopctl" ./cmd/workshopctl
       CGO_ENABLED=0 go build -o "${CRAFT_PART_INSTALL}/bin/sdk" ./cmd/sdk
 
       # Set snap version including git commit hash
@@ -81,7 +79,7 @@ parts:
     prime:
       - bin/workshop
       - bin/workshopd
-      - bin/workshopctl
+      - lib/workshop/guest/workshopctl
       - bin/sdk
   zstd:
     plugin: nil

--- a/tests/main/start/task.yaml
+++ b/tests/main/start/task.yaml
@@ -14,6 +14,28 @@ execute: |
     workshop_exec exec -- test -d /run/user/1000
   }
 
+  # TODO: remove this when `workshop start` begins to rely on LXD events.
+  function check_lxd_ready() {
+    echo "Check LXD itself reports the instance as Ready"
+    filter="name=ws-start-$(< .workshop.lock)"
+
+    for _ in {1..50}; do
+      if lxc list --format csv --columns s --project workshop.ubuntu "$filter" | grep -Fqx READY; then
+        return 0
+      fi
+      sleep 0.1
+    done
+
+    echo "Timed out waiting for LXD to report instance as READY" >&2
+    workshop_exec exec -- systemctl status workshop-waitready.service || true
+    workshop_exec exec -- journalctl -u workshop-waitready.service || true
+    workshop_exec exec -- systemctl || true
+    workshop_exec exec -- systemctl status || true
+    workshop_exec exec -- journalctl -b || true
+    lxc info --show-log --project workshop.ubuntu "ws-start-$(< .workshop.lock)"
+    exit 1
+  }
+
   check_linger
   workshop_exec stop
 
@@ -26,4 +48,14 @@ execute: |
   echo "Check the workshop is in Ready state"
   workshop_exec list | MATCH "^ws-start[[:space:]]+Ready[[:space:]]+-$"
 
+  check_lxd_ready
   check_linger
+
+  echo "Check the workshop also becomes Ready when systemd boots degraded"
+  workshop_exec exec -- sudo cp /project/workshop-test-degraded.service /etc/systemd/system/
+  workshop_exec exec -- sudo systemctl enable workshop-test-degraded.service
+  workshop_exec stop
+  workshop_exec start
+  workshop_exec list | MATCH "^ws-start[[:space:]]+Ready[[:space:]]+-$"
+  check_lxd_ready
+  workshop_exec exec -- systemctl is-system-running | MATCH '^degraded$'

--- a/tests/main/start/workshop-test-degraded.service
+++ b/tests/main/start/workshop-test-degraded.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Intentionally failing unit for the workshop start test
+
+[Service]
+Type=oneshot
+ExecStart=/bin/false
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Description

By default, LXD returns from a `start` operation ASAP. For VMs, it happens even before the `lxd-agent` is running, so lots of other operations are unavailable, including `exec`.

Workshop has a different approach of waiting until systemd says the instance is ready. For VMs, we need a new implementation that doesn't rely on `exec`. Thankfully, LXD partially supports this scenario by distinguishing between "running" and "ready." See https://discuss.linuxcontainers.org/t/lxd-instance-ready-state/14657 for context.

This PR adds a systemd service to every workshop that handles the task of updating the instance state. The implementation is based on `systemctl is-system-running --wait`. To avoid the need for multiple `workshopctl`-type binaries, the logic is embedded in `workshopctl` itself, and activated by setting `argv[0]` to `waitready` (e.g. running it via a symlink with that name).

In future, we'll be able to rely on this service for `workshop start`, but for now the existing implementation remains in place. However, there's a workaround for a race condition where Workshop loads the instance config, LXD adds the `volatile.last_state.ready` option, and then Workshop tries to add `boot.autostart` to the config. This race only happens one way, DevLXD does a direct DB update without resetting the entire config.

## Guest bin directory

Another issue with VMs is they don't support mounting single files, so this PR moves `workshopctl` into a dedicated directory (while still supporting "all binaries in the same dir" for local development).

This is not quite a breaking change because `workshopctl` is only supposed to be used towards the end of a launch or refresh, so it doesn't really matter if it stops working in old-format workshops (and we don't support restoring or resuming refresh for old workshops).

## Minor changes

Fixes the permissions on `/var/lib/workshop/state` when it's not mounted.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
