### PR TITLE
Add task-backed secret retrieval for workshopctl

### DIFF
--- a/internal/daemon/api_workshopctl_test.go
+++ b/internal/daemon/api_workshopctl_test.go
@@ -107,6 +107,10 @@ func (s *apiSuite) TestWorkshopCtlRejectsUnknownInstanceID(c *check.C) {
 func (s *apiSuite) TestWorkshopCtlAcceptsOwnedInstanceID(c *check.C) {
 	s.daemon(c)
 	s.addWorkshopWithInstanceID("instance-id")
+	s.d.overlord.Loop()
+	defer func() {
+		c.Check(s.d.overlord.Stop(), check.IsNil)
+	}()
 
 	wctl := apiCmd("/v1/workshopctl")
 	buf := bytes.NewBufferString(

--- a/internal/overlord/hookstate/ctlcmd/getsecret.go
+++ b/internal/overlord/hookstate/ctlcmd/getsecret.go
@@ -16,8 +16,14 @@ package ctlcmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/canonical/workshop/internal/logger"
+	"github.com/canonical/workshop/internal/overlord/secretstate"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
 type getSecretCommand struct {
@@ -30,10 +36,6 @@ type getSecretPositional struct {
 }
 
 const (
-	// hardCodedSecret is a placeholder secret value returned until secret
-	// resolution via workshopd is implemented.
-	hardCodedSecret = "workshop-placeholder-secret"
-
 	longGetSecretHelp = `
 The get-secret command retrieves the value of a secret connected to the
 workshop, identified as "<SDK>.<secret>" (e.g. "my-sdk.api-key").
@@ -53,12 +55,68 @@ func init() {
 	)
 }
 
-// Execute runs the get-secret command, writing the secret value to stdout.
-func (c *getSecretCommand) Execute(context.Context, []string) error {
-	// Log the requested identifier only; never the resolved value.
-	logger.Debugf("get-secret request for %q", c.Secret)
+// parseSecretIdentifier splits an SDK-qualified secret plug identifier into
+// its SDK and plug names.
+func parseSecretIdentifier(identifier string) (sdkName, plugName string, err error) {
+	sdkName, plugName, found := strings.Cut(identifier, ".")
 
-	// TODO: resolve the requested secret via workshopd instead of
-	// returning a hard-coded value.
-	return c.printf("%s", hardCodedSecret)
+	if !found || sdkName == "" || plugName == "" {
+		return "", "", errors.New(
+			`invalid secret identifier: expected "<SDK>.<secret>" with both names present`,
+		)
+	}
+	err = sdk.ValidateName(sdkName)
+	if err != nil {
+		return "", "", fmt.Errorf(
+			"invalid SDK name: expected at most %d characters using "+
+				"lowercase letters, digits and single internal hyphens, "+
+				"with at least one letter; the name agent and prefixes "+
+				"try- and project- are reserved",
+			sdk.MAX_SDK_NAME_LENGTH,
+		)
+	}
+	err = sdk.ValidatePlugName(plugName)
+	if err != nil {
+		return "", "", errors.New(
+			"invalid secret plug name: expected a lowercase letter " +
+				"followed by lowercase letters or digits, optionally " +
+				"separated by single hyphens",
+		)
+	}
+	return sdkName, plugName, nil
+}
+
+// Execute runs the get-secret command, writing the secret value to stdout.
+func (c *getSecretCommand) Execute(ctx context.Context, _ []string) error {
+	sdkName, plugName, err := parseSecretIdentifier(c.Secret)
+	if err != nil {
+		return err
+	}
+
+	// Log the requested identifier only; never the resolved value.
+	logger.Debugf("get-secret request for SDK %q plug %q", sdkName, plugName)
+
+	hookContext, err := c.ensureContext()
+	if err != nil {
+		return err
+	}
+
+	// TODO: use the validated workshop identity before enabling real providers.
+	project := workshop.Project{
+		Path:      "/project",
+		ProjectId: "placeholder-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      plugName,
+		ProjectId: project.ProjectId,
+		Sdk:       sdkName,
+		Workshop:  "placeholder-workshop",
+	}
+
+	value, err := secretstate.GetSecret(ctx, hookContext.State(), project, ref)
+
+	if err != nil {
+		return err
+	}
+	return c.printf("%s", value)
 }

--- a/internal/overlord/hookstate/ctlcmd/getsecret_test.go
+++ b/internal/overlord/hookstate/ctlcmd/getsecret_test.go
@@ -16,37 +16,247 @@ package ctlcmd_test
 
 import (
 	"context"
+	"errors"
+	"strings"
+	"time"
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/workshop/internal/overlord/hookstate"
 	"github.com/canonical/workshop/internal/overlord/hookstate/ctlcmd"
+	"github.com/canonical/workshop/internal/overlord/secretstate"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/workshop"
 )
 
-// getSecretSuite tests the get-secret workshopctl command, which currently
-// returns a hard-coded placeholder secret value.
-type getSecretSuite struct{}
+// getSecretResult carries command output back from the request goroutine.
+type getSecretResult struct {
+	err    error
+	stderr []byte
+	stdout []byte
+}
+
+// getSecretSuite tests secret retrieval through the state task runner.
+type getSecretSuite struct {
+	backend *secretStateBackend
+	hookCtx *hookstate.Context
+	runner  *state.TaskRunner
+	st      *state.State
+}
 
 var _ = check.Suite(&getSecretSuite{})
 
-func (s *getSecretSuite) TestGetSecret(c *check.C) {
-	stdout, stderr, err := ctlcmd.Run(context.TODO(), nil, []string{"get-secret", "ollama.ollama-api-key"}, 0)
+// checkSuccess verifies the scheduled identity and returned secret value.
+func (s *getSecretSuite) checkSuccess(
+	c *check.C,
+	results <-chan getSecretResult,
+	sdkName string,
+	plugName string,
+) {
+	delay := <-s.backend.ensureBefore
+	c.Check(delay, check.Equals, time.Duration(0))
+	err := s.runner.Ensure()
 	c.Assert(err, check.IsNil)
-	c.Check(string(stdout), check.Equals, "workshop-placeholder-secret")
-	c.Check(string(stderr), check.Equals, "")
+	s.runner.Wait()
+	result := <-results
+	c.Assert(result.err, check.IsNil)
+	c.Check(string(result.stdout), check.Equals, "workshop-placeholder-secret")
+	c.Check(string(result.stderr), check.Equals, "")
+
+	s.st.Lock()
+	defer s.st.Unlock()
+	changes := s.st.Changes()
+	c.Assert(changes, check.HasLen, 1)
+	change := changes[0]
+	c.Check(change.Kind(), check.Equals, "get-secret")
+	var user, projectID string
+	c.Assert(change.Get("user", &user), check.IsNil)
+	c.Check(user, check.Equals, "test-user")
+	c.Assert(change.Get("project-id", &projectID), check.IsNil)
+	c.Check(projectID, check.Equals, "placeholder-project")
+	tasks := change.Tasks()
+	c.Assert(tasks, check.HasLen, 1)
+	task := tasks[0]
+	c.Check(task.Kind(), check.Equals, "get-secret")
+	c.Check(task.Status(), check.Equals, state.DoneStatus)
+	var project workshop.Project
+	c.Assert(task.Get("project", &project), check.IsNil)
+	c.Check(project, check.DeepEquals, workshop.Project{
+		Path:      "/project",
+		ProjectId: "placeholder-project",
+	})
+	var actualSDK, actualPlug, workshopName string
+	c.Assert(task.Get("sdk", &actualSDK), check.IsNil)
+	c.Check(actualSDK, check.Equals, sdkName)
+	c.Assert(task.Get("plug", &actualPlug), check.IsNil)
+	c.Check(actualPlug, check.Equals, plugName)
+	c.Assert(task.Get("workshop", &workshopName), check.IsNil)
+	c.Check(workshopName, check.Equals, "placeholder-workshop")
+
+}
+
+// SetUpTest wires a real hook context and secret task handler.
+func (s *getSecretSuite) SetUpTest(c *check.C) {
+	s.backend = &secretStateBackend{
+		ensureBefore: make(chan time.Duration, 1),
+	}
+	s.st = state.New(s.backend)
+	s.runner = state.NewTaskRunner(s.st)
+	secretstate.New(s.runner)
+	var err error
+	s.hookCtx, err = hookstate.NewContext(
+		nil,
+		s.st,
+		&hookstate.HookSetup{},
+		nil,
+		"",
+	)
+	c.Assert(err, check.IsNil)
+}
+
+// start runs the command without blocking the test's task runner.
+func (s *getSecretSuite) start(
+	ctx context.Context,
+	identifier string,
+	uid uint32,
+) <-chan getSecretResult {
+	results := make(chan getSecretResult, 1)
+	go func() {
+		stdout, stderr, err := ctlcmd.Run(
+			ctx,
+			s.hookCtx,
+			[]string{"get-secret", identifier},
+			uid,
+		)
+		results <- getSecretResult{err: err, stderr: stderr, stdout: stdout}
+	}()
+	return results
+}
+
+// TearDownTest stops any task handlers before the next case.
+func (s *getSecretSuite) TearDownTest(c *check.C) {
+	s.runner.Stop()
+}
+
+// TestGetSecret checks root requests retrieve and consume the task result.
+func (s *getSecretSuite) TestGetSecret(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	results := s.start(ctx, "ollama.ollama-api-key", 0)
+	s.checkSuccess(c, results, "ollama", "ollama-api-key")
+}
+
+// TestGetSecretCancelled checks request cancellation reaches secretstate
+// without scheduling a task or writing a secret.
+func (s *getSecretSuite) TestGetSecretCancelled(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	cancel()
+
+	result := <-s.start(ctx, "ollama.ollama-api-key", 0)
+	c.Check(errors.Is(result.err, context.Canceled), check.Equals, true)
+	c.Check(string(result.stdout), check.Equals, "")
+	c.Check(string(result.stderr), check.Equals, "")
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), check.HasLen, 0)
+	c.Check(s.backend.ensureBefore, check.HasLen, 0)
+}
+
+// TestGetSecretInvalidFormat checks that a missing separator reports the
+// expected identifier structure without echoing the supplied value.
+func (s *getSecretSuite) TestGetSecretInvalidFormat(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	identifier := "private-identifier"
+
+	_, _, err := ctlcmd.Run(ctx, nil, []string{"get-secret", identifier}, 0)
+
+	c.Assert(err, check.NotNil)
+	c.Check(err.Error(), check.Equals,
+		`invalid secret identifier: expected "<SDK>.<secret>" `+
+			"with both names present")
+	c.Check(strings.Contains(err.Error(), identifier), check.Equals, false)
+}
+
+// TestGetSecretInvalidSDK checks that SDK validation reports naming rules
+// without exposing the rejected SDK or qualified identifier.
+func (s *getSecretSuite) TestGetSecretInvalidSDK(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	identifier := "Private_SDK.api-key"
+
+	_, _, err := ctlcmd.Run(ctx, nil, []string{"get-secret", identifier}, 0)
+
+	c.Assert(err, check.NotNil)
+	c.Check(err.Error(), check.Equals,
+		"invalid SDK name: expected at most 40 characters using "+
+			"lowercase letters, digits and single internal hyphens, "+
+			"with at least one letter; the name agent and prefixes "+
+			"try- and project- are reserved")
+	c.Check(strings.Contains(err.Error(), "Private_SDK"), check.Equals, false)
+}
+
+// TestGetSecretInvalidPlug checks that plug validation reports naming rules
+// without exposing the rejected plug name.
+func (s *getSecretSuite) TestGetSecretInvalidPlug(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	identifier := "ollama.Private_Key"
+
+	_, _, err := ctlcmd.Run(ctx, nil, []string{"get-secret", identifier}, 0)
+
+	c.Assert(err, check.NotNil)
+	c.Check(err.Error(), check.Equals,
+		"invalid secret plug name: expected a lowercase letter "+
+			"followed by lowercase letters or digits, optionally "+
+			"separated by single hyphens")
+	c.Check(strings.Contains(err.Error(), "Private_Key"), check.Equals, false)
 }
 
 // TestGetSecretMissingArg checks that get-secret requires a secret
 // identifier argument.
 func (s *getSecretSuite) TestGetSecretMissingArg(c *check.C) {
-	_, _, err := ctlcmd.Run(context.TODO(), nil, []string{"get-secret"}, 0)
-	c.Check(err, check.ErrorMatches, ".*the required argument `<SDK>.<secret>` was not provided.*")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	_, _, err := ctlcmd.Run(ctx, nil, []string{"get-secret"}, 0)
+	c.Check(err, check.ErrorMatches,
+		".*the required argument `<SDK>.<secret>` was not provided.*")
+}
+
+// TestGetSecretMissingContext checks retrieval requires a hook context.
+func (s *getSecretSuite) TestGetSecretMissingContext(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	stdout, stderr, err := ctlcmd.Run(
+		ctx,
+		nil,
+		[]string{"get-secret", "ollama.ollama-api-key"},
+		0,
+	)
+	c.Check(err, check.FitsTypeOf, &ctlcmd.MissingContextError{})
+	c.Check(string(stdout), check.Equals, "")
+	c.Check(string(stderr), check.Equals, "")
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), check.HasLen, 0)
 }
 
 // TestGetSecretNonRoot checks that get-secret is allowed without root, as
 // both the socket-activated systemd path and SDK wrapper scripts invoke it
 // as the workshop user.
 func (s *getSecretSuite) TestGetSecretNonRoot(c *check.C) {
-	stdout, _, err := ctlcmd.Run(context.TODO(), nil, []string{"get-secret", "ollama.ollama-api-key"}, 1000)
-	c.Assert(err, check.IsNil)
-	c.Check(string(stdout), check.Equals, "workshop-placeholder-secret")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	results := s.start(ctx, "my-sdk.api-key", 1000)
+	s.checkSuccess(c, results, "my-sdk", "api-key")
 }

--- a/internal/overlord/hookstate/ctlcmd/mocks_test.go
+++ b/internal/overlord/hookstate/ctlcmd/mocks_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package ctlcmd_test
+
+import "time"
+
+// secretStateBackend signals task scheduling without persistence or timers.
+type secretStateBackend struct {
+	ensureBefore chan time.Duration
+}
+
+// Checkpoint discards state snapshots for command tests.
+func (b *secretStateBackend) Checkpoint([]byte) error {
+	return nil
+}
+
+// EnsureBefore records a notification without blocking the state lock.
+func (b *secretStateBackend) EnsureBefore(delay time.Duration) {
+	select {
+	case b.ensureBefore <- delay:
+	default:
+	}
+}

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -37,6 +37,7 @@ import (
 	"github.com/canonical/workshop/internal/overlord/patch"
 	"github.com/canonical/workshop/internal/overlord/restart"
 	"github.com/canonical/workshop/internal/overlord/sdkstate"
+	"github.com/canonical/workshop/internal/overlord/secretstate"
 	"github.com/canonical/workshop/internal/overlord/state"
 	"github.com/canonical/workshop/internal/overlord/workshopstate"
 	"github.com/canonical/workshop/internal/sdk"
@@ -86,6 +87,7 @@ type Overlord struct {
 	inited      bool
 	startedUp   bool
 	sdkmgr      *sdkstate.SdkManager
+	secretmgr   secretstate.SecretManager
 	workshopmgr *workshopstate.WorkshopManager
 	hookmgr     *hookstate.HookManager
 	commandmgr  *cmdstate.CommandManager
@@ -167,6 +169,9 @@ func New(dir string, restartHandler restart.Handler) (*Overlord, error) {
 
 	o.sdkmgr = sdkstate.New(s, o.runner, o.ifacemgr.Repository())
 	o.addManager(o.sdkmgr)
+
+	o.secretmgr = secretstate.New(o.runner)
+	o.addManager(o.secretmgr)
 
 	// the shared task runner should be added last!
 	o.stateEng.AddManager(o.runner)
@@ -535,6 +540,11 @@ func (o *Overlord) InterfaceManager() *ifacestate.InterfaceManager {
 
 func (o *Overlord) SdkManager() *sdkstate.SdkManager {
 	return o.sdkmgr
+}
+
+// SecretManager returns the manager responsible for secret operations.
+func (o *Overlord) SecretManager() secretstate.SecretManager {
+	return o.secretmgr
 }
 
 func MockWorkshopBackend(b workshop.Backend) func() {

--- a/internal/overlord/overlord_test.go
+++ b/internal/overlord/overlord_test.go
@@ -110,6 +110,15 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	c.Check(patchSublevel, Equals, 2)
 }
 
+// TestSecretManager checks that a new overlord exposes a usable secret manager.
+func (ovs *overlordSuite) TestSecretManager(c *C) {
+	o, err := overlord.New(ovs.dir, nil)
+	c.Assert(err, IsNil)
+
+	manager := o.SecretManager()
+	c.Check(manager.Ensure(), IsNil)
+}
+
 func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"patch-sublevel-last-version":%q,"some":"data"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, version.Version))
 	err := os.WriteFile(ovs.statePath, fakeState, 0600)

--- a/internal/overlord/secretstate/doc.go
+++ b/internal/overlord/secretstate/doc.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+// Package secretstate provides the overlord manager and task handler for
+// secret retrieval. Retrieval currently returns a placeholder value.
+package secretstate

--- a/internal/overlord/secretstate/getsecret.go
+++ b/internal/overlord/secretstate/getsecret.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package secretstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+// GetSecret schedules retrieval for a previously authorised secret consumer
+// and waits for its result. The caller must not hold the state lock, and the
+// state engine must be running. Results are consumed from the in-memory cache.
+// Cancellation aborts the change and discards any result.
+//
+// The following errors may be expected:
+//   - [context.Canceled]: the request was cancelled.
+//   - [context.DeadlineExceeded]: the request deadline expired.
+func GetSecret(
+	ctx context.Context,
+	st *state.State,
+	project workshop.Project,
+	ref sdk.PlugRef,
+) ([]byte, error) {
+	err := ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	user, ok := ctx.Value(workshop.ContextUser).(string)
+	if !ok || user == "" {
+		return nil, errors.New("secret request has no user")
+	}
+
+	err = validateGetSecretArgs(project, ref)
+	if err != nil {
+		return nil, fmt.Errorf("validating get secret request arguments: %w", err)
+	}
+
+	st.Lock()
+	task := st.NewTask("get-secret", "Retrieve a workshop secret")
+	change := st.NewChange("get-secret", "Retrieve a workshop secret")
+	change.AddTask(task)
+	change.Set("user", user)
+	change.Set("project-id", project.ProjectId)
+	task.Set("project", project)
+	task.Set("workshop", ref.Workshop)
+	task.Set("sdk", ref.Sdk)
+	task.Set("plug", ref.Name)
+	st.EnsureBefore(0)
+	st.Unlock()
+
+	select {
+	case <-change.Ready():
+	case <-ctx.Done():
+	}
+
+	resultKey := secretResultKey(task.ID())
+
+	st.Lock()
+	defer st.Unlock()
+	// Remove the secret on every return path so results do not outlive their
+	// request. This defer runs before the state is unlocked.
+	defer st.Cache(resultKey, nil)
+
+	// Prefer cancellation if it raced with task completion. Aborting under
+	// this lock prevents the handler from publishing a result after cleanup.
+	err = ctx.Err()
+	if err != nil {
+		change.Abort()
+		st.EnsureBefore(0)
+		return nil, err
+	}
+
+	err = change.Err()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"checking secret retrieval change %s: %w",
+			change.ID(),
+			err,
+		)
+	}
+
+	status := task.Status()
+	if status != state.DoneStatus {
+		return nil, fmt.Errorf(
+			"secret task %s in change %s finished with unexpected status %s",
+			task.ID(),
+			change.ID(),
+			status,
+		)
+	}
+
+	value, ok := st.Cached(resultKey).([]byte)
+	if !ok {
+		return nil, fmt.Errorf(
+			"secret task %s in change %s completed without a result",
+			task.ID(),
+			change.ID(),
+		)
+	}
+
+	return value, nil
+}
+
+// validateGetSecretArgs checks that the project and secret consumer identity
+// are complete and refer to the same project.
+func validateGetSecretArgs(project workshop.Project, ref sdk.PlugRef) error {
+	if project.ProjectId == "" {
+		return errors.New("project ID is missing")
+	}
+	if project.Path == "" {
+		return errors.New("project path is missing")
+	}
+	if ref.ProjectId == "" {
+		return errors.New("plug reference project ID is missing")
+	}
+	if ref.ProjectId != project.ProjectId {
+		return errors.New(
+			"plug reference project ID does not match project ID",
+		)
+	}
+	if ref.Workshop == "" {
+		return errors.New("workshop name is missing")
+	}
+	if ref.Sdk == "" {
+		return errors.New("sdk name is missing")
+	}
+	if ref.Name == "" {
+		return errors.New("plug name is missing")
+	}
+	return nil
+}

--- a/internal/overlord/secretstate/getsecret.go
+++ b/internal/overlord/secretstate/getsecret.go
@@ -54,9 +54,11 @@ func GetSecret(
 		return nil, fmt.Errorf("validating get secret request arguments: %w", err)
 	}
 
+	summary := fmt.Sprintf("Retrieve secret %q", ref.ShortRef())
+
 	st.Lock()
-	task := st.NewTask("get-secret", "Retrieve a workshop secret")
-	change := st.NewChange("get-secret", "Retrieve a workshop secret")
+	task := st.NewTask("get-secret", summary)
+	change := st.NewChange("get-secret", summary)
 	change.AddTask(task)
 	change.Set("user", user)
 	change.Set("project-id", project.ProjectId)

--- a/internal/overlord/secretstate/getsecret.go
+++ b/internal/overlord/secretstate/getsecret.go
@@ -84,8 +84,12 @@ func GetSecret(
 	// handles undo if retrieval succeeds despite the abort.
 	err = ctx.Err()
 	if err != nil {
-		change.Abort()
-		st.EnsureBefore(0)
+		// A ready change must not become unready through an abort. Check
+		// under the same lock so completion cannot race with this decision.
+		if !change.IsReady() {
+			change.Abort()
+			st.EnsureBefore(0)
+		}
 		return nil, err
 	}
 

--- a/internal/overlord/secretstate/getsecret.go
+++ b/internal/overlord/secretstate/getsecret.go
@@ -27,7 +27,8 @@ import (
 // GetSecret schedules retrieval for a previously authorised secret consumer
 // and waits for its result. The caller must not hold the state lock, and the
 // state engine must be running. Results are consumed from the in-memory cache.
-// Cancellation aborts the change and discards any result.
+// Cancellation aborts the change and discards any cached result. Results
+// published after cancellation are discarded when the task is undone.
 //
 // The following errors may be expected:
 //   - [context.Canceled]: the request was cancelled.
@@ -75,12 +76,12 @@ func GetSecret(
 
 	st.Lock()
 	defer st.Unlock()
-	// Remove the secret on every return path so results do not outlive their
-	// request. This defer runs before the state is unlocked.
+	// Remove any cached result before returning and unlocking the state.
+	// If an aborted handler publishes later, its undo handler removes it.
 	defer st.Cache(resultKey, nil)
 
-	// Prefer cancellation if it raced with task completion. Aborting under
-	// this lock prevents the handler from publishing a result after cleanup.
+	// Prefer cancellation if it raced with task completion. The runner
+	// handles undo if retrieval succeeds despite the abort.
 	err = ctx.Err()
 	if err != nil {
 		change.Abort()

--- a/internal/overlord/secretstate/getsecret_test.go
+++ b/internal/overlord/secretstate/getsecret_test.go
@@ -92,6 +92,47 @@ func (s *getSecretSuite) TearDownTest(c *C) {
 	s.runner.Stop()
 }
 
+// TestCancelledAfterCompletion checks cancellation discards a completed result
+// without aborting the ready change or making it unready.
+func (s *getSecretSuite) TestCancelledAfterCompletion(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: project.ProjectId,
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	results := s.start(ctx, project, ref)
+	task := s.awaitTask(c)
+
+	s.st.Lock()
+	// Complete and cancel under one lock so GetSecret observes both before
+	// it can consume the result, regardless of which select case wakes it.
+	task.SetStatus(state.DoingStatus)
+	s.st.Cache(secretResultKey(task.ID()), []byte("workshop-placeholder-secret"))
+	task.SetStatus(state.DoneStatus)
+	c.Check(task.Change().IsReady(), Equals, true)
+	cancel()
+	s.st.Unlock()
+
+	result := <-results
+	c.Check(errors.Is(result.err, context.Canceled), Equals, true)
+	c.Check(result.value, IsNil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(task.Change().IsReady(), Equals, true)
+	c.Check(task.Change().Err(), IsNil)
+	c.Check(s.st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
 // TestCancelledBeforeScheduling checks cancellation creates no changes.
 func (s *getSecretSuite) TestCancelledBeforeScheduling(c *C) {
 	project := workshop.Project{

--- a/internal/overlord/secretstate/getsecret_test.go
+++ b/internal/overlord/secretstate/getsecret_test.go
@@ -448,6 +448,10 @@ func (s *getSecretSuite) TestSuccess(c *C) {
 		c.Check(workshopName, Equals, ref.Workshop)
 		c.Check(sdkName, Equals, ref.Sdk)
 		c.Check(plugName, Equals, ref.Name)
+		c.Check(task.Summary(), Equals,
+			`Retrieve secret "test-workshop/ollama:api-key"`)
+		c.Check(task.Change().Summary(), Equals,
+			`Retrieve secret "test-workshop/ollama:api-key"`)
 	}()
 
 	err := s.runner.Ensure()

--- a/internal/overlord/secretstate/getsecret_test.go
+++ b/internal/overlord/secretstate/getsecret_test.go
@@ -1,0 +1,551 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package secretstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
+
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+// getSecretResult carries retrieval completion without blocking its goroutine.
+type getSecretResult struct {
+	err   error
+	value []byte
+}
+
+// getSecretSuite checks synchronous retrieval through the task runner.
+type getSecretSuite struct {
+	backend *secretStateBackend
+	runner  *state.TaskRunner
+	st      *state.State
+}
+
+var _ = Suite(&getSecretSuite{})
+
+// awaitTask waits for scheduling before inspecting the task under lock.
+func (s *getSecretSuite) awaitTask(c *C) *state.Task {
+	s.awaitEnsure(c)
+	s.st.Lock()
+	defer s.st.Unlock()
+	changes := s.st.Changes()
+	c.Assert(changes, HasLen, 1)
+	tasks := changes[0].Tasks()
+	c.Assert(tasks, HasLen, 1)
+	c.Check(changes[0].Kind(), Equals, "get-secret")
+	c.Check(tasks[0].Kind(), Equals, "get-secret")
+	return tasks[0]
+}
+
+// awaitEnsure waits for an immediate ensure request without polling.
+func (s *getSecretSuite) awaitEnsure(c *C) {
+	delay := <-s.backend.ensureBefore
+	c.Check(delay, Equals, time.Duration(0))
+}
+
+// SetUpTest provides the state backend and task runner.
+func (s *getSecretSuite) SetUpTest(c *C) {
+	s.backend = &secretStateBackend{
+		ensureBefore: make(chan time.Duration, 1),
+	}
+	s.st = state.New(s.backend)
+	s.runner = state.NewTaskRunner(s.st)
+	New(s.runner)
+}
+
+// start launches retrieval with a buffered completion channel.
+func (s *getSecretSuite) start(
+	ctx context.Context,
+	project workshop.Project,
+	ref sdk.PlugRef,
+) <-chan getSecretResult {
+	results := make(chan getSecretResult, 1)
+	go func() {
+		value, err := GetSecret(ctx, s.st, project, ref)
+		results <- getSecretResult{err: err, value: value}
+	}()
+	return results
+}
+
+// TearDownTest stops the runner.
+func (s *getSecretSuite) TearDownTest(c *C) {
+	s.runner.Stop()
+}
+
+// TestCancelledBeforeScheduling checks cancellation creates no changes.
+func (s *getSecretSuite) TestCancelledBeforeScheduling(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	cancel()
+
+	result := <-s.start(ctx, project, ref)
+	c.Check(errors.Is(result.err, context.Canceled), Equals, true)
+	c.Check(result.value, IsNil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+	c.Check(s.backend.ensureBefore, HasLen, 0)
+}
+
+// TestCancelledWhileQueued checks cancellation aborts an unstarted task and
+// removes even a cached result before requesting another ensure pass.
+func (s *getSecretSuite) TestCancelledWhileQueued(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	results := s.start(ctx, project, ref)
+	task := s.awaitTask(c)
+
+	s.st.Lock()
+	c.Check(task.Status(), Equals, state.DoStatus)
+	s.st.Cache(secretResultKey(task.ID()), []byte("stale"))
+	s.st.Unlock()
+	cancel()
+
+	result := <-results
+	c.Check(errors.Is(result.err, context.Canceled), Equals, true)
+	c.Check(result.value, IsNil)
+	s.awaitEnsure(c)
+
+	err := s.runner.Ensure()
+	c.Assert(err, IsNil)
+	s.runner.Wait()
+
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(task.Status(), Equals, state.HoldStatus)
+	c.Check(s.st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestMissingUser checks that unauthenticated requests create no tasks.
+func (s *getSecretSuite) TestMissingUser(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := <-s.start(ctx, project, ref)
+
+	c.Check(result.err, ErrorMatches, "secret request has no user")
+	c.Check(result.value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+}
+
+// TestMismatchedProject checks that inconsistent lookup identity is rejected
+// before a task is scheduled.
+func (s *getSecretSuite) TestMismatchedProject(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "another-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	result := <-s.start(ctx, project, ref)
+
+	c.Check(result.err, ErrorMatches,
+		"validating get secret request arguments: "+
+			"plug reference project ID does not match project ID")
+	c.Check(result.value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+}
+
+// TestMissingPlug checks that an absent plug name is identified before scheduling.
+func (s *getSecretSuite) TestMissingPlug(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	value, err := GetSecret(ctx, s.st, project, ref)
+
+	c.Check(err, ErrorMatches,
+		"validating get secret request arguments: plug name is missing")
+	c.Check(value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+}
+
+// TestMissingPlugProjectID checks that an absent reference project ID is
+// distinguished from a project mismatch before scheduling.
+func (s *getSecretSuite) TestMissingPlugProjectID(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:     "api-key",
+		Sdk:      "ollama",
+		Workshop: "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	value, err := GetSecret(ctx, s.st, project, ref)
+
+	c.Check(err, ErrorMatches,
+		"validating get secret request arguments: "+
+			"plug reference project ID is missing")
+	c.Check(value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+}
+
+// TestMissingProjectID checks that an absent project ID prevents scheduling.
+func (s *getSecretSuite) TestMissingProjectID(c *C) {
+	project := workshop.Project{
+		Path: c.MkDir(),
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	value, err := GetSecret(ctx, s.st, project, ref)
+
+	c.Check(err, ErrorMatches,
+		"validating get secret request arguments: project ID is missing")
+	c.Check(value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+}
+
+// TestMissingProjectPath checks that an absent project path prevents scheduling.
+func (s *getSecretSuite) TestMissingProjectPath(c *C) {
+	project := workshop.Project{
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	value, err := GetSecret(ctx, s.st, project, ref)
+
+	c.Check(err, ErrorMatches,
+		"validating get secret request arguments: project path is missing")
+	c.Check(value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+}
+
+// TestMissingSDK checks that an absent SDK name prevents scheduling.
+func (s *getSecretSuite) TestMissingSDK(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	value, err := GetSecret(ctx, s.st, project, ref)
+
+	c.Check(err, ErrorMatches,
+		"validating get secret request arguments: sdk name is missing")
+	c.Check(value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+}
+
+// TestMissingWorkshop checks that an absent workshop name prevents scheduling.
+func (s *getSecretSuite) TestMissingWorkshop(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+
+	value, err := GetSecret(ctx, s.st, project, ref)
+
+	c.Check(err, ErrorMatches,
+		"validating get secret request arguments: workshop name is missing")
+	c.Check(value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(s.st.Changes(), HasLen, 0)
+}
+
+// TestSuccess checks identity metadata, result delivery and cache consumption.
+func (s *getSecretSuite) TestSuccess(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	results := s.start(ctx, project, ref)
+	task := s.awaitTask(c)
+
+	func() {
+		s.st.Lock()
+		defer s.st.Unlock()
+		var user, projectID, workshopName, sdkName, plugName string
+		var actualProject workshop.Project
+		c.Assert(task.Change().Get("user", &user), IsNil)
+		c.Assert(task.Change().Get("project-id", &projectID), IsNil)
+		c.Assert(task.Get("project", &actualProject), IsNil)
+		c.Assert(task.Get("workshop", &workshopName), IsNil)
+		c.Assert(task.Get("sdk", &sdkName), IsNil)
+		c.Assert(task.Get("plug", &plugName), IsNil)
+		c.Check(user, Equals, "test-user")
+		c.Check(projectID, Equals, project.ProjectId)
+		c.Check(actualProject, DeepEquals, project)
+		c.Check(workshopName, Equals, ref.Workshop)
+		c.Check(sdkName, Equals, ref.Sdk)
+		c.Check(plugName, Equals, ref.Name)
+	}()
+
+	err := s.runner.Ensure()
+	c.Assert(err, IsNil)
+	s.runner.Wait()
+	result := <-results
+	c.Check(result.err, IsNil)
+	c.Check(result.value, DeepEquals, []byte("workshop-placeholder-secret"))
+
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(task.Change().Err(), IsNil)
+	c.Check(s.st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestSuccessWithoutResult checks a done task must supply a cached secret.
+func (s *getSecretSuite) TestSuccessWithoutResult(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	s.runner.AddHandler("get-secret", func(*state.Task, *tomb.Tomb) error {
+		return nil
+	}, nil)
+	results := s.start(ctx, project, ref)
+	task := s.awaitTask(c)
+
+	err := s.runner.Ensure()
+	c.Assert(err, IsNil)
+	s.runner.Wait()
+	result := <-results
+	c.Check(result.value, IsNil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Assert(result.err, NotNil)
+	c.Check(result.err.Error(), Equals, fmt.Sprintf(
+		"secret task %s in change %s completed without a result",
+		task.ID(),
+		task.Change().ID(),
+	))
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(s.st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestUnexpectedStatus checks that a held task reports both IDs and its
+// status, and discards any cached result rather than returning it.
+func (s *getSecretSuite) TestUnexpectedStatus(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	results := s.start(ctx, project, ref)
+	task := s.awaitTask(c)
+
+	s.st.Lock()
+	s.st.Cache(secretResultKey(task.ID()), []byte("stale"))
+	task.Change().Abort()
+	s.st.Unlock()
+	result := <-results
+
+	c.Check(result.value, IsNil)
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Assert(task.Status(), Equals, state.HoldStatus)
+	c.Assert(result.err, NotNil)
+	c.Check(result.err.Error(), Equals, fmt.Sprintf(
+		"secret task %s in change %s finished with unexpected status Hold",
+		task.ID(),
+		task.Change().ID(),
+	))
+	c.Check(s.st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestTaskFailure checks task errors propagate without returning cached data.
+func (s *getSecretSuite) TestTaskFailure(c *C) {
+	project := workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	}
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, workshop.ContextUser, "test-user")
+	s.runner.AddHandler("get-secret", func(
+		task *state.Task,
+		_ *tomb.Tomb,
+	) error {
+		s.st.Lock()
+		s.st.Cache(secretResultKey(task.ID()), []byte("stale"))
+		s.st.Unlock()
+		return errors.New("secret provider unavailable")
+	}, nil)
+	results := s.start(ctx, project, ref)
+	task := s.awaitTask(c)
+
+	err := s.runner.Ensure()
+	c.Assert(err, IsNil)
+	s.runner.Wait()
+	result := <-results
+	c.Check(result.value, IsNil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+	c.Assert(result.err, NotNil)
+	changeErr := task.Change().Err()
+	c.Assert(changeErr, ErrorMatches, "(?s).*secret provider unavailable.*")
+	c.Check(result.err.Error(), Equals, fmt.Sprintf(
+		"checking secret retrieval change %s: %s",
+		task.Change().ID(),
+		changeErr,
+	))
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(s.st.Cached(secretResultKey(task.ID())), IsNil)
+}

--- a/internal/overlord/secretstate/manager.go
+++ b/internal/overlord/secretstate/manager.go
@@ -83,21 +83,11 @@ func (m SecretManager) doGetSecret(
 	st.Lock()
 	defer st.Unlock()
 
-	// Check under the publication lock: an abort may precede tomb cancellation.
-	switch status := task.Status(); status {
-	case state.DoingStatus:
-		st.Cache(secretResultKey(task.ID()), value)
-		return nil
-
-	case state.AbortStatus:
-		return context.Canceled
-
-	default:
-		return fmt.Errorf(
-			"cannot publish secret result: unexpected task status %s",
-			status,
-		)
-	}
+	st.Cache(secretResultKey(task.ID()), value)
+	// Do not return an error after publication: the runner only schedules
+	// undo for a successful aborted handler. An error would skip undo and
+	// could leave a late result cached after the caller has returned.
+	return nil
 }
 
 // Ensure implements the state manager lifecycle. There is currently no
@@ -125,6 +115,20 @@ func (m SecretManager) getSecret(
 // New creates a secret manager and registers its task handlers.
 func New(runner *state.TaskRunner) SecretManager {
 	manager := SecretManager{}
-	runner.AddHandler("get-secret", manager.doGetSecret, nil)
+	runner.AddHandler("get-secret", manager.doGetSecret, manager.undoGetSecret)
 	return manager
+}
+
+// undoGetSecret removes a result published by an aborted retrieval.
+// Removing an already-consumed or absent result is harmless.
+func (m SecretManager) undoGetSecret(
+	task *state.Task,
+	_ *tomb.Tomb,
+) error {
+	st := task.State()
+	st.Lock()
+	defer st.Unlock()
+
+	st.Cache(secretResultKey(task.ID()), nil)
+	return nil
 }

--- a/internal/overlord/secretstate/manager.go
+++ b/internal/overlord/secretstate/manager.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package secretstate
+
+import (
+	"context"
+	"fmt"
+
+	"gopkg.in/tomb.v2"
+
+	"github.com/canonical/workshop/internal/overlord/handlersetup"
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
+)
+
+// SecretManager registers and handles secret operation tasks.
+type SecretManager struct{}
+
+// secretResultKey identifies a task's []byte result in the non-persisted state
+// cache. The consumer must remove the entry after reading the result.
+type secretResultKey string
+
+// doGetSecret extracts the caller and secret consumer from task metadata
+// before attempting retrieval outside the state lock.
+func (m SecretManager) doGetSecret(
+	task *state.Task,
+	tomb *tomb.Tomb,
+) error {
+	user, project, workshopName, err :=
+		handlersetup.UserProjectWorkshop(task)
+	if err != nil {
+		return fmt.Errorf("cannot resolve secret task identity: %w", err)
+	}
+
+	var sdkName, plugName string
+	st := task.State()
+
+	st.Lock()
+	err = task.Get("sdk", &sdkName)
+	if err == nil {
+		err = task.Get("plug", &plugName)
+	}
+	st.Unlock()
+
+	if err != nil {
+		return fmt.Errorf(
+			"cannot read get secret task parameters for sdk and plug: %w",
+			err,
+		)
+	}
+
+	ctx, cancel := handlersetup.BackendContext(
+		tomb,
+		user,
+		project.ProjectId,
+	)
+	defer cancel()
+
+	ref := sdk.PlugRef{
+		Name:      plugName,
+		ProjectId: project.ProjectId,
+		Sdk:       sdkName,
+		Workshop:  workshopName,
+	}
+
+	value, err := m.getSecret(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	st.Lock()
+	defer st.Unlock()
+
+	// Check under the publication lock: an abort may precede tomb cancellation.
+	switch status := task.Status(); status {
+	case state.DoingStatus:
+		st.Cache(secretResultKey(task.ID()), value)
+		return nil
+
+	case state.AbortStatus:
+		return context.Canceled
+
+	default:
+		return fmt.Errorf(
+			"cannot publish secret result: unexpected task status %s",
+			status,
+		)
+	}
+}
+
+// Ensure implements the state manager lifecycle. There is currently no
+// periodic secret maintenance to perform.
+func (m SecretManager) Ensure() error {
+	return nil
+}
+
+// getSecret returns a placeholder until provider support is implemented.
+//
+// The following errors may be expected:
+//   - [context.Canceled]: the retrieval was cancelled.
+//   - [context.DeadlineExceeded]: the retrieval deadline expired.
+func (m SecretManager) getSecret(
+	ctx context.Context,
+	_ sdk.PlugRef,
+) ([]byte, error) {
+	err := ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+	return []byte("workshop-placeholder-secret"), nil
+}
+
+// New creates a secret manager and registers its task handlers.
+func New(runner *state.TaskRunner) SecretManager {
+	manager := SecretManager{}
+	runner.AddHandler("get-secret", manager.doGetSecret, nil)
+	return manager
+}

--- a/internal/overlord/secretstate/manager_test.go
+++ b/internal/overlord/secretstate/manager_test.go
@@ -226,27 +226,26 @@ func (s *managerSuite) TestGetSecretMissingWorkshop(c *C) {
 		"(?s).*cannot resolve secret task identity.*")
 }
 
-// TestGetSecretCancelledBeforeTomb checks that an aborted task cannot publish
-// a result even before the runner cancels its tomb.
+// TestGetSecretCancelledBeforeTomb checks successful retrieval publishes a
+// result and returns nil even when the task has already been aborted.
 func (s *managerSuite) TestGetSecretCancelledBeforeTomb(c *C) {
 	st := state.New(nil)
 	task := newSecretTask(c, st)
-
 	st.Lock()
 	task.SetStatus(state.DoingStatus)
 	task.Change().Abort()
-	c.Check(task.Status(), Equals, state.AbortStatus)
 	st.Unlock()
-
 	var taskTomb tomb.Tomb
 	manager := SecretManager{}
+
 	err := manager.doGetSecret(task, &taskTomb)
 
-	c.Check(errors.Is(err, context.Canceled), Equals, true)
-	c.Check(taskTomb.Alive(), Equals, true)
+	c.Check(err, IsNil)
 	st.Lock()
 	defer st.Unlock()
-	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+	c.Check(task.Status(), Equals, state.AbortStatus)
+	c.Check(st.Cached(secretResultKey(task.ID())), DeepEquals,
+		[]byte("workshop-placeholder-secret"))
 }
 
 // TestGetSecretCancelledContext checks retrieval returns the context error
@@ -308,22 +307,88 @@ func (s *managerSuite) TestGetSecretExpiredContext(c *C) {
 	c.Check(errors.Is(err, context.DeadlineExceeded), Equals, true)
 }
 
-// TestGetSecretUnexpectedStatus checks that a completed task cannot publish
-// another result and reports a lifecycle error rather than cancellation.
-func (s *managerSuite) TestGetSecretUnexpectedStatus(c *C) {
+// TestGetSecretUndoneAfterFailure checks the runner invokes the registered
+// undo handler when a subsequent task fails in the same change.
+func (s *managerSuite) TestGetSecretUndoneAfterFailure(c *C) {
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	defer runner.Stop()
+	New(runner)
+	task := newSecretTask(c, st)
+	runner.AddHandler("fail", func(*state.Task, *tomb.Tomb) error {
+		return errors.New("subsequent task failed")
+	}, nil)
+	st.Lock()
+	failure := st.NewTask("fail", "Fail after secret retrieval")
+	failure.WaitFor(task)
+	task.Change().AddTask(failure)
+	st.Unlock()
+
+	err := runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(st.Cached(secretResultKey(task.ID())), DeepEquals,
+		[]byte("workshop-placeholder-secret"))
+	st.Unlock()
+
+	err = runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	c.Check(failure.Status(), Equals, state.ErrorStatus)
+	c.Check(task.Status(), Equals, state.UndoStatus)
+	st.Unlock()
+
+	err = runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+	c.Check(task.Status(), Equals, state.UndoneStatus)
+	c.Check(task.Change().Err(), ErrorMatches,
+		"(?s).*subsequent task failed.*")
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestUndoGetSecretRemovesResult checks undo discards a cached secret.
+func (s *managerSuite) TestUndoGetSecretRemovesResult(c *C) {
 	st := state.New(nil)
 	task := newSecretTask(c, st)
 	st.Lock()
-	task.SetStatus(state.DoneStatus)
+	st.Cache(secretResultKey(task.ID()), []byte("workshop-placeholder-secret"))
 	st.Unlock()
 	var taskTomb tomb.Tomb
 	manager := SecretManager{}
 
-	err := manager.doGetSecret(task, &taskTomb)
+	err := manager.undoGetSecret(task, &taskTomb)
 
-	c.Check(err, ErrorMatches,
-		"cannot publish secret result: unexpected task status Done")
-	c.Check(errors.Is(err, context.Canceled), Equals, false)
+	c.Check(err, IsNil)
+	st.Lock()
+	defer st.Unlock()
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestUndoGetSecretWithoutResult checks undo succeeds when the caller has
+// already removed the cached result, even if the undo tomb is cancelled.
+func (s *managerSuite) TestUndoGetSecretWithoutResult(c *C) {
+	st := state.New(nil)
+	task := newSecretTask(c, st)
+	st.Lock()
+	st.Cache(secretResultKey(task.ID()), []byte("workshop-placeholder-secret"))
+	st.Cache(secretResultKey(task.ID()), nil)
+	st.Unlock()
+	var taskTomb tomb.Tomb
+	taskTomb.Kill(nil)
+	manager := SecretManager{}
+
+	err := manager.undoGetSecret(task, &taskTomb)
+
+	c.Check(err, IsNil)
 	st.Lock()
 	defer st.Unlock()
 	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)

--- a/internal/overlord/secretstate/manager_test.go
+++ b/internal/overlord/secretstate/manager_test.go
@@ -1,0 +1,342 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package secretstate
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
+
+	"github.com/canonical/workshop/internal/overlord/state"
+	"github.com/canonical/workshop/internal/sdk"
+	"github.com/canonical/workshop/internal/workshop"
+)
+
+// managerSuite checks secret task registration and execution.
+type managerSuite struct{}
+
+var _ = Suite(&managerSuite{})
+
+// newSecretTask creates a retrieval task with complete lookup metadata.
+func newSecretTask(c *C, st *state.State) *state.Task {
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("get-secret", "Retrieve a workshop secret")
+	change := st.NewChange("get-secret", "Retrieve a workshop secret")
+	change.AddTask(task)
+	change.Set("user", "test-user")
+	task.Set("project", workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	})
+	task.Set("workshop", "test-workshop")
+	task.Set("sdk", "ollama")
+	task.Set("plug", "api-key")
+
+	return task
+}
+
+// TestSecretState runs the secret manager suite.
+func TestSecretState(t *testing.T) {
+	TestingT(t)
+}
+
+// TestGetSecretCachesResult checks that successful retrieval stores its result
+// in memory without including the secret in serialised state.
+func (s *managerSuite) TestGetSecretCachesResult(c *C) {
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	defer runner.Stop()
+	New(runner)
+
+	st.Lock()
+	task := st.NewTask("get-secret", "Retrieve a workshop secret")
+	change := st.NewChange("get-secret", "Retrieve a workshop secret")
+	change.AddTask(task)
+	change.Set("user", "test-user")
+	task.Set("project", workshop.Project{
+		Path:      c.MkDir(),
+		ProjectId: "test-project",
+	})
+	task.Set("workshop", "test-workshop")
+	task.Set("sdk", "ollama")
+	task.Set("plug", "api-key")
+	st.Unlock()
+
+	err := runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(change.Err(), IsNil)
+	value, ok := st.Cached(secretResultKey(task.ID())).([]byte)
+	c.Assert(ok, Equals, true)
+	c.Check(string(value), Equals, "workshop-placeholder-secret")
+
+	data, err := st.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(strings.Contains(string(data), string(value)), Equals, false)
+	encoded := base64.StdEncoding.EncodeToString(value)
+	c.Check(strings.Contains(string(data), encoded), Equals, false)
+}
+
+// TestGetSecretMissingPlug checks that a missing plug fails without caching
+// a secret result.
+func (s *managerSuite) TestGetSecretMissingPlug(c *C) {
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	defer runner.Stop()
+	New(runner)
+	task := newSecretTask(c, st)
+
+	st.Lock()
+	task.Set("plug", nil)
+	st.Unlock()
+
+	err := runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+	c.Check(task.Change().Err(), ErrorMatches,
+		"(?s).*cannot read get secret task parameters for sdk and plug:.*")
+}
+
+// TestGetSecretMissingProject checks that a missing project fails without
+// caching a secret result.
+func (s *managerSuite) TestGetSecretMissingProject(c *C) {
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	defer runner.Stop()
+	New(runner)
+	task := newSecretTask(c, st)
+
+	st.Lock()
+	task.Set("project", nil)
+	st.Unlock()
+
+	err := runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+	c.Check(task.Change().Err(), ErrorMatches,
+		"(?s).*cannot resolve secret task identity.*")
+}
+
+// TestGetSecretMissingSDK checks that a missing SDK fails without caching
+// a secret result.
+func (s *managerSuite) TestGetSecretMissingSDK(c *C) {
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	defer runner.Stop()
+	New(runner)
+	task := newSecretTask(c, st)
+
+	st.Lock()
+	task.Set("sdk", nil)
+	st.Unlock()
+
+	err := runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+	c.Check(task.Change().Err(), ErrorMatches,
+		"(?s).*cannot read get secret task parameters for sdk and plug:.*")
+}
+
+// TestGetSecretMissingUser checks that a missing change user fails without
+// caching a secret result.
+func (s *managerSuite) TestGetSecretMissingUser(c *C) {
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	defer runner.Stop()
+	New(runner)
+	task := newSecretTask(c, st)
+
+	st.Lock()
+	task.Change().Set("user", nil)
+	st.Unlock()
+
+	err := runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+	c.Check(task.Change().Err(), ErrorMatches,
+		"(?s).*cannot resolve secret task identity.*")
+}
+
+// TestGetSecretMissingWorkshop checks that a missing workshop fails without
+// caching a secret result.
+func (s *managerSuite) TestGetSecretMissingWorkshop(c *C) {
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	defer runner.Stop()
+	New(runner)
+	task := newSecretTask(c, st)
+
+	st.Lock()
+	task.Set("workshop", nil)
+	st.Unlock()
+
+	err := runner.Ensure()
+	c.Assert(err, IsNil)
+	runner.Wait()
+
+	st.Lock()
+	defer st.Unlock()
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+	c.Check(task.Change().Err(), ErrorMatches,
+		"(?s).*cannot resolve secret task identity.*")
+}
+
+// TestGetSecretCancelledBeforeTomb checks that an aborted task cannot publish
+// a result even before the runner cancels its tomb.
+func (s *managerSuite) TestGetSecretCancelledBeforeTomb(c *C) {
+	st := state.New(nil)
+	task := newSecretTask(c, st)
+
+	st.Lock()
+	task.SetStatus(state.DoingStatus)
+	task.Change().Abort()
+	c.Check(task.Status(), Equals, state.AbortStatus)
+	st.Unlock()
+
+	var taskTomb tomb.Tomb
+	manager := SecretManager{}
+	err := manager.doGetSecret(task, &taskTomb)
+
+	c.Check(errors.Is(err, context.Canceled), Equals, true)
+	c.Check(taskTomb.Alive(), Equals, true)
+	st.Lock()
+	defer st.Unlock()
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestGetSecretCancelledContext checks retrieval returns the context error
+// without a value when cancellation precedes retrieval.
+func (s *managerSuite) TestGetSecretCancelledContext(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancel()
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+	manager := SecretManager{}
+
+	value, err := manager.getSecret(ctx, ref)
+
+	c.Check(value, IsNil)
+	c.Check(errors.Is(err, context.Canceled), Equals, true)
+}
+
+// TestGetSecretCancelledTomb checks the handler propagates retrieval
+// cancellation without caching a result, even while its task is Doing.
+func (s *managerSuite) TestGetSecretCancelledTomb(c *C) {
+	st := state.New(nil)
+	task := newSecretTask(c, st)
+	st.Lock()
+	task.SetStatus(state.DoingStatus)
+	st.Unlock()
+	var taskTomb tomb.Tomb
+	taskTomb.Kill(nil)
+	manager := SecretManager{}
+
+	err := manager.doGetSecret(task, &taskTomb)
+
+	c.Check(errors.Is(err, context.Canceled), Equals, true)
+	st.Lock()
+	defer st.Unlock()
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestGetSecretExpiredContext checks retrieval returns the deadline error
+// without a value when its deadline has already elapsed.
+func (s *managerSuite) TestGetSecretExpiredContext(c *C) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Time{})
+	defer cancel()
+	ref := sdk.PlugRef{
+		Name:      "api-key",
+		ProjectId: "test-project",
+		Sdk:       "ollama",
+		Workshop:  "test-workshop",
+	}
+	manager := SecretManager{}
+
+	value, err := manager.getSecret(ctx, ref)
+
+	c.Check(value, IsNil)
+	c.Check(errors.Is(err, context.DeadlineExceeded), Equals, true)
+}
+
+// TestGetSecretUnexpectedStatus checks that a completed task cannot publish
+// another result and reports a lifecycle error rather than cancellation.
+func (s *managerSuite) TestGetSecretUnexpectedStatus(c *C) {
+	st := state.New(nil)
+	task := newSecretTask(c, st)
+	st.Lock()
+	task.SetStatus(state.DoneStatus)
+	st.Unlock()
+	var taskTomb tomb.Tomb
+	manager := SecretManager{}
+
+	err := manager.doGetSecret(task, &taskTomb)
+
+	c.Check(err, ErrorMatches,
+		"cannot publish secret result: unexpected task status Done")
+	c.Check(errors.Is(err, context.Canceled), Equals, false)
+	st.Lock()
+	defer st.Unlock()
+	c.Check(st.Cached(secretResultKey(task.ID())), IsNil)
+}
+
+// TestNewRegistersGetSecret checks that construction registers the task kind.
+func (s *managerSuite) TestNewRegistersGetSecret(c *C) {
+	st := state.New(nil)
+	runner := state.NewTaskRunner(st)
+	defer runner.Stop()
+
+	manager := New(runner)
+
+	c.Check(manager.Ensure(), IsNil)
+	c.Check(runner.KnownTaskKinds(), DeepEquals, []string{"get-secret"})
+}

--- a/internal/overlord/secretstate/mocks_test.go
+++ b/internal/overlord/secretstate/mocks_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package secretstate
+
+import "time"
+
+// secretStateBackend signals ensure requests without blocking the state lock.
+type secretStateBackend struct {
+	ensureBefore chan time.Duration
+}
+
+// Checkpoint discards state snapshots in retrieval tests.
+func (b *secretStateBackend) Checkpoint([]byte) error {
+	return nil
+}
+
+// EnsureBefore records a request unless an unread notification is pending.
+func (b *secretStateBackend) EnsureBefore(delay time.Duration) {
+	select {
+	case b.ensureBefore <- delay:
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

Add task-backed secret retrieval for `workshopctl get-secret`, establishing
the path from the daemon-side command through the overlord to the response.

- Register a secret manager and a `get-secret` task handler.
- Add `secretstate.GetSecret` to validate arguments, schedule a task, and
  wait for its result.
- Pass secret values through the non-persistent state cache, removing them
  after consumption or cancellation.
- Route the command through this flow and provide specific identifier
  validation errors without echoing the supplied value.
- Start the overlord loop in the existing daemon test so its request can
  complete.

## Why

Secret retrieval needs to run through the overlord without persisting
secret values in task or change data. This establishes task scheduling,
result delivery, and request cancellation before introducing real secret
providers and workshop identity resolution.

## Current limitations

This is deliberately an incremental implementation:

- The command supplies placeholder project and workshop identity.
- The task handler returns `workshop-placeholder-secret`.
- Restart recovery and handling tasks whose original caller is no longer
  waiting are deferred.

## Validation

- Unit tests cover the secret manager, scheduling, command integration,
  and overlord registration.
- Race checks passed for the secretstate and command packages.
- The existing daemon instance-ID test passes with task execution enabled.
- Manually confirmed that `workshopctl get-secret` inside a workshop
  returns the placeholder value.