### PR TITLE
Enable ID-mapped mounts for new SDK volumes

### DIFF
--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -173,6 +173,13 @@ func (s *Backend) ImportSdk(ctx context.Context, meta sdk.Meta, tarball *os.File
 	if err != nil {
 		return err
 	}
+
+	// Shifted means all user namespaces share the same file ownership, thanks to
+	// ID-mapped mounts. This would normally be a security issue (allowing
+	// workshops to create set-user-ID executables owned by real root), but it's
+	// fine because SDK mounts are read-only.
+	volume.Config["security.shifted"] = "true"
+
 	volume.Config["user.kind"] = "sdk"
 	volume.Config["user.sdk.name"] = meta.Name
 	volume.Config["user.sdk.package-id"] = meta.PackageID

--- a/tests/main/sdk-multi-user-mount/project-1/workshop.yaml
+++ b/tests/main/sdk-multi-user-mount/project-1/workshop.yaml
@@ -1,0 +1,4 @@
+name: ws-multi-user-1
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic-2

--- a/tests/main/sdk-multi-user-mount/project-2/workshop.yaml
+++ b/tests/main/sdk-multi-user-mount/project-2/workshop.yaml
@@ -1,0 +1,4 @@
+name: ws-multi-user-2
+base: ubuntu@22.04
+sdks:
+  - name: test-sdk-basic-2

--- a/tests/main/sdk-multi-user-mount/task.yaml
+++ b/tests/main/sdk-multi-user-mount/task.yaml
@@ -1,0 +1,28 @@
+summary: Check that multiple users can mount the same SDK volume
+restore: |
+  . "$TESTSLIB"/utils.sh
+
+  workshop_exec remove --project $(pwd)/project-1 || true
+  sudo -u otheruser -- workshop remove --project $(pwd)/project-2 || true
+  loginctl disable-linger otheruser || true
+  deluser --remove-home otheruser || true
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Create another user"
+  useradd -m -s /bin/bash otheruser
+  loginctl enable-linger otheruser
+
+  echo "Launch workshops owned by different users"
+  workshop_exec launch --project project-1
+  sudo -u otheruser -- workshop launch --project project-2
+
+  echo "Check workshops are scoped to original user"
+  workshop_exec list --project project-1 | MATCH "^ws-multi-user-1[[:space:]]+Ready[[:space:]]+-$"
+  workshop_exec list --project project-2 | MATCH "^ws-multi-user-2[[:space:]]+Off[[:space:]]+-$"
+  sudo -u otheruser -- workshop list --project project-1 | MATCH "^ws-multi-user-1[[:space:]]+Off[[:space:]]+-$"
+  sudo -u otheruser -- workshop list --project project-2 | MATCH "^ws-multi-user-2[[:space:]]+Ready[[:space:]]+-$"
+
+  echo "Check SDK ownership"
+  workshop_exec exec --project project-1 -- stat -c '%U:%G' /var/lib/workshop/sdk/test-sdk-basic-2/sdk/hooks/setup-project | MATCH '^root:root$'
+  sudo -u otheruser -- workshop exec --project project-2 -- stat -c '%U:%G' /var/lib/workshop/sdk/test-sdk-basic-2/sdk/hooks/setup-project | MATCH '^root:root$'


### PR DESCRIPTION
# Description

Fixes an issue when mutiple users try to mount the same SDK. LXD doesn't allow it, because it can't adjust the file ownership to match both idmaps simultaneously (technically it can, if the UIDs and GIDs of the files in the SDK belong to the equaliser of the two maps, but it doesn't check that).

Instead of adjusting the file ownership, LXD can be instructed to attach an idmap to the mount, so that mounted files within the workshop user namespaces appear to have the same ownership as the source files in the initial user namespace. This requires the `security.shifted` option to be set on the volume. It's a security issue because it can allow namespaced users to act on behalf of the real user with the same UID. Not an issue for SDKs, which are read-only and shouldn't contain any sensitive information.

Adds a regression test for multi-user support, but we probably still need more coverage in this area.

This change only affects newly downloaded SDKs. Users who want multi-user support immediately can either reinstall Workshop, or remove all workshops and wait an hour. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/contributing.rst#error-messages) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [x] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
