### PR TITLE
Implement system-info response

### DIFF
--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -21,6 +21,10 @@ import (
 )
 
 var api = []*Command{{
+	Path:    "/v1/system-info",
+	GuestOK: true,
+	GET:     v1GetSystemInfo,
+}, {
 	// See daemon.go:canAccess for details how the access is controlled.
 	Path:    "/v1/projects",
 	GuestOK: false,

--- a/internal/daemon/api_system_info.go
+++ b/internal/daemon/api_system_info.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"net/http"
+
+	"github.com/canonical/workshop/internal/version"
+)
+
+type sysInfo struct {
+	Version string `json:"version"`
+}
+
+func v1GetSystemInfo(_ *Command, _ *http.Request, _ *userState) Response {
+	return SyncResponse(&sysInfo{Version: version.Version}, http.StatusOK)
+}

--- a/internal/daemon/api_system_info_test.go
+++ b/internal/daemon/api_system_info_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"net/http"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/version"
+)
+
+func (s *apiSuite) TestSystemInfoOk(c *check.C) {
+	s.daemon(c)
+	restore := version.MockVersion("1.2.3")
+	defer restore()
+
+	req, err := http.NewRequest("GET", "/v1/system-info", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := v1GetSystemInfo(apiCmd("/v1/system-info"), req, nil).(*resp)
+	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Status, check.Equals, http.StatusOK)
+	c.Check(rsp.Result, check.DeepEquals, &sysInfo{Version: "1.2.3"})
+}


### PR DESCRIPTION
# Description

Support `system-info` endpoint for `workshopd` clients. Currently, the response includes only the daemon's version.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
