### PR TITLE
Make InterfaceManager syscheck idempotent

### DIFF
--- a/internal/interfaces/repo.go
+++ b/internal/interfaces/repo.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/sdk"
 	"github.com/canonical/workshop/internal/workshop"
 )
@@ -37,9 +38,9 @@ type Repository struct {
 	// Protects the internals from concurrent access.
 	m      sync.Mutex
 	ifaces map[string]Interface
-	// Indexed by [project-id-workshop-sdk][plugName]
+	// Indexed by [project-id/workshop/sdk][plugName]
 	plugs map[string]map[string]*sdk.PlugInfo
-	// Indexed by [project-id-workshop-sdk][slotName]
+	// Indexed by [project-id/workshop/sdk][slotName]
 	slots map[string]map[string]*sdk.SlotInfo
 	// given a slot and a plug, are they connected?
 	slotPlugs map[*sdk.SlotInfo]map[*sdk.PlugInfo]*Connection
@@ -62,7 +63,7 @@ func NewRepository() *Repository {
 }
 
 func plugOrSlotKey(projectId, workshop, sdkName string) string {
-	return strings.Join([]string{projectId, workshop, sdkName}, "-")
+	return strings.Join([]string{projectId, workshop, sdkName}, "/")
 }
 
 // Interface returns an interface with a given name.
@@ -225,6 +226,26 @@ func (r *Repository) AddBackend(backend SecurityBackend) error {
 	}
 	r.backends = append(r.backends, backend)
 	return nil
+}
+
+func (r *Repository) AllSdks() []sdk.Ref {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	keys := append(slices.Collect(maps.Keys(r.plugs)), slices.Collect(maps.Keys(r.slots))...)
+	slices.Sort(keys)
+	keys = slices.Compact(keys)
+
+	var sdks []sdk.Ref
+	for _, key := range keys {
+		parts := strings.Split(key, "/")
+		if len(parts) != 3 {
+			logger.Noticef("Unexpected plugOrSlotKey: %q", key)
+			continue
+		}
+		sdks = append(sdks, sdk.Ref{ProjectId: parts[0], Workshop: parts[1], Sdk: parts[2]})
+	}
+	return sdks
 }
 
 // AllPlugs returns all plugs of the given interface.
@@ -868,13 +889,12 @@ func (r *Repository) AddSdk(sdkInfo *sdk.Info) error {
 	if r.plugs[key] != nil || r.slots[key] != nil {
 		return fmt.Errorf("cannot register interfaces for %q SDK more than once", key)
 	}
+	r.plugs[key] = make(map[string]*sdk.PlugInfo, len(sdkInfo.Plugs))
+	r.slots[key] = make(map[string]*sdk.SlotInfo, len(sdkInfo.Slots))
 
 	for plugName, plugInfo := range sdkInfo.Plugs {
 		if _, ok := r.ifaces[plugInfo.Interface]; !ok {
 			continue
-		}
-		if r.plugs[key] == nil {
-			r.plugs[key] = make(map[string]*sdk.PlugInfo)
 		}
 		r.plugs[key][plugName] = plugInfo
 	}
@@ -882,9 +902,6 @@ func (r *Repository) AddSdk(sdkInfo *sdk.Info) error {
 	for slotName, slotInfo := range sdkInfo.Slots {
 		if _, ok := r.ifaces[slotInfo.Interface]; !ok {
 			continue
-		}
-		if r.slots[key] == nil {
-			r.slots[key] = make(map[string]*sdk.SlotInfo)
 		}
 		r.slots[key][slotName] = slotInfo
 	}

--- a/internal/overlord/ifacestate/ifacemgr.go
+++ b/internal/overlord/ifacestate/ifacemgr.go
@@ -189,6 +189,17 @@ func (m *InterfaceManager) ensureBackendInit() error {
 		return fmt.Errorf("interface manager not ready: %w", err)
 	}
 
+	defer func() {
+		if m.backendReady {
+			return
+		}
+		for _, s := range m.repo.AllSdks() {
+			if reverr := m.repo.RemoveSdk(s.ProjectId, s.Workshop, s.Sdk); reverr != nil {
+				logger.Noticef("Cannot unregister %q SDK interfaces: %v", s.Sdk, reverr)
+			}
+		}
+	}()
+
 	workshopNames := make(map[string][]string)
 	for user, projects := range allprojects {
 

--- a/internal/overlord/ifacestate/ifacemgr_test.go
+++ b/internal/overlord/ifacestate/ifacemgr_test.go
@@ -29,11 +29,13 @@ import (
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/interfaces/ifacetest"
+	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/osutil"
 	"github.com/canonical/workshop/internal/overlord"
 	"github.com/canonical/workshop/internal/overlord/ifacestate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/syscheck"
 	"github.com/canonical/workshop/internal/testutil"
 	"github.com/canonical/workshop/internal/workshop"
 	"github.com/canonical/workshop/internal/workshop/fakebackend"
@@ -209,6 +211,8 @@ plugs:
 	})
 	s.state.Unlock()
 
+	defer syscheck.MockChecks()()
+
 	mgr := ifacestate.New(s.state, s.o.TaskRunner())
 	err := mgr.StartUp()
 	c.Assert(err, check.IsNil)
@@ -216,7 +220,6 @@ plugs:
 	repo := mgr.Repository()
 
 	ifaces := repo.Interfaces()
-	c.Assert(ifaces.Connections, check.HasLen, 1)
 	cref := &interfaces.ConnRef{
 		PlugRef: sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
 		SlotRef: sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: sdk.System.String(), Name: "mount"}}
@@ -234,6 +237,75 @@ plugs:
 		"mount": "foo",
 		"attr":  "stored-value",
 	})
+
+	// Check the InterfaceManager continues to report as ready after StartUp.
+	err = syscheck.CheckSystem()
+	c.Assert(err, check.IsNil)
+
+	ifaces = repo.Interfaces()
+	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{cref})
+}
+
+func (s *interfaceManagerSuite) TestManagerReloadsConnectionsAfterError(c *check.C) {
+	var consumerYaml = `
+name: consumer
+base: ubuntu@22.04
+plugs:
+ plug:
+  interface: mount
+  attr: plug-value
+`
+
+	s.launchWorkshop(c, "ws", []sdk.Meta{
+		{Setup: consumer.Setup, SdkYAML: consumerYaml},
+	})
+
+	s.state.Lock()
+	s.state.Set("conns", "bad-type")
+	s.state.Unlock()
+
+	defer syscheck.MockChecks()()
+
+	logs, restore := logger.MockLogger()
+	defer restore()
+
+	mgr := ifacestate.New(s.state, s.o.TaskRunner())
+	err := mgr.StartUp()
+	c.Assert(err, check.IsNil)
+	c.Check(logs.String(), check.Matches, "(?s).*: cannot decode data about existing connections: .*")
+
+	repo := mgr.Repository()
+
+	ifaces := repo.Interfaces()
+	c.Check(ifaces.Plugs, check.HasLen, 0)
+	c.Check(ifaces.Slots, check.HasLen, 0)
+	c.Check(ifaces.Connections, check.HasLen, 0)
+
+	// Check we remain in degraded mode, with an empty repo.
+	err = syscheck.CheckSystem()
+	c.Assert(err, check.ErrorMatches, "cannot decode data about existing connections: .*")
+
+	ifaces = repo.Interfaces()
+	c.Check(ifaces.Plugs, check.HasLen, 0)
+	c.Check(ifaces.Slots, check.HasLen, 0)
+	c.Check(ifaces.Connections, check.HasLen, 0)
+
+	s.state.Lock()
+	key := fmt.Sprintf("%s/ws/consumer:plug %s/ws/system:mount", s.prj.ProjectId, s.prj.ProjectId)
+	s.state.Set("conns", map[string]any{
+		key: map[string]any{"interface": "mount"},
+	})
+	s.state.Unlock()
+
+	// Check the connections are reloaded once the issue is resolved.
+	err = syscheck.CheckSystem()
+	c.Assert(err, check.IsNil)
+
+	ifaces = repo.Interfaces()
+	cref := &interfaces.ConnRef{
+		PlugRef: sdk.PlugRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: "consumer", Name: "plug"},
+		SlotRef: sdk.SlotRef{ProjectId: s.prj.ProjectId, Workshop: "ws", Sdk: sdk.System.String(), Name: "mount"}}
+	c.Check(ifaces.Connections, check.DeepEquals, []*interfaces.ConnRef{cref})
 }
 
 func (s *interfaceManagerSuite) TestManagerDoesntReloadUndesiredAutoconnections(c *check.C) {

--- a/internal/syscheck/check.go
+++ b/internal/syscheck/check.go
@@ -40,3 +40,19 @@ func CheckSystem() error {
 
 	return nil
 }
+
+// MockChecks replaces the registered checks with an empty list and returns a
+// function restoring the previous ones. For testing.
+func MockChecks() (restore func()) {
+	m.Lock()
+	defer m.Unlock()
+
+	old := checks
+	checks = nil
+
+	return func() {
+		m.Lock()
+		defer m.Unlock()
+		checks = old
+	}
+}

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -372,6 +372,20 @@ func (f *FakeWorkshopBackend) AddWorkshopMount(ctx context.Context, name string,
 		return errors.New("fake backend only supports HostWorkshop mounts")
 	}
 
+	_, projectId, err := f.userProject(ctx)
+	if err != nil {
+		return err
+	}
+
+	f.workshopLock.Lock()
+	old := f.Workshops[projectId][name].Devices[mount.Name]
+	f.workshopLock.Unlock()
+
+	device := map[string]string{"type": "disk", "source": mount.What, "path": mount.Where}
+	if maps.Equal(device, old) {
+		return nil
+	}
+
 	wfs, err := f.WorkshopFs(ctx, name)
 	if err != nil {
 		return err
@@ -393,16 +407,10 @@ func (f *FakeWorkshopBackend) AddWorkshopMount(ctx context.Context, name string,
 		return err
 	}
 
-	_, projectId, err := f.userProject(ctx)
-	if err != nil {
-		return err
-	}
-
 	f.workshopLock.Lock()
 	defer f.workshopLock.Unlock()
 
-	f.Workshops[projectId][name].Devices[mount.Name] = map[string]string{"type": "disk", "source": mount.What,
-		"path": mount.Where}
+	f.Workshops[projectId][name].Devices[mount.Name] = device
 	return nil
 }
 


### PR DESCRIPTION
# Description

Follows up on a review comment in https://github.com/canonical/workshop/pull/817.

That PR turned some warnings in the InterfaceManager startup process into hard errors, and it's possible for AddSdk to fail if the SDK was already added previously. Now, if something goes wrong we just clear out the repo.

There's an apparent issue where, once the connections are reloaded, unregistering the SDKs is no longer allowed. I ignored this one because the only partial failure mode is when reloadConnections calls ParseConnRef, and this is guaranteed to work because getConns calls it first.

Also fixes an issue where `AddWorkshopMount` wasn't idempotent for the fake backend; in https://github.com/canonical/workshop/pull/991 I started to rely on this behaviour for the LXD backend, but didn't notice that the fake one needed adjusting as well. It only became apparently when running the test I added in this PR.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
