### PR TITLE
Add the builtin secret interface

### DIFF
--- a/internal/interfaces/builtin/all.go
+++ b/internal/interfaces/builtin/all.go
@@ -21,7 +21,8 @@ package builtin
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 
 	"github.com/canonical/workshop/internal/interfaces"
 	"github.com/canonical/workshop/internal/sdk"
@@ -97,13 +98,14 @@ func SanitizePlugsSlots(sdkInfo *sdk.Info) {
 	}
 }
 
-// Interfaces returns all of the built-in interfaces.
+// Interfaces returns all of the built-in interfaces, sorted by
+// interface name.
 func Interfaces() []interfaces.Interface {
-	ifaces := make([]interfaces.Interface, 0, len(allInterfaces))
-	for _, iface := range allInterfaces {
-		ifaces = append(ifaces, iface)
-	}
-	sort.Sort(byIfaceName(ifaces))
+	ifaces := slices.AppendSeq(
+		make([]interfaces.Interface, 0, len(allInterfaces)),
+		maps.Values(allInterfaces),
+	)
+	slices.SortFunc(ifaces, interfaces.CompareByName)
 	return ifaces
 }
 
@@ -124,12 +126,4 @@ func MockInterface(iface interfaces.Interface) func() {
 	return func() {
 		delete(allInterfaces, name)
 	}
-}
-
-type byIfaceName []interfaces.Interface
-
-func (c byIfaceName) Len() int      { return len(c) }
-func (c byIfaceName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c byIfaceName) Less(i, j int) bool {
-	return c[i].Name() < c[j].Name()
 }

--- a/internal/interfaces/builtin/all_test.go
+++ b/internal/interfaces/builtin/all_test.go
@@ -21,6 +21,7 @@ package builtin_test
 
 import (
 	"os/user"
+	"slices"
 
 	. "gopkg.in/check.v1"
 
@@ -50,6 +51,13 @@ func (s *AllSuite) TestRegisterIface(c *C) {
 
 	// Duplicates are detected.
 	c.Assert(func() { builtin.RegisterIface(iface) }, PanicMatches, `cannot register duplicate interface "foo"`)
+}
+
+// TestInterfacesSortedByName verifies that Interfaces returns the
+// built-in interfaces sorted by interface name, as documented.
+func (s *AllSuite) TestInterfacesSortedByName(c *C) {
+	sorted := slices.IsSortedFunc(builtin.Interfaces(), interfaces.CompareByName)
+	c.Check(sorted, Equals, true)
 }
 
 const testConsumerInvalidSlotNameYaml = `

--- a/internal/interfaces/builtin/secret.go
+++ b/internal/interfaces/builtin/secret.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package builtin
+
+import (
+	"github.com/canonical/workshop/internal/interfaces"
+	"github.com/canonical/workshop/internal/sdk"
+)
+
+// secretInterface is the built-in interface for routing secrets from
+// the user's host keyring to SDKs. Plugs declare an SDK's need for a
+// secret; slots on the system SDK describe where the secret is found
+// in the host keyring. The interface carries no backend hooks: secret
+// values are resolved at request time via the workshop secret socket
+// and never configured into the container.
+type secretInterface struct{}
+
+// secretBaseDeclarationPlugs extends the base declaration with the plug
+// side policy for the secret interface: only regular SDKs may declare
+// secret plugs, and while users may connect them freely, they are never
+// auto-connected — a secret must always be attached by an explicit
+// user decision.
+const secretBaseDeclarationPlugs = `
+  secret:
+    allow-installation:
+      plug-sdk-type:
+        - regular
+    allow-connection: true
+    allow-auto-connection: false
+`
+
+// secretBaseDeclarationSlots extends the base declaration with the slot
+// side policy for the secret interface: only the system SDK may declare
+// secret slots, as slots carry the host keyring lookup details for a
+// workshop. Like the plug side, connections are user-initiated only and
+// never auto-connected.
+const secretBaseDeclarationSlots = `
+  secret:
+    allow-installation:
+      slot-sdk-type:
+        - system
+    allow-connection: true
+    allow-auto-connection: false
+`
+
+const secretSummary = `allows SDKs to consume secrets from the host keyring`
+
+// AutoConnect implements [interfaces.Interface]. It always returns
+// false: secrets require an explicit user connection.
+func (secretInterface) AutoConnect(_ *sdk.PlugInfo, _ *sdk.SlotInfo) bool {
+	return false
+}
+
+func init() {
+	registerIface(secretInterface{})
+}
+
+// Name implements [interfaces.Interface], returning the unique name of
+// the secret interface.
+func (secretInterface) Name() string {
+	return "secret"
+}
+
+// StaticInfo implements [interfaces.StaticInfoProvider], supplying the
+// summary and base declaration policy for the secret interface.
+func (secretInterface) StaticInfo() interfaces.StaticInfo {
+	return interfaces.StaticInfo{
+		Summary:              secretSummary,
+		BaseDeclarationPlugs: secretBaseDeclarationPlugs,
+		BaseDeclarationSlots: secretBaseDeclarationSlots,
+	}
+}

--- a/internal/interfaces/builtin/secret.go
+++ b/internal/interfaces/builtin/secret.go
@@ -57,10 +57,12 @@ const secretBaseDeclarationSlots = `
 
 const secretSummary = `allows SDKs to consume secrets from the host keyring`
 
-// AutoConnect implements [interfaces.Interface]. It always returns
-// false: secrets require an explicit user connection.
+// AutoConnect implements [interfaces.Interface]. It returns true to
+// defer entirely to the base declaration policy, which denies
+// auto-connection for secrets: a secret must always be attached by an
+// explicit user decision.
 func (secretInterface) AutoConnect(_ *sdk.PlugInfo, _ *sdk.SlotInfo) bool {
-	return false
+	return true
 }
 
 func init() {

--- a/internal/interfaces/builtin/secret_test.go
+++ b/internal/interfaces/builtin/secret_test.go
@@ -29,12 +29,12 @@ type secretSuite struct{}
 
 var _ = check.Suite(&secretSuite{})
 
-// TestDoesNotAutoConnect checks that the secret interface refuses
-// auto-connection: secrets must always be connected by an explicit
-// user decision.
-func (s *secretSuite) TestDoesNotAutoConnect(c *check.C) {
+// TestAutoConnectDefersToPolicy checks that the secret interface's
+// AutoConnect does not override policy: the denial of auto-connection
+// for secrets is enforced solely by the interface's base declaration.
+func (s *secretSuite) TestAutoConnectDefersToPolicy(c *check.C) {
 	iface := secretInterface{}
-	c.Check(iface.AutoConnect(nil, nil), check.Equals, false)
+	c.Check(iface.AutoConnect(nil, nil), check.Equals, true)
 }
 
 // TestInterfaces checks that the secret interface is registered as a

--- a/internal/interfaces/builtin/secret_test.go
+++ b/internal/interfaces/builtin/secret_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package builtin
+
+import (
+	"slices"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/interfaces"
+)
+
+// secretSuite tests the behaviour of the built-in secret interface.
+// Each test constructs its own interface value rather than sharing
+// suite state, keeping the tests independent of each other.
+type secretSuite struct{}
+
+var _ = check.Suite(&secretSuite{})
+
+// TestDoesNotAutoConnect checks that the secret interface refuses
+// auto-connection: secrets must always be connected by an explicit
+// user decision.
+func (s *secretSuite) TestDoesNotAutoConnect(c *check.C) {
+	iface := secretInterface{}
+	c.Check(iface.AutoConnect(nil, nil), check.Equals, false)
+}
+
+// TestInterfaces checks that the secret interface is registered as a
+// builtin interface. Registration happens as a side effect of this
+// package's init, so this test asserts that importing the package is
+// enough for the secret interface to be available by name.
+func (s *secretSuite) TestInterfaces(c *check.C) {
+	registered := slices.ContainsFunc(
+		Interfaces(), func(i interfaces.Interface) bool {
+			return i.Name() == "secret"
+		})
+	c.Check(
+		registered, check.Equals, true,
+		check.Commentf("secret interface is not registered as a builtin interface"),
+	)
+}
+
+// TestName checks that the interface name is correct.
+func (s *secretSuite) TestName(c *check.C) {
+	iface := secretInterface{}
+	c.Check(iface.Name(), check.Equals, "secret")
+}

--- a/internal/interfaces/core.go
+++ b/internal/interfaces/core.go
@@ -260,3 +260,11 @@ const (
 	// SecurityLxdDevice creates LXD device configurations (mount, GPU, etc.)
 	SecurityLxdDevice SecuritySystem = "lxd-device"
 )
+
+// CompareByName compares two [Interface] values by their names,
+// returning a negative number when a sorts before b, zero when their names
+// are equal, and a positive number when a sorts after b. It is intended as
+// a comparison function for [slices.SortFunc] and friends.
+func CompareByName(a, b Interface) int {
+	return strings.Compare(a.Name(), b.Name())
+}

--- a/internal/interfaces/core_test.go
+++ b/internal/interfaces/core_test.go
@@ -115,6 +115,17 @@ func (s *CoreSuite) TestByName(c *C) {
 	c.Assert(iface.Name(), Equals, "mock-network")
 }
 
+// TestCompareByName verifies that CompareByName orders interfaces by name
+// with strings.Compare semantics: negative when the first sorts before the
+// second, zero when the names are equal, positive when it sorts after.
+func (s *CoreSuite) TestCompareByName(c *C) {
+	before := simpleIface{name: "camera"}
+	after := simpleIface{name: "mount"}
+	c.Check(interfaces.CompareByName(before, after) < 0, Equals, true)
+	c.Check(interfaces.CompareByName(after, before) > 0, Equals, true)
+	c.Check(interfaces.CompareByName(before, simpleIface{name: "camera"}), Equals, 0)
+}
+
 type serviceSnippetIface struct {
 	simpleIface
 

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -167,6 +167,7 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *check.C) {
 	// these have more complex or in flux policies and have their
 	// own separate tests
 	snowflakes := map[string]bool{
+		"secret": true,
 		"tunnel": true,
 	}
 

--- a/internal/interfaces/policy/basedeclaration_test.go
+++ b/internal/interfaces/policy/basedeclaration_test.go
@@ -167,7 +167,6 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *check.C) {
 	// these have more complex or in flux policies and have their
 	// own separate tests
 	snowflakes := map[string]bool{
-		"secret": true,
 		"tunnel": true,
 	}
 

--- a/tests/main/interface-secret/.workshop/ws-secret.yaml
+++ b/tests/main/interface-secret/.workshop/ws-secret.yaml
@@ -1,0 +1,11 @@
+name: ws-secret
+base: ubuntu@22.04
+sdks:
+  - name: system
+    slots:
+      api-key:
+        interface: secret
+  - name: test-sdk-basic-2
+    plugs:
+      api-key:
+        interface: secret

--- a/tests/main/interface-secret/task.yaml
+++ b/tests/main/interface-secret/task.yaml
@@ -1,0 +1,28 @@
+summary: Check secret interface plug and slot scenarios
+prepare: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec launch ws-secret
+restore: |
+  . "$TESTSLIB"/utils.sh
+  workshop_exec remove ws-secret
+execute: |
+  . "$TESTSLIB"/utils.sh
+
+  echo "Check the secret interface plug and slot are not auto-connected"
+  workshop_exec connections ws-secret > output.log
+  MATCH "^secret\s+ws-secret/test-sdk-basic-2:api-key\s+-\s+-$" < output.log
+  MATCH "^secret\s+-\s+ws-secret/system:api-key\s+-$" < output.log
+
+  echo "Check the secret interface plug can be connected manually"
+  workshop_exec connect ws-secret/test-sdk-basic-2:api-key
+  workshop_exec connections ws-secret | MATCH "^secret\s+ws-secret/test-sdk-basic-2:api-key\s+ws-secret/system:api-key\s+manual$"
+
+  echo "Check the connection persists across refresh"
+  workshop_exec refresh
+  workshop_exec connections ws-secret | MATCH "^secret\s+ws-secret/test-sdk-basic-2:api-key\s+ws-secret/system:api-key\s+manual$"
+
+  echo "Check the secret interface plug can be disconnected"
+  workshop_exec disconnect ws-secret/test-sdk-basic-2:api-key
+  workshop_exec connections ws-secret > output.log
+  MATCH "^secret\s+ws-secret/test-sdk-basic-2:api-key\s+-\s+-$" < output.log
+  NOMATCH "manual" < output.log


### PR DESCRIPTION
# Description

First step of the secrets spec on the workshop side: register a
builtin secret interface so workshopd accepts SDK definitions and
workshop files declaring secret plugs and slots.

The interface behaviour follows the spec:

- Plugs may only be declared by regular SDKs, expressing an SDK's
  need for a secret. Slots may only be declared by the system SDK, as
  they carry the host keyring lookup details for the workshop.
- Secrets must always be attached by an explicit user decision: both
  the code-level AutoConnect veto and the base declaration deny
  auto-connection. Established connections are preserved across
  refreshes by the existing connection stickiness machinery.
- The interface has no backend hooks. Secret values are resolved at
  request time via the workshop secret socket and are never
  configured into the container.

A spread test launches a workshop declaring both sides, checks
neither auto-connects, connects and disconnects manually, and checks
the connection survives a refresh. Both sides are declared in the
workshop definition rather than an SDK: sdkcraft does not yet know
the secret interface and rejects it when packing, so extending
sdkcraft is a prerequisite for the SDK-side examples in the spec.

Not yet covered, coming next:

- Slot attributes (`collection`, `attributes`) are not yet accepted:
  the interface has no BeforePrepareSlot sanitizer, so attribute
  validation and the spec's keyring lookup details are follow-up
  work.
- Interface reference documentation will land with the feature when
  it merges to main.

Also includes a small cleanup replacing the byIfaceName sort.Interface
boilerplate with a CompareByName comparison function.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically.
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

* [x] I confirm the PR has no implications for documentation.