### PR TITLE
Speed up recreateInternalMounts

### DIFF
--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -358,8 +358,6 @@ func (m *InterfaceManager) recreateInternalMounts(pctx context.Context, w string
 		ReadOnly: true,
 	}
 
-	_ = m.backend.RemoveWorkshopMount(pctx, w, mount.Name)
-
 	if err := m.backend.AddWorkshopMount(pctx, w, mount); err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -778,7 +778,11 @@ func (s *Backend) AddWorkshopMount(ctx context.Context, name string, mount works
 		return err
 	}
 
-	inst.Devices[mount.Name] = mountToLxdDisk(mount)
+	disk := mountToLxdDisk(mount)
+	if maps.Equal(inst.Devices[mount.Name], disk) {
+		return nil
+	}
+	inst.Devices[mount.Name] = disk
 
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
 	if err != nil {
@@ -818,7 +822,11 @@ func (s *Backend) RemoveWorkshopMount(ctx context.Context, name, mount string) e
 		return err
 	}
 
+	if _, ok := inst.Devices[mount]; !ok {
+		return nil
+	}
 	delete(inst.Devices, mount)
+
 	op, err := conn.UpdateInstance(inst.Name, inst.Writable(), etag)
 	if err != nil {
 		return err

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -824,6 +824,71 @@ func (f *wsOps) TestLxdBackendWorkshopStartStopIdempotent(c *check.C) {
 	c.Check(err, check.IsNil)
 }
 
+func (f *wsOps) TestLxdBackendWorkshopMount(c *check.C) {
+	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
+
+	mount := workshop.Mount{
+		Name:  "test-mount",
+		Type:  workshop.HostWorkshop,
+		What:  filepath.Join(c.MkDir(), "mnt"),
+		Where: "/mnt",
+	}
+
+	err := os.MkdirAll(filepath.Join(mount.What, "test-dir"), 0755)
+	c.Assert(err, check.IsNil)
+
+	err = f.bd.AddWorkshopMount(f.ctx, "test", mount)
+	c.Assert(err, check.IsNil)
+
+	entries := f.lsMnt(c)
+	c.Assert(entries, check.HasLen, 1)
+	c.Check(entries[0].Name(), check.Equals, "test-dir")
+
+	err = f.bd.AddWorkshopMount(f.ctx, "test", mount)
+	c.Assert(err, check.IsNil)
+
+	entries = f.lsMnt(c)
+	c.Assert(entries, check.HasLen, 1)
+	c.Check(entries[0].Name(), check.Equals, "test-dir")
+
+	mount.What = filepath.Join(c.MkDir(), "mnt")
+	err = os.MkdirAll(filepath.Join(mount.What, "test-dir2"), 0755)
+	c.Assert(err, check.IsNil)
+
+	err = f.bd.AddWorkshopMount(f.ctx, "test", mount)
+	c.Assert(err, check.IsNil)
+
+	entries = f.lsMnt(c)
+	c.Assert(entries, check.HasLen, 1)
+	c.Check(entries[0].Name(), check.Equals, "test-dir2")
+
+	err = f.bd.RemoveWorkshopMount(f.ctx, "test", mount.Name)
+	c.Assert(err, check.IsNil)
+
+	entries = f.lsMnt(c)
+	c.Check(entries, check.HasLen, 0)
+
+	err = f.bd.RemoveWorkshopMount(f.ctx, "test", mount.Name)
+	c.Check(err, check.IsNil)
+
+	entries = f.lsMnt(c)
+	c.Check(entries, check.HasLen, 0)
+}
+
+func (f *wsOps) lsMnt(c *check.C) []os.FileInfo {
+	fs, err := f.bd.WorkshopFs(f.ctx, "test")
+	c.Assert(err, check.IsNil)
+	defer func() {
+		c.Check(fs.Close(), check.IsNil)
+	}()
+
+	entries, err := fs.ReadDir("/mnt")
+	c.Assert(err, check.IsNil)
+
+	return entries
+}
+
 func (f *wsOps) TestLxdBackendWorkshopLaunch(c *check.C) {
 	image, err := f.bd.GetBase(f.ctx, "ubuntu@24.04")
 	c.Assert(err, check.IsNil)

--- a/tests/main/autostart/task.yaml
+++ b/tests/main/autostart/task.yaml
@@ -23,18 +23,20 @@ execute: |
     REBOOT
   fi
   if [ $SPREAD_REBOOT = 1 ]; then
+    lxd waitready
     workshop_exec list | MATCH 'Ready'
     retry 3 check_dns
   fi
 
   echo "Make sure a workshop can start independently of the workshop daemon"
   if [ $SPREAD_REBOOT = 1 ]; then
-    snap stop --disable workshop
     REBOOT
   fi
   if [ $SPREAD_REBOOT = 2 ]; then
-    snap start --enable workshop
-    workshop_exec list | MATCH 'Ready'
+    lxd waitready
+    filter="name=ws-autostart-$(< .workshop.lock)"
+    lxc list --format csv --columns s --project workshop.ubuntu "$filter" | MATCH '^RUNNING|READY$'
+    ! systemctl is-active snap.workshop.workshopd.service || false
     retry 3 check_dns
   fi
 


### PR DESCRIPTION
# Description

Before:
```console
$ sudo WORKSHOP_DEBUG=1 workshopd run --create-dirs
Acquiring state lock file
Acquired state lock file
DEBUG: socket "/var/lib/workshop/workshop.socket" was not activated; listening
DEBUG: socket "/var/lib/workshop/workshop.socket.untrusted" was not activated; listening
Started daemon.
DEBUG: activation done in 21.906s
```

After:
```console
$ sudo WORKSHOP_DEBUG=1 workshopd run --create-dirs
Acquiring state lock file
Acquired state lock file
DEBUG: socket "/var/lib/workshop/workshop.socket" was not activated; listening
DEBUG: socket "/var/lib/workshop/workshop.socket.untrusted" was not activated; listening
Started daemon.
DEBUG: activation done in 2.466s
```

This is on my specific system with a random assortment of workshops:
```console
$ workshop list --global
PROJECT                                          WORKSHOP  STATUS  NOTES
~/code/workshop/main/prj                         dev       Ready   -
~/code/workshop/feature/vm                       dev       Ready   -
~/code/ansiterm                                  dev       Ready   -
~/code/ansiterm/git                              dev       Error   missing-project
~/code/lxd                                       lxd       Ready   -
~/code/workshop/fix/refresh-forgets-connections  dev       Ready   -
WARNING: There is 1 new warning. See "workshop warnings".
```

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
