### PR TITLE
lxd: install secret socket systemd units on workshop creation

### DIFF
--- a/internal/dirs/dirs.go
+++ b/internal/dirs/dirs.go
@@ -54,6 +54,10 @@ var (
 	// socket name (which varies, e.g. under "go tool try").
 	WorkshopSocketPath = filepath.Join(WorkshopRunDir, "workshop.socket")
 
+	// Path to the unix socket inside a workshop that systemd units connect
+	// to for secret resolution (via LoadCredential).
+	WorkshopSecretSocketPath = filepath.Join(WorkshopRunDir, "workshop.socket.secret")
+
 	// Directory for actions inside workshop
 	WorkshopActionsDir = filepath.Join(WorkshopRunDir, "actions")
 

--- a/internal/workshop/lxd/cloudconfig.go
+++ b/internal/workshop/lxd/cloudconfig.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package lxdbackend
+
+import (
+	"path/filepath"
+	"sync"
+	"text/template"
+
+	"github.com/canonical/x-go/strutil/shlex"
+
+	"github.com/canonical/workshop/internal/dirs"
+)
+
+// cloudConfigVars holds the variables interpolated into the cloud-init
+// user-data template.
+type cloudConfigVars struct {
+	// WorkshopCtlPath is the path of the workshopctl binary inside the
+	// workshop.
+	WorkshopCtlPath string
+
+	// WorkshopSecretSocketPath is the path inside the workshop of the unix
+	// socket that systemd units connect to for secret resolution.
+	WorkshopSecretSocketPath string
+
+	// WorkshopStateDir is the directory inside the workshop used to store
+	// workshop state.
+	WorkshopStateDir string
+}
+
+// makeCloudConfigVars constructs the variables for the cloud-init user-data
+// template.
+func makeCloudConfigVars() cloudConfigVars {
+	return cloudConfigVars{
+		WorkshopCtlPath:          filepath.Join(dirs.WorkshopGuestBinDir, filepath.Base(dirs.WorkshopCtlPath)),
+		WorkshopSecretSocketPath: dirs.WorkshopSecretSocketPath,
+		WorkshopStateDir:         dirs.WorkshopStateDir,
+	}
+}
+
+// cloudConfigTemplate returns the parsed cloud-init user-data template used
+// when creating a workshop instance. The template is parsed once and reused.
+var cloudConfigTemplate = sync.OnceValues(parseCloudConfigTemplate)
+
+// parseCloudConfigTemplate parses the cloud-init user-data template.
+func parseCloudConfigTemplate() (*template.Template, error) {
+	const tmpl = `#cloud-config
+users:
+  - default
+  - name: workshop
+    primary_group: workshop
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    create_groups: false
+    groups:
+    - 'adm'
+    - 'cdrom'
+    - 'sudo'
+    - 'dip'
+    - 'plugdev'
+    - 'audio'
+    - 'netdev'
+    - 'lxd'
+    - 'video'
+    - 'render'
+    # Compatibility GIDs for various host systems:
+    - '108' # netdev on 26.04
+    - '111' # netdev on 24.04
+    - '118' # netdev on 20.04
+    - '119' # netdev on 22.04
+    - '109' # render on 20.04
+    - '110' # render on 22.04
+    - '990' # render on 26.04
+    - '992' # render on 24.04
+bootcmd:
+- |
+  set -e
+  maybe_groupadd() {
+      # Ignore GID not unique (exit code 4) or group name not unique (exit code 9)
+      groupadd -g "$1" -r "$2" || case $? in 4|9) ;; *) return $? ;; esac
+  }
+  maybe_groupadd 1000 workshop
+  maybe_groupadd 108 netdev-compat-108
+  maybe_groupadd 111 netdev-compat-111
+  maybe_groupadd 118 netdev-compat-118
+  maybe_groupadd 119 netdev-compat-119
+  maybe_groupadd 109 render-compat-109
+  maybe_groupadd 110 render-compat-110
+  maybe_groupadd 990 render-compat-990
+  maybe_groupadd 992 render-compat-992
+- chmod 0600 /etc/ssh/ssh_host_ed25519_key
+apt:
+  conf: |
+    # Installed by workshop
+
+    # Don't automatically install recommended packages
+    APT::Install-Recommends "0";
+
+    # Don't automatically install suggested packages
+    APT::Install-Suggests "0";
+
+    # Bypass confirmation prompts
+    APT::Get::Assume-Yes "1";
+grub_dpkg:
+  enabled: false
+ssh_deletekeys: false
+ssh_genkeytypes: [ed25519]
+write_files:
+  - path: /etc/cloud/cloud-init.disabled
+    defer: true
+  - path: /etc/ssh/sshd_config.d/90-workshop.conf
+    content: |
+      HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub
+      TrustedUserCAKeys /etc/ssh/ssh_ca_ed25519_key.pub
+  - path: /etc/systemd/system/workshop-waitready.service
+    content: |
+      [Unit]
+      Description=Signal workshop readiness to LXD
+
+      [Service]
+      Type=notify
+      ExecStart=/usr/local/lib/workshop/waitready
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/workshop-secret.socket
+    content: |
+      [Unit]
+      Description=Workshop systemd load credential socket
+
+      [Socket]
+      ListenStream={{.WorkshopSecretSocketPath}}
+      SocketMode=0660
+      Accept=no
+
+      [Install]
+      WantedBy=sockets.target
+  - path: /etc/systemd/system/workshop-secret.service
+    content: |
+      [Unit]
+      Description=Workshop systemd load credential socket resolver
+
+      [Service]
+      ExecStart={{.WorkshopCtlPath}} get-secret --systemd
+runcmd:
+  # Project directory is required for 'workshop exec'.
+  - install --directory --mode=755 /project /usr/local/bin /usr/local/lib/workshop {{shquote .WorkshopStateDir}}
+  # Create XDG base directories so SDKs don't need an extra mode=700 step.
+  - install --directory --mode=700 --owner=workshop --group=workshop /home/workshop/.cache /home/workshop/.config /home/workshop/.local
+  # Create ~/.local/bin so SDKs don't need to source ~/.profile to add it to the PATH.
+  - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/.local/bin
+  # Put workshopctl on the PATH.
+  - ln -sf {{shquote .WorkshopCtlPath}} /usr/local/bin/workshopctl
+  - ln -sf ../../bin/workshopctl /usr/local/lib/workshop/waitready
+  - systemctl enable --now workshop-waitready.service
+  - systemctl enable --now workshop-secret.socket
+`
+
+	funcs := map[string]any{
+		"shquote": shlex.Quote,
+	}
+
+	return template.New("cloud-config").Funcs(funcs).Parse(tmpl)
+}

--- a/internal/workshop/lxd/cloudconfig.go
+++ b/internal/workshop/lxd/cloudconfig.go
@@ -143,17 +143,20 @@ write_files:
       [Socket]
       ListenStream={{.WorkshopSecretSocketPath}}
       SocketMode=0660
-      Accept=no
+      Accept=yes
 
       [Install]
       WantedBy=sockets.target
-  - path: /etc/systemd/system/workshop-secret.service
+  - path: /etc/systemd/system/workshop-secret@.service
     content: |
       [Unit]
       Description=Workshop systemd load credential socket resolver
 
       [Service]
       ExecStart={{.WorkshopCtlPath}} get-secret --systemd
+      StandardError=journal
+      StandardInput=socket
+      StandardOutput=socket
 runcmd:
   # Project directory is required for 'workshop exec'.
   - install --directory --mode=755 /project /usr/local/bin /usr/local/lib/workshop {{shquote .WorkshopStateDir}}

--- a/internal/workshop/lxd/cloudconfig_test.go
+++ b/internal/workshop/lxd/cloudconfig_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package lxdbackend
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+type cloudConfigSuite struct{}
+
+var _ = check.Suite(&cloudConfigSuite{})
+
+func TestCloudConfig(t *testing.T) {
+	check.TestingT(t)
+}
+
+// TestCloudConfigTemplateParses checks that the embedded cloud-init user-data
+// template compiles without error, catching template syntax mistakes before
+// release.
+func (s *cloudConfigSuite) TestCloudConfigTemplateParses(c *check.C) {
+	_, err := cloudConfigTemplate()
+	c.Assert(err, check.IsNil)
+}
+
+// TestCloudConfigTemplateRendersVars checks that the cloud-init user-data
+// template parses and that the template variables are interpolated into the
+// rendered output.
+func (s *cloudConfigSuite) TestCloudConfigTemplateRendersVars(c *check.C) {
+	tmpl, err := cloudConfigTemplate()
+	c.Assert(err, check.IsNil)
+
+	vars := cloudConfigVars{
+		WorkshopCtlPath:          "/wsp/bin/workshopctl",
+		WorkshopSecretSocketPath: "/wsp/run/workshop.socket.secret",
+		WorkshopStateDir:         "/wsp/state",
+	}
+
+	var buf strings.Builder
+	err = tmpl.Execute(&buf, vars)
+	c.Assert(err, check.IsNil)
+
+	out := buf.String()
+	c.Check(out, check.Matches, `(?s).*ListenStream=/wsp/run/workshop\.socket\.secret.*`)
+	c.Check(out, check.Matches, `(?s).*ExecStart=/wsp/bin/workshopctl get-secret --systemd.*`)
+	c.Check(out, check.Matches, `(?s).*- ln -sf /wsp/bin/workshopctl /usr/local/bin/workshopctl.*`)
+	c.Check(out, check.Matches, `(?s).*- install --directory --mode=755 /project /usr/local/bin /usr/local/lib/workshop /wsp/state.*`)
+}
+
+// TestCloudConfigTemplateCached checks that the template is parsed once and
+// the same instance is returned on subsequent calls.
+func (s *cloudConfigSuite) TestCloudConfigTemplateCached(c *check.C) {
+	first, err := cloudConfigTemplate()
+	c.Assert(err, check.IsNil)
+
+	second, err := cloudConfigTemplate()
+	c.Assert(err, check.IsNil)
+
+	c.Check(first == second, check.Equals, true)
+}

--- a/internal/workshop/lxd/cloudconfig_test.go
+++ b/internal/workshop/lxd/cloudconfig_test.go
@@ -56,7 +56,11 @@ func (s *cloudConfigSuite) TestCloudConfigTemplateRendersVars(c *check.C) {
 
 	out := buf.String()
 	c.Check(out, check.Matches, `(?s).*ListenStream=/wsp/run/workshop\.socket\.secret.*`)
+	c.Check(out, check.Matches, `(?s).*Accept=yes.*`)
+	c.Check(out, check.Matches, `(?s).*path: /etc/systemd/system/workshop-secret@\.service.*`)
 	c.Check(out, check.Matches, `(?s).*ExecStart=/wsp/bin/workshopctl get-secret --systemd.*`)
+	c.Check(out, check.Matches, `(?s).*StandardInput=socket.*`)
+	c.Check(out, check.Matches, `(?s).*StandardOutput=socket.*`)
 	c.Check(out, check.Matches, `(?s).*- ln -sf /wsp/bin/workshopctl /usr/local/bin/workshopctl.*`)
 	c.Check(out, check.Matches, `(?s).*- install --directory --mode=755 /project /usr/local/bin /usr/local/lib/workshop /wsp/state.*`)
 }

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -28,16 +28,13 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/x-go/strutil/shlex"
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 
@@ -1239,113 +1236,20 @@ func proxyToLxdDevice(usr *user.User, proxy workshop.ProxyEntry) map[string]stri
 	return device
 }
 
-func (s *Backend) workshopConfig(projectId string, userid, groupid string, file *workshop.File, format sdk.Revision, baseFingerprint string) (map[string]string, error) {
-	cloudConfigTemplate := `
-#cloud-config
-users:
-  - default
-  - name: workshop
-    primary_group: workshop
-    sudo: ALL=(ALL) NOPASSWD:ALL
-    shell: /bin/bash
-    create_groups: false
-    groups:
-    - 'adm'
-    - 'cdrom'
-    - 'sudo'
-    - 'dip'
-    - 'plugdev'
-    - 'audio'
-    - 'netdev'
-    - 'lxd'
-    - 'video'
-    - 'render'
-    # Compatibility GIDs for various host systems:
-    - '108' # netdev on 26.04
-    - '111' # netdev on 24.04
-    - '118' # netdev on 20.04
-    - '119' # netdev on 22.04
-    - '109' # render on 20.04
-    - '110' # render on 22.04
-    - '990' # render on 26.04
-    - '992' # render on 24.04
-bootcmd:
-- |
-  set -e
-  maybe_groupadd() {
-      # Ignore GID not unique (exit code 4) or group name not unique (exit code 9)
-      groupadd -g "$1" -r "$2" || case $? in 4|9) ;; *) return $? ;; esac
-  }
-  maybe_groupadd 1000 workshop
-  maybe_groupadd 108 netdev-compat-108
-  maybe_groupadd 111 netdev-compat-111
-  maybe_groupadd 118 netdev-compat-118
-  maybe_groupadd 119 netdev-compat-119
-  maybe_groupadd 109 render-compat-109
-  maybe_groupadd 110 render-compat-110
-  maybe_groupadd 990 render-compat-990
-  maybe_groupadd 992 render-compat-992
-- chmod 0600 /etc/ssh/ssh_host_ed25519_key
-apt:
-  conf: |
-    # Installed by workshop
-
-    # Don't automatically install recommended packages
-    APT::Install-Recommends "0";
-
-    # Don't automatically install suggested packages
-    APT::Install-Suggests "0";
-
-    # Bypass confirmation prompts
-    APT::Get::Assume-Yes "1";
-grub_dpkg:
-  enabled: false
-ssh_deletekeys: false
-ssh_genkeytypes: [ed25519]
-write_files:
-  - path: /etc/cloud/cloud-init.disabled
-    defer: true
-  - path: /etc/ssh/sshd_config.d/90-workshop.conf
-    content: |
-      HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub
-      TrustedUserCAKeys /etc/ssh/ssh_ca_ed25519_key.pub
-  - path: /etc/systemd/system/workshop-waitready.service
-    content: |
-      [Unit]
-      Description=Signal workshop readiness to LXD
-
-      [Service]
-      Type=notify
-      ExecStart=/usr/local/lib/workshop/waitready
-
-      [Install]
-      WantedBy=multi-user.target
-runcmd:
-  # Project directory is required for 'workshop exec'.
-  - install --directory --mode=755 /project /usr/local/bin /usr/local/lib/workshop {{shquote .WorkshopStateDir}}
-  # Create XDG base directories so SDKs don't need an extra mode=700 step.
-  - install --directory --mode=700 --owner=workshop --group=workshop /home/workshop/.cache /home/workshop/.config /home/workshop/.local
-  # Create ~/.local/bin so SDKs don't need to source ~/.profile to add it to the PATH.
-  - install --directory --mode=755 --owner=workshop --group=workshop /home/workshop/.local/bin
-  # Put workshopctl on the PATH.
-  - ln -sf {{shquote .WorkshopCtlPath}} /usr/local/bin/workshopctl
-  - ln -sf ../../bin/workshopctl /usr/local/lib/workshop/waitready
-  - systemctl enable --now workshop-waitready.service
-`[1:]
+func (s *Backend) workshopConfig(
+	projectId string,
+	userid, groupid string,
+	file *workshop.File,
+	format sdk.Revision,
+	baseFingerprint string,
+) (map[string]string, error) {
+	t, err := cloudConfigTemplate()
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse cloud-config template: %w", err)
+	}
 
 	var cloudConfig strings.Builder
-	funcs := map[string]any{
-		"shquote": shlex.Quote,
-	}
-	dot := struct {
-		WorkshopCtlPath  string
-		WorkshopStateDir string
-	}{
-		WorkshopCtlPath:  filepath.Join(dirs.WorkshopGuestBinDir, filepath.Base(dirs.WorkshopCtlPath)),
-		WorkshopStateDir: dirs.WorkshopStateDir,
-	}
-	t := template.Must(template.New("cloud-config").Funcs(funcs).Parse(cloudConfigTemplate))
-	if err := t.Execute(&cloudConfig, dot); err != nil {
+	if err := t.Execute(&cloudConfig, makeCloudConfigVars()); err != nil {
 		return nil, err
 	}
 

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -828,7 +828,7 @@ func (s *Backend) snapshotClients(ctx context.Context) (lxd.InstanceServer, lxd.
 // replay some of the install-sdk and setup-base tasks. These can be handled in
 // the same way as in-progress launches and refreshes.
 func (s *Backend) FormatRevision() sdk.Revision {
-	return sdk.R(11)
+	return sdk.R(12)
 }
 
 func (s *Backend) HashSnapshot(snapshot workshop.Snapshot) (string, error) {

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -122,8 +122,11 @@ func (f *LxdBeTests) TestWorkshopConfigSecretSocketUnits(c *check.C) {
 	userData := cfg["cloud-init.user-data"]
 	c.Check(userData, check.Matches, `(?s).*path: /etc/systemd/system/workshop-secret\.socket.*`)
 	c.Check(userData, check.Matches, `(?s).*ListenStream=/var/lib/workshop/run/workshop\.socket\.secret.*`)
-	c.Check(userData, check.Matches, `(?s).*path: /etc/systemd/system/workshop-secret\.service.*`)
+	c.Check(userData, check.Matches, `(?s).*Accept=yes.*`)
+	c.Check(userData, check.Matches, `(?s).*path: /etc/systemd/system/workshop-secret@\.service.*`)
 	c.Check(userData, check.Matches, `(?s).*ExecStart=/var/lib/workshop/bin/workshopctl get-secret --systemd.*`)
+	c.Check(userData, check.Matches, `(?s).*StandardInput=socket.*`)
+	c.Check(userData, check.Matches, `(?s).*StandardOutput=socket.*`)
 	c.Check(userData, check.Matches, `(?s).*systemctl enable --now workshop-secret\.socket.*`)
 }
 

--- a/internal/workshop/lxd/lxd_backend_test.go
+++ b/internal/workshop/lxd/lxd_backend_test.go
@@ -106,6 +106,27 @@ func (f *LxdBeTests) TestDefaultWorkshopConfig(c *check.C) {
 	c.Assert(cfg["user.workshop.base-fingerprint"], check.Equals, "fakeimage12345")
 }
 
+// The cloud-init user-data must install and enable the systemd socket unit
+// that SDK units connect to for LoadCredential secret resolution, along with
+// its associated service unit.
+func (f *LxdBeTests) TestWorkshopConfigSecretSocketUnits(c *check.C) {
+	b := &lxdbackend.Backend{}
+	file := &workshop.File{
+		Name: "test",
+		Base: "ubuntu@22.04",
+	}
+
+	cfg, err := lxdbackend.DefaultConfig(b, f.project.ProjectId, "1001", "1001", file, b.FormatRevision(), "fakeimage12345")
+	c.Assert(err, check.IsNil)
+
+	userData := cfg["cloud-init.user-data"]
+	c.Check(userData, check.Matches, `(?s).*path: /etc/systemd/system/workshop-secret\.socket.*`)
+	c.Check(userData, check.Matches, `(?s).*ListenStream=/var/lib/workshop/run/workshop\.socket\.secret.*`)
+	c.Check(userData, check.Matches, `(?s).*path: /etc/systemd/system/workshop-secret\.service.*`)
+	c.Check(userData, check.Matches, `(?s).*ExecStart=/var/lib/workshop/bin/workshopctl get-secret --systemd.*`)
+	c.Check(userData, check.Matches, `(?s).*systemctl enable --now workshop-secret\.socket.*`)
+}
+
 func (f *LxdBeTests) TestCheckLxdVersion(c *check.C) {
 	err := lxdbackend.CheckServerVersion("6.8")
 	c.Assert(err, check.IsNil)

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -15,7 +15,7 @@ launched:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
+    cloud-init.user-data: '928ee47998bbbf36a1e9fa11603adfefc0a04803652600544a7c53d1a57e3c8a737af9261cf54b290931385d461e4301'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -55,7 +55,7 @@ started:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
+    cloud-init.user-data: '928ee47998bbbf36a1e9fa11603adfefc0a04803652600544a7c53d1a57e3c8a737af9261cf54b290931385d461e4301'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -95,7 +95,7 @@ sdk-attached:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
+    cloud-init.user-data: '928ee47998bbbf36a1e9fa11603adfefc0a04803652600544a7c53d1a57e3c8a737af9261cf54b290931385d461e4301'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -147,7 +147,7 @@ sdk-mounted:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
+    cloud-init.user-data: '928ee47998bbbf36a1e9fa11603adfefc0a04803652600544a7c53d1a57e3c8a737af9261cf54b290931385d461e4301'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''

--- a/internal/workshop/lxd/tests/integration/snapshot_test.go
+++ b/internal/workshop/lxd/tests/integration/snapshot_test.go
@@ -560,6 +560,7 @@ func extractUniqueFiles(c *check.C, path string) uniqueFiles {
 		"etc/sudoers.d/90-cloud-init-users",
 		"etc/systemd/network/10-cloud-init-eth0.network.d/workshop.conf",
 		"var/cache/ldconfig/aux-cache",
+		"var/lib/workshop/run/workshop.socket.secret",
 		"var/lib/workshop/run/workshop.socket.untrusted",
 		"var/log/cloud-init.log",
 		"var/log/cloud-init-output.log",


### PR DESCRIPTION
## Summary

First building block of the secrets interface spec: install the systemd
socket that SDK units will use to consume secrets via `LoadCredential`.

When a workshop is created, cloud-init now installs two units:

- `workshop-secret.socket` — listens on
  `/var/lib/workshop/run/workshop.socket.secret` (mode 0660, `Accept=yes`),
  wanted by `sockets.target`.
- `workshop-secret@.service` — a per-connection socket-activated resolver,
  running `workshopctl get-secret --systemd`.

The socket is enabled and started on first boot. Each credential request is
accepted by systemd and passed to a resolver instance on standard input and
output. Resolver diagnostics go to the journal so only credential bytes are
returned on the connection.

The `get-secret` subcommand itself is added in a follow-up; nothing connects
to the socket yet, so this change is inert until then.

## Refactoring

The cloud-init template was a ~100-line string literal embedded in
`workshopConfig`, which made the function hard to read and the template hard
to review in isolation. It is now:

- extracted into a dedicated `cloudconfig.go`,
- parsed once via `sync.OnceValues` instead of on every workshop creation,
- returned as an error rather than panicking via `template.Must`,
- parameterised by a `cloudConfigVars` struct so paths come from the `dirs`
  package instead of being hard-coded in the template text.

`dirs.WorkshopSecretSocketPath` is defined as the single canonical source for
the socket path, which the upcoming daemon-side secret resolution will also
need.

## Snapshot compatibility

The LXD snapshot format revision is bumped to 12 because cloud-init now
creates persistent secret socket and resolver unit files in the workshop
rootfs. The volatile runtime secret socket is excluded from snapshot rootfs
comparisons, consistent with the existing untrusted socket.

## Testing

- `TestWorkshopConfigSecretSocketUnits` — asserts the units and the enable
  command land in generated cloud-init user-data.
- `TestCloudConfigTemplateParses` — the embedded template compiles.
- `TestCloudConfigTemplateRendersVars` — template variables are interpolated
  into rendered output.
- `TestCloudConfigTemplateCached` — the template is parsed once and reused.
- `go test ./internal/workshop/lxd`

## Follow-ups

- `workshopctl get-secret` subcommand (plain and `--systemd` modes).
- Daemon-side secret resolution.
- `SDK_SYSTEMD_SECRET_SOCKET` env var for SDK hooks.
