### PR TITLE
Rework release workflow to run on signed version tags

### DIFF
--- a/.github/workflows/generate-ref-docs.yaml
+++ b/.github/workflows/generate-ref-docs.yaml
@@ -1,0 +1,50 @@
+name: Generate CLI Reference Docs
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate-ref-docs:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on:
+      - self-hosted
+      - Linux
+      - noble
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+
+      - name: Generate CLI reference docs
+        run: |
+          go run ./cmd/sdk generate-docs ./docs/reference/cli
+          go run ./cmd/workshop generate-docs ./docs/reference/cli
+
+      - name: Check for changes, commit, and create PR if any
+        run: |
+          if git diff --exit-code; then
+            echo "No changes detected, skipping commit and PR creation."
+          else
+            pr_branch="docs/reference-cli-$(date +'%Y%m%d%H%M%S')"
+            git checkout -b $pr_branch
+
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+            git add .
+            git commit -m "Update CLI reference docs"
+            git push --set-upstream origin $pr_branch
+
+            gh pr create --title "Update CLI reference docs" --body "This PR updates the generated CLI reference documentation." --base main
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,41 @@
 name: Release
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - 'v[0-9]*'
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
+  verify-tag:
+    environment: release
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - Linux
+      - noble
+      - X64
+      - medium
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify signed tag
+        env:
+          MAINTAINERS_SSH_PUBKEYS: ${{ vars.MAINTAINERS_SSH_PUBKEYS }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          echo "$MAINTAINERS_SSH_PUBKEYS" > "$RUNNER_TEMP/allowed_signers"
+          git config gpg.ssh.allowedSignersFile "$RUNNER_TEMP/allowed_signers"
+          git config gpg.format ssh
+          git verify-tag "$TAG_NAME"
+
   build:
+    needs: verify-tag
     permissions:
       contents: read
     strategy:
@@ -48,10 +80,6 @@ jobs:
       - X64
       - medium
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: snap-*
@@ -59,55 +87,9 @@ jobs:
           merge-multiple: true
 
       - run: |
-          gh release create --notes-file=- "${GITHUB_REF#refs/tags/}" snaps/*.snap <<'EOF'
-          ## Docs Checklist
-          - [ ] JSON for SDKs
-          - [ ] JSON for workshops
-          - [ ] Release notes
-          - [ ] Version bump
-          - [ ] Coverage map update
+          gh release create --notes-file=- "$TAG_NAME" snaps/*.snap <<EOF
+          See [release notes](https://ubuntu.com/workshop/docs/release-notes/$TAG_NAME/).
           EOF
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  generate-docs:
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on:
-      - self-hosted
-      - Linux
-      - noble
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: "1.26"
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: true
-
-      - name: Generate CLI reference docs
-        run: |
-          go run ./cmd/sdk generate-docs ./docs/reference/cli
-          go run ./cmd/workshop generate-docs ./docs/reference/cli
-
-      - name: Check for changes, commit, and create PR if any
-        run: |
-          if git diff --exit-code; then
-            echo "No changes detected, skipping commit and PR creation."
-          else
-            pr_branch="docs/reference-cli-$(date +'%Y%m%d%H%M%S')"
-            git checkout -b $pr_branch
-
-            git config --global user.name 'github-actions[bot]'
-            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-
-            git add .
-            git commit -m "Update CLI reference docs"
-            git push --set-upstream origin $pr_branch
-
-            gh pr create --title "Update CLI reference docs" --body "This PR updates the generated CLI reference documentation." --base main
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
# Description

- Extract the reference CLI documentation as a separate workflow.
- Run the release workflow on a release PR merge which follows by a signed version tag on main. The release PR includes release notes and a version bump.
- Run tag check for the signed version tags.