### PR TITLE
Workaround snapd.service delaying workshop stop

### DIFF
--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1327,6 +1327,12 @@ ssh_genkeytypes: [ed25519]
 write_files:
   - path: /etc/cloud/cloud-init.disabled
     defer: true
+  # Workaround https://bugs.launchpad.net/snapd/+bug/2165972. Without network
+  # access snapd retries certain HTTP requests a few times before timing out.
+  - path: /etc/systemd/system/snapd.service.d/70-snapd-after-network.conf
+    content: |
+      [Unit]
+      After=network.target
   - path: /etc/ssh/sshd_config.d/90-workshop.conf
     content: |
       HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub

--- a/internal/workshop/lxd/lxd_backend_snapshots.go
+++ b/internal/workshop/lxd/lxd_backend_snapshots.go
@@ -828,7 +828,7 @@ func (s *Backend) snapshotClients(ctx context.Context) (lxd.InstanceServer, lxd.
 // replay some of the install-sdk and setup-base tasks. These can be handled in
 // the same way as in-progress launches and refreshes.
 func (s *Backend) FormatRevision() sdk.Revision {
-	return sdk.R(11)
+	return sdk.R(12)
 }
 
 func (s *Backend) HashSnapshot(snapshot workshop.Snapshot) (string, error) {

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -15,7 +15,7 @@ launched:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
+    cloud-init.user-data: '39f9fef0b483808013efecff454d897974b8d7c7a403a9cebd2a497aaac55a76f6ed6c9a4c5dae1c0384c9ec326811d1'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -55,7 +55,7 @@ started:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
+    cloud-init.user-data: '39f9fef0b483808013efecff454d897974b8d7c7a403a9cebd2a497aaac55a76f6ed6c9a4c5dae1c0384c9ec326811d1'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -95,7 +95,7 @@ sdk-attached:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
+    cloud-init.user-data: '39f9fef0b483808013efecff454d897974b8d7c7a403a9cebd2a497aaac55a76f6ed6c9a4c5dae1c0384c9ec326811d1'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -147,7 +147,7 @@ sdk-mounted:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: '17fd6f33c4c2802b0142eefe3d41d4f98b1c0ce338ce06da2b3e6d06776ac3c2204ed2cc7c6c367d40cdfc6e11d82e6a'
+    cloud-init.user-data: '39f9fef0b483808013efecff454d897974b8d7c7a403a9cebd2a497aaac55a76f6ed6c9a4c5dae1c0384c9ec326811d1'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''


### PR DESCRIPTION
# Description

See https://bugs.launchpad.net/snapd/+bug/2165972. Without network access, snapd gets stuck retrying HTTP requests.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
