### PR TITLE
Fix desktop connection for WSL

### DIFF
--- a/internal/osutil/export_test.go
+++ b/internal/osutil/export_test.go
@@ -31,7 +31,15 @@ var (
 	ParseRawEnvironment       = parseRawEnvironment
 	ParseSystemctlEnvironment = parseSystemctlEnvironment
 	DoCopyFile                = doCopyFile
+	SupplementWSLgDisplayEnv  = supplementWSLgDisplayEnv
 )
+
+// MockWSLg overrides WSLg detection for tests and returns a restore function.
+func MockWSLg(available bool) (restore func()) {
+	old := onWSLg
+	onWSLg = func() bool { return available }
+	return func() { onWSLg = old }
+}
 
 // ParseRawExpandableEnv returns a new expandable environment parsed from key=value strings.
 func ParseRawExpandableEnv(entries []string) (ExpandableEnv, error) {

--- a/internal/osutil/user.go
+++ b/internal/osutil/user.go
@@ -15,6 +15,7 @@
 package osutil
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -23,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/osutil/sys"
@@ -238,7 +241,67 @@ func userEnvironment(user *user.User) (map[string]string, error) {
 
 	// TODO: use --output=json once systemd >= 250.
 	rawEnv := strings.FieldsFunc(string(out), func(r rune) bool { return r == '\n' })
-	return parseSystemctlEnvironment(rawEnv)
+	userEnv, err := parseSystemctlEnvironment(rawEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	// Work around microsoft/WSL#12436: the systemd --user manager on WSL
+	// lacks the WSLg display variables, so fill them in here.
+	supplementWSLgDisplayEnv(user, userEnv)
+
+	return userEnv, nil
+}
+
+// wslgMountDir is where WSLg exposes the display sockets and PulseAudio
+// server. Its presence is the signal that WSLg's DISPLAY/WAYLAND_DISPLAY
+// sockets are actually available on this WSL instance.
+var wslgMountDir = "/mnt/wslg"
+
+// IsWSL reports whether the host is running under Windows Subsystem for Linux.
+func IsWSL() bool {
+	var utsname unix.Utsname
+	if err := unix.Uname(&utsname); err != nil {
+		return false
+	}
+	data := utsname.Release[:]
+	if idx := bytes.IndexByte(data, 0); idx >= 0 {
+		data = data[:idx]
+	}
+	version := strings.ToLower(string(data))
+	return strings.Contains(version, "microsoft") || strings.Contains(version, "wsl2")
+}
+
+// onWSLg reports whether the host is a WSL instance with WSLg available.
+var onWSLg = func() bool {
+	if !IsWSL() {
+		return false
+	}
+	_, err := os.Stat(wslgMountDir)
+	return err == nil
+}
+
+// supplementWSLgDisplayEnv works around microsoft/WSL#12436. On WSL, WSLg
+// injects DISPLAY, WAYLAND_DISPLAY and friends only into login shells (via
+// /etc/profile.d) and never into the systemd --user manager. As a result
+// `systemctl --user show-environment` omits them, and the desktop interface
+// reports "neither DISPLAY nor WAYLAND_DISPLAY are set" even though the host
+// compositor is reachable. When WSLg is available we fill in its well-known,
+// stable socket values for any variable the user manager did not provide.
+func supplementWSLgDisplayEnv(user *user.User, env map[string]string) {
+	if !onWSLg() {
+		return
+	}
+	defaults := map[string]string{
+		"DISPLAY":         ":0",
+		"WAYLAND_DISPLAY": "wayland-0",
+		"XDG_RUNTIME_DIR": filepath.Join(dirs.XdgRuntimeDirBase, user.Uid),
+	}
+	for key, value := range defaults {
+		if env[key] == "" {
+			env[key] = value
+		}
+	}
 }
 
 func timezone() (string, error) {

--- a/internal/osutil/user_test.go
+++ b/internal/osutil/user_test.go
@@ -157,3 +157,43 @@ func (s *userSuite) TestNormalizeUidGid(c *check.C) {
 	groupErr = fmt.Errorf("GROUP ERROR!")
 	test(ptr(1), nil, "", "GROUP", nil, nil, "GROUP ERROR!")
 }
+
+func (s *userSuite) TestSupplementWSLgDisplayEnvNotWSL(c *check.C) {
+	defer osutil.MockWSLg(false)()
+
+	env := map[string]string{"HOME": "/home/ubuntu"}
+	osutil.SupplementWSLgDisplayEnv(&user.User{Uid: "1000"}, env)
+
+	c.Check(env, check.DeepEquals, map[string]string{"HOME": "/home/ubuntu"})
+}
+
+func (s *userSuite) TestSupplementWSLgDisplayEnvFillsMissing(c *check.C) {
+	defer osutil.MockWSLg(true)()
+
+	env := map[string]string{"HOME": "/home/ubuntu"}
+	osutil.SupplementWSLgDisplayEnv(&user.User{Uid: "1000"}, env)
+
+	c.Check(env, check.DeepEquals, map[string]string{
+		"HOME":            "/home/ubuntu",
+		"DISPLAY":         ":0",
+		"WAYLAND_DISPLAY": "wayland-0",
+		"XDG_RUNTIME_DIR": "/run/user/1000",
+	})
+}
+
+func (s *userSuite) TestSupplementWSLgDisplayEnvKeepsExisting(c *check.C) {
+	defer osutil.MockWSLg(true)()
+
+	env := map[string]string{
+		"DISPLAY":         ":1",
+		"WAYLAND_DISPLAY": "wayland-7",
+		"XDG_RUNTIME_DIR": "/run/user/2000",
+	}
+	osutil.SupplementWSLgDisplayEnv(&user.User{Uid: "1000"}, env)
+
+	c.Check(env, check.DeepEquals, map[string]string{
+		"DISPLAY":         ":1",
+		"WAYLAND_DISPLAY": "wayland-7",
+		"XDG_RUNTIME_DIR": "/run/user/2000",
+	})
+}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -15,7 +15,6 @@
 package lxdbackend
 
 import (
-	"bytes"
 	"cmp"
 	"context"
 	"embed"
@@ -76,22 +75,8 @@ var (
 //go:embed start_command.sh
 var startCommand string
 
-// isWSL checks if we're running on Windows Subsystem for Linux
-func isWSL() bool {
-	var utsname unix.Utsname
-	if err := unix.Uname(&utsname); err != nil {
-		return false
-	}
-	data := utsname.Release[:]
-	if idx := bytes.IndexByte(data, 0); idx >= 0 {
-		data = data[:idx]
-	}
-	version := strings.ToLower(string(data))
-	return strings.Contains(version, "microsoft") || strings.Contains(version, "wsl2")
-}
-
 func init() {
-	if isWSL() {
+	if osutil.IsWSL() {
 		storagePoolDriver = "btrfs"
 	}
 


### PR DESCRIPTION
# Description

WSL does not set the `DISPLAY` and `WAYLAND_DISPLAY` in systemd environment. This change detects WSL and sets the desired variables to where they live in WSLg.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
