### PR TITLE
Allow in-project, try, and no SDKs for workshop init

### DIFF
--- a/cmd/workshop/init.go
+++ b/cmd/workshop/init.go
@@ -34,6 +34,8 @@ The NAME argument sets the workshop name. The command creates a named
 workshop file at .workshop/<NAME>.yaml. This fails if a workshop with
 the same name already exists.
 
+The supported bases are ubuntu@20.04, ubuntu@22.04, ubuntu@24.04, and ubuntu@26.04.
+
 SDKs are specified as a comma-separated list. Each SDK entry can optionally
 include a channel using the <NAME>/<CHANNEL> syntax (e.g., "go/1.26/stable").
 `,

--- a/cmd/workshop/init.go
+++ b/cmd/workshop/init.go
@@ -105,7 +105,8 @@ func parseSdkArgs(args []string) ([]workshop.SdkRecord, error) {
 			continue
 		}
 
-		name, channel, _ := strings.Cut(arg, "/")
+		yamlName, channel, _ := strings.Cut(arg, "/")
+		name, source := workshop.ParseSdkName(yamlName)
 
 		if _, ok := seen[name]; ok {
 			return nil, fmt.Errorf("duplicate SDK %q", name)
@@ -115,6 +116,7 @@ func parseSdkArgs(args []string) ([]workshop.SdkRecord, error) {
 		sdks = append(sdks, workshop.SdkRecord{
 			Name:    name,
 			Channel: channel,
+			Source:  source,
 		})
 	}
 

--- a/cmd/workshop/init.go
+++ b/cmd/workshop/init.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,14 +45,12 @@ Create a workshop with a specific SDK channel:
 $ workshop init dev --sdks go/1.26/stable
 
 Create a workshop using a specific base:
-$ workshop init dev --sdks go --base ubuntu@22.04`,
+$ workshop init dev --base ubuntu@22.04 --sdks go`,
 		RunE: c.Run,
 	}
 
 	cmd.Flags().StringSliceVar(&c.sdks, "sdks", nil, `Comma-separated list of SDKs (e.g., "go,uv/latest/stable").`)
 	cmd.Flags().StringVar(&c.base, "base", defaultBase, "Base image for the workshop.")
-
-	_ = cmd.MarkFlagRequired("sdks")
 
 	return cmd
 }
@@ -93,18 +90,10 @@ func (c *CmdInit) Run(cmd *cobra.Command, args []string) error {
 // parseSdkArgs converts a list of strings like ["go/1.26/stable", "python"]
 // into SdkRecord entries.
 func parseSdkArgs(args []string) ([]workshop.SdkRecord, error) {
-	if len(args) == 0 {
-		return nil, errors.New("at least one SDK must be specified")
-	}
-
 	var sdks []workshop.SdkRecord
 	seen := make(map[string]bool)
 	for _, arg := range args {
 		arg = strings.TrimSpace(arg)
-		if arg == "" {
-			continue
-		}
-
 		yamlName, channel, _ := strings.Cut(arg, "/")
 		name, source := workshop.ParseSdkName(yamlName)
 
@@ -118,10 +107,6 @@ func parseSdkArgs(args []string) ([]workshop.SdkRecord, error) {
 			Channel: channel,
 			Source:  source,
 		})
-	}
-
-	if len(sdks) == 0 {
-		return nil, errors.New("at least one SDK must be specified")
 	}
 
 	return sdks, nil

--- a/cmd/workshop/init.go
+++ b/cmd/workshop/init.go
@@ -59,15 +59,10 @@ func (c *CmdInit) Run(cmd *cobra.Command, args []string) error {
 	projectDir := c.root.project()
 	name := args[0]
 
-	sdks, err := parseSdkArgs(c.sdks)
-	if err != nil {
-		return err
-	}
-
 	wfile := &workshop.File{
 		Name: name,
 		Base: c.base,
-		Sdks: sdks,
+		Sdks: parseSdkArgs(c.sdks),
 	}
 
 	if err := workshop.ValidateFile(wfile); err != nil {
@@ -89,18 +84,12 @@ func (c *CmdInit) Run(cmd *cobra.Command, args []string) error {
 
 // parseSdkArgs converts a list of strings like ["go/1.26/stable", "python"]
 // into SdkRecord entries.
-func parseSdkArgs(args []string) ([]workshop.SdkRecord, error) {
+func parseSdkArgs(args []string) []workshop.SdkRecord {
 	var sdks []workshop.SdkRecord
-	seen := make(map[string]bool)
 	for _, arg := range args {
 		arg = strings.TrimSpace(arg)
 		yamlName, channel, _ := strings.Cut(arg, "/")
 		name, source := workshop.ParseSdkName(yamlName)
-
-		if _, ok := seen[name]; ok {
-			return nil, fmt.Errorf("duplicate SDK %q", name)
-		}
-		seen[name] = true
 
 		sdks = append(sdks, workshop.SdkRecord{
 			Name:    name,
@@ -109,7 +98,7 @@ func parseSdkArgs(args []string) ([]workshop.SdkRecord, error) {
 		})
 	}
 
-	return sdks, nil
+	return sdks
 }
 
 // ensureCanCreate checks that no single-file workshop definition exists in the

--- a/cmd/workshop/init.go
+++ b/cmd/workshop/init.go
@@ -24,7 +24,7 @@ type CmdInit struct {
 
 func (c *CmdInit) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "init <NAME> --sdks <SDKs> [--base <BASE>]",
+		Use:     "init <NAME>",
 		Args:    cobra.ExactArgs(1),
 		Short:   "Create a new workshop definition in the project directory",
 		GroupID: GrpCRUD,
@@ -36,7 +36,7 @@ workshop file at .workshop/<NAME>.yaml. This fails if a workshop with
 the same name already exists.
 
 SDKs are specified as a comma-separated list. Each SDK entry can optionally
-include a channel using the <name>/<channel> syntax (e.g., "go/1.26/stable").
+include a channel using the <NAME>/<CHANNEL> syntax (e.g., "go/1.26/stable").
 `,
 		Example: `
 Create a workshop called "dev" with the Go and UV SDKs:

--- a/cmd/workshop/init.go
+++ b/cmd/workshop/init.go
@@ -59,10 +59,15 @@ func (c *CmdInit) Run(cmd *cobra.Command, args []string) error {
 	projectDir := c.root.project()
 	name := args[0]
 
+	sdks, err := parseSdkArgs(c.sdks)
+	if err != nil {
+		return err
+	}
+
 	wfile := &workshop.File{
 		Name: name,
 		Base: c.base,
-		Sdks: parseSdkArgs(c.sdks),
+		Sdks: sdks,
 	}
 
 	if err := workshop.ValidateFile(wfile); err != nil {
@@ -84,12 +89,15 @@ func (c *CmdInit) Run(cmd *cobra.Command, args []string) error {
 
 // parseSdkArgs converts a list of strings like ["go/1.26/stable", "python"]
 // into SdkRecord entries.
-func parseSdkArgs(args []string) []workshop.SdkRecord {
+func parseSdkArgs(args []string) ([]workshop.SdkRecord, error) {
 	var sdks []workshop.SdkRecord
 	for _, arg := range args {
 		arg = strings.TrimSpace(arg)
 		yamlName, channel, _ := strings.Cut(arg, "/")
-		name, source := workshop.ParseSdkName(yamlName)
+		name, source, err := workshop.ParseSdkName(yamlName)
+		if err != nil {
+			return nil, err
+		}
 
 		sdks = append(sdks, workshop.SdkRecord{
 			Name:    name,
@@ -98,7 +106,7 @@ func parseSdkArgs(args []string) []workshop.SdkRecord {
 		})
 	}
 
-	return sdks
+	return sdks, nil
 }
 
 // ensureCanCreate checks that no single-file workshop definition exists in the

--- a/cmd/workshop/init_test.go
+++ b/cmd/workshop/init_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"gopkg.in/check.v1"
@@ -30,6 +32,19 @@ func (s *workshopInit) makeCmd(projectDir string) *CmdInit {
 
 func (s *workshopInit) run(cmd *CmdInit, name string) error {
 	return cmd.Run(nil, []string{name})
+}
+
+func (s *workshopInit) TestInitBaseUsage(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+
+	bases := slices.Clone(workshop.SupportedBases)
+	bases[len(bases)-1] = "and " + bases[len(bases)-1]
+	line := fmt.Sprintf("\nThe supported bases are %s.\n", strings.Join(bases, ", "))
+
+	help := cmd.Command().Long
+	outdated := !strings.Contains(help, line)
+	c.Check(outdated, check.Equals, false, check.Commentf(strings.TrimSpace(line)))
 }
 
 // --- Success cases ---

--- a/cmd/workshop/init_test.go
+++ b/cmd/workshop/init_test.go
@@ -306,6 +306,26 @@ func (s *workshopInit) TestInitReservedSdkName(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `"agent" is a reserved SDK name`)
 }
 
+func (s *workshopInit) TestInitReservedTrySdkName(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"try-system"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `"system" is a reserved SDK name`)
+}
+
+func (s *workshopInit) TestInitReservedProjectSdkName(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"project-sketch"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `"sketch" is a reserved SDK name`)
+}
+
 func (s *workshopInit) TestInitWorkshopYamlExists(c *check.C) {
 	projectDir := c.MkDir()
 	err := os.WriteFile(filepath.Join(projectDir, "workshop.yaml"), []byte("name: old\n"), 0644)

--- a/cmd/workshop/init_test.go
+++ b/cmd/workshop/init_test.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 )
 
@@ -53,6 +54,20 @@ func (s *workshopInit) TestInitBasic(c *check.C) {
 	c.Assert(strings.Contains(string(content), "python"), check.Equals, true)
 
 	c.Assert(s.stdout.String(), check.Matches, `"dev" workshop created at .*\n`)
+}
+
+func (s *workshopInit) TestInitEmptySdks(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	path := workshop.Filepath(projectDir, "dev")
+	c.Check(path, testutil.FileEquals, `name: dev
+base: ubuntu@24.04
+`)
 }
 
 func (s *workshopInit) TestInitWithSdkChannel(c *check.C) {
@@ -251,16 +266,6 @@ func (s *workshopInit) TestInitDuplicateSdk(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `duplicate SDK "go"`)
 }
 
-func (s *workshopInit) TestInitEmptySdks(c *check.C) {
-	projectDir := c.MkDir()
-	cmd := s.makeCmd(projectDir)
-	cmd.sdks = []string{}
-
-	err := s.run(cmd, "dev")
-	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "at least one SDK must be specified")
-}
-
 func (s *workshopInit) TestInitInvalidChannel(c *check.C) {
 	projectDir := c.MkDir()
 	cmd := s.makeCmd(projectDir)
@@ -439,9 +444,9 @@ func (s *workshopInit) TestParseSdkArgsDuplicate(c *check.C) {
 }
 
 func (s *workshopInit) TestParseSdkArgsEmpty(c *check.C) {
-	_, err := parseSdkArgs([]string{})
-	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "at least one SDK must be specified")
+	sdks, err := parseSdkArgs([]string{})
+	c.Assert(err, check.IsNil)
+	c.Check(sdks, check.HasLen, 0)
 }
 
 func (s *workshopInit) TestParseSdkArgsWhitespace(c *check.C) {
@@ -455,5 +460,5 @@ func (s *workshopInit) TestParseSdkArgsWhitespace(c *check.C) {
 func (s *workshopInit) TestParseSdkArgsOnlyWhitespace(c *check.C) {
 	_, err := parseSdkArgs([]string{" ", "  "})
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "at least one SDK must be specified")
+	c.Assert(err, check.ErrorMatches, `duplicate SDK ""`)
 }

--- a/cmd/workshop/init_test.go
+++ b/cmd/workshop/init_test.go
@@ -256,20 +256,40 @@ func (s *workshopInit) TestInitInvalidSdkName(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `invalid SDK name "INVALID_SDK"`)
 }
 
-func (s *workshopInit) TestInitDuplicateSdk(c *check.C) {
+func (s *workshopInit) TestInitEmptySdkName(c *check.C) {
 	projectDir := c.MkDir()
 	cmd := s.makeCmd(projectDir)
-	cmd.sdks = []string{"go", "go"}
+	cmd.sdks = []string{""}
 
 	err := s.run(cmd, "dev")
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `duplicate SDK "go"`)
+	c.Assert(err, check.ErrorMatches, `invalid SDK name ""`)
+}
+
+func (s *workshopInit) TestInitBlankSdkName(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go", "  ", "uv"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `invalid SDK name ""`)
+}
+
+func (s *workshopInit) TestInitDuplicateSdk(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"go", " go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `"go" SDK must only be included once`)
 }
 
 func (s *workshopInit) TestInitInvalidChannel(c *check.C) {
 	projectDir := c.MkDir()
 	cmd := s.makeCmd(projectDir)
-	cmd.sdks = []string{"go/latest/foo"}
+	cmd.sdks = []string{"go/latest/foo "}
 
 	err := s.run(cmd, "dev")
 	c.Assert(err, check.NotNil)
@@ -416,49 +436,4 @@ func (s *workshopInit) TestInitYamlRoundTrip(c *check.C) {
 	c.Assert(file.Sdks[0].Channel, check.Equals, "1.26/stable")
 	c.Assert(file.Sdks[1].Name, check.Equals, "system")
 	c.Assert(file.Sdks[2].Name, check.Equals, "python")
-}
-
-// --- parseSdkArgs unit tests ---
-
-func (s *workshopInit) TestParseSdkArgsSimple(c *check.C) {
-	sdks, err := parseSdkArgs([]string{"go", "python"})
-	c.Assert(err, check.IsNil)
-	c.Assert(sdks, check.HasLen, 2)
-	c.Assert(sdks[0].Name, check.Equals, "go")
-	c.Assert(sdks[0].Channel, check.Equals, "")
-	c.Assert(sdks[1].Name, check.Equals, "python")
-}
-
-func (s *workshopInit) TestParseSdkArgsWithChannel(c *check.C) {
-	sdks, err := parseSdkArgs([]string{"go/1.26/stable"})
-	c.Assert(err, check.IsNil)
-	c.Assert(sdks, check.HasLen, 1)
-	c.Assert(sdks[0].Name, check.Equals, "go")
-	c.Assert(sdks[0].Channel, check.Equals, "1.26/stable")
-}
-
-func (s *workshopInit) TestParseSdkArgsDuplicate(c *check.C) {
-	_, err := parseSdkArgs([]string{"go", "go"})
-	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `duplicate SDK "go"`)
-}
-
-func (s *workshopInit) TestParseSdkArgsEmpty(c *check.C) {
-	sdks, err := parseSdkArgs([]string{})
-	c.Assert(err, check.IsNil)
-	c.Check(sdks, check.HasLen, 0)
-}
-
-func (s *workshopInit) TestParseSdkArgsWhitespace(c *check.C) {
-	sdks, err := parseSdkArgs([]string{" go ", " python "})
-	c.Assert(err, check.IsNil)
-	c.Assert(sdks, check.HasLen, 2)
-	c.Assert(sdks[0].Name, check.Equals, "go")
-	c.Assert(sdks[1].Name, check.Equals, "python")
-}
-
-func (s *workshopInit) TestParseSdkArgsOnlyWhitespace(c *check.C) {
-	_, err := parseSdkArgs([]string{" ", "  "})
-	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `duplicate SDK ""`)
 }

--- a/cmd/workshop/init_test.go
+++ b/cmd/workshop/init_test.go
@@ -128,6 +128,34 @@ func (s *workshopInit) TestInitSystemSdk(c *check.C) {
 	c.Assert(strings.Contains(string(content), "system"), check.Equals, true)
 }
 
+func (s *workshopInit) TestInitTrySdk(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"try-uv", "go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	path := workshop.Filepath(projectDir, "dev")
+	content, err := os.ReadFile(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(string(content), "try-uv"), check.Equals, true)
+}
+
+func (s *workshopInit) TestInitProjectSdk(c *check.C) {
+	projectDir := c.MkDir()
+	cmd := s.makeCmd(projectDir)
+	cmd.sdks = []string{"project-uv", "go"}
+
+	err := s.run(cmd, "dev")
+	c.Assert(err, check.IsNil)
+
+	path := workshop.Filepath(projectDir, "dev")
+	content, err := os.ReadFile(path)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(string(content), "project-uv"), check.Equals, true)
+}
+
 // --- Failure: same name already exists ---
 
 func (s *workshopInit) TestInitNameAlreadyExists(c *check.C) {

--- a/cmd/workshop/refresh.go
+++ b/cmd/workshop/refresh.go
@@ -35,7 +35,7 @@ type CmdRefresh struct {
 
 func (c *CmdRefresh) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "refresh [--abort|--continue|--wait-on-error] <WORKSHOP>...",
+		Use:     "refresh <WORKSHOP>...",
 		Short:   "Update workshops according to their definitions",
 		GroupID: GrpCRUD,
 		Long: `

--- a/cmd/workshop/restore.go
+++ b/cmd/workshop/restore.go
@@ -29,7 +29,7 @@ type CmdRestore struct {
 
 func (c *CmdRestore) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "restore [flags] <WORKSHOP>...",
+		Use:     "restore <WORKSHOP>...",
 		Short:   "Restore workshops to the state of the last launch or refresh",
 		GroupID: GrpCRUD,
 		Long: `

--- a/cmd/workshop/sketch.go
+++ b/cmd/workshop/sketch.go
@@ -47,7 +47,7 @@ type CmdSketch struct {
 
 func (c *CmdSketch) Command() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "sketch-sdk [--stash|--restore|--eject|--remove] [<WORKSHOP>]",
+		Use:     "sketch-sdk [<WORKSHOP>]",
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Customize a workshop",
 		GroupID: GrpSketch,

--- a/cmd/workshopd/configure_dns.go
+++ b/cmd/workshopd/configure_dns.go
@@ -42,7 +42,7 @@ type cmdConfigureDNS struct{}
 
 func (c *cmdConfigureDNS) Command() *cobra.Command {
 	return &cobra.Command{
-		Use:   "configure-dns <interface> <domain>",
+		Use:   "configure-dns <INTERFACE> <DOMAIN>",
 		Args:  cobra.ExactArgs(2),
 		Short: shortConfigureDNSHelp,
 		Long:  longConfigureDNSHelp,

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -162,11 +162,11 @@ func (s SdkRecord) MarshalYAML() (any, error) {
 func (s *SdkRecord) UnmarshalYAML(value *yaml.Node) error {
 	type record SdkRecord
 	err := value.Decode((*record)(s))
-	s.Name, s.Source = parseSdkName(s.Name)
+	s.Name, s.Source = ParseSdkName(s.Name)
 	return err
 }
 
-func parseSdkName(name string) (string, sdk.Source) {
+func ParseSdkName(name string) (string, sdk.Source) {
 	if sdk.IsSystem(name) {
 		return name, sdk.SystemSource
 	}

--- a/internal/workshop/workshop_file.go
+++ b/internal/workshop/workshop_file.go
@@ -161,31 +161,45 @@ func (s SdkRecord) MarshalYAML() (any, error) {
 
 func (s *SdkRecord) UnmarshalYAML(value *yaml.Node) error {
 	type record SdkRecord
-	err := value.Decode((*record)(s))
-	s.Name, s.Source = ParseSdkName(s.Name)
-	return err
+	if err := value.Decode((*record)(s)); err != nil {
+		return err
+	}
+
+	name, source, err := ParseSdkName(s.Name)
+	if err != nil {
+		return err
+	}
+
+	s.Name, s.Source = name, source
+	return nil
 }
 
-func ParseSdkName(name string) (string, sdk.Source) {
+func ParseSdkName(name string) (string, sdk.Source, error) {
 	if sdk.IsSystem(name) {
-		return name, sdk.SystemSource
+		return name, sdk.SystemSource, nil
 	}
 
 	if sdk.IsSketch(name) {
-		return name, sdk.SketchSource
+		return name, sdk.SketchSource, nil
 	}
 
 	suffix, found := strings.CutPrefix(name, "try-")
 	if found {
-		return suffix, sdk.TrySource
+		if sdk.IsSystem(suffix) || sdk.IsSketch(suffix) {
+			return "", sdk.StoreSource, fmt.Errorf("%q is a reserved SDK name", suffix)
+		}
+		return suffix, sdk.TrySource, nil
 	}
 
 	suffix, found = strings.CutPrefix(name, "project-")
 	if found {
-		return suffix, sdk.ProjectSource
+		if sdk.IsSystem(suffix) || sdk.IsSketch(suffix) {
+			return "", sdk.StoreSource, fmt.Errorf("%q is a reserved SDK name", suffix)
+		}
+		return suffix, sdk.ProjectSource, nil
 	}
 
-	return name, sdk.StoreSource
+	return name, sdk.StoreSource, nil
 }
 
 type Connection struct {


### PR DESCRIPTION
# Description

Fixes #952.
Fixes #953.

We'll need to make `--sdks` optional for the first pass at VM support anyway. For the SDK prefixes, I don't think we should have used this syntax in the first place, but since we do we should support it here as well.

Also fixes some inconsistencies in CLI help messages.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
