### PR TITLE
Set SDK_SYSTEMD_SECRET_SOCKET during hook invocation

### DIFF
--- a/internal/daemon/snapshot-format.yaml
+++ b/internal/daemon/snapshot-format.yaml
@@ -51,7 +51,7 @@ test-sdk-2:
     snapshot-sdk: 2
   fs-calls: 12
   exec-calls:
-    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_SYSTEMD_SECRET_SOCKET", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
 test-sdk:
   files:
     - drwxr-xr-x var
@@ -70,8 +70,8 @@ test-sdk:
     snapshot-sdk: 3
   fs-calls: 16
   exec-calls:
-    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
-    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_SYSTEMD_SECRET_SOCKET", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk-2/sdk/hooks/setup-base"]
+    - ["sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_SYSTEMD_SECRET_SOCKET", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", 'exec -- "$0" "$@"', "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/test-sdk/sdk/hooks/setup-base"]
 sketch:
   files:
     - drwxr-xr-x var

--- a/internal/overlord/hookstate/handlers.go
+++ b/internal/overlord/hookstate/handlers.go
@@ -84,7 +84,8 @@ func (h *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		GroupId: 0,
 		Command: command,
 		Environment: map[string]string{
-			"SDK": sdk.SdkDir(hook.Sdk),
+			"SDK":                       sdk.SdkDir(hook.Sdk),
+			"SDK_SYSTEMD_SECRET_SOCKET": dirs.WorkshopSecretSocketPath,
 		},
 		WorkDir: sdk.SdkHooksDir(hook.Sdk),
 		Timeout: hook.Timeout,

--- a/internal/overlord/hookstate/handlers_test.go
+++ b/internal/overlord/hookstate/handlers_test.go
@@ -262,6 +262,7 @@ func (s *hookSuite) TestExecSetupProject(c *check.C) {
 		"--preserve-env=DBUS_SESSION_BUS_ADDRESS",
 		"--preserve-env=HOME",
 		"--preserve-env=SDK",
+		"--preserve-env=SDK_SYSTEMD_SECRET_SOCKET",
 		"--preserve-env=WORKSHOP_COOKIE",
 		"--preserve-env=XDG_RUNTIME_DIR",
 		"--",
@@ -325,10 +326,10 @@ func (s *hookSuite) TestExecSaveState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=SDK_SYSTEMD_SECRET_SOCKET", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
-	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
+	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 4)
 }
 
 func (s *hookSuite) TestExecRestoreState(c *check.C) {
@@ -360,10 +361,10 @@ func (s *hookSuite) TestExecRestoreState(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "-o", "xtrace", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=SDK_SYSTEMD_SECRET_SOCKET", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "-o", "xtrace", "/var/lib/workshop/sdk/one/sdk/hooks/restore-state"})
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["SDK_STATE_DIR"], check.Equals, "/var/lib/workshop/state/sdk/one")
 	c.Assert(s.backend.ExecCalls[0].Args.Environment["WORKSHOP_COOKIE"], check.NotNil)
-	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 3)
+	c.Assert(s.backend.ExecCalls[0].Args.Environment, check.HasLen, 4)
 }
 
 func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
@@ -401,7 +402,7 @@ func (s *hookSuite) TestExecHandlesFailedHook(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_STATE_DIR", "--preserve-env=SDK_SYSTEMD_SECRET_SOCKET", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/save-state"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)
@@ -441,7 +442,7 @@ func (s *hookSuite) TestExecHandlesHookTimedout(c *check.C) {
 
 	c.Check(s.backend.ExecCalls, check.HasLen, 1)
 	c.Assert(s.backend.ExecCalls[0].Args.Command, check.DeepEquals,
-		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
+		[]string{"sudo", "--user=#0", "--group=#0", "--preserve-env=SDK", "--preserve-env=SDK_SYSTEMD_SECRET_SOCKET", "--preserve-env=WORKSHOP_COOKIE", "--", "bash", "-l", "-c", `exec -- "$0" "$@"`, "bash", "-o", "errexit", "-o", "pipefail", "/var/lib/workshop/sdk/one/sdk/hooks/fake-hook"})
 
 	c.Check(t1.Status(), check.Equals, state.ErrorStatus)
 	c.Check(t1.Log(), check.HasLen, 1)


### PR DESCRIPTION
# Description

Adds `SDK_SYSTEMD_SECRET_SOCKET` to the environment for all SDK hook
invocations, set to the path of the workshop systemd secret socket.
This allows SDK authors to read the socket location from the environment
rather than hard-coding it, so that the path can change over time
without breaking existing SDKs.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically.
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

* [x] I confirm the PR has no implications for documentation.