### PR TITLE
Update autostart config before starting instance

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -654,8 +654,19 @@ func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, na
 	rev := revert.New()
 	defer rev.Fail()
 
+	// Enable autostart first so it doesn't race with workshop-waitready.service.
+	// See https://github.com/canonical/lxd/issues/18833.
+	if err := s.setAutoStart(conn, ctx, name, true); err != nil {
+		return err
+	}
+
 	cleanupCtx := context.WithoutCancel(ctx)
 	rev.Add(func() {
+		// TODO: if this becomes a long-term thing, consider adding a timeout.
+		if e := s.setAutoStart(conn, cleanupCtx, name, false); e != nil {
+			logger.Noticef("On StartWorkshop: cannot reset %q workshop boot.autostart: %v", name, e)
+		}
+
 		// Stop workshop's timeout is handled by LXD API, so no need to have
 		// a context with a timeout.
 		if e := s.stopWorkshop(conn, cleanupCtx, name, true); e != nil {
@@ -665,22 +676,6 @@ func (s *Backend) startWorkshop(conn lxd.InstanceServer, ctx context.Context, na
 
 	if err := s.updateInstanceState(conn, ctx, name, "start", 60); err != nil {
 		return err
-	}
-
-	for i := range 2 {
-		// Workshop started, enable autostart.
-		if err := s.setAutoStart(conn, ctx, name, true); err != nil {
-			if i == 0 && api.StatusErrorCheck(err, http.StatusPreconditionFailed) && strings.HasPrefix(err.Error(), "ETag does not match: ") {
-				// TODO: remove the loop after modifying the logic to wait for
-				// LXD's instance ready event. Currently, the instance may or
-				// may not set itself to Ready, so we can't rely on it. When it
-				// does so, LXD sets volatile.last_state.ready, which can
-				// invalidates the ETag; a single retry is enough to fix it.
-				continue
-			}
-			return err
-		}
-		break
 	}
 
 	var stderr strings.Builder


### PR DESCRIPTION
# Description

Works around https://github.com/canonical/lxd/issues/18833.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
