### PR TITLE
Fix zizmor issues

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   documentation-checks:
-    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@aaeaf091e8f55145184ad897cb9834f224bd31de # main
+    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@309dd382b6a07cbd23d84e3912fb05e6bc1f4ffb # main
     with:
       working-directory: "docs"
       fetch-depth: 0

--- a/.github/workflows/automatic-tests.yaml
+++ b/.github/workflows/automatic-tests.yaml
@@ -27,12 +27,12 @@ jobs:
   # Call spread and unit tests as reusable workflows. This is the most
   # dependable method by which to share the artifacts
   spread:
-    uses: ./.github/workflows/spread.yaml
+    uses: $/.github/workflows/spread.yaml
     secrets:
       STORE_CREDENTIALS: ${{ secrets.STORE_CREDENTIALS }}
       SDKCRAFT_STORE_CREDENTIALS: ${{ secrets.SDKCRAFT_STORE_CREDENTIALS_PROD }}
   unit-tests:
-    uses: ./.github/workflows/unit-tests.yaml
+    uses: $/.github/workflows/unit-tests.yaml
 
   code-coverage:
     needs: [spread, unit-tests]

--- a/.github/workflows/lxd-candidate-check.yaml
+++ b/.github/workflows/lxd-candidate-check.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   spread:
-    uses: ./.github/workflows/spread.yaml
+    uses: $/.github/workflows/spread.yaml
     with:
       lxd_channel: 6/candidate
     secrets:

--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build-deps:
-    uses: ./.github/workflows/build-deps.yaml
+    uses: $/.github/workflows/build-deps.yaml
     secrets:
       SDKCRAFT_STORE_CREDENTIALS: ${{ secrets.SDKCRAFT_STORE_CREDENTIALS }}
   snap-tests:


### PR DESCRIPTION
# Description

See https://github.com/canonical/workshop/actions/runs/34077934758/job/101607587001.

Switch to the new GitHub syntax for "this repo." It avoids an issue where the workflow can overwrite the `workflow.yaml` files before they are loaded.

Update the `documentation-workflows` hash. This won't fix the issue for good, but it doesn't seem like renovate has been bumping it so zizmor can serve as a reminder to update it manually.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
