### PR TITLE
Fix typo in DOCKER-USER nft commands

### DIFF
--- a/internal/workshop/lxd/firewall.go
+++ b/internal/workshop/lxd/firewall.go
@@ -181,7 +181,7 @@ func bridgeBlockedWarning(bridgeName string, cause firewallCause) string {
 	case causeDocker:
 		return base + ". " +
 			"This is likely caused by Docker. To resolve, run: " +
-			"sudo nft insert rule ip filter DOCKER-USER iifname " + bridgeName + " accept \\; " +
+			"sudo nft insert rule ip filter DOCKER-USER iifname " + bridgeName + " accept; " +
 			"sudo nft insert rule ip filter DOCKER-USER oifname " + bridgeName +
 			" ct state related,established accept" +
 			" (see " + firewallDocLink + ")"


### PR DESCRIPTION
# Description

Tested that the new command works in a 24.04 VM.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
