### PR TITLE
Add workshop identity to workshopctl requests

### DIFF
--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -104,7 +104,7 @@ var api = []*Command{{
 	Path:        "/v1/workshopctl",
 	UserOK:      true,
 	UntrustedOK: true,
-	POST:        v1PostWorkshopCtl,
+	POST:        withWorkshopInstanceID(v1PostWorkshopCtl),
 },
 }
 

--- a/internal/daemon/api_request.go
+++ b/internal/daemon/api_request.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+// workshopInstanceIDHeader identifies the workshop instance from which an API
+// request originated.
+const workshopInstanceIDHeader = "workshop-instance-id"
+
+// withWorkshopInstanceID returns a response function that adds the workshop
+// instance ID header value to the request context when the header is present,
+// then calls next.
+func withWorkshopInstanceID(next ResponseFunc) ResponseFunc {
+	return func(c *Command, r *http.Request, user *userState) Response {
+		instanceID := r.Header.Get(workshopInstanceIDHeader)
+		if instanceID != "" {
+			ctx := context.WithValue(
+				r.Context(),
+				workshop.ContextWorkshopInstanceID,
+				instanceID,
+			)
+			r = r.WithContext(ctx)
+		}
+
+		return next(c, r, user)
+	}
+}

--- a/internal/daemon/api_request_test.go
+++ b/internal/daemon/api_request_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+type apiRequestSuite struct{}
+
+var _ = check.Suite(&apiRequestSuite{})
+
+// TestWithWorkshopInstanceIDAddsIDToContext checks that the middleware copies
+// the workshop instance ID header into the request context before calling the
+// next response function. It asserts that the next function's response is
+// returned and that the context contains the header value.
+func (apiRequestSuite) TestWithWorkshopInstanceIDAddsIDToContext(c *check.C) {
+	request := httptest.NewRequest(http.MethodPost, "/v1/workshopctl", nil)
+	request.Header.Set(workshopInstanceIDHeader, "instance-id")
+
+	var instanceID string
+	next := func(_ *Command, request *http.Request, _ *userState) Response {
+		instanceID, _ = request.Context().
+			Value(workshop.ContextWorkshopInstanceID).(string)
+		return nil
+	}
+
+	response := withWorkshopInstanceID(next)(nil, request, nil)
+
+	c.Check(response, check.IsNil)
+	c.Check(instanceID, check.Equals, "instance-id")
+}
+
+// TestWithWorkshopInstanceIDLeavesContextUnsetWithoutHeader checks that the
+// middleware calls the next response function without adding a workshop
+// instance ID when the header is absent. It asserts that the next function's
+// response is returned and that the context value remains unset.
+func (apiRequestSuite) TestWithWorkshopInstanceIDLeavesContextUnsetWithoutHeader(
+	c *check.C,
+) {
+	request := httptest.NewRequest(http.MethodPost, "/v1/workshopctl", nil)
+
+	var instanceID any
+	next := func(_ *Command, request *http.Request, _ *userState) Response {
+		instanceID = request.Context().Value(workshop.ContextWorkshopInstanceID)
+		return nil
+	}
+
+	response := withWorkshopInstanceID(next)(nil, request, nil)
+
+	c.Check(response, check.IsNil)
+	c.Check(instanceID, check.IsNil)
+}
+
+// TestWithWorkshopInstanceIDCallsNextWithHeader checks that the middleware
+// calls the next response function and returns its response when the workshop
+// instance ID header is present.
+func (apiRequestSuite) TestWithWorkshopInstanceIDCallsNextWithHeader(c *check.C) {
+	command := &Command{}
+	request := httptest.NewRequest(http.MethodPost, "/v1/workshopctl", nil)
+	request.Header.Set(workshopInstanceIDHeader, "instance-id")
+	user := &userState{}
+	expected := SyncResponse(nil, http.StatusAccepted)
+
+	called := false
+	next := func(
+		actualCommand *Command,
+		_ *http.Request,
+		actualUser *userState,
+	) Response {
+		called = true
+		c.Check(actualCommand, check.Equals, command)
+		c.Check(actualUser, check.Equals, user)
+		return expected
+	}
+
+	response := withWorkshopInstanceID(next)(command, request, user)
+
+	c.Check(called, check.Equals, true)
+	c.Check(response, check.Equals, expected)
+}
+
+// TestWithWorkshopInstanceIDCallsNextWithoutHeader checks that the middleware
+// calls the next response function and returns its response when the workshop
+// instance ID header is absent.
+func (apiRequestSuite) TestWithWorkshopInstanceIDCallsNextWithoutHeader(c *check.C) {
+	command := &Command{}
+	request := httptest.NewRequest(http.MethodPost, "/v1/workshopctl", nil)
+	user := &userState{}
+	expected := SyncResponse(nil, http.StatusAccepted)
+
+	called := false
+	next := func(
+		actualCommand *Command,
+		actualRequest *http.Request,
+		actualUser *userState,
+	) Response {
+		called = true
+		c.Check(actualCommand, check.Equals, command)
+		c.Check(actualRequest, check.Equals, request)
+		c.Check(actualUser, check.Equals, user)
+		return expected
+	}
+
+	response := withWorkshopInstanceID(next)(command, request, user)
+
+	c.Check(called, check.Equals, true)
+	c.Check(response, check.Equals, expected)
+}

--- a/internal/daemon/snapshot-ingredients.yaml
+++ b/internal/daemon/snapshot-ingredients.yaml
@@ -19,6 +19,7 @@ SdkRecord:
 Workshop:
   Backend:
   Project: workshop.Project
+  InstanceID: string
   File: '*workshop.File'
   Name: string
   Format: sdk.Revision

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -38,8 +38,8 @@ type ContextKeyUser string
 type ContextKeyWorkshopInstanceID string
 
 const (
-	ContextProjectId          = ContextKeyProjectId("project-id")
-	ContextUser               = ContextKeyUser("user")
+	ContextProjectId = ContextKeyProjectId("project-id")
+	ContextUser      = ContextKeyUser("user")
 	// ContextWorkshopInstanceID stores the identifier of the workshop instance
 	// from which a request originated.
 	ContextWorkshopInstanceID = ContextKeyWorkshopInstanceID("workshop-instance-id")

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -247,6 +247,10 @@ type Backend interface {
 	// has a username key that the corresponding projects belong to.
 	Projects(ctx context.Context) (map[string][]Project, error)
 
+	// Returns the projects belonging to the user in context. If the context
+	// does not contain a user, it returns an empty slice.
+	UserProjects(ctx context.Context) ([]Project, error)
+
 	// Loads a workshop instance.
 	Workshop(ctx context.Context, name string) (*Workshop, error)
 

--- a/internal/workshop/backend.go
+++ b/internal/workshop/backend.go
@@ -35,10 +35,14 @@ import (
 
 type ContextKeyProjectId string
 type ContextKeyUser string
+type ContextKeyWorkshopInstanceID string
 
 const (
-	ContextProjectId = ContextKeyProjectId("project-id")
-	ContextUser      = ContextKeyUser("user")
+	ContextProjectId          = ContextKeyProjectId("project-id")
+	ContextUser               = ContextKeyUser("user")
+	// ContextWorkshopInstanceID stores the identifier of the workshop instance
+	// from which a request originated.
+	ContextWorkshopInstanceID = ContextKeyWorkshopInstanceID("workshop-instance-id")
 
 	Uid = 1000
 	Gid = 1000

--- a/internal/workshop/fakebackend/backend.go
+++ b/internal/workshop/fakebackend/backend.go
@@ -193,9 +193,21 @@ func (s *FakeWorkshopBackend) CreateOrLoadProject(ctx context.Context, path stri
 func (f *FakeWorkshopBackend) Projects(ctx context.Context) (map[string][]workshop.Project, error) {
 	userName, ok := ctx.Value(workshop.ContextUser).(string)
 	if ok {
-		return map[string][]workshop.Project{userName: f.projects[userName]}, nil
+		projects, err := f.UserProjects(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return map[string][]workshop.Project{userName: projects}, nil
 	}
 	return maps.Clone(f.projects), nil
+}
+
+func (f *FakeWorkshopBackend) UserProjects(ctx context.Context) ([]workshop.Project, error) {
+	userName, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok {
+		return nil, nil
+	}
+	return slices.Clone(f.projects[userName]), nil
 }
 
 func (f *FakeWorkshopBackend) project(user, id string) *workshop.Project {

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -51,6 +51,10 @@ const (
 	storagePool           = "workshop"
 	storagePoolMinimalGiB = 5
 
+	// instanceUUIDConfigKey identifies the LXD configuration value used to
+	// derive the workshop's machine ID.
+	instanceUUIDConfigKey = "volatile.uuid"
+
 	networkName = "workshopbr0"
 	networkType = "bridge"
 
@@ -1063,17 +1067,24 @@ func (b *Backend) loadWorkshop(conn lxd.InstanceServer, inst *api.Instance, p wo
 	hostname := b.hostname(f.Name, p, running, cnames)
 
 	return &workshop.Workshop{
-		Backend:  b,
-		Project:  p,
-		Name:     f.Name,
-		Format:   format,
-		Image:    image,
-		Running:  running,
-		Sdks:     sdks,
-		Profiles: profs,
-		File:     f,
-		Hostname: hostname,
+		Backend:    b,
+		Project:    p,
+		InstanceID: instanceIDFromLXDUUID(inst.Config[instanceUUIDConfigKey]),
+		Name:       f.Name,
+		Format:     format,
+		Image:      image,
+		Running:    running,
+		Sdks:       sdks,
+		Profiles:   profs,
+		File:       f,
+		Hostname:   hostname,
 	}, nil
+}
+
+// instanceIDFromLXDUUID converts an LXD instance UUID to the identifier
+// written to the workshop's machine ID file.
+func instanceIDFromLXDUUID(uuid string) string {
+	return strings.ReplaceAll(uuid, "-", "")
 }
 
 func (s *Backend) hostname(name string, p workshop.Project, running bool, cnames []cname) workshop.Hostname {

--- a/internal/workshop/lxd/lxd_backend_dns.go
+++ b/internal/workshop/lxd/lxd_backend_dns.go
@@ -83,7 +83,7 @@ func (s *Backend) addWorkshopCNAMEs(conn lxd.InstanceServer, ctx context.Context
 	}
 
 	// Call this before locking because it might prune the dnsmasq config.
-	projects, err := s.userProjects(ctx)
+	projects, err := s.UserProjects(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/workshop/lxd/lxd_backend_project.go
+++ b/internal/workshop/lxd/lxd_backend_project.go
@@ -169,7 +169,7 @@ func (s *Backend) CreateOrLoadProject(ctx context.Context, path string) (*worksh
 
 func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, error) {
 	if user, ok := ctx.Value(workshop.ContextUser).(string); ok {
-		projects, err := s.userProjects(ctx)
+		projects, err := s.UserProjects(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +203,7 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, 
 		}
 
 		prjctx := context.WithValue(ctx, workshop.ContextUser, username)
-		projects, err := s.userProjects(prjctx)
+		projects, err := s.UserProjects(prjctx)
 		if err != nil {
 			return nil, err
 		}
@@ -213,7 +213,11 @@ func (s *Backend) Projects(ctx context.Context) (map[string][]workshop.Project, 
 	return allProjects, nil
 }
 
-func (s *Backend) userProjects(ctx context.Context) ([]workshop.Project, error) {
+func (s *Backend) UserProjects(ctx context.Context) ([]workshop.Project, error) {
+	if _, ok := ctx.Value(workshop.ContextUser).(string); !ok {
+		return nil, nil
+	}
+
 	client, err := s.LxdClient(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -240,6 +240,28 @@ func fullInstance(c *check.C, conn lxd.InstanceServer, name string) *api.Instanc
 	return inst
 }
 
+// TestLxdBackendWorkshopInstanceID checks that loading a workshop exposes the
+// LXD instance UUID in the same normalized form written to its machine ID file.
+func (f *wsOps) TestLxdBackendWorkshopInstanceID(c *check.C) {
+	helper.LaunchTestWorkshop(c, f.ctx, f.bd, f.project.Path)
+	defer helper.RemoveTestWorkshop(c, f.ctx, f.bd)
+
+	loaded, err := f.bd.Workshop(f.ctx, "test")
+	c.Assert(err, check.IsNil)
+
+	conn, err := f.bd.LxdClient(f.ctx)
+	c.Assert(err, check.IsNil)
+	defer conn.Disconnect()
+
+	inst, _, err := conn.GetInstance(
+		lxdbackend.InstanceName("test", f.project.ProjectId),
+	)
+	c.Assert(err, check.IsNil)
+	expected := strings.ReplaceAll(inst.Config["volatile.uuid"], "-", "")
+
+	c.Check(loaded.InstanceID, check.Equals, expected)
+}
+
 func includeWhenCopying(key string) bool {
 	if strings.HasPrefix(key, "user.ed25519-key.") {
 		return false

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -69,7 +69,14 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 	f.bd, err = lxdbackend.New()
 	c.Assert(err, check.IsNil)
 
-	f.usr = &user.User{Username: "testuser", Uid: "1000", Gid: "1000", HomeDir: c.MkDir()}
+	currentUser, err := user.Current()
+	c.Assert(err, check.IsNil)
+	f.usr = &user.User{
+		Username: "testuser",
+		Uid:      currentUser.Uid,
+		Gid:      currentUser.Gid,
+		HomeDir:  c.MkDir(),
+	}
 	f.project = workshop.Project{
 		ProjectId: "42424242",
 		Path:      filepath.Join(c.MkDir(), "testprj"),

--- a/internal/workshop/lxd/tests/integration/workshop_test.go
+++ b/internal/workshop/lxd/tests/integration/workshop_test.go
@@ -71,10 +71,19 @@ func (f *wsOps) SetUpSuite(c *check.C) {
 
 	currentUser, err := user.Current()
 	c.Assert(err, check.IsNil)
+	uid := currentUser.Uid
+	gid := currentUser.Gid
+	// Spread runs integration tests as root, but mapping host root into an
+	// unprivileged instance prevents LXD from starting it. Retain the historical
+	// test IDs for root while allowing non-root developers to use their own IDs.
+	if os.Geteuid() == 0 {
+		uid = workshop.User.Uid
+		gid = workshop.User.Gid
+	}
 	f.usr = &user.User{
 		Username: "testuser",
-		Uid:      currentUser.Uid,
-		Gid:      currentUser.Gid,
+		Uid:      uid,
+		Gid:      gid,
 		HomeDir:  c.MkDir(),
 	}
 	f.project = workshop.Project{

--- a/internal/workshop/workshop.go
+++ b/internal/workshop/workshop.go
@@ -47,6 +47,9 @@ var InstallTimeNow = time.Now
 type Workshop struct {
 	Backend Backend
 	Project Project
+	// InstanceID uniquely identifies the running backend instance. It is used
+	// to associate requests originating inside the workshop with this record.
+	InstanceID string
 	// Workshop file that was used to launch it; it may be out of sync with the
 	// file in the project directory due to user's edits, etc.
 	File    *File


### PR DESCRIPTION
# Description

Lay the groundwork for associating workshopctl requests with the workshop instance from which they originated.

Add user-scoped project lookup to workshop backends and expose the LXD instance UUID on loaded workshop metadata. The UUID is normalized to match the value written to `/etc/machine-id`.

Add request middleware that copies the optional `workshop-instance-id` header into the request context, and apply it to the workshopctl endpoint.

This change only propagates workshop identity. Validation of the supplied instance ID will be added separately.

## LXD integration test identity

Update the LXD integration fixture to use the test runner's numeric UID and GID rather than assuming both are `1000`. Workshop instance configuration uses these values in `raw.idmap` to map the owning host user to the fixed workshop user inside the container.

The previous fixture worked only on hosts where the test runner happened to use UID and GID `1000`. On other hosts, those IDs can belong to different accounts or groups, causing LXD container creation to fail with `operation not permitted`. Using `user.Current()` makes the mapping represent the user actually running the test while retaining the synthetic `testuser` name and isolated LXD project. This is a test portability fix and does not change production identity handling.

## Testing

- `go test ./internal/workshop/fakebackend ./internal/workshop/lxd ./internal/overlord/workshopstate`
- `go test ./internal/daemon -check.f TestWithWorkshopInstanceID`
- `go test -v -tags integration ./internal/workshop/lxd/tests/integration -check.v -check.f TestLxdBackendWorkshopInstanceID`

## Docs

- [x] I confirm the PR has no implications for documentation.