### PR TITLE
Temporarily use PATCH to update autostart config

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -667,20 +667,9 @@ func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, na
 		return err
 	}
 
-	for i := range 2 {
-		// Workshop started, enable autostart.
-		if err := s.setAutoStart(conn, ctx, name, true); err != nil {
-			if i == 0 && api.StatusErrorCheck(err, http.StatusPreconditionFailed) && strings.HasPrefix(err.Error(), "ETag does not match: ") {
-				// TODO: remove the loop after modifying the logic to wait for
-				// LXD's instance ready event. Currently, the instance may or
-				// may not set itself to Ready, so we can't rely on it. When it
-				// does so, LXD sets volatile.last_state.ready, which can
-				// invalidates the ETag; a single retry is enough to fix it.
-				continue
-			}
-			return err
-		}
-		break
+	// Workshop started, enable autostart.
+	if err := s.setAutoStart(conn, ctx, name, true); err != nil {
+		return err
 	}
 
 	var stderr strings.Builder
@@ -765,14 +754,14 @@ func (s *Backend) setAutoStart(conn lxd.InstanceServer, ctx context.Context, nam
 		return fmt.Errorf("context key project-id not found")
 	}
 
-	inst, etag, err := conn.GetInstance(InstanceName(name, projectId))
-	if err != nil {
-		return err
+	// TODO: switch back to PUT instead of PATCH. We have to use PATCH for now
+	// because there's a race where LXD validates the ETag, then DevLXD updates
+	// the instance state before LXD finishes the PUT. Once we start waiting
+	// for the ready event, we can just use PUT after that.
+	req := api.InstancePut{
+		Config: map[string]string{"boot.autostart": strconv.FormatBool(autostart)},
 	}
-
-	inst.Config["boot.autostart"] = strconv.FormatBool(autostart)
-
-	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
+	op, _, err := conn.RawOperation(http.MethodPatch, "/instances/"+InstanceName(name, projectId), req, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

I saw this test run: https://github.com/canonical/workshop/actions/runs/30675813928/job/91303401902. The `workshop-waitready` service completed successfully, and some time passed before `workshop start` timed out. It's likely caused by this bug: https://github.com/canonical/lxd/issues/18833.

I think we should temporarily switch from PUT to PATCH and see if we continue to see flakiness here. The LXD client library only officially supports PUT, so we should switch back after the tests start working reliably.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
