### PR TITLE
Subscribe to systemd signals before waiting for StartupFinished

### DIFF
--- a/internal/waitready/waitready.go
+++ b/internal/waitready/waitready.go
@@ -90,7 +90,12 @@ func waitReady(ctx context.Context) error {
 		return err
 	}
 
-	ready, err := isReady(conn)
+	manager := conn.Object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+	if err := manager.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.Subscribe", 0).Err; err != nil {
+		return err
+	}
+
+	ready, err := isReady(manager)
 	if err != nil {
 		return err
 	}
@@ -119,8 +124,7 @@ func waitReady(ctx context.Context) error {
 	}
 }
 
-func isReady(conn *dbus.Conn) (bool, error) {
-	manager := conn.Object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+func isReady(manager dbus.BusObject) (bool, error) {
 	variant, err := manager.GetProperty("org.freedesktop.systemd1.Manager.SystemState")
 	if err != nil {
 		return false, err


### PR DESCRIPTION
# Description

According to `org.freedesktop.systemd1(5)`:

> Signals are only sent out if at least one client invoked this method.

In most cases we were able to get away with this, but occasionally an Ubuntu 20.04 VM would time out waiting to start, when running inside a spread VM on a GitHub runner. After testing a few runs with this patch, the problem has gone away. Hopefully this is the last bug we'll see in `waitready`.

# Self-review quick check

 * [x] Make decisions that cost a lot to reverse explicit in the PR description.
 * [x] Avoid nested conditions.
 * [x] Delete dead code and redundant comments.
 * [x] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [x] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [x] Put variable declaration and initialisation together.
 * [x] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [x] Put a blank line between two logically different chunks of code.
 * [x] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [x] I confirm the PR has no implications for documentation.
