### PR TITLE
Add shell completion for workshop exec --env

### DIFF
--- a/cmd/internal/cmdutil/completion.go
+++ b/cmd/internal/cmdutil/completion.go
@@ -20,6 +20,9 @@
 package cmdutil
 
 import (
+	"os"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
@@ -27,4 +30,17 @@ func CompleteChoices(choices ...string) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return choices, cobra.ShellCompDirectiveNoFileComp
 	}
+}
+
+func CompleteEnv(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	environ := os.Environ()
+	names := make([]string, 0, len(environ))
+	for _, e := range environ {
+		if strings.HasPrefix(e, "_") && !strings.HasPrefix(toComplete, "_") {
+			continue
+		}
+		name, _, _ := strings.Cut(e, "=")
+		names = append(names, name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/workshop/exec.go
+++ b/cmd/workshop/exec.go
@@ -33,6 +33,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/workshop/client"
+	"github.com/canonical/workshop/cmd/internal/cmdutil"
 	"github.com/canonical/workshop/internal/dirs"
 	"github.com/canonical/workshop/internal/logger"
 	"github.com/canonical/workshop/internal/ptyutil"
@@ -213,6 +214,7 @@ $ workshop exec sh`,
 	cmd.Flags().SortFlags = false
 	cmd.Flags().SetInterspersed(false)
 	commonVars(cmd.Flags(), &c.flags)
+	_ = cmd.RegisterFlagCompletionFunc("env", cmdutil.CompleteEnv)
 
 	return cmd
 }
@@ -313,6 +315,7 @@ $ workshop run dev -- tests -run TestFoo ./pkg/...`,
 	cmd.Flags().SortFlags = false
 	cmd.Flags().SetInterspersed(false)
 	commonVars(cmd.Flags(), &c.flags)
+	_ = cmd.RegisterFlagCompletionFunc("env", cmdutil.CompleteEnv)
 
 	return cmd
 }

--- a/tests/main/completion/bash.sh
+++ b/tests/main/completion/bash.sh
@@ -32,6 +32,11 @@ echo "Test launch completion"
 do_complete workshop launch o
 [ "$COMPREPLY" = off ]
 
+echo "Test exec --env completion"
+export OBSCURE_ENVIRONMENT_VARIABLE_WITH_NO_SHARED_PREFIX=1
+do_complete workshop exec --env OBSCURE_ENVIRONMENT_VARIABLE_WITH_NO_SHARED_PR
+[ "$COMPREPLY" = 'OBSCURE_ENVIRONMENT_VARIABLE_WITH_NO_SHARED_PREFIX' ]
+
 echo "Test connect completion"
 do_complete workshop connect w
 [ "$COMPREPLY" = 'ws-comp/test-sdk-desktop:desktop' ]


### PR DESCRIPTION
# Description

Only just realised this was missing.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
