### PR TITLE
Remove some old LXD TODOs

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -273,11 +273,7 @@ func New() (*Backend, error) {
 // ensureBackendReady creates the LXD storage pool and network the backend
 // relies on, it is idempotent.
 func ensureBackendReady() error {
-	// TODO: run this logic for a specific user. The code below implies the
-	// default project activated for the connection. As we have seen, every user
-	// has to create its own storage pool to avoid issues with id mapping of a
-	// volume with the same name (e.g. both users have system-1 volume for the
-	// system SDK that cannot be successfully mounted for another user).
+	// TODO: consider separating the storage pool or network for different users.
 	conn, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {
 		return ErrorLxdBackend(err)

--- a/internal/workshop/lxd/lxd_backend_sdk.go
+++ b/internal/workshop/lxd/lxd_backend_sdk.go
@@ -246,18 +246,9 @@ func (s *Backend) checkPartialImportSdk(conn lxd.InstanceServer, name string) (b
 
 // Export this so the LXD candidate tests pick up format changes.
 func IsImportSdkOperation(op api.Operation, name string) (bool, error) {
-	// TODO: use api.MetadataEntityURL constant.
-	// See https://github.com/canonical/lxd/pull/18033.
-	entityUrl, ok := op.Metadata["entity_url"].(string)
+	entityUrl, ok := op.Metadata[api.MetadataEntityURL].(string)
 	if !ok {
-		// TODO: return false, nil here when we bump LXD to 6.8+.
-		if op.Description == "Creating storage volume" {
-			return true, nil
-		}
-		if op.Description != "Updating storage volume" || len(op.Resources["storage_volume"]) != 1 {
-			return false, nil
-		}
-		entityUrl = op.Resources["storage_volume"][0]
+		return false, nil
 	}
 
 	u, err := url.Parse(entityUrl)

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -463,15 +463,9 @@ func (s *Backend) resolveSnapshotConflict(snapshotConn lxd.InstanceServer, snaps
 }
 
 func IsInstanceOperation(op api.Operation, lxdProject, name string) (bool, error) {
-	// TODO: use api.MetadataEntityURL constant.
-	// See https://github.com/canonical/lxd/pull/18033.
-	entityUrl, ok := op.Metadata["entity_url"].(string)
+	entityUrl, ok := op.Metadata[api.MetadataEntityURL].(string)
 	if !ok {
-		// TODO: return false, nil here when we bump LXD to 6.8+.
-		if op.Description != "Updating instance" || len(op.Resources["instance"]) != 1 {
-			return false, nil
-		}
-		entityUrl = op.Resources["instance"][0]
+		return false, nil
 	}
 
 	u, err := url.Parse(entityUrl)


### PR DESCRIPTION
# Description

For the comment about sharing SDK volumes between users, we've solved it another way. It might still be worth using different pools and networks for different users though (the network could be tricky since it would need a new TLD).

Removes support for response metadata from old versions of LXD.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
