### PR TITLE
docs,internal,etc: update LXD docs URLs

### DIFF
--- a/.github/skills/documentation-style/references/doc-style-guide.md
+++ b/.github/skills/documentation-style/references/doc-style-guide.md
@@ -529,7 +529,7 @@ Common external links are defined in `docs/reuse/links.txt` for consistent refer
 ```restructuredtext
 .. _Canonical website: https://canonical.com/
 .. _GitHub: https://github.com/canonical/workshop/
-.. _LXD: https://documentation.ubuntu.com/lxd/latest/
+.. _LXD: https://canonical.com/lxd/docs/latest/
 .. _SDKcraft: https://github.com/canonical/sdkcraft/
 .. _Releases: https://github.com/canonical/workshop/releases/
 ```
@@ -1071,7 +1071,7 @@ For all other internal documentation links, prefer `:ref:` with semantic anchor 
 Inline:
 
 ```restructuredtext
-`LXD documentation <https://documentation.ubuntu.com/lxd/latest/>`_
+`LXD documentation <https://canonical.com/lxd/docs/latest/>`_
 ```
 
 Anonymous:

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -485,7 +485,7 @@ func exec(root *CmdRoot, flags *ExecFlags, args *ExecArgs) error {
 		// Obtain an exec session as close to a real login shell as possible.
 		// This is required as an lxd exec call is a simple namespace exec, and LXD
 		// ignores the instance configuration by design:
-		// https://documentation.ubuntu.com/lxd/en/latest/instance-exec/#user-groups-and-working-directory
+		// https://canonical.com/lxd/docs/latest/instance-exec/#user-groups-and-working-directory
 		commandPrefix = []string{
 			"sudo",
 			"-u",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,8 +186,8 @@ exclude_patterns = [
 rst_epilog = """
 .. _Canonical website: https://canonical.com/
 .. _GitHub: https://github.com/canonical/workshop/
-.. _LXC: https://documentation.ubuntu.com/lxd/latest/explanation/lxd_lxc/
-.. _LXD: https://documentation.ubuntu.com/lxd/latest/
+.. _LXC: https://canonical.com/lxd/docs/latest/explanation/lxd_lxc/
+.. _LXD: https://canonical.com/lxd/docs/latest/
 .. _SDKcraft: https://github.com/canonical/sdkcraft/
 .. _Releases: https://github.com/canonical/workshop/releases/
 

--- a/docs/contributing/maintenance.rst
+++ b/docs/contributing/maintenance.rst
@@ -28,7 +28,7 @@ Build the snaps locally
 `Snapcraft <https://documentation.ubuntu.com/snapcraft/stable/>`_
 is used to build, package, and publish :program:`workshop` snaps.
 All these processes run in a self-launched
-`LXD <https://documentation.ubuntu.com/lxd/latest/>`_ container.
+`LXD <https://canonical.com/lxd/docs/latest/>`_ container.
 To run the build,
 install :program:`snapcraft` and :program:`lxd` using :program:`snap`:
 

--- a/docs/doc-style-guide.md
+++ b/docs/doc-style-guide.md
@@ -558,7 +558,7 @@ Common external links are defined in `docs/reuse/links.txt` for consistent refer
 ```restructuredtext
 .. _Canonical website: https://canonical.com/
 .. _GitHub: https://github.com/canonical/workshop/
-.. _LXD: https://documentation.ubuntu.com/lxd/latest/
+.. _LXD: https://canonical.com/lxd/docs/latest/
 .. _SDKcraft: https://github.com/canonical/sdkcraft/
 .. _Releases: https://github.com/canonical/workshop/releases/
 ```
@@ -1100,7 +1100,7 @@ For all other internal documentation links, prefer `:ref:` with semantic anchor 
 Inline:
 
 ```restructuredtext
-`LXD documentation <https://documentation.ubuntu.com/lxd/latest/>`_
+`LXD documentation <https://canonical.com/lxd/docs/latest/>`_
 ```
 
 Anonymous:

--- a/docs/how-to/fix-workshops/fix-installation.rst
+++ b/docs/how-to/fix-workshops/fix-installation.rst
@@ -50,7 +50,7 @@ You may need to add yourself to the :samp:`lxd` group to access its resources:
    $ sudo usermod -a -G lxd $USER
 
 As a final step, see the
-`troubleshooting guides <https://documentation.ubuntu.com/lxd/latest/howto/troubleshoot/>`_
+`troubleshooting guides <https://canonical.com/lxd/docs/latest/howto/troubleshoot/>`_
 in LXD documentation.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 :slug: home-page
-:relatedlinks: [Workshop](https://github.com/canonical/workshop/), [SDKcraft](https://github.com/canonical/sdkcraft/), [LXD](https://documentation.ubuntu.com/lxd/default/), [Snap](https://snapcraft.io/docs/)
+:relatedlinks: [Workshop](https://github.com/canonical/workshop/), [SDKcraft](https://github.com/canonical/sdkcraft/), [LXD](https://canonical.com/lxd/docs/default/), [Snap](https://snapcraft.io/docs/)
 
 .. _home:
 

--- a/docs/reference/workshops.rst
+++ b/docs/reference/workshops.rst
@@ -162,7 +162,7 @@ If you need more space or different performance,
 you can resize or tune the storage pool (it's named :samp:`workshop`),
 using the :command:`lxc storage` command
 as suggested in this `LXD documentation section
-<https://documentation.ubuntu.com/lxd/latest/howto/storage_pools/>`_.
+<https://canonical.com/lxd/docs/latest/howto/storage_pools/>`_.
 However, day-to-day usage requires little manual intervention.
 
 .. attention::

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,7 +9,7 @@ for the users, is confined as a snap and neither needs nor requires elevated
 privileges to run. Instead, it uses a RESTful API to communicate with the
 `workshopd` daemon, which performs all the heavy lifting and does indeed run
 with elevated privileges. The use of
-[LXD](https://documentation.ubuntu.com/lxd/latest/) for implementation provides
+[LXD](https://canonical.com/lxd/docs/latest/) for implementation provides
 the benefits of a mature container technology.
 
 SDKcraft is an instance of
@@ -26,7 +26,7 @@ limited capabilities on the host. To achieve this, LXD is used to add a level of
 confinement: everything users do ends up in a [nonprivileged
 container](https://ubuntu.com/server/docs/how-to/containers/lxd-containers/)
 within a dedicated
-[project](https://documentation.ubuntu.com/lxd/latest/explanation/projects/),
+[project](https://canonical.com/lxd/docs/latest/explanation/projects/),
 which separates workshops that belong to different users and isolates them from
 each other and the host system.
 

--- a/docs/tutorial/part-1-get-started.rst
+++ b/docs/tutorial/part-1-get-started.rst
@@ -54,7 +54,7 @@ where it uses Btrfs instead of ZFS for storage.
 `LXD 6.8+ <https://canonical.com/lxd>`_
 for low-level operation
 and uses its
-`REST API <https://documentation.ubuntu.com/lxd/latest/restapi_landing/>`_
+`REST API <https://canonical.com/lxd/docs/latest/restapi_landing/>`_
 to handle individual *workshops*.
 
 To install it from scratch with :program:`snap`:
@@ -76,11 +76,11 @@ To refresh an existing :program:`snap` installation:
    If you prefer another installation method,
    see the available installation options in
    `LXD documentation
-   <https://documentation.ubuntu.com/lxd/latest/installing/>`__;
+   <https://canonical.com/lxd/docs/latest/installing/>`__;
    after installation,
    make sure the
    `LXD daemon
-   <https://documentation.ubuntu.com/lxd/latest/explanation/lxd_lxc/#lxd-daemon>`__
+   <https://canonical.com/lxd/docs/latest/explanation/lxd_lxc/#lxd-daemon>`__
    is enabled and running.
    If in doubt, refer to LXD documentation
    and your distribution's manuals for guidance.

--- a/docs/tutorial/part-4-craft-sdks.rst
+++ b/docs/tutorial/part-4-craft-sdks.rst
@@ -46,7 +46,7 @@ Prerequisites
 `LXD 6.8+ <https://canonical.com/lxd>`_
 for low-level operation,
 using its
-`REST API <https://documentation.ubuntu.com/lxd/latest/restapi_landing/>`_
+`REST API <https://canonical.com/lxd/docs/latest/restapi_landing/>`_
 to craft the SDKs.
 
 If the :command:`snap install` command reports an issue with LXD,
@@ -71,10 +71,10 @@ To refresh an existing installation:
    For other ways to install LXD,
    see the available installation options in
    `LXD documentation
-   <https://documentation.ubuntu.com/lxd/latest/installing/>`_.
+   <https://canonical.com/lxd/docs/latest/installing/>`_.
    Also, you need to ensure the
    `LXD daemon
-   <https://documentation.ubuntu.com/lxd/latest/explanation/lxd_lxc/#lxd-daemon>`_
+   <https://canonical.com/lxd/docs/latest/explanation/lxd_lxc/#lxd-daemon>`_
    is enabled and running.
    Again, refer to LXD documentation
    and your distribution's manuals for guidance.

--- a/internal/interfaces/lxd_device/spec.go
+++ b/internal/interfaces/lxd_device/spec.go
@@ -159,7 +159,7 @@ func (s *Specification) AddMountEntry(dev workshop.Mount) error {
 // Tunnel, SSH Agent and Desktop are all of the lxc 'proxy' type
 // These are network protocol proxy devices that open a port on the host or in a workhop.
 // 'listen', 'connect' are the source and destination addresses (paths in the case of unix sockets),
-// see https://documentation.ubuntu.com/lxd/en/latest/reference/devices_proxy/#device-proxy-device-conf:bind
+// see https://canonical.com/lxd/docs/latest/reference/devices_proxy/#device-proxy-device-conf:bind
 // bind denotes where the port is open (can be: instance, host)
 
 func (s *Specification) AddTunnelEntry(tunnel workshop.Tunnel) error {

--- a/internal/workshop/lxd/firewall.go
+++ b/internal/workshop/lxd/firewall.go
@@ -8,7 +8,7 @@ import (
 	"github.com/canonical/workshop/internal/logger"
 )
 
-const firewallDocLink = "https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/"
+const firewallDocLink = "https://canonical.com/lxd/docs/latest/howto/network_bridge_firewalld/"
 
 // CheckBridgeFirewall detects whether firewall rules block forwarding on the
 // workshop bridge. It returns a non-empty warning message with a proposed
@@ -22,7 +22,7 @@ const firewallDocLink = "https://documentation.ubuntu.com/lxd/latest/howto/netwo
 //
 // Uses `nft -j` (JSON output) for structured, robust parsing.
 //
-// See: https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/
+// See: https://canonical.com/lxd/docs/latest/howto/network_bridge_firewalld/
 func CheckBridgeFirewall(bridgeName string) string {
 	return firewallChecker(bridgeName)
 }

--- a/internal/workshop/lxd/firewall_test.go
+++ b/internal/workshop/lxd/firewall_test.go
@@ -120,13 +120,13 @@ func (s *FirewallTests) TestAnalyzeNftJSONNoForwardChain(c *check.C) {
 func (s *FirewallTests) TestBridgeBlockedWarningDocker(c *check.C) {
 	msg := bridgeBlockedWarning("workshopbr0", causeDocker)
 	c.Check(msg, check.Matches, ".*Docker.*nft.*DOCKER-USER.*workshopbr0.*")
-	c.Check(msg, check.Matches, ".*documentation.ubuntu.com.*")
+	c.Check(msg, check.Matches, ".*canonical.com/lxd/docs.*")
 }
 
 func (s *FirewallTests) TestBridgeBlockedWarningUFW(c *check.C) {
 	msg := bridgeBlockedWarning("workshopbr0", causeUFW)
 	c.Check(msg, check.Matches, ".*UFW.*ufw allow.*workshopbr0.*")
-	c.Check(msg, check.Matches, ".*documentation.ubuntu.com.*")
+	c.Check(msg, check.Matches, ".*canonical.com/lxd/docs.*")
 }
 
 func (s *FirewallTests) TestBridgeBlockedWarningUnknown(c *check.C) {
@@ -134,5 +134,5 @@ func (s *FirewallTests) TestBridgeBlockedWarningUnknown(c *check.C) {
 	c.Check(msg, check.Not(check.Matches), ".*Docker.*")
 	c.Check(msg, check.Not(check.Matches), ".*UFW.*")
 	c.Check(msg, check.Matches, ".*workshopbr0.*")
-	c.Check(msg, check.Matches, ".*documentation.ubuntu.com.*")
+	c.Check(msg, check.Matches, ".*canonical.com/lxd/docs.*")
 }


### PR DESCRIPTION
# Description

LXD docs are now at https://canonical.com/lxd/docs/.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.
