### PR TITLE
Enable zizmor online-audits now that no tokens are needed

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -23,5 +23,3 @@ jobs:
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           advanced-security: false
-          # TODO: enable this when we go public
-          online-audits: false


### PR DESCRIPTION
Just found this when looking at the TODOs