### PR TITLE
Improve error message when removing a workshop twice

### DIFF
--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -662,7 +662,9 @@ func v1PostProjectWorkshop(c *Command, r *http.Request, _ *userState) Response {
 		return changeConflictErrorResponse(changeConflictErr)
 	case errors.Is(err, conflict.ErrorNoWaitingChange):
 		return noWaitingChangeResponse(err)
-	case err != nil:
+	case errors.Is(err, workshop.ErrWorkshopNotLaunched):
+		return statusNotFound("%w", err)
+	default:
 		return statusBadRequest("%w", err)
 	}
 

--- a/internal/daemon/api_workshops_test.go
+++ b/internal/daemon/api_workshops_test.go
@@ -4330,8 +4330,8 @@ func (s *apiSuite) TestValidateIncorrectActionModeInputs(c *check.C) {
 		}, {
 			cmd: "remove",
 			result: map[string]string{
-				"":              `cannot remove "basic": workshop not launched`,
-				"transactional": `cannot remove "basic": workshop not launched`,
+				"":              `cannot remove "basic": workshop already removed`,
+				"transactional": `cannot remove "basic": workshop already removed`,
 				"wait-on-error": `cannot remove: mode "wait-on-error" is not valid with the "remove" command`,
 				"continue":      `cannot remove: mode "continue" is not valid with the "remove" command`,
 				"abort":         `cannot remove: mode "abort" is not valid with the "remove" command`,
@@ -4352,6 +4352,9 @@ func (s *apiSuite) TestValidateIncorrectActionModeInputs(c *check.C) {
 				Type:    ResponseTypeError,
 				Status:  http.StatusBadRequest,
 				Message: experr,
+			}
+			if strings.HasSuffix(experr, "workshop not launched") || strings.HasSuffix(experr, "workshop already removed") {
+				exp.Status = http.StatusNotFound
 			}
 
 			// Execute
@@ -5418,8 +5421,8 @@ func (s *apiSuite) TestRemoveWorkshopNotFound(c *check.C) {
 	expected := []*expectedResp{
 		{
 			Type:    ResponseTypeError,
-			Status:  http.StatusBadRequest,
-			Message: `cannot remove "workshopconns": workshop not launched`,
+			Status:  http.StatusNotFound,
+			Message: `cannot remove "workshopconns": workshop already removed`,
 		},
 	}
 	s.runActionTest(c, requests, expected)

--- a/internal/overlord/workshopstate/manifest.go
+++ b/internal/overlord/workshopstate/manifest.go
@@ -142,6 +142,9 @@ func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string,
 	running = make(map[string]bool, len(names))
 	for _, name := range names {
 		wp, err := w.backend.Workshop(ctx, name)
+		if errors.Is(err, workshop.ErrWorkshopNotLaunched) {
+			err = errAlreadyRemoved{}
+		}
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("cannot remove %q: %w", name, err)
 		}
@@ -169,6 +172,16 @@ func (w *WorkshopManager) RemoveManifests(ctx context.Context, projectId string,
 	}
 
 	return stashed, current, running, nil
+}
+
+type errAlreadyRemoved struct{}
+
+func (errAlreadyRemoved) Error() string {
+	return "workshop already removed"
+}
+
+func (errAlreadyRemoved) Unwrap() error {
+	return workshop.ErrWorkshopNotLaunched
 }
 
 func (w *WorkshopManager) maybeDiscardWaitingRefresh(projectId string, file *workshop.File) (*Manifest, error) {


### PR DESCRIPTION
# Description

This is a minor API break: `v1PostProjectWorkshop` returns 404 when a workshop isn't found. TBH not sure if this is a good idea.

Before:
```console
$ workshop remove dev
error: cannot remove "dev": workshop not launched
```

After:
```console
$ workshop remove dev
error: cannot remove "dev": workshop already removed
```

The intent of `not launched` is to hint that the user should launch the workshop; in this case that doesn't apply.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
