### PR TITLE
Filter waitready signals by name

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   documentation-checks:
-    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@aaeaf091e8f55145184ad897cb9834f224bd31de # main
+    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@309dd382b6a07cbd23d84e3912fb05e6bc1f4ffb # main
     with:
       working-directory: "docs"
       fetch-depth: 0

--- a/.github/workflows/automatic-tests.yaml
+++ b/.github/workflows/automatic-tests.yaml
@@ -27,12 +27,12 @@ jobs:
   # Call spread and unit tests as reusable workflows. This is the most
   # dependable method by which to share the artifacts
   spread:
-    uses: ./.github/workflows/spread.yaml
+    uses: $/.github/workflows/spread.yaml
     secrets:
       STORE_CREDENTIALS: ${{ secrets.STORE_CREDENTIALS }}
       SDKCRAFT_STORE_CREDENTIALS: ${{ secrets.SDKCRAFT_STORE_CREDENTIALS_PROD }}
   unit-tests:
-    uses: ./.github/workflows/unit-tests.yaml
+    uses: $/.github/workflows/unit-tests.yaml
 
   code-coverage:
     needs: [spread, unit-tests]

--- a/.github/workflows/lxd-candidate-check.yaml
+++ b/.github/workflows/lxd-candidate-check.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   spread:
-    uses: ./.github/workflows/spread.yaml
+    uses: $/.github/workflows/spread.yaml
     with:
       lxd_channel: 6/candidate
     secrets:

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build-deps:
-    uses: ./.github/workflows/build-deps.yaml
+    uses: $/.github/workflows/build-deps.yaml
     secrets:
       SDKCRAFT_STORE_CREDENTIALS: ${{ secrets.SDKCRAFT_STORE_CREDENTIALS }}
   snap-tests:

--- a/internal/waitready/waitready.go
+++ b/internal/waitready/waitready.go
@@ -54,6 +54,10 @@ func WaitReady() error {
 	}
 	defer server.Disconnect()
 
+	if err := server.UpdateState(api.DevLXDPut{State: api.Started.String()}); err != nil {
+		return err
+	}
+
 	if err := waitReady(ctx); err != nil {
 		return err
 	}

--- a/internal/waitready/waitready.go
+++ b/internal/waitready/waitready.go
@@ -75,7 +75,7 @@ func waitReady(ctx context.Context) error {
 	}
 	defer conn.Close()
 
-	signal := make(chan *dbus.Signal, 1)
+	signal := make(chan *dbus.Signal, 8)
 	conn.Signal(signal)
 
 	options := []dbus.MatchOption{
@@ -98,11 +98,20 @@ func waitReady(ctx context.Context) error {
 	if ready {
 		return nil
 	}
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-signal:
-		return nil
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case sig := <-signal:
+			if sig == nil {
+				return errors.New("bus connection closed unexpectedly")
+			}
+			if sig.Name != "org.freedesktop.systemd1.Manager.StartupFinished" {
+				continue
+			}
+			return nil
+		}
 	}
 }
 

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -714,11 +714,12 @@ func (s *Backend) awaitReadyEvent(conn lxd.InstanceServer, ctx context.Context, 
 	defer listener.Disconnect()
 
 	events := make(chan api.Event, 1)
-	defer close(events)
 
 	target, err := listener.AddHandler([]string{"lifecycle"}, func(event api.Event) {
-		defer func() { _ = recover() }()
-		events <- event
+		select {
+		case events <- event:
+		case <-ctx.Done():
+		}
 	})
 	if err != nil {
 		return err

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -1381,6 +1381,8 @@ write_files:
     content: |
       [Unit]
       Description=Signal workshop readiness to LXD
+      After=dbus.socket
+      Requires=dbus.socket
 
       [Service]
       Type=notify

--- a/internal/workshop/lxd/lxd_backend.go
+++ b/internal/workshop/lxd/lxd_backend.go
@@ -713,7 +713,7 @@ func (s *Backend) awaitReadyEvent(conn lxd.InstanceServer, ctx context.Context, 
 	}
 	defer listener.Disconnect()
 
-	events := make(chan api.Event, 1)
+	events := make(chan api.Event, 16)
 
 	target, err := listener.AddHandler([]string{"lifecycle"}, func(event api.Event) {
 		select {

--- a/internal/workshop/lxd/tests/integration/snapshot-format.yaml
+++ b/internal/workshop/lxd/tests/integration/snapshot-format.yaml
@@ -15,7 +15,7 @@ launched:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'b2a2ea09a7e8433b710b86768b90e96e0040cfc47aa8d0a8bf50544c208faa970657e6c0c8fa92f2c051e85962b54b98'
+    cloud-init.user-data: '4cf587533327b22c997544bfaade54d028486c2ca359810fb8d2c66e87e0e7e2b7a20176b1c31284edd4cd28ed166780'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -55,7 +55,7 @@ started:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'b2a2ea09a7e8433b710b86768b90e96e0040cfc47aa8d0a8bf50544c208faa970657e6c0c8fa92f2c051e85962b54b98'
+    cloud-init.user-data: '4cf587533327b22c997544bfaade54d028486c2ca359810fb8d2c66e87e0e7e2b7a20176b1c31284edd4cd28ed166780'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -95,7 +95,7 @@ sdk-attached:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'b2a2ea09a7e8433b710b86768b90e96e0040cfc47aa8d0a8bf50544c208faa970657e6c0c8fa92f2c051e85962b54b98'
+    cloud-init.user-data: '4cf587533327b22c997544bfaade54d028486c2ca359810fb8d2c66e87e0e7e2b7a20176b1c31284edd4cd28ed166780'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''
@@ -147,7 +147,7 @@ sdk-mounted:
       gid 1000 1000
     raw.lxc: lxc.mount.entry = tmpfs tmp tmpfs defaults
     security.nesting: 'true'
-    cloud-init.user-data: 'b2a2ea09a7e8433b710b86768b90e96e0040cfc47aa8d0a8bf50544c208faa970657e6c0c8fa92f2c051e85962b54b98'
+    cloud-init.user-data: '4cf587533327b22c997544bfaade54d028486c2ca359810fb8d2c66e87e0e7e2b7a20176b1c31284edd4cd28ed166780'
     user.workshop.name: test
     user.workshop.project-id: '42424242'
   description: ''


### PR DESCRIPTION
# Description

Fixes an issue where the waitready service exited early, which may be the cause of this flakiness: https://github.com/canonical/workshop/actions/runs/33814683980/job/100845883962.

I added some logging before the `continue` and observed this in the logs, which confirms there was an issue before:
```
Sep 07 10:14:32 one systemd[1]: Starting workshop-waitready.service - Signal workshop readiness to LXD...
Sep 07 10:14:32 one waitready[262]: spurious signal: org.freedesktop.DBus.NameAcquired
Sep 07 10:14:32 one systemd[1]: Started workshop-waitready.service - Signal workshop readiness to LXD.
Sep 07 10:14:33 one systemd[1]: workshop-waitready.service: Deactivated successfully.
```

Luckily we should still be OK to start 0.9.5 and 0.9.6 workshops, because the fix is contained to `workshopctl` and not cloud-init.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
