### PR TITLE
Doc: Propose and document policy for backward compatibility

### DIFF
--- a/docs/explanation/workshops/concepts.rst
+++ b/docs/explanation/workshops/concepts.rst
@@ -544,6 +544,29 @@ This mechanism avoids the need to maintain helper scripts manually,
 ensuring instead that they are stored with the rest of the workshop's metadata.
 
 
+Backward compatibility
+----------------------
+
+|ws_markup| strives to maintain backward compatibility between adjacent versions.
+A workshop created by the current version of |ws_markup|
+should continue working after updating to the next version.
+However, maintaining backward compatibility indefinitely is not currently feasible.
+To avoid running into compatibility issues,
+workshops should be refreshed regularly.
+
+The |ws_markup| daemon exposes a REST API for managing workshops.
+Most changes to this API add new endpoints,
+or additional fields to the requests and responses of existing endpoints.
+These are not considered breaking changes.
+Breaking changes will be announced in the |ws_markup| release notes.
+
+The :program:`workshop` and :program:`sdk` CLIs are mainly intended for interactive use,
+and in particular the output format can change at any time.
+Use the :program:`workshopd` API for a more stable output format.
+However, to support running |ws_markup| in scripts and CI environments,
+breaking changes to CLI arguments will be announced in the |ws_markup| release notes.
+
+
 Origins and locations
 ---------------------
 

--- a/docs/reference/workshops.rst
+++ b/docs/reference/workshops.rst
@@ -148,6 +148,36 @@ Unlike the automatic rollback during a failed refresh,
 :command:`restore` is a deliberate user action
 to discard all changes made to a workshop since it was last set up.
 
+Updates to |ws_markup| can introduce new features
+that require changes to existing workshops.
+After updating the |ws_markup| snap,
+these changes will be applied on the next :command:`workshop refresh`.
+Before this refresh, the new features remain unavailable,
+but most operations should continue to work.
+The exceptions are :command:`workshop restore`,
+:command:`workshop launch --continue`,
+and :command:`workshop refresh --continue`.
+|ws_markup| will refuse to perform these operations on an old workshop,
+because it may not be able to reproduce the exact behavior of the previous version.
+
+The |ws_markup| daemon embeds a special :samp:`system` SDK
+that it adds to every workshop.
+When this SDK is updated,
+existing workshops will start using the new version on the next :command:`workshop refresh`.
+Old workshops continue to use the old SDK,
+which is no longer embedded in |ws_markup| itself
+but continues to exist as a LXD storage volume
+until garbage collection.
+
+
+Forward compatibility
+---------------------
+
+|ws_markup| is not forward compatible.
+To downgrade the snap,
+remove it and then reinstall it from scratch.
+Removing the snap removes all workshops and SDKs.
+
 
 Storage pools and drivers
 -------------------------

--- a/internal/overlord/sdkstate/handlers.go
+++ b/internal/overlord/sdkstate/handlers.go
@@ -446,7 +446,9 @@ func (m *SdkManager) doDeleteUnusedSdkVolumes(task *state.Task, tomb *tomb.Tomb)
 		return nil
 	}
 
-	if !sdkSetup.IsVolume() || sdkSetup.Source == sdk.SystemSource {
+	// Either no volume to clean up, or it's the current system SDK, which we
+	// might as well keep as an optimization.
+	if !sdkSetup.IsVolume() || (sdkSetup.Source == sdk.SystemSource && sdkSetup.Revision == system.SystemSdkRevision) {
 		return nil
 	}
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -86,6 +86,7 @@ func init() {
 	// LXD is installed or refreshed, without a restart.
 	syscheck.RegisterCheck(checkServerCapabilities)
 	syscheck.RegisterCheck(ensureBackendReady)
+	syscheck.RegisterCheck(checkWorkshopFormats)
 	syscheck.RegisterCheck(checkStorageSpace)
 }
 
@@ -236,6 +237,32 @@ func checkServerCapabilities() error {
 	}
 
 	return checkStorageDriver(info.Environment.StorageSupportedDrivers)
+}
+
+func checkWorkshopFormats() error {
+	backend := Backend{}
+	allprojects, err := backend.Projects(context.Background())
+	if err != nil {
+		return fmt.Errorf("interface manager not ready: %w", err)
+	}
+
+	for user, projects := range allprojects {
+		ctx := context.WithValue(context.Background(), workshop.ContextUser, user)
+		for _, project := range projects {
+			pctx := context.WithValue(ctx, workshop.ContextProjectId, project.ProjectId)
+			workshops, err := backend.ProjectWorkshops(pctx)
+			if err != nil {
+				return fmt.Errorf("cannot load workshops from %q: %v", project.Path, err)
+			}
+			for _, workshop := range workshops {
+				if workshop.Format.N > backend.FormatRevision().N {
+					return fmt.Errorf("cannot load %q workshop from %q: upgrade Workshop and remove all workshops before downgrading again", workshop.Name, project.Path)
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // New constructs the LXD backend and attempts to prepare the required LXD


### PR DESCRIPTION
# Description

Some of this documents existing behaviour (of `restore` and `--continue`). The rest is an attempt to codify our promise to users at this early stage. Let me know what you think!

I also fixed an issue where old system SDKs weren't being cleaned up as I had claimed. And added a check to guard against downgrading Workshop while some new workshops exist.

There's still a caveat that it's possible for the snap to refresh in the middle of a `workshop launch` or `workshop refresh`, e.g. if using `--no-wait`. We don't handle this situation correctly at the moment, and it's not clear to me what the consequences are when this happens, but I also think it's not something users are likely to encounter.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [x] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
