### PR TITLE
Make conflict errors to always retain the error kind in the response

### DIFF
--- a/internal/daemon/api_connections.go
+++ b/internal/daemon/api_connections.go
@@ -371,6 +371,9 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 			ts, connErr := ifacestate.Connect(st, plugW, slotW, connRef)
 			if connErr != nil {
 				if _, ok := connErr.(*ifacestate.ErrAlreadyConnected); !ok {
+					if rsp := changeConflictResponse(connErr); rsp != nil {
+						return rsp
+					}
 					return statusBadRequest("%w", connErr)
 				}
 			} else {
@@ -420,6 +423,9 @@ func v1PostConnections(c *Command, r *http.Request, _ *userState) Response {
 		}
 	}
 	if err != nil {
+		if rsp := changeConflictResponse(err); rsp != nil {
+			return rsp
+		}
 		return statusBadRequest("%w", err)
 	}
 

--- a/internal/daemon/api_connections_test.go
+++ b/internal/daemon/api_connections_test.go
@@ -1428,6 +1428,13 @@ func (s *apiSuite) TestConnectFailureOnConflict(c *check.C) {
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
 			"message": `cannot connect "producer-ws/producer:slot": workshop "producer-ws" has "conflict" change in progress`,
+			"kind":    "change-conflict",
+			"value": map[string]any{
+				"change-id":   chg.ID(),
+				"change-kind": "conflict",
+				"project-id":  "b8639dea",
+				"workshop":    "producer-ws",
+			},
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,
@@ -1972,6 +1979,13 @@ func (s *apiSuite) TestDisconnectFailureOnConflict(c *check.C) {
 	c.Check(body, check.DeepEquals, map[string]any{
 		"result": map[string]any{
 			"message": `cannot disconnect "consumer-ws/consumer:plug": workshop "consumer-ws" has "conflict" change in progress`,
+			"kind":    "change-conflict",
+			"value": map[string]any{
+				"change-id":   chg.ID(),
+				"change-kind": "conflict",
+				"project-id":  "b8639dea",
+				"workshop":    "consumer-ws",
+			},
 		},
 		"status":      "Bad Request",
 		"status-code": 400.0,

--- a/internal/daemon/api_workshop_mount.go
+++ b/internal/daemon/api_workshop_mount.go
@@ -108,6 +108,9 @@ func v1PostWorkshopMount(c *Command, r *http.Request, _ *userState) Response {
 
 	taskset, err := o.WorkshopManager().Remount(r.Context(), st, reqData.Plug, reqData.HostSource)
 	if err != nil {
+		if rsp := changeConflictResponse(err); rsp != nil {
+			return rsp
+		}
 		return statusBadRequest("%w", err)
 	}
 

--- a/internal/daemon/api_workshops.go
+++ b/internal/daemon/api_workshops.go
@@ -172,6 +172,46 @@ func changeConflictErrorResponse(conflictErr *conflict.ChangeConflictError) Resp
 	}
 }
 
+// changeConflictResponse returns a structured change-conflict API error when
+// err wraps either conflict type the daemon uses for "one change per workshop
+// at a time": a [conflict.ChangeConflictError] (workshop lifecycle checks) or a
+// [healthstate.ChangeInProgressError] (interface health checks). It keeps err's
+// full message so operation context (e.g. `cannot connect %q: ...`) is
+// preserved, and returns nil for any other error so callers fall through to
+// their default handling.
+func changeConflictResponse(err error) Response {
+	var value changeConflictValue
+	var conflictErr *conflict.ChangeConflictError
+	var inProgressErr healthstate.ChangeInProgressError
+	switch {
+	case errors.As(err, &conflictErr):
+		value = changeConflictValue{
+			ChangeID:   conflictErr.ChangeID,
+			ChangeKind: conflictErr.ChangeKind,
+			ProjectID:  conflictErr.ProjectId,
+			Workshop:   conflictErr.Workshop,
+		}
+	case errors.As(err, &inProgressErr):
+		value = changeConflictValue{
+			ChangeID:   inProgressErr.ChangeID,
+			ChangeKind: inProgressErr.ChangeKind,
+			ProjectID:  inProgressErr.ProjectID,
+			Workshop:   inProgressErr.Workshop,
+		}
+	default:
+		return nil
+	}
+	return &resp{
+		Type:   ResponseTypeError,
+		Status: http.StatusBadRequest,
+		Result: &errorResult{
+			Kind:    errorKindChangeConflict,
+			Message: err.Error(),
+			Value:   value,
+		},
+	}
+}
+
 // noWaitingChangeResponse converts a [conflict.ErrorNoWaitingChange] into a
 // no-waiting-change-in-progress API error response, preserving the wrapped
 // message.


### PR DESCRIPTION
# Description

# Self-review quick check

 * [ ] Make decisions that cost a lot to reverse explicit in the PR description.
 * [ ] Avoid nested conditions.
 * [ ] Delete dead code and redundant comments.
 * [ ] Normalise symmetries by sticking to doing identical things identically. 
 ```
 // one way to handle errors
 if err := f(); err != nil {
    ...
 }
 
 // one way to handle multiple returns
 val, err := f()
 if err != nil {
    ...
 }
 ...
 ```
 * [ ] Check that coupled code elements, files, and directories are adjacent. For example, test data is stored as close as possible to a test.
 * [ ] Put variable declaration and initialisation together.
 * [ ] Divide large expressions into digestable and self-explanatory ones. Use multiple variables if required.
 * [ ] Put a blank line between two logically different chunks of code.
 * [ ] Follow the [style guide](https://github.com/canonical/workshop/tree/main/docs/coding-style-guide.md#error-handling) for new error messages.

## Docs

Procedure:

* [ ] I have checked and added or updated relevant documentation.
* [ ] I have checked and added or updated relevant release notes.
* [ ] I have included the technical author in the review.

Content:

* [ ] Headings and titles accurately describe the content.
* [ ] New and updated pages include correct metadata.
* [ ] Documentation tests are added or updated where applicable (for `tutorial/` and `how-to/` sections).
* [ ] Documentation follows the [style guide](https://github.com/canonical/workshop/tree/main/docs/doc-style-guide.md).
* [ ] If needed, `docs/.coverage.yaml` updated, coverage tags added (`.. artefact`).

---

Or:

* [ ] I confirm the PR has no implications for documentation.
