### PR TITLE
workshopctl: add systemd secret retrieval

### DIFF
--- a/client/error.go
+++ b/client/error.go
@@ -39,10 +39,25 @@ type ChangeConflictError struct {
 // equality, so each ConstError message must be unique.
 type ConstError string
 
-// ErrorNoWaitingChange signals that an abort or continue request could not be
-// applied because no change is in progress to resume for the workshop. Match
-// it with [errors.Is].
-const ErrorNoWaitingChange = ConstError("no waiting change in progress")
+const (
+	// ErrorNoWaitingChange signals that an abort or continue request could
+	// not be applied because no change is in progress to resume for the
+	// workshop. Match it with [errors.Is].
+	ErrorNoWaitingChange = ConstError("no waiting change in progress")
+
+	// ErrorPlugNotConnected signals that the requested plug has no
+	// connection and therefore has no value to supply. Match it with
+	// [errors.Is].
+	ErrorPlugNotConnected = ConstError("plug not connected")
+
+	// ErrorSecretNotFound signals that a requested secret does not exist or
+	// matches no entries in the secret provider. Match it with [errors.Is].
+	ErrorSecretNotFound = ConstError("secret not found")
+
+	// ErrorSecretProviderLocked signals that a secret cannot be accessed
+	// because the secret provider is locked. Match it with [errors.Is].
+	ErrorSecretProviderLocked = ConstError("secret provider locked")
+)
 
 // As maps generic API errors into richer client-side error types.
 func (e *Error) As(target any) bool {

--- a/client/error.go
+++ b/client/error.go
@@ -15,7 +15,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -34,10 +33,16 @@ type ChangeConflictError struct {
 	Workshop string
 }
 
+// ConstError is a string-based error type for declaring sentinel errors as
+// constants. Unlike sentinels created with [errors.New], a ConstError
+// cannot be reassigned and is matched by [errors.Is] through string
+// equality, so each ConstError message must be unique.
+type ConstError string
+
 // ErrorNoWaitingChange signals that an abort or continue request could not be
 // applied because no change is in progress to resume for the workshop. Match
 // it with [errors.Is].
-var ErrorNoWaitingChange = errors.New("no waiting change in progress")
+const ErrorNoWaitingChange = ConstError("no waiting change in progress")
 
 // As maps generic API errors into richer client-side error types.
 func (e *Error) As(target any) bool {
@@ -53,14 +58,9 @@ func (e *Error) As(target any) bool {
 	}
 }
 
-// Is reports whether the error matches a sentinel for the error's kind.
-func (e *Error) Is(target error) bool {
-	switch target {
-	case ErrorNoWaitingChange:
-		return e.Kind == ErrorKindNoWaitingChange
-	default:
-		return false
-	}
+// Error returns the error message, implementing the error interface.
+func (c ConstError) Error() string {
+	return string(c)
 }
 
 // Error returns a human-readable description of the blocking change.
@@ -73,6 +73,16 @@ func (e ChangeConflictError) Error() string {
 		)
 	}
 	return fmt.Sprintf("workshop %q has changes in progress", e.Workshop)
+}
+
+// Is reports whether the error matches a sentinel for the error's kind.
+func (e *Error) Is(target error) bool {
+	switch target {
+	case ErrorNoWaitingChange:
+		return e.Kind == ErrorKindNoWaitingChange
+	default:
+		return false
+	}
 }
 
 // toChangeConflictError extracts change-conflict details from a generic API

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -45,11 +45,3 @@ func (client *Client) SetGetWebsocket(f getWebsocketFunc) {
 }
 
 type ClientWebsocket = clientWebsocket
-
-func MockStdinReadLimit(new int64) (restore func()) {
-	oldStdinReadLimit := stdinReadLimit
-	stdinReadLimit = new
-	return func() {
-		stdinReadLimit = oldStdinReadLimit
-	}
-}

--- a/client/workshopctl.go
+++ b/client/workshopctl.go
@@ -48,11 +48,17 @@ type workshopctlOutput struct {
 	Stderr string `json:"stderr"`
 }
 
-// protect against too much data via stdin
-var stdinReadLimit = int64(4 * 1000 * 1000)
+// stdinReadLimit is the maximum number of bytes read from stdin when
+// forwarding it to the daemon. Larger input is rejected to bound the size
+// of the request body, as stdin is currently buffered in full rather than
+// streamed.
+const stdinReadLimit = 4_000_000
 
 // RunWorkshopctl requests a workshopctl run for the given options.
-func (client *Client) RunWorkshopctl(options *WorkshopCtlOptions, stdin io.Reader) (stdout, stderr []byte, err error) {
+func (client *Client) RunWorkshopctl(
+	options *WorkshopCtlOptions,
+	stdin io.Reader,
+) (stdout, stderr []byte, err error) {
 	// TODO: instead of reading all of stdin here we need to forward it to
 	//       the daemon eventually
 	var stdinData []byte

--- a/client/workshopctl.go
+++ b/client/workshopctl.go
@@ -28,19 +28,24 @@ import (
 type WorkshopCtlOptions struct {
 	// ContextID is a string used to determine the context of this call (e.g.
 	// which context and handler should be used, etc.)
-	ContextID string `json:"context-id"`
+	ContextID string
 
 	// Args contains a list of parameters to use for this invocation.
-	Args []string `json:"args"`
+	Args []string
+
+	// Stdin is forwarded to the daemon as the invocation's stdin. It may be
+	// nil for invocations without stdin.
+	Stdin io.Reader
 }
 
-// WorkshopCtlPostData is the data posted to the daemon /v2/workshopctl endpoint
+// WorkshopCtlPostData is the data posted to the daemon /v1/workshopctl
+// endpoint.
 // TODO: this can be removed again once we no longer need to pass stdin data
 // but instead use a real stdin stream
 type WorkshopCtlPostData struct {
-	WorkshopCtlOptions
-
-	Stdin []byte `json:"stdin,omitempty"`
+	ContextID string   `json:"context-id"`
+	Args      []string `json:"args"`
+	Stdin     []byte   `json:"stdin,omitempty"`
 }
 
 type workshopctlOutput struct {
@@ -57,13 +62,12 @@ const stdinReadLimit = 4_000_000
 // RunWorkshopctl requests a workshopctl run for the given options.
 func (client *Client) RunWorkshopctl(
 	options *WorkshopCtlOptions,
-	stdin io.Reader,
 ) (stdout, stderr []byte, err error) {
 	// TODO: instead of reading all of stdin here we need to forward it to
 	//       the daemon eventually
 	var stdinData []byte
-	if stdin != nil {
-		limitedStdin := &io.LimitedReader{R: stdin, N: stdinReadLimit + 1}
+	if options.Stdin != nil {
+		limitedStdin := &io.LimitedReader{R: options.Stdin, N: stdinReadLimit + 1}
 		stdinData, err = io.ReadAll(limitedStdin)
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot read stdin: %v", err)
@@ -74,8 +78,9 @@ func (client *Client) RunWorkshopctl(
 	}
 
 	b, err := json.Marshal(WorkshopCtlPostData{
-		WorkshopCtlOptions: *options,
-		Stdin:              stdinData,
+		ContextID: options.ContextID,
+		Args:      options.Args,
+		Stdin:     stdinData,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot marshal options: %s", err)

--- a/client/workshopctl_test.go
+++ b/client/workshopctl_test.go
@@ -79,17 +79,14 @@ func (cs *clientSuite) TestClientRunWorkshoctlReadLimitOneTooMuch(c *check.C) {
 		}
 	}`
 
-	restore := client.MockStdinReadLimit(10)
-	defer restore()
-
-	mockStdin := bytes.NewBufferString("12345678901")
+	mockStdin := bytes.NewReader(make([]byte, 4_000_000+1))
 	options := &client.WorkshopCtlOptions{
 		ContextID: "1234ABCD",
 		Args:      []string{"foo", "bar"},
 	}
 
 	_, _, err := cs.cli.RunWorkshopctl(options, mockStdin)
-	c.Check(err, check.ErrorMatches, "cannot read more than 10 bytes of data from stdin")
+	c.Check(err, check.ErrorMatches, "cannot read more than 4000000 bytes of data from stdin")
 }
 
 func (cs *clientSuite) TestClientRunWorkshoctlReadLimitExact(c *check.C) {
@@ -100,10 +97,7 @@ func (cs *clientSuite) TestClientRunWorkshoctlReadLimitExact(c *check.C) {
 		}
 	}`
 
-	restore := client.MockStdinReadLimit(10)
-	defer restore()
-
-	mockStdin := bytes.NewBufferString("1234567890")
+	mockStdin := bytes.NewReader(make([]byte, 4_000_000))
 	options := &client.WorkshopCtlOptions{
 		ContextID: "1234ABCD",
 		Args:      []string{"foo", "bar"},

--- a/client/workshopctl_test.go
+++ b/client/workshopctl_test.go
@@ -27,12 +27,22 @@ import (
 	"github.com/canonical/workshop/client"
 )
 
+// TestClientRunWorkshopCtlCallsEndpoint verifies that
+// [client.Client.RunWorkshopctl] dispatches a POST request to the
+// /v1/workshopctl daemon endpoint.
 func (cs *clientSuite) TestClientRunWorkshopCtlCallsEndpoint(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200,
+		"result": {}
+	}`
+
 	options := &client.WorkshopCtlOptions{
 		ContextID: "1234ABCD",
 		Args:      []string{"foo", "bar"},
 	}
-	cs.cli.RunWorkshopctl(options)
+	_, _, err := cs.cli.RunWorkshopctl(options)
+	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v1/workshopctl")
 }

--- a/client/workshopctl_test.go
+++ b/client/workshopctl_test.go
@@ -32,7 +32,7 @@ func (cs *clientSuite) TestClientRunWorkshopCtlCallsEndpoint(c *check.C) {
 		ContextID: "1234ABCD",
 		Args:      []string{"foo", "bar"},
 	}
-	cs.cli.RunWorkshopctl(options, nil)
+	cs.cli.RunWorkshopctl(options)
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v1/workshopctl")
 }
@@ -51,9 +51,10 @@ func (cs *clientSuite) TestClientRunWorkshoctl(c *check.C) {
 	options := &client.WorkshopCtlOptions{
 		ContextID: "1234ABCD",
 		Args:      []string{"foo", "bar"},
+		Stdin:     mockStdin,
 	}
 
-	stdout, stderr, err := cs.cli.RunWorkshopctl(options, mockStdin)
+	stdout, stderr, err := cs.cli.RunWorkshopctl(options)
 	c.Assert(err, check.IsNil)
 	c.Check(string(stdout), check.Equals, "test stdout")
 	c.Check(string(stderr), check.Equals, "test stderr")
@@ -83,9 +84,10 @@ func (cs *clientSuite) TestClientRunWorkshoctlReadLimitOneTooMuch(c *check.C) {
 	options := &client.WorkshopCtlOptions{
 		ContextID: "1234ABCD",
 		Args:      []string{"foo", "bar"},
+		Stdin:     mockStdin,
 	}
 
-	_, _, err := cs.cli.RunWorkshopctl(options, mockStdin)
+	_, _, err := cs.cli.RunWorkshopctl(options)
 	c.Check(err, check.ErrorMatches, "cannot read more than 4000000 bytes of data from stdin")
 }
 
@@ -101,8 +103,9 @@ func (cs *clientSuite) TestClientRunWorkshoctlReadLimitExact(c *check.C) {
 	options := &client.WorkshopCtlOptions{
 		ContextID: "1234ABCD",
 		Args:      []string{"foo", "bar"},
+		Stdin:     mockStdin,
 	}
 
-	_, _, err := cs.cli.RunWorkshopctl(options, mockStdin)
+	_, _, err := cs.cli.RunWorkshopctl(options)
 	c.Check(err, check.IsNil)
 }

--- a/cmd/workshopctl/getsecret.go
+++ b/cmd/workshopctl/getsecret.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/workshop/client"
+)
+
+// systemdSecretRequest describes a decoded systemd LoadCredential request:
+// which unit asked for which secret.
+type systemdSecretRequest struct {
+	// Unit is the name of the systemd unit requesting the secret
+	// (e.g. "ollama.service").
+	Unit string
+
+	// SDK is the name of the SDK providing the secret (e.g. "ollama").
+	SDK string
+
+	// Secret is the name of the requested secret plug within the SDK
+	// (e.g. "ollama-api-key").
+	Secret string
+}
+
+const (
+	// exitCodeProviderLocked indicates the secret provider is locked and
+	// the secret cannot be accessed until it is unlocked.
+	exitCodeProviderLocked = 2
+
+	// exitCodeSecretError indicates the requested secret does not exist or
+	// matches no entries in the secret provider.
+	exitCodeSecretError = 1
+
+	// exitCodeSecretSystemError indicates an internal infrastructure error,
+	// such as the secret provider being unavailable.
+	exitCodeSecretSystemError = 255
+
+	// getSecretCommandName is the workshopctl subcommand name for
+	// retrieving secrets.
+	getSecretCommandName = "get-secret"
+)
+
+// decodeSystemdSecretRequest reads the peer address of a LoadCredential
+// connection and decodes which unit requested which secret. Systemd connects
+// with an abstract address of the form "\0<random>/unit/<unit>/<secret>".
+func decodeSystemdSecretRequest(fd uintptr) (systemdSecretRequest, error) {
+	sa, err := unix.Getpeername(int(fd))
+	if err != nil {
+		return systemdSecretRequest{}, fmt.Errorf("cannot decode secret request: %w", err)
+	}
+
+	addr, ok := sa.(*unix.SockaddrUnix)
+	if !ok {
+		return systemdSecretRequest{}, errors.New("peer is not a unix socket")
+	}
+
+	return parseSystemdPeerAddressName(addr.Name)
+}
+
+// interceptGetSecret handles local interception of the get-secret
+// subcommand.
+//
+// With --systemd, workshopctl is invoked by the workshop-secret socket unit
+// with the accepted connection on stdin. The request is decoded locally,
+// then forwarded to the daemon as a regular get-secret invocation.
+func interceptGetSecret(
+	req workshopctlRequest,
+	stdin fdReader,
+	stdout, stderr io.Writer,
+) (workshopctlRequest, error) {
+	args := req.Args[1:]
+	if len(args) != 1 || args[0] != "--systemd" {
+		return req, nil
+	}
+
+	systemdSecretReq, err := decodeSystemdSecretRequest(stdin.Fd())
+	if err != nil {
+		return workshopctlRequest{}, err
+	}
+
+	fmt.Fprintf(
+		stderr,
+		"processed systemd load credential request for unit %q, sdk %q and secret %q",
+		systemdSecretReq.Unit,
+		systemdSecretReq.SDK,
+		systemdSecretReq.Secret,
+	)
+
+	req.Args = []string{
+		getSecretCommandName,
+		systemdSecretReq.SDK + "." + systemdSecretReq.Secret,
+	}
+	// The connection was consumed locally to decode the request; it must
+	// not be forwarded to the daemon as the invocation's stdin.
+	req.Stdin = nil
+	req.responseHandler = handleSystemdSecretResponse(systemdSecretReq, stdout, stderr)
+	return req, nil
+}
+
+// handleSystemdSecretResponse returns the response handler for a get-secret
+// request made on behalf of a systemd LoadCredential connection. The
+// returned handler produces the process exit code, using the requested
+// secret's identity in error messages.
+func handleSystemdSecretResponse(
+	secretReq systemdSecretRequest,
+	stdout, stderr io.Writer,
+) func([]byte, []byte, error) int {
+	credential := secretReq.SDK + "." + secretReq.Secret
+
+	return func(responseStdout, responseStderr []byte, err error) int {
+		switch {
+		case errors.Is(err, client.ErrorPlugNotConnected):
+			// An unconnected plug is not an error: systemd receives a
+			// zero-byte credential and the unit handles the missing value.
+			return 0
+		case errors.Is(err, client.ErrorSecretNotFound):
+			fmt.Fprintf(
+				stderr, "error: credential %q not found\n", credential)
+			return exitCodeSecretError
+		case errors.Is(err, client.ErrorSecretProviderLocked):
+			fmt.Fprintf(
+				stderr,
+				"error: cannot get credential %q: unlock the secret provider and try again\n",
+				credential,
+			)
+			return exitCodeProviderLocked
+		case err != nil:
+			fmt.Fprintf(
+				stderr,
+				"error: cannot get credential %q: %s\n",
+				credential,
+				err,
+			)
+			return exitCodeSecretSystemError
+		}
+
+		stdout.Write(responseStdout)
+		return 0
+	}
+}
+
+// parseSystemdPeerAddressName decodes a LoadCredential peer address name of
+// the form "\0<random>/unit/<unit>/<sdk>.<secret>" into a
+// systemdSecretRequest.
+func parseSystemdPeerAddressName(addr string) (systemdSecretRequest, error) {
+	// Strip the leading NUL of the abstract namespace and split off the
+	// random component systemd prepends to the address.
+	addr = strings.TrimPrefix(addr, "\x00")
+	parts := strings.SplitN(addr, "/unit/", 2)
+	if len(parts) != 2 {
+		return systemdSecretRequest{}, errors.New(
+			"malformed peer address missing \"/unit/\" delimiter")
+	}
+
+	unit, credentialName, ok := strings.Cut(parts[1], "/")
+	if !ok {
+		return systemdSecretRequest{}, errors.New(
+			"unable to identify requesting unit and systemd credential name from peer address")
+	} else if unit == "" {
+		return systemdSecretRequest{}, errors.New(
+			"unit name in systemd peer address cannot be empty")
+	} else if credentialName == "" {
+		return systemdSecretRequest{}, errors.New(
+			"credential name in systemd peer address cannot be empty")
+	}
+
+	sdk, secret, ok := strings.Cut(credentialName, ".")
+	if !ok {
+		return systemdSecretRequest{}, fmt.Errorf(
+			"unable to identify workshop sdk and secret name from systemd credential name %q",
+			credentialName,
+		)
+	} else if sdk == "" {
+		return systemdSecretRequest{}, errors.New(
+			"workshop sdk in systemd credential name cannot be empty")
+	} else if secret == "" {
+		return systemdSecretRequest{}, errors.New(
+			"workshop secret name in systemd credential name cannot be empty")
+	}
+
+	req := systemdSecretRequest{
+		Unit:   unit,
+		SDK:    sdk,
+		Secret: secret,
+	}
+	return req, nil
+}

--- a/cmd/workshopctl/getsecret.go
+++ b/cmd/workshopctl/getsecret.go
@@ -98,7 +98,7 @@ func interceptGetSecret(
 
 	fmt.Fprintf(
 		stderr,
-		"processed systemd load credential request for unit %q, sdk %q and secret %q",
+		"processed systemd load credential request for unit %q, %q SDK and secret %q",
 		systemdSecretReq.Unit,
 		systemdSecretReq.SDK,
 		systemdSecretReq.Secret,
@@ -185,12 +185,12 @@ func parseSystemdPeerAddressName(addr string) (systemdSecretRequest, error) {
 	sdk, secret, ok := strings.Cut(credentialName, ".")
 	if !ok {
 		return systemdSecretRequest{}, fmt.Errorf(
-			"unable to identify workshop sdk and secret name from systemd credential name %q",
+			"unable to identify workshop SDK and secret name from systemd credential name %q",
 			credentialName,
 		)
 	} else if sdk == "" {
 		return systemdSecretRequest{}, errors.New(
-			"workshop sdk in systemd credential name cannot be empty")
+			"workshop SDK in systemd credential name cannot be empty")
 	} else if secret == "" {
 		return systemdSecretRequest{}, errors.New(
 			"workshop secret name in systemd credential name cannot be empty")

--- a/cmd/workshopctl/getsecret_test.go
+++ b/cmd/workshopctl/getsecret_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/client"
+)
+
+// getSecretSuite tests decoding of systemd LoadCredential secret requests.
+type getSecretSuite struct{}
+
+var _ = check.Suite(&getSecretSuite{})
+
+// TestHandleSystemdSecretResponse checks that the response handler delivers
+// the secret value on stdout.
+func (s *getSecretSuite) TestHandleSystemdSecretResponse(c *check.C) {
+	secretReq := systemdSecretRequest{
+		Unit:   "ollama.service",
+		SDK:    "ollama",
+		Secret: "ollama-api-key",
+	}
+
+	var stdout, stderr bytes.Buffer
+	handler := handleSystemdSecretResponse(secretReq, &stdout, &stderr)
+
+	exitCode := handler([]byte("secret-value"), nil, nil)
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(stdout.String(), check.Equals, "secret-value")
+	c.Check(stderr.String(), check.Equals, "")
+}
+
+// TestHandleSystemdSecretResponsePlugNotConnected checks that an unconnected
+// plug yields a zero-byte credential and exit code 0.
+func (s *getSecretSuite) TestHandleSystemdSecretResponsePlugNotConnected(c *check.C) {
+	secretReq := systemdSecretRequest{
+		Unit:   "ollama.service",
+		SDK:    "ollama",
+		Secret: "ollama-api-key",
+	}
+
+	var stdout, stderr bytes.Buffer
+	handler := handleSystemdSecretResponse(secretReq, &stdout, &stderr)
+
+	exitCode := handler(nil, nil, client.ErrorPlugNotConnected)
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(stdout.String(), check.Equals, "")
+	c.Check(stderr.String(), check.Equals, "")
+}
+
+// TestHandleSystemdSecretResponseError checks that the response handler maps
+// daemon errors to the exit codes defined by the secrets spec.
+func (s *getSecretSuite) TestHandleSystemdSecretResponseError(c *check.C) {
+	secretReq := systemdSecretRequest{
+		Unit:   "ollama.service",
+		SDK:    "ollama",
+		Secret: "ollama-api-key",
+	}
+
+	table := []struct {
+		err      error
+		exitCode int
+		stderr   string
+	}{
+		{
+			err:      client.ErrorSecretNotFound,
+			exitCode: 1,
+			stderr:   "error: credential \"ollama.ollama-api-key\" not found\n",
+		}, {
+			err:      client.ErrorSecretProviderLocked,
+			exitCode: 2,
+			stderr:   "error: cannot get credential \"ollama.ollama-api-key\": unlock the secret provider and try again\n",
+		}, {
+			err:      errors.New("daemon unavailable"),
+			exitCode: 255,
+			stderr:   "error: cannot get credential \"ollama.ollama-api-key\": daemon unavailable\n",
+		},
+	}
+
+	for _, t := range table {
+		var stdout, stderr bytes.Buffer
+		handler := handleSystemdSecretResponse(secretReq, &stdout, &stderr)
+
+		exitCode := handler(nil, nil, t.err)
+		c.Check(exitCode, check.Equals, t.exitCode, check.Commentf("err %v", t.err))
+		c.Check(stdout.String(), check.Equals, "", check.Commentf("err %v", t.err))
+		c.Check(stderr.String(), check.Equals, t.stderr, check.Commentf("err %v", t.err))
+	}
+}
+
+// TestParseSystemdPeerAddressName checks that a valid LoadCredential peer
+// address name is decoded into the requesting unit, sdk and secret.
+func (s *getSecretSuite) TestParseSystemdPeerAddressName(c *check.C) {
+	req, err := parseSystemdPeerAddressName(
+		"\x00DEADBEEF/unit/ollama.service/ollama.ollama-api-key")
+	c.Assert(err, check.IsNil)
+	c.Check(req, check.DeepEquals, systemdSecretRequest{
+		Unit:   "ollama.service",
+		SDK:    "ollama",
+		Secret: "ollama-api-key",
+	})
+}
+
+// TestParseSystemdPeerAddressNameInvalid checks that malformed LoadCredential
+// peer address names are rejected with a descriptive error and no request.
+func (s *getSecretSuite) TestParseSystemdPeerAddressNameInvalid(c *check.C) {
+	tests := []struct {
+		addr string
+		err  string
+	}{
+		{
+			addr: "ollama.service/ollama.ollama-api-key",
+			err:  `malformed peer address missing "/unit/" delimiter`,
+		}, {
+			addr: "\x00DEADBEEF/unit/ollama.service",
+			err:  `unable to identify requesting unit and systemd credential name from peer address`,
+		}, {
+			addr: "\x00DEADBEEF/unit//ollama.ollama-api-key",
+			err:  `unit name in systemd peer address cannot be empty`,
+		}, {
+			addr: "\x00DEADBEEF/unit/ollama.service/",
+			err:  `credential name in systemd peer address cannot be empty`,
+		}, {
+			addr: "\x00DEADBEEF/unit/ollama.service/ollama-api-key",
+			err:  `unable to identify workshop sdk and secret name from systemd credential name "ollama-api-key"`,
+		}, {
+			addr: "\x00DEADBEEF/unit/ollama.service/.ollama-api-key",
+			err:  `workshop sdk in systemd credential name cannot be empty`,
+		}, {
+			addr: "\x00DEADBEEF/unit/ollama.service/ollama.",
+			err:  `workshop secret name in systemd credential name cannot be empty`,
+		},
+	}
+
+	for _, t := range tests {
+		req, err := parseSystemdPeerAddressName(t.addr)
+		c.Check(err, check.ErrorMatches, t.err, check.Commentf("addr %q", t.addr))
+		c.Check(req, check.DeepEquals, systemdSecretRequest{}, check.Commentf("addr %q", t.addr))
+	}
+}
+
+// TestDecodeSystemdSecretRequest checks that the requesting unit and secret
+// are decoded from the peer address of a real socket connection, mirroring
+// how systemd connects for LoadCredential.
+func (s *getSecretSuite) TestDecodeSystemdSecretRequest(c *check.C) {
+	addr := "\x00" + fmt.Sprintf("%d", os.Getpid()) + "/unit/ollama.service/ollama.ollama-api-key"
+	name := filepath.Join(c.MkDir(), "conn")
+
+	server, err := net.ListenUnix("unix", &net.UnixAddr{Name: name})
+	c.Assert(err, check.IsNil)
+	defer server.Close()
+
+	type acceptResult struct {
+		conn *net.UnixConn
+		err  error
+	}
+	accepted := make(chan acceptResult, 1)
+	go func() {
+		conn, err := server.AcceptUnix()
+		accepted <- acceptResult{conn: conn, err: err}
+	}()
+
+	client, err := net.DialUnix("unix",
+		&net.UnixAddr{Name: addr},
+		&net.UnixAddr{Name: name},
+	)
+	c.Assert(err, check.IsNil)
+	defer client.Close()
+
+	result := <-accepted
+	c.Assert(result.err, check.IsNil)
+	defer result.conn.Close()
+
+	f, err := result.conn.File()
+	c.Assert(err, check.IsNil)
+	defer f.Close()
+
+	req, err := decodeSystemdSecretRequest(f.Fd())
+	c.Check(err, check.IsNil)
+	c.Check(req, check.DeepEquals, systemdSecretRequest{
+		Unit:   "ollama.service",
+		SDK:    "ollama",
+		Secret: "ollama-api-key",
+	})
+}

--- a/cmd/workshopctl/getsecret_test.go
+++ b/cmd/workshopctl/getsecret_test.go
@@ -142,10 +142,10 @@ func (s *getSecretSuite) TestParseSystemdPeerAddressNameInvalid(c *check.C) {
 			err:  `credential name in systemd peer address cannot be empty`,
 		}, {
 			addr: "\x00DEADBEEF/unit/ollama.service/ollama-api-key",
-			err:  `unable to identify workshop sdk and secret name from systemd credential name "ollama-api-key"`,
+			err:  `unable to identify workshop SDK and secret name from systemd credential name "ollama-api-key"`,
 		}, {
 			addr: "\x00DEADBEEF/unit/ollama.service/.ollama-api-key",
-			err:  `workshop sdk in systemd credential name cannot be empty`,
+			err:  `workshop SDK in systemd credential name cannot be empty`,
 		}, {
 			addr: "\x00DEADBEEF/unit/ollama.service/ollama.",
 			err:  `workshop secret name in systemd credential name cannot be empty`,

--- a/cmd/workshopctl/main.go
+++ b/cmd/workshopctl/main.go
@@ -30,10 +30,59 @@ import (
 	"github.com/canonical/workshop/internal/waitready"
 )
 
+// fdReader is an [io.Reader] that also exposes its underlying file
+// descriptor, such as [*os.File].
+type fdReader interface {
+	io.Reader
+
+	// Fd returns the file descriptor of the reader.
+	Fd() uintptr
+}
+
+// workshopctlRequest is a request to the daemon's workshopctl endpoint,
+// potentially altered by local interception of the invocation.
+type workshopctlRequest struct {
+	client.WorkshopCtlOptions
+
+	// responseHandler, when set by an interceptor, is invoked with the
+	// daemon's response to the request and returns the process exit code.
+	responseHandler func([]byte, []byte, error) int
+}
+
 var clientConfig = client.Config{
 	// we need the less privileged workshop socket in workshopctl, proxied to a
 	// fixed path inside the workshop by the daemon (see dirs.WorkshopSocketPath)
 	Socket: dirs.WorkshopSocketPath + ".untrusted",
+}
+
+// defaultResponseHandler returns a response handler implementing the
+// standard workshopctl response behaviour: the response stdout and stderr
+// are written to the given writers, daemon-reported exit codes are
+// honoured, and any other error is reported with exit code 1.
+func defaultResponseHandler(stdout, stderr io.Writer) func([]byte, []byte, error) int {
+	return func(responseStdout, responseStderr []byte, err error) int {
+		if err == nil {
+			stdout.Write(responseStdout)
+			stderr.Write(responseStderr)
+			return 0
+		}
+
+		if e, ok := err.(*client.Error); ok && e.Kind == client.ErrorKindUnsuccessful {
+			if errRes, ok := e.Value.(map[string]any); ok {
+				if out, ok := errRes["stdout"].(string); ok {
+					stdout.Write([]byte(out))
+				}
+				if errOut, ok := errRes["stderr"].(string); ok {
+					stderr.Write([]byte(errOut))
+				}
+				if errCode, ok := errRes["exit-code"].(float64); ok {
+					return int(errCode)
+				}
+			}
+		}
+		fmt.Fprintf(stderr, "error: %s\n", err)
+		return 1
+	}
 }
 
 func main() {
@@ -54,49 +103,53 @@ func main() {
 		return
 	}
 
-	stdout, stderr, err := run(nil)
-	if err != nil {
-		if e, ok := err.(*client.Error); ok {
-			switch e.Kind {
-			case client.ErrorKindUnsuccessful:
-				if errRes, ok := e.Value.(map[string]any); ok {
-					if stdout, ok := errRes["stdout"].(string); ok {
-						os.Stdout.Write([]byte(stdout))
-					}
-					if stderr, ok := errRes["stderr"].(string); ok {
-						os.Stderr.Write([]byte(stderr))
-					}
-					if errCode, ok := errRes["exit-code"].(float64); ok {
-						os.Exit(int(errCode))
-					}
-				}
-			}
-		}
-		fmt.Fprintf(os.Stderr, "error: %s\n", err)
-		os.Exit(1)
-	}
-
-	if stdout != nil {
-		os.Stdout.Write(stdout)
-	}
-
-	if stderr != nil {
-		os.Stderr.Write(stderr)
-	}
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
 }
 
-func run(stdin io.Reader) (stdout, stderr []byte, err error) {
+func run(args []string, stdin fdReader, stdout, stderr io.Writer) int {
+	req, err := interceptArgs(args, stdin, stdout, stderr)
+	if err != nil {
+		// The request may not have a handler if interception failed.
+		return defaultResponseHandler(stdout, stderr)(nil, nil, err)
+	}
+
 	config := clientConfig
-	config.RoundTripperWrapper = client.NewWorkshopInstanceIDRoundTripper(os.Stderr)
+	config.RoundTripperWrapper = client.NewWorkshopInstanceIDRoundTripper(stderr)
 
 	cli, err := client.New(&config)
 	if err != nil {
-		return nil, nil, err
+		return req.responseHandler(nil, nil, err)
 	}
 
-	cookie := os.Getenv("WORKSHOP_COOKIE")
-	return cli.RunWorkshopctl(&client.WorkshopCtlOptions{
-		ContextID: cookie,
-		Args:      os.Args[1:],
-	}, stdin)
+	req.ContextID = os.Getenv("WORKSHOP_COOKIE")
+	responseStdout, responseStderr, err := cli.RunWorkshopctl(
+		&req.WorkshopCtlOptions,
+	)
+	return req.responseHandler(responseStdout, responseStderr, err)
+}
+
+// interceptArgs inspects the workshopctl invocation for subcommands that
+// need local interception before being forwarded to the daemon, returning
+// the request to forward. Subcommands with no local handling are forwarded
+// unchanged.
+func interceptArgs(
+	args []string,
+	stdin fdReader,
+	stdout, stderr io.Writer,
+) (workshopctlRequest, error) {
+	req := workshopctlRequest{
+		WorkshopCtlOptions: client.WorkshopCtlOptions{Args: args},
+		responseHandler:    defaultResponseHandler(stdout, stderr),
+	}
+
+	if len(args) == 0 {
+		return req, nil
+	}
+
+	switch args[0] {
+	case getSecretCommandName:
+		return interceptGetSecret(req, stdin, stdout, stderr)
+	}
+
+	return req, nil
 }

--- a/cmd/workshopctl/main_test.go
+++ b/cmd/workshopctl/main_test.go
@@ -167,5 +167,5 @@ func (s *workshopctlSuite) TestWorkshopctlGetSecretSystemd(c *check.C) {
 	c.Check(run(args, f, &stdout, &stderr), check.Equals, 0)
 	c.Check(stdout.String(), check.Equals, "test stdout")
 	c.Check(stderr.String(), check.Equals,
-		"processed systemd load credential request for unit \"ollama.service\", sdk \"ollama\" and secret \"ollama-api-key\"")
+		"processed systemd load credential request for unit \"ollama.service\", \"ollama\" SDK and secret \"ollama-api-key\"")
 }

--- a/cmd/workshopctl/main_test.go
+++ b/cmd/workshopctl/main_test.go
@@ -21,9 +21,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -35,7 +38,6 @@ func TestT(t *testing.T) { check.TestingT(t) }
 
 type workshopctlSuite struct {
 	server            *httptest.Server
-	oldArgs           []string
 	expectedContextID string
 	expectedArgs      []string
 	expectedStdin     []byte
@@ -68,8 +70,6 @@ func (s *workshopctlSuite) SetUpTest(c *check.C) {
 		n++
 	}))
 	clientConfig.BaseURL = s.server.URL
-	s.oldArgs = os.Args
-	os.Args = []string{"workshopctl"}
 	s.expectedContextID = "workshop-context-test"
 	s.expectedArgs = []string{}
 }
@@ -78,41 +78,94 @@ func (s *workshopctlSuite) TearDownTest(c *check.C) {
 	c.Assert(os.Unsetenv("WORKSHOP_COOKIE"), check.IsNil)
 	clientConfig.BaseURL = ""
 	s.server.Close()
-	os.Args = s.oldArgs
 }
 
 func (s *workshopctlSuite) TestWorkshopctl(c *check.C) {
-	stdout, stderr, err := run(nil)
-	c.Check(err, check.IsNil)
-	c.Check(string(stdout), check.Equals, "test stdout")
-	c.Check(string(stderr), check.Equals, "test stderr")
+	var stdout, stderr bytes.Buffer
+	c.Check(run([]string{}, nil, &stdout, &stderr), check.Equals, 0)
+	c.Check(stdout.String(), check.Equals, "test stdout")
+	c.Check(stderr.String(), check.Equals, "test stderr")
 }
 
 func (s *workshopctlSuite) TestWorkshopctlWithArgs(c *check.C) {
-	os.Args = []string{"workshopctl", "foo", "--bar"}
-
 	s.expectedArgs = []string{"foo", "--bar"}
-	stdout, stderr, err := run(nil)
-	c.Check(err, check.IsNil)
-	c.Check(string(stdout), check.Equals, "test stdout")
-	c.Check(string(stderr), check.Equals, "test stderr")
+	var stdout, stderr bytes.Buffer
+	c.Check(run([]string{"foo", "--bar"}, nil, &stdout, &stderr), check.Equals, 0)
+	c.Check(stdout.String(), check.Equals, "test stdout")
+	c.Check(stderr.String(), check.Equals, "test stderr")
 }
 
 func (s *workshopctlSuite) TestWorkshopctlHelp(c *check.C) {
 	os.Unsetenv("WORKSHOP_COOKIE")
 	s.expectedContextID = ""
-
-	os.Args = []string{"workshopctl", "-h"}
 	s.expectedArgs = []string{"-h"}
 
-	_, _, err := run(nil)
-	c.Check(err, check.IsNil)
+	var stdout, stderr bytes.Buffer
+	c.Check(run([]string{"-h"}, nil, &stdout, &stderr), check.Equals, 0)
 }
 
-func (s *workshopctlSuite) TestWorkshopctlWithStdin(c *check.C) {
-	s.expectedStdin = []byte("hello")
-	mockStdin := bytes.NewBuffer(s.expectedStdin)
+// TestWorkshopctlStdinNotForwarded checks that stdin is not forwarded to
+// the daemon by default; interceptors must opt in to forwarding it.
+func (s *workshopctlSuite) TestWorkshopctlStdinNotForwarded(c *check.C) {
+	s.expectedStdin = nil
+	mockStdin := &fakeFdReader{Reader: bytes.NewReader([]byte("hello"))}
 
-	_, _, err := run(mockStdin)
-	c.Check(err, check.IsNil)
+	var stdout, stderr bytes.Buffer
+	c.Check(run([]string{}, mockStdin, &stdout, &stderr), check.Equals, 0)
+}
+
+// fakeFdReader is an fdReader backed by an in-memory reader, for tests that
+// do not exercise the file descriptor.
+type fakeFdReader struct {
+	io.Reader
+}
+
+func (f *fakeFdReader) Fd() uintptr {
+	return 0
+}
+
+// TestWorkshopctlGetSecretSystemd checks that get-secret --systemd decodes
+// the request from the stdin connection and forwards it to the daemon as a
+// regular get-secret invocation.
+func (s *workshopctlSuite) TestWorkshopctlGetSecretSystemd(c *check.C) {
+	addr := "\x00" + fmt.Sprintf("%d-main", os.Getpid()) + "/unit/ollama.service/ollama.ollama-api-key"
+	name := filepath.Join(c.MkDir(), "conn")
+
+	server, err := net.ListenUnix("unix", &net.UnixAddr{Name: name})
+	c.Assert(err, check.IsNil)
+	defer server.Close()
+
+	type acceptResult struct {
+		conn *net.UnixConn
+		err  error
+	}
+	accepted := make(chan acceptResult, 1)
+	go func() {
+		conn, err := server.AcceptUnix()
+		accepted <- acceptResult{conn: conn, err: err}
+	}()
+
+	clientConn, err := net.DialUnix("unix",
+		&net.UnixAddr{Name: addr},
+		&net.UnixAddr{Name: name},
+	)
+	c.Assert(err, check.IsNil)
+	defer clientConn.Close()
+
+	result := <-accepted
+	c.Assert(result.err, check.IsNil)
+	defer result.conn.Close()
+
+	f, err := result.conn.File()
+	c.Assert(err, check.IsNil)
+	defer f.Close()
+
+	s.expectedArgs = []string{"get-secret", "ollama.ollama-api-key"}
+
+	var stdout, stderr bytes.Buffer
+	args := []string{"get-secret", "--systemd"}
+	c.Check(run(args, f, &stdout, &stderr), check.Equals, 0)
+	c.Check(stdout.String(), check.Equals, "test stdout")
+	c.Check(stderr.String(), check.Equals,
+		"processed systemd load credential request for unit \"ollama.service\", sdk \"ollama\" and secret \"ollama-api-key\"")
 }

--- a/docs/reference/cli/workshopctl.rst
+++ b/docs/reference/cli/workshopctl.rst
@@ -15,6 +15,70 @@ SDKs use the :program:`workshopctl` tool when reporting to the workshop;
 to invoke a subcommand, add it to your :ref:`SDK hook <ref_sdk_hooks>`.
 
 
+workshopctl get-secret
+----------------------
+
+Get the value of a secret connected to the workshop.
+
+.. rubric:: Usage
+
+.. code-block:: console
+
+   $ workshopctl get-secret [--systemd] <SDK>.<secret>
+
+
+.. rubric:: Description
+
+This command retrieves the value of a secret made available to an SDK
+through a connected secret plug and writes it to standard output.
+SDKs typically call it from wrapper scripts to inject secrets into
+one-shot commands.
+
+.. list-table::
+   :header-rows: 1
+   :width: 95
+   :widths: 1 2 3
+
+   * - Placeholder
+     - Required
+     - Value
+
+   * - :samp:`<SDK>.<secret>`
+     - Required unless :samp:`--systemd` is given.
+     - The name of the SDK and of its secret plug, joined by a dot.
+
+
+.. rubric:: Examples
+
+Read a secret into an environment variable in a wrapper script:
+
+.. code-block:: console
+
+   $ API_KEY=$(workshopctl get-secret my-sdk.api-key)
+
+
+.. rubric:: Flags
+
+--systemd
+
+   Service a systemd :samp:`LoadCredential` request.
+   The workshop secret socket unit invokes :program:`workshopctl`
+   with this flag, passing the accepted socket connection on
+   standard input.
+   The credential name in the requesting unit's
+   :samp:`LoadCredential` entry must take the form
+   :samp:`{<SDK>}.{<secret>}` so that the requesting SDK and secret
+   can be identified from the connection, for example:
+
+   .. code-block:: none
+
+      LoadCredential=my-sdk.api-key:${SDK_SYSTEMD_SECRET_SOCKET}
+
+   The secret value is delivered back to systemd through the
+   connection.
+   Not intended for interactive use.
+
+
 workshopctl set-health
 ----------------------
 

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -137,7 +137,7 @@ func (f ForbiddenCommandError) Error() string {
 
 // nonRootAllowed lists the commands that can be performed even when workshopctl
 // is invoked not by root.
-var nonRootAllowed = []string{"set-health"}
+var nonRootAllowed = []string{"get-secret", "set-health"}
 
 // Run runs the requested command.
 func Run(context *hookstate.Context, args []string, uid uint32) (stdout, stderr []byte, err error) {

--- a/internal/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/internal/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -53,22 +53,24 @@ func (c *baseCommand) setStdout(w io.Writer) {
 	c.stdout = w
 }
 
-func (c *baseCommand) printf(format string, a ...any) (int, error) {
-	if c.stdout != nil {
-		return fmt.Fprintf(c.stdout, format, a...)
+func (c *baseCommand) printf(format string, a ...any) error {
+	if c.stdout == nil {
+		return nil
 	}
-	return 0, nil
+	_, err := fmt.Fprintf(c.stdout, format, a...)
+	return err
 }
 
 func (c *baseCommand) setStderr(w io.Writer) {
 	c.stderr = w
 }
 
-func (c *baseCommand) errorf(format string, a ...any) (int, error) {
-	if c.stderr != nil {
-		return fmt.Fprintf(c.stderr, format, a...)
+func (c *baseCommand) errorf(format string, a ...any) error {
+	if c.stderr == nil {
+		return nil
 	}
-	return 0, nil
+	_, err := fmt.Fprintf(c.stderr, format, a...)
+	return err
 }
 
 func (c *baseCommand) setContext(context *hookstate.Context) {

--- a/internal/overlord/hookstate/ctlcmd/export_test.go
+++ b/internal/overlord/hookstate/ctlcmd/export_test.go
@@ -45,14 +45,14 @@ func (c *MockCommand) Execute(args []string) error {
 	c.Args = args
 
 	if c.FakeStdout != "" {
-		_, err := c.printf("%s", c.FakeStdout)
+		err := c.printf("%s", c.FakeStdout)
 		if err != nil {
 			return err
 		}
 	}
 
 	if c.FakeStderr != "" {
-		_, err := c.errorf("%s", c.FakeStderr)
+		err := c.errorf("%s", c.FakeStderr)
 		if err != nil {
 			return err
 		}

--- a/internal/overlord/hookstate/ctlcmd/getsecret.go
+++ b/internal/overlord/hookstate/ctlcmd/getsecret.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ctlcmd
+
+import "github.com/canonical/workshop/internal/logger"
+
+type getSecretCommand struct {
+	baseCommand
+	getSecretPositional `positional-args:"yes"`
+}
+
+type getSecretPositional struct {
+	Secret string `positional-arg-name:"<sdk>.<secret>" required:"yes" description:"the secret to retrieve, in the form <sdk>.<secret>"`
+}
+
+const (
+	// hardCodedSecret is a placeholder secret value returned until secret
+	// resolution via workshopd is implemented.
+	hardCodedSecret = "workshop-placeholder-secret"
+
+	longGetSecretHelp = `
+The get-secret command retrieves the value of a secret connected to the
+workshop, identified as "<sdk>.<secret>" (e.g. "ollama.ollama-api-key").
+`
+
+	shortGetSecretHelp = "Get the value of a secret"
+)
+
+func init() {
+	addCommand(
+		"get-secret",
+		shortGetSecretHelp,
+		longGetSecretHelp,
+		func() command {
+			return &getSecretCommand{}
+		},
+	)
+}
+
+// Execute runs the get-secret command, writing the secret value to stdout.
+func (c *getSecretCommand) Execute([]string) error {
+	// Log the requested identifier only; never the resolved value.
+	logger.Debugf("get-secret request for %q", c.Secret)
+
+	// TODO: resolve the requested secret via workshopd instead of
+	// returning a hard-coded value.
+	_, err := c.printf("%s", hardCodedSecret)
+	return err
+}

--- a/internal/overlord/hookstate/ctlcmd/getsecret.go
+++ b/internal/overlord/hookstate/ctlcmd/getsecret.go
@@ -32,7 +32,7 @@ const (
 
 	longGetSecretHelp = `
 The get-secret command retrieves the value of a secret connected to the
-workshop, identified as "<SDK>.<secret>" (e.g. "ollama.ollama-api-key").
+workshop, identified as "<SDK>.<secret>" (e.g. "my-sdk.api-key").
 `
 
 	shortGetSecretHelp = "Get the value of a secret"

--- a/internal/overlord/hookstate/ctlcmd/getsecret.go
+++ b/internal/overlord/hookstate/ctlcmd/getsecret.go
@@ -56,6 +56,5 @@ func (c *getSecretCommand) Execute([]string) error {
 
 	// TODO: resolve the requested secret via workshopd instead of
 	// returning a hard-coded value.
-	_, err := c.printf("%s", hardCodedSecret)
-	return err
+	return c.printf("%s", hardCodedSecret)
 }

--- a/internal/overlord/hookstate/ctlcmd/getsecret.go
+++ b/internal/overlord/hookstate/ctlcmd/getsecret.go
@@ -22,7 +22,7 @@ type getSecretCommand struct {
 }
 
 type getSecretPositional struct {
-	Secret string `positional-arg-name:"<sdk>.<secret>" required:"yes" description:"the secret to retrieve, in the form <sdk>.<secret>"`
+	Secret string `positional-arg-name:"<SDK>.<secret>" required:"yes" description:"the secret to retrieve, in the form <SDK>.<secret>"`
 }
 
 const (
@@ -32,7 +32,7 @@ const (
 
 	longGetSecretHelp = `
 The get-secret command retrieves the value of a secret connected to the
-workshop, identified as "<sdk>.<secret>" (e.g. "ollama.ollama-api-key").
+workshop, identified as "<SDK>.<secret>" (e.g. "ollama.ollama-api-key").
 `
 
 	shortGetSecretHelp = "Get the value of a secret"

--- a/internal/overlord/hookstate/ctlcmd/getsecret_test.go
+++ b/internal/overlord/hookstate/ctlcmd/getsecret_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ctlcmd_test
+
+import (
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/overlord/hookstate/ctlcmd"
+)
+
+// getSecretSuite tests the get-secret workshopctl command, which currently
+// returns a hard-coded placeholder secret value.
+type getSecretSuite struct{}
+
+var _ = check.Suite(&getSecretSuite{})
+
+func (s *getSecretSuite) TestGetSecret(c *check.C) {
+	stdout, stderr, err := ctlcmd.Run(nil, []string{"get-secret", "ollama.ollama-api-key"}, 0)
+	c.Assert(err, check.IsNil)
+	c.Check(string(stdout), check.Equals, "workshop-placeholder-secret")
+	c.Check(string(stderr), check.Equals, "")
+}
+
+// TestGetSecretMissingArg checks that get-secret requires a secret
+// identifier argument.
+func (s *getSecretSuite) TestGetSecretMissingArg(c *check.C) {
+	_, _, err := ctlcmd.Run(nil, []string{"get-secret"}, 0)
+	c.Check(err, check.ErrorMatches, ".*the required argument `<sdk>.<secret>` was not provided.*")
+}
+
+// TestGetSecretNonRoot checks that get-secret is allowed without root, as
+// both the socket-activated systemd path and SDK wrapper scripts invoke it
+// as the workshop user.
+func (s *getSecretSuite) TestGetSecretNonRoot(c *check.C) {
+	stdout, _, err := ctlcmd.Run(nil, []string{"get-secret", "ollama.ollama-api-key"}, 1000)
+	c.Assert(err, check.IsNil)
+	c.Check(string(stdout), check.Equals, "workshop-placeholder-secret")
+}

--- a/internal/overlord/hookstate/ctlcmd/getsecret_test.go
+++ b/internal/overlord/hookstate/ctlcmd/getsecret_test.go
@@ -37,7 +37,7 @@ func (s *getSecretSuite) TestGetSecret(c *check.C) {
 // identifier argument.
 func (s *getSecretSuite) TestGetSecretMissingArg(c *check.C) {
 	_, _, err := ctlcmd.Run(nil, []string{"get-secret"}, 0)
-	c.Check(err, check.ErrorMatches, ".*the required argument `<sdk>.<secret>` was not provided.*")
+	c.Check(err, check.ErrorMatches, ".*the required argument `<SDK>.<secret>` was not provided.*")
 }
 
 // TestGetSecretNonRoot checks that get-secret is allowed without root, as


### PR DESCRIPTION
## Summary

Add the `workshopctl get-secret` plumbing used by systemd
`LoadCredential=` requests.

The implementation has two paths:

- Plain `workshopctl get-secret <sdk>.<secret>` forwards a secret request to
  the daemon.
- `workshopctl get-secret --systemd` handles a request from the Workshop
  secret socket. It reads the peer address of the accepted Unix connection to
  identify the requesting systemd unit and credential, then forwards a normal
  `<sdk>.<secret>` request to the daemon.

The systemd path writes only credential bytes to stdout. Diagnostics go to
stderr, allowing the socket-activated unit to route them to the journal
without contaminating the credential value.

## Systemd behaviour

A systemd peer address has the form:

```text
\0<random>/unit/<unit>/<sdk>.<secret>
```

For example:

```text
\0<random>/unit/ollama.service/ollama.ollama-api-key
```

`workshopctl` decodes this into the requesting unit, SDK, and secret plug.
The systemd response handler implements the secret-spec exit codes:

| Result | Exit code | Credential output |
| --- | ---: | --- |
| Plug not connected | `0` | Zero-byte credential |
| Secret not found | `1` | None |
| Secret provider locked | `2` | None |
| Other failure | `255` | None |
| Success | `0` | Secret value |

## Current scope

The daemon command currently returns the placeholder value:

```text
workshop-placeholder-secret
```

It logs the requested secret identifier but never its value. Host secret
provider lookup and secret-interface connection resolution are follow-up work.

This PR depends on the base branch's Workshop secret socket units.

## Client refactor

`WorkshopCtlOptions` now owns its optional stdin reader. This lets local
interceptors consume or clear stdin before forwarding the request to the
daemon. The systemd interceptor clears it after reading the peer address, so
the accepted socket is not buffered into the API request body.

## Testing

Added coverage for:

- plain `get-secret` invocation and non-root access;
- required secret argument validation;
- systemd peer-address parsing and malformed input;
- decoding a peer address from a real Unix socket;
- systemd success and error response handling;
- interception of `get-secret --systemd`;
- client stdin size limit handling.

Validated with:

```text
go test ./client ./cmd/workshopctl ./internal/overlord/hookstate/ctlcmd
```

## Manual QA

Requires a Workshop build containing both this PR and the Workshop secret
socket units.

1. Launch a new workshop, then enter it as root.

2. Confirm the resolver socket is active:

   ```sh
   systemctl is-active workshop-secret.socket
   ```

   Expected output:

   ```text
   active
   ```

3. Create a one-shot system service that requests a credential and writes it
   to a temporary file:

   ```sh
   cat >/etc/systemd/system/workshop-secret-smoke.service <<'EOF'
   [Unit]
   Description=Workshop secret smoke test
   After=workshop-secret.socket
   Wants=workshop-secret.socket

   [Service]
   Type=oneshot
   LoadCredential=smoke-test.api-token:/var/lib/workshop/run/workshop.socket.secret
   ExecStart=/bin/sh -c 'cat "$CREDENTIALS_DIRECTORY/smoke-test.api-token" > /tmp/workshop-secret-smoke-value'
   EOF

   systemctl daemon-reload
   systemctl start workshop-secret-smoke.service
   ```

4. Confirm systemd received the credential:

   ```sh
   cat /tmp/workshop-secret-smoke-value
   ```

   Expected output for the current placeholder implementation:

   ```text
   workshop-placeholder-secret
   ```

5. Confirm the socket-activated resolver processed the request:

   ```sh
   systemctl list-units --all 'workshop-secret@*.service'
   ```

   Copy an instance name from the output, then inspect its log:

   ```sh
   journalctl --no-pager -u <workshop-secret-instance>
   ```

   The log should identify the requesting unit, SDK, and secret name, but must
   not include the credential value.

6. Confirm the plain command is authorised as the Workshop user:

   ```sh
   sudo -u workshop workshopctl get-secret smoke-test.api-token
   ```

   Expected output:

   ```text
   workshop-placeholder-secret
   ```

This verifies the success path and systemd transport only. Host keyring lookup,
plug connection state, missing secrets, and locked providers require the future
daemon-side secret resolver.

## Docs

Procedure:

* [x] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [x] Headings and titles accurately describe the content.
* [x] New and updated pages include correct metadata.
* [x] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [x] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`) — not needed: workshopctl is tracked as a single artefact already tagged on the page.

