### PR TITLE
Move workshopd run directory to SNAP_COMMON

### DIFF
--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -152,8 +152,6 @@ func setDataDir(dataDir string) {
 	DataDir = dataDir
 
 	WorkshopStateLockFile = filepath.Join(DataDir, "state.lock")
-	WorkshopdRunDir = filepath.Join(DataDir, "run", "workshopd")
-	WorkshopdLocksDir = filepath.Join(WorkshopdRunDir, "locks")
 }
 
 func setCommonDir(commonDir string) {
@@ -164,6 +162,11 @@ func setCommonDir(commonDir string) {
 
 	WorkshopSSHDir = filepath.Join(CommonDir, "ssh")
 	WorkshopTlsDir = filepath.Join(CommonDir, "tls")
+
+	// Runtime data (X cookies, SDK locks) is used as an LXD mount source, so it
+	// must live on a revision-independent path to survive snap refreshes.
+	WorkshopdRunDir = filepath.Join(CommonDir, "run", "workshopd")
+	WorkshopdLocksDir = filepath.Join(WorkshopdRunDir, "locks")
 }
 
 func setCacheDir(cachedir string) {

--- a/snap/local/hooks/post-refresh
+++ b/snap/local/hooks/post-refresh
@@ -2,3 +2,4 @@
 
 # TODO: remove a one-off data -> common migration cleanup
 rm -rf "${SNAP_DATA}/ssh"
+rm -rf "${SNAP_DATA}/run"


### PR DESCRIPTION
# Description

Having the run directory in `SNAP_DATA` is problematic because it gets snap revision in its path. Thus, artifacts like Xauthority become unavailable after `snap refresh` cleans up the old snap's revisions. It breaks workshops that connect a desktop interface plug as the mount cannot find the source. Moving it to `SNAP_COMMON` keeps the data shared among the snap instances.

The `run` directory maintains locks for SDKs too. I could not identify any issues with these being moved to the common location either. Locks that are held at the refresh time will be cleared by the kernel and recaptured if needed on the daemon restart. The only cosmetic effect will be that the lock files will not be cleared on the system's reboot automatically as it would be expected from a run location.

## Known problems

Existing workshops using the desktop interfaces will have to be re-launched. 

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
